### PR TITLE
chore(phai): test run-surface reconnect/error banner across layers

### DIFF
--- a/products/posthog_ai/frontend/components/RunAlertActivity.stories.tsx
+++ b/products/posthog_ai/frontend/components/RunAlertActivity.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { RunAlertActivity } from './RunAlertActivity'
+
+// Logic-free leaf — the one card for every run stream/connection alert, driven entirely by props (no kea
+// binding), so each story is just `args`. `reconnecting` renders a live Spinner and drives the thread footer;
+// the failed kinds render inline in the thread for genuine agent failures.
+const meta: Meta<typeof RunAlertActivity> = {
+    title: 'Products/PostHog AI/RunAlertActivity',
+    component: RunAlertActivity,
+    tags: ['autodocs'],
+    render: (args) => (
+        <div className="max-w-180 mx-auto p-4">
+            <RunAlertActivity {...args} />
+        </div>
+    ),
+}
+export default meta
+
+type Story = StoryObj<typeof RunAlertActivity>
+
+/** Terminal state after reconnect attempts are exhausted — title only, no detail to surface. */
+export const ConnectionLost: Story = {
+    args: { kind: 'connection_failed' },
+}
+
+/** Genuine agent failure — the detail message rides the always-visible region, not the collapsed body. */
+export const AgentError: Story = {
+    args: { kind: 'agent_error', message: 'The agent hit an unexpected error while running a tool.' },
+}
+
+/** The agent process died mid-run — same failed card, distinct title. */
+export const AgentCrash: Story = {
+    args: { kind: 'agent_crash', message: 'The agent stopped unexpectedly. Restart the run to continue.' },
+}
+
+/** Live reconnect banner with the attempt counter. */
+export const Reconnecting: Story = {
+    args: { kind: 'reconnecting', attempt: 2, maxAttempts: 10 },
+    // The reconnecting icon is an indefinitely-spinning Spinner the VR snapshot runner would wait forever to
+    // settle, so exclude this story from the snapshot run (same precedent as Composer's Loading story).
+    tags: ['test-skip'],
+}

--- a/products/posthog_ai/frontend/components/ThreadView.connection.test.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.connection.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+
+import { runStreamLogic } from '../logics/runStreamLogic'
+import type { StoredLogEntry } from '../types/wireTypes'
+import { ThreadView } from './ThreadView'
+
+// runStreamLogic.test.ts's frame builder isn't exported — copy the one-liner rather than import it.
+function notification(method: string, params: Record<string, unknown>): StoredLogEntry {
+    return { type: 'notification', notification: { method, params } }
+}
+
+describe('ThreadView connection state', () => {
+    let logic: ReturnType<typeof runStreamLogic.build>
+    const props = { streamKey: 'run-1', conversationId: 'run-1', replayOnly: false }
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = runStreamLogic(props)
+        logic.mount()
+        // virtualized={false} so react-window rows render in document flow under jsdom.
+        render(
+            <Provider>
+                <BindLogic logic={runStreamLogic} props={props}>
+                    <ThreadView virtualized={false} />
+                </BindLogic>
+            </Provider>
+        )
+    })
+
+    afterEach(() => {
+        cleanup()
+        logic?.unmount()
+    })
+
+    // Reconnecting projects runConnectionState → footer RunAlertActivity, and its showConnectionStatus gate
+    // must suppress the thinking indicator so a mid-run reconnect doesn't read as normal thinking.
+    it('renders the reconnecting banner and suppresses the thinking indicator', async () => {
+        logic.actions.sseReconnecting(2)
+
+        await waitFor(() => {
+            expect(screen.getByText('Reconnecting to agent')).toBeInTheDocument()
+        })
+        // maxAttempts flows from the selector (MAX_SSE_RECONNECT_ATTEMPTS = 10), not a hand-passed prop.
+        expect(screen.getByText('Attempt 2 of 10')).toBeInTheDocument()
+        // Reconnecting drives streamPhase to 'provisioning'; without the gate its "Setting up sandbox" line shows.
+        expect(screen.queryByText('Setting up sandbox')).toBeNull()
+    })
+
+    // A non-retryable stream error sets sseStatus='error', which the selector projects as connection_failed.
+    it('renders the connection-failed banner on a non-retryable stream error', async () => {
+        logic.actions.handleStreamError({ errorTitle: 'x', retryable: false })
+
+        await waitFor(() => {
+            expect(screen.getByText('Connection lost')).toBeInTheDocument()
+        })
+    })
+
+    // A folded _posthog/error frame renders inline through ThreadRow's RunAlertActivity swap (agent_error kind).
+    it('renders an inline agent-error card for a _posthog/error frame', async () => {
+        logic.actions.ingestAcpFrame(notification('_posthog/error', { message: 'boom' }), 'replay')
+
+        await waitFor(() => {
+            expect(screen.getByText('Agent error')).toBeInTheDocument()
+        })
+        expect(screen.getByText('boom')).toBeInTheDocument()
+    })
+
+    // A fresh, healthy mount must paint no connection banner.
+    it('shows no connection banner on a fresh mount', () => {
+        expect(screen.queryByText('Reconnecting to agent')).toBeNull()
+        expect(screen.queryByText('Connection lost')).toBeNull()
+    })
+})

