### PR TITLE
feat(activity): filter events and sessions by saved action

### DIFF
--- a/frontend/src/queries/nodes/EventsNode/EventName.tsx
+++ b/frontend/src/queries/nodes/EventsNode/EventName.tsx
@@ -1,22 +1,62 @@
+import { useValues } from 'kea'
+
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 
-import { EventsNode, EventsQuery, SessionsQuery } from '~/queries/schema/schema-general'
-
-import { EventName as EventNameComponent } from 'products/actions/frontend/components/EventName'
+import { actionsModel } from '~/models/actionsModel'
+import { EventsQuery, SessionsQuery } from '~/queries/schema/schema-general'
 
 interface EventNameProps {
-    query: EventsNode | EventsQuery | SessionsQuery
-    setQuery?: (query: EventsNode | EventsQuery | SessionsQuery) => void
+    query: EventsQuery | SessionsQuery
+    setQuery?: (query: EventsQuery | SessionsQuery) => void
 }
 
+/** Single picker for filtering events by event name or by a saved action (mutually exclusive, like insights). */
 export function EventName({ query, setQuery }: EventNameProps): JSX.Element {
+    const { actionsById } = useValues(actionsModel)
+
+    const actionId = query.actionId || null
+    const value = actionId != null ? actionId : (query.event ?? null)
+
     return (
-        <EventNameComponent
-            value={query.event ?? ''}
+        <TaxonomicPopover
+            groupType={actionId != null ? TaxonomicFilterGroupType.Actions : TaxonomicFilterGroupType.Events}
+            groupTypes={[
+                TaxonomicFilterGroupType.SuggestedFilters,
+                TaxonomicFilterGroupType.Events,
+                TaxonomicFilterGroupType.Actions,
+            ]}
+            value={value}
+            onChange={(newValue, groupType) => {
+                if (!setQuery) {
+                    return
+                }
+                // The clear affordance emits an empty string, so treat empty/nullish as "no filter".
+                const cleared = newValue == null || newValue === ''
+                if (cleared) {
+                    setQuery({ ...query, event: null, actionId: undefined })
+                } else if (groupType === TaxonomicFilterGroupType.Actions) {
+                    setQuery({ ...query, event: null, actionId: Number(newValue) })
+                } else {
+                    setQuery({ ...query, actionId: undefined, event: String(newValue) })
+                }
+            }}
+            renderValue={(v) =>
+                actionId != null ? (
+                    <>{actionsById[actionId]?.name || `Action #${actionId}`}</>
+                ) : v != null ? (
+                    <PropertyKeyInfo value={String(v)} disablePopover type={TaxonomicFilterGroupType.Events} />
+                ) : null
+            }
             disabled={!setQuery}
-            onChange={(value) => setQuery?.({ ...query, event: value })}
-            allEventsOption="clear"
-            groupTypes={[TaxonomicFilterGroupType.SuggestedFilters, TaxonomicFilterGroupType.Events]}
+            allowClear
+            excludedProperties={{ [TaxonomicFilterGroupType.Events]: [null] }}
+            size="small"
+            type="secondary"
+            placeholder="Select an event"
+            data-attr="event-name-box"
+            selectingKeyOnly
         />
     )
 }


### PR DESCRIPTION
## Problem

The event picker on the Activity page (Explore events and Sessions tabs) only let you filter by event name. There was no way to filter the live event/session stream by a saved action, even though actions are a first-class filtering primitive everywhere else (insights, funnels, etc). Given actions are just reusable bundles of match conditions, it was surprising you couldn't point them at the raw activity feed.

## Changes

Added an Actions tab to the existing event picker on Activity. You can now filter by event name **or** by a saved action, mutually exclusive, mirroring the events-or-actions picker in product analytics.

The nice part: this needed no schema or backend work. `EventsQuery.actionId` and `SessionsQuery.actionId` already exist and are already resolved end-to-end by their query runners via `action_to_expr` (which expands an action into its event/URL/selector/element/property match conditions). The picker was simply never wired to write that field. So this is a single-file frontend change that repoints the existing `EventName` control at the field that was already there.

Mutual exclusivity: picking an action clears any event-name filter and vice versa. The clear affordance and default (Events) tab behave exactly as before.

Out of scope: the Live events tab. It uses a separate SSE stream that does not go through `EventsQuery`, so action resolution there would be a materially different change.

## How did you test this code?

Manually, by running the local stack and exercising the picker on Activity → Explore events: selecting an action filters the feed, selecting an event clears the action, and clearing removes the filter. Also confirmed the existing event-name path is unchanged.

Automated checks the agent ran locally: `oxlint` and `oxfmt` on the changed file (clean), and `tsgo` typecheck (no errors introduced by this file). No new automated tests were added — this repoints an existing UI control at an already-tested backend field (`action_to_expr` and the query runners' `actionId` handling are already covered), so there's no new backend behavior to regress. If reviewers want a guard, a Jest test asserting the onChange writes `actionId` vs `event` mutually exclusively is the natural candidate.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) did this with Luke driving. First pass built it as a separate standalone "Select action" filter button with a new `showActionFilter` DataTableNode view prop, a `QueryFeature.actionFilter`, a dedicated component, and the corresponding schema/generated-type regeneration. Luke pointed out that product analytics presents this as one events-or-actions picker, so we scrapped all of that scaffolding in favor of adding an Actions tab to the existing `EventName` picker. That collapsed the change to a single file with zero schema churn.

One gotcha worth flagging for review: `TaxonomicPopover`'s clear affordance emits an empty string (not `null`), so a naive `Number(newValue)` would have written `actionId: 0` and made the picker think "Action #0" was selected. Handled explicitly with a `cleared` guard plus a falsy-safe `actionId` read.

No repo skills were required for this change (no migrations, no DRF/serializer edits, no new tests).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
