### PR TITLE
fix(tasks): protect cloud resume snapshot state

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1200,6 +1200,8 @@ def _sync_automation_schedule(automation: TaskAutomation) -> None:
 #     provision an oversized or long-lived sandbox beyond what they're entitled to.
 #   - use_modal_directory_resume_snapshots is the server-side directory snapshot rollout decision;
 #     a caller could otherwise force directory snapshot creation while the feature flag is off.
+#   - snapshot_external_id / snapshot_kind / snapshot_mount_path control which Modal image is
+#     restored on resume and where directory snapshots are mounted.
 # These keys are reserved for server-owned run state, never PATCH input.
 _PROTECTED_RUN_STATE_KEYS = frozenset(
     {
@@ -1212,6 +1214,9 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "inactivity_timeout_seconds",
         "wizard_config",
         "use_modal_directory_resume_snapshots",
+        "snapshot_external_id",
+        "snapshot_kind",
+        "snapshot_mount_path",
     }
 )
 

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -37,6 +37,11 @@ class TestRunStateSnapshotPaths(TestCase):
                 {"snapshot_kind": SNAPSHOT_KIND_DIRECTORY, "snapshot_mount_path": DEFAULT_SANDBOX_WORKING_DIR},
                 DEFAULT_SANDBOX_WORKING_DIR,
             ),
+            (
+                "unsupported_directory_snapshot_path",
+                {"snapshot_kind": SNAPSHOT_KIND_DIRECTORY, "snapshot_mount_path": "/tmp/agent-env"},
+                DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+            ),
             ("filesystem_snapshot", {"snapshot_kind": "filesystem"}, None),
         ]
     )

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -17,6 +17,7 @@ from posthog.temporal.oauth import TOKEN_EXPIRATION_SECONDS, PosthogMcpScopes, h
 from products.mcp_store.backend.facade.api import get_active_installations
 from products.tasks.backend.constants import (
     DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+    DEFAULT_SANDBOX_WORKING_DIR,
     SNAPSHOT_KIND_DIRECTORY,
     SNAPSHOT_KIND_FILESYSTEM,
     InitialPermissionMode,
@@ -31,6 +32,13 @@ if TYPE_CHECKING:
     from products.tasks.backend.models import SandboxSnapshot, Task
 
 logger = logging.getLogger(__name__)
+
+_ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS = frozenset(
+    {
+        DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+        DEFAULT_SANDBOX_WORKING_DIR,
+    }
+)
 
 
 class PrAuthorshipMode(StrEnum):
@@ -211,6 +219,19 @@ def get_reasoning_effort_error(
     )
 
 
+def normalize_directory_resume_snapshot_mount_path(snapshot_mount_path: object) -> str:
+    if not snapshot_mount_path:
+        return DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+    if isinstance(snapshot_mount_path, str) and snapshot_mount_path in _ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS:
+        return snapshot_mount_path
+
+    logger.warning(
+        "Ignoring unsupported directory resume snapshot mount path",
+        extra={"snapshot_mount_path": snapshot_mount_path},
+    )
+    return DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+
+
 class RunState(BaseModel, extra="allow"):
     pr_authorship_mode: PrAuthorshipMode | None = None
     github_credential_source: GitHubCredentialSource | None = None
@@ -247,7 +268,7 @@ class RunState(BaseModel, extra="allow"):
     def resume_snapshot_mount_path(self) -> str | None:
         if self.resume_snapshot_kind() != SNAPSHOT_KIND_DIRECTORY:
             return None
-        return self.snapshot_mount_path or DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+        return normalize_directory_resume_snapshot_mount_path(self.snapshot_mount_path)
 
 
 def parse_run_state(state: dict[str, Any] | None) -> RunState:
@@ -266,8 +287,9 @@ def get_sandbox_snapshot_metadata(snapshot: SandboxSnapshot) -> SnapshotMetadata
         if snapshot.metadata.get("snapshot_kind") == SNAPSHOT_KIND_DIRECTORY
         else SNAPSHOT_KIND_FILESYSTEM
     )
