### PR TITLE
feat(phai): add thumbs + progressive feedback to run surface

### DIFF
--- a/frontend/src/scenes/max/AGENTS.md
+++ b/frontend/src/scenes/max/AGENTS.md
@@ -56,10 +56,15 @@ directory's `README.md` for the tier decision table + recipes and its `AGENTS.md
 and the hard rule that it must never import `scenes/max`.
 
 What stays in `scenes/max`: conversation orchestration (`maxLogic`, `maxThreadLogic`, `maxGlobalLogic`), the
-Max Context subsystem, slash commands, `useMaxTool`/`MaxTool`, feedback/ratings, the frozen LangGraph path,
-and Max's **product-specific tool renderers** (`messages/adapters/*`), which register themselves into the
-shared `toolRegistry` via `messages/adapters/registerMaxToolRenderers` (imported once from
+Max Context subsystem, slash commands, `useMaxTool`/`MaxTool`, the LangGraph path's own feedback/ratings, the
+frozen LangGraph path, and Max's **product-specific tool renderers** (`messages/adapters/*`), which register
+themselves into the shared `toolRegistry` via `messages/adapters/registerMaxToolRenderers` (imported once from
 `Thread.tsx`). Add a new product tool renderer there, not in `products/posthog_ai/frontend`.
+
+> Feedback is intentionally **duplicated**, not shared: the sandbox run surface has its own generic,
+> `runStreamLogic`-driven copy (thumbs + progressive good/okay/bad prompt) under
+> `products/posthog_ai/frontend/components/feedback/`. Max keeps this separate LangGraph copy. Changing one
+> does not change the other.
 
 ## 5. Where do I add X?
 

--- a/products/posthog_ai/frontend/AGENTS.md
+++ b/products/posthog_ai/frontend/AGENTS.md
@@ -156,12 +156,13 @@ components/         # RunSurfaceImpl (the RunSurface compound, heavy chunk); Rea
                     #   read-only layout) + ReadonlyRunSurface (its lazy wrapper, replaces the old RunViewer.tsx);
                     #   RunLogSkeleton (shared loader), Thread, Composer, perm/question/resource surfaces, activity, tool/
   composer/         #   the Composer compound
+  feedback/         #   RunFeedbackFooter (RunSurface.Feedback slot) + thumbs / progressive good-okay-bad prompt
   tool/             #   tool registry + renderers (built-ins, generic MCP, EditDiffRenderer, diff/exec utils)
-logics/             # runStreamLogic, runInteractionLogic; tasksLogic/taskLogic data logics (+ *LogicType.ts)
+logics/             # runStreamLogic, runInteractionLogic; feedbackPromptLogic/messageRatingsLogic; tasksLogic/taskLogic data logics (+ *LogicType.ts)
 policy/             # tool policy + permission/question utils
 types/              # streamTypes (folded thread), wireTypes (ACP), toolTypes, taskTypes (task/run domain)
 messages/           # MessageTemplate, MarkdownMessage, ReasoningAnswer, AssistantFailureMessage
-utils/              # thinkingMessages
+utils/              # thinkingMessages, feedback (captureFeedback + rating types)
 lib/                # task/run helpers (parse-logs, task-status, repository, ph-debug, util-functions)
 scenes/             # standalone scenes registered via ../manifest.tsx
   TaskTracker/      #   the runner scene (component, stories, scene logics, scene-specific components/)

--- a/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
+++ b/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
@@ -7,6 +7,7 @@ import { isTerminalRunStatus, runStreamLogic } from '../logics/runStreamLogic'
 import { taskLogic } from '../logics/taskLogic'
 import { OriginProduct } from '../types/taskTypes'
 import { ContextUsageBar } from './ContextUsageBar'
+import { RunFeedbackFooter } from './feedback/RunFeedbackFooter'
 import { PermissionInput } from './PermissionInput'
 import { QuestionInput } from './QuestionInput'
 import { ResourcesBar } from './ResourcesBar'
@@ -45,6 +46,8 @@ interface RunSurfaceContextValue {
     interaction: 'live' | 'read-only'
     /** Run created by a Signals scout — the context-usage line is suppressed for these. */
     isScout: boolean
+    /** Telemetry tag — the conversation id when there is one; feedback falls back to the run id. */
+    conversationId?: string
 }
 
 const RunSurfaceContext = createContext<RunSurfaceContextValue | null>(null)
@@ -99,6 +102,7 @@ function RunSurfaceRoot({
                     runId: logicKey,
                     interaction,
                     isScout,
+                    conversationId,
                 }}
             >
                 <RunSurfaceBootstrap taskId={taskId} />
@@ -190,6 +194,19 @@ function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element
 }
 
 /**
+ * Feedback slot: the per-run thumbs + progressive good/okay/bad prompt. Live-only — a read-only replay
+ * has nothing to rate in place. The telemetry session id is the conversation id when there is one, else the
+ * run id (task runs have no conversation).
+ */
+function RunSurfaceFeedback(): JSX.Element | null {
+    const { interaction, runId, rawRunId, conversationId } = useRunSurfaceContext()
+    if (interaction !== 'live') {
+        return null
+    }
+    return <RunFeedbackFooter streamKey={runId} sessionId={conversationId ?? rawRunId} />
+}
+
+/**
  * Compound run surface. `RunSurface.Root` binds the stream logic, bootstraps the run, and provides context;
  * the slots (`RunSurface.Thread/.Composer/.Resources/.ContextUsage`) compose into a custom layout — there is
  * no default layout. `RunSurface.Composer` owns the prompt-vs-composer precedence and takes the composer UI
@@ -200,6 +217,7 @@ export const RunSurface = Object.assign(RunSurfaceRoot, {
     Root: RunSurfaceRoot,
     Thread: RunSurfaceThread,
     Composer: RunSurfaceComposer,
+    Feedback: RunSurfaceFeedback,
     Resources: ResourcesBar,
     ContextUsage: ContextUsageBar,
 })

--- a/products/posthog_ai/frontend/components/feedback/FeedbackDisplay.tsx
+++ b/products/posthog_ai/frontend/components/feedback/FeedbackDisplay.tsx
@@ -1,0 +1,56 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { feedbackPromptLogic } from '../../logics/feedbackPromptLogic'
+import { FeedbackRating } from '../../utils/feedback'
+
+/** The good/okay/bad/dismiss buttons. Reads the bound `feedbackPromptLogic` from context (see `RunFeedbackFooter`). */
+export function FeedbackDisplay(): JSX.Element | null {
+    const { isPromptVisible } = useValues(feedbackPromptLogic)
+    const { submitRating } = useActions(feedbackPromptLogic)
+
+    // Global keyboard shortcuts - capture phase intercepts before input fields
+    useEffect(() => {
+        if (!isPromptVisible) {
+            return
+        }
+
+        const keyToRating: Record<string, FeedbackRating> = {
+            '1': 'good',
+            '2': 'okay',
+            '3': 'bad',
+            x: 'dismissed',
+        }
+
+        const handleGlobalKeyDown = (e: KeyboardEvent): void => {
+            const rating = keyToRating[e.key]
+            if (rating) {
+                e.preventDefault()
+                e.stopPropagation()
+                submitRating(rating)
+            }
+        }
+
+        window.addEventListener('keydown', handleGlobalKeyDown, true)
+        return () => window.removeEventListener('keydown', handleGlobalKeyDown, true)
+    }, [isPromptVisible, submitRating])
+
+    return (
+        <div className="flex items-center gap-1">
+            <LemonButton size="xsmall" type="secondary" onClick={() => submitRating('good')}>
+                Good <span className="text-muted ml-0.5">1</span>
+            </LemonButton>
+            <LemonButton size="xsmall" type="secondary" onClick={() => submitRating('okay')}>
+                Okay <span className="text-muted ml-0.5">2</span>
+            </LemonButton>
+            <LemonButton size="xsmall" type="secondary" onClick={() => submitRating('bad')}>
+                Bad <span className="text-muted ml-0.5">3</span>
+            </LemonButton>
+            <LemonButton size="xsmall" type="secondary" onClick={() => submitRating('dismissed')}>
+                Dismiss <span className="text-muted ml-0.5">x</span>
+            </LemonButton>
+        </div>
+    )
+}

