### PR TITLE
chore(clickhouse): sanity-check ai_events convergence gate (expected fail)

### DIFF
--- a/posthog/clickhouse/migrations/0285_ai_events_gate_drift_check.py
+++ b/posthog/clickhouse/migrations/0285_ai_events_gate_drift_check.py
@@ -1,0 +1,11 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(
+        "ALTER TABLE sharded_ai_events ADD COLUMN IF NOT EXISTS gate_drift_sanity_check UInt8 DEFAULT 0",
+        node_roles=[NodeRole.AI_EVENTS],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0284_message_assets
+0285_ai_events_gate_drift_check


### PR DESCRIPTION
## Problem

Deliberate negative test of the merged convergence gate (#67134, #67281): prove the multinode smoke fails when a migration drifts a managed cluster from its HCL golden.

## Changes

- Migration `0285` adds a column to `sharded_ai_events` on `NodeRole.AI_EVENTS`, with **no** matching `posthog/clickhouse/hcl/` change.

**Expected outcome:** `ci-clickhouse-multinode-migrations` fails at the `check_live_hcl` step with `DRIFT: local/ai_events … ALTER table posthog.sharded_ai_events`. **Not for merge — will be closed.**

## How did you test this code?

I'm an agent. Reproduced locally against the running multinode stack via the pinned hclexp container: with the ALTER applied, `check-live` (enforcing) reports the single `sharded_ai_events` drift and exits non-zero; ops stays clean. This PR is to confirm the same failure in real CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Sanity check requested to validate the enforcing gate end to end. Migration-only; to be closed once CI shows red.