--- a/products/posthog_ai/frontend/e2e/run-surface.spec.ts
+++ b/products/posthog_ai/frontend/e2e/run-surface.spec.ts
@@ -1,0 +1,226 @@
+// End-to-end coverage for the three run-surface connection states that only a real browser can prove:
+// a terminal run's inline error card, the live reconnecting banner on a stream drop, and the terminal
+// "Connection lost" card when the run history keeps failing. The whole tasks/runs API is mocked with
+// `page.route` so each state is deterministic; everything else (login, project, feature flags) rides the
+// real workspace harness, mirroring the surveys e2e precedent.
+
+import { mockFeatureFlags } from '@playwright-utils/mockApi'
+import { PlaywrightWorkspaceSetupResult, expect, test } from '@playwright-utils/workspace-test-base'
+import { Page, Route } from '@playwright/test'
+
+// Flag keys mirror `FEATURE_FLAGS.TASKS` / `FEATURE_FLAGS.TASKS_STREAM_VIA_PROXY` (frontend/src/lib/constants).
+// Inlined as literals rather than imported: pulling `lib/constants` into a Node-run Playwright spec drags its
+// heavy `types.ts` value-import graph into the test bundle. These keys are stable feature-flag wire strings.
+const TASKS_FLAG = 'tasks'
+const TASKS_STREAM_VIA_PROXY_FLAG = 'tasks-stream-via-proxy'
+
+// Fixed UUIDs so the `?runId=` deep link clears `taskDetailSceneLogic`'s `isUUIDLike` guard deterministically.
+const TASK_ID = '0190a000-0000-4000-8000-0000000000a1'
+const RUN_ID = '0190a000-0000-4000-8000-0000000000b2'
+
+interface AcpFrame {
+    type: 'notification'
+    timestamp?: string
+    notification: Record<string, unknown>
+}
+
+interface StreamMock {
+    // 'body' delivers the frames then EOFs (a clean-EOF live drop); 'hang' never responds so the SSE open
+    // stalls short of `sseOpened` — used when a different signal (terminal status, exhausted history) should
+    // drive the surface state without the reconnect loop flapping.
+    mode: 'body' | 'hang'
+    body?: string
+}
+
+interface TasksApiMock {
+    runStatus: string
+    logs: { status: number; body: string }
+    stream: StreamMock
+}
+
+function agentMessageFrame(messageId: string, text: string): AcpFrame {
+    return {
+        type: 'notification',
+        notification: {
+            method: 'session/update',
+            params: { update: { sessionUpdate: 'agent_message', messageId, content: { type: 'text', text } } },
+        },
+    }
+}
+
+// A persisted `_posthog/error` frame — the synthetic backend/agent error the run log carries; `foldLogToThread`
+// folds it into an inline error card titled "Agent error".
+function posthogErrorFrame(message: string): AcpFrame {
+    return { type: 'notification', notification: { method: '_posthog/error', params: { message } } }
+}
+
+// The `logs/` endpoint replays JSONL — one `StoredLogEntry` per line.
+function toJsonl(frames: AcpFrame[]): string {
+    return frames.map((frame) => JSON.stringify(frame)).join('\n')
+}
+
+// The `stream/` endpoint is `text/event-stream` — one `data:` event per frame. No terminal `task_run_state`
+// or `stream-end` sentinel, so once the atomic body is read the reader hits a clean EOF (a drop).
+function toSse(frames: AcpFrame[]): string {
+    return frames.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join('')
+}
+
+function makeRun(status: string): Record<string, unknown> {
+    return {
+        id: RUN_ID,
+        task: TASK_ID,
+        stage: null,
+        branch: null,
+        status,
+        environment: 'cloud',
+        log_url: null,
+        error_message: null,
+        output: null,
+        state: {},
+        artifacts: [],
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-01T00:00:00Z',
+        completed_at: status === 'in_progress' ? null : '2026-07-01T00:01:00Z',
+    }
+}
+
+function makeTask(status: string): Record<string, unknown> {
+    return {
+        id: TASK_ID,
+        task_number: 1,
+        slug: 'run-surface-e2e',
+        title: 'Run surface e2e task',
+        description: '',
+        origin_product: 'user_created',
+        repository: null,
+        github_integration: null,
+        json_schema: null,
+        internal: false,
+        latest_run: makeRun(status),
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-01T00:00:00Z',
+        created_by: { id: 1, uuid: 'user-1', distinct_id: 'user-1', first_name: 'Test', email: 'test@posthog.com' },
+    }
+}
+
+function fulfillJson(body: unknown): (route: Route) => Promise<void> {
+    return (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
+}
+
+async function routeTasksApi(page: Page, mock: TasksApiMock): Promise<void> {
+    const run = makeRun(mock.runStatus)
+    // Each pattern is `$`-anchored on the pathname so it matches exactly one endpoint despite the shared
+    // `/runs/:id/` prefix (mutually exclusive, so Playwright's route ordering doesn't matter).
+    const taskRe = new RegExp(`/tasks/${TASK_ID}/$`)
+    const runsRe = new RegExp(`/tasks/${TASK_ID}/runs/$`)
+    const runRe = new RegExp(`/tasks/${TASK_ID}/runs/${RUN_ID}/$`)
+    const tokenRe = new RegExp(`/runs/${RUN_ID}/stream_token/$`)
+    const logsRe = new RegExp(`/runs/${RUN_ID}/logs/$`)
+    const streamRe = new RegExp(`/runs/${RUN_ID}/stream/$`)
+
+    await page.route((url) => taskRe.test(url.pathname), fulfillJson(makeTask(mock.runStatus)))
+    await page.route(
+        (url) => runsRe.test(url.pathname),
+        fulfillJson({ results: [run], count: 1, next: null, previous: null })
+    )
+    await page.route((url) => runRe.test(url.pathname), fulfillJson(run))
+    // No `stream_base_url` ⇒ `resolveStreamTarget` returns null ⇒ streaming stays on the mockable Django
+    // `stream/` route even when the proxy gate (flag or preflight `is_debug`) is on.
+    await page.route((url) => tokenRe.test(url.pathname), fulfillJson({ token: 'e2e-token', stream_base_url: null }))
+    await page.route(
+        (url) => logsRe.test(url.pathname),
+        (route) => route.fulfill({ status: mock.logs.status, contentType: 'application/jsonl', body: mock.logs.body })
+    )
+
+    if (mock.stream.mode === 'hang') {
+        // Leave the request pending forever; the bootstrap aborts it once the history retries exhaust.
+        await page.route(
+            (url) => streamRe.test(url.pathname),
+            () => new Promise<void>(() => {})
+        )
+    } else {
+        const body = mock.stream.body ?? ''
+        await page.route(
+            (url) => streamRe.test(url.pathname),
+            (route) => route.fulfill({ status: 200, contentType: 'text/event-stream', body })
+        )
+    }
+}
+
+async function openRunDeepLink(page: Page, teamId: string): Promise<void> {
+    await page.goto(`/project/${teamId}/tasks/${TASK_ID}?runId=${RUN_ID}`)
+    // The fresh workspace has no tasks flag; force posthog-js to re-fetch so the mocked flag lands and the
+    // scene's `FEATURE_FLAGS.TASKS` gate opens.
+    await page.evaluate(() => {
+        const ph = (window as unknown as { posthog?: { reloadFeatureFlags?: () => void } }).posthog
+        ph?.reloadFeatureFlags?.()
+    })
+}
+
+test.describe('Task run surface', () => {
+    let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+    test.beforeAll(async ({ playwrightSetup }) => {
+        workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+    })
+
+    test.beforeEach(async ({ page, playwrightSetup }) => {
+        await playwrightSetup.login(page, workspace!)
+        await mockFeatureFlags(page, { [TASKS_FLAG]: true, [TASKS_STREAM_VIA_PROXY_FLAG]: false })
+    })
+
+    test('terminal replay surfaces the agent error inline', async ({ page }) => {
+        // Regression: a terminal run's persisted `_posthog/error` frame must fold into the inline "Agent error"
+        // card on replay — not be dropped, and not depend on a live SSE (a terminal run never opens one).
+        await routeTasksApi(page, {
+            runStatus: 'completed',
+            logs: {
+                status: 200,
+                body: toJsonl([
+                    agentMessageFrame('m1', 'Doing the thing'),
+                    posthogErrorFrame('The agent hit an unexpected error'),
+                ]),
+            },
+            stream: { mode: 'hang' },
+        })
+
+        await openRunDeepLink(page, workspace!.team_id)
+
+        await expect(page.getByText('Agent error')).toBeVisible({ timeout: 20000 })
+    })
+
+    test('live stream drop shows the reconnecting banner', async ({ page }) => {
+        // Regression: a clean-EOF drop on an in-progress run must surface the reconnecting banner (the backoff
+        // loop) rather than silently stalling or reading as ordinary thinking.
+        await routeTasksApi(page, {
+            runStatus: 'in_progress',
+            logs: { status: 200, body: toJsonl([agentMessageFrame('m1', 'Working on it')]) },
+            stream: {
+                mode: 'body',
+                body: toSse([agentMessageFrame('s1', 'Streaming'), agentMessageFrame('s2', 'Still streaming')]),
+            },
+        })
+
+        await openRunDeepLink(page, workspace!.team_id)
+
+        // Assert only the first reconnecting window — `reconnectAttempt` resets to 0 on each reopen so the banner
+        // cycles; a single visibility check on the title keeps it deterministic.
+        await expect(page.getByText('Reconnecting to agent')).toBeVisible({ timeout: 20000 })
+    })
+
+    test('exhausted run history shows connection lost', async ({ page }) => {
+        // Regression: exhausting the history-fetch retries on an in-progress run must tear the SSE down and
+        // surface the terminal "Connection lost" card — not spin forever or render a live-only, historyless thread.
+        await routeTasksApi(page, {
+            runStatus: 'in_progress',
+            logs: { status: 500, body: '' },
+            // Stall the SSE open so only the exhausted history drives the terminal state (no reconnect flapping).
+            stream: { mode: 'hang' },
+        })
+
+        await openRunDeepLink(page, workspace!.team_id)
+
+        // The history retries back off ~2s + ~4s before giving up, so allow generous headroom.
+        await expect(page.getByText('Connection lost')).toBeVisible({ timeout: 30000 })
+    })
+})


### PR DESCRIPTION
> Claude-written:

## Problem

The reconnect/error rework on the PostHog AI run surface added a UI-wiring layer — a footer reconnect banner and an inline error card, driven by a `runConnectionState` selector — that no existing test exercised. The logic tests assert state-machine values, not rendered DOM. The `RunAlertActivity` component test drives plain props, not the selector wiring. And `RunSurfaceImpl.test.tsx` mocks `useValues` shallowly, so it never binds the real logic.

The gap is the wiring itself: does `sseStatus` / `reconnectAttempt` → `runConnectionState` → the `ThreadView` footer actually render the banner, does it suppress the thinking indicator, and does a folded `_posthog/error` frame render the inline card? There was also no visual coverage and no browser proof.

## Changes

Three test layers, each placed at the cheapest level that catches its regression (nothing that the logic tests already cover was promoted up).

| File | Layer | Catches |
| --- | --- | --- |
| `components/ThreadView.connection.test.tsx` | Component-integration (RTL + real `runStreamLogic`) | Reconnecting banner + "Attempt N of M" render in the footer and the thinking indicator is suppressed; the connection-lost banner renders; a folded `_posthog/error` frame renders the inline agent-error card; a fresh mount shows no false banner |
| `components/RunAlertActivity.stories.tsx` | Storybook (visual regression) | Appearance of each alert kind: `ConnectionLost`, `AgentError`, `AgentCrash`, `Reconnecting` |
| `e2e/run-surface.spec.ts` | Playwright e2e | Cross-stack proof that the real app routes to the surface, the real API client issues the stream/log requests, and the banner / inline card render |

The component test mounts the real logic and drives states purely through actions (`sseReconnecting`, `handleStreamError`, `ingestAcpFrame`) with no network, so it stays deterministic. `ThreadView` is rendered with `virtualized={false}` so react-window rows land in document flow under jsdom. The `Reconnecting` story is tagged `test-skip` because its `<Spinner>` matches the visual-regression runner's loader selectors and would otherwise hang the snapshot.

**Dependency:** these tests exercise the reconnect/error wiring that currently lives on the `feat(phai): open task thread optimistically on send` branch (#67099), not master. This PR is based on master so its diff is clean (just the three test files), which means **its own CI stays red until it is rebased onto that wiring (or the wiring merges to master).** That trade-off is intentional per the plan — keep the tests as a separate, reviewable change without touching #67099.

## How did you test this code?

- `ThreadView.connection.test.tsx` was run green with `hogli test` on the branch that carries the wiring (#67099): 4/4 pass. It cannot pass on master alone because the source it asserts against is not present there yet.
- The Playwright e2e (`run-surface.spec.ts`) was **not** executed. It needs the full local stack up. Run it with:
  ```
  BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test products/posthog_ai/frontend/e2e/run-surface.spec.ts --repeat-each 10 --workers 3
  ```
- The Storybook story was not built here; visual regression is captured by the VR service in CI once this is rebased onto the wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes. Test-only PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via a Claude Code multi-agent workflow) implemented this from an approved test plan. The workflow used sonnet agents to map the source wiring and per-layer exemplars, then opus agents to write each of the three files, followed by a synthesis pass. The value-bar from the repo's writing-tests guidance and the playwright-test discipline were applied as guidance while authoring.

Decisions worth noting for review:
- The tests match the real source identifiers over the plan's initial guesses. Two corrections the agents made against live source and a green run: the reconnect cap is 10 (so the assertion is the exact "Attempt 2 of 10"), and thinking-indicator absence is anchored on the deterministic literal "Setting up sandbox" rather than a DOM id (the component's `id` prop is only a React key, never emitted as an attribute, so an id-based check would have false-greened).
- The optional full-surface read-only Storybook story was skipped by design: the read-only replay API (endpoint URLs, TaskRun payload, JSONL frame shapes) could not be pinned down confidently, and guessing was not worth it. Worth a follow-up if we want SSE-free full-surface visual coverage.
