### PR TITLE
feat(signals): port csp-violations scout to the report channel

### DIFF
--- a/products/signals/skills/signals-scout-csp-violations/SKILL.md
+++ b/products/signals/skills/signals-scout-csp-violations/SKILL.md
@@ -3,12 +3,15 @@ name: signals-scout-csp-violations
 description: >
   Signals scout for Content Security Policy violation reports. Watches `$csp_violation` events
   for blocked-URL clusters, per-directive bursts, post-deploy regressions, and suspicious
-  third-party domains.
+  third-party domains, and files each validated cluster as a report in the inbox.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP tool family plus the analytics tools listed in the body's MCP
-  tools section.
+  PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
+  (scratchpad) + signal_scout_report:write (report channel), plus the analytics tools in the
+  MCP tools section (execute-sql over `$csp_violation` events, read-data-schema,
+  activity-log-list).
+allowed_tools:
+  - emit_report
+  - edit_report
 metadata:
   owner_team: signals
   scope: csp_violations
@@ -19,13 +22,28 @@ metadata:
 
 You are a focused CSP scout. Spot meaningful changes in this team's
 `$csp_violation` event stream — fresh blocked-URL domains, per-directive bursts,
-deploy-correlated page regressions, suspicious third-party scripts — and emit findings
-only when a cluster clears the confidence bar.
+deploy-correlated page regressions, suspicious third-party scripts — and file reports
+only when a cluster clears the bar.
 
 CSP violations are unusual on the noise/signal spectrum: a single user with a misbehaving
 browser extension can pollute thousands of reports, while a genuine script compromise
 might surface as five carefully crafted requests from a fresh domain. **Reach (distinct
 users + distinct documents) matters more than raw count**. Internalize that shape.
+
+You author reports directly via the report channel (`signals-scout-emit-report` /
+`signals-scout-edit-report`): you've done the research, so you own each report 1:1 end-to-end
+rather than firing weak signals for a pipeline to cluster. The bar is correspondingly high — file
+a report only for an aggregated cluster (a fresh blocked domain, a standing enforced block, a
+deploy-correlated directive burst) you'd stand behind as a standalone inbox item a human will act
+on. A cluster the inbox already covers that's still active (or recovered then relapsed) is an
+**edit**, not a new report. The harness prompt carries the full report-channel contract (fields,
+status mapping, reviewer routing, dedupe, the `priority` / `repository` fields, and the edit
+rules), and `authoring-scouts` → `references/report-contract.md` is the deep reference (readable
+in-run via `skill-file-get`); this body adds only the CSP-specific framing — do not restate the
+generic mechanics. (Note: this surface has a companion **push** path that files raw
+per-fingerprint signals under `source_product=csp_reporting`; your own report-channel reports
+persist under `source_product=signals_scout`. Both live in the same inbox — see Decide for how
+they interact.)
 
 ## Quick close-out: is CSP reporting even active?
 
