### PR TITLE
chore(replay): log source locators on slow ml-mirror anonymize messages

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
@@ -66,6 +66,12 @@ export async function anonymizeParsedMessage(
             walkMs: Math.round(scrubMs - timing.decompressMs - timing.recompressMs),
             events: eventCount,
             blurJobs: blurJobs.length,
+            sessionId: parsedMessage.session_id,
+            topic: parsedMessage.metadata.topic,
+            partition: parsedMessage.metadata.partition,
+            offset: parsedMessage.metadata.offset,
+            kafkaTimestamp: parsedMessage.metadata.timestamp,
+            rawSize: parsedMessage.metadata.rawSize,
         })
     }
 


### PR DESCRIPTION
> Claude-written:

## Problem

The `anonymize_slow_breakdown` log (from #67340) shows *how long* a message takes but not *which* message. To turn slow messages into real optimization/regression test cases, we need to locate the exact source records.

## Changes

Adds source locators to the `anonymize_slow_breakdown` log: `sessionId` (a random client UUID — not PII), `topic`, `partition`, `offset`, `kafkaTimestamp`, `rawSize`. `partition`+`offset` uniquely identify the source Kafka record so it can be re-read; `kafkaTimestamp` tells us how much topic-retention headroom is left before it ages out; `sessionId` cross-references the anonymized block in the ML bucket. Deliberately excludes `distinct_id` (potential PII).

Diagnostic-only, no behavior change. Temporary alongside #67340 — revert both once we have the fixtures.

## How did you test this code?

Typecheck clean; fields read straight off `ParsedMessageData.metadata`. No new tests (temporary diagnostic logging).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Claude Code, at my direction.