### PR TITLE
fix(signals): spin only the pressed scout CTA, not all three

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5595,7 +5595,7 @@ snapshots:
     scenes-app-inbox-scene--inbox--dark:
         hash: v1.k794b7964.eae93d2c506e66eb23f36e19f05bf6f07286d9a895dbad8f970c009fd98f1d53.AqLzv_So4UaxCTEYyb-ZB24M8Z4KF2Zq8PyO-8FDfos
     scenes-app-inbox-scene--inbox--light:
-        hash: v1.k794b7964.f9b5a6f1ecd482963d9850ced2d07c1ea729d2d63be8679db907709e5a6fde89.kWZ_EUm4zZwm068_9nLGo5dWzvu78oVbcMTHqOHOEcY
+        hash: v1.k794b7964.5c8f64d4038a66ddb48273508b811bdd76582bab51968ea8716c69c6b621a2dd.EBQKvx3RssFEMQceajW5B6iDk7y73GySolK6L5vrnlo
     scenes-app-inbox-scene--self-driving-onboarding--dark:
         hash: v1.k794b7964.0730c341122d1d593f4e6acf7a176e05bdd79e9ca6bf5f785a909fd57ad274f1.qRvNaIt3BFQkYn9JRfSKCXUScoTY331T7aAtb5jHXsk
     scenes-app-inbox-scene--self-driving-onboarding--light:

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutsFleetSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutsFleetSection.tsx
@@ -207,14 +207,16 @@ function ScoutsFleetList(): JSX.Element {
  */
 function ScoutChatCta({ label, prompt, icon }: { label: string; prompt: string; icon?: JSX.Element }): JSX.Element {
     const { startScoutChatTask } = useActions(scoutFleetLogic)
-    const { chatTaskRunning } = useValues(scoutFleetLogic)
+    const { runningChatPrompt } = useValues(scoutFleetLogic)
+    const isRunning = runningChatPrompt === prompt
+    const anyRunning = runningChatPrompt !== null
     return (
         <LemonButton
             type="secondary"
             size="small"
             icon={icon ?? <IconSparkles />}
-            loading={chatTaskRunning}
-            disabledReason={chatTaskRunning ? 'Starting a task…' : undefined}
+            loading={isRunning}
+            disabledReason={anyRunning ? 'Starting a task…' : undefined}
             onClick={() => startScoutChatTask(prompt, label, label)}
         >
             {label}

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -158,13 +158,14 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
     })),
 
     reducers({
-        // Tracks whether any chat-task kickoff is mid-flight (CTA disabled state).
-        chatTaskRunning: [
-            false,
+        // Tracks which CTA's chat-task kickoff is mid-flight, keyed by its prompt, so only the
+        // pressed chip spins (the others merely disable). A shared boolean spun all three at once.
+        runningChatPrompt: [
+            null as string | null,
             {
-                startScoutChatTask: () => true,
-                startScoutChatTaskSuccess: () => false,
-                startScoutChatTaskFailure: () => false,
+                startScoutChatTask: (_, { prompt }) => prompt,
+                startScoutChatTaskSuccess: () => null,
+                startScoutChatTaskFailure: () => null,
             },
         ],
         expanded: [


### PR DESCRIPTION
## Problem

In the inbox Scout troop modal, the three CTA chips ("How is my scout troop performing?", "What signals were emitted recently?", "Make a scout") all shared a single `chatTaskRunning` boolean. Pressing any one of them flipped that flag, so all three chips showed their loading spinner and disabled state at once even though only one task was actually kicked off. Minor, but it looks broken.

## Changes

Track which chip is in flight instead of a shared boolean. The `chatTaskRunning` reducer becomes `runningChatPrompt: string | null`, set to the pressed chip's prompt on kickoff and cleared on success/failure. Each `ScoutChatCta` now spins only when `runningChatPrompt === prompt`; the other two disable (with the "Starting a task…" reason) while any kickoff is mid-flight, so you still can't fire two at once.

Two files: `scoutFleetLogic.ts` (reducer) and `ScoutsFleetSection.tsx` (CTA). The kea `*Type.ts` is gitignored so it isn't part of the diff.

## How did you test this code?

I (Claude) didn't run the app. I regenerated the kea types for the logic and confirmed both changed files lint clean with oxlint. No automated test added — this is a purely visual loading-state fix on a small component, and a Jest test asserting "only one chip has `loading`" would pin implementation detail without catching a realistic regression the type system doesn't already guard. Worth a quick manual check in the modal: press one chip, confirm only it spins.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy spotted the bug while comparing the cloud inbox scout CTAs against the equivalent flow in the `code` desktop app and asked me (Claude Code, Opus 4.8) to fix it. Root cause was a single shared `chatTaskRunning` boolean read by all three chips; the fix keys the in-flight state by prompt. No skills were needed for this change.

One thing worth flagging for reviewers: running `pnpm --filter=@posthog/frontend format` does a repo-wide `oxlint --fix --fix-dangerously` that corrupted several unrelated files (e.g. rewrote `deregisterTool` to `deregisterTool context` in `useMaxTool.ts`). I reverted all of those; this PR contains only the two intended files. The commit-time lint-staged hook formats just the staged files, which is the safe path.
