### PR TITLE
fix: widget tickets limit ignored on cached first page

### DIFF
--- a/products/conversations/backend/api/serializers.py
+++ b/products/conversations/backend/api/serializers.py
@@ -160,6 +160,9 @@ class WidgetMessagesQuerySerializer(WidgetAuthSerializer):
     limit = serializers.IntegerField(required=False, default=500, min_value=1, max_value=500)
 
 
+WIDGET_TICKETS_DEFAULT_LIMIT = 100
+
+
 class WidgetTicketsQuerySerializer(WidgetAuthSerializer):
     """Serializer for fetching tickets for a widget session."""
 
@@ -169,7 +172,7 @@ class WidgetTicketsQuerySerializer(WidgetAuthSerializer):
         allow_null=True,
         help_text="Filter by ticket status",
     )
-    limit = serializers.IntegerField(required=False, default=100, min_value=1, max_value=500)
+    limit = serializers.IntegerField(required=False, default=WIDGET_TICKETS_DEFAULT_LIMIT, min_value=1, max_value=500)
     offset = serializers.IntegerField(required=False, default=0, min_value=0)
 
 

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -396,6 +396,76 @@ class TestWidgetAPI(BaseTest):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["results"][0]["status"], Status.NEW)
 
+    def test_list_tickets_limit_respected_after_default_page_cached(self):
+        # Regression: the offset==0 cache key ignores limit, so a default-page
+        # poll (limit=100) must not leak its full cached page to a ?limit=2 request.
+        for _ in range(3):
+            Ticket.objects.create_with_number(
+                team=self.team,
+                widget_session_id=self.widget_session_id,
+                distinct_id=self.distinct_id,
+                channel_source="widget",
+                status=Status.NEW,
+            )
+
+        # Prime the cache with the default page size.
+        default_page = self.client.get(
+            f"/api/conversations/v1/widget/tickets?widget_session_id={self.widget_session_id}",
+            **self._get_headers(),
+        )
+        self.assertEqual(default_page.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(default_page.json()["results"]), 3)
+
+        limited = self.client.get(
+            f"/api/conversations/v1/widget/tickets?widget_session_id={self.widget_session_id}&limit=2",
+            **self._get_headers(),
+        )
+        self.assertEqual(limited.status_code, status.HTTP_200_OK)
+        self.assertEqual(limited.json()["count"], 3)
+        self.assertEqual(len(limited.json()["results"]), 2)
+
+    def test_list_tickets_default_page_still_served_from_cache(self):
+        # The widget polling path (offset=0, default limit) must still hit the
+        # cache — the fix must not disable caching for the hot path.
+        Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=self.widget_session_id,
+            distinct_id=self.distinct_id,
+            channel_source="widget",
+            status=Status.NEW,
+        )
+
+        url = f"/api/conversations/v1/widget/tickets?widget_session_id={self.widget_session_id}"
+
+        # First poll populates the cache, second poll is served from it.
+        first = self.client.get(url, **self._get_headers())
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+
+        with patch("products.conversations.backend.api.widget.get_cached_tickets") as mock_get:
+            mock_get.return_value = {"count": 99, "results": []}
+            second = self.client.get(url, **self._get_headers())
+            mock_get.assert_called_once()
+            # Response comes straight from the cache, not the DB.
+            self.assertEqual(second.json()["count"], 99)
+
+    def test_list_tickets_custom_limit_never_reads_cache(self):
+        # A custom limit must bypass the cache entirely (both read and write).
+        Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=self.widget_session_id,
+            distinct_id=self.distinct_id,
+            channel_source="widget",
+            status=Status.NEW,
+        )
+
+        with patch("products.conversations.backend.api.widget.get_cached_tickets") as mock_get:
+            response = self.client.get(
+                f"/api/conversations/v1/widget/tickets?widget_session_id={self.widget_session_id}&limit=2",
+                **self._get_headers(),
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_get.assert_not_called()
+
     def test_mark_read(self):
         ticket = Ticket.objects.create_with_number(
             team=self.team,

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -413,8 +413,12 @@ class WidgetTicketsView(APIView):
         limit = query_serializer.validated_data["limit"]
         offset = query_serializer.validated_data["offset"]
 
-        # Check cache for first page (most common case for polling)
-        if offset == 0:
+        # Only cache the default first page (limit=100, offset=0) used by widget
+        # polling. Custom limit/offset must bypass the cache — its key doesn't
+        # include limit/offset, so serving it for other page sizes returns the
+        # wrong slice (e.g. ?limit=2 getting the full cached page back).
+        use_cache = offset == 0 and limit == 100
+        if use_cache:
             cached = get_cached_tickets(team.id, cache_key_id, status_filter)
             if cached is not None:
                 return Response(cached)
@@ -454,7 +458,7 @@ class WidgetTicketsView(APIView):
         response_data = {"count": total_count, "results": ticket_list}
 
         # Cache first page (skip empty results to avoid stale cache after restore/migration)
-        if offset == 0 and total_count > 0:
+        if use_cache and total_count > 0:
             set_cached_tickets(team.id, cache_key_id, response_data, status_filter)
 
         return Response(response_data)

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -31,6 +31,7 @@ from posthog.models.comment import Comment
 from posthog.rate_limit import WidgetTeamThrottle, WidgetUserBurstThrottle
 
 from products.conversations.backend.api.serializers import (
+    WIDGET_TICKETS_DEFAULT_LIMIT,
     WidgetMarkReadSerializer,
     WidgetMessageSerializer,
     WidgetMessagesQuerySerializer,
@@ -413,11 +414,11 @@ class WidgetTicketsView(APIView):
         limit = query_serializer.validated_data["limit"]
         offset = query_serializer.validated_data["offset"]
 
-        # Only cache the default first page (limit=100, offset=0) used by widget
-        # polling. Custom limit/offset must bypass the cache — its key doesn't
-        # include limit/offset, so serving it for other page sizes returns the
-        # wrong slice (e.g. ?limit=2 getting the full cached page back).
-        use_cache = offset == 0 and limit == 100
+        # Only cache the default first page (WIDGET_TICKETS_DEFAULT_LIMIT, offset=0)
+        # used by widget polling. Custom limit/offset must bypass the cache — its
+        # key doesn't include limit/offset, so serving it for other page sizes
+        # returns the wrong slice (e.g. ?limit=2 getting the full cached page back).
+        use_cache = offset == 0 and limit == WIDGET_TICKETS_DEFAULT_LIMIT
         if use_cache:
             cached = get_cached_tickets(team.id, cache_key_id, status_filter)
             if cached is not None:


### PR DESCRIPTION
## Problem

Customers using the Support widget JavaScript API reported that `limit`/`offset` on `GET /api/conversations/v1/widget/tickets` had no effect. A request like `?limit=2` still returned the full ticket list while `count` reflected the total correctly.

The root cause was the first-page tickets cache. Any `offset=0` request was served from cache, but the cache key does not include `limit` or `offset`. After the widget polled with the default page size, a custom `?limit=2` request got the cached full page back.

## Changes

- Only read/write the tickets cache for the widget polling path (`offset=0`, default `limit=100`), matching the existing messages cache pattern (`limit == 50`)
- Custom `limit`/`offset` requests bypass the cache and hit the correctly sliced DB query
- Added regression tests for pagination after cache priming, default-page cache hits, and custom-limit cache bypass

## How did you test this code?

- `TestWidgetAPI::test_list_tickets_limit_respected_after_default_page_cached` — `?limit=2` returns 2 results after a default-page request primed the cache
- `TestWidgetAPI::test_list_tickets_default_page_still_served_from_cache` — default polling path still reads from cache
- `TestWidgetAPI::test_list_tickets_custom_limit_never_reads_cache` — custom limit never touches the cache