### PR TITLE
feat(replay-vision): note AI-credit usage in the action form

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -221,6 +221,11 @@ export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Elem
                     <h4 className="mb-1">Deliver to Slack</h4>
                     <DeliverySection />
                 </div>
+
+                <div className="text-xs text-muted">
+                    Each scheduled run generates an AI summary using your PostHog AI credits. Runs are skipped while
+                    you're over your AI-credit budget.
+                </div>
             </Form>
         </LemonModal>
     )


### PR DESCRIPTION
## Problem

A scheduled summary runs an LLM synthesis on every fire, so it's a recurring PostHog AI-credit cost — but the action create/edit form only said "AI summary," never that it spends credits. The backend also silently skips a run when the team is over its AI-credit budget (`skipped_over_budget`), which was undocumented in the UI.

## Changes

Add a muted note at the bottom of the create/edit modal:

> Each scheduled run generates an AI summary using your PostHog AI credits. Runs are skipped while you're over your AI-credit budget.

Mirrors the existing scanner-setup quota note ("Each observation counts against your monthly Vision quota").

## How did you test this code?

I'm an agent (agent-assisted, human-driven). Copy-only change; verified with `tsgo` typecheck + oxlint/oxfmt. No test — testing static copy would be low-value per the testing gate.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: PostHog Code (Claude). Prompted by the question of whether the action UI should disclose AI-credit usage.
- Chose a muted in-modal note (over the empty-state) as the primary spot since that's where the user commits to the recurring cost; also surfaces the over-budget skip behavior so it isn't a surprise.
- Stacked on #67513.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