@@ -38,7 +56,7 @@ signal is today. Cheap scratchpad entry + close out:
 
 **Before** taking the baseline close-out, run the [standing enforced / first-party
 block](#standing-enforced--first-party-block-no-freshness-required) check below. "No fresh
-24h burst" is **not** the same as "nothing to emit" — a high-reach `disposition=enforce`
+24h burst" is **not** the same as "nothing to report" — a high-reach `disposition=enforce`
 cluster (or a first-party domain blocked at scale) is a live problem even when it's been
 steady for weeks, and it's exactly what a burst-only reading hides. Only close out as
 baseline once that check is also clean.
@@ -59,28 +77,36 @@ Cycle between these moves; skip what's not useful.
 
 ### Get oriented
 
-Three cheap reads cold-start a run:
+Four cheap reads cold-start a run:
 
 - `signals-scout-scratchpad-search` (`text=csp` or `text=blocked`) — durable team steering
-  from past CSP runs. Entries with `pattern:`, `noise:`, `addressed:`, `dedupe:`, or
-  `allowlist:` key prefixes tell you the team's healthy domains, recurring
-  browser-extension noise, fingerprints already surfaced, and what to skip.
+  from past CSP runs. Entries with `pattern:`, `noise:`, `addressed:`, `dedupe:`, `allowlist:`,
+  `report:`, or `reviewer:` key prefixes tell you the team's healthy domains, recurring
+  browser-extension noise, clusters already surfaced, which report covers a cluster, who owns a
+  surface, and what to skip.
 - `signals-scout-runs-list` (last 7d) — what prior CSP scouts found and ruled out.
 - `signals-scout-project-profile-get` — the `$csp_violation` row in `top_events` carries
-  `count`, `distinct_users`, `recent_24h_count`, `recent_24h_users`. Pattern the
-  count/users ratio against the table below.
+  `count`, `distinct_users`, `recent_24h_count`, `recent_24h_users`, plus `existing_inbox_reports`.
+  Pattern the count/users ratio against the table below.
+- `inbox-reports-list` (`ordering=-updated_at`, `search`=the blocked domain / directive) — the
+  reports already in the inbox. **Two source_products matter here:** your own report-channel
+  reports persist under `source_product=signals_scout` (search these for edit-vs-author — don't
+  filter them out), while the companion push path files raw per-fingerprint signals under
+  `source_product=csp_reporting` (check these to stay quiet when the push path already covers a
+  cluster — see Decide). A cluster you've reported before is an **edit**, not a fresh report; pull
+  the closest matches with `inbox-reports-retrieve` before authoring.
 
 ### Profile shape — count vs distinct_users
 
-| Pattern                                                 | What it usually means                                             |
-| ------------------------------------------------------- | ----------------------------------------------------------------- |
-| Both `count` and `distinct_users` spike in 24h          | Fresh broad-impact CSP regression — deploy missed an allowlist    |
-| `recent_24h_count / count` ≫ `1/7`, users also spike    | Today's burst is unusually broad — investigate first              |
-| `count` very high, `distinct_users` very low (≤ 5)      | Single user / bot / browser extension — usually skip              |
-| `count` ~ `distinct_users` for one blocked URL          | Per-pageload violation hitting every visitor — broken policy      |
-| Steady high `count` across many users + many directives | Mature CSP policy in `report-only` mode — high baseline expected  |
-| Steady high reach on one `enforce` / first-party domain | **Standing block** — live breakage; emit even with no fresh burst |
-| `count` and `distinct_users` both quiet                 | Nothing fresh today — close out                                   |
+| Pattern                                                 | What it usually means                                               |
+| ------------------------------------------------------- | ------------------------------------------------------------------- |
+| Both `count` and `distinct_users` spike in 24h          | Fresh broad-impact CSP regression — deploy missed an allowlist      |
+| `recent_24h_count / count` ≫ `1/7`, users also spike    | Today's burst is unusually broad — investigate first                |
+| `count` very high, `distinct_users` very low (≤ 5)      | Single user / bot / browser extension — usually skip                |
+| `count` ~ `distinct_users` for one blocked URL          | Per-pageload violation hitting every visitor — broken policy        |
+| Steady high `count` across many users + many directives | Mature CSP policy in `report-only` mode — high baseline expected    |
+| Steady high reach on one `enforce` / first-party domain | **Standing block** — live breakage; report even with no fresh burst |
+| `count` and `distinct_users` both quiet                 | Nothing fresh today — close out                                     |
 
 ### Explore
 
@@ -129,7 +155,7 @@ Three lenses for triage — every blocked-URL finding should name which one fits
 3. **Third-party drift — vendor script the team should remove.** Old analytics SDK still
    loaded from a deprecated bundle, ad pixel from a churned vendor, etc.
 
-Emit only when one of these lenses fits with high confidence (≥ 0.85). If you're
+File a report only when one of these lenses fits with high confidence. If you're
 genuinely unsure which of the three it is, write a `pattern:csp_violations:<entity>`
 scratchpad entry for the next run and close out.
 
@@ -171,18 +197,18 @@ LIMIT 30
 
 Triage:
 
-- **Enforce + high reach** → emit; these users are actively blocked. Highest priority when
+- **Enforce + high reach** → report; these users are actively blocked. Highest priority when
   the directive is `script-src` / `connect-src` (breaks behaviour, not just styling).
 - **First-party blocked domain** (own CDN, status page, replay proxy, internal endpoint) →
-  emit as "policy allowlist gap — add `{domain}` to `{directive}`". One finding per domain.
+  file a report as "policy allowlist gap — add `{domain}` to `{directive}`". One report per domain.
 - **Third-party, report-only, high reach but stable** → report-only refinement case;
-  remember (`pattern:`/`allowlist:`) rather than emit, unless it's a fresh domain (that's
+  remember (`pattern:`/`allowlist:`) rather than report, unless it's a fresh domain (that's
   the fresh-domain path above).
 
 The `blocked_domain != ''` filter already drops the giant inline / `eval` / `unsafe-inline`
 and browser-extension clusters (non-empty `$csp_blocked_url`, empty `domain()`) — the
 baseline noise this surface always carries — so the limit is spent on the reach that
