### PR TITLE
fix(warehouse): stop cache warming capturing access denials as errors

### DIFF
--- a/posthog/caching/test/test_warming.py
+++ b/posthog/caching/test/test_warming.py
@@ -3,7 +3,11 @@ from datetime import UTC, datetime, timedelta
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
-from posthog.caching.warming import insights_to_keep_fresh, schedule_warming_for_teams_task
+from parameterized import parameterized
+
+from posthog.hogql.errors import TableAccessDeniedError
+
+from posthog.caching.warming import insights_to_keep_fresh, schedule_warming_for_teams_task, warm_insight_cache_task
 
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
@@ -156,3 +160,25 @@ class TestScheduleWarmingForTeamsTask(APIBaseTest):
         self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[0][0][0], "1234")
         self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[0][0][1], "5678")
         self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[1][0][0], "2345")
+
+
+class TestWarmInsightCacheTask(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("access_denied_skipped", TableAccessDeniedError("You don't have access to table `x`."), False),
+            ("other_errors_captured", ValueError("boom"), True),
+        ]
+    )
+    @patch("posthog.caching.warming.capture_exception")
+    @patch("posthog.caching.warming.process_query_dict")
+    def test_warehouse_access_denial_is_skipped_not_captured(
+        self, _name, raised_error, should_capture, mock_process_query_dict, mock_capture_exception
+    ):
+        insight = Insight.objects.create(
+            team=self.team, query={"kind": "HogQLQuery", "query": "select 1"}, created_by=self.user
+        )
+        mock_process_query_dict.side_effect = raised_error
+
+        warm_insight_cache_task(insight.pk, None)
+
+        self.assertEqual(mock_capture_exception.called, should_capture)

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -12,6 +12,7 @@ from celery.canvas import chain
 from prometheus_client import Counter, Gauge
 
 from posthog.hogql.constants import LimitContext
+from posthog.hogql.errors import TableAccessDeniedError
 
 from posthog.api.services.query import process_query_dict
 from posthog.caching.utils import largest_teams
@@ -273,5 +274,11 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
 
         except CHQueryErrorTooManySimultaneousQueries:
             raise
+        except TableAccessDeniedError:
+            # The insight's creator lacks access to a warehouse table/view it reads, so there is nothing
+            # to warm for them. Expected under warehouse access control - skip quietly instead of capturing.
+            logger.info(
+                f"Skipping cache warming for insight {insight.pk} (team {insight.team_id}): access-controlled table"
+            )
         except Exception as e:
             capture_exception(e)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -140,7 +140,7 @@ from posthog.hogql.database.schema.web_stats_preaggregated import WebStatsPreagg
 from posthog.hogql.database.schema.web_vitals_paths_preaggregated import WebVitalsPathsPreaggregatedTable
 from posthog.hogql.database.utils import get_join_field_chain, qualify_join_key_expr
 from posthog.hogql.database.warehouse_join_resolvers import data_warehouse_resolver_params
-from posthog.hogql.errors import QueryError, ResolutionError
+from posthog.hogql.errors import QueryError, ResolutionError, TableAccessDeniedError
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.timings import HogQLTimings
@@ -560,7 +560,7 @@ class Database(BaseModel):
             if isinstance(table_name, list):
                 table_name = ".".join(table_name)
             if table_name in self._denied_tables:
-                raise QueryError(f"You don't have access to table `{table_name}`.") from e
+                raise TableAccessDeniedError(f"You don't have access to table `{table_name}`.") from e
             suggestions = self._suggest_table_names(table_name)
             suffix = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
             raise QueryError(f"Unknown table `{table_name}`.{suffix}") from e

--- a/posthog/hogql/errors.py
+++ b/posthog/hogql/errors.py
@@ -59,6 +59,16 @@ class QueryError(ExposedHogQLError):
     pass
 
 
+class TableAccessDeniedError(QueryError):
+    """Access control denied the querying principal access to a table/view.
+
+    A QueryError subclass so the user-facing message is unchanged, but callers (e.g. cache warming)
+    can distinguish an expected access denial from a genuine query error.
+    """
+
+    pass
+
+
 class NotImplementedError(InternalHogQLError):
     """This feature isn't implemented in HogQL (yet)."""
 


### PR DESCRIPTION
## Problem

Ramping `hogql-warehouse-access-control` surfaced a flood of `ResolutionError: Unknown table` / `You don't have access to table` denials coming from **insight cache warming**, e.g. [`Unknown table nextdot_events`](https://us.posthog.com/project/2/error_tracking/019f1e13-1177-72d2-8afd-84558e7515b0).

`warm_insight_cache_task` runs each insight's query as `insight.created_by`. When that principal lacks access to a warehouse table/view the insight reads (or `created_by` is null), the HogQL database build fails closed and raises a denial. The task's catch-all `except Exception: capture_exception(e)` then reports every one of these to error tracking.

This is not a query bug and it is not user-facing breakage - a live query still runs with the requesting user's own access. But it means every warehouse-table-backed insight in an enrolled org throws a captured exception on each warm cycle (error-tracking noise) and its cache never warms (those insights always run cold). This is a separate path from the experiment over-denial in #67384.

## Changes

- Add `TableAccessDeniedError`, a `QueryError` subclass, raised at the denial site in `database.py`. Because it subclasses `QueryError` the user-facing message and all existing `QueryError` handling are unchanged - only now callers can tell an access denial apart from a real query error.
- `warm_insight_cache_task` catches `TableAccessDeniedError` and skips quietly (info log), instead of routing it to `capture_exception`. Every other error is still captured as before.

Denied insights simply don't warm, which is correct - the creator can't see that warehouse data anyway.

## How did you test this code?

Added `TestWarmInsightCacheTask` (parameterized) to `posthog/caching/test/test_warming.py`: a `TableAccessDeniedError` from the query path is skipped (no `capture_exception`), while a generic error is still captured. Guards the exact regression - reverting the skip re-floods error tracking. Ran locally, both cases pass in ~4s. I (Claude) did not exercise a real denied-warehouse-table warm end to end; the test mocks the query boundary and asserts on the capture sink.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Alex spotted the `nextdot_events` denial while monitoring the 30% ramp and asked me (Claude Code) to fix the cache-warming error if it was rollout-related. I traced it from the error-tracking stack (source `cache_warming`, trigger `warmingV2`) to `warm_insight_cache_task`, confirmed the task already attributes to `insight.created_by` (so it is not blanket-userless) and that the noise comes from the catch-all capturing expected denials.

Considered plumbing `bypass_warehouse_access_control` through `process_query_dict` and the base query runner so warming could resolve warehouse tables regardless; rejected it as too invasive and security-sensitive for this fix, and wrong in spirit (warming an inaccessible insight). Chose the typed-exception + skip approach, which keeps access semantics intact and is reusable by any other background caller that should treat denials as expected.

Note for reviewers: this is one of several userless / creator-attributed HogQL-DB-build sites the rollout touches. #67384 covers the experiment path; this covers cache warming. A broader audit of `Database.create_for` / `HogQLQueryExecutor` call sites that omit a principal is worth doing before 100%.
