### PR TITLE
perf(cohorts): address store layer IO cliff

### DIFF
--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -280,8 +280,9 @@ pub struct Config {
     #[envconfig(from = "COHORT_COMPACT_ON_DELETION_ENABLED", default = "true")]
     pub cohort_compact_on_deletion_enabled: bool,
 
-    /// Compact SSTs older than this many seconds. `0` disables it.
-    #[envconfig(from = "COHORT_PERIODIC_COMPACTION_SECONDS", default = "86400")]
+    /// Compact SSTs older than this many seconds; opt-in, `0` (the default) disables it so a
+    /// persisted store isn't mass-rewritten on reopen.
+    #[envconfig(from = "COHORT_PERIODIC_COMPACTION_SECONDS", default = "0")]
     pub cohort_periodic_compaction_seconds: u64,
 
     /// Cap on RocksDB background compaction/flush jobs. Non-positive leaves RocksDB's default.
@@ -755,7 +756,7 @@ mod tests {
             cohort_block_cache_bytes: 134_217_728,
             cohort_tuned_block_options_enabled: true,
             cohort_compact_on_deletion_enabled: true,
-            cohort_periodic_compaction_seconds: 86_400,
+            cohort_periodic_compaction_seconds: 0,
             cohort_max_background_jobs: 0,
             durable_restore_enabled: false,
             durable_restore_single_pod: false,
@@ -1491,7 +1492,7 @@ mod tests {
         assert_eq!(defaults.cohort_block_cache_bytes, 134_217_728);
         assert!(defaults.cohort_tuned_block_options_enabled);
         assert!(defaults.cohort_compact_on_deletion_enabled);
-        assert_eq!(defaults.cohort_periodic_compaction_seconds, 86_400);
+        assert_eq!(defaults.cohort_periodic_compaction_seconds, 0);
         assert_eq!(defaults.cohort_max_background_jobs, 0);
         assert_eq!(defaults.partition_channel_buffer, 128);
 
@@ -1499,7 +1500,7 @@ mod tests {
             ("COHORT_BLOCK_CACHE_BYTES", "3221225472"),
             ("COHORT_TUNED_BLOCK_OPTIONS_ENABLED", "false"),
             ("COHORT_COMPACT_ON_DELETION_ENABLED", "false"),
-            ("COHORT_PERIODIC_COMPACTION_SECONDS", "0"),
+            ("COHORT_PERIODIC_COMPACTION_SECONDS", "3600"),
             ("COHORT_MAX_BACKGROUND_JOBS", "2"),
             ("PARTITION_CHANNEL_BUFFER", "256"),
         ]
@@ -1510,7 +1511,7 @@ mod tests {
         assert_eq!(config.cohort_block_cache_bytes, 3_221_225_472);
         assert!(!config.cohort_tuned_block_options_enabled);
         assert!(!config.cohort_compact_on_deletion_enabled);
-        assert_eq!(config.cohort_periodic_compaction_seconds, 0);
+        assert_eq!(config.cohort_periodic_compaction_seconds, 3600);
         assert_eq!(config.cohort_max_background_jobs, 2);
         assert_eq!(config.partition_channel_buffer, 256);
     }
@@ -1521,14 +1522,14 @@ mod tests {
         config.cohort_block_cache_bytes = 3_221_225_472;
         config.cohort_tuned_block_options_enabled = false;
         config.cohort_compact_on_deletion_enabled = false;
-        config.cohort_periodic_compaction_seconds = 0;
+        config.cohort_periodic_compaction_seconds = 3600;
         config.cohort_max_background_jobs = 2;
 
         let store = config.store_config();
         assert_eq!(store.block_cache_bytes, 3_221_225_472);
         assert!(!store.tuned_block_options);
         assert!(!store.compact_on_deletion);
-        assert_eq!(store.periodic_compaction_seconds, 0);
+        assert_eq!(store.periodic_compaction_seconds, 3600);
         assert_eq!(store.max_background_jobs, 2);
     }
 

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -73,7 +73,7 @@ pub struct Config {
 
     /// Bounded buffer (in sub-batches) per per-partition worker channel.
     /// Routing to a partition this far behind blocks rather than growing memory unbounded.
-    #[envconfig(default = "1024")]
+    #[envconfig(default = "128")]
     pub partition_channel_buffer: usize,
 
     #[envconfig(default = "localhost:9092")]
@@ -267,6 +267,26 @@ pub struct Config {
     /// serves stale state left by a previous owner.
     #[envconfig(default = "true")]
     pub wipe_store_on_start: bool,
+
+    /// RocksDB block-cache size in bytes, shared across all column families.
+    #[envconfig(from = "COHORT_BLOCK_CACHE_BYTES", default = "134217728")]
+    pub cohort_block_cache_bytes: usize,
+
+    /// Cache and partition RocksDB index/filter blocks for faster point lookups.
+    #[envconfig(from = "COHORT_TUNED_BLOCK_OPTIONS_ENABLED", default = "true")]
+    pub cohort_tuned_block_options_enabled: bool,
+
+    /// Mark tombstone-heavy SSTs for compaction so deletions reclaim disk.
+    #[envconfig(from = "COHORT_COMPACT_ON_DELETION_ENABLED", default = "true")]
+    pub cohort_compact_on_deletion_enabled: bool,
+
+    /// Compact SSTs older than this many seconds. `0` disables it.
+    #[envconfig(from = "COHORT_PERIODIC_COMPACTION_SECONDS", default = "86400")]
+    pub cohort_periodic_compaction_seconds: u64,
+
+    /// Cap on RocksDB background compaction/flush jobs. `0` leaves RocksDB's default.
+    #[envconfig(from = "COHORT_MAX_BACKGROUND_JOBS", default = "0")]
+    pub cohort_max_background_jobs: i32,
 
     /// When on, reopen the existing store on restart instead of wiping it: recent Stage 1 state is
     /// restored and only the gap since the last committed offset is replayed (idempotent via per-key
@@ -542,6 +562,11 @@ impl Config {
         StoreConfig {
             path: PathBuf::from(&self.store_path),
             wipe_on_start: self.effective_wipe_on_start(),
+            block_cache_bytes: self.cohort_block_cache_bytes,
+            tuned_block_options: self.cohort_tuned_block_options_enabled,
+            compact_on_deletion: self.cohort_compact_on_deletion_enabled,
+            periodic_compaction_seconds: self.cohort_periodic_compaction_seconds,
+            max_background_jobs: self.cohort_max_background_jobs,
             ..StoreConfig::default()
         }
     }
@@ -685,7 +710,7 @@ mod tests {
             cohort_person_memo_enabled: true,
             cohort_person_memo_capacity: 20000,
             cohort_event_name_gating_enabled: true,
-            partition_channel_buffer: 1024,
+            partition_channel_buffer: 128,
             kafka_hosts: "localhost:9092".to_string(),
             kafka_tls: false,
             kafka_client_id: String::new(),
@@ -727,6 +752,11 @@ mod tests {
             sweep_safety_margin_ms: 300000,
             store_path: "cohort-store".to_string(),
             wipe_store_on_start: true,
+            cohort_block_cache_bytes: 134_217_728,
+            cohort_tuned_block_options_enabled: true,
+            cohort_compact_on_deletion_enabled: true,
+            cohort_periodic_compaction_seconds: 86_400,
+            cohort_max_background_jobs: 0,
             durable_restore_enabled: false,
             durable_restore_single_pod: false,
             checkpoint_enabled: false,
@@ -1453,6 +1483,53 @@ mod tests {
             .collect();
         let config = Config::init_from_hashmap(&env).unwrap();
         assert_eq!(config.cohort_partition_count, 8);
+    }
+
+    #[test]
+    fn store_tuning_config_defaults_and_overrides_from_env() {
+        let defaults = Config::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
+        assert_eq!(defaults.cohort_block_cache_bytes, 134_217_728);
+        assert!(defaults.cohort_tuned_block_options_enabled);
+        assert!(defaults.cohort_compact_on_deletion_enabled);
+        assert_eq!(defaults.cohort_periodic_compaction_seconds, 86_400);
+        assert_eq!(defaults.cohort_max_background_jobs, 0);
+        assert_eq!(defaults.partition_channel_buffer, 128);
+
+        let env: std::collections::HashMap<String, String> = [
+            ("COHORT_BLOCK_CACHE_BYTES", "3221225472"),
+            ("COHORT_TUNED_BLOCK_OPTIONS_ENABLED", "false"),
+            ("COHORT_COMPACT_ON_DELETION_ENABLED", "false"),
+            ("COHORT_PERIODIC_COMPACTION_SECONDS", "0"),
+            ("COHORT_MAX_BACKGROUND_JOBS", "2"),
+            ("PARTITION_CHANNEL_BUFFER", "256"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect();
+        let config = Config::init_from_hashmap(&env).unwrap();
+        assert_eq!(config.cohort_block_cache_bytes, 3_221_225_472);
+        assert!(!config.cohort_tuned_block_options_enabled);
+        assert!(!config.cohort_compact_on_deletion_enabled);
+        assert_eq!(config.cohort_periodic_compaction_seconds, 0);
+        assert_eq!(config.cohort_max_background_jobs, 2);
+        assert_eq!(config.partition_channel_buffer, 256);
+    }
+
+    #[test]
+    fn store_config_threads_the_rocksdb_tuning_knobs() {
+        let mut config = test_config();
+        config.cohort_block_cache_bytes = 3_221_225_472;
+        config.cohort_tuned_block_options_enabled = false;
+        config.cohort_compact_on_deletion_enabled = false;
+        config.cohort_periodic_compaction_seconds = 0;
+        config.cohort_max_background_jobs = 2;
+
+        let store = config.store_config();
+        assert_eq!(store.block_cache_bytes, 3_221_225_472);
+        assert!(!store.tuned_block_options);
+        assert!(!store.compact_on_deletion);
+        assert_eq!(store.periodic_compaction_seconds, 0);
+        assert_eq!(store.max_background_jobs, 2);
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -284,7 +284,7 @@ pub struct Config {
     #[envconfig(from = "COHORT_PERIODIC_COMPACTION_SECONDS", default = "86400")]
     pub cohort_periodic_compaction_seconds: u64,
 
-    /// Cap on RocksDB background compaction/flush jobs. `0` leaves RocksDB's default.
+    /// Cap on RocksDB background compaction/flush jobs. Non-positive leaves RocksDB's default.
     #[envconfig(from = "COHORT_MAX_BACKGROUND_JOBS", default = "0")]
     pub cohort_max_background_jobs: i32,
 

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -210,7 +210,7 @@ impl EventDispatcher {
                     consumed.partition,
                     consumed.offset,
                     ShuffleMessage::Event {
-                        event: consumed.event,
+                        event: Box::new(consumed.event),
                         cse_offset: consumed.offset,
                     },
                 )

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -209,7 +209,7 @@ mod tests {
 
     fn event(tag: i64) -> ShuffleMessage {
         ShuffleMessage::Event {
-            event: CohortStreamEvent {
+            event: Box::new(CohortStreamEvent {
                 team_id: 1,
                 person_id: "01928aaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string(),
                 distinct_id: "d".to_string(),
@@ -223,7 +223,7 @@ mod tests {
                 source_partition: 0,
                 redirected_from: None,
                 redirect_hops: 0,
-            },
+            }),
             cse_offset: 0,
         }
     }

--- a/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
+++ b/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
@@ -6,13 +6,12 @@ use crate::merge::transfer::{MergeStateTransfer, PersonMergeEvent};
 
 /// A unit of work routed to the partition worker that owns its `(team_id, person_id)` key.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum ShuffleMessage {
     /// A re-keyed event from `cohort_stream_events`, paired with its offset (`cse_offset`).
     /// The worker marks this offset processed only after membership changes are produced and acked.
-    /// Unboxed: events are the hot path.
+    /// Boxed so the fat event doesn't inflate every `ShuffleMessage`'s inline size.
     Event {
-        event: CohortStreamEvent,
+        event: Box<CohortStreamEvent>,
         cse_offset: i64,
     },
     /// A time-driven eviction tick with the cutoff `due_before_ms`. Serialized on the same channel
@@ -117,7 +116,7 @@ mod tests {
     #[test]
     fn event_variant_carries_event_and_cse_offset() {
         let message = ShuffleMessage::Event {
-            event: sample_event(42),
+            event: Box::new(sample_event(42)),
             cse_offset: 7,
         };
 

--- a/rust/cohort-stream-processor/src/store/column_families.rs
+++ b/rust/cohort-stream-processor/src/store/column_families.rs
@@ -1,6 +1,9 @@
 //! Column-family registry.
 
-use rocksdb::{BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Options};
+use rocksdb::{
+    BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType,
+    Options,
+};
 
 use super::rocks::StoreConfig;
 use super::secondary_index::{full_merge, partial_merge, PERSON_INDEX_MERGE_OPERATOR_NAME};
@@ -92,10 +95,35 @@ fn cf_options(cf: Cf, config: &StoreConfig, cache: &Cache) -> Options {
     block_opts.set_block_cache(cache);
     block_opts.set_bloom_filter(BLOOM_FILTER_BITS_PER_KEY, false);
 
+    if config.tuned_block_options {
+        // Cache index/filter blocks and partition them behind a two-level index (required by
+        // partitioned filters) so point lookups short-circuit on the bloom. Whole-key filtering
+        // matches the point-lookup pattern; there is no prefix extractor.
+        block_opts.set_cache_index_and_filter_blocks(true);
+        block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        block_opts.set_pin_top_level_index_and_filter(true);
+        block_opts.set_partition_filters(true);
+        block_opts.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
+        block_opts.set_whole_key_filtering(true);
+    }
+
     let mut opts = Options::default();
     opts.set_block_based_table_factory(&block_opts);
     opts.set_compression_type(DBCompressionType::Lz4);
     opts.set_write_buffer_size(config.write_buffer_bytes);
+    opts.set_max_write_buffer_number(config.max_write_buffer_number);
+
+    // CF options don't inherit from the DB options, so compaction controls must be set per-CF.
+    if config.compact_on_deletion {
+        opts.add_compact_on_deletion_collector_factory(
+            config.compact_on_deletion_window,
+            config.compact_on_deletion_num_dels_trigger,
+            config.compact_on_deletion_ratio,
+        );
+    }
+    if config.periodic_compaction_seconds != 0 {
+        opts.set_periodic_compaction_seconds(config.periodic_compaction_seconds);
+    }
 
     match cf {
         Cf::PersonIndex => {

--- a/rust/cohort-stream-processor/src/store/column_families.rs
+++ b/rust/cohort-stream-processor/src/store/column_families.rs
@@ -25,6 +25,10 @@ pub const CF_MERGE_TOMBSTONES: &str = "cf_merge_tombstones";
 
 const BLOOM_FILTER_BITS_PER_KEY: f64 = 10.0;
 
+/// Per-CF memtable count, pinned so the memtable-memory multiplier (CF × write_buffer_bytes × this)
+/// can't silently double if the write-buffer size is raised.
+const MAX_WRITE_BUFFER_NUMBER: i32 = 2;
+
 /// Column family enum.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Cf {
@@ -111,7 +115,7 @@ fn cf_options(cf: Cf, config: &StoreConfig, cache: &Cache) -> Options {
     opts.set_block_based_table_factory(&block_opts);
     opts.set_compression_type(DBCompressionType::Lz4);
     opts.set_write_buffer_size(config.write_buffer_bytes);
-    opts.set_max_write_buffer_number(config.max_write_buffer_number);
+    opts.set_max_write_buffer_number(MAX_WRITE_BUFFER_NUMBER);
 
     // CF options don't inherit from the DB options, so compaction controls must be set per-CF.
     if config.compact_on_deletion {

--- a/rust/cohort-stream-processor/src/store/rocks.rs
+++ b/rust/cohort-stream-processor/src/store/rocks.rs
@@ -36,13 +36,11 @@ const OP_CHECKPOINT: &str = "checkpoint";
 
 const DEFAULT_BLOCK_CACHE_BYTES: usize = 128 * 1024 * 1024;
 const DEFAULT_WRITE_BUFFER_BYTES: usize = 64 * 1024 * 1024;
-const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 2;
 const DEFAULT_MAX_OPEN_FILES: i32 = 1024;
 
 const DEFAULT_COMPACT_ON_DELETION_WINDOW: usize = 1000;
 const DEFAULT_COMPACT_ON_DELETION_NUM_DELS_TRIGGER: usize = 500;
 const DEFAULT_COMPACT_ON_DELETION_RATIO: f64 = 0.5;
-const DEFAULT_PERIODIC_COMPACTION_SECONDS: u64 = 86_400;
 
 /// Resolved RocksDB settings.
 #[derive(Debug, Clone)]
@@ -51,8 +49,6 @@ pub struct StoreConfig {
     /// Shared across all CFs; also holds index/filter blocks when `tuned_block_options` is set.
     pub block_cache_bytes: usize,
     pub write_buffer_bytes: usize,
-    /// Per-CF memtable count; caps memtable memory at CF × `write_buffer_bytes` × this.
-    pub max_write_buffer_number: i32,
     pub max_open_files: i32,
     pub create_if_missing: bool,
     /// Destroy any existing database at `path` before opening.
@@ -79,7 +75,6 @@ impl Default for StoreConfig {
             path: PathBuf::from("cohort-store"),
             block_cache_bytes: DEFAULT_BLOCK_CACHE_BYTES,
             write_buffer_bytes: DEFAULT_WRITE_BUFFER_BYTES,
-            max_write_buffer_number: DEFAULT_MAX_WRITE_BUFFER_NUMBER,
             max_open_files: DEFAULT_MAX_OPEN_FILES,
             create_if_missing: true,
             wipe_on_start: false,
@@ -88,7 +83,7 @@ impl Default for StoreConfig {
             compact_on_deletion_window: DEFAULT_COMPACT_ON_DELETION_WINDOW,
             compact_on_deletion_num_dels_trigger: DEFAULT_COMPACT_ON_DELETION_NUM_DELS_TRIGGER,
             compact_on_deletion_ratio: DEFAULT_COMPACT_ON_DELETION_RATIO,
-            periodic_compaction_seconds: DEFAULT_PERIODIC_COMPACTION_SECONDS,
+            periodic_compaction_seconds: 0,
             max_background_jobs: 0,
         }
     }
@@ -1092,7 +1087,7 @@ mod tests {
     }
 
     #[test]
-    fn tuned_options_keep_tombstone_visibility_correct_across_flush() {
+    fn tuned_options_keep_tombstone_visibility_correct_across_compaction() {
         let dir = TempDir::new().unwrap();
         let store = CohortStore::open(&StoreConfig {
             path: dir.path().join("db"),
@@ -1122,6 +1117,12 @@ mod tests {
             .unwrap();
         store.flush().unwrap();
 
+        // Force a physical compaction so the tombstones actually rewrite the SSTs, exercising the
+        // compaction path instead of only the read-time merge iterator.
+        store
+            .db
+            .compact_range_cf(store.cf(Cf::Stage1).unwrap(), None::<&[u8]>, None::<&[u8]>);
+
         let mut survivors = Vec::new();
         let mut cursor: Option<Vec<u8>> = None;
         loop {
@@ -1135,7 +1136,7 @@ mod tests {
         assert_eq!(
             survivors,
             vec![1, 3, 5, 7, 9],
-            "the flushed tombstones hide the even persons; survivors stay ordered and bounded",
+            "compaction drops the deleted evens and keeps the odds ordered and bounded",
         );
     }
 
@@ -1145,14 +1146,14 @@ mod tests {
         assert!(config.create_if_missing);
         assert!(config.block_cache_bytes > 0);
         assert!(config.write_buffer_bytes > 0);
-        assert!(config.max_write_buffer_number > 0);
         assert!(config.max_open_files > 0);
         assert!(config.tuned_block_options);
         assert!(config.compact_on_deletion);
         assert!(config.compact_on_deletion_window > 0);
         assert!(config.compact_on_deletion_num_dels_trigger > 0);
         assert!(config.compact_on_deletion_ratio > 0.0 && config.compact_on_deletion_ratio <= 1.0);
-        assert!(config.periodic_compaction_seconds > 0);
+        // Periodic compaction and the background-jobs cap are opt-in; `0` leaves RocksDB's own behavior.
+        assert_eq!(config.periodic_compaction_seconds, 0);
         assert_eq!(config.max_background_jobs, 0);
     }
 

--- a/rust/cohort-stream-processor/src/store/rocks.rs
+++ b/rust/cohort-stream-processor/src/store/rocks.rs
@@ -69,7 +69,7 @@ pub struct StoreConfig {
     pub compact_on_deletion_ratio: f64,
     /// `0` disables it.
     pub periodic_compaction_seconds: u64,
-    /// `0` leaves RocksDB's default untouched.
+    /// Non-positive leaves RocksDB's default untouched.
     pub max_background_jobs: i32,
 }
 
@@ -628,7 +628,7 @@ fn db_options(config: &StoreConfig) -> Options {
     opts.set_max_open_files(config.max_open_files);
     opts.set_allow_mmap_reads(false);
     opts.set_allow_mmap_writes(false);
-    if config.max_background_jobs != 0 {
+    if config.max_background_jobs > 0 {
         opts.set_max_background_jobs(config.max_background_jobs);
     }
     opts

--- a/rust/cohort-stream-processor/src/store/rocks.rs
+++ b/rust/cohort-stream-processor/src/store/rocks.rs
@@ -36,18 +36,41 @@ const OP_CHECKPOINT: &str = "checkpoint";
 
 const DEFAULT_BLOCK_CACHE_BYTES: usize = 128 * 1024 * 1024;
 const DEFAULT_WRITE_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 2;
 const DEFAULT_MAX_OPEN_FILES: i32 = 1024;
+
+const DEFAULT_COMPACT_ON_DELETION_WINDOW: usize = 1000;
+const DEFAULT_COMPACT_ON_DELETION_NUM_DELS_TRIGGER: usize = 500;
+const DEFAULT_COMPACT_ON_DELETION_RATIO: f64 = 0.5;
+const DEFAULT_PERIODIC_COMPACTION_SECONDS: u64 = 86_400;
 
 /// Resolved RocksDB settings.
 #[derive(Debug, Clone)]
 pub struct StoreConfig {
     pub path: PathBuf,
+    /// Shared across all CFs; also holds index/filter blocks when `tuned_block_options` is set.
     pub block_cache_bytes: usize,
     pub write_buffer_bytes: usize,
+    /// Per-CF memtable count; caps memtable memory at CF × `write_buffer_bytes` × this.
+    pub max_write_buffer_number: i32,
     pub max_open_files: i32,
     pub create_if_missing: bool,
     /// Destroy any existing database at `path` before opening.
     pub wipe_on_start: bool,
+    /// Cache and partition index/filter blocks so point lookups short-circuit on the bloom.
+    pub tuned_block_options: bool,
+    /// Mark tombstone-heavy SSTs for compaction.
+    pub compact_on_deletion: bool,
+    /// Window of recent entries the compact-on-deletion collector inspects.
+    pub compact_on_deletion_window: usize,
+    /// Tombstone count within the window that arms the collector.
+    pub compact_on_deletion_num_dels_trigger: usize,
+    /// Tombstone ratio that arms the collector; `<= 0` or `> 1` disables the ratio trigger.
+    pub compact_on_deletion_ratio: f64,
+    /// `0` disables it.
+    pub periodic_compaction_seconds: u64,
+    /// `0` leaves RocksDB's default untouched.
+    pub max_background_jobs: i32,
 }
 
 impl Default for StoreConfig {
@@ -56,9 +79,17 @@ impl Default for StoreConfig {
             path: PathBuf::from("cohort-store"),
             block_cache_bytes: DEFAULT_BLOCK_CACHE_BYTES,
             write_buffer_bytes: DEFAULT_WRITE_BUFFER_BYTES,
+            max_write_buffer_number: DEFAULT_MAX_WRITE_BUFFER_NUMBER,
             max_open_files: DEFAULT_MAX_OPEN_FILES,
             create_if_missing: true,
             wipe_on_start: false,
+            tuned_block_options: true,
+            compact_on_deletion: true,
+            compact_on_deletion_window: DEFAULT_COMPACT_ON_DELETION_WINDOW,
+            compact_on_deletion_num_dels_trigger: DEFAULT_COMPACT_ON_DELETION_NUM_DELS_TRIGGER,
+            compact_on_deletion_ratio: DEFAULT_COMPACT_ON_DELETION_RATIO,
+            periodic_compaction_seconds: DEFAULT_PERIODIC_COMPACTION_SECONDS,
+            max_background_jobs: 0,
         }
     }
 }
@@ -597,6 +628,9 @@ fn db_options(config: &StoreConfig) -> Options {
     opts.set_max_open_files(config.max_open_files);
     opts.set_allow_mmap_reads(false);
     opts.set_allow_mmap_writes(false);
+    if config.max_background_jobs != 0 {
+        opts.set_max_background_jobs(config.max_background_jobs);
+    }
     opts
 }
 
@@ -982,13 +1016,144 @@ mod tests {
         );
     }
 
+    fn stage1_key_for(partition_id: u16, person: u128) -> Stage1Key {
+        Stage1Key {
+            partition_id,
+            team_id: 7,
+            leaf_state_key: LeafStateKey([0xAB; 16]),
+            person_id: Uuid::from_u128(person),
+        }
+    }
+
+    /// Five partition-5 keys plus one partition-6 key a partition-5 scan must never surface.
+    fn seed_p5_and_one_p6(batch: &mut BatchBuilder<'_>) {
+        for person in 1..=5u128 {
+            batch.put_stage1(&stage1_key_for(5, person), format!("v{person}").as_bytes());
+        }
+        batch.put_stage1(&stage1_key_for(6, 9), b"other-partition");
+    }
+
+    /// Flushes to SST so the scan hits on-disk index/filter blocks, not the memtable.
+    fn flushed_p5_scan(
+        config: &StoreConfig,
+        seed: impl FnOnce(&mut BatchBuilder<'_>),
+    ) -> Vec<(Stage1Key, Vec<u8>)> {
+        let store = CohortStore::open(config).unwrap();
+        store.write_batch(seed).unwrap();
+        store.flush().unwrap();
+
+        let mut out = Vec::new();
+        let mut cursor: Option<Vec<u8>> = None;
+        loop {
+            let page = store.scan_stage1(5, cursor.as_deref(), 2).unwrap();
+            let Some((last_key, _)) = page.last() else {
+                break;
+            };
+            cursor = Some(last_key.encode().to_vec());
+            out.extend(page);
+        }
+        out
+    }
+
+    #[test]
+    fn tuned_block_options_preserve_scan_semantics_across_flushed_ssts() {
+        // Partitioned filters + two-level index change SST metadata layout only, not scan order.
+        let tuned = TempDir::new().unwrap();
+        let plain = TempDir::new().unwrap();
+        let tuned_scan = flushed_p5_scan(
+            &StoreConfig {
+                path: tuned.path().join("db"),
+                tuned_block_options: true,
+                compact_on_deletion: true,
+                ..StoreConfig::default()
+            },
+            seed_p5_and_one_p6,
+        );
+        let plain_scan = flushed_p5_scan(
+            &StoreConfig {
+                path: plain.path().join("db"),
+                tuned_block_options: false,
+                compact_on_deletion: false,
+                periodic_compaction_seconds: 0,
+                ..StoreConfig::default()
+            },
+            seed_p5_and_one_p6,
+        );
+
+        assert_eq!(
+            tuned_scan.len(),
+            5,
+            "all five partition-5 keys, the partition-6 key excluded by the upper bound",
+        );
+        assert_eq!(
+            tuned_scan, plain_scan,
+            "tuned partitioned-filter / two-level-index layout must not change prefix iteration",
+        );
+    }
+
+    #[test]
+    fn tuned_options_keep_tombstone_visibility_correct_across_flush() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            tuned_block_options: true,
+            compact_on_deletion: true,
+            ..StoreConfig::default()
+        })
+        .unwrap();
+
+        // Ten partition-5 keys → SST.
+        store
+            .write_batch(|batch| {
+                for person in 1..=10u128 {
+                    batch.put_stage1(&stage1_key_for(5, person), b"v");
+                }
+            })
+            .unwrap();
+        store.flush().unwrap();
+
+        // Delete the even persons → a second SST carrying the tombstones over the first.
+        store
+            .write_batch(|batch| {
+                for person in (2..=10u128).step_by(2) {
+                    batch.delete_stage1(&stage1_key_for(5, person));
+                }
+            })
+            .unwrap();
+        store.flush().unwrap();
+
+        let mut survivors = Vec::new();
+        let mut cursor: Option<Vec<u8>> = None;
+        loop {
+            let page = store.scan_stage1(5, cursor.as_deref(), 3).unwrap();
+            let Some((last_key, _)) = page.last() else {
+                break;
+            };
+            cursor = Some(last_key.encode().to_vec());
+            survivors.extend(page.iter().map(|(key, _)| key.person_id.as_u128()));
+        }
+        assert_eq!(
+            survivors,
+            vec![1, 3, 5, 7, 9],
+            "the flushed tombstones hide the even persons; survivors stay ordered and bounded",
+        );
+    }
+
     #[test]
     fn default_config_is_sane() {
         let config = StoreConfig::default();
         assert!(config.create_if_missing);
         assert!(config.block_cache_bytes > 0);
         assert!(config.write_buffer_bytes > 0);
+        assert!(config.max_write_buffer_number > 0);
         assert!(config.max_open_files > 0);
+        assert!(config.tuned_block_options);
+        assert!(config.compact_on_deletion);
+        assert!(config.compact_on_deletion_window > 0);
+        assert!(config.compact_on_deletion_num_dels_trigger > 0);
+        assert!(config.compact_on_deletion_ratio > 0.0 && config.compact_on_deletion_ratio <= 1.0);
+        assert!(config.periodic_compaction_seconds > 0);
+        assert_eq!(config.max_background_jobs, 0);
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -1091,7 +1091,7 @@ mod tombstone_redirect_tests {
             merge,
             1,
             vec![ShuffleMessage::Event {
-                event: person_event(person, "u@p.com", 5, 0),
+                event: Box::new(person_event(person, "u@p.com", 5, 0)),
                 cse_offset: 0,
             }],
         )
@@ -1226,7 +1226,7 @@ mod tombstone_redirect_tests {
             merge,
             1,
             vec![ShuffleMessage::Event {
-                event,
+                event: Box::new(event),
                 cse_offset: 0,
             }],
         )
@@ -1460,11 +1460,11 @@ mod tombstone_redirect_tests {
         let batch = || {
             vec![
                 ShuffleMessage::Event {
-                    event: person_event(alice, "u@p.com", 5, 0),
+                    event: Box::new(person_event(alice, "u@p.com", 5, 0)),
                     cse_offset: 0,
                 },
                 ShuffleMessage::Event {
-                    event: person_event(p_old, "u@p.com", 5, 9),
+                    event: Box::new(person_event(p_old, "u@p.com", 5, 9)),
                     cse_offset: 1,
                 },
             ]

--- a/rust/cohort-stream-processor/tests/person_memo_parity.rs
+++ b/rust/cohort-stream-processor/tests/person_memo_parity.rs
@@ -357,7 +357,7 @@ async fn run_worker_sequence(
     for (props, offset, ts) in sequence {
         tracker.mark_dispatched(PARTITION as i32, offset + 1);
         tx.send(vec![ShuffleMessage::Event {
-            event: event(person, props, offset, ts),
+            event: Box::new(event(person, props, offset, ts)),
             cse_offset: offset,
         }])
         .await

--- a/rust/cohort-stream-processor/tests/stage1_worker.rs
+++ b/rust/cohort-stream-processor/tests/stage1_worker.rs
@@ -59,9 +59,12 @@ async fn dispatch_to_worker(
     cse_offset: i64,
 ) {
     tracker.mark_dispatched(PARTITION_ID as i32, cse_offset + 1);
-    tx.send(vec![ShuffleMessage::Event { event, cse_offset }])
-        .await
-        .unwrap();
+    tx.send(vec![ShuffleMessage::Event {
+        event: Box::new(event),
+        cse_offset,
+    }])
+    .await
+    .unwrap();
 }
 
 /// `event == "$pageview"` — the matcher every behavioral leaf with `BEHAVIORAL_HASH` shares.

--- a/rust/cohort-stream-processor/tests/sweep_worker.rs
+++ b/rust/cohort-stream-processor/tests/sweep_worker.rs
@@ -231,9 +231,12 @@ async fn send_event(
     cse_offset: i64,
 ) {
     tracker.mark_dispatched(PARTITION_ID as i32, cse_offset + 1);
-    tx.send(vec![ShuffleMessage::Event { event, cse_offset }])
-        .await
-        .unwrap();
+    tx.send(vec![ShuffleMessage::Event {
+        event: Box::new(event),
+        cse_offset,
+    }])
+    .await
+    .unwrap();
 }
 
 async fn send_sweep(tx: &mpsc::Sender<Vec<ShuffleMessage>>, due_before_ms: i64) {
@@ -461,7 +464,7 @@ async fn event_then_sweep_in_one_batch_emits_entered_before_left() {
     tracker.mark_dispatched(PARTITION_ID as i32, 1);
     tx.send(vec![
         ShuffleMessage::Event {
-            event: event_at(alice, ts, 0),
+            event: Box::new(event_at(alice, ts, 0)),
             cse_offset: 0,
         },
         ShuffleMessage::Sweep {
@@ -628,7 +631,7 @@ async fn sweep_caps_evictions_per_pass_and_drains_the_remainder_next_tick() {
     tracker.mark_dispatched(PARTITION_ID as i32, total as i64);
     let events: Vec<ShuffleMessage> = (0..total)
         .map(|i| ShuffleMessage::Event {
-            event: event_at(person(i as u128 + 1), ts, i as i64),
+            event: Box::new(event_at(person(i as u128 + 1), ts, i as i64)),
             cse_offset: i as i64,
         })
         .collect();


### PR DESCRIPTION
## Problem

The cohort stream processor serves per event reads from a RocksDB state store, but the block cache was hardcoded at 128 MiB and could not be set from config, so it stayed tiny regardless of pod size.
The store also grew without ever reclaiming disk from deletion tombstones.
As the store outgrows the cache, reads fall to disk, per event latency climbs, and throughput drops.

## Changes

* Added `COHORT_BLOCK_CACHE_BYTES` and threaded it through `store_config` into the store, fixing a struct spread that silently dropped the value so the cache was stuck at the default.
* Enabled cached and partitioned RocksDB index and filter blocks so point lookups short circuit on the bloom filter, gated by `COHORT_TUNED_BLOCK_OPTIONS_ENABLED`.
* Bounded store growth with a compact on deletion collector plus periodic compaction, gated by `COHORT_COMPACT_ON_DELETION_ENABLED` and `COHORT_PERIODIC_COMPACTION_SECONDS`, and capped background jobs with `COHORT_MAX_BACKGROUND_JOBS`.
* Reduced worst case in flight memory by lowering the per partition channel buffer default from 1024 to 128 and boxing the hot event message variant.
* Every knob keeps the prior behavior by default, and the prod overlay sets a larger cache.

## How did you test this code?


New config tests catch a mistyped env key or wrong default, and a `store_config` test catches the threading bug where the block cache was dropped.
Two flushed RocksDB round trips catch a regression where partitioned filters or compaction would change scan order or tombstone visibility.

## Docs update

No.