### PR TITLE
fix(replay): show slack channel name in vision action delivery column

### DIFF
--- a/products/replay_vision/backend/api/delivery.py
+++ b/products/replay_vision/backend/api/delivery.py
@@ -36,6 +36,12 @@ def _managed_destinations(action: VisionAction, team: Team) -> QuerySet[HogFunct
     )
 
 
+def _channel_id(value: str) -> str:
+    # The channel is stored as the `${id}|#${name}` picker composite so the UI can show a friendly
+    # name; the Slack template wants the bare id. Mirrors `slackChannelId` in the frontend.
+    return value.split("|", 1)[0].strip()
+
+
 def _slack_destination_payload(action: VisionAction, target: dict[str, Any]) -> dict[str, Any]:
     return {
         "type": _INTERNAL_DESTINATION,
@@ -50,7 +56,7 @@ def _slack_destination_payload(action: VisionAction, target: dict[str, Any]) -> 
         },
         "inputs": {
             "slack_workspace": {"value": target["integration_id"]},
-            "channel": {"value": target["channel"]},
+            "channel": {"value": _channel_id(target["channel"])},
             # Hog-templated pass-through of the pre-formatted Slack text carried on the event.
             "text": {"value": "{event.properties.slack_text}"},
         },

--- a/products/replay_vision/backend/tests/test_vision_action_delivery.py
+++ b/products/replay_vision/backend/tests/test_vision_action_delivery.py
@@ -123,6 +123,14 @@ class TestVisionActionDelivery(APIBaseTest):
         self.assertEqual(self._inputs(fn)["channel"]["value"], "#general")
         self.assertEqual(self._inputs(fn)["text"]["value"], "{event.properties.slack_text}")
 
+    def test_channel_composite_is_stripped_to_bare_id_for_slack(self) -> None:
+        # The UI stores the `${id}|#${name}` picker composite; the Slack destination must receive the
+        # bare id, or the channel input is malformed and delivery fails.
+        action = self._create_action(
+            delivery_config=[{"type": "slack", "integration_id": self.integration.id, "channel": "C123|#general"}],
+        )
+        self.assertEqual(self._inputs(self._destinations(action)[0])["channel"]["value"], "C123")
+
     def test_create_two_targets_makes_two_destinations(self) -> None:
         action = self._create_action(
             delivery_config=[

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonSwitch, LemonTable, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { slackChannelDisplayName } from 'lib/integrations/slackChannel'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
@@ -47,7 +48,17 @@ function EditorGate({ children }: { children: JSX.Element }): JSX.Element {
 
 function deliverySummary(action: VisionActionApi): string {
     const targets = action.delivery_config ?? []
-    return targets.length ? targets.map((t) => t.channel).join(', ') : '—'
+    if (!targets.length) {
+        return '—'
+    }
+    return targets
+        .map((t) => {
+            // channel is the `${id}|#${name}` picker composite for actions saved with a friendly name;
+            // fall back to "Slack" rather than exposing a bare channel id (older rows, id-only input).
+            const name = slackChannelDisplayName(t.channel)
+            return name.startsWith('#') ? name : 'Slack'
+        })
+        .join(', ')
 }
 
 export function VisionActionsTab({ scannerId }: { scannerId: string }): JSX.Element {

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -155,7 +155,9 @@ describe('visionActionsLogic', () => {
             scanner: 's1',
             trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
             synthesis_config: { prompt_guide: 'focus on checkout' },
-            delivery_config: [{ type: DeliveryTargetTypeEnumApi.Slack, integration_id: 5, channel: 'C123' }],
+            // The full `${id}|#${name}` composite is stored so the actions table can show the channel
+            // name; the backend strips it to the bare id for the Slack destination.
+            delivery_config: [{ type: DeliveryTargetTypeEnumApi.Slack, integration_id: 5, channel: 'C123|#general' }],
         })
     })
 

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -2,7 +2,6 @@ import { actions, afterMount, kea, key, listeners, path, props, reducers } from 
 import { forms } from 'kea-forms'
 
 import { dayjs } from 'lib/dayjs'
-import { slackChannelId } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -55,7 +54,9 @@ export function buildActionBody(form: VisionActionForm, scannerId: string): Para
                       {
                           type: DeliveryTargetTypeEnumApi.Slack,
                           integration_id: form.integration_id,
-                          channel: slackChannelId(form.channel),
+                          // Store the `${id}|#${name}` picker composite so the table can show the
+                          // channel name; delivery.py strips it to the bare id for the Slack destination.
+                          channel: form.channel,
                       },
                   ]
                 : [],


### PR DESCRIPTION
## Problem

In Replay Vision, the Actions tab (scheduled group summaries delivered to Slack) rendered a raw Slack channel id like `C0881TYHT41` in the Delivery column instead of a human-readable destination. Not useful at a glance.

## Changes

Root cause: the frontend stripped the `id|#name` Slack picker composite down to the bare id before saving, so `delivery_config.channel` only ever held an id for the table to show.

- Store the full `id|#name` composite in `delivery_config.channel` (frontend `buildActionBody`) so the table has a name to display.
- Split it back to the bare id in `delivery.py` when building the `template-slack` internal destination, so the actual Slack delivery is unchanged.
- The Delivery column now shows `#channel-name`, falling back to "Slack" rather than exposing a bare id (covers older rows saved with an id only).

Delivery behavior is unchanged - the HogFunction still receives the bare channel id it expects.

One known limitation by design: actions saved before this change stored a bare id, so they display "Slack" (not their specific channel) until re-saved. The feature is newly shipped, so this set is negligible.

## How did you test this code?

I (Claude) added automated tests but could not run the suites - this checkout has no provisioned Python venv or `node_modules`, and `flox`/`hogli` aren't on PATH. `python3 -m py_compile` passes on the backend files, and I statically verified the frontend changes (import resolves, no dangling references). CI is the first real run.

- Backend: added `test_channel_composite_is_stripped_to_bare_id_for_slack` in `test_vision_action_delivery.py` - asserts an `id|#name` composite reaches the Slack destination as the bare id. Catches a regression where a composite leaks into the channel input and breaks delivery; no existing test used a composite value.
- Frontend: updated the `buildActionBody` assertion in `visionActionsLogic.test.ts` to reflect that the composite is now stored.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim directed this work via Claude Code (Opus 4.8). The ask was a small display bug on the newly shipped Replay Vision Actions MVP: the Delivery column showed a Slack channel id instead of a name.

I considered three fixes: (a) store the composite and split on the backend, (b) render a generic "Slack" label, (c) resolve id to name at display time via `slackIntegrationLogic`. I chose (a) because it yields the friendly channel name, keeps delivery correct, and mirrors the existing signals convention (`_channel_display_name` / `slackChannelId`) that the frontend `slackChannelDisplayName` helper already documents itself as mirroring. Option (c) was rejected as it adds a channel-list fetch dependency to a table cell; (b) loses which channel.

No skills were required - the change touches a delivery helper and display logic, not a serializer/viewset contract or migration.
