### PR TITLE
chore(marketing-analytics): surface create_for timing spans

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -147,7 +147,11 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         filtering). Built with the runner's user+modifiers so it's valid for resolving the final
         query, not just the factory's warehouse-name lookup."""
         modifiers = create_default_modifiers_for_team(self.team, self.modifiers)
-        return Database.create_for(team=self.team, user=self.user, modifiers=modifiers)
+        # Pass the runner's timings so create_for's internal spans (data_warehouse_tables,
+        # filter_system_tables_for_user, saved queries, revenue views, …) surface in the query's
+        # timings instead of a discarded HogQLTimings — otherwise this whole build shows as an
+        # opaque flat span.
+        return Database.create_for(team=self.team, user=self.user, modifiers=modifiers, timings=self.timings)
 
     @cached_property
     def _shared_hogql_context(self) -> HogQLContext:
@@ -897,21 +901,30 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             # Apply drill-down level from query to config
             self._apply_drill_down_level()
 
+            # Force the shared warehouse Database build here, in its own span, so its cost is isolated
+            # from adapter construction (both otherwise collapse into ma_get_adapters via the cached
+            # property's first access).
+            with self.timings.measure("ma_build_database"):
+                _ = self._shared_hogql_database
+
             # Get marketing source adapters
-            adapters = self._get_marketing_source_adapters(date_range=self.query_date_range)
+            with self.timings.measure("ma_get_adapters"):
+                adapters = self._get_marketing_source_adapters(date_range=self.query_date_range)
 
             # Build the cost source. When cost precompute is enabled, read the native materialized table
             # (no S3); fall back to the live S3 adapter union if not enabled or jobs aren't ready.
             union_subquery: ast.SelectQuery | ast.SelectSetQuery | None = None
             if self.config.costs_precomputation_enabled:
-                try:
-                    union_subquery = self._build_costs_from_precompute(self.query_date_range)
-                except Exception:
-                    logger.exception("cost_precompute_failed", team_id=self.team.pk)
-                    union_subquery = None
+                with self.timings.measure("ma_build_costs_precompute"):
+                    try:
+                        union_subquery = self._build_costs_from_precompute(self.query_date_range)
+                    except Exception:
+                        logger.exception("cost_precompute_failed", team_id=self.team.pk)
+                        union_subquery = None
             if union_subquery is None:
-                # AST form to skip parse_select.
-                union_subquery = self._factory(date_range=self.query_date_range).build_union_query_ast(adapters)
+                with self.timings.measure("ma_build_union_s3"):
+                    # AST form to skip parse_select.
+                    union_subquery = self._factory(date_range=self.query_date_range).build_union_query_ast(adapters)
 
             # Get conversion goals and filter out invalid ones
             conversion_goals = self._get_team_conversion_goals()


### PR DESCRIPTION
## Problem

The marketing analytics query build shows up as a single opaque `marketing_analytics_base_query` span in server-timing. When that build is slow, there's no way to tell which sub-step is responsible — warehouse database construction, adapter discovery, or cost precompute — because `_shared_hogql_database` called `Database.create_for` with a throwaway `HogQLTimings` that was discarded.

## Changes

- Pass the runner's own `timings` into `Database.create_for`, so its internal spans (`data_warehouse_tables`, `filter_system_tables_for_user`, saved queries, revenue views, …) surface under the query's timings instead of vanishing.
- Split `to_query`'s build into named spans: `ma_build_database`, `ma_get_adapters`, `ma_build_costs_precompute`, and `ma_build_union_s3`, so the expensive sub-step is attributable in the same server-timing waterfall.

Observability only — no behavior change. `_shared_hogql_database` is a cached property, so forcing it a few lines earlier (to isolate its span) does not rebuild it.

## How did you test this code?

Agent-authored. Ran the marketing table query runner against a local dev team and confirmed the new spans appear correctly nested under `marketing_analytics_base_query`, including the `create_for` internals. Lint and type checks (`ruff`, `ty`) ran via lint-staged on commit.

No automated tests added: this is pure instrumentation with no logic to assert, and adding a test that asserts span names would be a change-detector with no real regression to catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

While profiling a slow marketing dashboard load, the build phase (`marketing_analytics_base_query`) was a flat, opaque span that consistently dominated wall-clock time, but its internal composition wasn't visible. Several hypotheses for the cost (warehouse-table schema construction, saved-query view building, warehouse RBAC, per-source N+1) were each tested with local micro-benchmarks and none reproduced the slowness locally — pointing at environment-specific factors (database round-trip latency / large result fetches) rather than CPU or logic. This change exposes the real breakdown so the dominant sub-step can be identified from server-timing directly, without further guessing.

Tool: Claude Code.

<img width="324" height="564" alt="image" src="https://github.com/user-attachments/assets/b418e703-c607-490f-bf00-b672726906ab" />
<img width="336" height="539" alt="image" src="https://github.com/user-attachments/assets/815525b8-37cf-4b83-ac2b-588abb39d77e" />
