### PR TITLE
fix(insights): resolve warehouse access control in system queries

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -64,7 +64,13 @@ PRINTER_CLASSES: dict[HogQLDialect, type[BasePrinter]] = {
 }
 
 
-def to_printed_hogql(query: ast.Expr, team: Team, modifiers: "HogQLQueryModifiers | None" = None) -> str:
+def to_printed_hogql(
+    query: ast.Expr,
+    team: Team,
+    modifiers: "HogQLQueryModifiers | None" = None,
+    *,
+    bypass_warehouse_access_control: bool = False,
+) -> str:
     """Prints the HogQL query without mutating the node"""
     return prepare_and_print_ast(
         clone_expr(query),
@@ -73,6 +79,7 @@ def to_printed_hogql(query: ast.Expr, team: Team, modifiers: "HogQLQueryModifier
             team_id=team.pk,
             enable_select_queries=True,
             modifiers=create_default_modifiers_for_team(team, modifiers),
+            bypass_warehouse_access_control=bypass_warehouse_access_control,
         ),
         pretty=True,
     )[0]

--- a/posthog/hogql_queries/insights/utils/utils.py
+++ b/posthog/hogql_queries/insights/utils/utils.py
@@ -81,5 +81,8 @@ def get_response_hogql(
 
     response_hogql_query = ast.SelectSetQuery.create_from_queries(queries, "UNION ALL")
 
+    # This only prints the query for the response payload — it doesn't execute — and access to the
+    # underlying warehouse tables is already enforced on the executed query. Bypass warehouse access
+    # control so building the printer's database doesn't fail closed in userless contexts.
     with timings.measure("printing_hogql_for_response"):
-        return to_printed_hogql(response_hogql_query, team, modifiers)
+        return to_printed_hogql(response_hogql_query, team, modifiers, bypass_warehouse_access_control=True)

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -198,18 +198,22 @@ def _get_earliest_timestamp_from_node(
         # datetime values written after the fix and repairs the stale ones.
         return _coerce_to_datetime(cached_result, team.timezone_info)
 
-    if (
+    is_warehouse_node = (
         isinstance(node, DataWarehouseNode)
         or isinstance(node, FunnelsDataWarehouseNode)
         or isinstance(node, LifecycleDataWarehouseNode)
-    ):
+    )
+    if is_warehouse_node:
         query = _get_data_warehouse_earliest_timestamp_query(node)
     else:
         query = _get_event_earliest_timestamp_query(team, node)
 
     earliest_timestamp = EARLIEST_EVENT_TIMESTAMP
+    # This is team-scoped date-range metadata (cached per team+node, not per user) that runs without a
+    # request user. Access to the warehouse table is enforced on the insight's executed query; bypass
+    # warehouse access control here so building the database doesn't fail closed in this userless context.
     with _earliest_timestamp_query_tags():
-        result = execute_hogql_query(query=query, team=team)
+        result = execute_hogql_query(query=query, team=team, bypass_warehouse_access_control=is_warehouse_node)
     if result and len(result.results) > 0 and len(result.results[0]) > 0 and result.results[0][0] is not None:
         earliest_timestamp = _coerce_to_datetime(result.results[0][0], team.timezone_info)
 

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -1276,13 +1276,16 @@ def _build_manual_insert_sql(
     expires_at_expr = ast.Alias(alias="expires_at", expr=ast.Constant(value=ch_expires_at))
     query.select.append(expires_at_expr)
 
-    # Print to SQL
+    # Print to SQL. Materialization is a system, team-scoped process with no request user — access to
+    # the source warehouse tables is enforced when the user reads the dashboard. Bypass warehouse access
+    # control so building the printer's database doesn't fail closed in this userless context.
     context = HogQLContext(
         team_id=team.id,
         team=team,
         enable_select_queries=True,
         limit_top_select=False,
         modifiers=create_default_modifiers_for_team(team),
+        bypass_warehouse_access_control=True,
     )
     select_sql, _ = prepare_and_print_ast(
         query,


### PR DESCRIPTION
## Problem

#61686 added HogQL access control for warehouse tables (gated by the `hogql-warehouse-access-control` flag), which **fails closed** when a database is built without a request user. It covered the interactive query paths, but not the **system / auxiliary queries** that run userless while serving an insight over a data warehouse table. When the flag is on, these fail closed even though the user has access, breaking the whole insight on a secondary path.

Three such paths were affected:

1. **Response HogQL printer** (`to_printed_hogql` / `get_response_hogql`) — trends/boxplot/stickiness print the response HogQL after executing, building a second database without a user → the insight 500s with `You don't have access to table ...`.
2. **Earliest-timestamp date-range helper** (`_get_earliest_timestamp_from_node`) — team-scoped metadata (cached per `team+node`, not per user) that runs userless → same failure.
3. **Cost-precompute materialization** (`_build_manual_insert_sql`) — the INSERT that materializes `marketing_costs_preaggregated` runs userless. Once the flag rolled out it started failing to resolve the source warehouse tables, so the precompute **stopped materializing** (froze), and dashboards reading the native table went stale/empty.

## Changes

Bypass warehouse access control on these system paths (`bypass_warehouse_access_control=True`). None of them are user data reads:

- the printer only formats text, it doesn't execute;
- the earliest-timestamp query is team-scoped metadata cached per `(team, node)`, so it can't carry a per-user principal;
- materialization is a system, team-scoped process with no request user.

Access to the underlying warehouse tables stays enforced on the insight's **executed** query with the real user — this only stops the userless *system* queries from failing closed.

## How did you test this code?

I'm an agent (Claude Code). Root-caused and verified locally by forcing the `hogql-warehouse-access-control` flag on:

- Reproduced each failure (userless build → `QueryError: don't have access`) and confirmed the fix flips it to success (printer/materialization: `bypass=False` denies, `bypass=True` resolves).
- Verified end-to-end in the local app: warehouse-backed trend charts render again, and the cost-precompute table re-materializes (chart fills in).
- Confirmed the production symptom via ClickHouse telemetry: materialization had frozen (last `computed_at` matched the flag rollout, 0 INSERTs since), which this fix addresses.

No automated tests added yet — a regression test that builds a warehouse-backed insight with the flag on (asserting no fail-closed) is worth adding; happy to include it here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused with Claude Code, driven by @jabahamondes. The bug surfaced as marketing-analytics charts erroring and the cost precompute freezing; traced both to the same root — #61686's warehouse RBAC failing closed in userless system queries it didn't cover. Chose `bypass` (not user-propagation) because these are system/metadata queries: the earliest-timestamp cache is keyed per team (a user principal would be wrong), and the printer/materialization don't read user data. Suggested reviewer: the #61686 author (Alex Lider). Supersedes an earlier misdiagnosis (cache-warming, PR #66549) which will be closed.
