### PR TITLE
fix(ingestion-consumer): keep deferred keys sticky to one survivor on drain

### DIFF
--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -364,10 +364,27 @@ impl Dispatcher {
 
         let mut router = self.router.lock().unwrap();
         for group in groups {
-            let Some(worker) = router.select(&healthy, &working_load) else {
-                // No healthy worker yet — keep it stashed for a later flush.
-                table.stash.put_back(batch_id, group);
-                continue;
+            // Prefer the key's existing pin when it still points to a healthy
+            // worker, so a key deferred across several batches re-homes to a
+            // single survivor — preserving per-distinct_id (person-batching)
+            // locality instead of scattering its messages across workers.
+            // Fall back to load-based selection for a fresh key, or when the
+            // pinned worker is itself unhealthy (e.g. the drainer we're leaving).
+            let sticky = table
+                .pins
+                .get(&group.routing_key)
+                .map(|pin| pin.worker.clone())
+                .filter(|w| healthy.contains(w));
+            let worker = match sticky {
+                Some(worker) => worker,
+                None => {
+                    let Some(worker) = router.select(&healthy, &working_load) else {
+                        // No healthy worker yet — keep it stashed for a later flush.
+                        table.stash.put_back(batch_id, group);
+                        continue;
+                    };
+                    worker
+                }
             };
             bump_load(&mut working_load, &worker, group.messages.len());
             // Re-pin the key to the new worker. The deferral is NOT cleared here:
@@ -1342,6 +1359,46 @@ mod tests {
         assert_eq!(offsets(&f2), vec![1], "batch-2 flushes its own message");
         assert_eq!(offsets(&f3), vec![2], "batch-3 flushes its own message");
         assert!(!dispatcher.has_deferred("batch-2") && !dispatcher.has_deferred("batch-3"));
+    }
+
+    #[test]
+    fn test_cross_batch_deferred_flush_stays_on_one_survivor() {
+        // A key deferred across multiple batches during a drain must re-home to a
+        // SINGLE survivor — otherwise one distinct_id's events scatter across
+        // workers and lose person-batching locality. Needs >=2 survivors after a
+        // drain, so 3 workers. (With 2 workers there's one survivor and the bug is
+        // masked, which is why `..._preserves_order` above can't catch it.)
+        let registry = healthy_registry(3);
+        let dispatcher = Dispatcher::new(Arc::clone(&registry));
+
+        // Pin user-1, keep it in-flight, then drain its worker.
+        let b1 = dispatcher.assign("batch-1", make_msgs(&[("t", "user-1")]));
+        let pinned = b1[0].worker.clone();
+        registry.start_draining(&pinned);
+
+        // Two later batches each carry user-1 → both defer behind the drainer.
+        assert!(dispatcher
+            .assign("batch-2", make_msgs(&[("t", "user-1")]))
+            .is_empty());
+        assert!(dispatcher
+            .assign("batch-3", make_msgs(&[("t", "user-1")]))
+            .is_empty());
+
+        // Drain completes when batch-1's in-flight resolves.
+        dispatcher.on_sub_batch_resolved(&pinned, b1[0].messages.len(), &b1[0].routing_keys, false);
+
+        // Flush oldest-first. batch-2 re-homes user-1 onto a survivor; batch-3 must
+        // land on the SAME survivor. Without the fix, batch-2's flush bumps that
+        // survivor's load, so batch-3's least-loaded pick scatters to the other one.
+        let f2 = dispatcher.flush_deferred("batch-2");
+        let f3 = dispatcher.flush_deferred("batch-3");
+        assert_eq!(f2.len(), 1);
+        assert_eq!(f3.len(), 1);
+        assert_ne!(f2[0].worker, pinned, "re-homes off the drainer");
+        assert_eq!(
+            f3[0].worker, f2[0].worker,
+            "a key deferred across batches must re-home to one survivor, not scatter"
+        );
     }
 
     fn offsets(sub_batches: &[SubBatch]) -> Vec<i64> {


### PR DESCRIPTION
## Problem

At `max_in_flight_batches > 1`, a `distinct_id` whose worker drains mid-flight loses person-batching locality. When a key is deferred across more than one in-flight batch, `flush_deferred` re-ran load-based `select()` for each batch independently, ignoring where the key was already re-homed. It's self-inflicted: flushing the first batch bumps that survivor's in-flight load, so the next batch's least-loaded pick deterministically lands on a different survivor. One person's queued events end up smeared across workers instead of consolidated on one.

Ordering was never at risk here (flushes are serialized, oldest-batch-first). This is purely a locality regression, but it defeats the whole point of sticky per-person assignment, and we run with `max_in_flight_batches > 1`.

## Changes

In `flush_deferred`, prefer the key's existing pin when it still points to a healthy worker, so a key deferred across several batches re-homes to a single survivor. Fall back to load-based `select()` only for a genuinely fresh key, or when the pinned worker is itself unhealthy (the drainer we're leaving). About 13 lines at the routing decision.

## How did you test this code?

TDD. I added `test_cross_batch_deferred_flush_stays_on_one_survivor`, which uses 3 workers so that ≥2 survivors remain after a drain. The existing `test_cross_batch_deferred_flush_preserves_order` uses only 2 workers, leaving a single survivor, so it structurally cannot observe the scatter.

I confirmed the test red before the fix (batch-2 flushed to one survivor, batch-3 scattered to the other), then green after. Full crate suite passes with Kafka running: 105 lib unit tests, 6 dispatcher integration, 14 e2e integration, 10 transport integration. `cargo fmt --check` clean, `cargo clippy` clean (the one workspace patch notice is pre-existing and unrelated). No manual/production testing was done.

New test catches: a key deferred across multiple batches during a drain re-homing to different workers, which no existing test covered.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code), directed by me. The bug surfaced while reviewing the dispatcher for a talk: I questioned whether deferred groups for one key were rerouted consistently. We traced `flush_deferred` and found the per-group `select()` re-selection, confirmed with a failing 3-worker regression test, then fixed by reusing the key's live healthy pin. Considered leaving it as documented future work, but since we run `max_in_flight_batches > 1` it's a live locality bug worth fixing now. No skills were invoked.
