### PR TITLE
feat(cdp): fail closed when minting email tracking codes without a key

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/tracking-code.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/tracking-code.test.ts
@@ -1,6 +1,6 @@
 import { defaultConfig } from '~/common/config/config'
 
-import { EmailTrackingCodeSigner, trackingCodeMintCounter } from './tracking-code'
+import { EmailTrackingCodeSigner, hasEmailSigningKey, trackingCodeMintCounter } from './tracking-code'
 
 const TRACKING_URL = 'http://localhost:8010'
 
@@ -275,11 +275,11 @@ describe('email tracking code', () => {
             expect(spacedSigner.parse(code)?.format).toBe('signed')
         })
 
-        it('emits unsigned codes when no signing key is configured', () => {
+        it('fails closed instead of minting an unsigned code when no signing key is configured', () => {
             const unsignedSigner = new EmailTrackingCodeSigner('', TRACKING_URL)
-            const code = unsignedSigner.generate({ functionId: 'fn', id: 'inv', teamId: 1 })
-            expect(code).not.toContain('.')
-            expect(unsignedSigner.parse(code)?.format).toBe('unsigned')
+            expect(() => unsignedSigner.generate({ functionId: 'fn', id: 'inv', teamId: 1 })).toThrow(
+                /no signing key configured/
+            )
         })
     })
 
@@ -289,15 +289,36 @@ describe('email tracking code', () => {
             return metric.values.find((v) => v.labels.format === format)?.value ?? 0
         }
 
-        // The keyless branch is silent without this counter; it is the proof that fail-closed (#62624)
-        // is safe to enable, so guard that generate() labels each minted code correctly.
+        it('counts a signed mint when a key is configured', async () => {
+            const before = await mintCount('signed')
+            new EmailTrackingCodeSigner(defaultConfig.ENCRYPTION_SALT_KEYS, TRACKING_URL).generate({
+                functionId: 'fn',
+                id: 'inv',
+                teamId: 1,
+            })
+            expect(await mintCount('signed')).toBe(before + 1)
+        })
+
+        // Fail-closed still records the attempt before throwing, so a bypassed boot guard stays attributable.
+        it('records an unsigned mint before failing closed when no key is configured', async () => {
+            const before = await mintCount('unsigned')
+            expect(() =>
+                new EmailTrackingCodeSigner('', TRACKING_URL).generate({ functionId: 'fn', id: 'inv', teamId: 1 })
+            ).toThrow()
+            expect(await mintCount('unsigned')).toBe(before + 1)
+        })
+    })
+
+    describe('hasEmailSigningKey', () => {
+        // Guards the boot-time check: a whitespace/comma-only value must read as "no key" so a keyless
+        // email deployment refuses to start, while a real (possibly space-padded) key reads as present.
         it.each([
-            { name: 'signed when a key is configured', keys: defaultConfig.ENCRYPTION_SALT_KEYS, format: 'signed' },
-            { name: 'unsigned when no key is configured', keys: '', format: 'unsigned' },
-        ])('counts a mint as $name', async ({ keys, format }) => {
-            const before = await mintCount(format)
-            new EmailTrackingCodeSigner(keys, TRACKING_URL).generate({ functionId: 'fn', id: 'inv', teamId: 1 })
-            expect(await mintCount(format)).toBe(before + 1)
+            { name: 'a configured key', keys: 'a-signing-key-000000000000000000', expected: true },
+            { name: 'a space-padded key in a rotation list', keys: 'first-key-0000, second-key-0000', expected: true },
+            { name: 'an empty string', keys: '', expected: false },
+            { name: 'whitespace and commas only', keys: '  , ', expected: false },
+        ])('is $expected for $name', ({ keys, expected }) => {
+            expect(hasEmailSigningKey(keys)).toBe(expected)
         })
     })
 })

