### PR TITLE
fix(intercom): restart companies scroll drain on an expired cursor

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
@@ -308,6 +308,13 @@ _SCROLL_EXISTS_MAX_RETRIES = 2
 _SCROLL_SERVER_ERROR_BACKOFF_SECONDS = 2.0
 _SCROLL_SERVER_ERROR_MAX_RETRIES = 3
 
+# A companies scroll cursor can be invalidated mid-walk: Intercom expires an idle
+# scroll (~1 min) and permits only one open scroll per workspace, so a concurrent
+# sync opening its own scroll kills this one. The continuation then returns 404. A
+# scroll can't be resumed, only restarted from the beginning, so recovery is a full
+# re-walk — safe only where no rows have been emitted yet (see `_drain_company_ids`).
+_SCROLL_EXPIRED_MAX_RETRIES = 2
+
 
 def _scroll_companies_get(session: Session, scroll_param: str | None = None) -> dict[str, Any]:
     """Fetch one `/companies/scroll` page, retrying a transient 5xx inline.
@@ -387,6 +394,29 @@ def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
             return
 
 
+def _drain_company_ids(session: Session) -> list[str]:
+    """Walk the whole companies scroll and collect every id, restarting the walk
+    from the beginning if the scroll cursor expires mid-drain (404 on a
+    continuation — see `_SCROLL_EXPIRED_MAX_RETRIES`).
+
+    Restarting is safe here precisely because the ids are drained up front,
+    before any segment row is yielded downstream: nothing has been written to the
+    destination yet, so a re-walk can't duplicate rows. (The streaming `companies`
+    endpoint can't recover this way — it yields rows as it walks, and the load is
+    full-refresh with no primary-key dedup, so an expired cursor there surfaces
+    and Temporal restarts the whole run from a freshly-wiped table instead.)"""
+    for attempt in range(_SCROLL_EXPIRED_MAX_RETRIES + 1):
+        try:
+            return [company["id"] for company in _iter_companies(session)]
+        except HTTPError as exc:
+            if _is_not_found(exc) and attempt < _SCROLL_EXPIRED_MAX_RETRIES:
+                logger.warning("intercom_companies_scroll_expired_restart", attempt=attempt + 1)
+                continue
+            raise
+    # Unreachable: the final attempt either returns or re-raises above.
+    raise AssertionError("unreachable")
+
+
 def _company_segments_generator(session: Session) -> Iterator[dict[str, Any]]:
     """Walk all companies and yield each attached segment with `company_id`
     injected. Full refresh — Intercom has no server-side timestamp filter on
@@ -397,8 +427,10 @@ def _company_segments_generator(session: Session) -> Iterator[dict[str, Any]]:
     and a slow stretch of `/companies/{id}/segments` calls between two scroll
     pages lets the cursor lapse — the next continuation then 404s mid-walk.
     Draining first keeps the scroll requests back-to-back so it stays alive;
-    only the ids are held, so the memory cost stays flat regardless of count."""
-    company_ids = [company["id"] for company in _iter_companies(session)]
+    only the ids are held, so the memory cost stays flat regardless of count. If
+    the cursor is still invalidated mid-drain, `_drain_company_ids` restarts the
+    walk from scratch."""
+    company_ids = _drain_company_ids(session)
     for company_id in company_ids:
         try:
             payload = _intercom_get(session, f"/companies/{company_id}/segments")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
@@ -72,6 +72,16 @@ def _is_server_error(exc: HTTPError) -> bool:
     return resp is not None and 500 <= resp.status_code < 600
 
 
