### PR TITLE
chore(signals): document run-now in authoring-scouts test loop

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -166,29 +166,44 @@ config on the default every-24-hours schedule on its next tick (up to ~30 min). 
 
 ## Test loop
 
-You can't force a synchronous run as a user — scouts fire on their schedule. The standard
-loop is **emit + inspect**: ship the scout live, let it emit, and calibrate against what
-actually lands.
+You don't have to wait for the schedule — `posthog:signals-scout-run-now {"id": <config_id>}`
+dispatches one run of the scout immediately, regardless of its schedule (find the `id` via
+`-config-list`). This is the fastest way to test a scout right after authoring it, or to
+refresh its findings on demand. The run is **asynchronous**: the call returns a workflow id
+right away, so poll `-runs-list` / `-runs-retrieve` for the result. A few things to know:
 
-1. Ship the scout (the default `emit=true`) with a short `run_interval_minutes` so it fires
-   soon — set it at creation via
-   `posthog:signals-scout-config-create {"skill_name": ..., "run_interval_minutes": 30}`
-   right after `skill-create`, rather than waiting for the coordinator to
-   auto-register the default every-24-hours schedule.
-2. After a tick, read what it did: `posthog:inbox-reports-list` (the findings it actually
-   emitted), `posthog:signals-scout-runs-list` (run summaries), `-runs-retrieve` (full
+- A **disabled** scout can still be run this way — you can test it before ever enabling it.
+- A manual run does **not** change the scout's schedule or `last_run_at`.
+- It inherits every guard the scheduled path has: 403 if scouts aren't enabled for the
+  project, 429 if the project is over its Signals credits quota or daily run budget, 409 if a
+  run for this scout is already in progress.
+- It draws from the **same daily run budget** as scheduled runs — and a dry-run
+  (`emit=false`) still consumes a run. There's no free test run: every `-run-now` spends the
+  project's daily scout-run allowance, so firing the same scout repeatedly in a short window
+  burns through the budget (and can leave the project's scheduled scouts unable to run that
+  day). **Only trigger a run once you're genuinely ready for it** — get the body right first,
+  then spend a run to see what it does. Don't reflexively re-run after every tiny edit.
+
+The standard loop is **run + inspect**: fire the scout, let it emit, and calibrate against
+what actually lands.
+
+1. Author the scout and register its config (`-config-create`, the default `emit=true`), then
+   trigger a run with `-run-now` instead of waiting for the coordinator's next due tick. Leave
+   `run_interval_minutes` at a sustainable value — you no longer need a short interval to force
+   an early run.
+2. After the run finishes, read what it did: `posthog:inbox-reports-list` (the findings it
+   actually emitted), `posthog:signals-scout-runs-list` (run summaries), `-runs-retrieve` (full
    reasoning for one run), and `-scratchpad-search` (the durable memory it wrote).
 3. Refine the body — tighten the discriminator, add disqualifiers for whatever it
-   false-positived on, fix the emit calibration.
-4. Once it's landing the right findings, restore the interval to something sustainable
-   (the 3h default or longer).
+   false-positived on, fix the emit calibration. Batch your edits, then spend another
+   `-run-now` when you've got a meaningful change worth testing — not after every tweak.
 
 **Want to be extra careful?** Set `emit=false` to dry-run first — create the config with
-`emit=false` via `-config-create` so the scout never has a live first run; it runs and logs
-what it _would_ have emitted (visible via `-runs-list` / `-runs-retrieve`) without writing to
-the inbox. Inspect, refine, then flip `emit=true`. Worth it for a scout you expect to be
-chatty, expensive, or high-stakes; otherwise just emitting and watching the inbox is the
-faster path to a calibrated scout.
+`emit=false` via `-config-create`, then trigger it with `-run-now`: it runs and logs what it
+_would_ have emitted (visible via `-runs-list` / `-runs-retrieve`) without writing to the
+inbox. Inspect, refine, then flip `emit=true` and run it again. Worth it for a scout you
+expect to be chatty, expensive, or high-stakes; otherwise just emitting and watching the
+inbox is the faster path to a calibrated scout.
 
 Repo contributors get a faster loop — `hogli sync:skill` and the harness's local run path;
 see [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md).

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -166,11 +166,24 @@ config on the default every-24-hours schedule on its next tick (up to ~30 min). 
 
 ## Test loop
 
-You don't have to wait for the schedule — `posthog:signals-scout-run-now {"id": <config_id>}`
-dispatches one run of the scout immediately, regardless of its schedule (find the `id` via
-`-config-list`). This is the fastest way to test a scout right after authoring it, or to
-refresh its findings on demand. The run is **asynchronous**: the call returns a workflow id
-right away, so poll `-runs-list` / `-runs-retrieve` for the result. A few things to know:
+**Dogfood the scout yourself before you ever spend a real run.** You — the agent authoring
+the scout — have the same PostHog MCP tools a scout uses at runtime (`execute-sql`,
+`read-data-schema`, the per-product list tools, `signals-scout-project-profile-get`). The
+cheapest, fastest iteration doesn't touch a scout run at all: walk the scout's own logic
+against the live project by hand. Confirm the watched event/entity exists and has the shape
+you assumed, run the **discriminator** to check it actually separates signal from noise on
+_this_ project's data, and run each **explore pattern**'s queries to see what they surface.
+This loop is free and instant — refine the body against what you find, re-run the queries,
+repeat, until the scout's logic holds up on real data. This is where the real iteration
+happens.
+
+Only once you're happy with the body do you spend an actual run.
+`posthog:signals-scout-run-now {"id": <config_id>}` dispatches one run of the scout
+immediately, regardless of its schedule (find the `id` via `-config-list`). This is the
+**initial real run** — the scout executing end-to-end in the harness, writing scratchpad
+memory and (with the default `emit=true`) emitting to the inbox. The run is **asynchronous**:
+the call returns a workflow id right away, so poll `-runs-list` / `-runs-retrieve` for the
+result. A few things to know:
 
 - A **disabled** scout can still be run this way — you can test it before ever enabling it.
 - A manual run does **not** change the scout's schedule or `last_run_at`.
@@ -181,22 +194,23 @@ right away, so poll `-runs-list` / `-runs-retrieve` for the result. A few things
   (`emit=false`) still consumes a run. There's no free test run: every `-run-now` spends the
   project's daily scout-run allowance, so firing the same scout repeatedly in a short window
   burns through the budget (and can leave the project's scheduled scouts unable to run that
-  day). **Only trigger a run once you're genuinely ready for it** — get the body right first,
-  then spend a run to see what it does. Don't reflexively re-run after every tiny edit.
+  day). **Don't use `-run-now` as your iteration loop** — it's slow (async, one run per call)
+  and metered. Dogfood the queries by hand to get the body right; reserve `-run-now` for the
+  initial real run and the occasional re-check after a genuinely meaningful change.
 