--- a/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
@@ -20,10 +20,10 @@ export const trackingCodeFormatCounter = new Counter({
 
 // Mint-time signal: counts every code generate() produces, labelled by whether a signing key was
 // available. Unlike the parse-time counter above (which only sees codes that come back via the SES
-// webhook or click endpoints), this fires on the send path itself, so a sustained `unsigned` rate
-// pinpoints an email-sending deployment running without ENCRYPTION_SALT_KEYS. Watching this reach
-// zero is the prerequisite for making generate() fail closed (#62624). Note it counts per generate()
-// call (header + pixel + each redirect link), not per email, so it is a rate signal, not an email count.
+// webhook or click endpoints), this fires on the send path itself. Now that generate() fails closed,
+// an `unsigned` sample means a keyless deployment attempted a mint right before the send was refused —
+// a config alarm, not a benign tail. Note it counts per generate() call (header + pixel + each redirect
+// link), not per email, so it is a rate signal, not an email count.
 export const trackingCodeMintCounter = new Counter({
     name: 'email_tracking_code_mint_total',
     help: 'Count of email tracking codes minted by signature format (signed when a key is configured)',
@@ -55,6 +55,21 @@ export type TrackingInvocation = Pick<CyclotronJobInvocationHogFunction, 'functi
 
 export type TrackingCodeFormat = 'signed' | 'unsigned'
 
+// Parses the comma-separated ENCRYPTION_SALT_KEYS into the usable key list. Shared by the signer
+// and the boot-time guard so "is a signing key configured?" has a single definition.
+function parseSigningKeys(encryptionSaltKeys: string): string[] {
+    return (encryptionSaltKeys || '')
+        .split(',')
+        .map((key) => key.trim())
+        .filter(Boolean)
+}
+
+// Whether at least one email tracking-code signing key is configured. The boot-time guard uses this
+// to refuse to start an email-sending deployment that would otherwise mint unsigned tracking links.
+export function hasEmailSigningKey(encryptionSaltKeys: string): boolean {
+    return parseSigningKeys(encryptionSaltKeys).length > 0
+}
+
 export type ParsedTrackingCode = {
     functionId: string
     invocationId: string
@@ -77,10 +92,7 @@ export class EmailTrackingCodeSigner {
         encryptionSaltKeys: string,
         private trackingUrl: string
     ) {
-        this.signingKeys = (encryptionSaltKeys || '')
-            .split(',')
-            .map((key) => key.trim())
-            .filter(Boolean)
+        this.signingKeys = parseSigningKeys(encryptionSaltKeys)
     }
 
     private signPayload(payload: string, key: string): string {
@@ -166,11 +178,14 @@ export class EmailTrackingCodeSigner {
             `${invocation.functionId}:${invocation.id}:${invocation.teamId}:${actionId}:${parentRunId}:${isTest ? '1' : ''}:${distinctId}`
         )
         if (this.signingKeys.length === 0) {
-            // Fail open while signing rolls out so sends never break; tighten to throw once enforced (#62624).
-            // The mint counter makes this branch observable so we can confirm it is never hit in prod
-            // before flipping to fail-closed.
+            // Fail closed (#62624): a deployment with no signing key must never mint unsigned tracking
+            // links. Email-sending deployments are guarded at boot (see hasEmailSigningKey), so this is
+            // unreachable in prod; the counter still records the attempt before we refuse, keeping the
+            // failure attributable if the guard is ever bypassed.
             trackingCodeMintCounter.inc({ format: 'unsigned' })
-            return payload
+            throw new Error(
+                'Cannot mint email tracking code: no signing key configured (ENCRYPTION_SALT_KEYS is empty)'
+            )
         }
         trackingCodeMintCounter.inc({ format: 'signed' })
         return `${payload}.${this.signPayload(payload, this.signingKeys[0])}`

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -47,6 +47,7 @@ import { CyclotronJobQueueKafka } from './cdp/services/job-queue/job-queue-kafka
 import { CyclotronJobQueuePostgres } from './cdp/services/job-queue/job-queue-postgres'
 import { CyclotronJobQueuePostgresV2 } from './cdp/services/job-queue/job-queue-postgres-v2'
 import { CyclotronJobQueueRateLimitedPostgresV2 } from './cdp/services/job-queue/job-queue-rate-limited-postgres-v2'
+import { hasEmailSigningKey } from './cdp/services/messaging/helpers/tracking-code'
 import { createSesRateLimiterValkeyPool } from './cdp/services/rate-limiter/rate-limiter-valkey-pool'
 import { RateLimiterService } from './cdp/services/rate-limiter/rate-limiter.service'
 import { EncryptedFields } from './cdp/utils/encryption-utils'
@@ -292,6 +293,17 @@ export class PluginServer implements NodeServer {
                 await worker.start()
                 return worker.service
             })
+        }
+
+        // Boot-time guard: an email-sending deployment must carry a signing key, otherwise every send
+        // would either mint an unsigned tracking link or (now that generate() fails closed) fail. Refuse
+        // to start instead of degrading silently. Both email workers below sign tracking codes.
+        const isEmailWorker = capabilities.cdpCyclotronWorkerEmail || capabilities.cdpCyclotronWorkerEmailLegacyPg
+        if (isEmailWorker && !hasEmailSigningKey(this.config.ENCRYPTION_SALT_KEYS)) {
+            throw new Error(
+                'Email worker requires ENCRYPTION_SALT_KEYS to sign tracking codes — refusing to start. ' +
+                    'Configure ENCRYPTION_SALT_KEYS so outbound emails never mint unsigned tracking links.'
+            )
         }
 
         // Transitional drain for email jobs stranded on the legacy V1 queue — the email worker


### PR DESCRIPTION
## Problem

Email tracking codes are HMAC-signed so the public tracking endpoints can reject forged `ph_id` values. But `EmailTrackingCodeSigner.generate()` failed open: with no signing key configured it returned an unsigned code instead of failing. That branch was silent, so we couldn't prove no prod deployment was quietly minting unsigned links.

The mint counter shipped in the previous PR (`email_tracking_code_mint_total`) closed that blind spot. Since it went out it has reported zero unsigned mints across prod-us and prod-eu - the `unsigned` series has never even materialized, across a full week of production traffic and through every deploy in that cycle. Every email-sending deployment already carries `ENCRYPTION_SALT_KEYS`, so nothing legitimately depends on the fail-open path.

## Changes

- `generate()` now **fails closed**: with no signing key it throws instead of returning an unsigned code. It still increments the mint counter with `format="unsigned"` before throwing, so if the guard is ever bypassed the failure stays attributable.
- **Boot-time guard** in `server.ts`: an email worker (`cdp_cyclotron_worker_email` and its legacy-pg drain variant) refuses to start without `ENCRYPTION_SALT_KEYS`, with a precise message.
- Extracted key parsing into `hasEmailSigningKey` so the guard and the signer share one definition of "is a signing key configured".

This is forward-only. It runs at send time, never at click time, so it cannot break tracking links already sitting in inboxes. Rejecting unsigned links at the click endpoints is a separate, later step and is **not** part of this PR.

## Why this is safe

Three independent reasons the fail-closed throw is unreachable in any deployment that sends email today:

1. **Prod evidence.** Zero unsigned mints across both regions since the counter shipped, across a full week of production traffic and every deploy in that cycle. The `unsigned` series has never materialized; the fail-open branch has not executed once.
2. **Structural.** A keyless email deployment already cannot start today, before this PR. `EmailService`'s constructor builds a `RecipientTokensService`, which builds a `JWT`, whose constructor throws `Encryption keys are not set` on an empty `ENCRYPTION_SALT_KEYS` (locked by an existing test). So there is no live keyless email path for the new throw to newly break - the boot guard just makes that pre-existing hard requirement explicit and early, with a clear message instead of a generic one surfaced deep in the JWT layer.
3. **Dev/test.** Both default `ENCRYPTION_SALT_KEYS` to a fixed local key, so local maildev sending and the Jest suite keep signing.

Charts cross-check: both email deployments inherit the key from `shared/cdp/common.yaml` (`secret_env`) across dev, prod-us, and prod-eu.

## How did you test this code?

Automated tests only. I (Claude) could not run the nodejs Jest suite in this environment (the Node 24 toolchain and workspace deps were not available), so CI runs them. The Node.js Tests check is green on this PR.

Unit tests in `tracking-code.test.ts`:
- `generate()` with no key throws instead of emitting an unsigned code - catches a revert of the fail-closed flip back to fail-open.
- the fail-closed path still increments the `unsigned` mint counter before throwing - catches losing attribution on that path.
- `hasEmailSigningKey` parameterized over configured / space-padded-rotation / empty / whitespace-and-commas-only - catches the boot guard misreading a whitespace-only value as a real key (would boot a keyless email deployment) or a real key as absent (would refuse a valid one). Tested as a pure function rather than booting the server.

The boot guard wiring itself is not unit-tested - exercising it means standing up the server, and the meaningful logic is the pure `hasEmailSigningKey`, which is tested directly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel drove this as the second step of a plan to enforce signed-only email tracking links. Step one (a mint-time counter, merged separately) was the safety gate: watch for zero unsigned mints in prod before flipping. That held across both regions for a full week and every deploy in that cycle, so this PR does the flip.

Built with Claude Code (Opus). Invoked the `/writing-tests` skill before touching tests to apply the value gate - that pushed the tests toward pure-function coverage (`hasEmailSigningKey`) and folding the keyless cases together rather than adding a server-boot test.

Design decisions:
- Chose a boot-time guard scoped to the email worker capabilities over throwing in the `EmailTrackingCodeSigner` constructor. The signer is constructed on several CDP deployments (api, hog-transformer) where a constructor throw would be too broad, and `generate()` is only ever called on the send path, so the throw there is correctly scoped.
- Boot-guard scope is intentional: it covers only the dedicated email workers. `cdp-api` can also mint (the editor's "Run test" / `sendEmailsInline` path sends inline), but it structurally can't be keyless - it builds `EmailService` → `RecipientTokensService`/`JWT`, which throws on an empty key (see "Why this is safe" #2). So cdp-api is covered by runtime fail-closed rather than the boot guard, by design - we don't want to fail cdp-api's whole boot over the email signing key.
- While verifying safety I found the stronger structural fact in the "Why this is safe" section: keyless email already can't boot via the RecipientTokensService/JWT chain. That downgraded the perceived risk of the flip from "might break keyless senders" to "no keyless email path exists to break". The guard stays as defense-in-depth and for a clearer error.
- Kept the `unsigned` counter increment before the throw so a bypassed guard still leaves a metric trail.
- Left the SES webhook and the click/redirect endpoints untouched. The unsigned tail on the webhook is SNS-authenticated and benign, and legacy in-flight links must keep resolving on click.
