### PR TITLE
feat(tasks): tag automated CI follow-up messages with metadata

### DIFF
--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -117,6 +117,7 @@ def send_agent_command(
     params: dict[str, Any] | None = None,
     timeout: int = COMMAND_TIMEOUT_SECONDS,
     auth_token: str | None = None,
+    meta: dict[str, Any] | None = None,
 ) -> CommandResult:
     """Send a JSON-RPC command to the sandbox agent.
 
@@ -127,6 +128,10 @@ def send_agent_command(
             When provided, sent as Authorization header with connect_token
             as ``_modal_connect_token`` query param for Modal tunnel auth.
             When omitted, connect_token is used directly as Authorization.
+        meta: Optional metadata attached verbatim under ``_meta`` on the
+            JSON-RPC params — used to tag automated turns (e.g. CI follow-ups)
+            so the desktop client can render them distinctly. When omitted, the
+            payload is byte-identical to a call without it.
     """
     sandbox_url, connect_token = _get_sandbox_url_and_token(task_run)
     if not sandbox_url:
@@ -160,6 +165,10 @@ def send_agent_command(
         "id": 1,
         "method": method,
     }
+    if meta is not None:
+        # Merge into a fresh dict so we never mutate the caller's params and so
+        # a params-less command still carries `_meta`.
+        params = {**(params or {}), "_meta": meta}
     if params:
         payload["params"] = params
 
@@ -252,8 +261,13 @@ def send_user_message(
     artifacts: list[dict[str, Any]] | None = None,
     auth_token: str | None = None,
     timeout: int = COMMAND_TIMEOUT_SECONDS,
+    meta: dict[str, Any] | None = None,
 ) -> CommandResult:
-    """Send a user_message command to the sandbox agent."""
+    """Send a user_message command to the sandbox agent.
+
+    ``meta`` is forwarded verbatim to ``_meta`` on the JSON-RPC params (see
+    ``send_agent_command``). Human turns pass ``meta=None`` and stay untagged.
+    """
     params: dict[str, Any] = {}
     if message:
         params["content"] = message
@@ -265,6 +279,7 @@ def send_user_message(
         params=params,
         auth_token=auth_token,
         timeout=timeout,
+        meta=meta,
     )
 
 

--- a/products/tasks/backend/logic/services/tests/test_agent_command.py
+++ b/products/tasks/backend/logic/services/tests/test_agent_command.py
@@ -280,36 +280,79 @@ class TestSendAgentCommand:
         assert "content filtering" in (result.error or "")
         assert not result.retryable
 
+    @patch("products.tasks.backend.logic.services.agent_command.validate_sandbox_url", return_value=None)
+    @patch("products.tasks.backend.logic.services.agent_command.requests.post")
+    def test_meta_added_to_params_under_meta_key_when_provided(self, mock_post, mock_validate):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"jsonrpc": "2.0", "result": "ok"}
+        mock_post.return_value = mock_resp
+
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 2, "maxIterations": 3}}
+        task_run = self._make_task_run(sandbox_url="https://sandbox.modal.run/rpc", connect_token="tok")
+        result = send_agent_command(task_run, "user_message", params={"content": "hi"}, meta=meta)
+
+        assert result.success
+        sent_params = mock_post.call_args.kwargs["json"]["params"]
+        assert sent_params["_meta"] == meta
+        # Existing params are preserved alongside `_meta`.
+        assert sent_params["content"] == "hi"
+
+    @patch("products.tasks.backend.logic.services.agent_command.validate_sandbox_url", return_value=None)
+    @patch("products.tasks.backend.logic.services.agent_command.requests.post")
+    def test_no_meta_key_when_meta_absent(self, mock_post, mock_validate):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"jsonrpc": "2.0", "result": "ok"}
+        mock_post.return_value = mock_resp
+
+        task_run = self._make_task_run(sandbox_url="https://sandbox.modal.run/rpc", connect_token="tok")
+        result = send_agent_command(task_run, "user_message", params={"content": "hi"})
+
+        assert result.success
+        # Byte-identical to before the feature: no `_meta` key is added.
+        assert mock_post.call_args.kwargs["json"]["params"] == {"content": "hi"}
+
 
 class TestSendUserMessage:
     @patch("products.tasks.backend.logic.services.agent_command.send_agent_command")
     @pytest.mark.parametrize(
-        "message,artifacts,expected_params",
+        "message,artifacts,meta,expected_params",
         [
-            ("hello world", None, {"content": "hello world"}),
+            ("hello world", None, None, {"content": "hello world"}),
             (
                 None,
                 [{"id": "artifact-1", "name": "notes.txt"}],
+                None,
                 {"artifacts": [{"id": "artifact-1", "name": "notes.txt"}]},
             ),
             (
                 "hello world",
                 [{"id": "artifact-1", "name": "notes.txt"}],
+                None,
                 {"content": "hello world", "artifacts": [{"id": "artifact-1", "name": "notes.txt"}]},
             ),
+            # An automated (CI) turn forwards its `_meta` tag to send_agent_command.
+            (
+                "address ci",
+                None,
+                {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 1, "maxIterations": 3}},
+                {"content": "address ci"},
+            ),
         ],
-        ids=["message_only", "artifacts_only", "message_and_artifacts"],
+        ids=["message_only", "artifacts_only", "message_and_artifacts", "ci_meta_forwarded"],
     )
