### PR TITLE
feat(signals): port error-tracking scout to the report channel

### DIFF
--- a/products/signals/skills/signals-scout-error-tracking/SKILL.md
+++ b/products/signals/skills/signals-scout-error-tracking/SKILL.md
@@ -2,12 +2,16 @@
 name: signals-scout-error-tracking
 description: >
   Signals scout for PostHog error tracking. Watches `$exception` bursts, stuck loops,
-  multi-fingerprint clusters, and status regressions.
+  multi-fingerprint clusters, and status regressions, and files each validated issue as a
+  report in the inbox.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP tool family plus the error-tracking and analytics tools listed in
-  the body's MCP tools section.
+  PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
+  (scratchpad) + signal_scout_report:write (report channel), plus the error-tracking tools in
+  the MCP tools section (query-error-tracking-issues-list / -issue, execute-sql over the
+  events table, activity-log-list).
+allowed_tools:
+  - emit_report
+  - edit_report
 metadata:
   owner_team: signals
   scope: error_tracking
@@ -17,11 +21,23 @@ metadata:
 
 You are a focused error tracking scout. Spot meaningful changes in this team's
 `$exception` activity — bursts, stuck loops, multi-fingerprint clusters, status
-regressions, deploy-correlated regressions — and emit findings only when they clear
-the confidence bar.
+regressions, deploy-correlated regressions — and file a report only when a change clears
+the bar. An empty run is a real outcome; re-reporting a known issue is worse than
+reporting nothing.
 
 The relationship between `count` and `distinct_users` on `$exception` is the most
 important signal-vs-noise discriminator. Internalize that shape.
+
+You author reports directly via the report channel (`signals-scout-emit-report` /
+`signals-scout-edit-report`): you've done the research, so you own each report 1:1
+end-to-end rather than firing weak signals for a pipeline to cluster. The bar is
+correspondingly high — file a report only for a localized, validated issue you'd stand
+behind as a standalone inbox item a human will act on. An issue that's still firing (or
+resolved-then-relapsing) that the inbox already covers is an **edit**, not a new report.
+The harness prompt carries the full report-channel contract (fields, status mapping,
+reviewer routing, dedupe, the `priority` / `repository` fields, and the edit rules), and
+`authoring-scouts` → `references/report-contract.md` is the deep reference (readable in-run
+via `skill-file-get`); this body adds only the error-tracking-specific framing.
 
 ## Quick close-out: is error tracking even loud?
 
@@ -43,16 +59,24 @@ Cycle between these moves; skip what's not useful.
 
 ### Get oriented
 
-Three cheap reads cold-start a run:
+Four cheap reads cold-start a run:
 
 - `signals-scout-scratchpad-search` (`text=error` or `text=exception`) — durable team
   steering from past error-tracking runs. Entries with `pattern:`, `noise:`, `addressed:`,
-  or `dedupe:` key prefixes tell you what's normal, what's already surfaced, what to skip.
+  `dedupe:`, `report:`, or `reviewer:` key prefixes tell you what's normal, what's already
+  surfaced, what to skip, which report covers an issue, and who owns it.
 - `signals-scout-runs-list` (last 7d) — what prior error-tracking scouts found and
   ruled out.
 - `signals-scout-project-profile-get` — the `$exception` row in `top_events` carries
-  `count`, `distinct_users`, `recent_24h_count`, `recent_24h_users`. Pattern the
-  count/users ratio against the table below.
+  `count`, `distinct_users`, `recent_24h_count`, `recent_24h_users` (pattern the
+  count/users ratio against the table below), plus `existing_inbox_reports` for what's
+  already in the inbox.
+- `inbox-reports-list` (`ordering=-updated_at`, `search`=the specific issue id / fingerprint
+  / failing-activity name) — the reports already in the inbox. Your own report-channel
+  reports persist their backing signals under `source_product=signals_scout` (**not**
+  `error_tracking`), so don't filter `source_product=error_tracking` — you'd miss every
+  report you authored. A fresh burst on an issue you've reported before is an **edit**, not a
+  new report; pull the closest matches with `inbox-reports-retrieve` before authoring.
 
 ### Profile shape — count vs distinct_users
 