-matters: **named** domains. Dedupe standing emissions with
+matters: **named** domains. Dedupe standing reports with
 `addressed:csp_violations:{blocked_domain}-{directive}` so a confirmed-and-allowlisted (or
 accepted) block doesn't re-surface every run.
 
@@ -226,7 +252,7 @@ then flipping to `enforce` will see violations turn into actual blocks. If the p
 profile shows `count` for `disposition='enforce'` rising sharply (`recent_24h_count`
 materially above baseline) while `report-only` shows a corresponding fall, the team has
 flipped enforcement — write a `pattern:csp_violations:disposition-flip` scratchpad entry
-and emit only if a critical page is suddenly seeing enforced blocks.
+and file a report only if a critical page is suddenly seeing enforced blocks.
 
 ### Save memory as you go
 
@@ -244,14 +270,19 @@ a future CSP run should know. Encode the "category" in the key prefix — `patte
 - key `noise:csp_violations:chrome-extension-scheme` — _"Blocked URL pattern
   `chrome-extension://*` is a recurring browser-extension noise source for this team —
   skip unless `disposition=enforce` and `effective_directive=script-src`."_
-- key `addressed:csp_violations:cdn.suspicious.example.com-2026-05-13` — _"Surfaced fresh
+- key `addressed:csp_violations:cdn.suspicious.example.com` — _"Surfaced fresh
   `script-src` cluster from `cdn.suspicious.example.com` on 2026-05-12; team confirmed
-  it was a legitimate new vendor, allowlisted in policy on 2026-05-13. Do not re-emit
+  it was a legitimate new vendor, allowlisted in policy on 2026-05-13. Do not re-file
   unless the domain re-appears after policy was widened."_
 - key `dedupe:csp_violations:a1b2c3d4` — _"Fingerprint `a1b2c3d4...` (`script-src` |
-  `evil.example.com/x.js` | `/checkout` | `bundle.js`) — surfaced 2026-05-08, finding
-  still open in inbox. If this exact fingerprint fires again, attach to the existing
-  report; don't emit fresh."_
+  `evil.example.com/x.js` | `/checkout` | `bundle.js`) — surfaced 2026-05-08, report
+  still open in inbox. If this exact fingerprint fires again, edit the existing report;
+  don't author fresh."_
+- key `report:csp_violations:<blocked_domain>-<directive>` — _the `report_id` of a report you
+  filed for a cluster on this domain/directive, so the next run edits it (append_note with the
+  fresh reach) instead of duplicating._
+- key `reviewer:csp_violations:<area>` — _a resolved owner (bare lowercase GitHub login) for the
+  security / frontend / policy surface, so reports route to a human faster._
 
 By run #5 you'll have a per-team domain allowlist in the scratchpad, known
 browser-extension noise patterns, and the typical per-directive shape — and burn
