### PR TITLE
fix(experiments): thread user into live metric SQL generation

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -485,7 +485,12 @@ class ExperimentQueryRunner(QueryRunner):
             experiment_scan_date_from=self.date_range.date_from,
             experiment_scan_date_to=self.date_range.date_to,
         )
-        experiment_query_debug = get_experiment_query_debug(experiment_query_ast, self.team)
+        experiment_query_debug = get_experiment_query_debug(
+            experiment_query_ast,
+            self.team,
+            user=self.user,
+            bypass_warehouse_access_control=self.bypass_warehouse_access_control,
+        )
         self.hogql = experiment_query_debug[0]
         self.clickhouse_sql = experiment_query_debug[1]
 

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 import structlog
 
@@ -24,7 +24,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import HogQLQueryExecutor
 
 from posthog.clickhouse.client.escape import substitute_params_for_display
-from posthog.models import Team
+from posthog.models import Team, User
 
 from products.experiments.backend.hogql_queries import CONTROL_VARIANT_KEY
 from products.experiments.backend.hogql_queries.cuped_config import CupedQueryConfig, get_cuped_config
@@ -50,14 +50,24 @@ logger = structlog.get_logger(__name__)
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
 
 
-def get_experiment_query_debug(experiment_query_ast: ast.SelectQuery, team: Team) -> tuple[str, str]:
+def get_experiment_query_debug(
+    experiment_query_ast: ast.SelectQuery,
+    team: Team,
+    *,
+    user: Optional[User] = None,
+    bypass_warehouse_access_control: bool = False,
+) -> tuple[str, str]:
     """
     Generate both HogQL and ClickHouse SQL for debugging from experiment query AST.
     Returns (hogql, clickhouse_sql) tuple.
+
+    user/bypass must match the execution step, since resolving here also applies warehouse access control.
     """
     executor = HogQLQueryExecutor(
         query=experiment_query_ast,
         team=team,
+        user=user,
+        bypass_warehouse_access_control=bypass_warehouse_access_control,
         modifiers=create_default_modifiers_for_team(team),
     )
     clickhouse_sql_with_params, clickhouse_context_with_values = executor.generate_clickhouse_sql()


### PR DESCRIPTION
## Problem

Rolling out warehouse HogQL access control (#61686) to real orgs surfaced a burst of denials on live experiment results. Data-warehouse experiment metrics started failing on dashboard refresh with `You don't have access to table ...` (chained under a `ResolutionError: Unknown table`), hitting the metric owners themselves, not just users who actually lack access.

Error tracking :

- [Unknown table test_emails](https://us.posthog.com/project/2/error_tracking/019f1d9d-e4ae-7da2-8262-98367d36beb8)
- [Unknown table experiment_onboarding_mrr](https://us.posthog.com/project/2/error_tracking/019f1da4-c26a-7802-b40d-a6b0b8a73a62)
- [Unknown table customer](https://us.posthog.com/project/2/error_tracking/019f1da5-f659-7e90-b78a-f389aee131ef)

Root cause: `ExperimentQueryRunner._evaluate_experiment_query` resolves the metric query twice. `get_experiment_query_debug` generates the HogQL/ClickHouse SQL (building the HogQL database, which is where warehouse access control is applied), and `execute_hogql_query` then runs it. The execution call already forwards `user` and `bypass_warehouse_access_control`, but the generation call built a userless `HogQLQueryExecutor` with no bypass. Userless context fails closed and denies every warehouse table, so the generation step raised before execution was ever reached.

#66677 covered the other experiment surfaces (authoring-time enforcement, `bypass=True` for the Temporal recompute/recalc jobs, `user` threading in the Max summary service) but did not touch this live results path, so it stayed userless.

## Changes

Forward the runner's `user` and `bypass_warehouse_access_control` into `get_experiment_query_debug`, so the SQL-generation step uses the same principal as execution. This mirrors the existing `execute_hogql_query` call a few lines down. A real-time viewer is now enforced against their own warehouse access, and userless background recomputes bypass, instead of failing closed.

The generation and execution steps now resolve with identical access-control inputs, so they can no longer disagree.

## How did you test this code?

Existing tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
