### PR TITLE
fix(phai): show sandbox liveness dot instead of tasklist loader

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4385,7 +4385,7 @@ snapshots:
     products-posthog-ai-queuedmessagelist--single--light:
         hash: v1.k794b7964.80c03908f588a87222265093441fb1a923d47c312fdc4936d9396b1759a44232.-zIaOwO0H_QNqp98fu2Of3ZE-TL8tCQdVLfWQoun2ws
     products-posthog-ai-runalertactivity--agent-crash--dark:
-        hash: v1.k794b7964.76173d0e37304db146985034c13118b964b58aacd67f79b1b23fd749f2812968.5t-_qtjRmaGwTtCDO9QtDFA0ldYjlMnxtpgt5kxfoeA
+        hash: v1.k794b7964.ae751e0b5a3b319d195452c8d646a95c2a84e6cb10438c0b66296c730589f857.-LaCsJ7PjA-izRznS3wFs-YmeF7WVqTxo_s5vMXBIlI
     products-posthog-ai-runalertactivity--agent-crash--light:
         hash: v1.k794b7964.ce4475c7b2f43b0682b4f2eff9a5b15e8e94617845294dbbe24a389def860158.Lmo5t2PJwGNDO8_541yNP6G4xmu31tWSzlPw8zjUlaU
     products-posthog-ai-runalertactivity--agent-error--dark:
@@ -4393,9 +4393,9 @@ snapshots:
     products-posthog-ai-runalertactivity--agent-error--light:
         hash: v1.k794b7964.99976cce79d3f860b23d1d4773d1ba45301682a03fe4c0c33b5f9e67f8db119a.oWckFqDvm-e7ifE-r6cqFdmRVrFvzp2Z8ucNCQIN5t4
     products-posthog-ai-runalertactivity--connection-lost--dark:
-        hash: v1.k794b7964.8bdb645a7ba358ded15342e3b1e255074ed71de360a3cddc22e7fe11ecb67753._AA7m1NZ3G3rq30siy0ZpzZvgsPp1o8sb_incGK0-o4
+        hash: v1.k794b7964.7d42222ea3b3472183c676ef7a66f546b31dc178c0f160cf857356f64d63ea53.sXR8gsAy2i5_S9Ty1fnLGgnZmP8MGncm1iEt6z2esI8
     products-posthog-ai-runalertactivity--connection-lost--light:
-        hash: v1.k794b7964.80ee310e5db116a96505ff364d55e68a8e07922ea08eca9e1ccfdc44c79abf37.DwLSFQhTYea47P0SPTaP50bRj-ELceiUVBOU98i0wEQ
+        hash: v1.k794b7964.2112a18454f05a8ad2283cf4784f8bfb308c08e971a8c1ba7d1c9f09295b4ecf.DgVdEj2TYus9n65ozaoy2nm_4L6vJx38hJPE3pxq45g
     products-workflows-customerioimportmodal--all-steps-completed--dark:
         hash: v1.k794b7964.679720cf72d72cd35bb4c4a2e86094627df27ff2798b4244c5d29a6a767f3861.AvZ-0V3qNglzE2ZWUOcEjHFnSe9Qs68t-u03-ytn7VI
     products-workflows-customerioimportmodal--all-steps-completed--light:

--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -21,6 +21,7 @@ import { SANDBOX_BIND_TASK_PARAM } from 'scenes/max/maxLogic'
 import { urls } from 'scenes/urls'
 
 import { isTerminalRunStatus } from 'products/posthog_ai/frontend/api/logics'
