### PR TITLE
feat(tasks): add tasks-agent-proxy-keep-stream-open flag

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -1,6 +1,7 @@
 from typing import Literal, get_args
 
 SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
+AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG = "tasks-agent-proxy-keep-stream-open"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
 MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG = "tasks-modal-directory-resume-snapshots"

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -724,6 +724,7 @@ class DockerSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
     ) -> str:
         # The host proxy URL (e.g. localhost:8003) is unreachable from inside the container;
@@ -738,6 +739,7 @@ class DockerSandbox(SandboxBase):
             reasoning_effort=reasoning_effort,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
@@ -803,6 +805,7 @@ class DockerSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
     ) -> None:
@@ -852,6 +855,7 @@ class DockerSandbox(SandboxBase):
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
         )
 
@@ -897,6 +901,7 @@ class DockerSandbox(SandboxBase):
                 allowed_domains=allowed_domains,
                 event_ingest_token=event_ingest_token,
                 event_ingest_url=event_ingest_url,
+                event_ingest_keep_stream_open=event_ingest_keep_stream_open,
                 repo_ready_file=repo_ready_file,
             )
             if self._launch_and_check(command):

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -739,6 +739,7 @@ class ModalSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
     ) -> str:
         env_prefix = build_agent_runtime_env_prefix(
@@ -749,6 +750,7 @@ class ModalSandbox(SandboxBase):
             reasoning_effort=reasoning_effort,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
@@ -841,6 +843,7 @@ class ModalSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
     ) -> None:
