### PR TITLE
fix(logs): parse liveLogsCheckpoint before ClickHouse comparison

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -364,10 +364,16 @@ class LogsFilterBuilder:
             )
 
         if self.query.liveLogsCheckpoint:
+            try:
+                checkpoint = dt.datetime.fromisoformat(self.query.liveLogsCheckpoint)
+            except ValueError as e:
+                raise ValueError(f"Invalid liveLogsCheckpoint format: {e}")
+            if checkpoint.tzinfo is None:
+                checkpoint = checkpoint.replace(tzinfo=ZoneInfo("UTC"))
             exprs.append(
                 parse_expr(
                     "observed_timestamp >= {liveLogsCheckpoint}",
-                    placeholders={"liveLogsCheckpoint": ast.Constant(value=self.query.liveLogsCheckpoint)},
+                    placeholders={"liveLogsCheckpoint": ast.Constant(value=checkpoint)},
                 )
             )
 

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -473,6 +473,25 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(response["results"]), 101)
         self.assertEqual(len(queries), 2)
 
+    @parameterized.expand(
+        [
+            ("utc_aware", "2025-12-16T00:00:00+00:00"),
+            ("naive", "2025-12-16T00:00:00"),
+        ]
+    )
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_live_tail_checkpoint_iso_string(self, _name, checkpoint):
+        query_params = {
+            "dateRange": {"date_from": "2025-12-16 09:32:36.178572Z", "date_to": None},
+            "limit": 50,
+            "orderBy": "latest",
+            "liveLogsCheckpoint": checkpoint,
+            "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+        }
+
+        response = self._make_logs_api_request(query_params)
+        self.assertGreater(len(response["results"]), 0)
+
     @freeze_time("2025-12-16T10:33:00Z")
     def test_resource_filters(self):
         query_params = {


### PR DESCRIPTION
## Problem

Live tail in the logs viewer 500s on every poll. The frontend surfaces it as a repeating `Live tail polling error: $t: A server error occurred.` from `pollForNewLogs`, and the underlying `/logs/query` request returns 500.

The regression came from #67074, which changed the ingestion checkpoint from a naive datetime to a UTC-aware one:

```python
"live_logs_checkpoint": result[14].replace(tzinfo=ZoneInfo("UTC")) if result[14] else None
```

An aware datetime serializes to JSON with a `+00:00` offset (`"2026-07-01T15:30:00+00:00"`). The frontend stores that string and sends it straight back as `liveLogsCheckpoint`, and the backend fed it raw into the checkpoint filter as a string constant. HogQL prints a string constant as a literal, so the generated SQL became `observed_timestamp >= '2026-07-01T15:30:00+00:00'`. ClickHouse's string to `DateTime64` cast rejects the trailing offset, which 500s the query. Live tail is the only path that auto-retries, so it's where it shows up loudest.

## Changes

In `LogsFilterBuilder`, parse `liveLogsCheckpoint` into a `datetime` before building the AST constant. HogQL then emits a proper `toDateTime64(...)` instead of a raw string, so the comparison is unambiguous. This mirrors the existing `after`-cursor path, which already parses ISO strings with `fromisoformat`.

Naive checkpoints (from a client cached before this fix) are normalized to UTC so `visit_datetime`'s `astimezone` doesn't mis-shift them using the server's local zone. The checkpoint is always UTC semantically, since `observed_timestamp` is stored in UTC.

## How did you test this code?

Added a parameterized integration test in `test_logs_query_runner.py` that posts a live-tail query (`liveLogsCheckpoint` set) through the real endpoint against ClickHouse. The `utc_aware` case is the actual regression guard: it reproduces the `+00:00` string that broke the cast, and would 500 without this fix. The `naive` case pins the timezone-normalization branch.

I (Claude) ran both cases locally against real ClickHouse: `2 passed in 386s`. `ruff check`, `ruff format`, and `ty check` are clean. I did not manually drive the browser live-tail UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank directed this; I (Claude, via PostHog Code) diagnosed and implemented it. Starting from the frontend `pollForNewLogs` error, I traced the live-tail query path to `LogsQueryRunner`/`LogsFilterBuilder`, then bisected recent logs commits to #67074, which flipped the checkpoint to a UTC-aware datetime. Confirmed the mechanism against `escape_sql.py`'s `visit_datetime` (datetime constants print as `toDateTime64(...)`, strings print as raw literals).

I chose to fix at the backend query builder rather than the frontend, since the backend should accept any valid ISO timestamp and not depend on the client's exact string format. Invoked the `/writing-tests` skill before adding the test and kept it to one parameterized integration test at the ClickHouse layer, since that's where the cast actually fails.

Separately, exploration surfaced a second known failure mode for this same query (`Unknown table expression identifier 'logs_kafka_metrics'` when the distributed-table migration hasn't reached every ClickHouse node). That's an infra concern, not touched here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
