### PR TITLE
fix(google_ads): recover from stale page token with unrecognised error code

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -659,6 +659,30 @@ def _is_stale_page_token_error(exc: GoogleAdsException) -> bool:
     return any(request_error in failure_text for request_error in _STALE_PAGE_TOKEN_REQUEST_ERRORS)
 
 
+def _is_rejected_page_token_error(exc: GoogleAdsException, page_token: str) -> bool:
+    """Return True if the failure names ``page_token`` as the value that triggered it.
+
+    Google sometimes rejects a stale page token with a ``request_error`` code newer than the
+    pinned client library knows, which the SDK surfaces as ``request_error: UNKNOWN`` /
+    "The error code is not in this version." rather than the ``INVALID_PAGE_TOKEN`` /
+    ``EXPIRED_PAGE_TOKEN`` that ``_is_stale_page_token_error`` matches — so that check misses it
+    and the sync fails permanently. The failure still echoes the offending value in an error
+    ``trigger``, so when a trigger equals the token we sent, treat it as a stale token and
+    restart pagination from the first page. Matched on the exact token (not the volatile error
+    code) to stay low-false-positive.
+    """
+    if not page_token:
+        return False
+    failure = getattr(exc, "failure", None)
+    if failure is None:
+        return False
+    for error in getattr(failure, "errors", None) or []:
+        trigger = getattr(error, "trigger", None)
+        if trigger is not None and getattr(trigger, "string_value", None) == page_token:
+            return True
+    return False
+
+
 def _search_as_arrow_tables(
     service: GoogleAdsServiceClient,
     customer_id: str | None,
@@ -676,9 +700,10 @@ def _search_as_arrow_tables(
       over ``primary_keys`` dedupe those repeated rows.
     * A resumed token may have expired between runs (Google Ads page tokens are
       short-lived). If Google rejects it with ``INVALID_PAGE_TOKEN`` or
-      ``EXPIRED_PAGE_TOKEN`` we discard the saved token and restart pagination
-      from the first page — the same merge semantics make re-yielding
-      already-synced rows safe.
+      ``EXPIRED_PAGE_TOKEN`` — or an unrecognised error code whose ``trigger``
+      names the token we sent (see ``_is_rejected_page_token_error``) — we
+      discard the saved token and restart pagination from the first page. The
+      same merge semantics make re-yielding already-synced rows safe.
     """
     page_token = ""
     if resumable_source_manager.can_resume():
@@ -703,7 +728,7 @@ def _search_as_arrow_tables(
             # Only a non-empty (resumed or mid-stream) token can be stale; an empty
             # token always requests the first page, so the guard also prevents an
             # infinite restart loop if the first page itself were ever rejected.
-            if page_token and _is_stale_page_token_error(e):
+            if page_token and (_is_stale_page_token_error(e) or _is_rejected_page_token_error(e, page_token)):
                 resumable_source_manager.save_state(GoogleAdsResumeConfig(page_token=""))
                 page_token = ""
                 continue

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -24,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads
     GoogleAdsColumn,
     GoogleAdsTable,
     _get_integration,
+    _is_rejected_page_token_error,
     _is_stale_page_token_error,
     _is_transient_client_init_error,
     _is_transient_grpc_error,
@@ -396,6 +397,18 @@ def _google_ads_exception(request_error: int) -> GoogleAdsException:
     return GoogleAdsException(error=None, call=None, failure=failure, request_id="req-1")
 
 
+def _google_ads_exception_with_trigger(request_error: int, trigger_value: str) -> GoogleAdsException:
+    # A failure whose request_error code the pinned library can't decode (surfaced as UNKNOWN /
+    # "The error code is not in this version.") but whose trigger still echoes the offending value.
+    error = GoogleAdsError(
+        error_code=ErrorCode(request_error=request_error),
+        message="The error code is not in this version.",
+    )
+    error.trigger.string_value = trigger_value
+    failure = GoogleAdsFailure(errors=[error])
+    return GoogleAdsException(error=None, call=None, failure=failure, request_id="req-1")
+
+
 def _string_column(qualified_name: str) -> GoogleAdsColumn:
     return GoogleAdsColumn(
         qualified_name=qualified_name,
@@ -473,6 +486,29 @@ class TestStalePageTokenDetection:
         assert _is_stale_page_token_error(exc) is expected
 
 
+class TestRejectedPageTokenDetection:
+    @pytest.mark.parametrize(
+        "exc, page_token, expected",
+        [
+            # Google rejected our token with a code the pinned library can't decode, but the
+            # failure trigger echoes the exact token we sent — recognise it as a stale token.
+            (
+                _google_ads_exception_with_trigger(RequestErrorEnum.RequestError.UNKNOWN, "SAVED_TOKEN"),
+                "SAVED_TOKEN",
+                True,
+            ),
+            # A trigger naming some other value must not be mistaken for a rejected page token.
+            (_google_ads_exception_with_trigger(RequestErrorEnum.RequestError.UNKNOWN, "other"), "SAVED_TOKEN", False),
+            # An empty page token (first-page request) can never be the rejected value.
+            (_google_ads_exception_with_trigger(RequestErrorEnum.RequestError.UNKNOWN, ""), "", False),
+            # A non-``GoogleAdsException`` shape (no ``failure``) must not match.
+            (SimpleNamespace(failure=None), "SAVED_TOKEN", False),
+        ],
+    )
+    def test_is_rejected_page_token_error(self, exc, page_token, expected):
+        assert _is_rejected_page_token_error(exc, page_token) is expected
+
+
 class TestSearchPageTokenResumption:
     @pytest.mark.parametrize(
         "request_error",
@@ -500,6 +536,30 @@ class TestSearchPageTokenResumption:
         # The stale token is cleared from saved state so a later resume won't reuse it.
         assert manager.saved_states == [""]
         # Rows are still yielded — the data was never lost.
+        assert [t.to_pylist() for t in tables] == [[{"campaign_name": "Acme"}]]
+
+    def test_restarts_pagination_when_page_token_rejected_with_unrecognised_code(self):
+        # Google rejected the saved token with a request_error code the pinned library can't
+        # decode (UNKNOWN / "The error code is not in this version."), so the code-text match
+        # misses it; the trigger echoing the token is the only stable signal to restart.
+        service = _FakeService(
+            _single_page(),
+            error_on_token=_google_ads_exception_with_trigger(RequestErrorEnum.RequestError.UNKNOWN, "STALE_TOKEN"),
+        )
+        manager = _FakeResumableManager(saved_token="STALE_TOKEN")
+
+        tables = list(
+            _search_as_arrow_tables(
+                service=service,  # type: ignore[arg-type]
+                customer_id="1234567890",
+                query="SELECT campaign.name FROM campaign",
+                table=_single_row_table(),
+                resumable_source_manager=manager,  # type: ignore[arg-type]
+            )
+        )
+
+        assert service.calls == ["STALE_TOKEN", ""]
+        assert manager.saved_states == [""]
         assert [t.to_pylist() for t in tables] == [[{"campaign_name": "Acme"}]]
 
     def test_other_google_ads_errors_propagate(self):


### PR DESCRIPTION
## Problem

The `google_ads` import source paginates `GoogleAdsService.Search` and checkpoints the next `page_token` after each page so a Temporal retry can resume where it left off. These tokens are short-lived, so on resume we already detect a rejected token and restart pagination from the first page - but only when Google returns the recognised `INVALID_PAGE_TOKEN` / `EXPIRED_PAGE_TOKEN` request errors.

Error tracking surfaced a `GoogleAdsException` where Google rejected our saved token with `INVALID_ARGUMENT`, but returned a `request_error` enum value newer than our pinned client library knows about. The SDK can't decode it, so it surfaces `request_error: UNKNOWN` with the message "The error code is not in this version." Our stale-token check matches on the code text, so it misses this shape, re-raises, and the whole import activity fails. Temporal then retries from the same stale checkpoint and fails identically - the issue logged 135 failures in a ~3 minute window, all from one source looping on the same token.

The failure still names the offending value in the error `trigger`, and it matched the exact page token we sent.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1f0e-6fd5-7280-a863-63f40db76046

## Changes

Added `_is_rejected_page_token_error(exc, page_token)`: it inspects the failure's error `trigger`s and returns true when one equals the page token we sent. The pagination loop now restarts from the first page when either the existing code-text check matches or this trigger check matches.

I matched on the exact token value rather than the volatile, version-dependent error code, which keeps false positives low. This is also safe against loops: an empty first-page token can never match a trigger, so the existing infinite-restart guard still holds. And if some non-token error ever did carry a matching trigger, the restart sets the token to empty, the first-page request runs, and any genuine error re-raises there (no loop).

This is scoped strictly to this error. No change to global retry policy, and nothing added to `NonRetryableErrors` - this is a recoverable condition, not a give-up condition.

## How did you test this code?

Automated tests only (I'm an agent - no manual sync run). Added to `test_google_ads_source.py`:

- `TestRejectedPageTokenDetection` - parameterized cases for `_is_rejected_page_token_error`: trigger matches the sent token (true), trigger names a different value (false), empty token (false), non-`GoogleAdsException` shape (false). Catches a regression where detection reverts to code-text-only matching and this variant goes unrecognised again - no existing test exercised trigger-based matching.
- `test_restarts_pagination_when_page_token_rejected_with_unrecognised_code` in `TestSearchPageTokenResumption` - drives `_search_as_arrow_tables` end to end with an `UNKNOWN`-code rejection whose trigger echoes the saved token, and asserts pagination restarts from the first page and still yields the rows. Distinct from the existing `INVALID_PAGE_TOKEN` restart test, which uses the recognised-code path.

Ran the full `test_google_ads_source.py` (123 passed) plus `ruff check` / `ruff format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Opus 4.8) via the Claude Code / PostHog code tooling. Confirmed the issue in error tracking (135 occurrences, single source, top in-app frame at the `service.search` call in `_search_as_arrow_tables`), read the full stack trace to confirm the failure originates in this source's pagination loop, then read the source to find why the stale-token recovery didn't fire.

Decision: this is a fixable bug in our recovery logic, not a user/upstream condition, so I fixed the code rather than extending `NonRetryableErrors`. I considered broadening the code-text match to also treat "The error code is not in this version." as stale, but rejected it as too broad - it would swallow any unknown error. Matching the trigger against the exact page token we sent is the precise, stable signal. Invoked the `/writing-tests` skill before adding tests.
