### PR TITLE
fix(ci): keep stamphog review-threads query under github node limit

### DIFF
--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -211,6 +211,8 @@ def _gh_api(endpoint: str, *, paginate: bool = False) -> dict | list:
     return json.loads(result.stdout)
 
 
+# GitHub rejects GraphQL queries whose worst-case node count — the product of
+# nested `first:` sizes — exceeds 500,000, before executing anything.
 _REVIEW_THREADS_QUERY = """
 query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
   repository(owner: $owner, name: $name) {
@@ -236,7 +238,7 @@ query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
               body
               databaseId
               replyTo { databaseId }
-              reactions(first: 100) {
+              reactions(first: 20) {
                 nodes {
                   content
                   user { login }

--- a/tools/pr-approval-agent/test_github.py
+++ b/tools/pr-approval-agent/test_github.py
@@ -1,5 +1,7 @@
 """Tests for GitHub review normalization used by the PR approval agent."""
 
+import re
+
 import pytest
 
 import github
@@ -126,3 +128,27 @@ def test_trusted_reactor_predicate_gates_untrusted_and_author(
 )
 def test_is_bot_author(user: dict, expected: bool) -> None:
     assert is_bot_author(user) is expected
+
+
+def _worst_case_node_count(query: str) -> int:
+    # Mirrors GitHub's pre-execution node-limit check: each connection requests
+    # `first` nodes multiplied by the `first` of every ancestor connection.
+    total = 0
+    multipliers = [1]
+    pending = 1
+    for match in re.finditer(r"first:\s*(\d+)|[{}]", query):
+        if match.group(1):
+            pending = int(match.group(1))
+            total += multipliers[-1] * pending
+        elif match.group(0) == "{":
+            multipliers.append(multipliers[-1] * pending)
+            pending = 1
+        else:
+            multipliers.pop()
+    return total
+
+
+def test_review_threads_query_stays_under_github_node_limit() -> None:
+    # GitHub rejects any GraphQL query whose worst-case node count exceeds
+    # 500,000 before executing it, which hard-fails the review on every PR.
+    assert _worst_case_node_count(github._REVIEW_THREADS_QUERY) < 500_000


### PR DESCRIPTION
## Problem

Stamphog (the PR approval agent) is hard-failing on every labeled PR, for example [this run](https://github.com/PostHog/posthog/actions/runs/28545630445/job/84630081026?pr=67511):

```
RuntimeError: gh api graphql failed: gh: This query requests up to 505,200 possible nodes which exceeds the maximum limit of 500,000.
```

GitHub caps any GraphQL query at 500,000 worst-case nodes, computed pre-execution as the product of nested `first:` page sizes. `_REVIEW_THREADS_QUERY` requests 100 threads x 50 comments x 100 reactions, which with the outer connections comes to exactly 505,200. Because the check runs before execution, it fails on every PR regardless of how much data actually exists.

## Changes

- Shrink per-comment `reactions` from `first: 100` to `first: 20`, bringing the worst case to 105,200 nodes. Reactions on inline review comments are only used as trusted ack signals, so 20 is plenty.
- Add a regression test that computes the query's worst-case node budget the same way GitHub does and asserts it stays under 500,000.

## How did you test this code?

- `pytest tools/pr-approval-agent/test_github.py` – 27 passed.
- Verified the test helper reproduces GitHub's arithmetic exactly: it returns 505,200 for the old query (matching the error message verbatim) and 105,200 for the fixed one.
- New test catches a regression no existing test did: bumping any `first:` size past the 500k node budget, which is exactly what broke stamphog today.
- I wasn't able to exercise a real stamphog run end to end from this session; the next labeled PR will confirm in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed – internal CI tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy pointed Claude Code at the failing workflow run. Claude pulled the job logs, matched the 505,200 figure in the error to the product of the query's nested `first:` sizes, shrank the dominant term, and added the node-budget regression test (via the /writing-tests skill). Reducing `reviewThreads` page size was considered instead but rejected since it would double pagination round trips; the reactions page size was the unrealistic term.