### PR TITLE
fix(mcp-hint): show PostHog Code logo and always close on X

### DIFF
--- a/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
+++ b/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
@@ -22,7 +22,7 @@ interface BadgeAgent {
 
 const POSTHOG_CODE_URL = 'https://posthog.com/code'
 const POSTHOG_SLACK_URL = 'https://posthog.com/slack'
-const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0 dark:text-white" />
+const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0 text-black dark:text-white" />
 const POSTHOG_SLACK_LOGO = <IconSlack className="size-4 shrink-0" />
 
 // Show PostHog Code + Slack more often to increase engagement

--- a/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
+++ b/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
@@ -22,10 +22,7 @@ interface BadgeAgent {
 
 const POSTHOG_CODE_URL = 'https://posthog.com/code'
 const POSTHOG_SLACK_URL = 'https://posthog.com/slack'
-// `IconLogomark` is monochrome (fill: currentColor) — inherit the toast's text color so it stays
-// visible on both light and dark themes. Forcing `text-white` made it invisible on the light toast,
-// which read as stray padding before the name.
-const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0" />
+const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0 dark:text-white" />
 const POSTHOG_SLACK_LOGO = <IconSlack className="size-4 shrink-0" />
 
 // Show PostHog Code + Slack more often to increase engagement

--- a/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
+++ b/frontend/src/lib/components/MCPHint/AgentBadgeRotator.tsx
@@ -22,7 +22,10 @@ interface BadgeAgent {
 
 const POSTHOG_CODE_URL = 'https://posthog.com/code'
 const POSTHOG_SLACK_URL = 'https://posthog.com/slack'
-const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0 text-white" />
+// `IconLogomark` is monochrome (fill: currentColor) — inherit the toast's text color so it stays
+// visible on both light and dark themes. Forcing `text-white` made it invisible on the light toast,
+// which read as stray padding before the name.
+const POSTHOG_CODE_LOGO = <IconLogomark className="size-4 shrink-0" />
 const POSTHOG_SLACK_LOGO = <IconSlack className="size-4 shrink-0" />
 
 // Show PostHog Code + Slack more often to increase engagement

--- a/frontend/src/lib/components/MCPHint/mcpHintLogic.tsx
+++ b/frontend/src/lib/components/MCPHint/mcpHintLogic.tsx
@@ -131,14 +131,15 @@ export const mcpHintLogic = kea<mcpHintLogicType>([
                     icon: false,
                     // Clicking the X is the only way to permanently hide this surface — auto-dismiss
                     // (timeout) shouldn't count, so we wire dismissSurface here, not in onClose.
+                    // Close first so the toast always dismisses, independent of the bookkeeping action.
                     closeButton: ({ closeToast }) => (
                         <LemonButton
                             type="tertiary"
                             size="small"
                             icon={<IconX />}
                             onClick={(e) => {
-                                actions.dismissSurface(surfaceKey)
                                 closeToast(e)
+                                actions.dismissSurface(surfaceKey)
                             }}
                             data-attr="mcp-hint-close"
                         />


### PR DESCRIPTION
## Problem

Two issues on the MCP hint toast:

1. There's stray padding before "PostHog Code" in the rotating agent badge. It looks like a broken logo.
2. A report that clicking the X sometimes doesn't close the toast.

## Changes

**Logo (real bug).** The PostHog Code badge used `IconLogomark` with `text-white`. That icon is monochrome (`fill: currentColor`), so on the light-themed toast it rendered white on light and was invisible. Its `size-4` footprint plus the `gap-1` between logo and text is exactly the "stray padding" people saw. Every other agent (Claude, Cursor, Codex, Gemini) uses a colored brand SVG, so only PostHog Code was affected. Dropping `text-white` lets the mark inherit the toast text color, so it shows on both light and dark themes, matching the neighbouring `IconSparkles` and Slack icons.

**Close button.** I could not reproduce a case where the X fails to close. The handler is wired correctly for react-toastify v10 (`closeToast` is a stable `() => removeToast(id)`), and it's the same `LemonButton`-as-close-button pattern used app-wide via `ToastCloseButton`, which works everywhere. I also checked for CSS occlusion (rainbow decoration, the `CommandBlock` flash overlay, global `Toastify__*` overrides, badge overflow) and found nothing covering or disabling the close button.

The one fragility worth removing: the handler ran the dismiss bookkeeping action before `closeToast`, so closing was sequenced after it. I reordered so `closeToast` runs first. Now the toast always dismisses regardless of the bookkeeping. Zero behaviour change on the happy path.

## How did you test this code?

I (Claude) could not run the frontend in this environment because node_modules isn't installed, so no manual browser testing or automated tests were run by me. The changes are a Tailwind class removal and a two-line reorder in an event handler. Reasoning is static: traced `IconLogomark` (confirmed monochrome/currentColor) and the react-toastify v10 close path (`closeToast` ignores its argument and removes by toast id), cross-checked against the working app-wide `ToastCloseButton`. Recommend a quick visual check of the toast in both light and dark mode.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI is @rafaeelaudibert.

Claude Code (Opus 4.8) authored this. No repo skills were needed for the change itself. Approach: two Explore subagents mapped the components and independently red-teamed the "X doesn't close" claim; both concluded the close is correctly wired with no CSS occlusion, so I treated issue 2 as a non-defect and applied only a defensive reorder rather than a speculative fix. The logo issue traced cleanly to the monochrome `IconLogomark` being forced to `text-white` on a light background. I could not validate at runtime (frontend deps not installed here), which is why the testing section is explicit about what I did and didn't run.
