### PR TITLE
feat(signals): port data-pipelines scout to the report channel

### DIFF
--- a/products/signals/skills/signals-scout-data-pipelines/SKILL.md
+++ b/products/signals/skills/signals-scout-data-pipelines/SKILL.md
@@ -3,12 +3,15 @@ name: signals-scout-data-pipelines
 description: >
   Signals scout for PostHog data pipelines — CDP destinations and transformations, batch
   exports, and hog flows. Watches for delivery failures, degraded functions, and stalled
-  exports against each pipeline's baseline.
+  exports against each pipeline's baseline, and files each validated delivery contradiction
+  as a report in the inbox.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP tool family plus the CDP function, batch export, workflow, and
-  analytics tools listed in the body's MCP tools section.
+  PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
+  (scratchpad) + signal_scout_report:write (report channel), plus the CDP function, batch
+  export, workflow, and analytics tools in the MCP tools section.
+allowed_tools:
+  - emit_report
+  - edit_report
 metadata:
   owner_team: signals
   scope: data_pipelines
@@ -39,6 +42,16 @@ signal. Drafts, archived flows, paused exports, and deliberately disabled functi
 operator choices, not anomalies. You are auditing delivery, not judging what the team
 chose to ship where.
 
+You author reports directly via the report channel (`signals-scout-emit-report` /
+`signals-scout-edit-report`): you've done the research, so you own each report 1:1
+end-to-end rather than firing weak signals for a pipeline to cluster. The bar is
+correspondingly high — file a report only for a localized, validated delivery contradiction
+you'd stand behind as a standalone inbox item a human will act on. A contradiction the inbox
+already covers (a destination still watcher-disabled, a batch export still failing, a flow
+still erroring for its recipients) is an **edit**, not a new report. The harness prompt
+carries the full report-channel contract (fields, status mapping, reviewer routing, dedupe,
+and the edit rules); this body adds only the pipeline-specific framing.
+
 ## Quick close-out: are pipelines even in use?
 
 Read `recent_hog_functions` and `recent_hog_flows` off `signals-scout-project-profile-get`,
@@ -53,7 +66,7 @@ WHERE deleted = 0
 - **No enabled functions, no non-archived flows, no batch exports** — pipelines aren't
   in play. Write one scratchpad entry and close out empty (re-running with the same key
   idempotently refreshes it):
-  - key: `not-in-use:pipelines:team{team_id}`
+  - key: `not-in-use:pipelines` (the scratchpad is already team-scoped — no id in the key)
   - content: brief note ("checked at {timestamp}, no enabled pipelines")
 - **Only one leg in use** — scope the run to that leg; skip the others silently.
 
@@ -67,10 +80,17 @@ Three cheap reads cold-start a run:
 
 - `signals-scout-scratchpad-search` (`text=pipeline`) — durable steering: the watchlist
   of high-value pipelines and their baselines, `noise:` / `addressed:` / `dedupe:`
-  entries gating re-emits.
+  entries gating re-reports, plus `report:` / `reviewer:` entries pointing at the open
+  report for a pipeline and who owns it.
 - `signals-scout-runs-list` (last 7d) — what prior pipeline runs found and ruled out.
 - `signals-scout-project-profile-get` — `recent_hog_functions` (total, enabled count, 5
   most recently modified) and `recent_hog_flows` (total, active count, 5 most recent).
+- `inbox-reports-list` (`search`=pipeline name, `ordering=-updated_at`) — the reports
+  already in the inbox. A contradiction on a pipeline you've reported before is an
+  **edit**, not a fresh report; pull the closest matches with `inbox-reports-retrieve`
+  before authoring. Your own report-channel reports persist their backing signals under
+  `source_product=signals_scout`, so don't filter `source_product=cdp` — you'd miss every
+  report you authored.
 
 Then orient on each leg with one fleet-wide read apiece:
 
