### PR TITLE
feat(logs): add path→HogQL lowering helper for custom columns

### DIFF
--- a/products/logs/backend/column_expressions.py
+++ b/products/logs/backend/column_expressions.py
@@ -1,0 +1,39 @@
+import hashlib
+
+from posthog.hogql import ast
+
+# The wire descriptor's `source` selects the lowering strategy (source-driven):
+# flat map lookup for attribute maps, JSON dig for the body string.
+FLAT_MAP_SOURCES = ("attributes", "resource_attributes")
+JSON_BODY_SOURCE = "body"
+
+
+def path_to_expr(source: str, path: str) -> ast.Expr:
+    """Lower a custom-column descriptor `(source, path)` into a HogQL AST expression.
+
+    - `attributes` / `resource_attributes`: the whole `path` is a single map key
+      (dots are part of the OTel key, never split) -> `attributes['http.url']`.
+    - `body`: `path` is a dot-separated JSON path -> `JSONExtractString(body, 'user', 'id')`.
+
+    `path` is always carried as a bound chain member / Constant, so it cannot escape
+    the map-index or JSONExtract boundary as interpolated SQL.
+    """
+    if source in FLAT_MAP_SOURCES:
+        return ast.Field(chain=[source, path])
+
+    if source == JSON_BODY_SOURCE:
+        keys = [ast.Constant(value=segment) for segment in path.split(".")]
+        return ast.Call(name="JSONExtractString", args=[ast.Field(chain=[JSON_BODY_SOURCE]), *keys])
+
+    raise ValueError(f"Unknown custom-column source: {source!r}")
+
+
+def canonical_key(source: str, path: str) -> str:
+    """Derive a stable `col_<hash>` alias from `(source, path)`.
+
+    Independent of any client-generated uuid so identical column setups hash to the
+    same query (and therefore the same query cache key). The null separator keeps
+    e.g. `("ab", "c")` and `("a", "bc")` from colliding.
+    """
+    digest = hashlib.sha256(f"{source}\x00{path}".encode()).hexdigest()
+    return f"col_{digest[:12]}"

--- a/products/logs/backend/test/test_column_expressions.py
+++ b/products/logs/backend/test/test_column_expressions.py
@@ -1,0 +1,71 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.hogql import ast
+
+from products.logs.backend.column_expressions import canonical_key, path_to_expr
+
+
+class TestPathToExpr(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("flat_attribute_key", "attributes", "http.url"),
+            ("flat_resource_attribute_key", "resource_attributes", "service.name"),
+        ]
+    )
+    def test_flat_map_key_lowers_to_field_chain(self, _name, source, path):
+        # attributes / resource_attributes: the whole path is a single map key (dots included)
+        assert path_to_expr(source, path) == ast.Field(chain=[source, path])
+
+    def test_dotted_attribute_path_stays_a_single_flat_key(self):
+        # source-driven: a dotted attribute path is NOT split into a nested dig
+        assert path_to_expr("attributes", "a.b.c") == ast.Field(chain=["attributes", "a.b.c"])
+
+    def test_body_nested_json_path_lowers_to_jsonextractstring(self):
+        assert path_to_expr("body", "user.id") == ast.Call(
+            name="JSONExtractString",
+            args=[ast.Field(chain=["body"]), ast.Constant(value="user"), ast.Constant(value="id")],
+        )
+
+    def test_body_single_segment_path_lowers_to_jsonextractstring(self):
+        assert path_to_expr("body", "message") == ast.Call(
+            name="JSONExtractString",
+            args=[ast.Field(chain=["body"]), ast.Constant(value="message")],
+        )
+
+    def test_injection_in_attribute_key_is_kept_as_bound_string(self):
+        malicious = "x'] AS y, (SELECT 1) --"
+        expr = path_to_expr("attributes", malicious)
+        # the malicious input survives verbatim as a chain member, never parsed as SQL
+        assert isinstance(expr, ast.Field)
+        assert expr.chain == ["attributes", malicious]
+
+    def test_injection_in_body_path_is_kept_as_bound_constants(self):
+        malicious = "') OR 1=1 --"
+        expr = path_to_expr("body", malicious)
+        # no dots -> one segment, carried as a bound Constant, not interpolated SQL
+        assert isinstance(expr, ast.Call)
+        assert expr.name == "JSONExtractString"
+        assert expr.args[0] == ast.Field(chain=["body"])
+        assert expr.args[1] == ast.Constant(value=malicious)
+
+
+class TestCanonicalKey(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("attributes", "http.url", "col_4d1ef362ef20"),
+            ("body", "user.id", "col_b74ba7d37d48"),
+            ("resource_attributes", "service.name", "col_acc699467fd2"),
+        ]
+    )
+    def test_canonical_key_is_stable(self, source, path, expected):
+        assert canonical_key(source, path) == expected
+
+    def test_canonical_key_differs_by_source_and_path(self):
+        assert canonical_key("attributes", "http.url") != canonical_key("body", "http.url")
+        assert canonical_key("attributes", "http.url") != canonical_key("attributes", "http.method")
+
+    def test_canonical_key_separator_prevents_collisions(self):
+        # ("ab","c") and ("a","bc") must not collide despite naive concatenation
+        assert canonical_key("ab", "c") != canonical_key("a", "bc")


