### PR TITLE
fix(insights): back off and cap property-value refresh polling

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
@@ -158,13 +158,18 @@ export const lemonToast = {
         return id
     },
     warning(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}) {
-        posthog.capture('toast warning', {
-            message: String(message),
-            button: button?.label,
-            toastId: toastOptions.toastId,
-        })
         const options = ensureToastId(toastOptions, 'warning', message)
         const id = options.toastId!
+        // Only capture when a toast with this id isn't already on screen. react-toastify skips
+        // re-showing a duplicate toast, so capturing per shown toast (rather than per call) keeps a
+        // single repeatedly-failing action from emitting hundreds of identical events.
+        if (!toast.isActive(id)) {
+            posthog.capture('toast warning', {
+                message: String(message),
+                button: button?.label,
+                toastId: id,
+            })
+        }
         queueMicrotask(() => {
             if (cancelledIds.delete(id)) {
                 return
@@ -177,18 +182,19 @@ export const lemonToast = {
         return id
     },
     error(message: string | JSX.Element, { button, hideButton, ...toastOptions }: ToastOptionsWithButton = {}) {
-        // when used inside the posthog toolbar, `posthog.capture` isn't loaded
-        // check if the function is available before calling it.
-        if (posthog.capture) {
+        const options = ensureToastId(toastOptions, 'error', message)
+        const id = options.toastId!
+        // Only capture when a toast with this id isn't already on screen. react-toastify skips
+        // re-showing a duplicate toast, so capturing per shown toast (rather than per call) keeps a
+        // single repeatedly-failing action from emitting hundreds of identical events.
+        // (`posthog.capture` isn't loaded inside the posthog toolbar, so guard for it too.)
+        if (posthog.capture && !toast.isActive(id)) {
             posthog.capture('toast error', {
                 message: String(message),
                 button: button?.label,
-                toastId: toastOptions.toastId,
+                toastId: id,
             })
         }
-
-        const options = ensureToastId(toastOptions, 'error', message)
-        const id = options.toastId!
         queueMicrotask(() => {
             if (cancelledIds.delete(id)) {
                 return

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -622,5 +622,60 @@ describe('the property definitions model', () => {
             expect(capturedUrls).toHaveLength(2)
             expect(capturedUrls[1]).toContain('refresh=force_cache')
         })
+
+        it('stops polling after a bounded number of attempts when the backend stays refreshing', async () => {
+            const requestUrls: string[] = []
+            let pendingPoll: (() => void) | null = null
+
+            // Capture the backed-off poll timers (>= base delay) and run them synchronously below;
+            // let short timers (kea breakpoints) run normally. Without a cap this chain is infinite.
+            const originalSetTimeout = global.setTimeout.bind(global)
+            jest.spyOn(global, 'setTimeout').mockImplementation(((
+                fn: TimerHandler,
+                delay?: number,
+                ...args: unknown[]
+            ) => {
+                if (typeof delay === 'number' && delay >= 2000) {
+                    pendingPoll = () => (fn as (...a: unknown[]) => unknown)(...args)
+                    return 0 as unknown as ReturnType<typeof setTimeout>
+                }
+                return originalSetTimeout(fn, delay, ...args)
+            }) as typeof setTimeout)
+
+            useMocks({
+                get: {
+                    // Never finishes refreshing — the client must give up on its own.
+                    '/api/event/values': ({ request }) => {
+                        requestUrls.push(request.url)
+                        return [200, { results: [], refreshing: true }]
+                    },
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.Event,
+                    newInput: undefined,
+                    propertyKey: 'browser',
+                })
+            }).toFinishAllListeners()
+
+            // Drain the poll chain; the loop is bounded so a missing cap fails loudly instead of hanging.
+            let iterations = 0
+            while (pendingPoll && iterations < 50) {
+                const next = pendingPoll
+                pendingPoll = null
+                await expectLogic(logic, () => next()).toFinishAllListeners()
+                iterations += 1
+            }
+
+            jest.restoreAllMocks()
+
+            // Polling terminated on its own after the initial request plus the capped follow-up polls.
+            expect(pendingPoll).toBeNull()
+            expect(requestUrls.length).toBeGreaterThan(1)
+            expect(requestUrls.length).toBeLessThanOrEqual(9)
+        })
     })
 })

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -625,7 +625,7 @@ describe('the property definitions model', () => {
 
         it('stops polling after a bounded number of attempts when the backend stays refreshing', async () => {
             const requestUrls: string[] = []
-            let pendingPoll: (() => void) | null = null
+            const scheduledPolls: (() => void)[] = []
 
             // Capture the backed-off poll timers (>= base delay) and run them synchronously below;
             // let short timers (kea breakpoints) run normally. Without a cap this chain is infinite.
@@ -636,7 +636,7 @@ describe('the property definitions model', () => {
                 ...args: unknown[]
             ) => {
                 if (typeof delay === 'number' && delay >= 2000) {
-                    pendingPoll = () => (fn as (...a: unknown[]) => unknown)(...args)
+                    scheduledPolls.push(() => (fn as (...a: unknown[]) => unknown)(...args))
                     return 0 as unknown as ReturnType<typeof setTimeout>
                 }
                 return originalSetTimeout(fn, delay, ...args)
@@ -663,9 +663,8 @@ describe('the property definitions model', () => {
 
             // Drain the poll chain; the loop is bounded so a missing cap fails loudly instead of hanging.
             let iterations = 0
-            while (pendingPoll && iterations < 50) {
-                const next = pendingPoll
-                pendingPoll = null
+            while (scheduledPolls.length > 0 && iterations < 50) {
+                const next = scheduledPolls.shift()!
                 await expectLogic(logic, () => next()).toFinishAllListeners()
                 iterations += 1
             }
@@ -673,7 +672,7 @@ describe('the property definitions model', () => {
             jest.restoreAllMocks()
 
             // Polling terminated on its own after the initial request plus the capped follow-up polls.
-            expect(pendingPoll).toBeNull()
+            expect(scheduledPolls).toHaveLength(0)
             expect(requestUrls.length).toBeGreaterThan(1)
             expect(requestUrls.length).toBeLessThanOrEqual(9)
         })

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -671,10 +671,10 @@ describe('the property definitions model', () => {
 
             jest.restoreAllMocks()
 
-            // Polling terminated on its own after the initial request plus the capped follow-up polls.
+            // Polling terminated on its own: the initial request plus exactly PROPERTY_VALUES_MAX_POLLS
+            // (8) capped follow-up polls = 9. A weaker lower bound would still pass if the cap dropped.
             expect(scheduledPolls).toHaveLength(0)
-            expect(requestUrls.length).toBeGreaterThan(1)
-            expect(requestUrls.length).toBeLessThanOrEqual(9)
+            expect(requestUrls).toHaveLength(9)
         })
     })
 })

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -4,9 +4,11 @@ import api, { ApiMethodOptions, CountedPaginatedResponse } from 'lib/api'
 import { TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { retryWithBackoff } from 'lib/utils/async'
 import { colonDelimitedDuration } from 'lib/utils/durations'
 import { isKeyOf } from 'lib/utils/guards'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
+import { isAbortedRequest, isTimedOutRequest } from 'lib/utils/requests'
 import { toString } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -36,6 +38,29 @@ export const PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS = [
     // (see RAW_SELECT_SESSION_PROP_STRING_VALUES_SQL_WITH_FILTER)
     PropertyFilterType.Session,
 ]
+
+// The backend can report that property values are still being built in the background, asking the
+// client to poll again. Back off between polls and cap the number of them so a slow or degraded
+// endpoint can't be hit on a fixed 2s timer indefinitely (a single stuck dropdown could otherwise
+// fire hundreds of requests).
+const PROPERTY_VALUES_POLL_BASE_MS = 2000
+const PROPERTY_VALUES_POLL_MAX_MS = 30000
+const PROPERTY_VALUES_POLL_BACKOFF = 1.5
+const PROPERTY_VALUES_MAX_POLLS = 8
+// Retry transient (network / 5xx) failures a few times with exponential backoff before giving up
+// and surfacing an error toast, rather than failing on the first blip.
+const PROPERTY_VALUES_MAX_ATTEMPTS = 3
+const PROPERTY_VALUES_RETRY_DELAY_MS = 1000
+
+/** Retry transient failures only — an aborted/superseded request, a client timeout, or a 4xx won't
+ * succeed on retry, so fail fast on those and only back off for network errors and 5xx responses. */
+const shouldRetryPropertyValues = (error: unknown): boolean => {
+    if (isAbortedRequest(error) || isTimedOutRequest(error)) {
+        return false
+    }
+    const status = (error as { status?: number })?.status
+    return status === undefined || status === 0 || status >= 500
+}
 
 // List of property definitions that are calculated on the backend. These
 // are valid properties that do not exist on events.
@@ -216,6 +241,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             eventNames?: string[]
             properties?: { key: string; values: string | string[] }[]
             refresh?: string
+            /** Set internally when this call is a background-refresh poll; drives poll backoff and the poll cap. */
+            pollAttempt?: number
         }) => payload,
         setOptionsLoading: (key: string) => ({ key }),
         setOptions: (key: string, values: PropValue[], allowCustomValues: boolean, refreshing?: boolean) => ({
@@ -411,7 +438,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
         },
 
         loadPropertyValues: async (
-            { endpoint, type, newInput, propertyKey, eventNames, properties, refresh },
+            { endpoint, type, newInput, propertyKey, eventNames, properties, refresh, pollAttempt },
             breakpoint
         ) => {
             if (!endpoint && ['cohort', 'log', 'span', 'workflow_variable'].includes(type)) {
@@ -442,18 +469,27 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             actions.setOptionsSearchInput(propertyKey, newInput || '')
 
             try {
-                const responseData: { results: PropValue[]; refreshing: boolean } = await api.get(
-                    constructValuesEndpoint(
-                        endpoint,
-                        values.currentTeamId,
-                        type,
-                        propertyKey,
-                        eventNames,
-                        newInput,
-                        properties,
-                        refresh
-                    ),
-                    methodOptions
+                const responseData: { results: PropValue[]; refreshing: boolean } = await retryWithBackoff(
+                    () =>
+                        api.get(
+                            constructValuesEndpoint(
+                                endpoint,
+                                values.currentTeamId as number,
+                                type,
+                                propertyKey,
+                                eventNames,
+                                newInput,
+                                properties,
+                                refresh
+                            ),
+                            methodOptions
+                        ),
+                    {
+                        maxAttempts: PROPERTY_VALUES_MAX_ATTEMPTS,
+                        initialDelayMs: PROPERTY_VALUES_RETRY_DELAY_MS,
+                        signal: cache.abortController.signal,
+                        shouldRetry: shouldRetryPropertyValues,
+                    }
                 )
                 breakpoint()
 
@@ -463,12 +499,20 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 actions.setOptions(propertyKey, propValues, type !== PropertyDefinitionType.FlagValue, refreshing)
                 cache.abortController = null
 
-                // Schedule a poll when the backend signals a background refresh is in progress
+                // Schedule a poll when the backend signals a background refresh is in progress, backing
+                // off exponentially and giving up after PROPERTY_VALUES_MAX_POLLS so a perpetually
+                // "refreshing" response can't keep the client polling forever.
                 cache.pollingTimeouts = cache.pollingTimeouts || {}
-                if (refreshing) {
-                    if (cache.pollingTimeouts[propertyKey]) {
-                        clearTimeout(cache.pollingTimeouts[propertyKey])
-                    }
+                if (cache.pollingTimeouts[propertyKey]) {
+                    clearTimeout(cache.pollingTimeouts[propertyKey])
+                    delete cache.pollingTimeouts[propertyKey]
+                }
+                const nextPollAttempt = (pollAttempt ?? 0) + 1
+                if (refreshing && nextPollAttempt <= PROPERTY_VALUES_MAX_POLLS) {
+                    const pollDelayMs = Math.min(
+                        PROPERTY_VALUES_POLL_BASE_MS * PROPERTY_VALUES_POLL_BACKOFF ** (pollAttempt ?? 0),
+                        PROPERTY_VALUES_POLL_MAX_MS
+                    )
                     cache.pollingTimeouts[propertyKey] = setTimeout(() => {
                         actions.loadPropertyValues({
                             endpoint,
@@ -478,18 +522,22 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                             eventNames,
                             properties,
                             refresh: 'force_cache',
+                            pollAttempt: nextPollAttempt,
                         })
-                    }, 2000)
-                } else if (cache.pollingTimeouts[propertyKey]) {
-                    clearTimeout(cache.pollingTimeouts[propertyKey])
-                    delete cache.pollingTimeouts[propertyKey]
+                    }, pollDelayMs)
                 }
             } catch (e) {
                 // Bail if a newer listener invocation has superseded this one
                 breakpoint()
 
+                // A failed/superseded load must not leave a background poll scheduled for this key.
+                if (cache.pollingTimeouts?.[propertyKey]) {
+                    clearTimeout(cache.pollingTimeouts[propertyKey])
+                    delete cache.pollingTimeouts[propertyKey]
+                }
+
                 // Don't show error for aborted requests (user typed new search query)
-                if ((e as any)?.name === 'AbortError') {
+                if (isAbortedRequest(e)) {
                     return
                 }
                 cache.abortController = null

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -4,11 +4,10 @@ import api, { ApiMethodOptions, CountedPaginatedResponse } from 'lib/api'
 import { TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
-import { retryWithBackoff } from 'lib/utils/async'
 import { colonDelimitedDuration } from 'lib/utils/durations'
 import { isKeyOf } from 'lib/utils/guards'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
-import { isAbortedRequest, isTimedOutRequest } from 'lib/utils/requests'
+import { isAbortedRequest } from 'lib/utils/requests'
 import { toString } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -47,20 +46,6 @@ const PROPERTY_VALUES_POLL_BASE_MS = 2000
 const PROPERTY_VALUES_POLL_MAX_MS = 30000
 const PROPERTY_VALUES_POLL_BACKOFF = 1.5
 const PROPERTY_VALUES_MAX_POLLS = 8
-// Retry transient (network / 5xx) failures a few times with exponential backoff before giving up
-// and surfacing an error toast, rather than failing on the first blip.
-const PROPERTY_VALUES_MAX_ATTEMPTS = 3
-const PROPERTY_VALUES_RETRY_DELAY_MS = 1000
-
-/** Retry transient failures only — an aborted/superseded request, a client timeout, or a 4xx won't
- * succeed on retry, so fail fast on those and only back off for network errors and 5xx responses. */
-const shouldRetryPropertyValues = (error: unknown): boolean => {
-    if (isAbortedRequest(error) || isTimedOutRequest(error)) {
-        return false
-    }
-    const status = (error as { status?: number })?.status
-    return status === undefined || status === 0 || status >= 500
-}
 
 // List of property definitions that are calculated on the backend. These
 // are valid properties that do not exist on events.
@@ -475,27 +460,18 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             actions.setOptionsSearchInput(propertyKey, newInput || '')
 
             try {
-                const responseData: { results: PropValue[]; refreshing: boolean } = await retryWithBackoff(
-                    () =>
-                        api.get(
-                            constructValuesEndpoint(
-                                endpoint,
-                                values.currentTeamId as number,
-                                type,
-                                propertyKey,
-                                eventNames,
-                                newInput,
-                                properties,
-                                refresh
-                            ),
-                            methodOptions
-                        ),
-                    {
-                        maxAttempts: PROPERTY_VALUES_MAX_ATTEMPTS,
-                        initialDelayMs: PROPERTY_VALUES_RETRY_DELAY_MS,
-                        signal: cache.abortController.signal,
-                        shouldRetry: shouldRetryPropertyValues,
-                    }
+                const responseData: { results: PropValue[]; refreshing: boolean } = await api.get(
+                    constructValuesEndpoint(
+                        endpoint,
+                        values.currentTeamId as number,
+                        type,
+                        propertyKey,
+                        eventNames,
+                        newInput,
+                        properties,
+                        refresh
+                    ),
+                    methodOptions
                 )
                 breakpoint()
 

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -241,8 +241,6 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             eventNames?: string[]
             properties?: { key: string; values: string | string[] }[]
             refresh?: string
-            /** Set internally when this call is a background-refresh poll; drives poll backoff and the poll cap. */
-            pollAttempt?: number
         }) => payload,
         setOptionsLoading: (key: string) => ({ key }),
         setOptions: (key: string, values: PropValue[], allowCustomValues: boolean, refreshing?: boolean) => ({
@@ -438,7 +436,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
         },
 
         loadPropertyValues: async (
-            { endpoint, type, newInput, propertyKey, eventNames, properties, refresh, pollAttempt },
+            { endpoint, type, newInput, propertyKey, eventNames, properties, refresh },
             breakpoint
         ) => {
             if (!endpoint && ['cohort', 'log', 'span', 'workflow_variable'].includes(type)) {
@@ -460,6 +458,14 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             await breakpoint(300)
             actions.setOptionsLoading(propertyKey)
             actions.abortAnyRunningQuery()
+
+            // Track background-refresh poll attempts per key so we can back off and cap them. A poll
+            // re-dispatches with refresh 'force_cache'; any other (caller-initiated) load is a fresh
+            // request that resets the count so it can poll again from scratch.
+            cache.pollAttempts = cache.pollAttempts || {}
+            if (refresh !== 'force_cache') {
+                cache.pollAttempts[propertyKey] = 0
+            }
 
             cache.abortController = new AbortController()
             const methodOptions: ApiMethodOptions = {
@@ -507,10 +513,11 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                     clearTimeout(cache.pollingTimeouts[propertyKey])
                     delete cache.pollingTimeouts[propertyKey]
                 }
-                const nextPollAttempt = (pollAttempt ?? 0) + 1
-                if (refreshing && nextPollAttempt <= PROPERTY_VALUES_MAX_POLLS) {
+                const attemptsSoFar = cache.pollAttempts[propertyKey] ?? 0
+                if (refreshing && attemptsSoFar < PROPERTY_VALUES_MAX_POLLS) {
+                    cache.pollAttempts[propertyKey] = attemptsSoFar + 1
                     const pollDelayMs = Math.min(
-                        PROPERTY_VALUES_POLL_BASE_MS * PROPERTY_VALUES_POLL_BACKOFF ** (pollAttempt ?? 0),
+                        PROPERTY_VALUES_POLL_BASE_MS * PROPERTY_VALUES_POLL_BACKOFF ** attemptsSoFar,
                         PROPERTY_VALUES_POLL_MAX_MS
                     )
                     cache.pollingTimeouts[propertyKey] = setTimeout(() => {
@@ -522,9 +529,11 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                             eventNames,
                             properties,
                             refresh: 'force_cache',
-                            pollAttempt: nextPollAttempt,
                         })
                     }, pollDelayMs)
+                } else if (!refreshing) {
+                    // Settled — reset so a later refresh for this key starts a fresh poll budget.
+                    cache.pollAttempts[propertyKey] = 0
                 }
             } catch (e) {
                 // Bail if a newer listener invocation has superseded this one
@@ -534,6 +543,9 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 if (cache.pollingTimeouts?.[propertyKey]) {
                     clearTimeout(cache.pollingTimeouts[propertyKey])
                     delete cache.pollingTimeouts[propertyKey]
+                }
+                if (cache.pollAttempts) {
+                    cache.pollAttempts[propertyKey] = 0
                 }
 
                 // Don't show error for aborted requests (user typed new search query)


### PR DESCRIPTION
> Claude-written:

## Problem

A property-value filter dropdown on an insight can hammer the values endpoint. When the backend reports a background refresh is in progress (`refreshing: true`), the client re-polls on a fixed 2s timer with no cap and no backoff. On a slow or degraded endpoint that never settles, this polls indefinitely, and the error path never cancels a scheduled poll. A single stuck dropdown can generate hundreds of failed requests (and matching error toasts) in an hour, which is what we saw in a recent spike of dashboard/insight error toasts. Raised from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1782902254708939).

## Changes

In `propertyDefinitionsModel`:

- The background-refresh poll now uses exponential backoff (2s base, 1.5x multiplier, capped at 30s) and stops after a bounded number of attempts instead of polling on a fixed 2s timer forever.
- A load that errors or is superseded now clears any scheduled poll for that key, so a failed or aborted request can't leave a timer running.

In `LemonToast`:

- `error()` and `warning()` capture their analytics event once per *shown* toast (gated on react-toastify's `isActive`) rather than on every call. The deterministic per-message toast id already deduped the visible toast; this makes the capture match, so one repeatedly-failing action no longer emits hundreds of identical events.

No behavior change for the common case (first poll delay is still 2s); the difference only shows up when an endpoint stays unhealthy.

Possible follow-up: migrate the poll timer to `cache.disposables` (auto-pauses polling on hidden tabs), left out here to keep the change tight and consistent with the existing timer pattern.

## How did you test this code?

- Added a kea logic test: with the backend stuck on `refreshing: true`, the poll chain now terminates on its own after the capped number of attempts instead of looping forever. Without the cap this test hangs/exceeds the bound, so it locks in the regression.
- The existing follow-up-poll test still passes (first poll delay is unchanged at 2s).
- I (Claude) could not run the JS test suite, linter, or typecheck in this environment — frontend `node_modules` were not installed. Those run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a spike in insight/dashboard error toasts, traced it to `Failed to load property values` concentrated on a single session, and found the root cause in the fixed-interval poll loop. An earlier revision wrapped the request in the repo's `retryWithBackoff` helper, but that added real-time delays that blew up the property-value Jest suites and tripled requests on failure, so I dropped it — the backoff/cap/cancel on the polling path is what addresses the reported storm. Considered wrapping the poll in `cache.disposables` (per the kea-disposables rule) but kept the existing `cache.pollingTimeouts` pattern since the logic is `permanentlyMount`ed and the change is a delay/cap tweak, not a new resource; noted as a follow-up.

Read the repo `writing-tests` guidance before adding the test and scoped it to the one regression this fix targets.

Authored by the PostHog Slack app (Claude).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1782902254708939)*

