### PR TITLE
fix(mcp): default project-get to the active project

### DIFF
--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -432,10 +432,12 @@ tools:
             idempotent: true
         title: Get project
         description: |
-            Retrieve a project and its settings. Pass `@current` as the ID to fetch the caller's active project.
+            Retrieve a project and its settings. Omit the ID to get the caller's active project.
         param_overrides:
             id:
-                description: Project ID, or `@current` to fetch the caller's active project.
+                description: Project ID. If omitted, returns the caller's active project.
+                optional: true
+                fallback: projectId
                 cast: string-int
         response:
             exclude:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5707,7 +5707,7 @@
         }
     },
     "project-get": {
-        "description": "Retrieve a project and its settings. Pass `@current` as the ID to fetch the caller's active project.",
+        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
         "category": "Core",
         "feature": "core",
         "summary": "Get project",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6158,7 +6158,7 @@
         }
     },
     "project-get": {
-        "description": "Retrieve a project and its settings. Pass `@current` as the ID to fetch the caller's active project.",
+        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
         "category": "Core",
         "feature": "core",
         "summary": "Get project",

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -673,6 +673,14 @@ function composeToolSchema(
                 paramFallbacks[paramName] = override.fallback
             }
 
+            // An `optional` override must also surface as optional in the agent-facing
+            // JSON Schema. When combined with `cast` the field is wrapped in
+            // `z.preprocess(...)`, which doesn't propagate inner `.optional()` (zod 4
+            // marks it required), so register it here for `wrapWithCast` to re-apply.
+            if (override.optional) {
+                optionalParamNames.add(paramName)
+            }
+
             const castHelper = override.cast === 'string-int' ? 'castStringToInt' : null
             if (castHelper) {
                 castHelperImports.add(castHelper)

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -200,12 +200,14 @@ const desktopFileSystemRetrieve = (): ToolBase<typeof DesktopFileSystemRetrieveS
 })
 
 const ProjectGetSchema = OrganizationsProjectsRetrieveParams.omit({ organization_id: true }).extend({
-    id: z.preprocess(
-        castStringToInt,
-        OrganizationsProjectsRetrieveParams.shape['id'].describe(
-            "Project ID, or `@current` to fetch the caller's active project."
+    id: z
+        .preprocess(
+            castStringToInt,
+            OrganizationsProjectsRetrieveParams.shape['id']
+                .describe("Project ID. If omitted, returns the caller's active project.")
+                .optional()
         )
-    ),
+        .optional(),
 })
 
 const projectGet = (): ToolBase<typeof ProjectGetSchema, Schemas.ProjectBackwardCompat> => ({
@@ -213,9 +215,13 @@ const projectGet = (): ToolBase<typeof ProjectGetSchema, Schemas.ProjectBackward
     schema: ProjectGetSchema,
     handler: async (context: Context, params: z.infer<typeof ProjectGetSchema>) => {
         const orgId = await context.stateManager.getOrgID()
+        const id = params.id ?? (await context.stateManager.getProjectId())
+        if (!id) {
+            throw new Error('id is required. Provide it explicitly or set an active project first.')
+        }
         const result = await context.api.request<Schemas.ProjectBackwardCompat>({
             method: 'GET',
-            path: `/api/organizations/${encodeURIComponent(String(orgId))}/projects/${encodeURIComponent(String(params.id))}/`,
+            path: `/api/organizations/${encodeURIComponent(String(orgId))}/projects/${encodeURIComponent(String(id))}/`,
         })
         const filtered = omitResponseFields(result, [
             'secret_api_token',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/project-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/project-get.json
@@ -2,12 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "id": {
-            "description": "Project ID, or `@current` to fetch the caller's active project.",
+            "description": "Project ID. If omitted, returns the caller's active project.",
             "maximum": 2147483647,
             "minimum": -2147483648,
             "type": "number"
         }
     },
-    "required": ["id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -1806,3 +1806,61 @@ describe('generateToolCode with confirmed_action', () => {
         expect(result.code).toContain('actionLabel: "Enforce 2FA"')
     })
 })
+
+describe('optional param with state fallback', () => {
+    const resolved = (): ResolvedOperation =>
+        makeResolved({
+            path: '/api/organizations/{organization_id}/things/{id}/',
+            operation: {
+                operationId: 'things_retrieve',
+                parameters: [
+                    { in: 'path', name: 'organization_id', required: true, schema: { type: 'string' } },
+                    { in: 'path', name: 'id', required: true, schema: { type: 'integer' } },
+                ],
+            },
+        })
+
+    const config = (): ToolConfig => ({
+        operation: 'things_retrieve',
+        enabled: true,
+        param_overrides: {
+            id: {
+                description: 'Thing ID. If omitted, uses the active project.',
+                optional: true,
+                fallback: 'projectId',
+                cast: 'string-int',
+            },
+        },
+    })
+
+    it('resolves the omitted param from state in the handler', () => {
+        const result = generateToolCode(
+            'things-retrieve',
+            config(),
+            resolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        const collapsed = result.code.replace(/\s+/g, ' ')
+        expect(collapsed).toContain('const id = params.id ?? await context.stateManager.getProjectId()')
+    })
+
+    it('surfaces the field as optional despite the cast wrapper (z.preprocess strips inner optionality)', () => {
+        const result = generateToolCode(
+            'things-retrieve',
+            config(),
+            resolved(),
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+        // The outer `.optional()` after the preprocess is what makes the agent-facing
+        // JSON Schema treat the param as optional. Without it, the tool would still
+        // demand the id the fallback exists to supply.
+        const collapsed = result.code.replace(/\s+/g, ' ')
+        expect(collapsed).toContain('.optional()).optional()')
+    })
+})


### PR DESCRIPTION
## What's wrong

The `project-get` MCP tool fails **about 1 in 3 times** (~34%), for every client. It's the single worst tool in the catalog for errors.

## Why

The tool demands a **numeric project ID**. But when an agent calls `project-get`, it almost always just wants *"the project I'm working in"* — and it doesn't have that ID number handy.

The tool's own description told agents to type `@current` to get the active project. But the tool then rejected `@current` because it isn't a number. So agents were stuck:

- Type `@current` (as documented) → rejected as invalid.
- Guess a number → often the wrong one (stale, or from another org) → 404.

Either way, it fails. (Confirmed with our new `$mcp_error_type` data: the failures are exactly these two — rejected input and 404s.)

## The fix

**You can now call `project-get` with no ID and get your active project** — the thing you almost always want. Passing a specific ID still works as before.

This mirrors how `organization-get` already behaves (omit the ID → active org). Same pattern, so the two tools are now consistent, and we drop the `@current` magic string that was causing the trouble.

There's also a small fix to the tool generator: without it, an optional-with-a-default field like this was still being *advertised* to agents as required — so they'd keep passing an ID and the fix wouldn't land. Now it correctly shows up as optional.

**Tradeoff:** if an agent omits the ID when it actually meant a *different* project, it silently gets the active one instead of an error. That's fine in practice — agents browse other projects with `projects-get`; `project-get` is for "details of this project."

Shipping straight (no feature flag): it's a clearly-positive fix on a low-traffic, read-only tool, and a plain revert is the safety net.

## What we want to accomplish

This is the first time we take something the MCP analytics flagged, fix the root cause, and watch the number move. Goal: **`project-get`'s error rate drops from ~34% toward single digits.**

Being honest about scope: `project-get` is low-traffic (~150 calls/day) and mostly internal, so this is *proof the analytics → fix → measure loop works*, not a big-impact win. The big one (`execute-sql`, ~49k failures/month) is the planned follow-up now that the loop is proven.

## How we'll know it worked

Monitoring insight (project 2): [MCP project-get error rate — fix monitoring](https://us.posthog.com/project/2/insights/AjCRCCv8), baseline ~34%.

- Compare **after the deploy date** (not the merge date) — add a deploy annotation to the insight.
- Break the failures down by `$mcp_error_type`: the "rejected input" and "404" buckets should shrink. That's how we know *this* fix caused the drop.
- Watch out for a new "no active project" error appearing (the fallback throwing) — that would be trading one failure for another, not a win.
- Success bar, set upfront: under ~10% within two weeks of deploy.

## How did you test this code?

Agent-authored (PostHog Code / Claude); no manual testing. Automated only:
- `services/mcp` `generate-tools.test.ts` — 83 pass, including 2 new cases: the omitted ID resolves to the active project, and the field is advertised as optional (the generator bug this prevents).
- `lint-tool-names` — pass.
- Regenerated with `hogli build:openapi`; only `project-get` changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @lucasheriques, authored with PostHog Code (Claude). Follow-up to the merged `$mcp_error_type` instrumentation — the first end-to-end use of that data to fix a tool. Root-caused `project-get` with the new error-type breakdown. Chose "omit ID → active project" (matching `organization-get`) over "make `@current` work" because it drops the magic string, needs no backend change, and follows an existing pattern. Shipped without a feature flag after weighing it: a ramp adds flag plumbing and a stale flag for insurance a cheap revert already provides on a low-traffic read tool.

Skills invoked: `/implementing-mcp-tools` (the YAML → generated-tool codegen workflow).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