-    def test_sends_user_message_method(self, mock_send, message, artifacts, expected_params):
+    def test_sends_user_message_method(self, mock_send, message, artifacts, meta, expected_params):
         mock_send.return_value = CommandResult(success=True, status_code=200)
         task_run = MagicMock()
-        result = send_user_message(task_run, message, artifacts=artifacts)
+        result = send_user_message(task_run, message, artifacts=artifacts, meta=meta)
         mock_send.assert_called_once_with(
             task_run,
             method="user_message",
             params=expected_params,
             auth_token=None,
             timeout=15,
+            meta=meta,
         )
         assert result.success
 

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -57,6 +57,13 @@ CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 # Upper bound on how many CI rounds the orchestrator will dispatch.
 MAX_CI_REPETITIONS = 3
 
+# Discriminator on the `_meta.automatedCheck` object attached to automated CI
+# follow-up turns. The desktop client keys off this to render them as a
+# collapsed "Automated CI check" row rather than a message in the user's voice.
+# Kept as a named constant (one `kind` for now) so other automated turn kinds
+# can reuse the same `_meta` plumbing later.
+CI_FOLLOWUP_META_KIND = "pr_ci_followup"
+
 # Long-lived SSE relay activity timeout. The relay reconnects internally on
 # transient failures; this is the outer cap.
 RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT = timedelta(hours=24)

--- a/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
@@ -212,6 +212,20 @@ class TestSignalHandlers:
             PendingFollowup(message=None, artifact_ids=[], ack_id="ack-3", source="user")
         ]
 
+    async def test_send_followup_message_preserves_meta_tag(self, silent_workflow_logger):
+        # A tagged (CI) follow-up carries `meta` onto the queued PendingFollowup
+        # so it survives to the sandbox `user_message` `_meta`. If the handler
+        # dropped it here, the whole tag would be lost at ingestion.
+        workflow = ExecuteSandboxWorkflow()
+        workflow._context = _build_context()
+
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 2, "maxIterations": 3}}
+        await workflow.send_followup_message("ack-ci", "address ci", source="ci", meta=meta)
+
+        assert workflow._pending_followups == [
+            PendingFollowup(message="address ci", artifact_ids=[], ack_id="ack-ci", source="ci", meta=meta)
+        ]
+
     async def test_heartbeat_from_relay_sets_flag_and_forwards(self, silent_workflow_logger):
         # Heartbeats only ever flow child -> parent. The in-workflow relay
         # signals us; we record activity locally and forward to the parent
@@ -386,7 +400,12 @@ class TestHandleFollowup:
         ]
         flush_mock.assert_awaited()
 
-    async def test_success_dispatches_and_acks_accepted(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "meta",
+        [None, {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 1, "maxIterations": 3}}],
+        ids=["untagged", "ci_tagged"],
+    )
+    async def test_success_dispatches_and_acks_accepted(self, monkeypatch, meta):
         workflow = ExecuteSandboxWorkflow()
         workflow._context = _build_context()
         workflow._parent_workflow_id = "parent-wf"
@@ -396,10 +415,12 @@ class TestHandleFollowup:
         monkeypatch.setattr(workflow, "_flush_pending_outbound", AsyncMock())
 
         await workflow._handle_followup(
-            PendingFollowup(message="msg", artifact_ids=["art-1"], ack_id="ack-ok", source="user")
+            PendingFollowup(message="msg", artifact_ids=["art-1"], ack_id="ack-ok", source="user", meta=meta)
         )
 