-The standard loop is **run + inspect**: fire the scout, let it emit, and calibrate against
-what actually lands.
+The standard loop is **dogfood → run once ready → inspect**:
 
-1. Author the scout and register its config (`-config-create`, the default `emit=true`), then
-   trigger a run with `-run-now` instead of waiting for the coordinator's next due tick. Leave
-   `run_interval_minutes` at a sustainable value — you no longer need a short interval to force
-   an early run.
-2. After the run finishes, read what it did: `posthog:inbox-reports-list` (the findings it
+1. Dogfood the discriminator + explore patterns yourself against the live project (above).
+   Refine the body until the logic holds on real data — this is the cheap, iterable part.
+2. Author the scout and register its config (`-config-create`, the default `emit=true`), then
+   spend one `-run-now` to watch the whole scout execute end-to-end. Leave
+   `run_interval_minutes` at a sustainable value — you no longer need a short interval to
+   force an early run.
+3. After the run finishes, read what it did: `posthog:inbox-reports-list` (the findings it
    actually emitted), `posthog:signals-scout-runs-list` (run summaries), `-runs-retrieve` (full
    reasoning for one run), and `-scratchpad-search` (the durable memory it wrote).
-3. Refine the body — tighten the discriminator, add disqualifiers for whatever it
-   false-positived on, fix the emit calibration. Batch your edits, then spend another
-   `-run-now` when you've got a meaningful change worth testing — not after every tweak.
+4. If it needs work, go back to dogfooding the queries by hand for the iteration — only spend
+   another `-run-now` once you've batched a meaningful change worth a fresh end-to-end run.
 
 **Want to be extra careful?** Set `emit=false` to dry-run first — create the config with
 `emit=false` via `-config-create`, then trigger it with `-run-now`: it runs and logs what it

--- a/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
@@ -98,31 +98,40 @@ the standalone skills repo) automatically.
 
 ## Testing
 