+def _is_scroll_expired(exc: HTTPError) -> bool:
+    """A companies scroll cursor can be invalidated mid-walk (idle expiry, or a
+    concurrent scroll on the workspace — only one is allowed); the continuation
+    then returns 404. The scroll walk only ever hits `/companies/scroll`, so any
+    404 there is a dead cursor rather than a missing row — distinct from
+    `_is_not_found`, which classifies a vanished child row on a per-row fetch."""
+    resp = exc.response
+    return resp is not None and resp.status_code == 404
+
+
 def _default_headers() -> dict[str, str]:
     return {
         "Accept": "application/json",
@@ -409,7 +419,7 @@ def _drain_company_ids(session: Session) -> list[str]:
         try:
             return [company["id"] for company in _iter_companies(session)]
         except HTTPError as exc:
-            if _is_not_found(exc) and attempt < _SCROLL_EXPIRED_MAX_RETRIES:
+            if _is_scroll_expired(exc) and attempt < _SCROLL_EXPIRED_MAX_RETRIES:
                 logger.warning("intercom_companies_scroll_expired_restart", attempt=attempt + 1)
                 continue
             raise
@@ -427,9 +437,9 @@ def _company_segments_generator(session: Session) -> Iterator[dict[str, Any]]:
     and a slow stretch of `/companies/{id}/segments` calls between two scroll
     pages lets the cursor lapse — the next continuation then 404s mid-walk.
     Draining first keeps the scroll requests back-to-back so it stays alive;
-    only the ids are held, so the memory cost stays flat regardless of count. If
-    the cursor is still invalidated mid-drain, `_drain_company_ids` restarts the
-    walk from scratch."""
+    only the ids are held, not the full company payloads, so the memory
+    footprint stays small. If the cursor is still invalidated mid-drain,
+    `_drain_company_ids` restarts the walk from scratch."""
     company_ids = _drain_company_ids(session)
     for company_id in company_ids:
         try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -22,6 +22,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.intercom.i
     _build_search_body,
     _company_segments_generator,
     _conversation_parts_generator,
+    _drain_company_ids,
     _is_scroll_exists,
     _is_server_error,
     _iter_companies,
@@ -367,6 +368,46 @@ class TestSubstreamGenerators:
         last_scroll = max(i for i, u in enumerate(urls) if u.endswith("/companies/scroll"))
         first_segments = min(i for i, u in enumerate(urls) if u.endswith("/segments"))
         assert last_scroll < first_segments
+
+    def test_company_segments_restarts_scroll_on_expired_cursor(self):
+        # The observed failure: the companies scroll cursor expires mid-drain and
+        # the continuation 404s (GET /companies/scroll?scroll_param=...). Because ids
+        # are drained before any segment is yielded, restarting the walk from the
+        # beginning is safe — nothing has been written yet — so the drain re-walks
+        # and the sync continues instead of failing the whole run.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            # First drain: one page, then the continuation 404s (expired scroll).
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response(None, status_code=404, text="Not Found"),
+            # Restarted drain from the beginning: walks to completion.
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s2"}),
+            _make_response({"data": []}),
+            # Segment fetch for the drained company.
+            _make_response({"data": [{"id": "seg1"}]}),
+        ]
+
+        segments = list(_company_segments_generator(mock_session))
+
+        assert [s["id"] for s in segments] == ["seg1"]
+        assert segments[0]["company_id"] == "co1"
+        # The retried open carries no scroll_param — a scroll only restarts from
+        # the beginning, never resumes from the dead cursor.
+        assert mock_session.get.call_args_list[2].kwargs["params"] is None
+
+    def test_drain_company_ids_reraises_expired_cursor_after_max_retries(self):
+        # A persistently-invalidated scroll must surface after the bounded retries
+        # rather than re-walking forever.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=404, text="Not Found")
+            for _ in range(intercom_module._SCROLL_EXPIRED_MAX_RETRIES + 1)
+        ]
+
+        with pytest.raises(HTTPError):
+            _drain_company_ids(mock_session)
+
+        assert mock_session.get.call_count == intercom_module._SCROLL_EXPIRED_MAX_RETRIES + 1
 
     def test_iter_companies_walks_scroll(self):
         # `POST /companies/list` is capped at 10,000 companies (60 * 167 page


### PR DESCRIPTION
## Problem

Error tracking surfaced a live `HTTPError` on the Intercom import source:

```
404 Client Error: Not Found for url: https://api.intercom.io/companies/scroll?scroll_param=<redacted>
```

Issue: https://us.posthog.com/project/2/error_tracking/019f1e5c-cee3-7b52-92fa-3cf63f0976e7

The stack lands squarely in our code:

```
_company_segments_generator (intercom.py)   ← the up-front scroll drain
  → _iter_companies
    → _scroll_companies_get
      → _intercom_get → raise_for_status → HTTPError 404
```

The `company_segments` substream walks every company via Intercom's Scroll API and drains all company ids up front (a deliberate choice so the scroll requests stay back-to-back and the cursor does not idle out). But Intercom can still invalidate a scroll mid-walk: it expires an idle scroll after about a minute, and it permits only one open scroll per workspace, so a concurrent sync opening its own scroll kills this one. When that happens the next continuation returns `404` and the whole sync crashes.

## Changes

When the scroll cursor expires during the drain, restart the walk from the beginning instead of failing. This is safe precisely because the ids are drained before any segment row is yielded downstream — nothing has been written to the destination yet, so re-walking cannot duplicate rows. The retry is bounded, so a persistently-invalidated scroll still surfaces rather than looping forever.

Why not just treat this as non-retryable? It is not a credential or config problem — retrying genuinely succeeds — so stopping the sync would be wrong. Matching a `404` substring would also be dangerous: we intentionally skip per-row `404`s elsewhere (a company or conversation deleted between listing and fetch), and a broad match would swallow those too.

Why not recover the streaming `companies` endpoint the same way? It yields rows as it walks, and that load is full-refresh with no primary-key dedup, so re-opening the scroll mid-walk would append duplicate rows. There, an expired cursor stays surfaced and Temporal restarts the whole run from a freshly-wiped table, which is the correct clean recovery. The fix is scoped to the drain, the only place an inline restart is provably safe.

## How did you test this code?

Automated only (I, Claude, could not exercise a live Intercom workspace). Added two unit tests to `test_intercom.py`, both run locally and passing (full file: 87 passed):

- `test_company_segments_restarts_scroll_on_expired_cursor` — a `404` on the scroll continuation during the drain now restarts the walk and the sync completes. No existing test covered a `404` on the scroll continuation; the existing `404` cases are per-row segment fetches, a different path.
- `test_drain_company_ids_reraises_expired_cursor_after_max_retries` — guards the retry cap so a persistently-failing scroll surfaces instead of looping forever.

Also re-ran the full `test_intercom.py` and `test_intercom_source.py` suites plus `ruff check`/`ruff format` — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I pulled the issue's representative event and stack trace via the PostHog error-tracking MCP tools to confirm the failure originates in the intercom source (not just serialized log context), then read the source and traced the load semantics.

Key decision: is this user/upstream (→ non-retryable), a fixable bug, or transient infra? I ruled out non-retryable (it self-heals on retry, and a `404` substring would over-match the intentional per-row `404` skips) and settled on a scoped fix. Before choosing the fix I verified via the pipeline that full-refresh loads do not dedupe by primary key and write per-batch (not staged), which is what makes an inline restart safe only during the up-front drain and unsafe for the streaming `companies` walk. Invoked the `/writing-tests` skill to gate the two new tests against realistic regressions.
