### PR TITLE
chore: allow opening PRs without human instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,6 @@ NEVER share sensitive information in a PR description. Users may share sensitive
 
 ### Pushing to remote
 
-Don't open GitHub issues or pull requests without human instruction.
 Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
 Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 


### PR DESCRIPTION
## Problem

The agent instructions in `AGENTS.md` told agents not to open GitHub issues or pull requests without human instruction. That blanket restriction gets in the way now that we want agents to be able to open PRs as part of their normal flow.

## Changes

Removed the line `Don't open GitHub issues or pull requests without human instruction.` from the "Pushing to remote" section of `AGENTS.md` (`CLAUDE.md` is a symlink to it). The surrounding guidance about keeping open PRs current and batching pushes to save CI credits stays in place.

## How did you test this code?

Docs-only change to agent instructions. No automated tests apply and none were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (Claude) to remove the line and open a PR. Single-line deletion in `AGENTS.md`; no skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
