### PR TITLE
fix(tasks): clear mobile Safari safe area in TaskTracker

### DIFF
--- a/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
+++ b/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
@@ -182,7 +182,7 @@ function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element
         return null // no composer UI supplied (e.g. ReadonlyRunSurface) or pre-bootstrap
     }
     return (
-        <div data-attr="composer" className="px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+        <div data-attr="composer" className="px-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))]">
             <LemonDivider className="mt-0 mb-4" />
             <div className="mx-auto w-full max-w-180">{children}</div>
         </div>

--- a/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
+++ b/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
@@ -182,7 +182,7 @@ function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element
         return null // no composer UI supplied (e.g. ReadonlyRunSurface) or pre-bootstrap
     }
     return (
-        <div data-attr="composer" className="px-4 pb-4">
+        <div data-attr="composer" className="px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
             <LemonDivider className="mt-0 mb-4" />
             <div className="mx-auto w-full max-w-180">{children}</div>
         </div>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -68,6 +68,7 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
                     type="secondary"
                     size="small"
                     icon={<IconExternal />}
+                    className="hidden lg:inline-flex"
                     onClick={() => window.open(`posthog-code://task/${task.id}`, '_blank')}
                 >
                     Open in PostHog Code

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
@@ -91,14 +91,14 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
                 <div className="shrink-0 lg:px-1">{searchInput}</div>
                 <LemonDivider className="mb-0 mt-4" />
                 <div className={cn('flex flex-col flex-1 min-h-0', tasks.length > 0 && '-mx-4')}>{content}</div>
-                <div className="shrink-0 h-20" />
+                <div className="shrink-0 h-[calc(5rem+env(safe-area-inset-bottom))]" />
                 <LemonButton
                     type="primary"
                     icon={<IconPlus />}
                     to={urls.taskNew()}
                     size="large"
                     data-attr="tasks-new-mobile"
-                    className="fixed bottom-4 right-4 z-20 shadow-md"
+                    className="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-20 shadow-md"
                 >
                     New task
                 </LemonButton>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
@@ -91,14 +91,14 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
                 <div className="shrink-0 lg:px-1">{searchInput}</div>
                 <LemonDivider className="mb-0 mt-4" />
                 <div className={cn('flex flex-col flex-1 min-h-0', tasks.length > 0 && '-mx-4')}>{content}</div>
-                <div className="shrink-0 h-[calc(5rem+env(safe-area-inset-bottom))]" />
+                <div className="shrink-0 h-[calc(5rem_+_env(safe-area-inset-bottom))]" />
                 <LemonButton
                     type="primary"
                     icon={<IconPlus />}
                     to={urls.taskNew()}
                     size="large"
                     data-attr="tasks-new-mobile"
-                    className="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-20 shadow-md"
+                    className="fixed bottom-[calc(1rem_+_env(safe-area-inset-bottom))] right-4 z-20 shadow-md"
                 >
                     New task
                 </LemonButton>


### PR DESCRIPTION
## Problem

On mobile Safari, the Tasks scene (`/tasks`) has a few rough edges:
- The tasks list's last row can end up hidden behind the floating "New task" button, since the reserved bottom space doesn't grow to clear the device's home-indicator safe area.
- The run thread's composer has the same issue — the input and send button can end up under the browser's bottom chrome.
- The "Open in PostHog Code" header action opens a desktop-only IDE deep link (`posthog-code://...`), which doesn't make sense on mobile and was showing there anyway.

## Changes

- `TasksListColumn.tsx`: the mobile list's trailing spacer and the floating "New task" button's offset now add `env(safe-area-inset-bottom)` on top of their existing fallback values, following the same `max()`/`calc()` safe-area idiom already used elsewhere in the app (e.g. `Navigation.scss`, `ProductSelection.tsx`).
- `RunSurfaceImpl.tsx`: the shared `RunSurface.Composer` slot's bottom padding does the same. This slot is currently only rendered by the Tasks run thread, so the change is scoped to that surface in practice.
- `TaskDetailPage.tsx`: "Open in PostHog Code" is now `hidden lg:inline-flex`, matching the same `lg` breakpoint already used to hide other desktop-only chrome in this file.

## How did you test this code?

Ran `oxlint` against the three changed files (clean). Did not verify in an actual mobile/emulated Safari viewport — please check the tasks list, thread composer, and header action at `<lg` widths before merging.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy described the three mobile bugs and I (Claude Code) located each one, then fixed them following existing conventions already in the codebase rather than introducing new patterns: the `env(safe-area-inset-bottom)` idiom from `Navigation.scss`/`ProductSelection.tsx` for the two padding bugs, and the existing `hidden lg:*` breakpoint convention already used in the same file for the button.