--- a/products/posthog_ai/frontend/components/feedback/FeedbackPrompt.tsx
+++ b/products/posthog_ai/frontend/components/feedback/FeedbackPrompt.tsx
@@ -1,0 +1,211 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useEffect, useState } from 'react'
+
+import { IconDocument } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+
+import { SupportForm } from 'lib/components/Support/SupportForm'
+import { supportLogic } from 'lib/components/Support/supportLogic'
+
+import { feedbackPromptLogic } from '../../logics/feedbackPromptLogic'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+import { captureFeedback } from '../../utils/feedback'
+
+export interface FeedbackPromptProps {
+    /** Telemetry session id — the conversation id when there is one, else the run id. */
+    sessionId: string
+}
+
+/**
+ * Detailed feedback form shown after the user clicks "Bad".
+ * Allows text feedback submission or escalation to a support ticket. Reads the bound `feedbackPromptLogic`.
+ */
+export function FeedbackPrompt({ sessionId }: FeedbackPromptProps): JSX.Element {
+    const { currentTriggerType, traceId } = useValues(feedbackPromptLogic)
+    const { recordFeedbackShown, completeDetailedFeedback } = useActions(feedbackPromptLogic)
+    const [feedbackText, setFeedbackText] = useState('')
+    const [status, setStatus] = useState<'feedback' | 'ticket_preview' | 'done'>('feedback')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)
+
+    const { sendSupportRequest, lastSubmittedTicketId } = useValues(supportLogic)
+    const { resetSendSupportRequest, setSendSupportRequestValue, submitSendSupportRequest } = useActions(supportLogic)
+
+    // Track when we're waiting for ticket submission to complete
+    const [pendingTicketSubmission, setPendingTicketSubmission] = useState(false)
+    // Track the ticket ID we had when starting submission to detect new tickets
+    const [ticketIdBeforeSubmission, setTicketIdBeforeSubmission] = useState<string | null>(null)
+
+    // Store the final message text when submitting ticket
+    const [ticketMessageText, setTicketMessageText] = useState<string>('')
+
+    useEffect(() => {
+        // When ticket submission completes (lastSubmittedTicketId changes to a new value), capture the events
+        if (pendingTicketSubmission && lastSubmittedTicketId && lastSubmittedTicketId !== ticketIdBeforeSubmission) {
+            captureFeedback(sessionId, traceId, 'bad', currentTriggerType, ticketMessageText || undefined)
+
+            posthog.capture('posthog_ai_support_ticket_created', {
+                $ai_conversation_id: sessionId,
+                $ai_session_id: sessionId,
+                $ai_trace_id: traceId,
+                $ai_support_ticket_id: lastSubmittedTicketId,
+                $ai_feedback_rating: 'bad',
+            })
+            setIsSupportModalOpen(false)
+            setPendingTicketSubmission(false)
+            completeDetailedFeedback()
+        }
+    }, [
+        lastSubmittedTicketId,
+        pendingTicketSubmission,
+        ticketIdBeforeSubmission,
+        completeDetailedFeedback,
+        sessionId,
+        traceId,
+        currentTriggerType,
+        ticketMessageText,
+    ])
+
+    function submitFeedback(): void {
+        if (isSubmitting) {
+            return
+        }
+        setIsSubmitting(true)
+        recordFeedbackShown()
+
+        captureFeedback(sessionId, traceId, 'bad', currentTriggerType, feedbackText)
+
+        setStatus('done')
+        setTimeout(completeDetailedFeedback, 2000)
+        setIsSubmitting(false)
+    }
+
+    function showTicketPreviewOrOpenModal(): void {
+        if (feedbackText.trim().length > 0) {
+            // Show preview if user entered feedback
+            setStatus('ticket_preview')
+        } else {
+            // Skip preview and open modal directly if no feedback
+            void openSupportModalWithPrefill()
+        }
+    }
+
+    function openSupportModalWithPrefill(): void {
+        resetSendSupportRequest({
+            name: '',
+            email: '',
+            kind: 'feedback',
+            target_area: 'posthog-ai',
+            severity_level: 'low',
+            message: feedbackText,
+        })
+
+        setIsSupportModalOpen(true)
+    }
+
+    function appendMetadataToMessage(message: string): string {
+        const metadataLines = [`Session ID: ${sessionId}`, traceId ? `Trace ID: ${traceId}` : null].filter(Boolean)
+        return message ? `${message}\n\n----\n${metadataLines.join('\n')}` : metadataLines.join('\n')
+    }
+
+    function handleSupportFormSubmit(): void {
+        setTicketMessageText(sendSupportRequest.message)
+        const finalMessage = appendMetadataToMessage(sendSupportRequest.message)
+
+        setSendSupportRequestValue('message', finalMessage)
+        setTicketIdBeforeSubmission(lastSubmittedTicketId)
+        setPendingTicketSubmission(true)
+        recordFeedbackShown()
+        submitSendSupportRequest()
+    }
+
+    function handleSupportModalCancel(): void {
+        setIsSupportModalOpen(false)
+        setPendingTicketSubmission(false)
+    }
+
+    const supportModal = (
+        <LemonModal
+            isOpen={isSupportModalOpen}
+            onClose={handleSupportModalCancel}
+            title="Give feedback"
+            footer={
+                <div className="flex items-center gap-2">
+                    <LemonButton type="secondary" onClick={handleSupportModalCancel}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" data-attr="submit" onClick={handleSupportFormSubmit}>
+                        Submit
+                    </LemonButton>
+                </div>
+            }
+        >
+            <SupportForm />
+        </LemonModal>
+    )
+
+    if (status === 'done') {
+        return (
+            <MessageTemplate type="ai">
+                <p className="m-0 text-sm text-secondary">Thanks for making PostHog AI better!</p>
+            </MessageTemplate>
+        )
+    }
+
+    if (status === 'feedback') {
+        return (
+            <>
+                <MessageTemplate type="ai">
+                    <div className="flex flex-col gap-2">
+                        <p className="m-0 font-medium">What could we improve?</p>
+                        <LemonInput
+                            placeholder="Help us improve PostHog AI..."
+                            value={feedbackText}
+                            onChange={setFeedbackText}
+                            onPressEnter={submitFeedback}
+                            fullWidth
+                            autoFocus
+                        />
+                        <div className="flex gap-2">
+                            <LemonButton type="primary" size="small" onClick={submitFeedback} loading={isSubmitting}>
+                                Submit
+                            </LemonButton>
+                            <LemonButton type="secondary" size="small" onClick={showTicketPreviewOrOpenModal}>
+                                Open support ticket
+                            </LemonButton>
+                        </div>
+                    </div>
+                </MessageTemplate>
+                {supportModal}
+            </>
+        )
+    }
+
+    return (
+        <>
+            <MessageTemplate type="ai">
+                <div className="flex flex-col gap-3">
+                    <div className="flex items-center gap-2">
+                        <IconDocument className="text-secondary" />
+                        <span className="font-medium">Support ticket ready for review</span>
+                    </div>
+                    <p className="m-0 text-sm text-secondary">
+                        Here's a draft of your support ticket. Please review and submit it to get help from PostHog
+                        support.
+                    </p>
+                    <div className="bg-bg-light border rounded p-3">
+                        <div className="text-xs font-medium text-secondary uppercase mb-1">Ticket description</div>
+                        <p className="m-0 text-sm whitespace-pre-wrap">{feedbackText}</p>
+                    </div>
+                    <div>
+                        <LemonButton type="primary" size="small" onClick={openSupportModalWithPrefill}>
+                            Review support ticket
+                        </LemonButton>
+                    </div>
+                </div>
+            </MessageTemplate>
+            {supportModal}
+        </>
+    )
+}

