### PR TITLE
chore(rules): add semantic line breaks rule for markdown files

### DIFF
--- a/.claude/rules/semantic-line-breaks.md
+++ b/.claude/rules/semantic-line-breaks.md
@@ -4,6 +4,4 @@ paths:
   - '**/*.mdx'
 ---
 
-Use semantic line breaks when writing or editing Markdown.
-Start a new line at each sentence — and optionally at clause boundaries — instead of wrapping to a fixed column width.
-Never hard-wrap paragraphs to a set line length; one sentence per line keeps diffs small and reviewable.
+Prefer semantic line breaks in Markdown; do not hard-wrap.

--- a/.claude/rules/semantic-line-breaks.md
+++ b/.claude/rules/semantic-line-breaks.md
@@ -4,6 +4,6 @@ paths:
   - '**/*.mdx'
 ---
 
-When writing or editing Markdown here:
-
-- Markdown: prefer semantic line breaks; no hard wrapping
+Use semantic line breaks when writing or editing Markdown.
+Start a new line at each sentence — and optionally at clause boundaries — instead of wrapping to a fixed column width.
+Never hard-wrap paragraphs to a set line length; one sentence per line keeps diffs small and reviewable.

--- a/.claude/rules/semantic-line-breaks.md
+++ b/.claude/rules/semantic-line-breaks.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - '**/*.md'
+  - '**/*.mdx'
+---
+
+When writing or editing Markdown here:
+
+- Markdown: prefer semantic line breaks; no hard wrapping


### PR DESCRIPTION
## Problem

Establish a consistent style guide for markdown formatting across the repository by documenting the preference for semantic line breaks rather than hard-wrapping.

## Changes

Added `.claude/rules/semantic-line-breaks.md` to define a linting rule that applies to all markdown and MDX files. The rule specifies that semantic line breaks should be preferred over hard-wrapping, helping maintain consistency in how markdown content is formatted.

## How did you test this code?

No testing needed. This is a configuration file that documents a style preference for use by Claude and other tools that read the rules directory.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

https://claude.ai/code/session_01HVkJeLuBoBTHVJyqQfDr68