@@ -889,6 +892,7 @@ class ModalSandbox(SandboxBase):
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
         )
 

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -146,6 +146,7 @@ def build_agent_runtime_env_prefix(
     reasoning_effort: str | None = None,
     event_ingest_token: str | None = None,
     event_ingest_url: str | None = None,
+    event_ingest_keep_stream_open: bool = False,
 ) -> str:
     env_vars = {
         "POSTHOG_CODE_INTERACTION_ORIGIN": interaction_origin,
@@ -155,6 +156,7 @@ def build_agent_runtime_env_prefix(
         "POSTHOG_CODE_REASONING_EFFORT": reasoning_effort,
         "POSTHOG_TASK_RUN_EVENT_INGEST_TOKEN": event_ingest_token,
         "POSTHOG_TASK_RUN_EVENT_INGEST_URL": event_ingest_url,
+        "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN": "true" if event_ingest_keep_stream_open else None,
     }
     assignments = " ".join(
         f"{name}={shlex.quote(value)}" for name, value in env_vars.items() if value is not None and value != ""
@@ -265,6 +267,7 @@ class SandboxBase(ABC):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
     ) -> None:

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -550,6 +550,37 @@ class TestDockerSandboxUnit:
         # The host proxy URL is rewritten so it resolves from inside the container.
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_URL=http://host.docker.internal:8003" in command
 
+    @pytest.mark.parametrize(
+        "keep_stream_open, expected_env_present",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_start_agent_server_keep_stream_open_env(self, keep_stream_open, expected_env_present):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                mock_execute.return_value = ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None)
+                sandbox.start_agent_server(
+                    "posthog/posthog",
+                    "task-123",
+                    "run-456",
+                    "background",
+                    event_ingest_keep_stream_open=keep_stream_open,
+                )
+
+        command = _agent_server_launch_command(mock_execute)
+        if expected_env_present:
+            assert "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN=true" in command
+        else:
+            assert "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN" not in command
+
 
 @pytest.mark.skipif(is_ci() or not docker_available(), reason="Docker sandbox tests only run locally, not in CI")
 class TestDockerSandboxIntegration:

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -447,6 +447,32 @@ class TestModalSandboxAgentServer:
         # Modal sandboxes reach the proxy by its real URL, no Docker-host rewrite.
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_URL=https://agent-proxy.example.com" in command
 
+    @pytest.mark.parametrize(
+        "keep_stream_open, expected_env_present",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_start_agent_server_keep_stream_open_env(self, mock_sandbox: Any, keep_stream_open, expected_env_present):
+        mock_sandbox.execute = MagicMock(
+            return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+        )
+
+        mock_sandbox.start_agent_server(
+            repository="posthog/posthog",
+            task_id="task-123",
+            run_id="run-456",
+            mode="background",
+            event_ingest_keep_stream_open=keep_stream_open,
+        )
+
+        command = _agent_server_launch_command(mock_sandbox.execute)
+        if expected_env_present:
+            assert "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN=true" in command
+        else:
+            assert "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN" not in command
+
     def test_start_agent_server_raises_when_not_running(self, mock_sandbox: Any):
         mock_sandbox._sandbox.poll.return_value = 0
 

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -12,6 +12,7 @@ from posthog.models import Team
 from posthog.temporal.common.utils import asyncify, close_db_connections
 
 from products.tasks.backend.constants import (
+    AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
@@ -81,6 +82,8 @@ class TaskProcessingContext:
     # (request == limit). Captured at workflow start so it's stable across activity retries.
     burstable_sandbox_resources_enabled: bool = True
     overlap_clone_boot_enabled: bool = False
+    # Captured at workflow start so the agent-proxy stream lifetime stays deterministic across retries.
+    agent_proxy_keep_stream_open: bool = False
 
     @property
     def mode(self) -> str:
@@ -201,6 +204,40 @@ class TaskProcessingContext:
             "model": self.model,
             "reasoning_effort": self.reasoning_effort,
         }
+
+
+def _is_agent_proxy_keep_stream_open_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    state_override = (state or {}).get("agent_proxy_keep_stream_open")
+    if isinstance(state_override, bool):
+        return state_override
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("agent_proxy_keep_stream_open_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "agent_proxy_keep_stream_open_flag_checked",
+        run_id=run_id,
+        agent_proxy_keep_stream_open=enabled,
+    )
+    return enabled
 
 
 def _is_sandbox_event_ingest_enabled(
@@ -609,6 +646,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"use_modal_directory_resume_snapshots: {use_modal_directory_resume_snapshots} for this task run",
     )
+    agent_proxy_keep_stream_open = _is_agent_proxy_keep_stream_open_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"agent_proxy_keep_stream_open: {agent_proxy_keep_stream_open} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -643,4 +691,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         use_modal_network_allowlist=use_modal_network_allowlist,
         burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
         overlap_clone_boot_enabled=overlap_clone_boot_enabled,
+        agent_proxy_keep_stream_open=agent_proxy_keep_stream_open,
     )

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -123,6 +123,7 @@ class _LaunchParams:
     protected_base_branch: str | None
     event_ingest_token: str | None
     event_ingest_url: str | None
+    event_ingest_keep_stream_open: bool
 
 
 def _agentsh_domains_for(ctx: TaskProcessingContext) -> list[str] | None:
@@ -221,6 +222,7 @@ def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes) -> _La
         protected_base_branch=protected_base_branch,
         event_ingest_token=event_ingest_token,
         event_ingest_url=event_ingest_url,
+        event_ingest_keep_stream_open=ctx.agent_proxy_keep_stream_open,
     )
 
 
