### PR TITLE
chore(integrations): pin mockDate on Slack integration stories

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1117,9 +1117,9 @@ snapshots:
     components-integrations-slack--slack-integration--light:
         hash: v1.k794b7964.5e31191fe884081eaecccc0ca410571bfea114969731061b25274559c377e9c2.48o8xuoIkdsSSYnrrvbAKMwn9XvAGobjR0zC3-wD7bc
     components-integrations-slack--slack-integration-added--dark:
-        hash: v1.k794b7964.8f7edaa75ee5a78345d8b9bf243a225dd4ce33c0d49736ba1c639058735917b3.2y8Hrz8TZeJMytRC68aWpdlYlrM_DOAXfHFgBlBAUFQ
+        hash: v1.k794b7964.a8dce18109f7259e4ebb6aa83b5026a6db344016ea991fbab6fb6a2675b11ed1.Ys18jnWc08XurOXQB-D31Hr_ylB4Brs8csqqf1C8KlU
     components-integrations-slack--slack-integration-added--light:
-        hash: v1.k794b7964.a2894354ba60c0274e03cec4401c2eaf175acb8920494244ed0fd9a834d8b06a.Nrd5QEZeXhY_62Re5ZJG0DaebRGgXlX5V0cdF5-vXq4
+        hash: v1.k794b7964.7339517d15e5185ead55817808e3241e63b516984df80398994c02af2be462b4.YK6e5ZGQdsI0Q_4q3nBbHs2D744fHRShmSZfYt-UZok
     components-integrations-slack--slack-integration-instance-not-configured--dark:
         hash: v1.k794b7964.b9ee8adc2251177b325e3775fe7fd391540c3dba77c06d9da9db33ec80eddf81.VkdQOtlSqpDDliAWoEWxISdK8UUYqJyt7gFvAGeB7HE
     components-integrations-slack--slack-integration-instance-not-configured--light:

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -15,7 +15,7 @@ import { IntegrationFullPage } from './IntegrationFullPage'
 const meta: Meta<typeof IntegrationFullPage> = {
     title: 'Scenes-Other/Integration landing page',
     component: IntegrationFullPage,
-    parameters: { layout: 'fullscreen', viewMode: 'story' },
+    parameters: { layout: 'fullscreen', viewMode: 'story', mockDate: '2023-01-01' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/integrations/components/SlackIntegration.stories.tsx
+++ b/frontend/src/scenes/integrations/components/SlackIntegration.stories.tsx
@@ -22,7 +22,7 @@ const SLACK_INSTANCE_SETTINGS = [
 
 const meta: Meta<StoryArgs> = {
     title: 'Components/Integrations/Slack',
-    parameters: {},
+    parameters: { mockDate: '2023-01-01' },
     render: ({ instanceConfigured = true, integrated = false }) => {
         useAvailableFeatures([AvailableFeature.SUBSCRIPTIONS])
 


### PR DESCRIPTION
## Problem

The PostHog Visual Review occasionally flags a diff on the Slack integration stories where only a date changes (e.g. the year rolls over). These stories render a connected integration whose `created_at` is a fixed mock date, displayed through `TZLabel` (via `UserActivityIndicator`) as a **relative** "added X ago" label. Because the label is computed against the real clock while `created_at` stays fixed, it drifts over time and produces spurious screenshot diffs that block PRs for no real UI change.

**Why:** raised in the PostHog Slack app thread — these date-driven diffs are noise, and the fix is to make the snapshots deterministic rather than to keep re-baselining them.

## Changes

Pin "now" via the existing `mockDate` story parameter (the `withMockDate` global decorator) on the two story files that render the connected Slack integration:

- `IntegrationFullPage.stories.tsx`
- `components/SlackIntegration.stories.tsx`

Set at the `meta` level so it applies to every story in each file. This freezes the relative timestamp so the rendered output is stable across runs. Matches the existing convention used by other stories with relative dates.

## How did you test this code?

Not run locally by the agent. The change is a Storybook parameter only, no runtime/production code is touched. Visual Review on this PR will regenerate the affected snapshots against the pinned date, after which they should stop drifting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafa Audibert directed this fix in a PostHog Slack app thread: the year-rolling visual-review diffs should be resolved by pinning the date rather than excluding regions (Visual Review diffs whole PNGs and has no region masking), and there is prior art of stories setting a fixed date via a decorator. I (the PostHog Slack app, powered by Claude) traced the leak to `TZLabel` rendering `mockIntegration.created_at` relatively in `IntegrationView.tsx`, confirmed `withMockDate`/`mockDate` is the established idiom, and applied it at the `meta` level of both connected-integration story files.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1782932184745099)*
