### PR TITLE
feat(conversations): add customer identity to ticket lifecycle events

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -69,6 +69,11 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["actor_type"] == "user"
         assert call_kwargs["properties"]["actor_id"] == self.user.id
         assert call_kwargs["properties"]["actor_email"] == self.user.email
+        # Customer identity travels alongside the actor so workflows can email the customer,
+        # not the team member the event's distinct_id is attributed to.
+        assert call_kwargs["properties"]["customer_name"] == "Test Customer"
+        assert call_kwargs["properties"]["customer_email"] == "test@example.com"
+        assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_capture_ticket_priority_changed_uses_team_token(self, mock_capture):
@@ -85,6 +90,8 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["actor_type"] == "user"
         assert call_kwargs["properties"]["actor_id"] == self.user.id
         assert call_kwargs["properties"]["actor_email"] == self.user.email
+        assert call_kwargs["properties"]["customer_email"] == "test@example.com"
+        assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_capture_ticket_assigned_uses_team_token(self, mock_capture):
@@ -101,6 +108,8 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["actor_type"] == "user"
         assert call_kwargs["properties"]["actor_id"] == self.user.id
         assert call_kwargs["properties"]["actor_email"] == self.user.email
+        assert call_kwargs["properties"]["customer_email"] == "test@example.com"
+        assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_capture_message_sent_uses_team_token(self, mock_capture):
@@ -127,6 +136,9 @@ class TestConversationEvents(BaseTest):
             ("capture_ticket_created", capture_ticket_created, []),
             ("capture_message_received", capture_message_received, ["msg-id", "content"]),
             ("capture_message_sent", capture_message_sent, ["msg-id", "content"]),
+            ("capture_ticket_status_changed", capture_ticket_status_changed, ["new", "pending"]),
+            ("capture_ticket_priority_changed", capture_ticket_priority_changed, [None, "high"]),
+            ("capture_ticket_assigned", capture_ticket_assigned, ["user", "123"]),
         ]
     )
     @patch("products.conversations.backend.events.capture_internal")

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -280,6 +280,7 @@ def capture_ticket_status_changed(
     properties["old_status"] = old_status
     properties["new_status"] = new_status
     properties.update(_get_actor_properties(actor, actor_type))
+    properties.update(_get_customer_properties(ticket, include_distinct_id=True))
 
     capture_internal(
         token=ticket.team.api_token,
@@ -302,6 +303,7 @@ def capture_ticket_priority_changed(
     properties["old_priority"] = old_priority
     properties["new_priority"] = new_priority
     properties.update(_get_actor_properties(actor, actor_type))
+    properties.update(_get_customer_properties(ticket, include_distinct_id=True))
 
     capture_internal(
         token=ticket.team.api_token,
@@ -324,6 +326,7 @@ def capture_ticket_assigned(
     properties["assignee_type"] = assignee_type
     properties["assignee_id"] = assignee_id
     properties.update(_get_actor_properties(actor, actor_type))
+    properties.update(_get_customer_properties(ticket, include_distinct_id=True))
 
     capture_internal(
         token=ticket.team.api_token,


### PR DESCRIPTION
## Problem

Ticket lifecycle events (`$conversation_ticket_status_changed`, `$conversation_ticket_priority_changed`, `$conversation_ticket_assigned`) are correctly attributed to the team member who performed the action — so the event's `distinct_id` resolves to a *team member*, not the customer.

That breaks workflows that email "the person waiting on a response." A reminder workflow triggered on `$conversation_ticket_status_changed` ends up emailing our own team members instead of the customer, because the only identity on the event is the actor.

`$conversation_message_sent` doesn't have this problem — it already carries `customer_email`, so its workflows target the customer directly.

## Changes

Add `customer_name`, `customer_email`, and `customer_distinct_id` to the three actor-attributed ticket lifecycle events, reusing the existing `_get_customer_properties(ticket, include_distinct_id=True)` helper that `$conversation_message_sent` already uses.

Key point: **event attribution is unchanged.** The event's top-level `distinct_id` still points at the actor (the team member did the action — that's correct). This only adds `customer_*` *properties* alongside it, sourced from the ticket (`ticket.distinct_id`, `anonymous_traits.email → email_from`), so workflows can target the customer explicitly via `event.properties.customer_email` instead of resolving the actor's `distinct_id`.

No signature changes, no new call sites, no new trust surface — `customer_email` resolves exactly as it already does on `$conversation_message_sent`.

Follow-up (workflow config, not code): point the reminder workflow's email recipient at `{event.properties.customer_email}`, mirroring the message-sent workflow.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — I did not manually test in a running app.

Extended `products/conversations/backend/api/tests/test_events.py`:
- The `capture_ticket_status_changed` / `priority_changed` / `assigned` tests now assert `customer_email`, `customer_name`, and `customer_distinct_id` are emitted.
- Added all three lifecycle events to the existing parameterized `customer_email` fallback test (verifies the `anonymous_traits.email → email_from` fallback path).

Ran `hogli test products/conversations/backend/api/tests/test_events.py` — 58 passed. Regression caught: a lifecycle event silently shipping without customer identity, which no prior test covered (they only checked actor/status properties).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). Started in plan mode: used `Explore` subagents to trace where `$conversation_ticket_status_changed` is emitted (`products/conversations/backend/events.py`) and how `$conversation_message_sent` sources `customer_email`, confirming the gap was simply that the lifecycle capture functions never called `_get_customer_properties`.

Decision worth flagging for review: scoped to all three actor-attributed lifecycle events (not just `status_changed`) since they share the identical gap, and included `customer_distinct_id` for full parity with `$conversation_message_sent` — it's sourced from the ticket (customer), independent of the actor the event is attributed to.

No skills required code changes beyond the test edits (reused an existing helper), so `/improving-drf-endpoints` and migration skills were not applicable — no serializer/viewset/migration changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