-You don't have to wait for the schedule: `posthog:signals-scout-run-now {"id": <config_id>}`
-dispatches one run of the scout immediately, regardless of its schedule (get the `id` from
-`-config-list`). It's the fastest way to test a scout right after authoring it. The run is
-**asynchronous** — the call returns a workflow id right away; poll `-runs-list` /
-`-runs-retrieve` for the result. A disabled scout can still be run this way (test before
-enabling), and a manual run doesn't touch the schedule or `last_run_at`. It inherits the
-scheduled path's guards (403 not enabled, 429 over quota / daily run budget, 409 a run already
-in progress) and draws from the **same daily run budget** as scheduled runs — a dry-run
-(`emit=false`) counts too. There's no free test run: firing the same scout repeatedly in a
-short window burns the project's daily allowance (and can starve its scheduled scouts). **Only
-trigger a run once you're genuinely ready** — get the body right first, then spend a run;
-don't re-run after every tiny edit. The standard loop is **run + inspect**: fire the scout,
-let it emit, and calibrate against what actually lands.
+**Dogfood the scout yourself first — before spending any real run.** The authoring agent has
+the same PostHog MCP tools a scout uses at runtime (`execute-sql`, `read-data-schema`, the
+per-product list tools, `signals-scout-project-profile-get`), so the cheapest iteration is to
+walk the scout's own logic against the live project by hand: confirm the watched entity
+exists and has the assumed shape, run the **discriminator** to check it separates signal from
+noise on this project's data, and run each **explore pattern**'s queries. Free and instant —
+refine the body, re-run the queries, repeat, until the logic holds on real data.
 
