### PR TITLE
fix(alerts): handle empty funnel query results in alert evaluation

### DIFF
--- a/products/alerts/backend/evaluation/funnel_strategies.py
+++ b/products/alerts/backend/evaluation/funnel_strategies.py
@@ -81,8 +81,7 @@ class HistoricalTrendsFunnelStrategy(FunnelVizStrategy):
 
     def to_series(self, result: Any, config: FunnelsAlertConfig) -> list[ComparableSeries]:
         series_dicts = _require_list(_current_period_only(result), "trends")
-        # An empty list means no users entered the funnel in the window — benign "no data this
-        # interval", not a misconfiguration — represent it so the comparator skips it.
+        # Empty = no one entered the funnel: benign, not a misconfig.
         if not series_dicts:
             return _no_data_series()
         # By default evaluate the last *complete* period — the latest one is still in progress, so
@@ -147,24 +146,14 @@ def _current_period_only(result: Any) -> Any:
 
 
 def _no_data_series() -> list[ComparableSeries]:
-    """The benign "no data this interval" result for an empty funnel query.
-
-    An empty funnel result means no users entered the funnel in the window — a benign transient
-    state, not a misconfiguration. Represented as a single missing point so the comparator skips it
-    (NOT_FIRING, no error), rather than raising and surfacing a benign empty funnel to error tracking
-    as if it were a crash.
-    """
+    # A missing anchor value the comparator skips (NOT_FIRING, no error), so a benign empty funnel
+    # isn't reported to error tracking as a crash.
     return [ComparableSeries(label="conversion", points=[SeriesPoint(date=None, value=None)], current_index=0)]
 
 
 def _require_list(result: Any, viz_label: str) -> list[Any]:
-    """Normalize a funnel query result to a list, or fail loud on an unexpected shape.
-
-    A genuinely unexpected shape (e.g. None from a swallowed query error) is a hard failure, not
-    "no data" — raise ``AlertExtractionError`` so the alert auto-disables rather than silently
-    reporting no data. An empty list passes through and the caller renders it as a benign no-data
-    series.
-    """
+    # A non-list (e.g. None from a swallowed query error) is a real failure, not "no data" — raise so
+    # the alert auto-disables. An empty list is left for the caller to treat as benign no-data.
     if not isinstance(result, list):
         raise AlertExtractionError(
             f"Funnel {viz_label} alert query returned an unexpected result shape ({type(result).__name__})."
@@ -173,10 +162,7 @@ def _require_list(result: Any, viz_label: str) -> list[Any]:
 
 
 def _steps_per_breakdown(result: list[Any]) -> list[list[dict[str, Any]]]:
-    """Normalize a non-empty steps funnel result into a list of step-lists (one per breakdown value).
-
-    A non-breakdown funnel returns ``list[step]``; a breakdown funnel returns ``list[list[step]]``.
-    """
+    # The runner returns ``list[step]`` without a breakdown and ``list[list[step]]`` with one; unify.
     if isinstance(result[0], list):
         return cast(list[list[dict[str, Any]]], result)
     return [cast(list[dict[str, Any]], result)]

--- a/products/alerts/backend/evaluation/funnel_strategies.py
+++ b/products/alerts/backend/evaluation/funnel_strategies.py
@@ -58,6 +58,8 @@ class StepsFunnelStrategy(FunnelVizStrategy):
         # A steps funnel is a single snapshot: the condition is always absolute (enforced upstream) and
         # check_ongoing_interval has no meaning (there are no periods), so neither is read here.
         breakdowns = _steps_per_breakdown(_current_period_only(result))
+        if not breakdowns:
+            return _no_data_series()
         return [
             ComparableSeries(
                 label=_label_for_breakdown(steps[0].get("breakdown_value") if steps else None),
@@ -78,7 +80,15 @@ class HistoricalTrendsFunnelStrategy(FunnelVizStrategy):
     supports_relative_conditions = True
 
     def to_series(self, result: Any, config: FunnelsAlertConfig) -> list[ComparableSeries]:
-        series_dicts = _require_series_list(_current_period_only(result), "trends")
+        series_dicts = _current_period_only(result)
+        # An empty result (no users entered the funnel in the window) is benign "no data this
+        # interval", not a misconfiguration — represent it so the comparator skips it.
+        if not series_dicts:
+            return _no_data_series()
+        if not isinstance(series_dicts, list):
+            raise AlertExtractionError(
+                f"Funnel trends alert query returned an unexpected result shape ({type(series_dicts).__name__})."
+            )
         # By default evaluate the last *complete* period — the latest one is still in progress, so
         # anchoring there would read a partial rate (and, for relative, diff a partial against a complete
         # one). check_ongoing_interval opts into that in-progress period. The anchor is the same for
@@ -140,21 +150,33 @@ def _current_period_only(result: Any) -> Any:
     return [row for row in result if _is_current_period_row(row)]
 
 
-def _require_series_list(result: Any, viz_label: str) -> list[Any]:
-    if not result or not isinstance(result, list):
-        raise AlertExtractionError(f"Funnel {viz_label} alert query returned no data.")
-    return result
+def _no_data_series() -> list[ComparableSeries]:
+    """The benign "no data this interval" result for an empty funnel query.
+
+    An empty funnel result means no users entered the funnel in the window — a benign transient
+    state, not a misconfiguration. Represented as a single missing point so the comparator skips it
+    (NOT_FIRING, no error), rather than raising and surfacing a benign empty funnel to error tracking
+    as if it were a crash.
+    """
+    return [ComparableSeries(label="conversion", points=[SeriesPoint(date=None, value=None)], current_index=0)]
 
 
 def _steps_per_breakdown(result: Any) -> list[list[dict[str, Any]]]:
     """Normalize a steps funnel result into a list of step-lists (one per breakdown value).
 
     A non-breakdown funnel returns ``list[step]``; a breakdown funnel returns ``list[list[step]]``.
+    An empty result (no users in the window) returns ``[]`` — the caller renders it as a benign
+    no-data series rather than an error.
     """
-    series = _require_series_list(result, "steps")
-    if isinstance(series[0], list):
-        return cast(list[list[dict[str, Any]]], series)
-    return [cast(list[dict[str, Any]], series)]
+    if not result:
+        return []
+    if not isinstance(result, list):
+        raise AlertExtractionError(
+            f"Funnel steps alert query returned an unexpected result shape ({type(result).__name__})."
+        )
+    if isinstance(result[0], list):
+        return cast(list[list[dict[str, Any]]], result)
+    return [cast(list[dict[str, Any]], result)]
 
 
 def _label_for_breakdown(breakdown: Any) -> str:

--- a/products/alerts/backend/evaluation/funnel_strategies.py
+++ b/products/alerts/backend/evaluation/funnel_strategies.py
@@ -57,8 +57,8 @@ class StepsFunnelStrategy(FunnelVizStrategy):
     def to_series(self, result: Any, config: FunnelsAlertConfig) -> list[ComparableSeries]:
         # A steps funnel is a single snapshot: the condition is always absolute (enforced upstream) and
         # check_ongoing_interval has no meaning (there are no periods), so neither is read here.
-        breakdowns = _steps_per_breakdown(_current_period_only(result))
-        if not breakdowns:
+        rows = _require_list(_current_period_only(result), "steps")
+        if not rows:
             return _no_data_series()
         return [
             ComparableSeries(
@@ -66,7 +66,7 @@ class StepsFunnelStrategy(FunnelVizStrategy):
                 points=[SeriesPoint(date=None, value=_conversion_rate(steps, config))],
                 current_index=0,
             )
-            for steps in breakdowns
+            for steps in _steps_per_breakdown(rows)
         ]
 
 
@@ -80,15 +80,11 @@ class HistoricalTrendsFunnelStrategy(FunnelVizStrategy):
     supports_relative_conditions = True
 
     def to_series(self, result: Any, config: FunnelsAlertConfig) -> list[ComparableSeries]:
-        series_dicts = _current_period_only(result)
-        # An empty result (no users entered the funnel in the window) is benign "no data this
+        series_dicts = _require_list(_current_period_only(result), "trends")
+        # An empty list means no users entered the funnel in the window — benign "no data this
         # interval", not a misconfiguration — represent it so the comparator skips it.
         if not series_dicts:
             return _no_data_series()
-        if not isinstance(series_dicts, list):
-            raise AlertExtractionError(
-                f"Funnel trends alert query returned an unexpected result shape ({type(series_dicts).__name__})."
-            )
         # By default evaluate the last *complete* period — the latest one is still in progress, so
         # anchoring there would read a partial rate (and, for relative, diff a partial against a complete
         # one). check_ongoing_interval opts into that in-progress period. The anchor is the same for
@@ -161,19 +157,26 @@ def _no_data_series() -> list[ComparableSeries]:
     return [ComparableSeries(label="conversion", points=[SeriesPoint(date=None, value=None)], current_index=0)]
 
 
-def _steps_per_breakdown(result: Any) -> list[list[dict[str, Any]]]:
-    """Normalize a steps funnel result into a list of step-lists (one per breakdown value).
+def _require_list(result: Any, viz_label: str) -> list[Any]:
+    """Normalize a funnel query result to a list, or fail loud on an unexpected shape.
 
-    A non-breakdown funnel returns ``list[step]``; a breakdown funnel returns ``list[list[step]]``.
-    An empty result (no users in the window) returns ``[]`` — the caller renders it as a benign
-    no-data series rather than an error.
+    A genuinely unexpected shape (e.g. None from a swallowed query error) is a hard failure, not
+    "no data" — raise ``AlertExtractionError`` so the alert auto-disables rather than silently
+    reporting no data. An empty list passes through and the caller renders it as a benign no-data
+    series.
     """
-    if not result:
-        return []
     if not isinstance(result, list):
         raise AlertExtractionError(
-            f"Funnel steps alert query returned an unexpected result shape ({type(result).__name__})."
+            f"Funnel {viz_label} alert query returned an unexpected result shape ({type(result).__name__})."
         )
+    return result
+
+
+def _steps_per_breakdown(result: list[Any]) -> list[list[dict[str, Any]]]:
+    """Normalize a non-empty steps funnel result into a list of step-lists (one per breakdown value).
+
+    A non-breakdown funnel returns ``list[step]``; a breakdown funnel returns ``list[list[step]]``.
+    """
     if isinstance(result[0], list):
         return cast(list[list[dict[str, Any]]], result)
     return [cast(list[dict[str, Any]], result)]

--- a/products/alerts/backend/evaluation/test/test_funnels_extractor.py
+++ b/products/alerts/backend/evaluation/test/test_funnels_extractor.py
@@ -84,7 +84,6 @@ def test_result_is_unframed_single_series():
         ),
         (_steps(100, 40), None, None, AlertConditionType.RELATIVE_INCREASE, "absolute value conditions"),
         (_steps(100, 40), None, None, AlertConditionType.RELATIVE_DECREASE, "absolute value conditions"),
-        ([], None, None, AlertConditionType.ABSOLUTE_VALUE, "no data"),
         ([{"order": 0}, {"order": 1}], None, None, AlertConditionType.ABSOLUTE_VALUE, "non-numeric count"),
         ([{"order": 0, "count": 100}, "broken"], None, None, AlertConditionType.ABSOLUTE_VALUE, "malformed"),
     ],
@@ -158,9 +157,14 @@ def test_trends_funnel_compare_evaluates_current_period_only():
     assert result.series[0].points[result.series[0].current_index].value == 40.0
 
 
-def test_trends_funnel_empty_result_raises_extraction_error():
-    with pytest.raises(AlertExtractionError, match="no data"):
-        _extract([], viz="trends")
+@pytest.mark.parametrize("viz", [None, "trends"])
+def test_empty_result_is_benign_no_data(viz):
+    # An empty funnel result (no users in the window) is benign "no data this interval", not a
+    # misconfiguration — it must NOT raise (which would surface a benign empty funnel to error
+    # tracking as a crash). It yields a single missing point so the comparator skips it.
+    result = _extract([], viz=viz)
+    assert len(result.series) == 1
+    assert result.series[0].points[result.series[0].current_index].value is None
 
 
 def test_unsupported_viz_raises():

--- a/products/alerts/backend/evaluation/test/test_funnels_extractor.py
+++ b/products/alerts/backend/evaluation/test/test_funnels_extractor.py
@@ -86,8 +86,7 @@ def test_result_is_unframed_single_series():
         (_steps(100, 40), None, None, AlertConditionType.RELATIVE_DECREASE, "absolute value conditions"),
         ([{"order": 0}, {"order": 1}], None, None, AlertConditionType.ABSOLUTE_VALUE, "non-numeric count"),
         ([{"order": 0, "count": 100}, "broken"], None, None, AlertConditionType.ABSOLUTE_VALUE, "malformed"),
-        # A falsy non-list result (e.g. {} — an unexpected shape) is a hard failure, not benign
-        # no-data: it must raise so the alert auto-disables rather than silently reporting no data.
+        # A falsy non-list ({}) must raise, not be swallowed as benign empty ([]).
         ({}, None, None, AlertConditionType.ABSOLUTE_VALUE, "unexpected result shape"),
         ({}, None, "trends", AlertConditionType.ABSOLUTE_VALUE, "unexpected result shape"),
     ],

--- a/products/alerts/backend/evaluation/test/test_funnels_extractor.py
+++ b/products/alerts/backend/evaluation/test/test_funnels_extractor.py
@@ -86,6 +86,10 @@ def test_result_is_unframed_single_series():
         (_steps(100, 40), None, None, AlertConditionType.RELATIVE_DECREASE, "absolute value conditions"),
         ([{"order": 0}, {"order": 1}], None, None, AlertConditionType.ABSOLUTE_VALUE, "non-numeric count"),
         ([{"order": 0, "count": 100}, "broken"], None, None, AlertConditionType.ABSOLUTE_VALUE, "malformed"),
+        # A falsy non-list result (e.g. {} — an unexpected shape) is a hard failure, not benign
+        # no-data: it must raise so the alert auto-disables rather than silently reporting no data.
+        ({}, None, None, AlertConditionType.ABSOLUTE_VALUE, "unexpected result shape"),
+        ({}, None, "trends", AlertConditionType.ABSOLUTE_VALUE, "unexpected result shape"),
     ],
 )
 def test_extract_raises_extraction_error(result, config, viz, condition_type, match):


### PR DESCRIPTION
## Problem

Funnel alerts were flooding error tracking with a benign, non-actionable exception: `AlertExtractionError: Funnel steps alert query returned no data.`

When a funnel returned no rows for an interval (nobody entered the funnel in the window), the extractor raised, and the alert-evaluation activity's catch-all handler reported it to error tracking as if it were a crash. This is expected, benign data — not a failure worth an exception.

## Changes

Scoped to the funnel extractor (`funnel_strategies.py`):

- **Empty funnel results are now benign "no data this interval."** The extractor yields a single missing point so the shared comparator skips it (evaluates to NOT_FIRING, no error) instead of raising.
- **A genuinely unexpected result *shape* (e.g. a non-list) still raises `AlertExtractionError`** — the shape check runs before the emptiness check, so a falsy non-list can't slip through as benign. This routes to the auto-disable + email path rather than being reported as a crash.
- Both funnel strategies (steps and trends) share a `_require_list` helper so the shape check and its error message live in one place.

Note on scope: this PR originally also wired the eval-time `AlertExtractionError` → auto-disable + email path into `evaluate_alert`. That change landed on `master` independently, so after resolving the conflict this branch is narrowed to just the funnel-extractor behavior that consumes it.

Note on catching earlier: config-level validation already runs at save time (the alert serializer's `validate()` calls `validate_alert_config` → the funnel strategy's `validate_config`, returning a 400). The empty-result case is data-dependent and can't be predicted at save time, which is why handling it at evaluation time is the right home for it.

## How did you test this code?

- Updated the funnel-extractor tests that asserted the old empty→raise behavior to assert the new benign no-data result (covers both steps and trends viz). These guard the exact regression: re-introducing a raise on an empty funnel result.
- Added parametrized cases asserting a falsy non-list result (`{}`) raises `AlertExtractionError` for both viz types, so an unexpected shape can't be silently swallowed.
- Ran the extractor suite locally: 28/28 pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread, driven by @vasco. Investigation traced the error-tracking noise to the funnel extractor raising on empty results.

Addressed a Greptile review point by ordering the shape check before the emptiness check (so `None`/non-list fails loud rather than being treated as no-data) and extracted the shared `_require_list` helper. Skills invoked: `/writing-tests`, `/simplify`, `/code-review`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1782900798589709?thread_ts=1782900798.589709&cid=C09BDQLM8KA)*