### PR DESCRIPTION
## Problem

The unified typed-column configurator for Logs needs a way to turn a user-configured custom column into a query expression. A column is described by a `(source, path)` pair, and we need to lower that into a HogQL AST node the query runner can select. This is the bottom of that stack — everything else (runner wiring, API, UI) builds on it.

Tracked in JON-37 (Spike 1).

## Changes

New standalone module `products/logs/backend/column_expressions.py` with two pure functions:

- `path_to_expr(source, path)` lowers a descriptor into a HogQL AST expression:
  - `attributes` / `resource_attributes`: the whole `path` is a single flat map key, OTel dots preserved (`http.url` stays one key, never split) → `ast.Field(chain=[source, path])`. This matches how `property_to_expr` already reads `log_attribute` / `log_resource_attribute`.
  - `body`: `path` is a dot-separated JSON path → `JSONExtractString(body, 'user', 'id')`, each segment carried as a bound `Constant`.
- `canonical_key(source, path)` derives a stable `col_<hash>` alias from a SHA-256 of the pair. It is independent of any client-generated uuid, so identical column setups hash to the same query and therefore share a query cache key. A null separator prevents `("ab","c")` and `("a","bc")` from colliding.

It is called by nothing yet, so it merges safely on its own.

Security note: `path` is always carried as a bound chain member or `Constant`, so it can never escape the map-index or `JSONExtract` boundary as interpolated SQL. There is a test for this.

## How did you test this code?

Automated only — I (Claude) did not manually exercise this since nothing calls it yet. Added `products/logs/backend/test/test_column_expressions.py`, 12 parameterized cases, all passing in 0.2s:

- flat attribute key, flat resource-attribute key, dotted attribute path stays a single flat key (not split)
- nested and single-segment body JSON paths
- injection safety: a malicious `path` (`x'] AS y, (SELECT 1) --`, `') OR 1=1 --`) survives verbatim as a bound chain member / `Constant`, never parsed as SQL
- `canonical_key` stability (pinned hashes), source/path sensitivity, and separator anti-collision

The tests use `SimpleTestCase` rather than the ClickHouse-backed `BaseTest` — this is pure AST logic with no DB access, so the lighter base is both correct (it blocks accidental DB access) and ~47× faster.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon directed this; I (Claude, via PostHog Code) wrote the helper and tests and ran `/simplify` over the diff before opening the PR.

Decisions from that pass:
- Dropped a `test_canonical_key_is_deterministic` case that was fully subsumed by the pinned-hash stability test.
- Switched the test base from `BaseTest` to `SimpleTestCase` after noticing the ClickHouse harness was both unnecessary for pure-logic tests and the source of a flaky `ASYNC_LOAD_FAILED` teardown error.
- Kept `path_to_expr` as a dedicated helper rather than routing the two map sources through `property_to_expr` — the unified single-entry-point across all three sources (including `body`, which `property_to_expr` has no concept of) is the intended deliverable.

One thing for reviewers to confirm: the `body` branch assumes `body` can hold structured JSON traversable by dotted path. The rest of the logs backend currently treats `body` as opaque text, so this is new territory — it's the intended behavior per the spike spec, but worth a sanity check against how `body` is actually stored.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
