### PR TITLE
chore(ci): upload backend and playwright junit to trunk

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -14,7 +14,9 @@
 # - permissions: pull-requests:read (no comment/auto-commit side effects)
 # - Stripped side effects: artifact uploads, PR comment posters, snapshot
 #   auto-commit (handle-snapshots), posthog-github-action telemetry,
-#   --store-durations write, test-selection verdict
+#   --store-durations write, test-selection verdict, Trunk flaky-test upload
+#   (trunk-upload — the shadow strips the junit artifact uploads it would aggregate,
+#   and must not post to the external Trunk service from a non-blocking timing trial)
 # - OpenAPI types: the check-openapi-types job is folded into check-migrations as a
 #   check-only step (drift still fails the run); only its auto-commit side effect is dropped
 # - actions/cache reads/writes route to Depot Cache, not GitHub Actions Cache,

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3222,3 +3222,31 @@ jobs:
                   uv run --script .github/scripts/report_test_timings.py \
                       --min-duration-seconds=0.5 \
                       ./junit-artifacts
+
+    trunk-upload:
+        name: Upload test results to Trunk
+        # Core/Temporal/async-migrations already emit and upload junit-results-* artifacts;
+        # this feeds them to Trunk (flaky-test detection) once. Trusted non-pull_request
+        # events only (master push + merge queue), so the secret token never runs in a
+        # PR-controlled context; the uploader is a pinned external action, not a local one.
+        needs: [django_tests]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        timeout-minutes: 10
+        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request'
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+            - name: Download JUnit artifacts
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
+              continue-on-error: true
+              with:
+                  path: ./junit-artifacts
+                  pattern: junit-results-*
+            - name: Upload to Trunk
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-artifacts/**/*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -680,6 +680,18 @@ jobs:
                   path: playwright/junit-results.xml
                   if-no-files-found: ignore
 
+            - name: Upload test results to Trunk
+              # Flaky-test detection. Trusted non-pull_request events only, so the secret token
+              # never runs in a PR-controlled context; continue-on-error so an upload hiccup
+              # never fails the job.
+              if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: playwright/junit-results.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
+
             - name: Publish report to Cloudflare Pages
               if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
               id: cf-deploy


### PR DESCRIPTION
## Problem

The Trunk GitHub App is installed on the repo, but nothing feeds it test results. This wires up flaky-test detection for the two highest-value, flakiest suites — with the smallest possible change.

## Changes

Uploads JUnit those suites **already produce** to [Trunk Flaky Tests](https://docs.trunk.io/flaky-tests):

- **ci-backend** — a small aggregation job downloads the existing `junit-results-*` artifacts (Core, Temporal, async-migrations) and uploads them once. No changes to any test step.
- **ci-e2e-playwright** — one step uploads the `junit-results.xml` it already writes.

+40 lines across 2 files, no new dependencies, no config changes, no lockfile churn.

### Security posture

Uploads run on **trusted, non-`pull_request` events only** (master push + merge queue), so the `TRUNK_API_TOKEN` secret never materializes in a PR-controlled run. The uploader is the **pinned external** `trunk-io/analytics-uploader` action (immutable — a PR can't swap it), not a local composite action, so there's no code-swap exfiltration vector either. Both steps are `continue-on-error`, so a Trunk hiccup never fails a job. Stable-branch runs are also Trunk's strongest flake signal.

### Setup required

- Add the **`TRUNK_API_TOKEN`** secret (org or repo) — the Trunk **organization** API token from app.trunk.io → Settings → Organization.
- The org slug (`posthog-inc`) is hardcoded, so no other config is needed.

Until the secret exists, the upload steps run on master/merge only and fail soft (swallowed by `continue-on-error`).

## How did you test this code?

I (Claude) verified YAML validity for both files locally. I could not run CI or exercise the upload — that can only be confirmed once the secret is set and a master/merge run completes. `actionlint` (the repo's CI gate for workflow syntax) validates on push.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this; I (Claude, via PostHog Code) implemented it. It started much larger (all JUnit-emitting suites, a shared composite action, jest/vitest reporter wiring). Review (Codex/hex/stamphog) flagged that passing a secret into a *local* composite action on PR runs was an exfiltration vector. Paul asked for the smallest possible change, so it was reset to the two suites that already emit JUnit. We explored the Trunk App's non-secret `public-repo-id` path, but it isn't surfaced in the dashboard, so this uses the documented org API token — kept safe by the non-PR event gate plus the pinned external action. Other suites (and the reporter wiring they'd need) can follow separately.

Skills invoked: /pr-shepherd, /qa-swarm.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*