### PR TITLE
feat(customer-analytics): collapse array/object properties by default

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -165,7 +165,7 @@ jobs:
     build-storybook:
         name: Build Storybook (depot-ubuntu-latest)
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 15
         needs: changes
         if: needs.changes.outputs.frontend == 'true'
         steps:

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -165,7 +165,7 @@ jobs:
     build-storybook:
         name: Build Storybook (depot-ubuntu-latest)
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 20
         needs: changes
         if: needs.changes.outputs.frontend == 'true'
         steps:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6365,9 +6365,9 @@ snapshots:
     scenes-app-people-groups--groups--light:
         hash: v1.k794b7964.894dcc1b6beb88e930a72308a4d1008244f7305a071d3ab38fc87919ac14dd8c.m0FdetDwDmNWz-hch9f3fOiPFpzYh4Op2P_OaaWz3jk
     scenes-app-people-person--person--dark:
-        hash: v1.k794b7964.4a46194e47a2e29e8347deaec80f795129ddbcebcb78b56750d318ae1c9cdd62.eO-T-SKxiZVeD9E-axeTh2g67Z5h7ZHpU03cKjcUESY
+        hash: v1.k794b7964.556a7e84b23616d3a1692e8612d00ddd2f344b2fc192b309ca33578acd5c599d.txNhtR_9XnShJkFE7ocSBO2Es3MkojKmatQ1eFQ-Pi0
     scenes-app-people-person--person--light:
-        hash: v1.k794b7964.0a63996549fc71cab17f6e7d57b4529920b63db646f8e1e373791668e556a93b.h90Ly27-QFuia41VvZaip0tk9-QAKw2EKm1vhWcTD1E
+        hash: v1.k794b7964.ebfa0a58e5c8ffe4768203ea8ffdb023625af85b56b624a29e3cb25c9b705752.qykleErq4ZzoltxkYeeujNnuSw65dGytbXzrC7P7pcU
     scenes-app-people-person--person-not-found--dark:
         hash: v1.k794b7964.ce572a54f38627af650ca022bce22418ba4f4df4a2adc99d73d9080d79f82591.VQJZMjET9BIhBZGP9V0L96mX6Rcku3XZ4zcpJgCQGXk
     scenes-app-people-person--person-not-found--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6365,9 +6365,9 @@ snapshots:
     scenes-app-people-groups--groups--light:
         hash: v1.k794b7964.894dcc1b6beb88e930a72308a4d1008244f7305a071d3ab38fc87919ac14dd8c.m0FdetDwDmNWz-hch9f3fOiPFpzYh4Op2P_OaaWz3jk
     scenes-app-people-person--person--dark:
-        hash: v1.k794b7964.556a7e84b23616d3a1692e8612d00ddd2f344b2fc192b309ca33578acd5c599d.txNhtR_9XnShJkFE7ocSBO2Es3MkojKmatQ1eFQ-Pi0
+        hash: v1.k794b7964.4a46194e47a2e29e8347deaec80f795129ddbcebcb78b56750d318ae1c9cdd62.eO-T-SKxiZVeD9E-axeTh2g67Z5h7ZHpU03cKjcUESY
     scenes-app-people-person--person--light:
-        hash: v1.k794b7964.ebfa0a58e5c8ffe4768203ea8ffdb023625af85b56b624a29e3cb25c9b705752.qykleErq4ZzoltxkYeeujNnuSw65dGytbXzrC7P7pcU
+        hash: v1.k794b7964.0a63996549fc71cab17f6e7d57b4529920b63db646f8e1e373791668e556a93b.h90Ly27-QFuia41VvZaip0tk9-QAKw2EKm1vhWcTD1E
     scenes-app-people-person--person-not-found--dark:
         hash: v1.k794b7964.ce572a54f38627af650ca022bce22418ba4f4df4a2adc99d73d9080d79f82591.VQJZMjET9BIhBZGP9V0L96mX6Rcku3XZ4zcpJgCQGXk
     scenes-app-people-person--person-not-found--light:

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
@@ -222,9 +222,12 @@ describe('PropertiesTable inline editor', () => {
         it.each([
             { collapsible: false, expectArrayTag: true },
             { collapsible: true, expectArrayTag: false },
-        ])('collapsible=$collapsible renders expanded array table: $expectArrayTag', ({ collapsible, expectArrayTag }) => {
-            renderWith(collapsible)
-            expect(!!screen.queryByText('array')).toBe(expectArrayTag)
-        })
+        ])(
+            'collapsible=$collapsible renders expanded array table: $expectArrayTag',
+            ({ collapsible, expectArrayTag }) => {
+                renderWith(collapsible)
+                expect(!!screen.queryByText('array')).toBe(expectArrayTag)
+            }
+        )
     })
 })

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
@@ -203,4 +203,30 @@ describe('PropertiesTable inline editor', () => {
             expect(screen.getByText('London')).toBeInTheDocument()
         })
     })