+import { TaskRunStatusDot } from 'products/posthog_ai/frontend/api/primitives'
 import { ReadonlyRunSurface } from 'products/posthog_ai/frontend/api/readableRun'
 import { Task, TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 
@@ -33,7 +34,6 @@ import { DetailSection } from './DetailSection'
 import { ReportActivitySection } from './ReportActivitySection'
 import { ReportDetailBadges } from './ReportDetail'
 import { ReportTasksSection } from './ReportTasksSection'
-import { TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * Ready-state run output: a polished outcome card that links to the produced PR or report,

--- a/frontend/src/scenes/inbox/components/detail/ArtefactTaskRun.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ArtefactTaskRun.tsx
@@ -7,11 +7,11 @@ import api from 'lib/api'
 import { identifierToHuman } from 'lib/utils/strings'
 
 import { isTerminalRunStatus } from 'products/posthog_ai/frontend/api/logics'
+import { TaskRunStatusDot } from 'products/posthog_ai/frontend/api/primitives'
 import { ReadonlyRunSurface } from 'products/posthog_ai/frontend/api/readableRun'
 import { Task, TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 
 import { isCustomAgentTaskRun, taskRunTypeLabel, TaskRunArtefactContent } from './artefactTypes'
-import { TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * A `task_run` artefact: the linked task badged from its `(product, type)` (signals-pipeline runs

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -4,6 +4,7 @@ import { IconChevronDown, IconChevronRight, IconTerminal } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { isTerminalRunStatus } from 'products/posthog_ai/frontend/api/logics'
+import { TaskRunStatusDot } from 'products/posthog_ai/frontend/api/primitives'
 import { ReadonlyRunSurface } from 'products/posthog_ai/frontend/api/readableRun'
 import { TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -11,7 +11,6 @@ import { TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 import { inboxReportDetailLogic, ReportTaskEntry } from '../../logics/inboxReportDetailLogic'
 import { SignalReport } from '../../types'
 import { DetailSection } from './DetailSection'
-import { TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * Renders the report's linked tasks inline (latest status + purpose). Each row expands in place to

--- a/products/posthog_ai/frontend/api/primitives.ts
+++ b/products/posthog_ai/frontend/api/primitives.ts
@@ -61,6 +61,9 @@ export type { ActivityStatus } from '../components/ActivityPrimitives'
 export { RunActivity } from '../components/RunActivity'
 export { RunAlertActivity } from '../components/RunAlertActivity'
 
+export { TaskRunStatusDot } from '../components/TaskRunStatusDot'
+export { TaskRunLivenessDot } from '../components/TaskRunLivenessDot'
+
 export { PermissionInput } from '../components/PermissionInput'
 export { QuestionInput } from '../components/QuestionInput'
 export { ResourcesBar } from '../components/ResourcesBar'

--- a/products/posthog_ai/frontend/components/ActivityPrimitives.tsx
+++ b/products/posthog_ai/frontend/components/ActivityPrimitives.tsx
@@ -113,7 +113,8 @@ export function ActivityHeader({
         <div
             className={clsx(
                 'group/activity-header transition-all duration-500 flex select-none min-w-0',
-                (isPending || isFailed) && 'text-muted',
+                isPending && 'text-muted',
+                isFailed && 'text-danger',
                 !isInProgress && !isPending && !isFailed && 'text-default',
                 hasDetails ? 'cursor-pointer' : 'cursor-default',
                 hasDetails && 'rounded px-1 -mx-1 hover:bg-fill-button-tertiary-hover',

--- a/products/posthog_ai/frontend/components/TaskRunLivenessDot.tsx
+++ b/products/posthog_ai/frontend/components/TaskRunLivenessDot.tsx
@@ -1,0 +1,10 @@
+import { TaskRunStatus } from '../types/taskTypes'
+import { TERMINAL_STATUSES } from './TaskRunStatusDot'
+
+/** Pulsing green dot while the task's sandbox is live; renders nothing once the run is terminal. */
+export function TaskRunLivenessDot({ status }: { status: TaskRunStatus }): JSX.Element | null {
+    if (TERMINAL_STATUSES.includes(status)) {
+        return null
+    }
+    return <span className="inline-block size-1.5 shrink-0 rounded-full bg-success animate-pulse" aria-hidden />
+}

--- a/products/posthog_ai/frontend/components/TaskRunStatusDot.tsx
+++ b/products/posthog_ai/frontend/components/TaskRunStatusDot.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-import { TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
+import { TaskRunStatus } from '../types/taskTypes'
 
 /** Run statuses that count as terminal. Mirrors desktop `isTerminalStatus`. */
 export const TERMINAL_STATUSES: TaskRunStatus[] = [

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
@@ -9,13 +9,14 @@ import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuGroup, DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { LinkListItem } from 'lib/ui/LinkListItem/LinkListItem'
+import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { urls } from 'scenes/urls'
 
-import { tasksLogic } from '../../../logics/tasksLogic'
-import { Task, TaskRunStatus } from '../../../types/taskTypes'
+import { TaskRunLivenessDot } from 'products/posthog_ai/frontend/api/primitives'
 
-const IN_PROGRESS_STATUSES = new Set<TaskRunStatus>([TaskRunStatus.QUEUED, TaskRunStatus.IN_PROGRESS])
+import { tasksLogic } from '../../../logics/tasksLogic'
+import { Task } from '../../../types/taskTypes'
 
 // Compact "time ago" using a single largest unit, e.g. 18m, 1h, 7d.
 function compactTimeAgo(iso: string): string {
@@ -40,7 +41,6 @@ export const TaskListItem = memo(function TaskListItem({
     const displayTitle = task.title || task.slug
     // "Started" reflects when the latest run began; fall back to creation for never-run tasks.
     const startedAt = task.latest_run?.created_at ?? task.created_at
-    const isInProgress = task.latest_run ? IN_PROGRESS_STATUSES.has(task.latest_run.status) : false
 
     return (
         <LinkListItem.Root>
@@ -65,11 +65,18 @@ export const TaskListItem = memo(function TaskListItem({
                     tooltip={displayTitle}
                     tooltipPlacement="right"
                 >
-                    <LinkListItem.Content
-                        title={displayTitle}
-                        isLoading={isInProgress}
-                        meta={compactTimeAgo(startedAt)}
-                    />
+                    <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                        <span className="min-w-0 line-clamp-1 text-primary">{displayTitle}</span>
+                        {task.latest_run && <TaskRunLivenessDot status={task.latest_run.status} />}
+                    </div>
+                    <span
+                        className={cn(
+                            'opacity-30 text-xs pr-1.5 transition-opacity duration-100',
+                            'group-hover:opacity-0 group-has-[[data-state=open]]:opacity-0 group-has-focus-within:opacity-0'
+                        )}
+                    >
+                        {compactTimeAgo(startedAt)}
+                    </span>
                 </Link>
                 <LinkListItem.Trigger />
             </LinkListItem.Group>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/VirtualizedTasksList.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/VirtualizedTasksList.tsx
@@ -41,7 +41,7 @@ function TaskRow({
     const task = tasks[index]
 
     return (
-        <div ref={rowRef} style={style} data-index={index} className="px-4 lg:px-0">
+        <div ref={rowRef} style={style} data-index={index} className="px-4 lg:pl-0">
             {task ? (
                 <TaskListItem task={task} isActive={task.id === selectedTaskId} />
             ) : (


### PR DESCRIPTION
## Problem

The `/tasks` list row showed a loading spinner keyed on the task's latest run being queued or in progress. On interactive runs, a run stays `in_progress` for the whole session (including idle stretches between turns), so the spinner stayed on even when the agent wasn't actively doing anything - misleading.

**Demo**

<img width="596" height="262" alt="Screenshot 2026-07-02 at 17 08 51" src="https://github.com/user-attachments/assets/7acbf011-21ba-4b2b-8241-37e812565d4a" />


## Changes

Replaced the spinner with a small dot that reflects sandbox liveness: pulsing green while the run is live (not yet terminal), nothing once it's completed, failed, or cancelled.

- Added `TaskRunLivenessDot` (`products/posthog_ai/frontend/components/TaskRunLivenessDot.tsx`), exported through the product's `api/primitives` surface, and used it in `TaskListItem.tsx` right after the task title.
- Relocated `TaskRunStatusDot` (the existing 3-color dot used in the inbox scene for the same `TaskRunStatus` enum) from `frontend/src/scenes/inbox/` into `products/posthog_ai/frontend/components/`, since it operates purely on a type this product owns. Re-pointed the three inbox call sites (`AgentRunDetail`, `ArtefactTaskRun`, `ReportTasksSection`) at the product's public API instead of importing it the other way around.
- Made the failed-state activity header in `ActivityPrimitives.tsx` use `text-danger` for its title text instead of the shared `text-muted`, so it matches the red error icon next to it.

## How did you test this code?

Ran a scoped `tsc --noEmit` pass over the changed files plus their direct importers (full-tree local typecheck is unreliable on this machine - tsgo SIGSEGVs on darwin) and `oxlint`/`oxfmt` on every touched file. Both came back clean.

I haven't manually verified this in a running app - worth a visual pass on `/tasks` and the inbox task-run views before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy drove this in a Claude Code session: started from "tasklist should only show the loader if the task's turn is in progress," which led to investigating whether a true per-turn "agent is actively generating" signal exists anywhere reachable from the list (it doesn't - it's either a live SSE-only computation or a Redis-only, non-persisted flag). We agreed a persisted per-turn field is out of scope, and pivoted to a simpler "sandbox liveness" dot instead of the loader. Iterated a few times on where the dot lives and how it's positioned - first added an `indicator` prop to the shared `LinkListItem` component, then reverted that and composed the dot directly inside `TaskListItem` instead, to avoid touching a component used by other list surfaces (Max chat list, nav recent items).