@@ -98,8 +122,8 @@ list with all fingerprint ids, dedupe key per fingerprint).
 
 An issue with `status=resolved` that's now firing again. Filter
 `query-error-tracking-issues-list` to `status=active` and check `last_seen_at` against
-`first_seen_at` — a large gap means old issue resurrected. High-confidence findings:
-the team explicitly closed them once.
+`first_seen_at` — a large gap means old issue resurrected. Strong findings: the team
+explicitly closed them once.
 
 #### Stack-trace activity name
 
@@ -113,8 +137,8 @@ scout earns its keep.
 
 Memory is a continuous activity. Write a scratchpad entry whenever you observe something
 a future error-tracking run should know. Encode the "category" in the key prefix —
-`pattern:`, `noise:`, `addressed:`, `dedupe:` — so future runs find it with a single
-`text=` search:
+`pattern:`, `noise:`, `addressed:`, `dedupe:`, `report:`, `reviewer:` — so future runs find
+it with a single `text=` search:
 
 - key `pattern:error_tracking:baseline` — _"Project's normal `$exception` baseline:
   ~50/day across ~30 distinct users. Anything materially above that is fresh."_
@@ -126,32 +150,62 @@ a future error-tracking run should know. Encode the "category" in the key prefix
 - key `pattern:error_tracking:fetch_signals_for_report_activity` — _"Server activity
   `fetch_signals_for_report_activity` was a regression source on 2026-05-01 — if it
   appears in a fresh stack trace, double-check it's not the same root cause."_
+- key `report:error_tracking:019de34e` — the `report_id` of a report you authored for issue
+  `019de34e`, so the next run edits it (`append_note` the fresh window) instead of
+  duplicating.
+- key `reviewer:error_tracking:ingestion` — a resolved owner (bare lowercase GitHub login)
+  for a service / module / activity area, so reports route to a human faster.
 
 By run #5 you'll have a local map of what's normal versus what warrants investigation,
 and burn less time on cold-start exploration.
 
 ### Decide
 
-For each candidate finding:
+The generic report mechanics — search the inbox first (via the
+`report:error_tracking:<issue_id>` pointer, else an `inbox-reports-list` search on the
+issue's _specific_ terms — the issue id, the fingerprint, the failing activity name, not a
+broad word like `error`), edit-vs-author, the status rules, reviewer routing,
+non-idempotent dedup, and the `priority` / `repository` / actionability fields — live in the
+harness prompt and in `authoring-scouts` → `references/report-contract.md`. Do not re-derive
+them here. This section is only the error-tracking judgment layered on top:
 
-- **Emit** via `signals-scout-emit-signal` if it clears the confidence bar.
-  Strong scout findings: confidence ≥ 0.85, with concrete issue ids,
-  hourly count, distinct-user counts in the evidence.
-- **Remember** if below the bar but worth carrying forward.
-- **Skip** with a one-line note if a scratchpad entry with a `noise:` or `addressed:`
-  key prefix already covers it.
+- **Edit** when a still-live report already tracks the same issue and it's still moving — a
+  burst still elevated, a stuck loop still looping, a cluster still growing. A persistent
+  issue is one report across runs: a fresh window confirming it's ongoing is a re-escalation
+  (`append_note` the fresh hourly counts and distinct-user numbers), not a new report per
+  tick. A **status regression** is the exception — an issue the team explicitly `resolved`
+  that's firing again is a genuinely new event; if its prior report is already closed, author
+  a fresh report (per the status rules) and repoint `report:error_tracking:<issue_id>` rather
+  than appending to a resolved item.
+- **Author** when nothing live covers the issue. A report-worthy finding names the issue
+  (issue id + fingerprint), shows the count-vs-distinct_users shape that makes it signal,
+  quantifies the burst against baseline with an hourly breakdown, dates the onset, and — when
+  the stack trace names a server activity / view — cites it with an `activity-log-list`
+  deploy correlation, all in the `evidence`. Most findings are investigations →
+  `actionability=requires_human_input` + `repository=NO_REPO`. The exception this surface
+  earns: a well-localized bug whose stack trace points at a specific named file / module in a
+  known repo can be `actionability=immediately_actionable` + `repository=owner/repo` to open
+  a draft fix PR. Priority: a fresh broad-reach regression (count and distinct_users both
+  spiking, per-request server path) or a resolved-issue status regression is **P1**, **P2**
+  when reach is moderate; a stuck loop or narrow-reach cluster is **P3**, **P2** when count
+  is in the thousands and fresh.
+- **Remember** if it's below the bar but worth carrying forward (an issue drifting inside the
+  noise band, a fingerprint building history), or to record what you ruled out and why.
+- **Skip** with a one-line note if a `noise:` / `addressed:` / `dedupe:` entry, or an
+  existing inbox report, already covers it.
 