@@ -259,27 +290,43 @@ near-zero time on cold-start exploration.
 
 ### Decide
 
-For each candidate finding:
+The generic report mechanics — searching the inbox for your own prior reports (via the
+`report:csp_violations:*` pointer, else an `inbox-reports-list` search on the specific blocked
+domain / directive, not a broad word like `script-src`), edit-vs-author, the status rules,
+reviewer routing, non-idempotent dedup, and the `priority` / `repository` fields — live in the
+harness prompt and in `authoring-scouts` → `references/report-contract.md`. Do not re-derive them
+here. This section is only the CSP judgment layered on top:
 
-- **Emit** via `signals-scout-emit-signal` if it clears the confidence bar.
-  Strong scout findings: confidence ≥ 0.85, with concrete blocked domain,
-  effective directive(s), document URL(s), distinct-user count, time-range evidence,
-  and an explicit lens (policy / compromise / vendor drift).
-- **Remember** if below the bar but worth carrying forward (e.g. fresh domain with only
-  3 distinct users — let it ripen).
-- **Skip** with a one-line note if a scratchpad entry with a `noise:`, `allowlist:`,
-  `addressed:`, or `dedupe:` key prefix already covers it.
+- **Edit** when a still-live report already tracks the domain/directive cluster — a fresh domain
+  still blocked, an enforced block still degrading users, a directive burst still elevated. A
+  persistent cluster is one report across runs: a new window confirming it's ongoing is a
+  re-escalation (`append_note` the fresh reach / occurrences), not a fresh report per tick.
+- **Author** when nothing live covers the cluster. A report-worthy finding names the blocked
+  domain, the effective directive(s), the document URL(s), the distinct-user count, and a time
+  range in the `evidence`, with an explicit lens (policy widen / compromise / vendor drift). These
+  are investigations, not code fixes → `actionability=requires_human_input` + `repository=NO_REPO`.
+  Priority: a `disposition=enforce` block on a `script-src` / `connect-src` directive with broad
+  reach, or a suspected compromise, is **P1–P2** (functionality broken / possible security
+  incident); a policy-allowlist-gap or vendor-drift finding is **P2–P3** by reach. After authoring,
+  write the `report:csp_violations:<domain>-<directive>` pointer so the next run edits it.
+- **Remember** if below the bar but worth carrying forward (a fresh domain with only 3 distinct
+  users — let it ripen), or to record what you ruled out.
+- **Skip** with a one-line note if a `noise:` / `allowlist:` / `addressed:` / `dedupe:` entry, or
+  an existing inbox report, already covers it.
 
-Cross-check `inbox-reports-list` filtered to `source_product=csp_reporting` before
-emitting — the push-based emission already drops individual raw signals into the inbox,
-one per violation fingerprint. Your aggregated finding should reference those source
-signals as evidence (by fingerprint) rather than re-stating them.
+**The push path is the key dedupe partner.** The companion push emission
+(`source_product=csp_reporting`) already drops one raw signal per violation fingerprint into the
+same inbox. Cross-check it (`inbox-reports-list` filtered to `source_product=csp_reporting`) before
+authoring: your aggregated report should **reference those raw signals as evidence** (by
+fingerprint) rather than re-state them, and stay quiet when a single raw fingerprint already covers
+the whole story — author only when the aggregation adds cross-fingerprint context the push path
+can't see.
 
 ### Close out
 
-**Summarize the run** — one paragraph: looked at what, emitted what, remembered what,
-ruled out what. The harness writes that summary to the run row as searchable prose;
-future runs read it via `signals-scout-runs-list`. Do **not** write a separate
+**Summarize the run** — one paragraph: looked at what, which reports you authored or edited,
+remembered what, ruled out what. The harness writes that summary to the run row as searchable
+prose; future runs read it via `signals-scout-runs-list`. Do **not** write a separate
 "run metadata" scratchpad entry — the run summary already serves that role.
 
 ## Disqualifiers (skip these)
