### PR TITLE
feat(inbox): show actual spend in the usage section

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5632,6 +5632,26 @@ snapshots:
         hash: v1.k794b7964.dd76b59536653a95f1d064c9bc2ad8aea9da9cb6595b487ce86bace171887a46.jvndkfnDbc-t_ydLYTUnT2psRi3WoFtNmFlZGaVUER0
     scenes-app-inbox-tabs--runs-many-agents--light:
         hash: v1.k794b7964.90b19fdceb30d6d27868420db1123615fe3ae01b3a8b1ec4b6d016bd4885d12d.sk9bQDwr1fH7njWhbM40oMj7px6aZ9NmA2Fz1V78VT0
+    scenes-app-inbox-usagewidget--approaching-limit--dark:
+        hash: v1.k794b7964.d1c4e73a982ac7067e4874efb215788dad85a4b23af33a7ec37d51fb21377ec9.5z9w-oNbDT8vJRdbwNSd0roWSOYoXidiufEtGvwZ9bU
+    scenes-app-inbox-usagewidget--approaching-limit--light:
+        hash: v1.k794b7964.d52dadca3844c33b1ddd12e56207d69c4a4f7d36c8c44025c4dd51c487939dd4.MCS_U229_KuAAcRp3AI5cYwTldLTGvf4pUuN1o88n7U
+    scenes-app-inbox-usagewidget--at-limit--dark:
+        hash: v1.k794b7964.ece7fe25847a18191225b27a74c518b16545fd6bfd7660721716dde9bd8aa715.woCwiy5ESFwOHxmHSVP34c-h_jGz1oTTx1qDS8MLNDw
+    scenes-app-inbox-usagewidget--at-limit--light:
+        hash: v1.k794b7964.4e35de5b500b7efde723f4adb13a3ea4c333612fba13cbd77073638c19f81393.45LNae9tYtWySwY5rZ71oQ7EpUqNS6Gxj9QFWiXDg9w
+    scenes-app-inbox-usagewidget--billable-usage--dark:
+        hash: v1.k794b7964.f8c1a4fa596a1e95672d7de31c341f622d3485197ffa932b49c2c7d468952099.LHQoJw3KcA9OjCsAD6xqUKcszG3-deSK_T51BCi6Y9g
+    scenes-app-inbox-usagewidget--billable-usage--light:
+        hash: v1.k794b7964.624f9f6e7f4899ad23e6bf4ff65e4f5d99ffca2d25d9258cb1c99af189b68e3f.6-MGTG5omCf5vKWsLCBa04CrGHEiWmHweTzsUyxfXd4
+    scenes-app-inbox-usagewidget--free-plan-zero-usage--dark:
+        hash: v1.k794b7964.aa7758840761b3a935de7e15fa077d57ec83088b8468ecf7260cccaa4126c1f8.0NAeWJtoOChkFBOZn8q-GDldISLDa9dtpRPzSF9sBP4
+    scenes-app-inbox-usagewidget--free-plan-zero-usage--light:
+        hash: v1.k794b7964.27449e9d707fb0f7ffb036bc055d575fbd36ca2570450f3c784bff392bef278b.-AA3PqJLJAZCNb82qrPij2QPwFAe8MKBt265T53wTRw
+    scenes-app-inbox-usagewidget--within-free-tier--dark:
+        hash: v1.k794b7964.379c8ed4a4d195917a934db8f2cce9392ad6709f62cc51785a04fc7a9af876a7._KPZ67PWLSacpU275xdGL38BYwVLAq4W1U-WbCbwtec
+    scenes-app-inbox-usagewidget--within-free-tier--light:
+        hash: v1.k794b7964.90a71da2a60246108ea03fc6676db82a429d0b95e39ef4f4a39e0e9e60cad141.1EcDy6cxmC217xylepEQXkDVGfssVGIFzYdyBt6mWVk
     scenes-app-insights-boldnumber--compare-null-previous--dark:
         hash: v1.k794b7964.ccab3f6785db86e659c4186e305b97ba81c7bda8c51e7fd5c05e179be4393fde.C-X-Y3nG_88O1MxV0YKV52bqS_DKlvdLVHa5HDj0GRI
     scenes-app-insights-boldnumber--compare-null-previous--light:

--- a/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.stories.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { useStorybookMocks } from '~/mocks/browser'
+import { billingJson } from '~/mocks/fixtures/_billing'
+import { BillingProductV2Type, BillingType } from '~/types'
+
+import { InboxUsageWidget } from './InboxUsageWidget'
+
+// Drives the inbox PR-usage widget purely off the billing payload: one `inbox` product whose
+// tiers / usage / limit place the run in a given state. `display_divisor: 1` keeps credits == PRs so
+// the numbers read directly; `current_usage` drives the bar.
+const PRICE_PER_PR = 2
+
+interface InboxState {
+    subscribed: boolean
+    freePrs: number
+    usedPrs: number
+    limitPrs: number | null
+}
+
+function inboxProduct({ subscribed, freePrs, usedPrs, limitPrs }: InboxState): BillingProductV2Type {
+    const base = billingJson.products[0]
+    const tierTemplate = base.tiers?.[0]
+    return {
+        ...base,
+        type: 'inbox',
+        name: 'Inbox',
+        usage_key: 'signals_credits',
+        subscribed,
+        display_divisor: 1,
+        free_allocation: subscribed ? 0 : freePrs,
+        current_usage: usedPrs,
+        usage_limit: limitPrs,
+        unit_amount_usd: PRICE_PER_PR.toFixed(2),
+        tiers: tierTemplate
+            ? [
+                  { ...tierTemplate, up_to: freePrs, unit_amount_usd: '0' },
+                  { ...tierTemplate, up_to: null, unit_amount_usd: PRICE_PER_PR.toFixed(2) },
+              ]
+            : null,
+    }
+}
+
+function billingFor(state: InboxState): BillingType {
+    return { ...billingJson, products: [inboxProduct(state)], custom_limits_usd: {} }
+}
+
+function StateMocks({ state }: { state: InboxState }): JSX.Element {
+    useStorybookMocks({
+        get: {
+            '/api/billing/': billingFor(state),
+        },
+    })
+    // Mimic the agents rail's narrow column so the widget lays out as it does in the scene.
+    return (
+        <div className="w-[260px] p-4 bg-surface-secondary">
+            <InboxUsageWidget />
+        </div>
+    )
+}
+
+const meta: Meta = {
+    title: 'Scenes-App/Inbox/UsageWidget',
+    component: InboxUsageWidget,
+    parameters: {
+        layout: 'centered',
+        viewMode: 'story',
+        mockDate: '2024-03-20',
+    },
+}
+export default meta
+
+type Story = StoryObj
+
+export const FreePlanZeroUsage: Story = {
+    render: () => <StateMocks state={{ subscribed: false, freePrs: 3, usedPrs: 0, limitPrs: 3 }} />,
+}
+
+export const WithinFreeTier: Story = {
+    render: () => <StateMocks state={{ subscribed: true, freePrs: 3, usedPrs: 2, limitPrs: 50 }} />,
+}
+
+export const BillableUsage: Story = {
+    render: () => <StateMocks state={{ subscribed: true, freePrs: 3, usedPrs: 12, limitPrs: 50 }} />,
+}
+
+export const ApproachingLimit: Story = {
+    render: () => <StateMocks state={{ subscribed: true, freePrs: 3, usedPrs: 42, limitPrs: 50 }} />,
+}
+
+export const AtLimit: Story = {
+    render: () => <StateMocks state={{ subscribed: true, freePrs: 3, usedPrs: 50, limitPrs: 50 }} />,
+}