@@ -113,13 +133,13 @@ ingestion trouble), not N per-destination findings.
 
 | Pattern                                                            | What it usually means                                                      |
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Enabled function at watcher state 3                                | Platform stopped it after sustained failures — team likely unaware; emit   |
+| Enabled function at watcher state 3                                | Platform stopped it after sustained failures — team likely unaware; report |
 | Enabled function at state 2, tokens draining                       | Degraded — failing or slow right now; investigate, date the onset          |
 | State 11/12 (forced)                                               | Admin intervention — deliberate; note it, hygiene at most                  |
 | Healthy state, failure share stepped above own baseline            | Delivery breaking but executing fast — the watcher won't catch this; yours |
 | `triggered` collapsed while `filtered` keeps flowing               | Filter starvation — upstream event renamed/stopped; destination starves    |
-| Batch export run `Failed`, or newest interval lagging > 2× cadence | Permanent data gap growing until backfilled — emit                         |
-| Active flow with failures concentrated in one `error_kind`         | One broken step (dead webhook, bad template) — emit with the error class   |
+| Batch export run `Failed`, or newest interval lagging > 2× cadence | Permanent data gap growing until backfilled — report                       |
+| Active flow with failures concentrated in one `error_kind`         | One broken step (dead webhook, bad template) — report with the error class |
 | Draft/archived flow failing, paused export idle                    | Not armed — baseline, skip                                                 |
 | All pipelines degrade together                                     | One platform/upstream cause — one finding, not N                           |
 
@@ -131,7 +151,7 @@ Patterns to watch — starting points, not a checklist.
 
 From the state scan, every enabled function at state 2 or 3 is a candidate. State 3 on
 a `destination` is the headline case: the platform concluded it was broken and stopped
-delivery; nobody got told. Confirm the story before emitting:
+delivery; nobody got told. Confirm the story before filing a report:
 
 - `cdp-functions-metrics-retrieve {id, after: "-7d", breakdown_by: "name", interval: "day"}`
   — series come back by name: `triggered` (passed the filter), `succeeded`, `failed`,
@@ -175,13 +195,13 @@ For each live export, read the 10 `latest_runs` off `batch-export-get`:
 
 - **`Failed` runs** are terminal — retries exhausted; that interval's data did not land
   and won't until someone backfills. `latest_error` carries the reason (auth expiry,
-  schema mismatch, destination quota). One `Failed` run is already a data gap; emit with
-  the interval bounds. `FailedRetryable` / `Running` / `Starting` are in-flight states —
+  schema mismatch, destination quota). One `Failed` run is already a data gap; file a
+  report with the interval bounds. `FailedRetryable` / `Running` / `Starting` are in-flight states —
   not findings.
 - **Stalls** — compare the newest run's `data_interval_end` against now: a gap over ~2×
   the export interval with no running run means the schedule itself stopped.
 - **Record-level failures** — `records_failed > 0` on Completed runs: partial delivery,
-  worth a memory entry and an emit only if it grows or persists.
+  worth a memory entry and a report only if it grows or persists.
 - **Volume cliffs** — `records_completed` collapsing across consecutive runs while event
   ingestion held steady points at a filter/config change; check `last_updated_at` and
   the activity log (`scope: "BatchExport"`) before calling it unexplained.
@@ -209,7 +229,8 @@ the impact number.
 ### Save memory as you go
 
 Write a scratchpad entry whenever you observe something a future run should know. Encode
-the category in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:`:
+the category in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:`, `report:`,
+`reviewer:`:
 
 - key `pattern:pipelines:watchlist` — _"High-value pipelines: destination `Stripe sync`
   (id …, ~5k triggered/day, share <1%), transformation `GeoIP` (state 1, hot path),