@@ -291,15 +338,16 @@ future runs read it via `signals-scout-runs-list`. Do **not** write a separate
 - **Domain matches an `allowlist:` scratchpad entry** — the team has already
   vetted this vendor; skip without re-surfacing.
 - **`disposition=report-only` with no enforcement signal** — the team is deliberately
-  collecting violations to refine policy. Emit only when reach / freshness / domain
+  collecting violations to refine policy. File a report only when reach / freshness / domain
   novelty is exceptional.
 - **Fingerprint matches a `dedupe:` scratchpad entry from an open inbox report** —
   the push-emission path already covered it; don't double-up.
 - **Team has no `signal_source_config` row for `csp_reporting`** — push emission is
   off for this team. Scout can still find clusters, but the user signal is "team
-  hasn't opted in to CSP signals yet"; raise the confidence bar (≥ 0.9) accordingly.
+  hasn't opted in to CSP signals yet"; raise the bar accordingly — require exceptional reach
+  before filing.
 
-When in doubt, write a memory entry instead of emitting.
+When in doubt, write a memory entry instead of filing a report.
 
 ## MCP tools
 
@@ -312,14 +360,23 @@ Direct calls (read-only):
   the team's actual `$csp_*` property surface and sample values.
 - `activity-log-list` — pair burst timestamps with recent deploys or feature-flag
   changes for cross-source convergence.
-- `inbox-reports-list` filtered to `source_product=csp_reporting` — verify a cluster
-  isn't already in the inbox via the push path before emitting.
+  Inbox & reviewer routing (mechanics in `authoring-scouts` → `references/report-contract.md`):
+
+- `inbox-reports-list` / `inbox-reports-retrieve` — the reports already in the inbox. Check your
+  own prior reports (`source_product=signals_scout`) so you edit instead of duplicating, and the
+  push path's raw signals (`source_product=csp_reporting`) so you don't re-state a fingerprint it
+  already covers.
+- `inbox-report-artefacts-list` — a comparable report's artefact log; reviewer precedent.
+- `signals-scout-members-list` — the in-run roster for routing `suggested_reviewers` to a
+  security / frontend / policy owner.
 
 Harness-level:
 
 - `signals-scout-project-profile-get` / `signals-scout-scratchpad-search` /
   `signals-scout-runs-list` / `signals-scout-runs-retrieve` — orientation + dedupe.
-- `signals-scout-emit-signal` / `signals-scout-scratchpad-remember` — emit / remember.
+- `signals-scout-emit-report` / `signals-scout-edit-report` — author a report / edit an existing
+  one (the report-channel contract is in the harness prompt).
+- `signals-scout-scratchpad-remember` — remember.
 
 ## When to stop
 
@@ -327,9 +384,9 @@ Harness-level:
   block check is clean → close out empty. A steady baseline alone is not enough — a standing
   high-reach enforced (or first-party) block is a live problem even with no fresh burst.
 - A candidate matches a scratchpad entry with `noise:` / `allowlist:` / `addressed:` /
-  `dedupe:` key prefix → skip.
-- You've validated some hypotheses and emitted what's solid → close out, even if
-  there's more you could look at. Fewer, better signals.
+  `dedupe:` key prefix, or an existing inbox report → edit-or-skip with a one-line note.
+- You've validated some hypotheses and filed reports for what's solid → close out, even if
+  there's more you could look at. Fewer, better reports.
 
 "Looked but found nothing meaningful" is a real outcome.
 
@@ -341,13 +398,13 @@ with a 24h Redis dedup TTL. That gives the inbox raw coverage of every fresh
 `(directive, blocked_url, document_url, source_file)` tuple, but per-fingerprint and
 without cross-fingerprint context.
 
-This scout is the **aggregation layer above it.** Its findings should:
+This scout is the **aggregation layer above it.** Its reports should:
 
