### PR TITLE
fix(logs): meter drop-rule rate limit on pro-rata header bytes

### DIFF
--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -330,7 +330,8 @@ export class LogsIngestionConsumer {
                 message.message.value!,
                 logsSettings,
                 ruleSet,
-                message.teamId
+                message.teamId,
+                message.bytesUncompressed
             )
             if (sampled.recordsDropped > 0) {
                 logsSamplingRecordsDroppedCounter.inc({ team_id: message.teamId.toString() }, sampled.recordsDropped)

--- a/nodejs/src/logs/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.test.ts
@@ -222,6 +222,53 @@ describe('LogsSamplingService', () => {
         expect(kept).toHaveLength(2)
     })
 
+    it('KB-mode meters each row against its pro-rata share of the batch header, not per-row bytes_uncompressed', async () => {
+        const ruleSet = compileRuleSet([
+            {
+                id: 'rl-kb',
+                rule_type: 'rate_limit',
+                scope_service: 'api',
+                scope_path_pattern: null,
+                scope_attribute_filters: [],
+                config: { kb_per_second: 1, burst_kb: 2 },
+            },
+        ])
+        // Per-row bytes_uncompressed is inflated (900 each) because shared batch data is
+        // re-counted on every row; content bytes (body only here) are 2/4/6 → total 12.
+        // Header = 24 → pro-rata scale 2 → per-row cost 4/8/12. Budget = 12:
+        // 4 (admit), 4+8=12 (admit), 12+12=24 > 12 (drop row c). Metering on the raw
+        // bytes_uncompressed sum (900 each) would have dropped every row.
+        const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', [
+            { ...baseLog('a', 'api', 900), body: 'aa' },
+            { ...baseLog('b', 'api', 900), body: 'bbbb' },
+            { ...baseLog('c', 'api', 900), body: 'cccccc' },
+        ])
+
+        const checkRateLimitV3 = jest.fn()
+        const mockRedis: RedisV2 = {
+            useClient: jest.fn(() => Promise.resolve(null)),
+            usePipeline: jest.fn((_opts, cb) => {
+                cb({ checkRateLimitV3 } as unknown as RedisClientPipeline)
+                const pipelineResult: [Error | null, any][] = [[null, [12, 0] as const]]
+                return Promise.resolve(pipelineResult)
+            }),
+        }
+
+        const service = new LogsSamplingService(mockRedis, 60)
+        const result = await service.processBuffer(buffer, logsSettings, ruleSet, 99, 24)
+
+        // The batch is metered at the header pro-rata total (= header bytes), not Σ bytes_uncompressed.
+        // Args are [key, now, cost, bucketSize, refillRate, ttl]; cost is index 2.
+        expect(checkRateLimitV3.mock.calls[0]![2]).toBe(24)
+        expect(result.recordsDropped).toBe(1)
+        expect(result.recordsDroppedByRuleId.get('rl-kb')).toBe(1)
+        // The dropped-bytes metric still reports the row's real bytes_uncompressed.
+        expect(result.bytesDropped).toBe(900)
+
+        const [, , kept] = await decodeLogRecords(result.value)
+        expect(kept).toHaveLength(2)
+    })
+
     it('fail-open keeps all rate_limit lines when Redis pipeline returns null', async () => {
         const ruleSet = compileRuleSet([
             {

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -113,7 +113,8 @@ export class LogsSamplingService {
         buffer: Buffer,
         settings: LogsSettings,
         ruleSet: CompiledRuleSet,
-        teamId?: number
+        teamId?: number,
+        headerBytesUncompressed: number = 0
     ): Promise<ProcessBufferWithSamplingResult> {
         const [logRecordType, compressionCodec, records] = await decodeLogRecords(buffer)
         if (!logRecordType) {
@@ -141,7 +142,14 @@ export class LogsSamplingService {
                     pendingByRule.set(c.ruleId, list)
                 }
             }
-            const rateKeep = await this.applyRateLimits(teamId, ruleSet, pendingByRule, records)
+            const rateKeep = await this.applyRateLimits(
+                teamId,
+                ruleSet,
+                pendingByRule,
+                records,
+                headerBytesUncompressed,
+                contentBytesTotal
+            )
 
             for (let i = 0; i < records.length; i++) {
                 const record = records[i]!
@@ -230,19 +238,31 @@ export class LogsSamplingService {
      * Maps a recordIndex -> keep (true) or drop (false) decision per rate_limit rule.
      * Each rule's pending lines share one Lua call; lines are admitted while their
      * accumulated cost stays within the pre-batch token budget. Cost is one token
-     * per record (`costUnit: 'records'`) or each record's `bytes_uncompressed`
-     * (`costUnit: 'bytes'`); rows missing the field contribute 0.
+     * per record (`costUnit: 'records'`) or, for `costUnit: 'bytes'`, each row's
+     * pro-rata share of the batch header `bytesUncompressed`
+     * (`headerBytesUncompressed × contentBytes(row) / contentBytesTotal`) — the same
+     * unit billing meters, so the limiter admits at the configured byte rate instead
+     * of over-counting the per-row `bytes_uncompressed` (which re-includes shared
+     * batch data on every row). Falls back to per-row `bytes_uncompressed` when the
+     * header is unavailable (older producers).
      */
     private async applyRateLimits(
         teamId: number,
         ruleSet: CompiledRuleSet,
         pendingByRule: RateLimitPendingByRule,
-        records: LogRecord[]
+        records: LogRecord[],
+        headerBytesUncompressed: number,
+        contentBytesTotal: number
     ): Promise<Map<number, boolean>> {
         const keepByIndex = new Map<number, boolean>()
         if (pendingByRule.size === 0) {
             return keepByIndex
         }
+
+        const proRataScale =
+            headerBytesUncompressed > 0 && contentBytesTotal > 0 ? headerBytesUncompressed / contentBytesTotal : 0
+        const byteCost = (idx: number): number =>
+            proRataScale > 0 ? contentBytes(records[idx]!) * proRataScale : recordBytes(records[idx]!)
 
         const ruleById = new Map(ruleSet.rules.map((r) => [r.id, r]))
         type Entry = { indices: number[]; costs: number[]; req: KeyedRateLimitRequest }
@@ -253,8 +273,7 @@ export class LogsSamplingService {
             if (!rl || indices.length === 0) {
                 continue
             }
-            const costs =
-                rl.costUnit === 'bytes' ? indices.map((idx) => recordBytes(records[idx]!)) : indices.map(() => 1)
+            const costs = rl.costUnit === 'bytes' ? indices.map(byteCost) : indices.map(() => 1)
             const totalCost = costs.reduce((a, b) => a + b, 0)
             entries.push({
                 indices,


### PR DESCRIPTION

## Problem

The logs drop-rule rate limiter (bytes mode, `kb_per_second` rules) was admitting less than the configured byte rate. A 10 MB/s rule let through ~500 MB/min instead of ~600.

The cause is a unit mismatch, not the refill logic. The limiter charged each row its own `bytes_uncompressed`, which re-includes shared batch and resource data on every row. Summed across a batch, that overcounts the batch's true size by a roughly fixed fraction, so the limiter thinks the batch costs more than it does and admits fewer rows. Billing, meanwhile, meters the batch at its header `bytesUncompressed` and pro-rates it down by the dropped content fraction (`billingByteReductionForDrops`). So the two sides were counting different bytes, and the ~17% gap between them showed up as under-admission.

## Changes

Meter bytes-mode rate limiting in the same unit billing uses. Each row's cost becomes its pro-rata share of the batch header:

```
headerBytesUncompressed × contentBytes(row) / contentBytesTotal
```

Summed over the batch this telescopes to the header size, so the limiter charges the batch at its real (billed) size and admission converges to the configured rate. This mirrors `billingByteReductionForDrops` exactly, so the limiter and billing now agree by construction.

`processBuffer` takes the header `bytesUncompressed` (the field billing already meters on) and threads it into `applyRateLimits`. When the header is unavailable (older producers that don't send it), it falls back to the previous per-row `bytes_uncompressed` behavior, so nothing regresses for them. The dropped-bytes observability metric still reports real per-row `bytes_uncompressed` - the cost unit and the reporting unit are deliberately decoupled.

Note for whoever owns drop-rule capacity: rules configured in `kb_per_second` will now admit the ~17% they were previously losing, since the meter shrank to the true batch size. That is the intended correction.

## How did you test this code?

I'm an agent (PostHog Code), human-driven by Frank. Automated only - no manual testing.

- Ran `nodejs/src/logs/sampling/logs-sampling.service.test.ts` (6 tests, all green).
- Ran `tsc --noEmit` on the nodejs package: no errors in the changed files (remaining errors are pre-existing missing-workspace-build issues unrelated to this change).
- Added one test case: `KB-mode meters each row against its pro-rata share of the batch header, not per-row bytes_uncompressed`. It sets per-row `bytes_uncompressed` to 900 (inflated) with content bytes 2/4/6 and a header of 24, so pro-rata costs are 4/8/12 against a budget of 12 and exactly one row drops. It asserts the batch is metered at 24 (the header total, not the 2700 raw sum) and that the dropped-bytes metric still reports 900. This fails on the pre-fix code (which sends 2700 and drops all three rows), so it guards the exact regression being fixed. No existing test passed the header argument - they all exercised the fallback path.

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and implemented with PostHog Code (Opus 4.8). Invoked the `/writing-tests` skill before adding the test to apply the value gate.

The investigation started from the observation that the earlier sub-second refill change caused many small partial batches instead of whole-batch admit/drop. Working through the token-bucket math showed the whole-second refill is actually rate-accurate in steady state (the burst reserve absorbs the once-per-second lump, the floor-drain keeps it conservative), so the reverted change was fixing granularity, not rate. That reframed the real question - why 500 instead of 600 - as a metering-unit problem rather than a refill-timing problem. Frank identified that billing accounts on the pro-rata'd batch header while the limiter charged per-row `bytes_uncompressed`, and that the per-row bytes exceed a row's true share because of shared batch data. The fix aligns the limiter to the billing unit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
