### PR TITLE
chore(experiments): add tooltip to distribution table analysis column

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -174,7 +174,9 @@ export function DistributionTable(): JSX.Element {
                   {
                       className,
                       key: 'analysis',
-                      title: 'Analysis',
+                      title: 'Include in analysis',
+                      tooltip:
+                          'Toggle off to exclude a variant from metric results. Excluded variants are still served to users but omitted from statistical analysis.',
                       render: function Analysis(_, { key }): JSX.Element {
                           /**
                            * bail early for holdouts


### PR DESCRIPTION
## Problem

Introduced in https://github.com/PostHog/posthog/pull/59998, the experiment Variants tab has a toggle that excludes a variant from analysis lived in a column labeled just "Analysis", sitting under the "Distribution" heading. That framing reads as traffic allocation, so it wasn't clear the toggle controls whether a variant is included in metric results.

## Changes

- Renamed the column from "Analysis" to "Include in analysis" so it reads as a toggle label at a glance.
- Added a tooltip

Column stays gated behind the existing `experiments-excluded-variants` flag.

<img width="961" height="434" alt="tooltip-analysis" src="https://github.com/user-attachments/assets/64edd82d-9ae0-4eef-a797-d001dc1e707a" />


## How did you test this code?

Locally

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) made this change on the human driver's direction. We confirmed LemonTable already supports column header tooltips via the `tooltip` prop (precedent in the Data warehouse Views table), so no custom JSX was needed. Considered also adding section-level helper text under the "Distribution" heading but kept scope to the column rename plus tooltip.
