### PR TITLE
fix(linear): retry truncated JSON responses instead of failing hard

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
@@ -117,10 +117,14 @@ def _make_paginated_request(
 
         try:
             payload = response.json()
-        except Exception:
+        except Exception as e:
             if not response.ok:
                 raise Exception(f"{response.status_code} Client Error: {response.reason} (Linear API: {response.text})")
-            raise Exception(f"Unexpected Linear response: {response.text}")
+            # A 2xx whose body won't parse as JSON is almost always a truncated transfer (the
+            # connection dropped mid-body on a large page), not a stable response Linear will keep
+            # returning. Ride it out on the same backoff path as other transient failures instead of
+            # failing the activity outright. Don't echo response.text — a partial body carries data.
+            raise LinearRetryableError(f"Linear: incomplete JSON response ({e})")
 
         if "errors" in payload:
             error_messages = [e.get("message", "") for e in payload["errors"]]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
@@ -119,12 +119,14 @@ def _make_paginated_request(
             payload = response.json()
         except Exception as e:
             if not response.ok:
-                raise Exception(f"{response.status_code} Client Error: {response.reason} (Linear API: {response.text})")
+                raise Exception(
+                    f"{response.status_code} Client Error: {response.reason} (Linear API: {response.text})"
+                ) from e
             # A 2xx whose body won't parse as JSON is almost always a truncated transfer (the
             # connection dropped mid-body on a large page), not a stable response Linear will keep
             # returning. Ride it out on the same backoff path as other transient failures instead of
             # failing the activity outright. Don't echo response.text — a partial body carries data.
-            raise LinearRetryableError(f"Linear: incomplete JSON response ({e})")
+            raise LinearRetryableError(f"Linear: incomplete JSON response ({e})") from e
 
         if "errors" in payload:
             error_messages = [e.get("message", "") for e in payload["errors"]]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linear/test_linear.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linear/test_linear.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from collections.abc import Iterable
 from typing import Any, cast
 
@@ -46,6 +47,17 @@ def _make_rate_limited_response(headers: dict[str, str] | None = None) -> MagicM
     response.text = "<!DOCTYPE html><html><head><title>Rate limited</title></head></html>"
     response.headers = headers or {}
     response.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    return response
+
+
+def _make_truncated_response(body: str) -> MagicMock:
+    """Mimic a large 2xx page cut mid-stream: status is OK but the body fails to JSON-decode."""
+    response = MagicMock()
+    response.status_code = 200
+    response.ok = True
+    response.reason = "OK"
+    response.text = body
+    response.json.side_effect = json.JSONDecodeError("Unterminated string starting at", body, len(body))
     return response
 
 
@@ -289,6 +301,63 @@ class TestMakePaginatedRequest:
             )
 
         assert session.post.call_count == LINEAR_MAX_RETRY_ATTEMPTS
+
+    @patch("time.sleep", return_value=None)
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_truncated_2xx_response_is_retried_then_succeeds(
+        self, mock_session_cls: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        # A large page cut mid-stream arrives as a 2xx whose body fails to JSON-decode. It must be
+        # retried with backoff, not surfaced as a non-retryable JSONDecodeError/Exception.
+        session = MagicMock()
+        session.post.side_effect = [
+            _make_truncated_response('{"data":{"issues":{"nodes":[{"id":"a"'),
+            _make_response([{"id": "a"}], False, None),
+        ]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[{"id": "a"}]]
+        assert session.post.call_count == 2
+
+    @patch("time.sleep", return_value=None)
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_persistent_truncated_response_raises_retryable_error_without_leaking_body(
+        self, mock_session_cls: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        # The partial body can embed customer data, so the retryable error must describe the failure
+        # without echoing response.text.
+        body = '{"data":{"issues":{"nodes":[{"title":"secret customer issue"'
+        session = MagicMock()
+        session.post.side_effect = [_make_truncated_response(body) for _ in range(LINEAR_MAX_RETRY_ATTEMPTS)]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        with pytest.raises(LinearRetryableError) as exc_info:
+            list(
+                _make_paginated_request(
+                    access_token="tok",
+                    endpoint_name="issues",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert session.post.call_count == LINEAR_MAX_RETRY_ATTEMPTS
+        assert "secret customer issue" not in str(exc_info.value)
 
 
 class TestRateLimitBackoff:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `JSONDecodeError` originating in the Linear data-warehouse source: [issue 019f1e38-ebfa-7052-ac27-9112d60fd133](https://us.posthog.com/project/2/error_tracking/019f1e38-ebfa-7052-ac27-9112d60fd133), message `Unterminated string starting at: line 1 column 163586`.

The stack lands squarely in our code: `linear.py` `execute` calls `response.json()` on a 200 response whose body was cut mid-stream around 160KB. The Linear `issues` query pulls large per-node fields (description, nested relations, labels) at a page size of 250, so a page can outgrow the size that transfers intact and arrive truncated.

The problem is how we handled it. `response.json()` raises, we catch it, and because the response status is OK we re-raise a plain `Exception`. tenacity only retries `LinearRetryableError`, so a plain `Exception` fails the whole import activity on the first blip. A truncated transfer is transient infrastructure noise, not a stable failure, so it should ride the same backoff path we already use for read timeouts and connection resets in this function.

## Changes

- On a 2xx response whose body won't JSON-decode, raise `LinearRetryableError` so the request retries with backoff instead of failing the activity. Non-2xx responses keep their existing non-retryable behavior (401/403 etc. still surface as before).
- Stop embedding `response.text` in the error on this path. A partial body can contain customer issue data, and the old message pushed it into error tracking.

This mirrors the maintainer's Stripe truncated-response backstop (`_is_truncated_stripe_list_response`) and the transient-network handling already in this same function.

Scope note: I kept this to the retry backstop and did not reduce the Linear page size. The issue shows a single occurrence (first seen == last seen), which points to a transient cut rather than a page that deterministically truncates. If truncation later proves deterministic for very large pages, capping the page size for the `issues` endpoint (as Stripe does for invoices/subscriptions) would be the follow-up.

## How did you test this code?

Automated only. I (Claude) added two cases to `TestMakePaginatedRequest` in `test_linear.py`:

- `test_truncated_2xx_response_is_retried_then_succeeds` - a 2xx whose `.json()` raises is retried and the next page succeeds. Guards against reverting to a non-retryable plain `Exception`; no existing test covered a 2xx with an unparseable body (the existing rate-limit helper is a non-ok 429, and the transient-network tests raise from `session.post`, not `response.json()`).
- `test_persistent_truncated_response_raises_retryable_error_without_leaking_body` - a persistently truncated response exhausts retries as `LinearRetryableError`, and the raised message does not contain the response body. Guards both "stays retryable" and the no-leak change.

Ran the full file locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/linear/test_linear.py` - 35 passed. `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue's stack trace and a representative event via the PostHog error-tracking tools to confirm the failure originates in `linear.py` rather than only appearing in serialized log context, read the Linear source and its Stripe counterpart, and checked open PRs (including the maintainer's) to rule out a duplicate - #67347 addresses the same truncated-response class but is Stripe-only.

Decision: this is a fixable bug, not a user or upstream error, so it does not belong in `NonRetryableErrors`. A truncated transfer is transient, and the fix is to make our handling retry it rather than fail hard. Invoked `/writing-tests` before adding tests.