-1. Author the scout and register its config (`-config-create`, default `emit=true`), leaving
-   `run_interval_minutes` at a sustainable value — no short-interval trick needed.
-2. Trigger a run with `posthog:signals-scout-run-now`, then inspect once it finishes:
+Only once you're happy do you spend a real run. `posthog:signals-scout-run-now {"id":
+<config_id>}` dispatches one run of the scout immediately, regardless of its schedule (get the
+`id` from `-config-list`) — the **initial real run**, the scout executing end-to-end in the
+harness. The run is **asynchronous** — the call returns a workflow id right away; poll
+`-runs-list` / `-runs-retrieve` for the result. A disabled scout can still be run this way
+(test before enabling), and a manual run doesn't touch the schedule or `last_run_at`. It
+inherits the scheduled path's guards (403 not enabled, 429 over quota / daily run budget, 409
+a run already in progress) and draws from the **same daily run budget** as scheduled runs — a
+dry-run (`emit=false`) counts too. There's no free test run, and it's slow (async, one run per
+call): firing the same scout repeatedly in a short window burns the project's daily allowance
+(and can starve its scheduled scouts). **Don't iterate via `-run-now`** — dogfood the queries
+by hand to get the body right, and reserve `-run-now` for the initial real run and the odd
+re-check after a genuinely meaningful change. The loop is **dogfood → run once ready →
+inspect**:
+
+1. Dogfood the discriminator + explore patterns yourself against the live project (above),
+   refining the body until the logic holds — the cheap, iterable part.
+2. Author the scout and register its config (`-config-create`, default `emit=true`), leaving
+   `run_interval_minutes` at a sustainable value — no short-interval trick needed. Then spend
+   one `-run-now` to watch the whole scout execute end-to-end, and inspect once it finishes:
    - `posthog:inbox-reports-list` — the findings it actually emitted.
    - `posthog:signals-scout-runs-list` — run summaries.
    - `posthog:signals-scout-runs-retrieve` — the full reasoning for one run.
    - `posthog:signals-scout-scratchpad-search` — the durable memory it wrote.
-3. Refine the body for whatever it false-positived or missed — tighten the discriminator,
-   add disqualifiers, fix emit calibration. Re-edit via `skill-update`, then batch your
-   changes and spend another `-run-now` only when you've got something meaningful to test —
-   not after every tweak.
+3. If it needs work, go back to dogfooding the queries by hand for the iteration, re-edit via
+   `skill-update`, and spend another `-run-now` only once you've batched a meaningful change.
 
 **Extra-careful variant — dry-run first.** For a scout you expect to be chatty, expensive,
 or high-stakes, set `emit=false` so it runs and logs what it _would_ have emitted (visible in

--- a/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
@@ -98,27 +98,37 @@ the standalone skills repo) automatically.
 
 ## Testing
 
-You can't trigger a synchronous run as a user — scouts fire on their schedule. The standard
-loop is **emit + inspect**: ship the scout live (`emit=true` is the default), let it emit,
-and calibrate against what actually lands.
+You don't have to wait for the schedule: `posthog:signals-scout-run-now {"id": <config_id>}`
+dispatches one run of the scout immediately, regardless of its schedule (get the `id` from
+`-config-list`). It's the fastest way to test a scout right after authoring it. The run is
+**asynchronous** — the call returns a workflow id right away; poll `-runs-list` /
+`-runs-retrieve` for the result. A disabled scout can still be run this way (test before
+enabling), and a manual run doesn't touch the schedule or `last_run_at`. It inherits the
+scheduled path's guards (403 not enabled, 429 over quota / daily run budget, 409 a run already
+in progress) and draws from the **same daily run budget** as scheduled runs — a dry-run
+(`emit=false`) counts too. There's no free test run: firing the same scout repeatedly in a
+short window burns the project's daily allowance (and can starve its scheduled scouts). **Only
+trigger a run once you're genuinely ready** — get the body right first, then spend a run;
+don't re-run after every tiny edit. The standard loop is **run + inspect**: fire the scout,
+let it emit, and calibrate against what actually lands.
 
-1. Ship with the default `emit=true` and a short `run_interval_minutes` (e.g. 30) so it
-   fires soon — set both at creation via `posthog:signals-scout-config-create`.
-2. After a tick, inspect:
+1. Author the scout and register its config (`-config-create`, default `emit=true`), leaving
+   `run_interval_minutes` at a sustainable value — no short-interval trick needed.
+2. Trigger a run with `posthog:signals-scout-run-now`, then inspect once it finishes:
    - `posthog:inbox-reports-list` — the findings it actually emitted.
    - `posthog:signals-scout-runs-list` — run summaries.
    - `posthog:signals-scout-runs-retrieve` — the full reasoning for one run.
    - `posthog:signals-scout-scratchpad-search` — the durable memory it wrote.
 3. Refine the body for whatever it false-positived or missed — tighten the discriminator,
-   add disqualifiers, fix emit calibration. Re-edit via `skill-update`.
-4. Once it's landing the right findings, `config-update` to restore a sustainable interval
-   (the 3h default or slower).
+   add disqualifiers, fix emit calibration. Re-edit via `skill-update`, then batch your
+   changes and spend another `-run-now` only when you've got something meaningful to test —
+   not after every tweak.
 
 **Extra-careful variant — dry-run first.** For a scout you expect to be chatty, expensive,
 or high-stakes, set `emit=false` so it runs and logs what it _would_ have emitted (visible in
-`-runs-list` / `-runs-retrieve`) without writing to the inbox. Inspect, refine, then
-`config-update` to `emit=true`. For most scouts, emitting straight away and watching the
-inbox is the faster calibration.
+`-runs-list` / `-runs-retrieve`) without writing to the inbox. Trigger it with `-run-now`,
+inspect, refine, then `config-update` to `emit=true`. For most scouts, emitting straight away
+and watching the inbox is the faster calibration.
 
 Repo contributors additionally get `hogli sync:skill` to run the scout against the local
 harness for a tighter loop before merging.


### PR DESCRIPTION
## Problem

The `authoring-scouts` Signals skill told users flat out that they "can't force a synchronous run as a user — scouts fire on their schedule," and its whole test loop was built around a workaround: create the config with a short `run_interval_minutes` (e.g. 30) so the coordinator picks the scout up sooner. That guidance is now stale. We ship a `signals-scout-run-now` MCP tool that dispatches an on-demand run of a scout regardless of its schedule.

But `run-now` shouldn't become the iteration loop. It's async and metered — every run (dry-run included) spends the project's daily scout-run allowance, and firing the same scout repeatedly in a short window burns the budget and can starve the project's scheduled scouts. It's also just slow to iterate against: one async run per call.

## Changes

Reframed the **Test loop** in `SKILL.md` and the **Testing** section in its bundled `references/lifecycle-and-testing.md` around a **dogfood → run once ready → inspect** flow:

- **Dogfood first.** The authoring agent has the same PostHog MCP tools a scout uses at runtime (`execute-sql`, `read-data-schema`, the per-product list tools, `signals-scout-project-profile-get`). The cheap, iterable loop is walking the scout's own logic against the live project by hand — confirm the watched entity exists and has the assumed shape, run the discriminator to check it separates signal from noise on real data, run each explore pattern's queries. Free and instant. This is where the real iteration happens.
- **Then run once ready.** Only once the body holds up do you spend a real run via `posthog:signals-scout-run-now {"id": <config_id>}` — the initial end-to-end run in the harness. It's async (returns a workflow id; poll `-runs-list` / `-runs-retrieve`), a disabled scout can still be run this way, and it doesn't touch the schedule or `last_run_at`.
- **Budget warning.** Explicit: no free test run (dry-runs count too), don't use `-run-now` as the iteration loop, reserve it for the initial run and the odd re-check after a genuinely meaningful change.
- Dropped the old short-`run_interval_minutes` trick — leave the interval sustainable and trigger a run when ready.

Tool name, scope, guards, and budget semantics were checked against `scout_harness/views.py` (the `run` action) and `products/signals/mcp/tools.yaml` (the `signals-scout-run-now` definition) rather than described from memory.

## How did you test this code?

Docs-only change to two markdown files in a skill. No code paths touched, so there's nothing to run beyond the repo's markdown formatter, which ran clean on commit via lint-staged. I did not run the scout harness or exercise the MCP tool.

## Docs update

Internal agent skill docs only — not posthog.com content.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Andy) noticed the `authoring-scouts` skill still said users couldn't force a run and asked Claude Code to fold the new `signals-scout-run-now` tool into it. Claude confirmed the tool exists and read its real semantics from `scout_harness/views.py` and `products/signals/mcp/tools.yaml` before editing.

The framing evolved across a couple of rounds. First pass just swapped the run-now tool into the test loop. I then flagged that manual runs eat the daily allowance and repeated short-window runs waste it, so we added a firm budget warning. Finally I pointed out the more important shift: the initial dogfooding shouldn't happen via `run-now` at all — you can't iterate easily that way and it's wasteful. The authoring agent should dogfood the scout's discriminator and explore queries locally with its own MCP tools first, and only trigger `run-now` for the initial real run once happy. The final version leads with that.

The dist copy under `products/posthog_ai/dist/skills/` is a gitignored build artifact, so it was left untouched — the source skill is the thing that matters.
