### PR TITLE
feat(mcp-analytics): enforce sessions-list pagination bounds

### DIFF
--- a/products/mcp_analytics/backend/presentation/serializers.py
+++ b/products/mcp_analytics/backend/presentation/serializers.py
@@ -5,6 +5,12 @@ from products.mcp_analytics.backend.models import MCPAnalyticsSubmission
 MAX_GOAL_LENGTH = 500
 MAX_SUMMARY_LENGTH = 5_000
 
+# Single source of truth for session-list pagination bounds. Referenced by the query serializer
+# (which enforces + advertises them in the OpenAPI spec, so the MCP Zod schema inherits the same
+# limits) and by MCPSessionPagination for its response envelope.
+MCP_SESSION_LIST_DEFAULT_LIMIT = 100
+MCP_SESSION_LIST_MAX_LIMIT = 500
+
 
 class MCPAnalyticsSubmissionSerializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True, help_text="Unique identifier for this submission.")
@@ -136,6 +142,57 @@ class MCPToolCallSerializer(serializers.Serializer):
     )
     duration_ms = serializers.IntegerField(
         read_only=True, allow_null=True, help_text="Duration of the tool call in milliseconds when captured."
+    )
+
+
+class MCPSessionListQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Case-insensitive substring filter matched against session_id, distinct_id, mcp_client_name, and tools_used.",
+    )
+    order_by = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text=(
+            "Sort column. Allowed: session_id, session_start, session_end, duration_seconds, "
+            "tool_call_count, mcp_client_name, distinct_id. Prefix with '-' for descending. "
+            "Defaults to '-session_start' (newest sessions first)."
+        ),
+    )
+    date_from = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Start of the window to aggregate sessions over. PostHog date string — relative "
+            "(e.g. '-7d', '-24h') or an absolute ISO timestamp. Defaults to '-7d'."
+        ),
+    )
+    date_to = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="End of the window. PostHog date string or absolute ISO timestamp. Defaults to now.",
+    )
+    limit = serializers.IntegerField(
+        required=False,
+        default=MCP_SESSION_LIST_DEFAULT_LIMIT,
+        min_value=1,
+        max_value=MCP_SESSION_LIST_MAX_LIMIT,
+        help_text=(
+            f"Maximum number of sessions to return per page. Defaults to {MCP_SESSION_LIST_DEFAULT_LIMIT}; "
+            f"values above {MCP_SESSION_LIST_MAX_LIMIT} are rejected."
+        ),
+    )
+    offset = serializers.IntegerField(
+        required=False,
+        default=0,
+        min_value=0,
+        help_text=(
+            "Number of sessions to skip before returning results. Combine with limit to page through "
+            "sessions; the response's has_next flag indicates whether more remain."
+        ),
     )
 
 

--- a/products/mcp_analytics/backend/presentation/views.py
+++ b/products/mcp_analytics/backend/presentation/views.py
@@ -23,11 +23,14 @@ from products.mcp_analytics.backend.facade import api, contracts, enums
 from products.mcp_analytics.backend.models import MCPAnalyticsSubmission
 
 from .serializers import (
+    MCP_SESSION_LIST_DEFAULT_LIMIT,
+    MCP_SESSION_LIST_MAX_LIMIT,
     MCPAnalyticsSubmissionSerializer,
     MCPFeedbackCreateSerializer,
     MCPIntentClusterSnapshotSerializer,
     MCPMissingCapabilityCreateSerializer,
     MCPSessionIntentSerializer,
+    MCPSessionListQuerySerializer,
     MCPSessionSerializer,
     MCPToolCallSerializer,
 )