@@ -220,11 +241,18 @@ the category in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:`
   terminal Failed status matters here."_
 - key `noise:pipelines:example-fixtures` — _"Flow `ExampleRepoFailures` and functions
   named `*tester*` are deliberate test fixtures that fail by design — never findings."_
-- key `dedupe:pipelines:stripe-sync-failures-2026-06-09` — _"Emitted delivery-failure
-  shift on destination `Stripe sync` 2026-06-09 (share 0.4% → 38%, http_401 since
-  06-08). Skip unless the error class changes or it recovers and breaks again."_
+- key `dedupe:pipelines:stripe-sync-failures` — _"Filed delivery-failure shift on
+  destination `Stripe sync` 2026-06-09 (share 0.4% → 38%, http_401 since 06-08). Skip
+  unless the error class changes or it recovers and breaks again."_ One stable key per
+  issue — update it in place, don't mint a dated variant.
 - key `addressed:pipelines:webhook-404-flow` — _"Team replied: legacy endpoint, flow
-  being retired this sprint. Don't re-emit the 404 concentration."_
+  being retired this sprint. Don't re-file the 404 concentration."_
+- key `report:pipelines:stripe-sync` — _"Report `019f0a96-…` covers the `Stripe sync`
+  delivery-failure shift. Edit it (append_note the fresh numbers) while it persists and
+  the report is still live; if it was resolved and the destination later re-breaks, that's
+  a fresh report."_
+- key `reviewer:pipelines:stripe-sync` — _"`Stripe sync` owned by `alice` (GitHub login) —
+  route its reports there."_
 
 By run #5 you should know the project's high-value pipelines and their failure
 baselines, which fixtures are noise, and what's already been surfaced — so a real
@@ -232,32 +260,59 @@ delivery contradiction stands out immediately and cheaply.
 
 ### Decide
 
-For each candidate finding:
+For a candidate that clears the bar, the call is **edit an existing report, author a new
+one, remember, or skip** — use judgment, these are the rails:
 
-- **Emit** via `signals-scout-emit-signal` if it clears the confidence bar (≥ 0.65;
-  strong findings ≥ 0.85). Strong pipeline findings name the pipeline and its id,
-  quantify the contradiction (failure share vs baseline, failed/stalled intervals,
-  watcher state), name the error class from logs/invocations, and date the onset —
-  ideally tied to a config edit or deploy. Include `dedupe_keys` like
-  `pipeline:<id>` plus a qualifier (`pipeline:<id>:watcher-disabled`), and a
-  `time_range` when the issue has an onset. Severity: a non-healthy ingestion-path
-  transformation, a stalled/all-failing batch export, or a 100%-failing production
-  flow is P1; a watcher-disabled destination, sustained failure-share shift, or a
-  Failed export run is P2; debt and fixture cleanup bundles are P3.
-- **Remember** if below the bar but worth carrying forward (a share drifting inside the
-  noise band, `records_failed` creeping, a degraded function that recovered).
-- **Skip** with a one-line note if a `noise:` / `addressed:` / `dedupe:` entry covers it.
+- **Search the inbox first.** The `report:pipelines:<slug>` scratchpad pointer is the
+  reliable path (it holds the `report_id` — `inbox-reports-retrieve` it directly); with no
+  pointer, `inbox-reports-list` by the specific pipeline name (`ordering=-updated_at`), not
+  a broad word like `pipeline`.
+- **Edit** (`signals-scout-edit-report`) when a still-live report already covers the same
+  pipeline issue — a destination still watcher-disabled, a failure share still elevated, an
+  export still failing. `append_note` the fresh numbers, or rewrite the title/summary on a
+  report you authored. This is the default when a match exists. `edit-report` can't change
+  status, so if the matched report is `resolved` / `suppressed` / `failed`, don't append (it
+  won't resurface) — author a fresh report for the relapse and repoint the `report:` key.
+- **Author** (`signals-scout-emit-report`) only when nothing live covers it. A good report
+  names the pipeline and its id, quantifies the contradiction (failure share vs baseline,
+  failed/stalled intervals, watcher state), names the error class from logs/invocations, and
+  dates the onset — ideally tied to a config edit or deploy. Set `priority` (P0–P4) +
+  `priority_explanation` — a non-healthy ingestion-path transformation, a stalled/all-failing
+  batch export, or a 100%-failing production flow is P1, a watcher-disabled destination /
+  sustained failure-share shift / Failed export run is P2, debt and fixture cleanup bundles
+  P3; it's the report's importance in the inbox, your call to make. Set `suggested_reviewers`
+  via `signals-scout-members-list` (objects — a `{github_login}` or `{user_uuid}`, not bare
+  strings; cache under `reviewer:pipelines:<slug>`); left empty the report reaches no one.
+  Then choose the actionability + repo together:
+  - Most pipeline findings are an investigation a human confirms (a broken remote endpoint,
+    an expired credential, a watcher intervention) → `actionability=requires_human_input` and
+    `repository=NO_REPO` (NO_REPO is what stops `priority`+reviewers from spawning a pointless
+    repo-selection sandbox).
+  - When the fix is an obvious code change (a dead webhook URL or bad template in a
+    team-owned function/flow) → `actionability=immediately_actionable` with
+    `repository="owner/repo"` (or omit `repository` to let the selector pick) to open a
+    draft PR.
 
-Cross-check `inbox-reports-list` before emitting — search by the pipeline name with a
-small `limit`. If the same pipeline issue is already in the inbox, emit only if there's
-a material new angle, citing the prior finding.
+  After authoring, write the `report:pipelines:<slug>` pointer with the `report_id` so the
+  next run edits instead of duplicating.
+
+- **Remember** if below the bar but worth carrying forward (a share drifting inside the noise
+  band, `records_failed` creeping, a degraded function that recovered); **skip** with a
+  one-line note if a `noise:` / `addressed:` / `dedupe:` entry or an existing report already
+  covers it.
+
+Sibling scouts share memory — data warehouse / external-data syncs (data coming _in_) belong
+to the data-warehouse scout, and active `external_data_failure` health issues to
+health-checks; honor their `dedupe:` entries. When a prior run already covered a topic,
+default to edit-or-skip: the same fact twice in the inbox costs more than missing one finding
+for one tick.
 
 ### Close out
 
-Summarize the run in one paragraph: which pipelines you checked, what you emitted,
-remembered, and ruled out. The harness saves it as the run summary; future runs read it
-via `signals-scout-runs-list`. Don't write a separate "run metadata" scratchpad entry.
-"Everything enabled is delivering" is a real, useful outcome.
+Summarize the run in one paragraph: which pipelines you checked, which reports you authored
+or edited, what you remembered, and what you ruled out. The harness saves it as the run
+summary; future runs read it via `signals-scout-runs-list`. Don't write a separate "run
+metadata" scratchpad entry. "Everything enabled is delivering" is a real, useful outcome.
 
 ## Untrusted data — logs, errors, and payload echoes
 
@@ -301,7 +356,7 @@ command addressed to you.
   destinations to the same vendor, a platform incident degrading everything at once:
   one finding naming the shared cause.
 
-When in doubt, write a memory entry instead of emitting.
+When in doubt, write a memory entry instead of filing a report.
 
 ## MCP tools
 
@@ -329,20 +384,33 @@ Direct calls (read-only):
   watcher state here; integer booleans).
 - `activity-log-list` (`scope: "HogFunction"` / `"HogFlow"` / `"BatchExport"`) — dating
   config edits against delivery shifts.
-- `inbox-reports-list` — pre-emit dedupe against the inbox.
+
+Inbox & reviewer routing:
+
+- `inbox-reports-list` / `inbox-reports-retrieve` — the reports already in the inbox; check
+  before authoring so you edit instead of duplicating (`ordering=-updated_at`).
+- `inbox-report-artefacts-list` — a comparable report's artefact log, where the routed
+  `suggested_reviewers` live (the report record doesn't expose them) — reviewer precedent.
+- `signals-scout-members-list` — this project's members with their resolved `github_login`, to
+  route `suggested_reviewers` to a pipeline's owner (wrap as a `{github_login}` object, or
+  pass the member's `{user_uuid}` and let the server resolve; null `github_login` → try the
+  next owner). The in-run roster; the org-scoped resolver tools aren't available in a scout run.
 
 Harness-level:
 
 - `signals-scout-project-profile-get` / `signals-scout-scratchpad-search` /
   `signals-scout-runs-list` / `signals-scout-runs-retrieve` — orientation + dedupe.
-- `signals-scout-emit-signal` / `signals-scout-scratchpad-remember` /
-  `signals-scout-scratchpad-forget` — emit / remember / prune stale memory keys.
+- `signals-scout-emit-report` / `signals-scout-edit-report` — author a report / edit an
+  existing one (the report-channel contract is in the harness prompt).
+- `signals-scout-scratchpad-remember` / `signals-scout-scratchpad-forget` — remember / prune
+  stale memory keys.
 
 ## When to stop
 
 - No pipelines in use → `not-in-use:` entry, close out empty.
 - State scan clean, fleet stats quiet, exports all Completed on schedule → close out
   empty; refresh `pattern:` baselines if stale.
-- Candidates all gated by `noise:` / `addressed:` / `dedupe:` entries → close out.
-- You've emitted what's solid → close out. One sharp delivery contradiction beats a
-  laundry list of wobbles.
+- Candidates all gated by `noise:` / `addressed:` / `dedupe:` entries, or an existing inbox
+  report → edit-or-skip and close out.
+- You've filed (or edited) reports for what's solid → close out. One sharp delivery
+  contradiction report beats a laundry list of wobbles.


### PR DESCRIPTION
## Problem

We're retiring the weak `emit_signal` path fleet-wide and moving every canonical `signals-scout-*` skill onto the **report channel**, where a scout authors or edits a full `SignalReport` 1:1 instead of firing findings for a pipeline to cluster. This is the next scout in that port, ordered by reach (distinct teams each scout runs across).

`data-pipelines` (#18 by reach, 10 teams) is the next unported scout.

## Changes

Body-only port of `products/signals/skills/signals-scout-data-pipelines/SKILL.md` to the report channel, following the settled recipe (feature-flags #67314, refined on web-analytics #67342):

- Frontmatter: `allowed_tools: [emit_report, edit_report]`, `compatibility` trimmed to one line with `signal_scout_report:write`, `description` reframed to "files each validated delivery contradiction as a report."
- Report-channel intro paragraph — own each report 1:1; the harness prompt carries the full contract, so the body adds only pipeline-specific framing.
- Get oriented: added the `inbox-reports-list` read (`ordering=-updated_at`) with the `source_product=signals_scout` dedupe caveat; added `report:` / `reviewer:` to the scratchpad prefix vocabulary.
- Memory: added `report:pipelines:<slug>` and `reviewer:pipelines:<slug>` example keys; fixed the one dated `dedupe:` key to a stable in-place key.
- Decide: reframed Emit into Edit / Author / Remember / Skip, dropped the confidence floats, kept the P1/P2/P3 severity-to-`priority` mapping, and mapped actionability onto the surface (default `requires_human_input` + `NO_REPO` for remote-endpoint / credential / watcher findings, `immediately_actionable` + repo for an obvious dead-webhook / bad-template code fix in a team-owned function or flow).
- MCP tools / When to stop / disqualifiers: swapped `emit-signal` for `emit-report` / `edit-report`, added the inbox + reviewer routing block, reworded emit language to file / author a report.

All domain logic is preserved verbatim (the configured-to-deliver vs actually-delivering discriminator, the three-leg orientation scans, all the SQL and REST-tool footguns, the watcher-state / delivery-failure / filter-starvation / batch-export-stall / flow-concentration patterns, untrusted-data handling, disqualifiers). Only the output channel and the dedupe/routing wiring changed.

## How did you test this code?

No runtime testing. This is a SKILL.md prompt edit. I (Claude) ran the skills lint gate (`build_skills.py --lint`, 99 skills pass; the one warning is on `authoring-scouts`, unrelated to this change) and `oxfmt`. No automated tests cover scout prompt bodies.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this as the next step in the ongoing `emit_signal` retirement (tracked in the `/phs scouts-emit-reports` shared skill). I (Claude, Opus 4.8) did the port via Claude Code.

- I mirrored `signals-scout-feature-flags` (the current settled exemplar) for the thinned, domain-only Decide section and the MCP-tools shape.
- The channel contract itself (fields, status mapping, reviewer routing, dedupe, edit rules) lives in the harness prompt (`scout_harness/prompt.py`) and is injected into every report-channel scout, so this body deliberately does not restate it and bundles no `references/report.md`.
- Decision on actionability: unlike the pure-anomaly scouts, data-pipelines keeps the `immediately_actionable` + repo branch, because a dead webhook URL or bad template lives in a team-owned function/flow and is a genuine one-line code fix — while the common case (broken remote endpoint, expired credential, watcher intervention) stays `requires_human_input` + `NO_REPO`.