--- a/products/posthog_ai/frontend/components/feedback/MessageFeedbackActions.tsx
+++ b/products/posthog_ai/frontend/components/feedback/MessageFeedbackActions.tsx
@@ -1,0 +1,120 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useState } from 'react'
+
+import { IconCopy, IconThumbsDown, IconThumbsDownFilled, IconThumbsUp, IconThumbsUpFilled, IconX } from '@posthog/icons'
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { stripMarkdown } from 'lib/utils/markdown'
+
+import { messageRatingsLogic } from '../../logics/messageRatingsLogic'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+
+export interface MessageFeedbackActionsProps {
+    /** Run-level trace id the rating attaches to; the widget no-ops until it's available. */
+    traceId: string | null
+    /** Answer text to offer a copy button for; omit to hide it. */
+    content?: string | null
+}
+
+/** Per-run thumbs up/down with an inline "what disappointed you?" box, sunk to trace-metric telemetry. */
+export function MessageFeedbackActions({ traceId, content }: MessageFeedbackActionsProps): JSX.Element {
+    const { ratingForTraceId } = useValues(messageRatingsLogic)
+    const { setRatingForTraceId } = useActions(messageRatingsLogic)
+
+    const rating = ratingForTraceId(traceId)
+    const [feedback, setFeedback] = useState<string>('')
+    const [feedbackInputStatus, setFeedbackInputStatus] = useState<'hidden' | 'pending' | 'submitted'>('hidden')
+
+    function submitRating(newRating: 'good' | 'bad'): void {
+        if (rating || !traceId) {
+            return // Already rated
+        }
+        setRatingForTraceId({ traceId, rating: newRating })
+        posthog.captureTraceMetric(traceId, 'quality', newRating)
+        if (newRating === 'bad') {
+            setFeedbackInputStatus('pending')
+        }
+    }
+
+    function submitFeedback(): void {
+        if (!feedback || !traceId) {
+            return // Input is empty
+        }
+        posthog.captureTraceFeedback(traceId, feedback)
+        setFeedbackInputStatus('submitted')
+    }
+
+    return (
+        <>
+            <div className="flex items-center ml-1">
+                {content && (
+                    <LemonButton
+                        icon={<IconCopy />}
+                        type="tertiary"
+                        size="xsmall"
+                        tooltip="Copy answer"
+                        onClick={() => copyToClipboard(stripMarkdown(content))}
+                    />
+                )}
+                {rating !== 'bad' && (
+                    <LemonButton
+                        icon={rating === 'good' ? <IconThumbsUpFilled /> : <IconThumbsUp />}
+                        type="tertiary"
+                        size="xsmall"
+                        tooltip="Good answer"
+                        onClick={() => submitRating('good')}
+                    />
+                )}
+                {rating !== 'good' && (
+                    <LemonButton
+                        icon={rating === 'bad' ? <IconThumbsDownFilled /> : <IconThumbsDown />}
+                        type="tertiary"
+                        size="xsmall"
+                        tooltip="Bad answer"
+                        onClick={() => submitRating('bad')}
+                    />
+                )}
+            </div>
+            {feedbackInputStatus !== 'hidden' && (
+                <MessageTemplate type="ai">
+                    <div className="flex items-center gap-1">
+                        <h4 className="m-0 text-sm grow">
+                            {feedbackInputStatus === 'pending'
+                                ? 'What disappointed you about the answer?'
+                                : 'Thank you for your feedback!'}
+                        </h4>
+                        <LemonButton
+                            icon={<IconX />}
+                            type="tertiary"
+                            size="xsmall"
+                            onClick={() => {
+                                setFeedbackInputStatus('hidden')
+                            }}
+                        />
+                    </div>
+                    {feedbackInputStatus === 'pending' && (
+                        <div className="flex w-full gap-1.5 items-center mt-1.5">
+                            <LemonInput
+                                placeholder="Help us improve PostHog AI…"
+                                fullWidth
+                                value={feedback}
+                                onChange={(newValue) => setFeedback(newValue)}
+                                onPressEnter={() => submitFeedback()}
+                                autoFocus
+                            />
+                            <LemonButton
+                                type="primary"
+                                onClick={() => submitFeedback()}
+                                disabledReason={!feedback ? 'Please type a few words!' : undefined}
+                            >
+                                Submit
+                            </LemonButton>
+                        </div>
+                    )}
+                </MessageTemplate>
+            )}
+        </>
+    )
+}

