### PR TITLE
chore: remove agent-written PR blockquote guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,6 +65,5 @@
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
 - Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
-- If written by agent, put in a plain blockquote before "## Problem" just saying "> Claude/Codex/etc.-written:" to set the context for readers.
 - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
 -->


### PR DESCRIPTION
## Problem

The PR template included guidance to add a blockquote marker ("> Claude/Codex/etc.-written:") before the Problem section for agent-written PRs. This instruction is redundant given the existing `## 🤖 Agent context` section that already clearly identifies agent involvement and provides detailed context about the work.

## Changes

Removed the line from `.github/pull_request_template.md` that instructed authors to add a plain blockquote before "## Problem" for agent-written PRs. The `## 🤖 Agent context` section provides sufficient transparency about agent authorship without needing an additional blockquote marker.

## How did you test this code?

N/A — documentation-only change to the PR template.

https://claude.ai/code/session_01ABus1Ya3uSjHT9ajP1fC8H