### PR TITLE
chore(ci): match depot shadow sharding to canonical timings

### DIFF
--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -1,0 +1,91 @@
+# Depot CI mirror of .github/workflows/ci-backend-update-test-timing.yml. Refreshes the
+# .test_durations the shadow restores for sharding, saving it to Depot Cache (the GitHub Actions
+# Cache copy is a separate store the shadow can't read). Merges timing artifacts from the newest
+# master ci-backend run; no test execution. Needs GH_APP_POSTHOG_TESTS_* in `depot ci secrets`.
+name: Depot CI shadow - update test timing
+on:
+    workflow_dispatch: {}
+    schedule:
+        - cron: '0 1,7,13,19 * * *'
+permissions:
+    contents: read
+    actions: read
+jobs:
+    refresh-depot-test-durations:
+        name: Refresh .test_durations in Depot Cache
+        runs-on: depot-ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Get app token
+              id: app-token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_TESTS_PRIVATE_KEY }}
+
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+
+            - name: Find newest Backend CI run with timing artifacts
+              id: find-backend-run
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  cutoff_date=$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-14d +%Y-%m-%dT%H:%M:%SZ)
+                  primary=$(gh api "repos/$REPO/actions/workflows/ci-backend.yml/runs?status=success&branch=master&per_page=100&created=>=$cutoff_date" \
+                      --jq '.workflow_runs[] | select(
+                          (.updated_at | fromdateiso8601) - (.run_started_at | fromdateiso8601) > 300
+                      ) | .id' | head -25 | \
+                      while read -r id; do
+                          count=$(gh api "repos/$REPO/actions/runs/$id/artifacts?per_page=100" \
+                              --jq '[.artifacts[] | select(.name | startswith("timing_data-")) | select(.expired == false)] | length' 2>/dev/null)
+                          if [ "$count" -ge "38" ]; then echo "$id"; break; fi
+                      done)
+                  if [ -z "$primary" ]; then
+                      echo "::error::No suitable Backend CI run found with timing artifacts"
+                      exit 1
+                  fi
+                  echo "run_id=$primary" >> "$GITHUB_OUTPUT"
+
+            - name: Download timing artifacts
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  BACKEND_RUN_ID: ${{ steps.find-backend-run.outputs.run_id }}
+              run: |
+                  gh run download "$BACKEND_RUN_ID" \
+                      --pattern "timing_data-Core-*" \
+                      --pattern "timing_data-Temporal-*" \
+                      --pattern "timing_data-Products-*" \
+                      --dir timing_artifacts
+                  gh run download "$BACKEND_RUN_ID" \
+                      --pattern "junit-results-backend-core-*" \
+                      --pattern "junit-results-backend-temporal-*" \
+                      --dir junit_artifacts || echo "::warning::No JUnit artifacts — statistical carrier detection"
+
+            - name: Merge into .test_durations
+              run: |
+                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/core_durations \
+                      --segment Core --junit-dir junit_artifacts
+                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/temporal_durations \
+                      --segment Temporal --junit-dir junit_artifacts
+                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
+                      --segment Products
+                  uv run .github/scripts/optimize_test_durations.py .test_durations \
+                      --merge-files /tmp/core_durations /tmp/temporal_durations /tmp/products_durations
+                  rm -rf timing_artifacts junit_artifacts /tmp/core_durations /tmp/temporal_durations /tmp/products_durations
+
+            - name: Compute cache key
+              id: durations-meta
+              run: echo "cache_key=posthog-test-durations-$(date -u +%FT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+            - name: Save test durations to Depot Cache
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              continue-on-error: true
+              with:
+                  path: .test_durations
+                  key: ${{ steps.durations-meta.outputs.cache_key }}

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -30,9 +30,9 @@
 # - Path-filter persons-SQL folded into migrations. check-migrations.if also gates
 #   on openapi_types so an OpenAPI-only PR still runs the folded check
 # - Snapshot mode matches canonical, but snapshot patch upload/commit is stripped
-# - Test-duration cache restore omitted: there is no Depot timing-update writer, so
-#   the shadow shards from the committed .test_durations (canonical refreshes from a
-#   daily cache) and the file-granularity split-plan probe stays dormant
+# - Test durations restored from Depot Cache (posthog-test-durations- prefix), refreshed by
+#   .depot/workflows/ci-backend-update-test-timing.yml, so shard counts match GitHub Actions.
+#   Committed .test_durations is the fallback.
 # - master (push) runs only check-migrations to prime the shared schema cache; the
 #   test matrices are skipped on master (canonical runs them). PRs/merge_group/dispatch
 #   run the full graph — that is where the apples-to-apples comparison happens
@@ -40,8 +40,8 @@
 
 # This workflow runs all of our backend django tests.
 #
-# Shards derive from the committed .test_durations; to re-time, refresh that file
-# (canonical's .github/workflows/ci-backend-update-test-timing.yml is the source of truth).
+# Shards derive from .test_durations (Amdahl), restored from Depot Cache (else committed);
+# .depot/workflows/ci-backend-update-test-timing.yml keeps that cache fresh.
 name: '[optional, does not block merge] Backend CI'
 # OPTIONAL, non-blocking shadow of canonical Backend CI — its statuses must never gate
 # merging (hence the "[optional, does not block merge]" name prefix). The
@@ -536,6 +536,14 @@ jobs:
               uses: ./.depot/actions/pnpm-install
               with:
                   install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+            - name: Restore test durations from cache
+              # Restore fresh timings so shard counts match GitHub Actions; miss falls back to committed.
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .test_durations
+                  key: posthog-test-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-test-durations-
             - name: Discover products to test
               id: discover
               env:


### PR DESCRIPTION
## Problem

The Depot CI shadow wasn't apples-to-apples with GitHub Actions on Django sharding: same commit, **36** shards vs **42**, so each shadow shard packs more tests and runs longer — biasing per-shard timing comparisons.

Cause: shard counts are Amdahl-derived from `.test_durations`. GitHub Actions restores a fresh copy before sharding; the shadow dropped that restore step and its `actions/cache` routes to Depot Cache (no writer), so it fell back to the stale committed file → fewer, larger shards.

## Changes

- Re-add the `.test_durations` cache restore to the shadow's `turbo-discover`.
- Add `.depot/workflows/ci-backend-update-test-timing.yml` — merges timing artifacts from the newest master run into Depot Cache (no test execution).

## How did you test this code?

No CI run (shadow only samples when `CI_DEPOT_SHADOW_PERCENT>0`). Locally: YAML + `actionlint` clean, drift check passes. Reproduced the cause — `turbo-discover.js` on the committed file → 36; the GitHub Actions run restored a same-day cache → 42.

## Open items

- ✅ `GH_APP_POSTHOG_TESTS_*` imported into `depot ci secrets` (2026-07-01) — the timing job can now auth.
- Confirm Depot CI honors `schedule:` triggers — `push` is verified to work as a fallback if not.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8). Traced a suspicious per-shard timing gap to divergent shard counts, then to the stale committed `.test_durations`; verified via `depot ci` + a local `turbo-discover.js` run before changing anything.