--- a/products/posthog_ai/frontend/components/feedback/RunFeedbackFooter.tsx
+++ b/products/posthog_ai/frontend/components/feedback/RunFeedbackFooter.tsx
@@ -1,0 +1,59 @@
+import { BindLogic, useValues } from 'kea'
+
+import { feedbackPromptLogic } from '../../logics/feedbackPromptLogic'
+import { isTerminalRunStatus, runStreamLogic } from '../../logics/runStreamLogic'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+import { FeedbackDisplay } from './FeedbackDisplay'
+import { FeedbackPrompt } from './FeedbackPrompt'
+import { MessageFeedbackActions } from './MessageFeedbackActions'
+
+export interface RunFeedbackFooterProps {
+    /** Stream/logic key of the run (matches the bound `runStreamLogic`). */
+    streamKey: string
+    /** Telemetry session id — the conversation id when there is one, else the run id. */
+    sessionId: string
+}
+
+/**
+ * Feedback footer for a live run. Shows the per-run thumbs once the turn settles, plus the progressive
+ * good/okay/bad prompt (and its detailed-feedback / thank-you states) that `feedbackPromptLogic` surfaces.
+ * Binds `feedbackPromptLogic` so its children read it from context and its `runStreamLogic` listeners run.
+ */
+export function RunFeedbackFooter({ streamKey, sessionId }: RunFeedbackFooterProps): JSX.Element | null {
+    return (
+        <BindLogic logic={feedbackPromptLogic} props={{ streamKey, sessionId }}>
+            <RunFeedbackFooterContent sessionId={sessionId} />
+        </BindLogic>
+    )
+}
+
+function RunFeedbackFooterContent({ sessionId }: { sessionId: string }): JSX.Element | null {
+    const { traceId, turnComplete, currentRunStatus } = useValues(runStreamLogic)
+    const { isPromptVisible, isDetailedFeedbackVisible, isThankYouVisible } = useValues(feedbackPromptLogic)
+
+    // Feedback only makes sense once the run has settled — don't rate a turn still streaming.
+    const runSettled = turnComplete || isTerminalRunStatus(currentRunStatus)
+    if (!runSettled) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-col gap-2 px-4 pb-2">
+            <MessageFeedbackActions traceId={traceId} />
+            {isPromptVisible && (
+                <MessageTemplate type="ai">
+                    <div className="flex flex-col gap-2">
+                        <p className="m-0 font-medium">How is PostHog AI doing? (optional)</p>
+                        <FeedbackDisplay />
+                    </div>
+                </MessageTemplate>
+            )}
+            {isDetailedFeedbackVisible && <FeedbackPrompt sessionId={sessionId} />}
+            {isThankYouVisible && (
+                <MessageTemplate type="ai">
+                    <p className="m-0 text-sm text-secondary">Thanks for your feedback and using PostHog AI!</p>
+                </MessageTemplate>
+            )}
+        </div>
+    )
+}