--- a/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
@@ -1,8 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { LemonButton, LemonInput, LemonModal, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
-import { Progress } from '@posthog/quill'
+import { LemonButton, LemonInput, LemonModal, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { BillingUpgradeCTA } from 'lib/components/BillingUpgradeCTA'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -14,13 +13,28 @@ import { BillingProductV2Type } from '~/types'
 
 import { InboxUsageStatus, inboxUsageLogic } from '../../logics/inboxUsageLogic'
 
-const PROGRESS_VARIANT: Record<InboxUsageStatus, 'info' | 'warning' | 'destructive'> = {
-    normal: 'info',
-    warning: 'warning',
-    limit: 'destructive',
+// Usage-bar fill colour by status. Main-app semantic Tailwind classes (not quill `--*` tokens —
+// those only resolve inside `[data-quill]` subtrees).
+const FILL_CLASS: Record<InboxUsageStatus, string> = {
+    normal: 'bg-brand-blue',
+    warning: 'bg-warning',
+    limit: 'bg-danger',
 }
 
 const CARD_CLASS = 'flex flex-col gap-2 rounded border border-primary bg-surface-primary px-2.5 py-2'
+
+/** A single status-coloured fill over a neutral track. Width is runtime-derived, hence inline. */
+function UsageBar({ percentage, status }: { percentage: number; status: InboxUsageStatus }): JSX.Element {
+    return (
+        <div className="relative h-1 w-full overflow-hidden rounded-md bg-fill-tertiary">
+            <div
+                className={`absolute inset-y-0 left-0 ${FILL_CLASS[status]}`}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{ width: `${percentage}%` }}
+            />
+        </div>
+    )
+}
 
 function UsageCardSkeleton(): JSX.Element {
     return (
@@ -117,10 +131,11 @@ function EditLimitModal(): JSX.Element {
 }
 
 /**
- * Compact PR-usage meter for the inbox agents rail: a progress bar, `X / Y PRs created` on the
- * left, `Resets <date>` on the right. On a paid plan the limit is editable (and the edit affordance
- * escalates to "Increase limit" at the cap); on the free plan it shows an in-place upgrade instead.
- * Renders nothing until billing has loaded and the inbox product is present.
+ * Compact PR-usage meter for the inbox agents rail: a status-coloured usage bar with USD spent so far
+ * alongside it, then `X / Y PRs created` on the left and `Resets <date>` on the right. On a paid plan
+ * the limit is editable (and the edit affordance escalates to "Increase limit" at the cap); on the
+ * free plan it shows an in-place upgrade instead. Renders nothing until billing has loaded and the
+ * inbox product is present.
  */
 export function InboxUsageWidget(): JSX.Element | null {
     const {
@@ -130,9 +145,11 @@ export function InboxUsageWidget(): JSX.Element | null {
         canAccessBilling,
         usedPrsDisplay,
         limitPrs,
-        percentage,
+        freePrs,
         status,
         resetDate,
+        spentUsd,
+        percentage,
     } = useValues(inboxUsageLogic)
     const { openModal } = useActions(inboxUsageLogic)
 
@@ -163,7 +180,18 @@ export function InboxUsageWidget(): JSX.Element | null {
                         </button>
                     ) : null}
                 </div>
-                <Progress value={percentage} variant={PROGRESS_VARIANT[status]} />
+                <div className="flex items-center gap-2">
+                    <Tooltip title={freePrs > 0 ? `The first ${freePrs} PRs each month are free` : undefined}>
+                        <div className="flex-1">
+                            <UsageBar percentage={percentage} status={status} />
+                        </div>
+                    </Tooltip>
+                    {spentUsd != null && (
+                        <span className="text-xs font-medium text-default tabular-nums">
+                            {currencyFormatter(spentUsd)}
+                        </span>
+                    )}
+                </div>
                 <div className="flex items-center justify-between gap-2 text-xs">
                     <span className="text-secondary tabular-nums">
                         <span className="font-medium text-default">{usedPrsDisplay}</span>

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
@@ -148,16 +148,6 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
                 return null
             },
         ],
-        percentage: [
-            (s) => [s.usedPrs, s.limitPrs, s.freePrs],
-            (usedPrs, limitPrs, freePrs): number => {
-                const denominator = limitPrs ?? (freePrs || null)
-                if (!denominator) {
-                    return 0
-                }
-                return Math.min(100, Math.round((usedPrs / denominator) * 100))
-            },
-        ],
         status: [
             (s) => [s.usedPrs, s.limitPrs],
             (usedPrs, limitPrs): InboxUsageStatus => {
@@ -177,6 +167,24 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
         usedPrsDisplay: [
             (s) => [s.usedPrs, s.limitPrs],
             (usedPrs, limitPrs): number => (limitPrs != null ? Math.min(usedPrs, limitPrs) : usedPrs),
+        ],
+        // USD spent so far this period: PRs beyond the free allowance, at the per-PR price.
+        // Null when we can't price a PR (so the widget hides the figure rather than show "$0").
+        spentUsd: [
+            (s) => [s.usedPrs, s.freePrs, s.pricePerPrUsd],
+            (usedPrs, freePrs, pricePerPrUsd): number | null =>
+                pricePerPrUsd == null ? null : Math.max(0, usedPrs - freePrs) * pricePerPrUsd,
+        ],
+        // Bar fill as a % of the denominator (the limit, or the free allowance when uncapped).
+        percentage: [
+            (s) => [s.usedPrs, s.limitPrs, s.freePrs],
+            (usedPrs, limitPrs, freePrs): number => {
+                const denominator = limitPrs ?? (freePrs || null)
+                if (!denominator) {
+                    return 0
+                }
+                return Math.min(100, Math.round((usedPrs / denominator) * 100))
+            },
         ],
         resetDate: [(s) => [s.billing], (billing): Dayjs | null => billing?.billing_period?.current_period_end ?? null],
         // USD spend cap implied by the limit currently typed into the modal. Drives the live budget.


### PR DESCRIPTION
Surface $ spend in the usage section of the inbox, here are some example states:

<img width="305" height="700" alt="Screenshot 2026-07-01 at 12 30 28" src="https://github.com/user-attachments/assets/2d23d3a2-ad2c-48bc-adf3-8cb0b72975b5" />