-        send_mock.assert_awaited_once_with(message="msg", artifact_ids=["art-1"])
+        # `_handle_followup` threads the followup's meta straight to dispatch —
+        # None stays untagged, a CI tag rides through to the sandbox.
+        send_mock.assert_awaited_once_with(message="msg", artifact_ids=["art-1"], meta=meta)
         assert workflow._pending_outbound == [
             OutboundSignal(
                 target_signal=PARENT_ACK_SIGNAL,
@@ -433,6 +454,28 @@ class TestHandleFollowup:
         assert ack.args[1] == "ack-fail"
         assert ack.args[2] is False
         assert "sandbox is dead" in (ack.args[3] or "")
+
+
+class TestSendFollowupToSandbox:
+    async def test_threads_meta_into_activity_input(self, monkeypatch, silent_workflow_logger):
+        # The last workflow-side hop before the activity: meta must land on
+        # SendFollowupToSandboxInput, or the live CI path reaches the sandbox
+        # untagged despite everything upstream carrying the tag.
+        workflow = ExecuteSandboxWorkflow()
+        workflow._context = _build_context()
+
+        captured: dict = {}
+
+        async def fake_execute_activity(activity_fn, input_arg, *args, **kwargs):
+            captured["input"] = input_arg
+            return None
+
+        monkeypatch.setattr(execute_sandbox_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 1, "maxIterations": 3}}
+        await workflow._send_followup_to_sandbox(message="m", artifact_ids=[], meta=meta)
+
+        assert captured["input"].meta == meta
 
 
 class TestReapOrphanedSandbox:
@@ -737,7 +780,7 @@ class TestHandleFollowupInFlightTracking:
 
         snapshot: dict[str, bool] = {}
 
-        async def fake_send(message=None, artifact_ids=None):
+        async def fake_send(message=None, artifact_ids=None, meta=None):
             snapshot["in_flight_at_await"] = "ack-track" in workflow._in_flight_followup_ack_ids
 
         monkeypatch.setattr(workflow, "_send_followup_to_sandbox", fake_send)
@@ -755,7 +798,7 @@ class TestHandleFollowupInFlightTracking:
         workflow = ExecuteSandboxWorkflow()
         workflow._context = _build_context()
 
-        async def fake_send_raises(message=None, artifact_ids=None):
+        async def fake_send_raises(message=None, artifact_ids=None, meta=None):
             raise RuntimeError("sandbox dead")
 
         monkeypatch.setattr(workflow, "_send_followup_to_sandbox", fake_send_raises)

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -162,13 +162,16 @@ class PendingFollowup:
 
     `ack_id` is echoed back to the parent once the follow-up has been
     dispatched to the sandbox. `source` is metadata for logs/metrics — the
-    child does not branch on it; the parent has already decided.
+    child does not branch on it; the parent has already decided. `meta` is
+    forwarded verbatim to the sandbox `user_message` under `_meta` (present
+    only for automated turns the parent tagged, e.g. CI follow-ups).
     """
 
     message: str | None
     artifact_ids: list[str]
     ack_id: str
     source: str = FOLLOWUP_SOURCE_USER  # FOLLOWUP_SOURCE_USER | FOLLOWUP_SOURCE_CI
+    meta: Optional[dict[str, Any]] = None
 
 
 @dataclass
@@ -636,12 +639,16 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         message: str | None = None,
         artifact_ids: Optional[list[str]] = None,
         source: str = FOLLOWUP_SOURCE_USER,
+        meta: Optional[dict[str, Any]] = None,
     ) -> None:
         """Accept a follow-up message from the parent and queue it.
 
         Whether this is a user-driven message or a CI prompt is decided by
         the parent; the `source` value is only used for logs/metrics. The
-        child always dispatches what it is told.
+        child always dispatches what it is told. `meta` (present only on
+        automated turns) rides through to the sandbox `user_message` `_meta`.
+        The param defaults to None so pre-existing 4-arg signals — human
+        follow-ups and in-flight replays — deserialize unchanged.
         """
         context = self._context
         workflow.logger.info(
@@ -677,6 +684,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 artifact_ids=artifact_ids or [],
                 ack_id=ack_id,
                 source=source,
+                meta=meta,
             )
         )
 
@@ -721,6 +729,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 await self._send_followup_to_sandbox(
                     message=followup.message,
                     artifact_ids=followup.artifact_ids,
+                    meta=followup.meta,
                 )
                 self._enqueue_ack(signal_name=SEND_FOLLOWUP_SIGNAL, ack_id=followup.ack_id)
             except Exception as e:
@@ -1169,7 +1178,9 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         elif result.error:
             workflow.logger.warning(f"Resume snapshot skipped: {result.error}")
 
-    async def _send_followup_to_sandbox(self, message: str | None, artifact_ids: list[str]) -> None:
+    async def _send_followup_to_sandbox(
+        self, message: str | None, artifact_ids: list[str], meta: Optional[dict[str, Any]] = None
+    ) -> None:
         workflow.logger.info(
             "execute_sandbox_send_followup_begin",
             run_id=self.context.run_id,
@@ -1183,6 +1194,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 message=message,
                 posthog_mcp_scopes=self._posthog_mcp_scopes,
                 artifact_ids=artifact_ids,
+                meta=meta,
             ),
             start_to_close_timeout=timedelta(minutes=35),
             retry_policy=RetryPolicy(maximum_attempts=1),

--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -76,6 +76,10 @@ def forward_pending_user_message(run_id: str) -> None:
         state = task_run.state or {}
         pending_message = state.get("pending_user_message")
         pending_user_artifact_ids = state.get("pending_user_artifact_ids") or []
+        # Automated-turn tag staged alongside the message (e.g. a CI follow-up
+        # forwarded via state rather than the live signal). None for human
+        # first messages, which stay untagged.
+        pending_message_meta = state.get("pending_user_message_meta")
         if not pending_message and not pending_user_artifact_ids:
             return
 
@@ -103,6 +107,7 @@ def forward_pending_user_message(run_id: str) -> None:
             artifacts=pending_artifacts or None,
             auth_token=auth_token,
             timeout=90,
+            meta=pending_message_meta,
         )
         logger.info(
             "forward_pending_message_attempted",
@@ -117,6 +122,7 @@ def forward_pending_user_message(run_id: str) -> None:
                 artifacts=pending_artifacts or None,
                 auth_token=auth_token,
                 timeout=90,
+                meta=pending_message_meta,
             )
 
         if not result.success and result.retryable:
@@ -139,7 +145,12 @@ def forward_pending_user_message(run_id: str) -> None:
 
         TaskRun.update_state_atomic(
             run_id,
-            remove_keys=["pending_user_message", "pending_user_artifact_ids", "pending_user_message_ts"],
+            remove_keys=[
+                "pending_user_message",
+                "pending_user_artifact_ids",
+                "pending_user_message_ts",
+                "pending_user_message_meta",
+            ],
         )
 
         if result.success:

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -42,6 +42,9 @@ class SendFollowupToSandboxInput:
     message: str | None = None
     posthog_mcp_scopes: PosthogMcpScopes = "read_only"
     artifact_ids: list[str] | None = None
+    # Automated-turn metadata forwarded to the sandbox `user_message` under
+    # `_meta`. None for human follow-ups.
+    meta: dict[str, Any] | None = None
 
 
 @activity.defn
@@ -88,6 +91,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
         artifacts=artifacts,
         auth_token=auth_token,
         timeout=FOLLOWUP_TIMEOUT_SECONDS,
+        meta=input.meta,
     )
     logger.info(
         "send_followup_to_sandbox_attempted",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
@@ -65,3 +65,24 @@ class TestSendFollowupToSandbox(BaseTest):
         payload = mock_conn.xadd.call_args.args[1]["data"]
         event = json.loads(payload)
         self.assertEqual(event["notification"]["params"]["stopReason"], "max_tokens")
+
+    @patch(
+        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_tasks_stream_redis_sync"
+    )
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_user_message")
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.TaskRun.objects")
+    def test_forwards_meta_to_user_message(
+        self, mock_task_run_objects, mock_send_user_message, mock_get_tasks_stream_redis_sync
+    ):
+        # The activity is the exit seam of the live CI path — it must pass the
+        # input's meta through to send_user_message (which puts it under _meta).
+        task_run = MagicMock()
+        task_run.task.created_by = None
+        mock_task_run_objects.select_related.return_value.get.return_value = task_run
+        mock_send_user_message.return_value = MagicMock(success=True, data={"result": {"stopReason": "end_turn"}})
+        mock_get_tasks_stream_redis_sync.return_value = MagicMock()
+
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 1, "maxIterations": 3}}
+        send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-123", message="hello", meta=meta))
+
+        self.assertEqual(mock_send_user_message.call_args.kwargs["meta"], meta)

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -94,8 +94,33 @@ class TestForwardPendingUserMessage(TestCase):
 
         mock_send.assert_called_once()
         assert mock_send.call_args[0][1] == "fix the tests"
+        # Untagged first message: no automated-check meta forwarded.
+        assert mock_send.call_args.kwargs["meta"] is None
         run.refresh_from_db()
         assert "pending_user_message" not in run.state
+
+    @patch("products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token", return_value="jwt")
+    @patch("products.tasks.backend.logic.services.agent_command.send_user_message")
+    def test_pending_message_meta_forwarded_and_cleared(self, mock_send, mock_token):
+        # A staged automated tag (e.g. a CI follow-up routed via state) is
+        # forwarded under _meta and cleared alongside the message, so it never
+        # leaks onto a later human turn.
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 2, "maxIterations": 3}}
+        run = self._make_run(
+            state={
+                "pending_user_message": "address ci",
+                "pending_user_message_meta": meta,
+                "sandbox_url": "https://sandbox.example.com/rpc",
+            }
+        )
+        mock_send.return_value = _command_result(success=True, status_code=200)
+
+        forward_pending_user_message(str(run.id))
+
+        assert mock_send.call_args.kwargs["meta"] == meta
+        run.refresh_from_db()
+        assert "pending_user_message" not in run.state
+        assert "pending_user_message_meta" not in run.state
 
     @patch("products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token", return_value="jwt")
     @patch("products.tasks.backend.temporal.observability.posthoganalytics.capture")

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -255,6 +255,9 @@ class RunState(BaseModel, extra="allow"):
     pending_user_message: str | None = None
     pending_user_artifact_ids: list[str] | None = None
     pending_user_message_ts: str | None = None
+    # Automated-turn metadata for a staged `pending_user_message` (forwarded to
+    # the sandbox `user_message` under `_meta`). None for human/first messages.
+    pending_user_message_meta: dict[str, Any] | None = None
     initial_permission_mode: InitialPermissionMode | None = None
     slack_thread_url: str | None = None
     interaction_origin: str | None = None

--- a/products/tasks/backend/temporal/task_management/activities/pending_followups.py
+++ b/products/tasks/backend/temporal/task_management/activities/pending_followups.py
@@ -30,7 +30,7 @@ PENDING_FOLLOWUPS_STATE_KEY = "pending_external_followups"
 @dataclass
 class PersistPendingFollowupsInput:
     run_id: str
-    # Pre-serialized list of {message, artifact_ids, source}. The workflow
+    # Pre-serialized list of {message, artifact_ids, source, meta}. The workflow
     # serializes its `PendingExternalFollowup` dataclasses here so the
     # activity doesn't need to import workflow-side types.
     followups: list[dict[str, Any]]

--- a/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
+++ b/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
@@ -300,6 +300,8 @@ class TestShouldRunCIFollowUp:
         assert decision is CIFollowUpDecision.FIRE
         # Fingerprint must persist so the next tick with the same fp returns SKIP.
         assert workflow._pr_fingerprint == "fp-1"
+        # The PR url is stashed so the CI follow-up's meta can carry `prUrl`.
+        assert workflow._pr_url == "https://github.com/org/repo/pull/1"
 
     async def test_returns_skip_when_fingerprint_unchanged(self, monkeypatch, silent_workflow_logger):
         workflow = TaskManagementWorkflow()
@@ -328,6 +330,9 @@ class TestMaybeDispatchCIFollowUp:
         workflow._context = _build_context(ci_prompt="custom prompt")
         workflow._run_id = "run-id"
         workflow._sandbox_workflow_id = "sandbox-wf"
+        # A real FIRE always has a PR url (stashed by `_should_run_ci_follow_up`,
+        # which is mocked here); mimic it so the meta carries `prUrl`.
+        workflow._pr_url = "https://github.com/org/repo/pull/1"
 
         monkeypatch.setattr(workflow, "_should_run_ci_follow_up", AsyncMock(return_value=CIFollowUpDecision.FIRE))
         signal_mock = AsyncMock()
@@ -337,7 +342,21 @@ class TestMaybeDispatchCIFollowUp:
 
         assert workflow._ci_repetitions == 1
         assert workflow._last_active_time == fixed_now.now
-        signal_mock.assert_awaited_once_with(message="custom prompt", artifact_ids=[], source="ci")
+        # The dispatched turn is tagged as an automated CI follow-up; iteration
+        # is 1-based (first repetition), maxIterations mirrors the cap.
+        signal_mock.assert_awaited_once_with(
+            message="custom prompt",
+            artifact_ids=[],
+            source="ci",
+            meta={
+                "automatedCheck": {
+                    "kind": "pr_ci_followup",
+                    "iteration": 1,
+                    "maxIterations": MAX_CI_REPETITIONS,
+                    "prUrl": "https://github.com/org/repo/pull/1",
+                }
+            },
+        )
 
     async def test_fire_falls_back_to_default_ci_message(self, monkeypatch, fixed_now):
         workflow = TaskManagementWorkflow()
@@ -350,7 +369,19 @@ class TestMaybeDispatchCIFollowUp:
 
         await workflow._maybe_dispatch_ci_follow_up()
 
-        signal_mock.assert_awaited_once_with(message=DEFAULT_CI_MESSAGE, artifact_ids=[], source="ci")
+        # No PR url stashed → the optional `prUrl` key is omitted from the meta.
+        signal_mock.assert_awaited_once_with(
+            message=DEFAULT_CI_MESSAGE,
+            artifact_ids=[],
+            source="ci",
+            meta={
+                "automatedCheck": {
+                    "kind": "pr_ci_followup",
+                    "iteration": 1,
+                    "maxIterations": MAX_CI_REPETITIONS,
+                }
+            },
+        )
 
     async def test_no_pr_disables_ci_loop(self, monkeypatch, silent_workflow_logger):
         # No PR → there will never be one; we have to disable the loop entirely
@@ -406,7 +437,13 @@ class TestDrainExternalSignals:
         workflow._pending_external_complete = ("completed", None)
 
         call_order: list[str] = []
-        followup_mock = AsyncMock(side_effect=lambda **kw: call_order.append(f"followup:{kw['message']}"))
+        drained_metas: list = []
+
+        def _record_followup(**kw):
+            call_order.append(f"followup:{kw['message']}")
+            drained_metas.append(kw["meta"])
+
+        followup_mock = AsyncMock(side_effect=_record_followup)
         complete_mock = AsyncMock(side_effect=lambda *a, **kw: call_order.append(f"complete:{a[0]}"))
         monkeypatch.setattr(workflow, "_signal_child_followup", followup_mock)
         monkeypatch.setattr(workflow, "_signal_child_complete", complete_mock)
@@ -415,6 +452,8 @@ class TestDrainExternalSignals:
         await workflow._drain_external_signals()
 
         assert call_order == ["followup:m1", "followup:m2", "complete:completed"]
+        # Human follow-ups forward `meta=None` so they stay untagged downstream.
+        assert drained_metas == [None, None]
         assert workflow._pending_external_followups == []
         assert workflow._pending_external_complete is None
 
@@ -534,6 +573,34 @@ class TestSignalChildFollowup:
         # signal_args must mirror the exact bytes we sent so the retry loop
         # can replay them — the child dedupes on ack_id so a replay is safe.
         assert slot.signal_args == ["ack-generated", "m", ["a"], "ci"]
+
+    async def test_appends_meta_as_fifth_arg_when_present(self, monkeypatch, fixed_now):
+        # A tagged (automated) follow-up appends meta as a 5th signal arg. The
+        # 4-arg case above is the untagged (human) wire shape — keeping the two
+        # distinct preserves byte-identical payloads for human turns.
+        workflow = TaskManagementWorkflow()
+        workflow._run_id = "run-id"
+        workflow._sandbox_workflow_id = "sandbox-wf"
+
+        handle = Mock()
+        handle.signal = AsyncMock()
+        monkeypatch.setattr(
+            task_management_workflow_module.workflow,
+            "get_external_workflow_handle",
+            Mock(return_value=handle),
+        )
+        monkeypatch.setattr(task_management_workflow_module.workflow, "uuid4", lambda: "ack-generated")
+
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 2, "maxIterations": 3}}
+        await workflow._signal_child_followup(message="m", artifact_ids=[], source="ci", meta=meta)
+
+        handle.signal.assert_awaited_once_with(
+            "send_followup_message",
+            args=["ack-generated", "m", [], "ci", meta],
+        )
+        # The retry loop replays the 5-arg shape verbatim, so the re-dispatch
+        # stays tagged with the same meta.
+        assert workflow._pending_ack_slots["ack-generated"].signal_args == ["ack-generated", "m", [], "ci", meta]
 
     async def test_skips_when_no_sandbox_id(self, monkeypatch, silent_workflow_logger):
         # If the sandbox workflow id was never set we have nowhere to deliver
@@ -942,6 +1009,29 @@ class TestSandboxSessionCompletionReset:
         assert workflow._pending_ack_slots == {}
         persist_mock.assert_awaited()
 
+    async def test_requeued_ci_followup_preserves_meta_tag(self, monkeypatch, silent_workflow_logger, fixed_now):
+        # A tagged (CI) follow-up still awaiting ACK when the session ends must
+        # keep its `_meta` through the re-queue (signal_args has a 5th element),
+        # so the re-dispatch to the next sandbox stays tagged with the same
+        # iteration rather than reverting to an untagged turn.
+        workflow = TaskManagementWorkflow()
+        workflow._run_id = "run-id"
+        workflow._sandbox_alive = True
+        workflow._child_completion = ChildCompletion(success=True, error=None, sandbox_id="sb-1", timed_out=False)
+        meta = {"automatedCheck": {"kind": "pr_ci_followup", "iteration": 2, "maxIterations": 3}}
+        workflow._pending_ack_slots["ack-ci"] = PendingAckSlot(
+            signal_name="send_followup_message",
+            sent_at=fixed_now.now,
+            signal_args=["ack-ci", "address ci", [], "ci", meta],
+        )
+        monkeypatch.setattr(workflow, "_persist_pending_followups", AsyncMock())
+
+        await workflow._on_sandbox_session_completed()
+
+        assert workflow._pending_external_followups == [
+            PendingExternalFollowup(message="address ci", artifact_ids=[], source="ci", meta=meta)
+        ]
+
 
 class TestPendingFollowupPersistence:
     async def test_restore_pending_seeds_in_memory_queue(self, monkeypatch, silent_workflow_logger):
@@ -1011,4 +1101,6 @@ class TestPendingFollowupPersistence:
         await workflow._persist_pending_followups()
 
         assert captured["input"].run_id == "run-id"
-        assert captured["input"].followups == [{"message": "persist-me", "artifact_ids": ["a1"], "source": "user"}]
+        assert captured["input"].followups == [
+            {"message": "persist-me", "artifact_ids": ["a1"], "source": "user", "meta": None}
+        ]

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -577,21 +577,27 @@ class TaskManagementWorkflow(PostHogWorkflow):
             # orchestrator restart would forget about the rejected follow-up.
             await self._persist_pending_followups()
 
+    @staticmethod
+    def _followup_from_signal_args(signal_args: list[Any]) -> PendingExternalFollowup:
+        """Rebuild a queued follow-up from a SEND_FOLLOWUP_SIGNAL args list.
+
+        signal_args = [ack_id, message, artifact_ids, source, (meta?)] — meta is
+        only present on tagged (CI) follow-ups. Kept in one place so the re-queue
+        sites don't drift if the arg layout changes.
+        """
+        _ack_id, message, artifact_ids, source, *rest = signal_args
+        meta = rest[0] if rest else None
+        return PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source, meta=meta)
+
     def _handle_shutdown_rejection(self, slot: PendingAckSlot) -> bool:
         """Re-queue rejected follow-up work. Returns True if anything was re-queued."""
         if slot.signal_name == SEND_FOLLOWUP_SIGNAL and slot.signal_args is not None:
-            # signal_args = [ack_id, message, artifact_ids, source, (meta?)] —
-            # meta is only present on tagged (CI) follow-ups.
-            _ack_id, message, artifact_ids, source, *rest = slot.signal_args
-            meta = rest[0] if rest else None
-            self._pending_external_followups.insert(
-                0,
-                PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source, meta=meta),
-            )
+            followup = self._followup_from_signal_args(slot.signal_args)
+            self._pending_external_followups.insert(0, followup)
             workflow.logger.warning(
                 "task_management_followup_requeued_after_shutdown",
                 run_id=self._run_id,
-                source=source,
+                source=followup.source,
             )
             return True
         workflow.logger.info(
@@ -632,12 +638,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
         requeued = 0
         for slot in list(self._pending_ack_slots.values()):
             if slot.signal_name == SEND_FOLLOWUP_SIGNAL and slot.signal_args is not None:
-                # signal_args = [ack_id, message, artifact_ids, source, (meta?)].
-                _ack_id, message, artifact_ids, source, *rest = slot.signal_args
-                meta = rest[0] if rest else None
-                self._pending_external_followups.append(
-                    PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source, meta=meta)
-                )
+                self._pending_external_followups.append(self._followup_from_signal_args(slot.signal_args))
                 requeued += 1
         if requeued:
             workflow.logger.warning(

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -15,6 +15,7 @@ from posthog.temporal.oauth import PosthogMcpScopes
 from products.tasks.backend.temporal.constants import (
     ACK_TIMEOUT,
     CI_FOLLOW_UP_DELAY,
+    CI_FOLLOWUP_META_KIND,
     DEFAULT_CI_MESSAGE,
     HEARTBEAT_DEBOUNCE,
     MAX_ACK_RETRIES,
@@ -87,6 +88,11 @@ class PendingExternalFollowup:
     message: str | None
     artifact_ids: list[str]
     source: str = FOLLOWUP_SOURCE_USER  # FOLLOWUP_SOURCE_USER | FOLLOWUP_SOURCE_CI
+    # Automated-turn metadata (e.g. `{"automatedCheck": {...}}`) forwarded to
+    # the sandbox's `user_message` under `_meta`. None for human follow-ups.
+    # Carried through re-queue and persistence so a re-dispatched CI follow-up
+    # keeps the iteration it was tagged with.
+    meta: Optional[dict[str, Any]] = None
 
 
 @dataclass
@@ -198,6 +204,10 @@ class TaskManagementWorkflow(PostHogWorkflow):
         self._last_active_time: Optional[datetime] = None
         self._ci_repetitions: int = 0
         self._pr_fingerprint: Optional[str] = None
+        # Last PR url seen for this sandbox session; fed into the CI follow-up's
+        # `_meta.automatedCheck.prUrl`. Set whenever `_should_run_ci_follow_up`
+        # finds a PR.
+        self._pr_url: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Input parsing
@@ -516,6 +526,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
                 message=followup.message,
                 artifact_ids=followup.artifact_ids,
                 source=followup.source,
+                meta=followup.meta,
             )
         # The persisted queue is the orchestrator's recovery buffer — keep
         # it in sync after every drain so a restart sees an accurate picture
@@ -569,11 +580,13 @@ class TaskManagementWorkflow(PostHogWorkflow):
     def _handle_shutdown_rejection(self, slot: PendingAckSlot) -> bool:
         """Re-queue rejected follow-up work. Returns True if anything was re-queued."""
         if slot.signal_name == SEND_FOLLOWUP_SIGNAL and slot.signal_args is not None:
-            # signal_args = [ack_id, message, artifact_ids, source]
-            _ack_id, message, artifact_ids, source = slot.signal_args
+            # signal_args = [ack_id, message, artifact_ids, source, (meta?)] —
+            # meta is only present on tagged (CI) follow-ups.
+            _ack_id, message, artifact_ids, source, *rest = slot.signal_args
+            meta = rest[0] if rest else None
             self._pending_external_followups.insert(
                 0,
-                PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source),
+                PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source, meta=meta),
             )
             workflow.logger.warning(
                 "task_management_followup_requeued_after_shutdown",
@@ -619,9 +632,11 @@ class TaskManagementWorkflow(PostHogWorkflow):
         requeued = 0
         for slot in list(self._pending_ack_slots.values()):
             if slot.signal_name == SEND_FOLLOWUP_SIGNAL and slot.signal_args is not None:
-                _ack_id, message, artifact_ids, source = slot.signal_args
+                # signal_args = [ack_id, message, artifact_ids, source, (meta?)].
+                _ack_id, message, artifact_ids, source, *rest = slot.signal_args
+                meta = rest[0] if rest else None
                 self._pending_external_followups.append(
-                    PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source)
+                    PendingExternalFollowup(message=message, artifact_ids=artifact_ids, source=source, meta=meta)
                 )
                 requeued += 1
         if requeued:
@@ -639,6 +654,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
         self._sandbox_alive = False
         self._ci_repetitions = 0
         self._pr_fingerprint = None
+        self._pr_url = None
         self._heartbeat_received = False
         self._last_active_time = None
 
@@ -670,6 +686,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
                     message=item.get("message"),
                     artifact_ids=list(item.get("artifact_ids") or []),
                     source=item.get("source", FOLLOWUP_SOURCE_USER),
+                    meta=item.get("meta"),
                 )
             )
         # Seed the persistence snapshot so the next `_persist_pending_followups`
@@ -760,6 +777,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
         message: str | None,
         artifact_ids: list[str],
         source: str = FOLLOWUP_SOURCE_USER,
+        meta: Optional[dict[str, Any]] = None,
     ) -> None:
         if self._sandbox_workflow_id is None:
             workflow.logger.warning(
@@ -770,6 +788,11 @@ class TaskManagementWorkflow(PostHogWorkflow):
             return
         ack_id = self._new_ack_id()
         signal_args: list[Any] = [ack_id, message, artifact_ids, source]
+        # Append meta only when present, so untagged (human) follow-ups keep the
+        # exact 4-arg wire shape they had before — byte-identical on the wire
+        # and across replay. The child's signal handler defaults meta to None.
+        if meta is not None:
+            signal_args.append(meta)
         # Register the slot *before* sending so an in-flight send-failure
         # leaves the slot intact for the retry loop to re-attempt. The child
         # dedupes by ack_id so re-sending is safe.
@@ -907,6 +930,9 @@ class TaskManagementWorkflow(PostHogWorkflow):
         )
         if not pr_context:
             return CIFollowUpDecision.NO_PR
+        # `get_pr_context` only returns a context when a PR url is present, so
+        # this is always the live PR — stash it for the CI follow-up's meta.
+        self._pr_url = pr_context.pr_url
         if pr_context.pr_state == "closed":
             workflow.logger.info(
                 "task_management_ci_skipped_pr_closed",
@@ -931,10 +957,29 @@ class TaskManagementWorkflow(PostHogWorkflow):
         return CIFollowUpDecision.SKIP
 
     async def _dispatch_ci_follow_up(self) -> None:
+        # Tag the turn *before* the increment: `_ci_repetitions` is the count
+        # already done, so the turn being dispatched is `+ 1` (1-based).
+        meta = self._build_ci_follow_up_meta(iteration=self._ci_repetitions + 1)
         self._ci_repetitions += 1
         ci_message = (self._context.ci_prompt if self._context else None) or DEFAULT_CI_MESSAGE
         self._last_active_time = workflow.now()
-        await self._signal_child_followup(message=ci_message, artifact_ids=[], source=FOLLOWUP_SOURCE_CI)
+        await self._signal_child_followup(message=ci_message, artifact_ids=[], source=FOLLOWUP_SOURCE_CI, meta=meta)
+
+    def _build_ci_follow_up_meta(self, *, iteration: int) -> dict[str, Any]:
+        """Build the `_meta` tagging an automated CI follow-up turn.
+
+        The desktop client reads `_meta.automatedCheck` to render these turns as
+        a compact, collapsed row instead of a wall of text in the user's voice.
+        `prUrl` is only included when a PR url is known.
+        """
+        automated_check: dict[str, Any] = {
+            "kind": CI_FOLLOWUP_META_KIND,
+            "iteration": iteration,
+            "maxIterations": MAX_CI_REPETITIONS,
+        }
+        if self._pr_url:
+            automated_check["prUrl"] = self._pr_url
+        return {"automatedCheck": automated_check}
 
     # ------------------------------------------------------------------
     # Activities used directly by the parent


### PR DESCRIPTION
## Problem

Cloud coding tasks with an open PR get automatically re-prompted on a timer to fix CI (we call it "babysitting"). Every 15 minutes, up to a fixed cap, the orchestrator injects a ~30-line CI prompt as a new follow-up turn.

In the desktop client (posthog/code) that turn arrives as an ordinary user message and renders as a wall of text in the user's own voice, cluttering the thread. We want the client to render these as a compact, collapsed "Automated CI check" row instead, but it can only do that if the message is tagged as automated.

The orchestrator already knows each follow-up's source (user vs CI), but the delivery path strips it. The message reaches the sandbox agent via `send_user_message` -> `send_agent_command`, whose JSON-RPC params carry only `content` and `artifacts`. So the ACP `session/prompt` request logged for the client has nothing marking it automated.

## Changes

Thread an optional `_meta` tag from the CI dispatch all the way down to the `user_message` JSON-RPC command. When (and only when) an automated CI follow-up is delivered, the command params carry:

```json
"_meta": {
  "automatedCheck": {
    "kind": "pr_ci_followup",
    "iteration": 2,
    "maxIterations": 3,
    "prUrl": "https://github.com/org/repo/pull/123"
  }
}
```

Human follow-ups and first messages stay untagged, so the client keeps rendering them as normal user turns.

The plumbing, by layer:

- **Transport** (`agent_command.py`): `send_agent_command` and `send_user_message` take an optional `meta`. `send_agent_command` sets `params["_meta"]` only when `meta` is provided, so absent-meta payloads stay byte-identical to today.
- **Live-signal path** (`task_management/workflow.py` -> `execute_sandbox/workflow.py` -> `send_followup_to_sandbox.py`): the CI dispatch builds the meta (`iteration` is 1-based, built before the repetition counter increments) and threads it through the child `send_followup_message` signal and the activity input, ending at `send_user_message(..., meta=...)`. It also rides through the re-queue and persistence paths so a re-dispatched turn keeps its original iteration.
- **State-forward path** (`process_task/utils.py`, `forward_pending_message.py`): a sibling `pending_user_message_meta` field on `RunState`, read and forwarded by `forward_pending_user_message`, then cleared alongside the existing pending keys.

`constants.py` holds the `pr_ci_followup` discriminator. It's CI-specific for now (one `kind`), but the `meta` plumbing is generic so other automated kinds can reuse it later.

On Temporal determinism: for the child signal, `meta` is appended as an extra arg only when present, so existing human-follow-up signals keep their exact wire shape and replay cleanly without a `workflow.patched` gate.

## How did you test this code?

I (Claude) added unit tests covering the seam and both delivery paths:

- `send_agent_command` writes `_meta` into the JSON-RPC params iff `meta` is provided; `send_user_message` forwards `meta` through.
- Dispatching a CI follow-up calls `send_user_message` (via the signal and activity input) with `meta={"automatedCheck": {"kind": "pr_ci_followup", "iteration": ..., "maxIterations": ..., "prUrl": ...}}`.
- A user follow-up (`FOLLOWUP_SOURCE_USER`) carries `meta=None`.
- Child-side ingest: the `send_followup_message` signal stores the meta and threads it into the activity input; the activity forwards `input.meta` to `send_user_message`.
- Re-queue preserves the tag across reschedule/restart.
- State-forward regression: `forward_pending_user_message` forwards the meta and still clears the pending keys after delivery.

I could not run pytest in this environment (no Python test deps provisioned), so my local verification is `python -m py_compile` on all 13 changed files (pass) plus `ruff check` and `ruff format --check` (pass). CI runs the actual suites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact. This is internal delivery plumbing between the orchestrator and the sandbox agent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8), directed by @adboio. Skill invoked: /writing-tests before adding or changing tests.

Key decisions:

- Append the signal `meta` arg only when present rather than always sending an extra arg, so human-follow-up signals keep an identical wire shape and replay without a `workflow.patched` gate.
- Kept a single `kind` (`pr_ci_followup`) but made the `meta` dict fully generic so future automated kinds reuse the same path.
- Left the legacy `process_task/workflow.py` untouched. It is not on the CI follow-up delivery path, so tagging it would be dead code.

Note: as above, I wasn't able to execute pytest in the sandbox, so the test verification is py_compile + ruff only; the suites run in CI.