--- a/products/posthog_ai/frontend/logics/feedbackPromptLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/feedbackPromptLogic.test.ts
@@ -1,0 +1,201 @@
+import { expectLogic } from 'kea-test-utils'
+
+import * as featureFlagLogic from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { feedbackPromptLogic } from './feedbackPromptLogic'
+
+const MOCK_STREAM_KEY = 'test-run-123'
+const MOCK_SESSION_ID = 'test-session-123'
+const STORAGE_KEY = 'posthog_ai_run_feedback_last_shown'
+
+const DEFAULT_CONFIG = {
+    cooldownMs: 86400000, // 24 hours
+    messageInterval: 10,
+    samplingRate: 0.05,
+    retryThreshold: 2,
+    cancelThreshold: 3,
+}
+
+describe('feedbackPromptLogic', () => {
+    let logic: ReturnType<typeof feedbackPromptLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        localStorage.clear()
+
+        jest.spyOn(featureFlagLogic, 'getFeatureFlagPayload').mockReturnValue(DEFAULT_CONFIG)
+
+        logic = feedbackPromptLogic({ streamKey: MOCK_STREAM_KEY, sessionId: MOCK_SESSION_ID })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+        localStorage.clear()
+    })
+
+    describe('checkShouldShowPrompt', () => {
+        it('does not show prompt when config is not available', async () => {
+            jest.spyOn(featureFlagLogic, 'getFeatureFlagPayload').mockReturnValue(null)
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(10)
+            }).toMatchValues({
+                isPromptVisible: false,
+            })
+        })
+
+        it('does not show prompt when already visible', async () => {
+            logic.actions.showPrompt('manual')
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(10)
+            }).toMatchValues({
+                isPromptVisible: true,
+                currentTriggerType: 'manual', // Should not change
+            })
+        })
+
+        it('does not show prompt when cooldown is active', async () => {
+            localStorage.setItem(STORAGE_KEY, Date.now().toString())
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(10)
+            }).toMatchValues({
+                isPromptVisible: false,
+            })
+        })
+
+        it('shows prompt with message_interval trigger at correct intervals', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(10)
+            }).toMatchValues({
+                isPromptVisible: true,
+                currentTriggerType: 'message_interval',
+                lastTriggeredIntervalIndex: 1,
+            })
+        })
+
+        it('does not trigger message_interval twice for same interval', async () => {
+            // Avoid the random-sampling trigger
+            jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
+            logic.actions.checkShouldShowPrompt(10)
+            expect(logic.values.isPromptVisible).toBe(true)
+            expect(logic.values.lastTriggeredIntervalIndex).toBe(1)
+
+            logic.actions.hidePrompt()
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(10)
+            }).toMatchValues({
+                isPromptVisible: false,
+                lastTriggeredIntervalIndex: 1,
+            })
+        })
+
+        it('triggers message_interval at next interval', async () => {
+            jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
+            logic.actions.checkShouldShowPrompt(10)
+            logic.actions.hidePrompt()
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(20)
+            }).toMatchValues({
+                isPromptVisible: true,
+                currentTriggerType: 'message_interval',
+                lastTriggeredIntervalIndex: 2,
+            })
+        })
+
+        it('does not show prompt when message count is not at interval', async () => {
+            jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
+            await expectLogic(logic, () => {
+                logic.actions.checkShouldShowPrompt(7)
+            }).toMatchValues({
+                isPromptVisible: false,
+            })
+        })
+    })
+
+    describe('showPrompt and hidePrompt', () => {
+        it('hidePrompt resets visibility and trigger type', async () => {
+            logic.actions.showPrompt('message_interval')
+
+            await expectLogic(logic, () => {
+                logic.actions.hidePrompt()
+            }).toMatchValues({
+                isPromptVisible: false,
+                currentTriggerType: 'manual',
+            })
+        })
+    })
+
+    describe('recordFeedbackShown', () => {
+        it('sets localStorage timestamp', async () => {
+            const beforeTime = Date.now()
+
+            await expectLogic(logic, () => {
+                logic.actions.recordFeedbackShown()
+            })
+
+            const storedTime = parseInt(localStorage.getItem(STORAGE_KEY) || '0', 10)
+            expect(storedTime).toBeGreaterThanOrEqual(beforeTime)
+            expect(storedTime).toBeLessThanOrEqual(Date.now())
+        })
+    })
+
+    describe('canShowPrompt selector', () => {
+        it('returns true when no cooldown is active', () => {
+            expect(logic.values.canShowPrompt).toBe(true)
+        })
+
+        it('returns false when cooldown is active', () => {
+            localStorage.setItem(STORAGE_KEY, Date.now().toString())
+
+            // Remount to pick up the new localStorage value (selector reads it at build time)
+            logic.unmount()
+            logic = feedbackPromptLogic({ streamKey: MOCK_STREAM_KEY, sessionId: MOCK_SESSION_ID })
+            logic.mount()
+
+            expect(logic.values.canShowPrompt).toBe(false)
+        })
+
+        it('returns false when config is not available', () => {
+            jest.spyOn(featureFlagLogic, 'getFeatureFlagPayload').mockReturnValue(null)
+
+            logic.unmount()
+            logic = feedbackPromptLogic({ streamKey: MOCK_STREAM_KEY, sessionId: MOCK_SESSION_ID })
+            logic.mount()
+
+            expect(logic.values.canShowPrompt).toBe(false)
+        })
+    })
+
+    describe('per-run isolation', () => {
+        it('maintains separate state for different runs', () => {
+            const logic1 = feedbackPromptLogic({ streamKey: 'run-1', sessionId: 'run-1' })
+            const logic2 = feedbackPromptLogic({ streamKey: 'run-2', sessionId: 'run-2' })
+
+            logic1.mount()
+            logic2.mount()
+
+            logic1.actions.showPrompt('message_interval')
+            logic1.actions.setLastTriggeredIntervalIndex(3)
+
+            expect(logic1.values.isPromptVisible).toBe(true)
+            expect(logic1.values.lastTriggeredIntervalIndex).toBe(3)
+
+            expect(logic2.values.isPromptVisible).toBe(false)
+            expect(logic2.values.lastTriggeredIntervalIndex).toBe(0)
+
+            logic1.unmount()
+            logic2.unmount()
+        })
+    })
+})

