### PR TITLE
perf(error-tracking): defer suppression/assignment rule serialization

### DIFF
--- a/rust/cymbal/src/modes/processing/rules/assignment.rs
+++ b/rust/cymbal/src/modes/processing/rules/assignment.rs
@@ -221,6 +221,22 @@ pub async fn try_assignment_rules(
     exception_properties: &OutputErrProps,
 ) -> Result<Option<NewAssignment>, UnhandledError> {
     let timing = common_metrics::timing_guard(ASSIGNMENT_RULES_PROCESSING_TIME, &[]);
+
+    let mut rules = team_manager
+        .get_assignment_rules(&mut *con, issue.team_id)
+        .await?;
+
+    metrics::counter!(ASSIGNMENT_RULES_FOUND).increment(rules.len() as u64);
+
+    // Most teams have no assignment rules; skip serializing the issue and the
+    // (expensive) event properties unless a rule might actually match.
+    if rules.is_empty() {
+        timing.label("outcome", "no_match").fin();
+        return Ok(None);
+    }
+
+    rules.sort_unstable_by_key(|r| r.order_key);
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct IssueJson {
         status: String,
@@ -235,14 +251,6 @@ pub async fn try_assignment_rules(
     })?;
 
     let props_json = serde_json::to_value(exception_properties)?;
-
-    let mut rules = team_manager
-        .get_assignment_rules(&mut *con, issue.team_id)
-        .await?;
-
-    metrics::counter!(ASSIGNMENT_RULES_FOUND).increment(rules.len() as u64);
-
-    rules.sort_unstable_by_key(|r| r.order_key);
 
     for rule in rules {
         match rule.try_match(&issue_json, &props_json) {

--- a/rust/cymbal/src/modes/processing/stages/linking/rule_suppression.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/rule_suppression.rs
@@ -25,11 +25,6 @@ impl ValueOperator for RuleSuppression {
     }
 
     async fn execute_value(&self, input: Self::Item, ctx: LinkingStage) -> OperatorResult<Self> {
-        let props_json = match serde_json::to_value(&input) {
-            Ok(v) => v,
-            Err(_) => return Ok(Ok(input)),
-        };
-
         let mut rules = ctx
             .app_context
             .team_manager
@@ -41,6 +36,12 @@ impl ValueOperator for RuleSuppression {
         }
 
         rules.sort_unstable_by_key(|r| r.order_key);
+
+        // Only serialize the event once we know the team has suppression rules.
+        let props_json = match serde_json::to_value(&input) {
+            Ok(v) => v,
+            Err(_) => return Ok(Ok(input)),
+        };
 
         for rule in rules {
             match rule.should_suppress(&props_json, &input.uuid) {


### PR DESCRIPTION
## Problem

Cymbal evaluates three kinds of custom error-tracking rules per event — grouping, suppression, and assignment. Each serializes the event (and, for assignment, the issue) to a `serde_json::Value` so the rule's HogVM bytecode can match against it. Most teams have no such rules, so that serialization is wasted work on the `POST /process` hot path.

[#67218](https://github.com/PostHog/posthog/pull/67218) fixed this for grouping rules. This applies the same idea to the two sibling rule types.

## Changes

- **Suppression** (`stages/linking/rule_suppression.rs`): the `if rules.is_empty()` early return already existed, but `serde_json::to_value(&input)` ran *above* it. Moved the serialization below the empty check.
- **Assignment** (`rules/assignment.rs::try_assignment_rules`): had no empty-rules short-circuit and serialized both the issue and the (expensive) exception properties before fetching rules. Added an `is_empty()` early return (recording the same `no_match` timing outcome as the existing no-match path) and moved both serializations after it.

Scope note: I intentionally did **not** apply the "pass the pool instead of a checked-out connection" part of #67218 here.
- Suppression already passes the pool (`get_suppression_rules` / `disable`), so there's nothing to change.
- Assignment's `&mut PgConnection` is held by the caller (`process_assignment` ← issue resolution) for genuine issue-linking DB work — loading/creating/reopening the issue and applying a matched assignment right after — sometimes inside a transaction. It's not idle-on-cache-hit like grouping's was, so it should stay on the shared connection; switching to per-query pool acquires would add connection pressure and risk moving the rule-disable write out of the caller's transaction scope.

All three rule lookups are cache-backed, so the early return is cheap and the change is behavior-preserving.

## How did you test this code?

I'm an agent (Claude Code). Automated checks in a worktree:

- `cargo clippy -p cymbal --all-targets` — clean
- `cargo fmt -p cymbal` — applied

No new tests: both changes are behavior-preserving reorderings guarded by the existing empty-rules paths, and are covered by the existing suppression/assignment rule tests (which need Postgres and run in CI, not in this environment).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Origin: follow-up to the cymbal CPU-profiling pass (Grafana Pyroscope) that produced #67216–#67218. The question was whether the grouping optimization should extend to the sibling rule types; this is the result of tracing both paths.
- Tooling: Claude Code (Opus); autoreview (Codex, read-only) on the diff before opening.
- Key decision: apply the serialization-deferral to both rule types, but keep the connection-management change grouping-only — see the scope note above.
- Rust-only change in the `cymbal` crate.