-Cross-check `inbox-reports-list` before emitting — if an issue is already in the inbox,
-emit only if the _new angle_ (broader reach, status regression, deploy correlation) is
-materially different. Otherwise the existing report's signals will pick yours up via
-cross-source clustering.
+Sibling courtesy: raw log-line rate/level shifts belong to the logs scout; LLM `$ai_*`
+errors to the ai-observability scout; CSP `$csp_violation` blocks to the csp-violations
+scout; errors surfaced through session friction to the session-replay scout. Honor their
+`dedupe:` entries — your unique angle is always the `$exception` issue-level burst /
+regression frame.
 
 ### Close out
 
-**Summarize the run** — one paragraph: looked at what, emitted what, remembered what,
-ruled out what. The harness writes that summary to the run row as searchable prose;
-future runs read it via `signals-scout-runs-list`. Do **not** write a separate
-"run metadata" scratchpad entry — the run summary already serves that role.
+**Summarize the run** — one paragraph: looked at what, which reports you authored or
+edited, what you remembered, what you ruled out. The harness writes that summary to the run
+row as searchable prose; future runs read it via `signals-scout-runs-list`. Do **not** write
+a separate "run metadata" scratchpad entry — the run summary already serves that role.
 
 ## Disqualifiers (skip these)
 
@@ -163,7 +217,7 @@ future runs read it via `signals-scout-runs-list`. Do **not** write a separate
   API outages already covered by past memory. Skip unless volume / shape changes
   meaningfully.
 
-When in doubt, write a memory entry instead of emitting.
+When in doubt, write a memory entry instead of filing a report.
 
 ## MCP tools
 
@@ -175,22 +229,32 @@ Direct calls (read-only):
   occurrence counts).
 - `execute-sql` against `events` — for hourly breakdowns, distinct-user counts,
   per-fingerprint correlation, time-window aggregations.
-- `inbox-reports-list` — check whether the issue is already in the inbox before emitting.
 - `activity-log-list` — pair stack-trace activity names with recent deploys or model
   changes for cross-source convergence.
+
+Inbox & reviewer routing (mechanics in `authoring-scouts` → `references/report-contract.md`):
+
+- `inbox-reports-list` / `inbox-reports-retrieve` — the reports already in the inbox; check
+  before authoring so you edit instead of duplicating (`ordering=-updated_at`).
+- `inbox-report-artefacts-list` — a comparable report's artefact log; reviewer precedent.
+- `signals-scout-members-list` — the in-run roster for routing `suggested_reviewers` to a
+  service / module / activity owner.
 
 Harness-level:
 
 - `signals-scout-project-profile-get` / `signals-scout-scratchpad-search` /
   `signals-scout-runs-list` / `signals-scout-runs-retrieve` — orientation + dedupe.
-- `signals-scout-emit-signal` / `signals-scout-scratchpad-remember` — emit / remember.
+- `signals-scout-emit-report` / `signals-scout-edit-report` — author a report / edit an
+  existing one (the report-channel contract is in the harness prompt).
+- `signals-scout-scratchpad-remember` / `signals-scout-scratchpad-forget` — remember /
+  prune stale memory keys.
 
 ## When to stop
 
 - `$exception` row in profile is at baseline → close out empty.
 - A candidate matches a scratchpad entry with `noise:` / `addressed:` / `dedupe:` key
