### PR TITLE
fix(apollo): honor Retry-After on rate-limited imports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/apollo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/apollo.py
@@ -1,11 +1,12 @@
 import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 
 import requests
 from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.apollo.settings import APOLLO_ENDPOINTS
@@ -19,10 +20,16 @@ MAX_PAGES = 500
 REQUEST_TIMEOUT_SECONDS = 60
 # Rate limits are plan-dependent fixed windows; back off on 429.
 MAX_RETRY_ATTEMPTS = 5
+# Cap how long a single in-function retry waits so a long fixed-window (hourly/daily)
+# Retry-After doesn't pin a worker thread; if the window is longer, the attempts
+# exhaust and Temporal retries the whole activity later from saved page state.
+MAX_RETRY_AFTER_SECONDS = 120
 
 
 class ApolloRetryableError(Exception):
-    pass
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 @dataclasses.dataclass
@@ -47,6 +54,36 @@ def _parse_timestamp(value: Any) -> Optional[datetime]:
         except ValueError:
             return None
     return None
+
+
+def _parse_retry_after(value: str | None) -> Optional[float]:
+    # Retry-After is either delta-seconds or an HTTP-date (RFC 7231).
+    if not value:
+        return None
+    value = value.strip()
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    return max(0.0, (retry_at - datetime.now(UTC)).total_seconds())
+
+
+_backoff = wait_exponential_jitter(initial=5, max=120)
+
+
+def _wait_apollo(retry_state: RetryCallState) -> float:
+    # Prefer the server's own backoff instruction on rate limits; fall back to
+    # exponential jitter when the header is absent (429 without one, or a 5xx).
+    exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
+    if isinstance(exc, ApolloRetryableError) and exc.retry_after is not None:
+        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
+    return _backoff(retry_state)
 
 
 def validate_credentials(api_key: str) -> bool:
@@ -83,7 +120,7 @@ def get_rows(
     @retry(
         retry=retry_if_exception_type((ApolloRetryableError, requests.ReadTimeout, requests.ConnectionError)),
         stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=5, max=120),
+        wait=_wait_apollo,
         reraise=True,
     )
     def fetch_page(page_number: int) -> dict[str, Any]:
@@ -96,7 +133,13 @@ def get_rows(
         response = session.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
 
         if response.status_code == 429 or response.status_code >= 500:
-            raise ApolloRetryableError(f"Apollo API error (retryable): status={response.status_code}, url={url}")
+            retry_after = (
+                _parse_retry_after(response.headers.get("Retry-After")) if response.status_code == 429 else None
+            )
+            raise ApolloRetryableError(
+                f"Apollo API error (retryable): status={response.status_code}, url={url}",
+                retry_after=retry_after,
+            )
 
         if not response.ok:
             logger.error(f"Apollo API error: status={response.status_code}, body={response.text}, url={url}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/tests/test_apollo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/tests/test_apollo.py
@@ -1,9 +1,10 @@
 from datetime import UTC, datetime
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from unittest import mock
+
+from tenacity import Future, RetryCallState
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.apollo.apollo import (
     MAX_PAGES,
@@ -260,8 +261,10 @@ class TestRetryAfter:
     def test_parse_retry_after(self, value, expected):
         assert _parse_retry_after(value) == expected
 
-    def _state(self, exc: Exception) -> SimpleNamespace:
-        return SimpleNamespace(outcome=SimpleNamespace(exception=lambda: exc))
+    def _state(self, exc: Exception) -> RetryCallState:
+        state = RetryCallState(retry_object=mock.MagicMock(), fn=None, args=(), kwargs={})
+        state.outcome = Future.construct(1, exc, has_exception=True)
+        return state
 
     def test_wait_honors_retry_after_below_cap(self):
         assert _wait_apollo(self._state(ApolloRetryableError("rate limited", retry_after=45.0))) == 45.0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/tests/test_apollo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apollo/tests/test_apollo.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -6,9 +7,13 @@ from unittest import mock
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.apollo.apollo import (
     MAX_PAGES,
+    MAX_RETRY_AFTER_SECONDS,
     PAGE_SIZE,
     ApolloResumeConfig,
+    ApolloRetryableError,
+    _parse_retry_after,
     _parse_timestamp,
+    _wait_apollo,
     apollo_source,
     get_rows,
     validate_credentials,
@@ -33,6 +38,14 @@ def _response(data_key: str, items: list[dict[str, Any]], total_pages: int = 1) 
     }
     resp.status_code = 200
     resp.ok = True
+    return resp
+
+
+def _rate_limited(retry_after: str | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.status_code = 429
+    resp.ok = False
+    resp.headers = {"Retry-After": retry_after} if retry_after is not None else {}
     return resp
 
 
@@ -228,3 +241,48 @@ class TestApolloSourceResponse:
     def test_partition_keys_are_stable_creation_fields(self, config):
         if config.partition_key:
             assert config.partition_key == "created_at"
+
+
+class TestRetryAfter:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("30", 30.0),
+            (" 30 ", 30.0),
+            ("0", 0.0),
+            (None, None),
+            ("", None),
+            ("soon", None),
+            # An HTTP-date already in the past clamps to no wait.
+            ("Wed, 21 Oct 2015 07:28:00 GMT", 0.0),
+        ],
+    )
+    def test_parse_retry_after(self, value, expected):
+        assert _parse_retry_after(value) == expected
+
+    def _state(self, exc: Exception) -> SimpleNamespace:
+        return SimpleNamespace(outcome=SimpleNamespace(exception=lambda: exc))
+
+    def test_wait_honors_retry_after_below_cap(self):
+        assert _wait_apollo(self._state(ApolloRetryableError("rate limited", retry_after=45.0))) == 45.0
+
+    def test_wait_caps_long_retry_after(self):
+        # An hourly/daily window can dwarf the cap; a single retry must stay bounded.
+        assert (
+            _wait_apollo(self._state(ApolloRetryableError("rate limited", retry_after=99999.0)))
+            == MAX_RETRY_AFTER_SECONDS
+        )
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_429_is_retried_and_recovers(self, mock_session):
+        # Retry-After "0" keeps the retry instant while still proving the header is
+        # read and honored end-to-end from the raise site through get_rows.
+        mock_session.return_value.post.side_effect = [
+            _rate_limited(retry_after="0"),
+            _response("contacts", [{"id": "c1", "updated_at": "2024-01-01T00:00:00Z"}]),
+        ]
+
+        batches = list(get_rows("key", "contacts", mock.MagicMock(), _make_manager()))
+
+        assert [item["id"] for batch in batches for item in batch] == ["c1"]
+        assert mock_session.return_value.post.call_count == 2


### PR DESCRIPTION
## Problem

Apollo enforces plan-dependent, per-token fixed-window rate limits (per minute, hour, and day) and returns HTTP 429 once a window is exhausted.
Error tracking surfaced `ApolloRetryableError: Apollo API error (retryable): status=429` from the Apollo import source ([issue](https://us.posthog.com/project/2/error_tracking/019f1f06-359f-7d23-8d3a-2b20437ac026)), raised in `apollo.py` `fetch_page`.

A 429 is transient (the window resets), so it is correct to keep retrying it. The bug is in how we retry: `fetch_page` backed off with a fixed exponential jitter and ignored Apollo's `Retry-After` header entirely. That means retries can fire before the window resets, burning all attempts inside the same window, and we never wait as long as Apollo tells us to.

## Changes

- Read the `Retry-After` header on 429 responses and wait exactly that long, bounded by a cap, before retrying.
- Fall back to the existing exponential jitter backoff when the header is absent (a 429 without one, or a 5xx).
- Parse both forms of `Retry-After` (delta-seconds and HTTP-date).

The cap keeps a long hourly or daily window from pinning a worker thread on a single wait. If Apollo asks for longer than the cap, the in-function attempts exhaust and Temporal retries the whole activity later from the saved page state, so no progress is lost.

429 stays retryable, so it is deliberately not added to the source's non-retryable errors. Treating a self-clearing rate limit as non-retryable would abort the sync on a transient condition.

## How did you test this code?

Automated only. I (Claude) added unit tests to `test_apollo.py` and ran them locally (`pytest`, 32 passed), plus `ruff check`/`ruff format`:

- `test_parse_retry_after` (parameterized): guards header parsing across delta-seconds, whitespace, empty/None/junk, and a past HTTP-date. Catches a regression that would silently disable Retry-After honoring.
- `test_wait_honors_retry_after_below_cap` / `test_wait_caps_long_retry_after`: lock in that the wait uses the header value and stays bounded. Catches a revert to blind exponential backoff or an unbounded wait.
- `test_429_is_retried_and_recovers`: the only test that exercises the 429 retry path end-to-end through `get_rows` (kept instant with `Retry-After: 0`). Catches 429 being made non-retryable or the header not being plumbed through to the raise site.

No existing test exercised a 429 or the retry path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Apollo data-warehouse import source. Claude (Opus) confirmed the issue in PostHog error tracking (stack trace originates in `apollo.py` `fetch_page` → `get_rows`), read the source and the shared import-error routing, and confirmed via Apollo's public rate-limit docs that 429s use fixed windows and that honoring `Retry-After` (with exponential-backoff fallback) is the recommended pattern.

Decision: this is upstream-but-retryable, not a credential/config error, so it does not belong in `get_non_retryable_errors` (adding it would abort syncs on a transient limit). The fragility is the retry backoff ignoring `Retry-After`, so the fix is scoped to that. Skills invoked: `/writing-tests`.


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from [an inbox report](posthog-code://inbox/019f1f54-04e6-7060-b99d-09313b13dfe2).*
