### PR TITLE
fix(conversations): shorten staff-action login buttons so they fit

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/AdminLoginButtons.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/AdminLoginButtons.tsx
@@ -19,7 +19,7 @@ export function AdminLoginButtons({
         <div className="flex flex-wrap justify-end gap-2">
             {disabledReason ? (
                 <LemonButton type="secondary" size="small" disabledReason={disabledReason}>
-                    Login as {ticketContext?.email || 'customer'}
+                    Login
                 </LemonButton>
             ) : (
                 adminLoginUrls.map(({ region, url }) => (
@@ -27,11 +27,10 @@ export function AdminLoginButtons({
                         key={region}
                         type="secondary"
                         size="small"
-                        tooltip="This currently redirects to the admin login page, but in future will log you in directly."
+                        tooltip={`Login as ${ticketContext?.email}. This currently redirects to the admin login page, but in future will log you in directly.`}
                         onClick={() => window.open(url, '_blank')}
                     >
-                        Login as {ticketContext?.email}
-                        {showRegionLabel ? ` (${region})` : ''}
+                        Login{showRegionLabel ? ` (${region})` : ''}
                     </LemonButton>
                 ))
             )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2820,6 +2820,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.0
     devDependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@testing-library/jest-dom':
         specifier: ^5.17.0
         version: 5.17.0

--- a/products/conversations/frontend/scenes/ticket/StaffActionsPanel.stories.tsx
+++ b/products/conversations/frontend/scenes/ticket/StaffActionsPanel.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, StoryFn } from '@storybook/react'
+import { useActions } from 'kea'
+import { useEffect } from 'react'
+
+import {
+    ImpersonationTicketContext,
+    impersonationNoticeLogic,
+} from '~/layout/navigation/ImpersonationNotice/impersonationNoticeLogic'
+import { Region } from '~/types'
+
+import { StaffActionsPanel } from './StaffActionsPanel'
+
+const meta: Meta<typeof StaffActionsPanel> = {
+    title: 'Scenes-App/Conversations/Staff Actions Panel',
+    component: StaffActionsPanel,
+    parameters: {
+        layout: 'padded',
+        viewMode: 'story',
+    },
+}
+export default meta
+
+function Template({ ticketContext }: { ticketContext: ImpersonationTicketContext | null }): JSX.Element {
+    const { setTicketContext } = useActions(impersonationNoticeLogic)
+    useEffect(() => {
+        setTicketContext(ticketContext)
+    }, [setTicketContext, ticketContext])
+    // Constrain the width to mirror the ticket sidebar, where the login buttons must fit.
+    return (
+        <div className="max-w-md">
+            <StaffActionsPanel />
+        </div>
+    )
+}
+
+// Region can't be inferred (e.g. Slack-opened tickets), so both regions are offered.
+export const UnknownRegion: StoryFn = () => (
+    <Template ticketContext={{ ticketId: 'abc', email: 'customer@example.com' }} />
+)
+
+export const KnownRegion: StoryFn = () => (
+    <Template ticketContext={{ ticketId: 'abc', email: 'customer@example.com', region: Region.US }} />
+)
+
+export const NoCustomerEmail: StoryFn = () => <Template ticketContext={null} />

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -12,6 +12,7 @@
         "ts-pattern": "catalog:"
     },
     "devDependencies": {
+        "@storybook/react": "catalog:",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Problem

In the conversations "Staff actions" panel the admin login buttons read `Login as <customer-email> (US)` / `(EU)`, which overflows the sidebar and looks broken (see before screenshot). The customer email is already shown right next to the buttons, so repeating it in every label is redundant.

## Changes

Drop the email from the button label — buttons now read `Login`, or `Login (US)` / `Login (EU)` when the region is ambiguous. The email moves into the button tooltip so staff still know which customer they're logging in as. This also improves the impersonation notice overlay, which shares the same `AdminLoginButtons` component.

Added a Storybook story for `StaffActionsPanel` covering the unknown-region (US + EU), known-region (single button), and no-email (disabled) states.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks run: `oxlint` on the changed files (clean) and the full `tsgo` typecheck (no errors from these files). No manual in-app or visual-regression testing was performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Xander directed the work from a screenshot of the overflowing buttons. Chose to move the email into the tooltip rather than truncate it, since the panel already displays the customer email adjacent to the buttons. Email in the story fixture is a redacted placeholder.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