-  prefix → skip.
-- You've validated some hypotheses and emitted what's solid → close out, even if
-  there's more you could look at. Fewer, better signals.
+  prefix, or an existing inbox report → edit-or-skip with a one-line note.
+- You've validated some hypotheses and filed reports for what's solid → close out, even if
+  there's more you could look at. Fewer, better reports.
 
 "Looked but found nothing meaningful" is a real outcome.


### PR DESCRIPTION
## Problem

We're retiring `emit_signal` across the canonical `signals-scout-*` fleet and moving every scout onto the report channel, where it authors and edits a full `SignalReport` 1:1 instead of firing weak findings for the clustering pipeline to reassemble. This PR ports the next scout by reach: error-tracking (#8 in the reach snapshot, ~30 teams). It follows the scouts already ported (general, logs, product-analytics, ai-observability, revenue-analytics, surveys, anomaly-detection, feature-flags) and the in-flight web-analytics port.

## Changes

Report-only rewrite of `signals-scout-error-tracking/SKILL.md`. This is a body-and-frontmatter change to one scout skill, no backend code.

- Frontmatter: added `allowed_tools: [emit_report, edit_report]` (mints the `signal_scout_report:write` scope for this scout), trimmed the verbose `compatibility` block to one line, and reframed the `description` to say it files reports.
- Body: added a report-channel intro (own each report 1:1; the harness prompt carries the full contract), an `inbox-reports-list` orientation read, and `report:` / `reviewer:` scratchpad key prefixes plus example keys.
- `Decide` is now domain-only, matching the web-analytics exemplar: a one-line pointer to the generic mechanics (harness prompt + `authoring-scouts/references/report-contract.md`), then only the error-tracking judgment — edit-vs-author framed as same-issue dedupe, the severity to `priority` mapping (broad-reach or resolved-issue regression P1/P2, stuck loop or narrow cluster P3), the `requires_human_input` + `NO_REPO` default with the `immediately_actionable` path for a well-localized bug that has a clear stack trace and repo, and sibling routing to logs / ai-observability / csp / session-replay.
- Dropped the LLM confidence-float bar and swapped the emit-signal / inbox wording throughout (close out, disqualifiers, when-to-stop, MCP tools) for author/edit-a-report.

All the domain logic is preserved verbatim: the count-vs-distinct_users discriminator, the profile-shape table, the four explore patterns (broad-reach burst, stuck loop, multi-fingerprint cluster, status regression, stack-trace activity name), the SQL, and the disqualifiers. Only the output channel and the dedupe/routing wiring changed.

## How did you test this code?

No app runtime. I (Claude) ran the skills linter (`build_skills.py --lint`, 99 skills pass; the one advisory warning is a pre-existing `authoring-scouts` reference, not this file) and formatted with oxfmt / lint-staged markdown. No automated tests exist for scout SKILL.md content. The scout exercises live on the next coordinator tick once merged and synced; calibration (author-vs-edit balance) is watched from the run rows per the spec.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this via the `scouts-emit-reports` tracking skill (`/phs`), which carries the canonical port order and the settled per-scout recipe. I followed `references/canonical-port-guidelines.md`: mirrored current-master `signals-scout-ai-observability` for overall shape and the in-flight `signals-scout-web-analytics` port (#67342) for the thinned domain-only `Decide` and MCP-tools sections.

Key judgment calls specific to error tracking: kept the issue-id as the stable entity key for `report:` / `dedupe:` pointers (the natural durable identifier here, analogous to a channel or model elsewhere), and included the `immediately_actionable` + repository path in `Decide` because this surface genuinely earns it — an `$exception` with a clear stack trace can point straight at a named file, unlike the pure-anomaly scouts that are always `requires_human_input`. Status regressions are called out as the edit-vs-author exception (a resolved issue firing again is a fresh report, not an append onto a closed item).

No skills with code-change side effects were invoked (no migrations, DRF, or type-gen touched — this is skill-store content).