-    metadata_mount_path = snapshot.metadata.get("snapshot_mount_path")
-    mount_path = metadata_mount_path if isinstance(metadata_mount_path, str) and metadata_mount_path else None
+    mount_path = None
+    if kind == SNAPSHOT_KIND_DIRECTORY:
+        mount_path = normalize_directory_resume_snapshot_mount_path(snapshot.metadata.get("snapshot_mount_path"))
     return SnapshotMetadata(kind=kind, mount_path=mount_path)
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3343,14 +3343,17 @@ class TestTaskRunAPI(BaseTaskAPITest):
                 "sandbox_ttl_seconds": 1800,
                 "inactivity_timeout_seconds": 600,
                 "use_modal_directory_resume_snapshots": True,
+                "snapshot_external_id": "im-real",
+                "snapshot_kind": "directory",
+                "snapshot_mount_path": "/tmp",
             },
         )
 
         # A caller cannot escalate to the creator's integration, flip authorship, repoint the
         # credential-propagation target at a sandbox they control, inflate the run's compute /
         # lifetime to provision an oversized, long-lived sandbox, or turn the run into a wizard run
-        # (which would mint a write-scoped wizard token into the sandbox), or change rollout
-        # decisions. Non-protected keys still merge.
+        # (which would mint a write-scoped wizard token into the sandbox), change rollout
+        # decisions, or change Modal resume snapshot metadata. Non-protected keys still merge.
         response = self.client.patch(
             f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/",
             {
@@ -3364,6 +3367,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "inactivity_timeout_seconds": 86400,
                     "wizard_config": {},
                     "use_modal_directory_resume_snapshots": False,
+                    "snapshot_external_id": "im-attacker",
+                    "snapshot_kind": "directory",
+                    "snapshot_mount_path": "/tmp/workspace",
                     "scratch": "ok",
                 }
             },
@@ -3380,6 +3386,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["inactivity_timeout_seconds"] == 600
         assert "wizard_config" not in run.state  # caller cannot mark a run as a wizard run
         assert run.state["use_modal_directory_resume_snapshots"] is True
+        assert run.state["snapshot_external_id"] == "im-real"
+        assert run.state["snapshot_kind"] == "directory"
+        assert run.state["snapshot_mount_path"] == "/tmp"
         assert run.state["scratch"] == "ok"  # non-protected keys still merge
 
         # Nor can a caller remove a protected key to force a fallback or unguarded path.
@@ -3391,6 +3400,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "github_credential_source",
                     "sandbox_id",
                     "use_modal_directory_resume_snapshots",
+                    "snapshot_external_id",
+                    "snapshot_kind",
+                    "snapshot_mount_path",
                     "scratch",
                 ],
             },
@@ -3401,6 +3413,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["github_credential_source"] == "caller_token"  # protected key survives removal
         assert run.state["sandbox_id"] == "sb-real"  # protected key survives removal
         assert run.state["use_modal_directory_resume_snapshots"] is True  # protected key survives removal
+        assert run.state["snapshot_external_id"] == "im-real"  # protected key survives removal
+        assert run.state["snapshot_kind"] == "directory"  # protected key survives removal
+        assert run.state["snapshot_mount_path"] == "/tmp"  # protected key survives removal
         assert "scratch" not in run.state  # non-protected key removed
 
     @patch("products.tasks.backend.facade.api.signal_workflow_completion")


### PR DESCRIPTION
## Problem

Cloud task resume snapshots store restore metadata in task run state. After directory snapshots were added, `snapshot_external_id`, `snapshot_kind`, and `snapshot_mount_path` became security-sensitive because they decide which Modal image is restored and where directory snapshots are mounted.

The PATCH endpoint already filters several server-owned run-state keys, but these snapshot keys were not included. That meant a caller with access to a visible run could mutate restore metadata before a later resume.

## Changes

This PR makes snapshot restore metadata server-owned for PATCH updates:

- Protects `snapshot_external_id`, `snapshot_kind`, and `snapshot_mount_path` from PATCH mutation and removal.
- Normalizes directory snapshot mount paths to the supported server paths before provisioning resumes.
- Extends existing tests for protected run-state PATCH behavior and snapshot mount-path resolution.