### PR TITLE
feat(cdp): add phase timing for external HTTP fetches

### DIFF
--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -2,6 +2,7 @@ import dns from 'dns/promises'
 import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
+import { register } from 'prom-client'
 
 import { parseJSON } from './json-parse'
 import { SecureRequestError, fetch, internalFetch, legacyFetch, raiseIfUserProvidedUrlUnsafe } from './request'
@@ -27,6 +28,11 @@ beforeAll(async () => {
         } else if (url.pathname === '/status/404') {
             res.writeHead(404)
             res.end()
+        } else if (url.pathname === '/slow') {
+            setTimeout(() => {
+                res.writeHead(200, { 'content-type': 'text/plain' })
+                res.end('ok')
+            }, 1000)
         } else if (url.pathname === '/stream/50') {
             res.writeHead(200, { 'content-type': 'application/json' })
             for (let i = 0; i < 50; i++) {
@@ -366,5 +372,59 @@ describe('_fetch response body handling', () => {
         for (const line of lines) {
             expect(() => parseJSON(line)).not.toThrow()
         }
+    })
+})
+
+describe('external request phase metrics', () => {
+    beforeEach(() => {
+        jest.setTimeout(3000)
+        jest.mocked(dns.lookup).mockImplementation(realDnsLookup)
+        process.env.NODE_ENV = 'production'
+    })
+
+    const histogramCount = async (name: string): Promise<number> => {
+        const metric = register.getSingleMetric(name) as any
+        if (!metric) {
+            return 0
+        }
+        const data = await metric.get()
+        return data.values
+            .filter((v: any) => v.metricName === `${name}_count`)
+            .reduce((sum: number, v: any) => sum + v.value, 0)
+    }
+
+    const counterValue = async (name: string, labels: Record<string, string>): Promise<number> => {
+        const metric = register.getSingleMetric(name) as any
+        if (!metric) {
+            return 0
+        }
+        const data = await metric.get()
+        return data.values
+            .filter((v: any) => Object.entries(labels).every(([k, val]) => v.labels[k] === val))
+            .reduce((sum: number, v: any) => sum + v.value, 0)
+    }
+
+    it('records acquire and TTFB timing on a successful request', async () => {
+        const acquireBefore = await histogramCount('cdp_http_acquire_ms')
+        const ttfbBefore = await histogramCount('cdp_http_ttfb_ms')
+
+        await internalFetch(baseUrl)
+
+        expect(await histogramCount('cdp_http_acquire_ms')).toBeGreaterThan(acquireBefore)
+        expect(await histogramCount('cdp_http_ttfb_ms')).toBeGreaterThan(ttfbBefore)
+    })
+
+    it('attributes a timeout to the awaiting_response phase when the endpoint is slow', async () => {
+        const before = await counterValue('cdp_http_request_error_phase', {
+            phase: 'awaiting_response',
+            timeout: 'true',
+        })
+
+        // Server delays 1s; abort well after the request is on the wire but before it responds.
+        await expect(internalFetch(`${baseUrl}/slow`, { method: 'POST', body: 'x', timeoutMs: 300 })).rejects.toThrow()
+
+        expect(
+            await counterValue('cdp_http_request_error_phase', { phase: 'awaiting_response', timeout: 'true' })
+        ).toBeGreaterThan(before)
     })
 })

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -1,8 +1,10 @@
 import { LookupAddress } from 'dns'
 import dns from 'dns/promises'
 import * as ipaddr from 'ipaddr.js'
+import diagnosticsChannel from 'node:diagnostics_channel'
 import net from 'node:net'
-import { Counter, Gauge } from 'prom-client'
+import { performance } from 'node:perf_hooks'
+import { Counter, Gauge, Histogram } from 'prom-client'
 // eslint-disable-next-line no-restricted-imports
 import {
     Agent,
@@ -41,6 +43,92 @@ const inflightExternalRequests = new Gauge({
     name: 'cdp_http_inflight_requests',
     help: 'Number of currently inflight external HTTP requests (undici). Use as HPA scaling metric for cdp-cyclotron-worker.',
 })
+
+// Phase-level timing for external HTTP requests, so a request's latency can be split into
+// "our side" (waiting for a pooled connection + establishing it) vs "the endpoint" (time to
+// respond once the request is on the wire). This is what tells us whether a longer fetch timeout
+// would actually help (slow endpoint) or would just mask connection-pool saturation (our side).
+const HTTP_PHASE_BUCKETS_MS = [0, 5, 10, 25, 50, 100, 200, 500, 1000, 2000, 3000, 5000, 10000]
+
+const cdpHttpAcquireMs = new Histogram({
+    name: 'cdp_http_acquire_ms',
+    help: 'Time from undici request creation to request sent (pool-acquire + connect + send start). High values point at our-side connection-pool saturation or connection setup, not a slow endpoint.',
+    buckets: HTTP_PHASE_BUCKETS_MS,
+})
+
+const cdpHttpTtfbMs = new Histogram({
+    name: 'cdp_http_ttfb_ms',
+    help: 'Time from request sent to response headers received (endpoint response latency). High values point at a genuinely slow endpoint.',
+    buckets: HTTP_PHASE_BUCKETS_MS,
+})
+
+const cdpHttpConnectMs = new Histogram({
+    name: 'cdp_http_connect_ms',
+    help: 'Time to establish a new undici connection (DNS + TCP + TLS). Only recorded when a new socket is opened, not on keep-alive reuse.',
+    buckets: HTTP_PHASE_BUCKETS_MS,
+})
+
+const cdpHttpRequestErrorPhase = new Counter({
+    name: 'cdp_http_request_error_phase',
+    help: 'External HTTP request errors split by the phase reached when they failed. before_send = failed before any bytes left the process (pool wait / connect); awaiting_response = failed after the request was sent while waiting for the endpoint.',
+    labelNames: ['phase', 'timeout'],
+})
+
+// undici publishes per-request and per-connection lifecycle events on these diagnostics channels.
+// We correlate them via the objects undici hands us (the request object is stable across a
+// request's events; connectParams across a connection's), so no tie-back to our own call sites is
+// needed. Timings are best-effort: a missing start simply skips the observation (fail-safe).
+type RequestPhaseTiming = { created: number; sent?: number }
+const requestPhaseTimings = new WeakMap<object, RequestPhaseTiming>()
+const connectStartTimes = new WeakMap<object, number>()
+
+function isTimeoutError(error: any): boolean {
+    return (
+        !!error &&
+        (error.name === 'TimeoutError' ||
+            error.name === 'AbortError' ||
+            error.code === 'UND_ERR_ABORTED' ||
+            /timeout|aborted/i.test(error.message ?? ''))
+    )
+}
+
+function subscribeToUndiciTimingChannels(): void {
+    diagnosticsChannel.subscribe('undici:request:create', (message: any) => {
+        if (message?.request) {
+            requestPhaseTimings.set(message.request, { created: performance.now() })
+        }
+    })
+    diagnosticsChannel.subscribe('undici:request:bodySent', (message: any) => {
+        const timing = message?.request && requestPhaseTimings.get(message.request)
+        if (timing) {
+            timing.sent = performance.now()
+            cdpHttpAcquireMs.observe(timing.sent - timing.created)
+        }
+    })
+    diagnosticsChannel.subscribe('undici:request:headers', (message: any) => {
+        const timing = message?.request && requestPhaseTimings.get(message.request)
+        if (timing?.sent !== undefined) {
+            cdpHttpTtfbMs.observe(performance.now() - timing.sent)
+        }
+    })
+    diagnosticsChannel.subscribe('undici:request:error', (message: any) => {
+        const timing = message?.request && requestPhaseTimings.get(message.request)
+        const phase = timing?.sent !== undefined ? 'awaiting_response' : 'before_send'
+        cdpHttpRequestErrorPhase.inc({ phase, timeout: String(isTimeoutError(message?.error)) })
+    })
+    diagnosticsChannel.subscribe('undici:client:beforeConnect', (message: any) => {
+        if (message?.connectParams) {
+            connectStartTimes.set(message.connectParams, performance.now())
+        }
+    })
+    diagnosticsChannel.subscribe('undici:client:connected', (message: any) => {
+        const start = message?.connectParams && connectStartTimes.get(message.connectParams)
+        if (start !== undefined) {
+            cdpHttpConnectMs.observe(performance.now() - start)
+        }
+    })
+}
+subscribeToUndiciTimingChannels()
 
 // NOTE: This isn't exactly fetch - it's meant to be very close but limited to only options we actually want to expose
 export type FetchOptions = {


### PR DESCRIPTION
## Problem

CDP destination fetches run on a fixed 3s timeout, and we only record *total* fetch duration. So when a request hits the timeout we can't see where the 3s went - whether it was spent on our side (waiting for a free connection in the undici pool, or establishing one) or on the endpoint (time to respond once the request is on the wire). Those point to opposite fixes: a bigger connection pool / connect tuning vs a longer timeout. Right now any timeout change is a guess.

## Changes

Instrument undici's per-request and per-connection diagnostics channels in `common/utils/request.ts` and emit phase-level metrics:

- `cdp_http_acquire_ms` - request created → request sent (pool-acquire + connect + start of send). High = our-side pool saturation / connection setup.
- `cdp_http_ttfb_ms` - request sent → response headers (endpoint response latency). High = genuinely slow endpoint.
- `cdp_http_connect_ms` - new-connection setup only (DNS + TCP + TLS).
- `cdp_http_request_error_phase{phase,timeout}` - failures split by the phase they died in (`before_send` vs `awaiting_response`), so we can see *where* timeouts land - the population the histograms (completions only) can't show.

Correlation uses the objects undici passes on the channels (the request object is stable across a request's events, connectParams across a connection's), so there's no tie-back to call sites. All timings are best-effort and fail safe: a missing start timestamp just skips the observation, never throws.

No behaviour change - this is observability only. Metrics are process-wide undici traffic; read them from the CDP worker deployment where destination fetches dominate.

## How did you test this code?

Added a `request.test.ts` block against the existing local test server:
- a successful request records both `acquire` and `ttfb` samples,
- a request aborted mid-flight against a slow endpoint increments `cdp_http_request_error_phase{phase="awaiting_response", timeout="true"}`.

This guards the diagnostics-channel contract - if undici renames a channel on upgrade the metrics would silently stop, and this catches that. Ran locally: both pass, typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Harley directed this. It came out of a CDP fetch-timeout investigation: before deciding whether to raise the 3s default, we want to know where the 3s actually goes, since a chunk of timeouts could be our-side connection-pool wait (which a longer timeout would only mask) rather than slow endpoints. This PR adds the metrics to make that call with data rather than guessing; the timeout change itself is deliberately held until this has baked.

Mechanism chosen: undici diagnostics channels (no new deps, near-zero overhead, no per-call correlation needed) over wrapping the dispatcher. `connect_ms` keys on the connectParams object undici provides; if that proves unstable across an undici version it degrades to recording nothing rather than wrong values.

Skill invoked: `/writing-tests` (to gate the diagnostics-channel-contract test).