@@ -249,6 +251,7 @@ def _invoke_start_agent_server(
             allowed_domains=params.agentsh_domains,
             event_ingest_token=params.event_ingest_token,
             event_ingest_url=params.event_ingest_url,
+            event_ingest_keep_stream_open=params.event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
             wait_for_health=wait_for_health,
         )

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -10,6 +10,7 @@ from posthog.models import OrganizationMembership, User
 from posthog.models.user_integration import UserIntegration
 
 from products.tasks.backend.constants import (
+    AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
@@ -19,6 +20,7 @@ from products.tasks.backend.models import SandboxEnvironment, Task
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
+    _is_agent_proxy_keep_stream_open_enabled,
     _is_burstable_sandbox_resources_enabled,
     _is_modal_vm_sandbox_enabled,
     _is_sandbox_event_ingest_enabled,
@@ -354,6 +356,68 @@ class TestGetTaskProcessingContextActivity:
                     organization_id="organization-id",
                     run_id="run-id",
                     state={"sandbox_event_ingest_enabled": True},
+                )
+                is True
+            )
+
+        feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "flag_value, expected",
+        [
+            (True, True),
+            (False, False),
+            (None, False),
+        ],
+    )
+    def test_agent_proxy_keep_stream_open_flag_uses_organization_rollout(self, flag_value, expected):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=flag_value,
+        ) as feature_enabled_mock:
+            assert (
+                _is_agent_proxy_keep_stream_open_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is expected
+            )
+
+        feature_enabled_mock.assert_called_once_with(
+            AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
+            distinct_id="distinct-id",
+            groups={"organization": "organization-id"},
+            group_properties={"organization": {"id": "organization-id"}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def test_agent_proxy_keep_stream_open_flag_fails_closed(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _is_agent_proxy_keep_stream_open_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is False
+            )
+
+    def test_agent_proxy_keep_stream_open_state_override_skips_flag_check(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
+        ) as feature_enabled_mock:
+            assert (
+                _is_agent_proxy_keep_stream_open_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"agent_proxy_keep_stream_open": True},
                 )
                 is True
             )


### PR DESCRIPTION
## Problem

Task-run events stream to the agent-proxy as one long-lived NDJSON upload. In `@posthog/code` the sender was changed to optionally close that upload per drained batch (companion PR PostHog/code#3067) so a buffering ingress forwards each batch within a round-trip instead of stranding events in a long-lived upload. We want to roll that out gradually rather than flip it for every run, so it needs a server-evaluated feature flag.

## Changes

Introduces the `tasks-agent-proxy-keep-stream-open` feature flag and threads its evaluated value to the sandbox agent-server, mirroring the existing `tasks-cloud-runs-sandbox-event-ingest` wiring:

- Add the flag constant and `_is_agent_proxy_keep_stream_open_enabled(...)`, evaluated once in `get_task_processing_context` and captured on `TaskProcessingContext.agent_proxy_keep_stream_open` so it stays deterministic across activity retries.
- Pass it through `_prepare_launch` -> `sandbox.start_agent_server` -> `build_agent_runtime_env_prefix`, which sets `POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN=true` only when enabled (unset otherwise).
- The agent-server reads that env var and keeps the proxy ingest stream open when set (companion PR PostHog/code#3067).

Off by default: no env var is emitted unless the flag resolves true, so existing runs are unaffected.

## How did you test this code?

Automated (ran locally, all green):

- `pytest -k keep_stream_open` across `test_docker_sandbox.py`, `test_modal_sandbox.py`, `test_get_task_processing_context.py` -> 9 passed.
- `ruff check` + `ruff format --check` on all changed files -> clean.
- Pre-commit hook ran `ruff` lint/format + `ty` type check -> clean.

I did not run the full tasks Temporal suite or exercise a live sandbox.

The docker/modal tests catch a regression where the flag stops reaching the sandbox launch command; the evaluator tests catch the flag failing open on a flag-service error or ignoring the run-state override.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs; internal rollout flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus), directed by @charlesvien to put the `@posthog/code` per-batch proxy stream-close behavior behind a real PostHog feature flag, off by default.
- Approach: mirrored the established `tasks-cloud-runs-sandbox-event-ingest` mechanism (flag constant -> context evaluator -> `TaskProcessingContext` field -> `_prepare_launch` -> sandbox env prefix) so the flag evaluates server-side and reaches the sandbox as an env var, rather than inventing a new path.
- Polarity chosen deliberately: flag on = keep the proxy stream open (buffered); default off = today's per-batch close, so enabling is the opt-in.