-- Bundle multiple raw fingerprints into a single aggregated finding with shared root
+- Bundle multiple raw fingerprints into a single aggregated report with shared root
   cause (one new domain across many pages, one deploy regression across many directives,
   one compromise pattern across many users).
-- Use the push path's existing signals as evidence in the finding's body (referenced by
+- Use the push path's existing signals as evidence in the report's body (referenced by
   fingerprint / source_id) rather than re-deriving them.
 - Stay quiet when the push path's coverage is sufficient — a single raw fingerprint
-  already in the inbox does not need a parallel scout finding unless the aggregation adds
+  already in the inbox does not need a parallel scout report unless the aggregation adds
   new context.


### PR DESCRIPTION
## Problem

We're retiring `emit_signal` fleet-wide: every canonical `signals-scout-*` skill becomes report-only, authoring or editing a full `SignalReport` directly instead of firing weak signals for the grouping/clustering pipeline to turn into a report. When a scout has already done the research, routing through clustering loses fidelity and 1:1 control. Ported one scout per PR, biggest reach first.

`csp-violations` is next by reach (#16, 15 distinct teams over the trailing 90d).

## Changes

SKILL.md-only change to `signals-scout-csp-violations`, mirroring the settled recipe (ai-observability for shape, web-analytics #67342 for the thinned domain-only `Decide`):

- Frontmatter: add `allowed_tools: [emit_report, edit_report]`, trim `compatibility` to one line with `signal_scout_report:write`, reframe `description` to say it files reports. Kept the `credits: pauldambra` line.
- Add a short report-channel intro paragraph. The full contract stays in the harness prompt and `authoring-scouts` → `references/report-contract.md`; the body carries only the CSP-specific framing. No bundled `references/report.md`.
- Get oriented: add an `inbox-reports-list` read and the `report:` / `reviewer:` scratchpad key prefixes.
- Memory: add `report:csp_violations:<domain>-<directive>` and `reviewer:csp_violations:<area>` keys, and strip the date out of the `addressed:` example key.
- Decide: thinned to domain-only — edit vs author, the severity→`priority` mapping (enforce `script-src`/`connect-src` broad reach or suspected compromise P1–P2, policy-gap/vendor-drift P2–P3), and the triage lenses (policy widen / compromise / vendor drift) preserved. Dropped the confidence floats.
- **Preserved the push-path relationship as domain logic.** This scout has a companion push emission (`source_product=csp_reporting`) that files one raw signal per violation fingerprint. Unlike the other ports, the dedupe search is two-sided: check `source_product=signals_scout` for the scout's own prior reports (edit-vs-author), and still cross-check `source_product=csp_reporting` to stay quiet when the push path already covers a fingerprint. Both the Decide section and the "How this relates to the push-based CSP source" section were updated to make that split explicit.
- MCP tools: swap `signals-scout-emit-signal` for `-emit-report` / `-edit-report`; add `inbox-reports-retrieve`, `inbox-report-artefacts-list`, `signals-scout-members-list`.
- Reworded residual emit language across the intro, profile-shape table, explore patterns, close-out, disqualifiers, and stop sections. All domain logic (the reach-over-count discriminator, the fresh-domain and standing-enforced-block queries, per-directive/document/disposition patterns, browser-extension noise handling, disqualifiers) is preserved verbatim.

## How did you test this code?

`python products/posthog_ai/scripts/build_skills.py --lint` passes (99 skills), and `oxfmt` formatted the file. No runtime exercise of the live channel in this PR — the change is skill content that the harness loads into the scout's system prompt; the report-channel backend already ships on master and the earlier ports validate the mechanics.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the port; assigned as DRI.

Claude Code shaped this PR following the `scouts-emit-reports` skill's `canonical-port-guidelines.md` recipe. The interesting wrinkle here was the companion push source: CSP is the one scout where the generic "don't filter `source_product`" rule doesn't fully apply, because the push path legitimately files under `csp_reporting` and the scout must still cross-check it. The port keeps that two-sided dedupe explicit rather than flattening it. No new bundled reference, per the settled body-only rule.
