### PR TITLE
fix(warehouse): only fail-closed-deny warehouse tables that are actually restricted

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -152,6 +152,7 @@ from posthog.models.team.team import Team, WeekStartDay
 from posthog.ph_client import feature_enabled_or_false
 from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl
 from posthog.schema_enums import DatabaseSerializedFieldType, PersonsOnEventsMode, SessionTableVersion
+from posthog.settings import EE_AVAILABLE
 from posthog.synthetic_user import SyntheticUser
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
@@ -216,6 +217,9 @@ class HogQLDatabaseSources:
     # Access-control decision, computed from a warmed UserAccessControl so build does no AC queries.
     user_access_control: Optional["UserAccessControl"]
     denied_system_table_names: set[str]  # node names under the "system" node to remove during build
+    # Warehouse resources/objects with an access-control rule; ungoverned objects are never denied.
+    governed_warehouse_resources: set[str]
+    governed_warehouse_object_ids: set[str]
     group_types: list[dict[str, Any]]
     saved_queries: list["DataWarehouseSavedQuery"]
     endpoint_saved_queries: list["DataWarehouseSavedQuery"]
@@ -478,6 +482,36 @@ def _compute_system_table_access_decision(
     return user_access_control, denied
 
 
+def _compute_governed_warehouse_objects(team: "Team") -> tuple[set[str], set[str]]:
+    """Warehouse resources/objects that carry an explicit access-control rule.
+
+    A warehouse table/view with no access-control rule resolves to the permissive default level
+    (`editor`), so it is accessible to everyone and must never be denied - not even in a userless /
+    fail-closed context (shared insights, cache warming, exports). Only objects that are actually
+    governed by a rule go through the per-principal access check.
+
+    Returns (resources_with_a_resource_wide_rule, governed_object_ids). A resource-wide rule
+    (resource_id IS NULL) governs every object of that resource.
+    """
+    if not EE_AVAILABLE:
+        return set(), set()
+
+    from ee.models.rbac.access_control import AccessControl  # noqa: PLC0415 — EE-only model, keep off import path
+
+    # "warehouse_objects" is the inheritance parent of both warehouse_table and warehouse_view, so a rule
+    # on it governs every warehouse object (see RESOURCE_INHERITANCE in user_access_control).
+    resources_with_rule: set[str] = set()
+    governed_object_ids: set[str] = set()
+    for resource, resource_id in AccessControl.objects.filter(
+        team_id=team.pk, resource__in=["warehouse_table", "warehouse_view", "warehouse_objects"]
+    ).values_list("resource", "resource_id"):
+        if resource_id is None:
+            resources_with_rule.add(resource)
+        else:
+            governed_object_ids.add(resource_id)
+    return resources_with_rule, governed_object_ids
+
+
 class Database(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -488,6 +522,10 @@ class Database(BaseModel):
     _warehouse_self_managed_table_names: list[str] = []
     _view_table_names: list[str] = []
     _denied_tables: set[str] = set()  # Tables user doesn't have permission to access
+    # Warehouse resources/objects that carry an access-control rule. Objects absent from both use the
+    # permissive default level and are never denied (see _compute_governed_warehouse_objects).
+    _governed_warehouse_resources: set[str] = set()
+    _governed_warehouse_object_ids: set[str] = set()
     _connection_id: str | None = None
     _direct_connection_metadata: dict[str, Any] | None = None
     _direct_access_warehouse_table_names: set[str] = set()
@@ -515,6 +553,8 @@ class Database(BaseModel):
         self._warehouse_self_managed_table_names = []
         self._view_table_names = []
         self._denied_tables = set()
+        self._governed_warehouse_resources = set()
+        self._governed_warehouse_object_ids = set()
         self._connection_id = None
         self._direct_connection_metadata = None
         self._direct_access_warehouse_table_names = set()
@@ -761,11 +801,28 @@ class Database(BaseModel):
 
         self._denied_tables = {f"system.{name}" for name in removed}
 
+    def _is_warehouse_object_governed(self, resource: str, object_id: Any) -> bool:
+        """True if this warehouse table/view is subject to any access-control rule.
+
+        Objects with no rule resolve to the permissive default level and are accessible to everyone,
+        so they are never denied - not even userless. Only governed objects hit the access check.
+        A rule on the "warehouse_objects" inheritance parent governs every warehouse object.
+        """
+        return (
+            resource in self._governed_warehouse_resources
+            or "warehouse_objects" in self._governed_warehouse_resources
+            or str(object_id) in self._governed_warehouse_object_ids
+        )
+
     def _is_warehouse_table_denied(self, table: "DataWarehouseTable") -> bool:
         """
         Returns True if the user can't query this warehouse table.
-        Userless context (no UserAccessControl) fails closed - every table is denied.
+        An ungoverned table (no access-control rule) uses the permissive default and is always allowed.
+        For a governed table a userless context (no UserAccessControl) fails closed.
         """
+        if not self._is_warehouse_object_governed("warehouse_table", table.id):
+            return False
+
         uac = self.user_access_control
         if uac is not None and (
             uac.is_organization_admin or uac.check_access_level_for_object(table, required_level="viewer")
@@ -784,8 +841,12 @@ class Database(BaseModel):
         View counterpart of `_is_warehouse_table_denied`.
         Closes the gap where a user denied access to a warehouse table could otherwise SELECT
         through a non-materialized view that references it.
-        Userless context (no UserAccessControl) fails closed - every view is denied.
+        An ungoverned view (no access-control rule) uses the permissive default and is always allowed.
+        For a governed view a userless context (no UserAccessControl) fails closed.
         """
+        if not self._is_warehouse_object_governed("warehouse_view", saved_query.id):
+            return False
+
         uac = self.user_access_control
         if uac is not None and (
             uac.is_organization_admin or uac.check_access_level_for_object(saved_query, required_level="viewer")
@@ -1164,6 +1225,14 @@ class Database(BaseModel):
             send_feature_flag_events=False,
         )
 
+        # Only objects with an explicit access-control rule are subject to denial; everything else uses
+        # the permissive default. Fetched here (behind the flag) so the build phase stays query-free.
+        governed_warehouse_resources: set[str] = set()
+        governed_warehouse_object_ids: set[str] = set()
+        if is_hogql_warehouse_access_control_enabled and not bypass_warehouse_access_control:
+            with timings.measure("warehouse_access_governance", emit_span=True):
+                governed_warehouse_resources, governed_warehouse_object_ids = _compute_governed_warehouse_objects(team)
+
         with timings.measure("modifiers", emit_span=True):
             modifiers = create_default_modifiers_for_team(team, modifiers)
 
@@ -1311,6 +1380,8 @@ class Database(BaseModel):
             direct_connection_metadata=direct_connection_metadata,
             user_access_control=user_access_control,
             denied_system_table_names=denied_system_table_names,
+            governed_warehouse_resources=governed_warehouse_resources,
+            governed_warehouse_object_ids=governed_warehouse_object_ids,
             group_types=group_types,
             saved_queries=saved_queries,
             endpoint_saved_queries=endpoint_saved_queries,
@@ -1348,6 +1419,8 @@ class Database(BaseModel):
 
         with timings.measure("filter_system_tables_for_user", emit_span=True):
             database._apply_system_table_access(sources.user_access_control, sources.denied_system_table_names)
+            database._governed_warehouse_resources = sources.governed_warehouse_resources
+            database._governed_warehouse_object_ids = sources.governed_warehouse_object_ids
 
         with timings.measure("modifiers", emit_span=True):
             if not database._is_direct_query():

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -472,11 +472,15 @@ class TestWarehouseTableAccessControl(BaseTest):
         assert "denied_table" not in database._denied_tables
         assert "allowed_table" not in database._denied_tables
 
-    def test_no_user_fails_closed_for_warehouse_tables(self):
+    def test_no_user_denies_only_governed_warehouse_tables(self):
+        # Userless/fail-closed applies only to a table governed by a rule. A table with no rule uses the
+        # permissive default, so principal-less paths (shared insights, cache warming, exports) resolve it.
+        self._create_ac(resource="warehouse_table", resource_id=str(self.denied_table.id), access_level="none")
+
         database = Database.create_for(team=self.team, user=None)
 
         assert "denied_table" in database._denied_tables
-        assert "allowed_table" in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
 
     def test_bypass_warehouse_access_control_skips_warehouse_acl(self):
         self._create_ac(
@@ -732,11 +736,15 @@ class TestWarehouseViewAccessControl(BaseTest):
         assert "denied_view" in database._denied_tables
         assert "allowed_view" in database._denied_tables
 
-    def test_no_user_fails_closed_for_warehouse_views(self):
+    def test_no_user_denies_only_governed_warehouse_views(self):
+        # Userless/fail-closed applies only to a view governed by a rule. A view with no rule uses the
+        # permissive default, so principal-less paths (shared insights, cache warming, exports) resolve it.
+        self._create_ac(resource="warehouse_view", resource_id=str(self.denied_view.id), access_level="none")
+
         database = Database.create_for(team=self.team, user=None)
 
         assert "denied_view" in database._denied_tables
-        assert "allowed_view" in database._denied_tables
+        assert "allowed_view" not in database._denied_tables
 
     def test_bypass_warehouse_access_control_skips_warehouse_view_acl(self):
         self._create_ac(


### PR DESCRIPTION
## Problem

Rolling out `hogql-warehouse-access-control` produced a wave of `You don't have access to table X` denials across many orgs — `stripe_invoice`, `nextdot_events`, `marketingwebnotion_pages`, `v_feature_usage`, `postgres.users`, and more — surfacing from shared dashboards, cache warming, exports, and experiment recalc.

These looked like "correct" denials, but they are **over-denials**. Root cause, confirmed against production data:

- The default access level for a warehouse object with **no** access-control rule is `editor` (permissive) — so an object nobody restricted is accessible to everyone.
- But `_is_warehouse_table_denied` / `_is_warehouse_view_denied` **denied every warehouse object whenever `UserAccessControl` was `None`** (any userless / principal-less query: shared insights, cache warming, exports, experiment SQL generation). The blanket fail-closed ignored that the object's default is permissive.
- A production audit of `ee_accesscontrol` showed **zero `none` rules and zero `warehouse_table` rules in the entire fleet** — the sum total is a handful of `warehouse_view` *grants* on one team. So essentially every warehouse denial in error tracking was the fail-closed path blocking access that was never restricted.

Verification queries used (prod, read-only): aggregate of all warehouse `ee_accesscontrol` rows (→ no `none` rules exist), and a per-object check confirming the denied tables have zero access-control rows.

## Changes

Deny a warehouse table/view **only when it is actually governed by an access-control rule**.

- Up front (behind the flag, so the build phase stays query-free), fetch the set of warehouse resources/objects that carry a rule — including the `warehouse_objects` inheritance parent, which governs every warehouse object.
- An object absent from that set uses the permissive default and is **never** denied — including in userless / fail-closed contexts. This restores pre-access-control behaviour for shared dashboards and background jobs.
- A **governed** object still goes through the existing per-principal check and still **fails closed when userless**, so orgs that do restrict warehouse objects keep full enforcement. `bypass_warehouse_access_control` and org-admin/creator shortcuts are unchanged.

This is the general fix for the whole class — it covers every principal-less path at the source (`_is_warehouse_*_denied`), rather than patching callers one at a time (experiment recalc, cache warming, exports, …).

## How did you test this code?

Rewrote the two tests that encoded the old blanket behaviour (`test_no_user_fails_closed_for_warehouse_{tables,views}`) into `test_no_user_denies_only_governed_warehouse_{tables,views}`: a userless build now denies a table/view that has a `none` rule but **not** an unrestricted one. This pins both directions — reverting the guard re-introduces the over-denial; dropping fail-closed entirely would leak a genuinely-restricted object userless. Full `test_hogql_access_control.py` passes (30 tests), including the governed-path cases (object-level deny, `warehouse_objects` parent lockdown, admin bypass, bypass flag). I (Claude) ran these locally; I did not exercise the live shared-dashboard/export paths end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Alex was monitoring the rollout and pushed back on my earlier (wrong) claim that the denials were "largely correct." We verified against prod: I gave Alex two SQL queries; the first showed the fleet has no `none` warehouse rules at all, which proved the denials had to be coming from the userless fail-closed branch, not real restrictions. I (Claude Code) then traced `_is_warehouse_table_denied`/`_is_warehouse_view_denied` and implemented the governed-object guard.

Design note: considered a per-caller fix (thread a principal into cache warming / exports / etc., as #67384 did for experiments) and a team-level "does this team use warehouse AC at all" skip. Chose the per-object governance guard because it fixes the whole class at the decision point, is correct for the `warehouse_objects` inheritance-parent lockdown, and keeps userless fail-closed for objects that are genuinely restricted. Invoked the `/writing-tests` skill before changing tests. Related in-flight PRs from this rollout: #67384 (experiment path, merged), #67430 (cache-warming denial-noise, draft) — this PR supersedes the *need* for those as denial-suppression, though #67430's typed-exception is still a reasonable cleanup.