--- a/products/posthog_ai/frontend/logics/feedbackPromptLogic.ts
+++ b/products/posthog_ai/frontend/logics/feedbackPromptLogic.ts
@@ -1,0 +1,257 @@
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
+
+import type { ThreadItem } from '../types/streamTypes'
+import { FeedbackRating, FeedbackTriggerType, captureFeedback } from '../utils/feedback'
+import type { feedbackPromptLogicType } from './feedbackPromptLogicType'
+import { runStreamLogic } from './runStreamLogic'
+
+export interface FeedbackConfig {
+    cooldownMs: number
+    messageInterval: number
+    samplingRate: number
+    retryThreshold: number
+    cancelThreshold: number
+}
+
+const STORAGE_KEY = 'posthog_ai_run_feedback_last_shown'
+
+export interface FeedbackPromptLogicProps {
+    /** Stream/logic key of the run this prompt belongs to (matches the bound `runStreamLogic`). */
+    streamKey: string
+    /** Telemetry session id — the conversation id when there is one, else the run id. */
+    sessionId: string
+}
+
+/**
+ * Decides when to show the conversation-level good/okay/bad feedback prompt for a run, tracks its
+ * multi-state UI (prompt → detailed feedback → thank-you), enforces a cooldown, and emits capture events.
+ *
+ * Runtime-agnostic: it connects to the in-product `runStreamLogic` (never Max), triggering off the run's
+ * own `markTurnComplete` / `pushHumanMessage` actions rather than a bridging hook.
+ */
+export const feedbackPromptLogic = kea<feedbackPromptLogicType>([
+    path(['products', 'posthog_ai', 'frontend', 'logics', 'feedbackPromptLogic']),
+
+    props({} as FeedbackPromptLogicProps),
+
+    key((props) => props.streamKey),
+
+    connect((props: FeedbackPromptLogicProps) => ({
+        values: [runStreamLogic({ streamKey: props.streamKey }), ['traceId', 'threadItems']],
+        actions: [runStreamLogic({ streamKey: props.streamKey }), ['markTurnComplete', 'pushHumanMessage']],
+    })),
+
+    actions({
+        submitRating: (rating: FeedbackRating) => ({ rating }),
+        completeDetailedFeedback: true,
+        checkShouldShowPrompt: (messageCount: number) => ({ messageCount }),
+        showPrompt: (triggerType: FeedbackTriggerType) => ({ triggerType }),
+        hidePrompt: true,
+        showDetailedFeedback: true,
+        hideDetailedFeedback: true,
+        showThankYou: true,
+        hideThankYou: true,
+        implicitDismissPrompt: true,
+        implicitDismissDetailedFeedback: true,
+        recordFeedbackShown: true,
+        setLastTriggeredIntervalIndex: (index: number) => ({ index }),
+    }),
+
+    reducers({
+        isPromptVisible: [
+            false,
+            {
+                showPrompt: () => true,
+                hidePrompt: () => false,
+                implicitDismissPrompt: () => false,
+                showDetailedFeedback: () => false,
+                showThankYou: () => false,
+            },
+        ],
+        isDetailedFeedbackVisible: [
+            false,
+            {
+                showDetailedFeedback: () => true,
+                hideDetailedFeedback: () => false,
+                implicitDismissDetailedFeedback: () => false,
+                hidePrompt: () => false,
+            },
+        ],
+        isThankYouVisible: [
+            false,
+            {
+                showThankYou: () => true,
+                hideThankYou: () => false,
+                showPrompt: () => false,
+            },
+        ],
+        currentTriggerType: [
+            'manual' as FeedbackTriggerType,
+            {
+                showPrompt: (_, { triggerType }) => triggerType,
+                hidePrompt: () => 'manual' as FeedbackTriggerType,
+            },
+        ],
+        lastTriggeredIntervalIndex: [
+            0,
+            {
+                setLastTriggeredIntervalIndex: (_, { index }) => index,
+            },
+        ],
+    }),
+
+    selectors({
+        feedbackConfig: [
+            () => [],
+            (): FeedbackConfig | null => {
+                const payload = getFeatureFlagPayload(FEATURE_FLAGS.POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG)
+                if (!payload || typeof payload !== 'object') {
+                    posthog.captureException(
+                        new Error('POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG feature flag is not set'),
+                        { tags: { product: 'posthog_ai' } }
+                    )
+                    return null
+                }
+                return {
+                    cooldownMs: payload.cooldownMs,
+                    messageInterval: payload.messageInterval,
+                    samplingRate: payload.samplingRate,
+                    retryThreshold: payload.retryThreshold,
+                    cancelThreshold: payload.cancelThreshold,
+                }
+            },
+        ],
+        canShowPrompt: [
+            (s) => [s.feedbackConfig],
+            (feedbackConfig): boolean => {
+                if (!feedbackConfig) {
+                    return false
+                }
+                const lastShown = localStorage.getItem(STORAGE_KEY)
+                if (!lastShown) {
+                    return true
+                }
+                return Date.now() - parseInt(lastShown, 10) > feedbackConfig.cooldownMs
+            },
+        ],
+        messageInterval: [(s) => [s.feedbackConfig], (feedbackConfig): number => feedbackConfig?.messageInterval ?? 10],
+        humanMessageCount: [
+            (s) => [s.threadItems],
+            (threadItems: ThreadItem[]): number => threadItems.filter((item) => item.type === 'human_message').length,
+        ],
+    }),
+
+    listeners(({ actions, values, props, cache }) => ({
+        submitRating: ({ rating }) => {
+            const { sessionId } = props
+            const { currentTriggerType, messageInterval, traceId, humanMessageCount } = values
+
+            // For "bad" rating, show the detailed feedback form instead of capturing immediately
+            if (rating === 'bad') {
+                actions.showDetailedFeedback()
+                return
+            }
+
+            captureFeedback(sessionId, traceId, rating, currentTriggerType)
+            actions.recordFeedbackShown()
+
+            // Set the interval index to current level so we don't re-trigger at the same message count
+            const currentIntervalIndex = Math.floor(humanMessageCount / messageInterval)
+            actions.setLastTriggeredIntervalIndex(currentIntervalIndex)
+
+            // Show thank you for okay/good, just hide for dismissed
+            if (rating === 'dismissed') {
+                actions.hidePrompt()
+            } else {
+                actions.showThankYou()
+            }
+        },
+
+        showThankYou: () => {
+            cache.disposables.add(() => {
+                const timer = setTimeout(() => actions.hideThankYou(), 2000)
+                return () => clearTimeout(timer)
+            }, 'thankYouTimer')
+        },
+
+        checkShouldShowPrompt: ({ messageCount }) => {
+            const { feedbackConfig } = values
+            if (!feedbackConfig) {
+                return
+            }
+
+            if (values.isPromptVisible) {
+                return
+            }
+
+            // Check cooldown directly (selector isn't reactive)
+            const lastShown = localStorage.getItem(STORAGE_KEY)
+            if (lastShown && Date.now() - parseInt(lastShown, 10) < feedbackConfig.cooldownMs) {
+                return
+            }
+
+            // Message interval - only trigger once per interval
+            if (messageCount > 0 && messageCount % feedbackConfig.messageInterval === 0) {
+                const currentIntervalIndex = Math.floor(messageCount / feedbackConfig.messageInterval)
+                if (currentIntervalIndex > values.lastTriggeredIntervalIndex) {
+                    actions.setLastTriggeredIntervalIndex(currentIntervalIndex)
+                    actions.showPrompt('message_interval')
+                    return
+                }
+            }
+
+            // Random sampling
+            if (Math.random() < feedbackConfig.samplingRate) {
+                actions.showPrompt('random_sample')
+            }
+        },
+
+        recordFeedbackShown: () => {
+            localStorage.setItem(STORAGE_KEY, Date.now().toString())
+        },
+
+        implicitDismissPrompt: () => {
+            const { sessionId } = props
+            const { currentTriggerType, traceId } = values
+
+            captureFeedback(sessionId, traceId, 'implicit_dismiss', currentTriggerType)
+            actions.recordFeedbackShown()
+        },
+
+        implicitDismissDetailedFeedback: () => {
+            const { sessionId } = props
+            const { currentTriggerType, traceId } = values
+
+            captureFeedback(sessionId, traceId, 'bad', currentTriggerType)
+            actions.recordFeedbackShown()
+        },
+
+        completeDetailedFeedback: () => {
+            const { messageInterval, humanMessageCount } = values
+
+            const currentIntervalIndex = Math.floor(humanMessageCount / messageInterval)
+            actions.setLastTriggeredIntervalIndex(currentIntervalIndex)
+            actions.hideDetailedFeedback()
+        },
+
+        // Run turn finished streaming — decide whether to surface the prompt.
+        markTurnComplete: () => {
+            if (values.humanMessageCount > 0) {
+                actions.checkShouldShowPrompt(values.humanMessageCount)
+            }
+        },
+
+        // User sent a follow-up while a prompt/form was open — treat it as an implicit dismissal.
+        pushHumanMessage: () => {
+            if (values.isPromptVisible) {
+                actions.implicitDismissPrompt()
+            } else if (values.isDetailedFeedbackVisible) {
+                actions.implicitDismissDetailedFeedback()
+            }
+        },
+    })),
+])

