### PR TITLE
fix(phai): match e2e stream route without trailing slash

### DIFF
--- a/products/posthog_ai/frontend/e2e/run-surface.spec.ts
+++ b/products/posthog_ai/frontend/e2e/run-surface.spec.ts
@@ -116,7 +116,10 @@ async function routeTasksApi(page: Page, mock: TasksApiMock): Promise<void> {
     const runRe = new RegExp(`/tasks/${TASK_ID}/runs/${RUN_ID}/$`)
     const tokenRe = new RegExp(`/runs/${RUN_ID}/stream_token/$`)
     const logsRe = new RegExp(`/runs/${RUN_ID}/logs/$`)
-    const streamRe = new RegExp(`/runs/${RUN_ID}/stream/$`)
+    // The `stream` action URL has no trailing slash (`.../stream?start=latest`), unlike the other
+    // resource paths — match it with an optional slash so the route intercepts instead of falling through
+    // to the real backend (a fall-through 404s the fake run id and masks the clean-EOF drop under test).
+    const streamRe = new RegExp(`/runs/${RUN_ID}/stream/?$`)
 
     await page.route((url) => taskRe.test(url.pathname), fulfillJson(makeTask(mock.runStatus)))
     await page.route(


### PR DESCRIPTION
## Problem

The new `run-surface.spec.ts` test "live stream drop shows the reconnecting banner" has been failing master since it merged in [open task thread optimistically on send (#67099)](https://github.com/PostHog/posthog/pull/67099). E2E Playwright is skipped on that PR's checks (draft/aggregate gate), so the test never actually ran in CI before merge and went red the moment master ran it for real.

## Changes

The test mocks the tasks/runs API with `page.route`. The SSE stream route regex required a trailing slash (`/stream/$`), but `api.tasks.runs.openStream` requests `.../runs/:id/stream?start=latest` with **no** trailing slash (unlike the `/logs/` and `/runs/:id/` paths, which have one). So the mock never matched, the request fell through to the real E2E backend, 404'd the fake run id, and surfaced "Connection lost" instead of the clean-EOF drop the test needs to trigger the reconnecting banner.

One-line fix: match the stream path with an optional trailing slash (`/stream/?$`). This also makes the sibling "connection lost" test pass for the right reason (its `hang` mock now intercepts instead of coincidentally 404ing).

## How did you test this code?

- Root-caused from the failed run's Playwright trace + screenshot: the page showed "Connection lost / Conversation backing run not found", and the network log showed the real `/stream?start=latest` request bypassing the mock and hitting the backend.
- Verified the regex fix against the exact pathname from the trace: the old regex does not match, the new one matches (with and without a trailing slash) and stays unique vs the run/logs routes.
- I (Claude) could not stand up the full E2E stack locally, so the end-to-end validation is this PR's E2E CI run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl pointed me at a DevEx "master is red" alert for E2E CI Playwright and asked me to confirm it and fix if real. I (Claude, Opus 4.8 via Claude Code) used the `/fixing-flaky-tests` skill, classified it as a deterministic regression (16/16 Playwright attempts across 4 master runs, not a flake), and traced the culprit to the test added in #67099 whose stream mock never matched the real request URL. The fix is confined to the test harness. The product streaming/reconnect logic is correct and its jest coverage passes, so I did not touch it.