+
+    describe('collapsible complex values', () => {
+        const renderWith = (collapsible: boolean): void => {
+            render(
+                <Provider>
+                    <PropertiesTable
+                        type={PropertyDefinitionType.Person}
+                        properties={{ tags: ['a', 'b', 'c'] }}
+                        collapsible={collapsible}
+                    />
+                </Provider>
+            )
+        }
+
+        // The expanded array table renders an "array" type tag in its header; the collapsed
+        // JSON viewer does not — so its absence is a reliable proxy for "not expanded".
+        it('expands array property values into a table by default', () => {
+            renderWith(false)
+            expect(screen.getByText('array')).toBeInTheDocument()
+        })
+
+        it('collapses array property values when collapsible', () => {
+            renderWith(true)
+            expect(screen.queryByText('array')).not.toBeInTheDocument()
+        })
+    })
 })

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
@@ -205,8 +205,8 @@ describe('PropertiesTable inline editor', () => {
     })
 
     describe('collapsible complex values', () => {
-        const renderWith = (collapsible: boolean): void => {
-            render(
+        const renderWith = (collapsible: boolean): ReturnType<typeof render> => {
+            return render(
                 <Provider>
                     <PropertiesTable
                         type={PropertyDefinitionType.Person}
@@ -229,5 +229,12 @@ describe('PropertiesTable inline editor', () => {
                 expect(!!screen.queryByText('array')).toBe(expectArrayTag)
             }
         )
+
+        // Complex values render through JSONViewer, which unlike ValueDisplay applies no masking —
+        // so the collapsed path must be wrapped in ph-no-capture to keep PII out of session replay.
+        it('masks collapsed complex values from capture', () => {
+            const { container } = renderWith(true)
+            expect(container.querySelector('.ph-no-capture')).not.toBeNull()
+        })
     })
 })

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
@@ -219,14 +219,12 @@ describe('PropertiesTable inline editor', () => {
 
         // The expanded array table renders an "array" type tag in its header; the collapsed
         // JSON viewer does not — so its absence is a reliable proxy for "not expanded".
-        it('expands array property values into a table by default', () => {
-            renderWith(false)
-            expect(screen.getByText('array')).toBeInTheDocument()
-        })
-
-        it('collapses array property values when collapsible', () => {
-            renderWith(true)
-            expect(screen.queryByText('array')).not.toBeInTheDocument()
+        it.each([
+            { collapsible: false, expectArrayTag: true },
+            { collapsible: true, expectArrayTag: false },
+        ])('collapsible=$collapsible renders expanded array table: $expectArrayTag', ({ collapsible, expectArrayTag }) => {
+            renderWith(collapsible)
+            expect(!!screen.queryByText('array')).toBe(expectArrayTag)
         })
     })
 })

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -349,9 +349,13 @@ export function PropertiesTable({
 
     if (Array.isArray(properties)) {
         // When collapsible, render the whole array in a collapsed JSON viewer instead of an
-        // expanded table of items — expandable on demand.
+        // expanded table of items — expandable on demand. Mask it from capture like scalar values.
         if (collapsible && properties.length) {
-            return <JSONViewer src={properties} collapsed={true} />
+            return (
+                <div className="ph-no-capture">
+                    <JSONViewer src={properties} collapsed={true} />
+                </div>
+            )
         }
         return (
             <div>
@@ -435,7 +439,11 @@ export function PropertiesTable({
                     const isComplexStructure = Array.isArray(item[1]) || (isObject(item[1]) && item[1] !== null)
 
                     if (isComplexStructure && collapsible) {
-                        return <JSONViewer src={item[1]} collapsed={true} />
+                        return (
+                            <div className="ph-no-capture">
+                                <JSONViewer src={item[1]} collapsed={true} />
+                            </div>
+                        )
                     }
                     return (
                         <PropertiesTable

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -8,10 +8,8 @@ import { useMemo, useState } from 'react'
 import { IconPencil, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonCheckbox, LemonDialog, LemonInput, LemonMenu, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTable, LemonTableColumns, LemonTableProps } from 'lib/lemon-ui/LemonTable'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { isObject, isKeyOf } from 'lib/utils/guards'
 import { isURL } from 'lib/utils/url'
@@ -226,6 +224,11 @@ export interface PropertiesTableProps extends BasePropertyType {
      * Can be used for e.g. to promote particular properties when sorting the properties
      */
     parent?: KNOWN_PROMOTED_PROPERTY_PARENTS
+    /**
+     * When true, complex values (arrays and objects) render collapsed by default in a JSON viewer
+     * that can be expanded on demand, rather than being expanded inline. Threads through nesting.
+     */
+    collapsible?: boolean
 }
 
 export function PropertiesTable({
@@ -245,12 +248,12 @@ export function PropertiesTable({
     highlightVariant = 'default',
     type,
     parent,
+    collapsible = false,
 }: PropertiesTableProps): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
     const { hidePostHogPropertiesInTable, hideNullValues } = useValues(userPreferencesLogic)
     const { setHidePostHogPropertiesInTable, setHideNullValues } = useActions(userPreferencesLogic)
     const { isCloudOrDev } = useValues(preflightLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const objectProperties = useMemo(() => {
         if (!properties || Array.isArray(properties) || !isObject(properties)) {
@@ -345,6 +348,11 @@ export function PropertiesTable({
     }, [properties, sortProperties, searchTerm, hidePostHogPropertiesInTable, hideNullValues, type]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     if (Array.isArray(properties)) {
+        // When collapsible, render the whole array in a collapsed JSON viewer instead of an
+        // expanded table of items — expandable on demand.
+        if (collapsible && properties.length) {
+            return <JSONViewer src={properties} collapsed={true} />
+        }
         return (
             <div>
                 {properties.length ? (
@@ -369,32 +377,10 @@ export function PropertiesTable({
                                 ),
                                 fullWidth: true,
                                 render: function Value(_, item: any): JSX.Element {
-                                    const arrayItem = item[1]
-                                    const isComplexStructure =
-                                        Array.isArray(arrayItem) || (isObject(arrayItem) && arrayItem !== null)
-                                    if (!featureFlags[FEATURE_FLAGS.TOGGLE_PROPERTY_ARRAYS]) {
-                                        return (
-                                            <PropertiesTable
-                                                type={type}
-                                                properties={item[1]}
-                                                nestingLevel={nestingLevel + 1}
-                                                useDetectedPropertyType={
-                                                    ['$set', '$set_once'].some((s) => s === rootKey)
-                                                        ? false
-                                                        : useDetectedPropertyType
-                                                }
-                                            />
-                                        )
-                                    }
-
-                                    if (isComplexStructure) {
-                                        return <JSONViewer src={arrayItem} collapsed={true} />
-                                    }
-
                                     return (
-                                        <ValueDisplay
+                                        <PropertiesTable
                                             type={type}
-                                            value={arrayItem}
+                                            properties={item[1]}
                                             nestingLevel={nestingLevel + 1}
                                             useDetectedPropertyType={
                                                 ['$set', '$set_once'].some((s) => s === rootKey)
@@ -448,7 +434,7 @@ export function PropertiesTable({
                 render: function Value(_, item: any): JSX.Element {
                     const isComplexStructure = Array.isArray(item[1]) || (isObject(item[1]) && item[1] !== null)
 
-                    if (isComplexStructure && featureFlags[FEATURE_FLAGS.TOGGLE_PROPERTY_ARRAYS]) {
+                    if (isComplexStructure && collapsible) {
                         return <JSONViewer src={item[1]} collapsed={true} />
                     }
                     return (
@@ -458,6 +444,7 @@ export function PropertiesTable({
                             rootKey={item[0]}
                             onEdit={onEdit}
                             nestingLevel={nestingLevel + 1}
+                            collapsible={collapsible}
                             useDetectedPropertyType={
                                 ['$set', '$set_once'].some((s) => s === rootKey) ? false : useDetectedPropertyType
                             }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -492,6 +492,7 @@ export const FEATURE_FLAGS = {
     TAXONOMIC_FILTER_CATEGORY_DROPDOWN: 'taxonomic-filter-category-dropdown', // owner: @pauldambra #team-product-analytics multivariate=control,pill
     TAXONOMIC_FILTER_DEFAULT_PINS: 'taxonomic-filter-default-pins', // owner: @pauldambra #team-product-analytics, seeds $current_url/email default pinned filters
     TAXONOMIC_FILTER_MENU_REBUILD: 'taxonomic-filter-menu-rebuild', // owner: @adamleith, opt-in to the rebuilt TaxonomicFilter — headless filter panel + new popover menu (column / preview-pane)
+    TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-customer-analytics
     TOOLBAR_HEATMAP_AREA_FILTER: 'toolbar-heatmap-area-filter', // owner: @pauldambra #team-replay, gates the target button that filters the toolbar heatmap/clickmap to a chosen page area
     TRACING: 'tracing', // owner: #team-apm (@jonmcwest, @frankh)
     TRACING_FACET_RAIL: 'tracing-facet-rail', // owner: #team-apm — gates the facet rail (faceted filter sidebar) in tracing

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -492,7 +492,6 @@ export const FEATURE_FLAGS = {
     TAXONOMIC_FILTER_CATEGORY_DROPDOWN: 'taxonomic-filter-category-dropdown', // owner: @pauldambra #team-product-analytics multivariate=control,pill
     TAXONOMIC_FILTER_DEFAULT_PINS: 'taxonomic-filter-default-pins', // owner: @pauldambra #team-product-analytics, seeds $current_url/email default pinned filters
     TAXONOMIC_FILTER_MENU_REBUILD: 'taxonomic-filter-menu-rebuild', // owner: @adamleith, opt-in to the rebuilt TaxonomicFilter — headless filter panel + new popover menu (column / preview-pane)
-    TOGGLE_PROPERTY_ARRAYS: 'toggle-property-arrays', // owner: @arthurdedeus #team-customer-analytics
     TOOLBAR_HEATMAP_AREA_FILTER: 'toolbar-heatmap-area-filter', // owner: @pauldambra #team-replay, gates the target button that filters the toolbar heatmap/clickmap to a chosen page area
     TRACING: 'tracing', // owner: #team-apm (@jonmcwest, @frankh)
     TRACING_FACET_RAIL: 'tracing-facet-rail', // owner: #team-apm — gates the facet rail (faceted filter sidebar) in tracing

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -155,6 +155,7 @@ export function Group(): JSX.Element {
                                 onEdit={editProperty}
                                 onDelete={deleteProperty}
                                 searchable
+                                collapsible
                             />
                         ),
                     },

--- a/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
@@ -102,6 +102,7 @@ export function Properties({
                                         type={type}
                                         embedded
                                         sortProperties={false}
+                                        collapsible
                                     />
                                 </div>
                             </div>

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -324,6 +324,7 @@ export function PersonScene(): JSX.Element | null {
                                 embedded={false}
                                 onDelete={(key) => deleteProperty(key)}
                                 filterable
+                                collapsible
                             />
                         ),
                     },


### PR DESCRIPTION
## Problem

When displaying group and person properties, values that are themselves arrays (or nested objects) were rendered fully expanded inline. Long arrays dominate the view and make the properties list hard to skim. There wasn't really a collapsed state for array properties at all.

## Changes

Adds a `collapsible` prop to `PropertiesTable`. When set, complex values (arrays and nested objects) render in a collapsed JSON viewer that can be expanded on demand, instead of an expanded inline table. The prop threads through nesting, and scalar values are unaffected.

Enabled on the surfaces owned by the customer-analytics team:
- Person detail → Properties tab
- Group detail → Properties tab
- The properties notebook node (used in customer profiles, both person and group)

Other `PropertiesTable` consumers (e.g. event properties) keep the existing expanded behavior by default.

This promotes the behavior that previously sat behind the `toggle-property-arrays` feature flag into an unflagged default for these surfaces; the flag has been removed.

## How did you test this code?

Added two Jest cases to `PropertiesTable.test.tsx` covering the new prop: by default an array property value still expands into a table, and with `collapsible` it does not (asserted via the presence/absence of the expanded array table's type tag, which is deterministic regardless of the lazily-loaded JSON viewer). No existing test exercised `collapsible` or array rendering.

I was not able to run the Jest suite or typecheck in this environment (frontend dependencies aren't installed here) — CI will run them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782893928442789?thread_ts=1782893928.442789&cid=C0ACRAMJUAG) where the customer-analytics team asked to collapse array/JSON property fields by default on group/person pages.

Key decisions:
- Reused the existing `JSONViewer` (react-json-view) collapse approach that was already wired behind the `toggle-property-arrays` flag, rather than building a new inline collapse widget — the flag owner had already validated that presentation.
- Made it an opt-in prop enabled on the specific customer-analytics surfaces instead of changing `PropertiesTable` globally, to avoid altering event-property rendering elsewhere. Easy to broaden in review if desired.
- Removed the now-unused feature flag since the request was to make this the default.

Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782893928442789?thread_ts=1782893928.442789&cid=C0ACRAMJUAG)*