@@ -53,8 +56,8 @@ class MCPSessionPagination(LimitOffsetPagination):
     logic layer over-fetching one row rather than a count query.
     """
 
-    default_limit = 100
-    max_limit = 500
+    default_limit = MCP_SESSION_LIST_DEFAULT_LIMIT
+    max_limit = MCP_SESSION_LIST_MAX_LIMIT
 
     def get_paginated_response(self, data: Any, *, has_next: bool = False) -> Response:
         return Response({"results": data, "has_next": has_next})
@@ -168,69 +171,27 @@ class MCPSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # (a plain manager) so .none() can't trip a team-scoped manager's guard.
         return MCPAnalyticsSubmission.objects.none()
 
-    @extend_schema(
+    @validated_request(
+        query_serializer=MCPSessionListQuerySerializer,
+        responses={200: MCPSessionSerializer(many=True)},
         operation_id="mcp_analytics_sessions_list",
         description="List MCP sessions for the current project, derived by grouping $mcp_tool_call events by $mcp_session_id. Ordered by newest session start first by default.",
-        parameters=[
-            OpenApiParameter(
-                name="search",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description="Case-insensitive substring filter matched against session_id, distinct_id, mcp_client_name, and tools_used.",
-            ),
-            OpenApiParameter(
-                name="order_by",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description=(
-                    "Sort column. Allowed: session_id, session_start, session_end, "
-                    "duration_seconds, tool_call_count, mcp_client_name, distinct_id. "
-                    "Prefix with '-' for descending. Defaults to '-session_start' (newest sessions first)."
-                ),
-            ),
-            OpenApiParameter(
-                name="date_from",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description=(
-                    "Start of the window to aggregate sessions over. PostHog date string — relative "
-                    "(e.g. '-7d', '-24h') or an absolute ISO timestamp. Defaults to '-7d'."
-                ),
-            ),
-            OpenApiParameter(
-                name="date_to",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description="End of the window. PostHog date string or absolute ISO timestamp. Defaults to now.",
-            ),
-        ],
-        responses={200: MCPSessionSerializer(many=True)},
     )
-    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        # Instantiate the concrete class (not self.pagination_class()) so the typed
-        # get_paginated_response(has_next=...) is visible to the type checker.
-        paginator = MCPSessionPagination()
-        limit = paginator.get_limit(request) or paginator.default_limit
-        offset = paginator.get_offset(request)
-        search = request.query_params.get("search", "")
-        order_by = request.query_params.get("order_by", "")
-        date_from = request.query_params.get("date_from") or None
-        date_to = request.query_params.get("date_to") or None
+    def list(self, request: ValidatedRequest, *args: Any, **kwargs: Any) -> Response:
+        params = request.validated_query_data
         page = api.list_mcp_sessions(
             self.team,
-            limit=limit,
-            offset=offset,
-            search=search,
-            order_by=order_by,
-            date_from=date_from,
-            date_to=date_to,
+            limit=params["limit"],
+            offset=params["offset"],
+            search=params["search"],
+            order_by=params["order_by"],
+            date_from=params.get("date_from") or None,
+            date_to=params.get("date_to") or None,
         )
         serializer = self.get_serializer(page.results, many=True)
-        return paginator.get_paginated_response(serializer.data, has_next=page.has_next)
+        # Instantiate the concrete class (not self.pagination_class()) so the typed
+        # get_paginated_response(has_next=...) is visible to the type checker.
+        return MCPSessionPagination().get_paginated_response(serializer.data, has_next=page.has_next)
 
     @extend_schema(
         operation_id="mcp_analytics_sessions_tool_calls",

--- a/products/mcp_analytics/backend/presentation/views.py
+++ b/products/mcp_analytics/backend/presentation/views.py
@@ -173,7 +173,7 @@ class MCPSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     @validated_request(
         query_serializer=MCPSessionListQuerySerializer,
-        responses={200: MCPSessionSerializer(many=True)},
+        responses={200: OpenApiResponse(response=MCPSessionSerializer(many=True))},
         operation_id="mcp_analytics_sessions_list",
         description="List MCP sessions for the current project, derived by grouping $mcp_tool_call events by $mcp_session_id. Ordered by newest session start first by default.",
     )

--- a/products/mcp_analytics/backend/tests/test_presentation.py
+++ b/products/mcp_analytics/backend/tests/test_presentation.py
@@ -14,7 +14,11 @@ from posthog.models.utils import uuid7
 
 from products.mcp_analytics.backend import intent_generation
 from products.mcp_analytics.backend.models import MCPAnalyticsSubmission, MCPIntentClusterSnapshot, MCPSession
-from products.mcp_analytics.backend.presentation.serializers import MCPSessionListQuerySerializer
+from products.mcp_analytics.backend.presentation.serializers import (
+    MCP_SESSION_LIST_DEFAULT_LIMIT,
+    MCP_SESSION_LIST_MAX_LIMIT,
+    MCPSessionListQuerySerializer,
+)
 from products.mcp_analytics.backend.tests import _MCPAnalyticsTeamScopedTestMixin
 
 
@@ -382,13 +386,13 @@ class TestMCPSessionListQuerySerializer(SimpleTestCase):
     def test_defaults_when_pagination_params_omitted(self) -> None:
         serializer = MCPSessionListQuerySerializer(data={})
         assert serializer.is_valid(), serializer.errors
-        assert serializer.validated_data["limit"] == 100
+        assert serializer.validated_data["limit"] == MCP_SESSION_LIST_DEFAULT_LIMIT
         assert serializer.validated_data["offset"] == 0
 
     @parameterized.expand(
         [
-            ("limit_at_cap", {"limit": 500}, True, None),
-            ("limit_over_cap", {"limit": 501}, False, "limit"),
+            ("limit_at_cap", {"limit": MCP_SESSION_LIST_MAX_LIMIT}, True, None),
+            ("limit_over_cap", {"limit": MCP_SESSION_LIST_MAX_LIMIT + 1}, False, "limit"),
             ("limit_below_min", {"limit": 0}, False, "limit"),
             ("offset_at_min", {"offset": 0}, True, None),
             ("offset_negative", {"offset": -1}, False, "offset"),

--- a/products/mcp_analytics/backend/tests/test_presentation.py
+++ b/products/mcp_analytics/backend/tests/test_presentation.py
@@ -4,6 +4,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.test import SimpleTestCase
 
 from parameterized import parameterized
 from rest_framework import status
@@ -13,6 +14,7 @@ from posthog.models.utils import uuid7
 
 from products.mcp_analytics.backend import intent_generation
 from products.mcp_analytics.backend.models import MCPAnalyticsSubmission, MCPIntentClusterSnapshot, MCPSession
+from products.mcp_analytics.backend.presentation.serializers import MCPSessionListQuerySerializer
 from products.mcp_analytics.backend.tests import _MCPAnalyticsTeamScopedTestMixin
 
 
@@ -374,6 +376,31 @@ class TestMCPSessionToolCallsEndpoint(_MCPAnalyticsTeamScopedTestMixin, Clickhou
         # The first event sits at exactly session_start; a `timestamp >= session_start` bound must
         # still include it after the round-trip — otherwise we'd get just ["last_tool"].
         assert [c["tool_name"] for c in response.json()["results"]] == ["first_tool", "last_tool"]
+
+
+class TestMCPSessionListQuerySerializer(SimpleTestCase):
+    def test_defaults_when_pagination_params_omitted(self) -> None:
+        serializer = MCPSessionListQuerySerializer(data={})
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["limit"] == 100
+        assert serializer.validated_data["offset"] == 0
+
+    @parameterized.expand(
+        [
+            ("limit_at_cap", {"limit": 500}, True, None),
+            ("limit_over_cap", {"limit": 501}, False, "limit"),
+            ("limit_below_min", {"limit": 0}, False, "limit"),
+            ("offset_at_min", {"offset": 0}, True, None),
+            ("offset_negative", {"offset": -1}, False, "offset"),
+        ]
+    )
+    def test_pagination_bounds(
+        self, _name: str, data: dict[str, int], expected_valid: bool, error_field: str | None
+    ) -> None:
+        serializer = MCPSessionListQuerySerializer(data=data)
+        assert serializer.is_valid() is expected_valid, serializer.errors
+        if error_field is not None:
+            assert error_field in serializer.errors
 
 
 class TestMCPAnalyticsCrossTeamIsolation(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest):

--- a/products/mcp_analytics/frontend/generated/api.schemas.ts
+++ b/products/mcp_analytics/frontend/generated/api.schemas.ts
@@ -404,11 +404,14 @@ export type McpAnalyticsSessionsListParams = {
      */
     date_to?: string
     /**
-     * Number of results to return per page.
+     * Maximum number of sessions to return per page. Defaults to 100; values above 500 are rejected.
+     * @minimum 1
+     * @maximum 500
      */
     limit?: number
     /**
-     * The initial index from which to return the results.
+     * Number of sessions to skip before returning results. Combine with limit to page through sessions; the response's has_next flag indicates whether more remain.
+     * @minimum 0
      */
     offset?: number
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -58078,11 +58078,14 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * Number of results to return per page.
+     * Maximum number of sessions to return per page. Defaults to 100; values above 500 are rejected.
+     * @minimum 1
+     * @maximum 500
      */
     limit?: number;
     /**
-     * The initial index from which to return the results.
+     * Number of sessions to skip before returning results. Combine with limit to page through sessions; the response's has_next flag indicates whether more remain.
+     * @minimum 0
      */
     offset?: number;
     /**
@@ -64713,11 +64716,14 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * Number of results to return per page.
+     * Maximum number of sessions to return per page. Defaults to 100; values above 500 are rejected.
+     * @minimum 1
+     * @maximum 500
      */
     limit?: number;
     /**
-     * The initial index from which to return the results.
+     * Number of sessions to skip before returning results. Combine with limit to page through sessions; the response's has_next flag indicates whether more remain.
+     * @minimum 0
      */
     offset?: number;
     /**


### PR DESCRIPTION
## Problem

The MCP-analytics sessions-list endpoint (`GET .../mcp_analytics/sessions/`) parsed `limit`/`offset` by hand off `request.query_params` and relied on `LimitOffsetPagination` to silently *clamp* an over-large `limit`. Two gaps:

- The `100` default and `500` cap only existed at runtime — they never reached the OpenAPI spec, so generated frontend and MCP types (and any agent calling the tool) had no idea the bounds existed.
- Over-cap requests were silently clamped rather than rejected, which is easy to paginate against incorrectly (ask for 2000, get 500, offset by 2000, skip 1500 rows).

## Changes

Introduce `MCPSessionListQuerySerializer` as the single source of truth for the query params. `limit` is an `IntegerField(default=100, min_value=1, max_value=500)`, `offset` is `IntegerField(default=0, min_value=0)`, and the existing `search`/`order_by`/`date_from`/`date_to` move onto it with their help text.

The viewset's `list` now uses `@validated_request(query_serializer=...)` instead of hand-parsing, so an out-of-range `limit` is a **400**, and the default is applied consistently. Because drf-spectacular reads `max_value`/`default` off the serializer, the spec now carries `maximum: 500` / `default: 100`, and the regenerated frontend + MCP types inherit them automatically — no constant duplicated across the Python/TS boundary. The shared `MCP_SESSION_LIST_*` constants are also referenced by `MCPSessionPagination` so the response envelope stays in sync.

This is the base for a follow-up PR that exposes sessions-list as an MCP tool — the MCP Zod schema will pick up `.min(1).max(500).default(100)` straight from this spec change.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I added and ran locally (`hogli test`, all green):

- `TestMCPSessionListQuerySerializer` — a `SimpleTestCase` (no DB) that locks in the contract this PR introduces: defaults (100 / 0) when omitted, and the bounds (500 accepted, 501/0 rejected on `limit`, negative rejected on `offset`). Parameterized. No existing test covered the query serializer.

I deliberately did **not** add a ClickHouse-backed HTTP test for the 400: the validation regression lives in the serializer/decorator, not in ClickHouse, and "is the serializer wired into the view" is already covered by the existing `TestMCPSessionToolCallsEndpoint` (it lists sessions, and an unwired `query_serializer` would 500 on `request.validated_query_data`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @gesh. Agent: Claude Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints` (query-serializer + `@validated_request` pattern) and `/writing-tests` (test value gate — which is why the CH-backed HTTP test was dropped in favour of a cheap serializer-level `SimpleTestCase`).

Key decision: put the bounds on a DRF query serializer rather than hardcoding `.max(500)` in the MCP YAML, so the `100`/`500` literals live in exactly one place and flow to every generated consumer via the spec. Modeled on `HeatmapsRequestSerializer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