--- a/products/posthog_ai/frontend/logics/messageRatingsLogic.ts
+++ b/products/posthog_ai/frontend/logics/messageRatingsLogic.ts
@@ -1,0 +1,79 @@
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+
+import type { messageRatingsLogicType } from './messageRatingsLogicType'
+
+export type MessageRating = 'good' | 'bad'
+export type MessageRatingOrNull = MessageRating | null
+
+const MAX_STORED_RATINGS = 1000
+
+/**
+ * Persists run-thread message ratings ("good"/"bad") keyed by trace ID.
+ *
+ * Uses Kea's localStorage plugin for automatic persistence.
+ */
+export const messageRatingsLogic = kea<messageRatingsLogicType>([
+    path(['products', 'posthog_ai', 'frontend', 'logics', 'messageRatingsLogic']),
+
+    actions({
+        setRatingForTraceId: (payload: { traceId: string; rating: MessageRating }) => ({
+            traceId: payload.traceId.trim(),
+            rating: payload.rating,
+        }),
+        clearRatingForTraceId: (payload: { traceId: string }) => ({ traceId: payload.traceId.trim() }),
+        clearAllRatings: true,
+        pruneOldRatings: true,
+    }),
+
+    reducers({
+        ratingsByTraceId: [
+            {} as Record<string, MessageRating>,
+            { persist: true, storageKey: 'posthog_ai_run_ratings' },
+            {
+                setRatingForTraceId: (state, { traceId, rating }) => ({
+                    ...state,
+                    [traceId]: rating,
+                }),
+                clearRatingForTraceId: (state, { traceId }) => {
+                    if (!(traceId in state)) {
+                        return state
+                    }
+                    const next = { ...state }
+                    delete next[traceId]
+                    return next
+                },
+                clearAllRatings: () => ({}),
+                pruneOldRatings: (state) => {
+                    const entries = Object.entries(state)
+                    if (entries.length <= MAX_STORED_RATINGS) {
+                        return state
+                    }
+                    return Object.fromEntries(entries.slice(-MAX_STORED_RATINGS))
+                },
+            },
+        ],
+    }),
+
+    selectors({
+        ratingForTraceId: [
+            (s) => [s.ratingsByTraceId],
+            (ratingsByTraceId: Record<string, MessageRating>) => {
+                return (traceId: string | null | undefined): MessageRatingOrNull => {
+                    if (!traceId) {
+                        return null
+                    }
+                    return ratingsByTraceId[traceId] ?? null
+                }
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        setRatingForTraceId: () => {
+            // Prune old ratings if we've exceeded the limit
+            if (Object.keys(values.ratingsByTraceId).length > MAX_STORED_RATINGS) {
+                actions.pruneOldRatings()
+            }
+        },
+    })),
+])

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -57,6 +57,7 @@ function TaskRunChatContent({ logicProps }: { logicProps: RunInteractionLogicPro
         <RunSurface.Root taskId={logicProps.taskId} runId={logicProps.runId} interaction="live">
             <div className="@container/thread flex flex-col h-full -mx-4">
                 <RunSurface.Thread className="flex-1 min-h-0" listClassName="py-4" rowClassName="px-4" />
+                <RunSurface.Feedback />
                 <RunSurface.Composer>
                     <RunSurface.Resources />
                     <Composer.Root

--- a/products/posthog_ai/frontend/utils/feedback.ts
+++ b/products/posthog_ai/frontend/utils/feedback.ts
@@ -1,0 +1,33 @@
+import posthog from 'posthog-js'
+
+export type FeedbackRating = 'bad' | 'okay' | 'good' | 'dismissed' | 'implicit_dismiss'
+export type FeedbackTriggerType = 'message_interval' | 'random_sample' | 'manual' | 'retry' | 'cancel'
+
+/**
+ * Sinks a conversation-level feedback rating (and optional free text) to PostHog telemetry.
+ * `sessionId` is the run's telemetry session id (the conversation id when there is one, else the run id).
+ */
+export function captureFeedback(
+    sessionId: string,
+    traceId: string | null,
+    rating: FeedbackRating,
+    triggerType: FeedbackTriggerType,
+    feedbackText?: string
+): void {
+    posthog.capture('$ai_metric', {
+        $ai_metric_name: 'feedback',
+        $ai_metric_value: rating,
+        $ai_session_id: sessionId,
+        $ai_trace_id: traceId,
+        feedback_trigger_type: triggerType,
+    })
+
+    if (feedbackText) {
+        posthog.capture('$ai_feedback', {
+            $ai_feedback_text: feedbackText,
+            $ai_session_id: sessionId,
+            $ai_trace_id: traceId,
+            ai_product: 'posthog_ai',
+        })
+    }
+}


### PR DESCRIPTION
## Problem

The PostHog AI run surface (`products/posthog_ai/frontend`), used by the task runner at `/tasks`, had no way for a user to rate an answer. Max's feedback — per-message thumbs and the periodic good/okay/bad prompt — was tied to the legacy LangGraph path and `maxThreadLogic`, so it couldn't be reused on the sandbox run surface.

## Changes

Ported both feedback systems into the run surface as self-contained, runtime-agnostic copies — no `scenes/max` imports (the product's coupling gate forbids them):

- **Per-run thumbs up/down** (`MessageFeedbackActions`), keyed to the run's trace id, with an inline "what disappointed you?" box → `captureTraceMetric` / `captureTraceFeedback`.
- **Progressive good/okay/bad prompt** (`feedbackPromptLogic` + `FeedbackDisplay` + `FeedbackPrompt`) that auto-triggers when a run turn settles and escalates a "bad" rating to a detailed form + support ticket → `$ai_metric` / `$ai_feedback`.
- Exposed as an opt-in `RunSurface.Feedback` slot (live-only) and wired into `TaskRunChat`.

Decoupled from Max: the trigger logic listens to `runStreamLogic`'s `markTurnComplete` / `pushHumanMessage` actions instead of bridging `maxThreadLogic` (no `kea-subscriptions`); the thank-you timer uses `cache.disposables`. Retry/cancel triggers were dropped — the surface has no such counters. Feedback is intentionally duplicated with Max's LangGraph copy; both `AGENTS.md` docs updated to say so.

No screenshots — feedback renders only on live runs: thumbs appear under the final answer once a run settles, and the good/okay/bad prompt appears when the `posthog-ai-conversation-feedback-config` flag payload is set.

## How did you test this code?

I'm an agent and ran automated checks only — I did **not** manually verify in the running app:

- Ported logic test `feedbackPromptLogic.test.ts` — 13 cases (interval fires once per interval, cooldown suppression, config-null disables, per-run isolation); all pass. Adapted from Max's test; dropped the retry/cancel-priority cases since those triggers no longer exist.
- `tsgo --noEmit`: every added/edited file typechecks clean. oxlint + oxfmt clean.
- Coupling gate: added files import nothing from `scenes/max` / `maxThreadLogic` / `MaxUIContext`.

Manual end-to-end verification (run a task, rate the answer, confirm the capture events fire) is still recommended before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. Internal `AGENTS.md` files updated to record that the run surface now owns its own feedback copy, separate from Max's.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (Opus 4.8). The human directed the work: copy Max's thumbs and progressive feedback into the `posthog_ai` run surface — copy, don't share.
- Skills invoked: `/writing-kea-logics`, `/using-kea-disposables`, `/writing-tests`.
- Decisions: chose **per-run** thumbs (the surface exposes one run-level `traceId`, not per-message) over extending the stream fold; moved the trigger orchestration into `feedbackPromptLogic` via **listeners on `runStreamLogic` actions** rather than `kea-subscriptions` (per the kea-logics skill), which removed Max's `useFeedback` hook entirely; made the progressive prompt an opt-in `RunSurface.Feedback` slot so read-only inbox embeds and other consumers are unaffected.
- Based on `master`, not the author's in-flight `phai-tasktracker-virtualize-list` branch — the one-line `TaskRunChat` slot insert may lightly conflict with that branch's composer refactor when both merge.
