### PR TITLE
fix(postgres): treat missing FDW user mapping as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -532,6 +532,19 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # against the source data, so retrying re-evaluates the same view and hits the same row.
             "cannot call jsonb_each on a non-object": "A view you're syncing calls jsonb_each() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
             "cannot call jsonb_each_text on a non-object": "A view you're syncing calls jsonb_each_text() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each_text() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
+            # A selected relation is a postgres_fdw foreign table and the connecting role has no user
+            # mapping for the foreign server it points at, so every SELECT fails with
+            # "UndefinedObject: user mapping not found for user <user>, server <server>" (SQLSTATE
+            # 42704). The mapping is fixed server-side config only the customer can create, so
+            # retrying re-reads into the same wall. Match the stable fragment and exclude the volatile
+            # user/server names.
+            "user mapping not found for": (
+                "One of the tables you selected to sync is a foreign table (postgres_fdw), and "
+                "PostHog's database role has no user mapping for the foreign server it points at "
+                '(PostgreSQL reported "user mapping not found"). Create a user mapping for the '
+                "connecting role on that foreign server (CREATE USER MAPPING ...), or remove the "
+                "foreign table from the sync, then re-enable the sync."
+            ),
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -754,6 +754,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
+            'user mapping not found for user "svc_role", server "remote_server"',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'UndefinedObject: user mapping not found for user "svc_role", server "remote_server"',
+        ],
+    )
+    def test_missing_fdw_user_mapping_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Missing FDW user mapping error should be non-retryable: {error_msg}"
+
+    def test_missing_fdw_user_mapping_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'user mapping not found for user "svc_role", server "remote_server"'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Missing FDW user mapping error should surface an actionable message"
+        assert "CREATE USER MAPPING" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

Postgres warehouse imports were surfacing a repeated failure in error tracking: `UndefinedObject: user mapping not found for user "...", server "..."`. This is a `postgres_fdw` error (SQLSTATE 42704). When a table selected for sync is a foreign table, PostgreSQL needs a user mapping for the connecting role on the underlying foreign server. If that mapping does not exist, every `SELECT` against the foreign table fails at `cursor.execute` in `get_rows`.

The mapping is fixed server-side config only the customer can create (`CREATE USER MAPPING ...`), so retrying just re-reads into the same wall. Before this change the error was unrecognised and Temporal burned its full retry budget on a deterministic, customer-fixable condition, adding noise to error tracking on every attempt.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1efc-0ae6-75d3-86e4-2212bc9c711e

## Changes

Add the stable fragment `"user mapping not found for"` to `PostgresSource.get_non_retryable_errors` with an actionable message telling the user to create a user mapping for the connecting role on the foreign server, or remove the foreign table from the sync.

This mirrors the existing per-relation config errors in the same dict (permission denied, unpopulated materialized view, `jsonb_each` on a non-object) which are all deterministic and outside our control. The match fragment deliberately excludes the volatile user and server names so it cannot key off customer values, and it matches both the raw activity-level `str(e)` and the Temporal-wrapped `UndefinedObject: ...` form.

## How did you test this code?

Added two tests to `TestPostgresSourceNonRetryableErrors`:

- `test_missing_fdw_user_mapping_is_non_retryable` — parameterized over the raw psycopg message and the Temporal-wrapped form, asserts both are classified non-retryable. Guards against the fragment being dropped or narrowed so the error silently reverts to retryable.
- `test_missing_fdw_user_mapping_returns_friendly_message` — asserts the surfaced message is actionable (mentions `CREATE USER MAPPING`).

No existing test covered this string. I (Claude) ran the two new tests plus the sibling transient-retryable cases locally with `uv run python -m pytest` (11 passed), and ran `ruff check` / `ruff format --check` on both files. I did not run the full suite or do manual end-to-end testing against a live foreign-table source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres data-warehouse import source. I (Claude) confirmed the issue in error tracking (exception type `UndefinedObject`, top in-app frame `get_rows` at `postgres.py:3352`, the `cursor.execute` that runs the read query), traced the call path, and read the source's `get_non_retryable_errors` implementation.

Decision: user/upstream config error, not a fixable bug. A foreign-table user mapping is static Postgres config; PostHog cannot create it and retrying is futile, so this belongs in `NonRetryableErrors` alongside the other per-relation config errors rather than being handled in code. Invoked the `/writing-tests` skill before adding tests. Checked open PRs (including the source maintainer's) for a duplicate first — none addressed this error.
