### PR TITLE
feat(inbox): Clarify self-driving PR pricing in onboarding

### DIFF
--- a/common/storybook/package.json
+++ b/common/storybook/package.json
@@ -34,6 +34,7 @@
         "vite": "^7.3.3"
     },
     "devDependencies": {
+        "@playwright/test": "catalog:",
         "http-server": "^14.1.1",
         "wait-on": "^7.2.0"
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -187,6 +187,7 @@
         "chartjs-plugin-trendline": "^3.2.0",
         "chartjs-plugin-zoom": "^2.2.0",
         "clsx": "^2.1.1",
+        "core-js": "^3.40.0",
         "country-flag-emoji-polyfill": "^0.1.8",
         "cron-parser": "^5.5.0",
         "cronstrue": "^3.14.0",

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -565,15 +565,15 @@ snapshots:
     components-hogcharts-barchart--stacked-mixed-sign--light:
         hash: v1.k794b7964.54ea51777cd1be48ada08afc6d9652348e58c55b4578259834125c1586df772a.puvvq3HL5w9hHEpev9dP2fRTzvd42bW7BZ-F7WiOIks
     components-hogcharts-barchart--stacked-with-track-ceiling--dark:
-        hash: v1.k794b7964.1f85d679741bd81ee3e7ab488ce82596c1e9f29f396295d863ed51a53f5a3a55.Q0JUJARVeJV8GdQs-EpptVEuOCgB0zYkwCApvNmEc7A
+        hash: v1.k794b7964.1ea8d87a1726a9a532850eb97fe6d93137d5dbb1aa960392741c9242778248b7.b88PGR3XtCLRXIoJ6hnH5yS7esXRS5Q2Ej3S6W7PO5g
     components-hogcharts-barchart--stacked-with-track-ceiling--light:
-        hash: v1.k794b7964.eb413728e33e4274883d8126d1634e408b221e6c9b3d880f6feaae458b891e09.55R7ZeVRnWxZjkWcMuLk_k8ZLPvrFXLxRqC8xOzYtAo
+        hash: v1.k794b7964.0d490f49e93f7af73d125716612fe4cb232d5476b6d8f29bd967dbe38fe5071c.ZPyhSX_pPV9Rg8G1VgMII5VYCH7ewyRl6ks4C0AGElg
     components-hogcharts-barchart--with-bar-track--dark:
         hash: v1.k794b7964.459993a07b1a8d239b43e5700fda3de963173c7c62792c3ca73ca7d26d3e967e.3i1wOTz8MkiBSViwUvFmF0H-bkd_5Yeu3YpGa4l5jP4
     components-hogcharts-barchart--with-bar-track--light:
         hash: v1.k794b7964.ba635da9134368b50adcd9ef7f0918d3c586f9282554e5395db438f04c1b9828.4CvwEAEAL4UT_K-Fs7S-laUq9wf3MMmOG2jnRIkffo4
     components-hogcharts-barchart--with-bar-track-ceiling--dark:
-        hash: v1.k794b7964.3326668de4a2d7d75de261b264de264a7a60113b703e67f687a8ef8a42f36109.2lqjmeix3iZwdrVjXi8ZpxMk9tuHmyV0LWVEIdaPJJ4
+        hash: v1.k794b7964.a59a7344c9cf9f18f144db6101af8e1484ba9fbf25d2e534ef7374b6ddc6349f.G1zekxfY0rzlPR7qvxJYOoNov8Oo6AQd-NSJ_3jCjUI
     components-hogcharts-barchart--with-bar-track-ceiling--light:
         hash: v1.k794b7964.e9accba1ecd78df7cf201f4eccdb1879ff90a450c7052c10940b1406892dcd65.fu8AiHQlPz_QXbMIH-RxgXyBXyhX9x365WS4pFWbKA4
     components-hogcharts-barchart--with-reference-line--dark:
@@ -5653,17 +5653,17 @@ snapshots:
     scenes-app-inbox-pullrequestdiffview--truncated--light:
         hash: v1.k794b7964.fb773b4c098b2f55cb393d1b9af9051deea9eee9a830940209e388ba916c01d4.kS1w3ZNx__r01yrTZZy7XXog7oqnDTDdJtfBBhnp4pk
     scenes-app-inbox-scene--empty--dark:
-        hash: v1.k794b7964.0284b54c79a12a21362c21da6d6d0c7931a6e7712175382d9403501bade25944.hTTIjAQuFDRQcXSxdhkHbDLUKzWGdWCizFXZO0pDGt4
+        hash: v1.k794b7964.4062dc535c6b287e7d179fc08f590cf44364851444688a16fde9cefdfe1a59fe.73H03n9uiyzATpE90PPhAJSCjMQdJycqfyb33SsM2Qw
     scenes-app-inbox-scene--empty--light:
-        hash: v1.k794b7964.8b499d6aa9e068adac6c22535509ea16ff73811a0d3576b0cb71c806bc0368f0.nvx1ive6oY4K9UKOvmkEUUkk9EFGTgTsbwRtirSVCzc
+        hash: v1.k794b7964.4dc18c81fce4d272a7fe528ce6dcf968226d28c3cba5c339427f3cae2fbff59b.ZuSWlL9bKliCCWwLoAFBZ8V4UJeJhORJHVc1hdNeZN4
     scenes-app-inbox-scene--inbox--dark:
-        hash: v1.k794b7964.3be049495351febd0fd0707ba5892fb476470206a01b3d4f4bf63a3b1f25fcf7.SgEWO4lvLKoR5BmG1ts5oXMwEbVYTqfpXZYWciXpDCc
+        hash: v1.k794b7964.74459b08895d8a687feb4700d1c83a3bee0bb1cd528b4b9282545d9575337b8c.CYkZaSQL4SLdAMhWdvLlMR4F50otejWUlRpcMRsqrwc
     scenes-app-inbox-scene--inbox--light:
-        hash: v1.k794b7964.88e28c4041b75b5ec02df0ad87e73d6cd2b1274781a7f47181eed609a5f9d4c1.i7mKwerSXPALau25BeHD_X-Xo7-MsOSIzkx3a2FJfaA
+        hash: v1.k794b7964.9d7488ba5550f2ac95e857753bd2ca09fce0bd92b41dbe8b20526faa901273d4.kFLMYntxGePRp7_PLiYlAz9IqiF-wI1SkybehONlfEc
     scenes-app-inbox-scene--self-driving-onboarding--dark:
-        hash: v1.k794b7964.0284b54c79a12a21362c21da6d6d0c7931a6e7712175382d9403501bade25944.JFxilh9rtU8eSo4d135Eak4WWNPaPWAF7zdqAUgyRlw
+        hash: v1.k794b7964.8ea91408055ea62484d3ae2d7d02e8dccb4a36f7f7cdf3aefc505d0dd46e8b9b.wFEU_msqY_8GDa-F0wGUMtrnq-ornhw6cz3MPilMsFo
     scenes-app-inbox-scene--self-driving-onboarding--light:
-        hash: v1.k794b7964.dd890b4dee0b457a54daa44c5d02b2995769bcc475f308aabae2f417b737efdf.t3pH8i49XFCWRI6oGXQ3uopBtavfiUUVGbXyDSrIWxI
+        hash: v1.k794b7964.be32db3ce6a6761655bbd1ccbb59559ac6548ce664b323aa20ffd8afbd1e6cce.T5ktNLx04c1AEDXKWjpcc_5iFGVE8JLPQJyj3814fAU
     scenes-app-inbox-scene--self-driving-paused--dark:
         hash: v1.k794b7964.eae93d2c506e66eb23f36e19f05bf6f07286d9a895dbad8f970c009fd98f1d53.7hksyy3ldoFdJY9rpLYMe7FNYuMAi-U1Vlh3OGhv3wY
     scenes-app-inbox-scene--self-driving-paused--light:

--- a/frontend/src/scenes/inbox/InboxScene.stories.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+
 import { mswDecorator } from '~/mocks/browser'
 
 import {
@@ -47,6 +49,7 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2026-06-11',
+        featureFlags: [FEATURE_FLAGS.PRODUCT_AUTONOMY],
         // The scene shell keeps a loader element mounted past the VR wait window, so don't block on it.
         testOptions: { waitForLoadersToDisappear: false },
     },

--- a/frontend/src/scenes/inbox/components/onboarding/InboxOnboarding.tsx
+++ b/frontend/src/scenes/inbox/components/onboarding/InboxOnboarding.tsx
@@ -24,6 +24,7 @@ const WIZARD_SETS_UP: { icon: JSX.Element; label: string }[] = [
 interface Beat {
     label: string
     description: JSX.Element
+    subtext: string | JSX.Element
     preview: JSX.Element
 }
 
@@ -58,8 +59,12 @@ const BEATS: Beat[] = [
         description: (
             <>
                 Agents read your product data and open a PR for anything safe to ship – with the diff, tests, and
-                reviewers already lined up. Your first 3 PRs each month are free, then it's $15 per PR after that{' '}
-                <PrPricingInfo />.
+                reviewers already lined up.
+            </>
+        ),
+        subtext: (
+            <>
+                Your first 3 PRs each month are free, then it's $15 per PR after that. <PrPricingInfo />
             </>
         ),
         preview: <PullRequestPreview />,
@@ -69,9 +74,10 @@ const BEATS: Beat[] = [
         description: (
             <>
                 Not everything is a clean code change. When something needs your judgment, agents file a report with the
-                context and what they'd do – you decide. Reports without PRs are free.
+                context and what they'd do – you decide.
             </>
         ),
+        subtext: 'Reports without PRs are free.',
         preview: <ReportPreview />,
     },
 ]
@@ -139,8 +145,8 @@ function CommandCard(): JSX.Element {
 
 function BeatRow({ beat, index }: { beat: Beat; index: number }): JSX.Element {
     return (
-        <div className="flex flex-col gap-3">
-            <div className="flex items-baseline gap-3">
+        <div className="flex flex-col gap-2">
+            <div className="flex items-baseline gap-3 mb-1">
                 <span className="font-mono text-xs text-muted tabular-nums">0{index + 1}</span>
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                     <span className="text-[15px] font-semibold leading-snug">{beat.label}</span>
@@ -150,6 +156,9 @@ function BeatRow({ beat, index }: { beat: Beat; index: number }): JSX.Element {
             {/* Real inbox cards, kept inert by the preview's click interception (it meeps instead).
                 Full-width on mobile; indented to align under the beat text from sm up. */}
             <div className="select-none pl-0 sm:pl-8">{beat.preview}</div>
+            {beat.subtext ? (
+                <span className="text-[13px] text-secondary leading-snug text-right">{beat.subtext}</span>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/inbox/components/onboarding/InboxOnboarding.tsx
+++ b/frontend/src/scenes/inbox/components/onboarding/InboxOnboarding.tsx
@@ -2,8 +2,8 @@ import './InboxOnboarding.scss'
 
 import { useActions } from 'kea'
 
-import { IconBolt, IconGithub, IconNotebook, IconPause, IconX } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconBolt, IconGithub, IconInfo, IconNotebook, IconPause, IconX } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { JumpingLogomark } from 'lib/brand/JumpingLogomark'
 import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
@@ -23,21 +23,55 @@ const WIZARD_SETS_UP: { icon: JSX.Element; label: string }[] = [
 
 interface Beat {
     label: string
-    description: string
+    description: JSX.Element
     preview: JSX.Element
+}
+
+/**
+ * Info icon explaining PR pricing on hover, kept separate from the sentence it follows so the
+ * sentiment (why $15, and that it's expected to fall) doesn't have to live in the onboarding copy itself.
+ */
+function PrPricingInfo(): JSX.Element {
+    return (
+        <Tooltip
+            title={
+                <>
+                    <p className="mb-2">We aim for the $15 cost to go down significantly in the coming months.</p>
+                    <p className="mb-0">
+                        The truth is that capable enough models <em>currently</em> cost quite a bit, so we're pricing
+                        with a very limited margin – similarly to our strategy with other PostHog tools. Like with our
+                        other tools, we will be passing savings along to you.
+                    </p>
+                </>
+            }
+        >
+            <span className="-m-1 inline-flex cursor-help items-center p-1 align-middle text-sm text-tertiary">
+                <IconInfo />
+            </span>
+        </Tooltip>
+    )
 }
 
 const BEATS: Beat[] = [
     {
         label: 'Pull requests, ready to merge.',
-        description:
-            'Agents read your product data and open a PR for anything safe to ship – with the diff, tests, and reviewers already lined up.',
+        description: (
+            <>
+                Agents read your product data and open a PR for anything safe to ship – with the diff, tests, and
+                reviewers already lined up. Your first 3 PRs each month are free, then it's $15 per PR after that{' '}
+                <PrPricingInfo />.
+            </>
+        ),
         preview: <PullRequestPreview />,
     },
     {
         label: 'Reports, when it needs your call.',
-        description:
-            "Not everything is a clean code change. When something needs your judgment, agents file a report with the context and what they'd do – you decide.",
+        description: (
+            <>
+                Not everything is a clean code change. When something needs your judgment, agents file a report with the
+                context and what they'd do – you decide. Reports without PRs are free.
+            </>
+        ),
         preview: <ReportPreview />,
     },
 ]

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -1,11 +1,11 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ExternalDataSourceType } from '~/queries/schema/schema-general'
 import { SignalSourceProduct, SignalSourceType } from '~/queries/schema/schema-signals'
@@ -118,7 +118,12 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
     path(['scenes', 'inbox', 'signalSourcesLogic']),
 
     connect(() => ({
-        values: [sourcesDataLogic, ['dataWarehouseSources', 'dataWarehouseSourcesLoading']],
+        values: [
+            sourcesDataLogic,
+            ['dataWarehouseSources', 'dataWarehouseSourcesLoading'],
+            featureFlagLogic,
+            ['featureFlags'],
+        ],
         actions: [sourcesDataLogic, ['loadSources']],
     })),
 
@@ -616,9 +621,9 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         }
     }),
 
-    events(({ actions }) => ({
+    events(({ actions, values }) => ({
         afterMount: () => {
-            if (posthog.isFeatureEnabled(FEATURE_FLAGS.PRODUCT_AUTONOMY)) {
+            if (values.featureFlags[FEATURE_FLAGS.PRODUCT_AUTONOMY]) {
                 // The condition allows us to safely mount this logic for user without the product autonomy feature flag
                 // without needlessly loading the source configs
                 actions.loadSourceConfigs()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,7 +369,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -448,7 +448,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -465,6 +465,9 @@ importers:
         specifier: ^7.3.3
         version: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
     devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.60.0
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -903,6 +906,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      core-js:
+        specifier: ^3.40.0
+        version: 3.40.0
       country-flag-emoji-polyfill:
         specifier: ^0.1.8
         version: 0.1.8
@@ -1839,7 +1845,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3088,6 +3094,9 @@ importers:
 
   products/engineering_analytics:
     dependencies:
+      '@posthog/icons':
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3605,6 +3614,9 @@ importers:
       '@posthog/brand':
         specifier: 'catalog:'
         version: 0.3.0(react@18.3.1)
+      '@posthog/icons':
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-charts':
         specifier: workspace:*
         version: link:../../packages/quill/packages/charts

--- a/products/engineering_analytics/package.json
+++ b/products/engineering_analytics/package.json
@@ -5,6 +5,7 @@
         "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
+        "@posthog/icons": "catalog:",
         "kea": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"

--- a/products/mcp_analytics/package.json
+++ b/products/mcp_analytics/package.json
@@ -4,6 +4,7 @@
         "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
     },
     "dependencies": {
+        "@posthog/icons": "catalog:",
         "@posthog/quill-charts": "workspace:*",
         "@posthog/quill-components": "workspace:*",
         "@posthog/quill-primitives": "workspace:*",


### PR DESCRIPTION
## Problem

The self-driving onboarding didn't mention pricing at all, so users had no idea that agent-opened PRs aren't free past a point, or that reports are always free.

## Changes

<img width="1708" height="1204" alt="Screenshot 2026-07-03 at 12 01 20@2x" src="https://github.com/user-attachments/assets/0975f1b5-9a77-48a2-b559-b479e9924d62" />

Spells out that the first 3 PRs opened by PostHog each month are free, and it's $15 per PR after that, with a hover tooltip explaining why (we expect this to come down, and we'll pass savings along, same as with our other tools, like I explained [in the comments here](https://posthog.com/docs/self-driving#quest-item-see-it-work)).

Also, fixes an unrelated but blocking issue found while trying to preview the above in Storybook, around webpack.
