### PR TITLE
fix(replay): fetch pinned session properties for the overview tab

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -501,45 +501,50 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             },
         ],
     })),
-    listeners(({ actions, values, props }) => ({
-        setPinnedProperties: () => {
+    listeners(({ actions, values, props }) => {
+        // Skip if the list-wide fetch is in flight; calling again cancels it via breakpoint.
+        const maybeLoadRecordingProperties = (): void => {
+            if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {
+                actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
+            }
+        }
+        return {
             // a newly pinned session property may not be in the cached recording properties yet
-            if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {
-                actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
-            }
-        },
-        loadRecordingMetaSuccess: () => {
-            // Skip if the list-wide fetch is in flight; calling again cancels it via breakpoint.
-            if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {
-                actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
-            }
-            if (values.sessionPlayerMetaData?.has_summary && !values.sessionSummary && !values.sessionSummaryLoading) {
-                actions.summarizeSession()
-            }
-        },
-        sessionSummaryFeedback: ({ feedback }) => {
-            posthog.capture('session summary feedback', {
-                feedback,
-                session_summary: values.sessionSummary,
-                summary_id: values.sessionSummaryId,
-                summarized_session_id: props.sessionRecordingId,
-            })
-            actions.markFeedbackGiven(props.sessionRecordingId)
-        },
-        summarizeSession: () => {
-            // TODO: Remove after testing
-            const local = false
-            if (local) {
-                actions.setSummary(props.sessionRecordingId, aiSummaryMock)
-                return
-            }
-            const id = props.sessionRecordingId || props.sessionRecordingData?.sessionRecordingId
-            if (!id) {
-                return
-            }
-            // Delegates the SSE stream + per-session state to the singleton so that
-            // progress survives navigation away from and back to a recording mid-stream.
-            actions.startSummarization(id)
-        },
-    })),
+            setPinnedProperties: maybeLoadRecordingProperties,
+            loadRecordingMetaSuccess: () => {
+                maybeLoadRecordingProperties()
+                if (
+                    values.sessionPlayerMetaData?.has_summary &&
+                    !values.sessionSummary &&
+                    !values.sessionSummaryLoading
+                ) {
+                    actions.summarizeSession()
+                }
+            },
+            sessionSummaryFeedback: ({ feedback }) => {
+                posthog.capture('session summary feedback', {
+                    feedback,
+                    session_summary: values.sessionSummary,
+                    summary_id: values.sessionSummaryId,
+                    summarized_session_id: props.sessionRecordingId,
+                })
+                actions.markFeedbackGiven(props.sessionRecordingId)
+            },
+            summarizeSession: () => {
+                // TODO: Remove after testing
+                const local = false
+                if (local) {
+                    actions.setSummary(props.sessionRecordingId, aiSummaryMock)
+                    return
+                }
+                const id = props.sessionRecordingId || props.sessionRecordingData?.sessionRecordingId
+                if (!id) {
+                    return
+                }
+                // Delegates the SSE stream + per-session state to the singleton so that
+                // progress survives navigation away from and back to a recording mid-stream.
+                actions.startSummarization(id)
+            },
+        }
+    }),
 ])

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -118,11 +118,12 @@ export function getPropertyDisplayInfo(
     type: TaxonomicFilterGroupType
     propertyFilterType?: PropertyFilterType
 } {
-    const propertyType = recordingProperties?.[property]
-        ? // HogQL query can return multiple types, so we need to check
-          // but if it doesn't match a core definition it must be an event property
-          getFirstFilterTypeFor(property) || TaxonomicFilterGroupType.EventProperties
-        : TaxonomicFilterGroupType.PersonProperties
+    const propertyType =
+        recordingProperties && property in recordingProperties
+            ? // HogQL query can return multiple types, so we need to check
+              // but if it doesn't match a core definition it must be an event property
+              getFirstFilterTypeFor(property) || TaxonomicFilterGroupType.EventProperties
+            : TaxonomicFilterGroupType.PersonProperties
 
     const propertyFilterType: PropertyFilterType | undefined =
         propertyType === TaxonomicFilterGroupType.EventProperties
@@ -501,6 +502,12 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         ],
     })),
     listeners(({ actions, values, props }) => ({
+        setPinnedProperties: () => {
+            // a newly pinned session property may not be in the cached recording properties yet
+            if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {
+                actions.maybeLoadPropertiesForSessions([values.sessionPlayerMetaData])
+            }
+        },
         loadRecordingMetaSuccess: () => {
             // Skip if the list-wide fetch is in flight; calling again cancels it via breakpoint.
             if (values.sessionPlayerMetaData && !values.recordingPropertiesLoading) {

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -120,8 +120,7 @@ export function getPropertyDisplayInfo(
 } {
     const propertyType =
         recordingProperties && property in recordingProperties
-            ? // HogQL query can return multiple types, so we need to check
-              // but if it doesn't match a core definition it must be an event property
+            ? // anything the query returned that doesn't match a core definition must be an event property
               getFirstFilterTypeFor(property) || TaxonomicFilterGroupType.EventProperties
             : TaxonomicFilterGroupType.PersonProperties
 
@@ -541,8 +540,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 if (!id) {
                     return
                 }
-                // Delegates the SSE stream + per-session state to the singleton so that
-                // progress survives navigation away from and back to a recording mid-stream.
+                // delegates the SSE stream + per-session state to the singleton so progress survives navigating away and back mid-stream
                 actions.startSummarization(id)
             },
         }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
@@ -203,7 +203,7 @@ describe('sessionRecordingsListPropertiesLogic', () => {
         useQueryMocks((query) => {
             issuedQueries.push(query)
             if (query.includes('$entry_utm_medium')) {
-                return [500, { detail: 'unknown field' }]
+                return [400, { detail: 'unknown field' }]
             }
             return {
                 results: [query.includes('$channel_type') ? [...S1_BASE_ROW, 'Paid Search'] : S1_BASE_ROW],
@@ -223,7 +223,7 @@ describe('sessionRecordingsListPropertiesLogic', () => {
             logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
         }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
 
-        // previously cached values survive the fallback; the failed pin reads as complete (null), so no refetch loop
+        // cached values survive the fallback and the failed pin reads as complete (null), so no refetch loop
         expect(logic.values.recordingPropertiesById['s1']).toMatchObject({
             $browser: 'Chrome',
             $channel_type: 'Paid Search',
@@ -240,5 +240,34 @@ describe('sessionRecordingsListPropertiesLogic', () => {
         }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
         expect(issuedQueries).toHaveLength(queriesSoFar + 1)
         expect(issuedQueries[issuedQueries.length - 1]).not.toContain('$entry_utm_medium')
+    })
+
+    it('retries the extended query after a transient failure', async () => {
+        const issuedQueries: string[] = []
+        let failWideQuery = true
+        useQueryMocks((query) => {
+            issuedQueries.push(query)
+            if (query.includes('$entry_utm_medium')) {
+                if (failWideQuery) {
+                    return [500, { detail: 'timeout' }]
+                }
+                return { results: [[...S2_BASE_ROW, 'paid']] }
+            }
+            return { results: [S1_BASE_ROW] }
+        })
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$entry_utm_medium'])
+
+        await expectLogic(logic, () => {
+            logic.actions.loadPropertiesForSessions([mockSessons[0]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        // a 5xx does not mark the pin set unqueryable — the next batch retries the wide query
+        failWideQuery = false
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[1]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        expect(issuedQueries[issuedQueries.length - 1]).toContain('$entry_utm_medium')
+        expect(logic.values.recordingPropertiesById['s2']).toMatchObject({ $entry_utm_medium: 'paid' })
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { sessionRecordingPinnedPropertiesLogic } from 'scenes/session-recordings/player/player-meta/sessionRecordingPinnedPropertiesLogic'
 import { sessionRecordingsListPropertiesLogic } from 'scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -83,8 +84,10 @@ const mockSessons: SessionRecordingType[] = [
 
 describe('sessionRecordingsListPropertiesLogic', () => {
     let logic: ReturnType<typeof sessionRecordingsListPropertiesLogic.build>
+    let issuedQueries: string[]
 
     beforeEach(() => {
+        issuedQueries = []
         useMocks({
             post: {
                 '/api/environments/:team_id/query/:kind': {
@@ -101,6 +104,7 @@ describe('sessionRecordingsListPropertiesLogic', () => {
     beforeEach(() => {
         logic = sessionRecordingsListPropertiesLogic()
         logic.mount()
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties([])
     })
 
     it('loads properties', async () => {
@@ -130,5 +134,128 @@ describe('sessionRecordingsListPropertiesLogic', () => {
         expect(logic.values).toMatchObject({
             recordingPropertiesById: EXPECTED_RECORDING_PROPERTIES_BY_ID,
         })
+    })
+
+    it('fetches pinned session properties alongside the base properties', async () => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/query/:kind': async (info: any) => {
+                    const body = await info.request.json()
+                    issuedQueries.push(body.query.query)
+                    return {
+                        results: [
+                            [
+                                's1',
+                                'AU',
+                                'Chrome',
+                                'Desktop',
+                                'Windows',
+                                'Windows 10',
+                                'google.com',
+                                null,
+                                null,
+                                null,
+                                'paid',
+                                'Paid Search',
+                            ],
+                        ],
+                    }
+                },
+            },
+        })
+
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties([
+            'Start',
+            'email',
+            '$entry_utm_medium',
+            '$channel_type',
+        ])
+
+        await expectLogic(logic, () => {
+            logic.actions.loadPropertiesForSessions([mockSessons[0]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        expect(issuedQueries).toHaveLength(1)
+        expect(issuedQueries[0]).toContain('any(session.$entry_utm_medium) as $entry_utm_medium')
+        expect(issuedQueries[0]).toContain('any(session.$channel_type) as $channel_type')
+        // non-session pins must not leak into the query
+        expect(issuedQueries[0]).not.toContain('email')
+        expect(issuedQueries[0]).not.toContain('Start')
+
+        expect(logic.values.recordingPropertiesById['s1']).toMatchObject({
+            $browser: 'Chrome',
+            $entry_utm_medium: 'paid',
+            $channel_type: 'Paid Search',
+        })
+    })
+
+    it('refetches cached sessions that are missing newly pinned session properties', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadPropertiesForSessions(mockSessons)
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        useMocks({
+            post: {
+                '/api/environments/:team_id/query/:kind': {
+                    results: [
+                        [
+                            's1',
+                            'AU',
+                            'Chrome',
+                            'Desktop',
+                            'Windows',
+                            'Windows 10',
+                            'google.com',
+                            null,
+                            null,
+                            null,
+                            'paid',
+                        ],
+                    ],
+                },
+            },
+        })
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$entry_utm_medium'])
+
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        expect(logic.values.recordingPropertiesById['s1']).toMatchObject({ $entry_utm_medium: 'paid' })
+
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
+        }).toNotHaveDispatchedActions(['loadPropertiesForSessions'])
+    })
+
+    it('falls back to the base properties when a pinned session property fails to query', async () => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/query/:kind': async (info: any) => {
+                    const body = await info.request.json()
+                    if (body.query.query.includes('$entry_utm_medium')) {
+                        return [500, { detail: 'unknown field' }]
+                    }
+                    return {
+                        results: [['s1', 'AU', 'Chrome', 'Desktop', 'Windows', 'Windows 10', 'google.com']],
+                    }
+                },
+            },
+        })
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$entry_utm_medium'])
+
+        await expectLogic(logic, () => {
+            logic.actions.loadPropertiesForSessions([mockSessons[0]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        expect(logic.values.recordingPropertiesById['s1']).toMatchObject({
+            $browser: 'Chrome',
+            $entry_utm_medium: null,
+        })
+
+        // the null placeholder marks the cache entry complete, so no refetch loop
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
+        }).toNotHaveDispatchedActions(['loadPropertiesForSessions'])
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
@@ -82,19 +82,30 @@ const mockSessons: SessionRecordingType[] = [
     },
 ]
 
+// matches the order of the base columns in the properties query, after the leading session_id
+const S1_BASE_ROW = ['s1', 'AU', 'Chrome', 'Desktop', 'Windows', 'Windows 10', 'google.com', null, null, null]
+const S2_BASE_ROW = ['s2', 'GB', 'Safari', 'Mobile', 'iOS', 'iOS 14', 'google.com', null, null, null]
+
+// mock the query endpoint with a per-request handler that receives the HogQL query string
+const useQueryMocks = (handler: (query: string) => unknown): void => {
+    useMocks({
+        post: {
+            '/api/environments/:team_id/query/:kind': async (info: any) => {
+                const body = await info.request.json()
+                return handler(body.query.query)
+            },
+        },
+    })
+}
+
 describe('sessionRecordingsListPropertiesLogic', () => {
     let logic: ReturnType<typeof sessionRecordingsListPropertiesLogic.build>
-    let issuedQueries: string[]
 
     beforeEach(() => {
-        issuedQueries = []
         useMocks({
             post: {
                 '/api/environments/:team_id/query/:kind': {
-                    results: [
-                        ['s1', 'AU', 'Chrome', 'Desktop', 'Windows', 'Windows 10', 'google.com'],
-                        ['s2', 'GB', 'Safari', 'Mobile', 'iOS', 'iOS 14', 'google.com'],
-                    ],
+                    results: [S1_BASE_ROW, S2_BASE_ROW],
                 },
             },
         })
@@ -137,31 +148,10 @@ describe('sessionRecordingsListPropertiesLogic', () => {
     })
 
     it('fetches pinned session properties alongside the base properties', async () => {
-        useMocks({
-            post: {
-                '/api/environments/:team_id/query/:kind': async (info: any) => {
-                    const body = await info.request.json()
-                    issuedQueries.push(body.query.query)
-                    return {
-                        results: [
-                            [
-                                's1',
-                                'AU',
-                                'Chrome',
-                                'Desktop',
-                                'Windows',
-                                'Windows 10',
-                                'google.com',
-                                null,
-                                null,
-                                null,
-                                'paid',
-                                'Paid Search',
-                            ],
-                        ],
-                    }
-                },
-            },
+        const issuedQueries: string[] = []
+        useQueryMocks((query) => {
+            issuedQueries.push(query)
+            return { results: [[...S1_BASE_ROW, 'paid', 'Paid Search']] }
         })
 
         sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties([
@@ -194,27 +184,7 @@ describe('sessionRecordingsListPropertiesLogic', () => {
             logic.actions.loadPropertiesForSessions(mockSessons)
         }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
 
-        useMocks({
-            post: {
-                '/api/environments/:team_id/query/:kind': {
-                    results: [
-                        [
-                            's1',
-                            'AU',
-                            'Chrome',
-                            'Desktop',
-                            'Windows',
-                            'Windows 10',
-                            'google.com',
-                            null,
-                            null,
-                            null,
-                            'paid',
-                        ],
-                    ],
-                },
-            },
-        })
+        useQueryMocks(() => ({ results: [[...S1_BASE_ROW, 'paid']] }))
         sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$entry_utm_medium'])
 
         await expectLogic(logic, () => {
@@ -229,33 +199,46 @@ describe('sessionRecordingsListPropertiesLogic', () => {
     })
 
     it('falls back to the base properties when a pinned session property fails to query', async () => {
-        useMocks({
-            post: {
-                '/api/environments/:team_id/query/:kind': async (info: any) => {
-                    const body = await info.request.json()
-                    if (body.query.query.includes('$entry_utm_medium')) {
-                        return [500, { detail: 'unknown field' }]
-                    }
-                    return {
-                        results: [['s1', 'AU', 'Chrome', 'Desktop', 'Windows', 'Windows 10', 'google.com']],
-                    }
-                },
-            },
+        const issuedQueries: string[] = []
+        useQueryMocks((query) => {
+            issuedQueries.push(query)
+            if (query.includes('$entry_utm_medium')) {
+                return [500, { detail: 'unknown field' }]
+            }
+            return {
+                results: [query.includes('$channel_type') ? [...S1_BASE_ROW, 'Paid Search'] : S1_BASE_ROW],
+            }
         })
-        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$entry_utm_medium'])
 
+        // a queryable pin loads fine on its own
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$channel_type'])
         await expectLogic(logic, () => {
             logic.actions.loadPropertiesForSessions([mockSessons[0]])
         }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+        expect(logic.values.recordingPropertiesById['s1']).toMatchObject({ $channel_type: 'Paid Search' })
 
+        // adding an unqueryable pin fails the wide query and falls back to the base one
+        sessionRecordingPinnedPropertiesLogic.actions.setPinnedProperties(['$channel_type', '$entry_utm_medium'])
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+
+        // previously cached values survive the fallback; the failed pin reads as complete (null), so no refetch loop
         expect(logic.values.recordingPropertiesById['s1']).toMatchObject({
             $browser: 'Chrome',
+            $channel_type: 'Paid Search',
             $entry_utm_medium: null,
         })
-
-        // the null placeholder marks the cache entry complete, so no refetch loop
         await expectLogic(logic, () => {
             logic.actions.maybeLoadPropertiesForSessions([mockSessons[0]])
         }).toNotHaveDispatchedActions(['loadPropertiesForSessions'])
+
+        // the failed pin set is remembered: new sessions load with a single base query
+        const queriesSoFar = issuedQueries.length
+        await expectLogic(logic, () => {
+            logic.actions.maybeLoadPropertiesForSessions([mockSessons[1]])
+        }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
+        expect(issuedQueries).toHaveLength(queriesSoFar + 1)
+        expect(issuedQueries[issuedQueries.length - 1]).not.toContain('$entry_utm_medium')
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -1,7 +1,7 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
+import api, { ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 
@@ -32,7 +32,8 @@ const BASE_PROPERTIES = BASE_QUERY_PROPERTIES.map(([, property]) => property)
 function pinnedSessionProperties(pinnedProperties: string[]): string[] {
     return pinnedProperties.filter(
         (property) =>
-            property in CORE_FILTER_DEFINITIONS_BY_GROUP.session_properties && !BASE_PROPERTIES.includes(property)
+            Object.hasOwn(CORE_FILTER_DEFINITIONS_BY_GROUP.session_properties, property) &&
+            !BASE_PROPERTIES.includes(property)
     )
 }
 
@@ -59,10 +60,7 @@ function buildPropertiesQuery(
                         FROM events
                         WHERE event IN ${Object.keys(CORE_FILTER_DEFINITIONS_BY_GROUP['events'])}
                         AND session_id IN ${sessionIds}
-                        -- the timestamp range here is only to avoid querying too much of the events table
-                        -- we don't really care about the absolute value,
-                        -- but we do care about whether timezones have an odd impact
-                        -- so, we extend the range by a day on each side so that timezones don't cause issues
+                        -- the timestamp range only bounds the events-table scan, padded a day each side so timezones can't cause issues
                         AND timestamp >= ${dayjs(oldestTimestamp).subtract(1, 'day')}
                         AND timestamp <= ${dayjs(newestTimestamp).add(1, 'day')}
                         GROUP BY session_id`
@@ -107,13 +105,14 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                         if (!extraSessionProperties.length) {
                             throw e
                         }
-                        // a pinned property may not exist on this project's session table version —
-                        // remember the failing set so subsequent batches skip the wide query
                         response = await api.queryHogQL(
                             buildPropertiesQuery(sessionIds, oldestTimestamp, newestTimestamp, []),
                             QUERY_TAGS
                         )
-                        actions.markExtraPropertiesUnqueryable(extraSessionProperties)
+                        // only a 400 (a pin missing from this project's session table) blacklists the pin set — transient errors retry next batch
+                        if (e instanceof ApiError && e.status === 400) {
+                            actions.markExtraPropertiesUnqueryable(extraSessionProperties)
+                        }
                     }
                     const loadTimeMs = performance.now() - startTime
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -5,11 +5,23 @@ import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 
-import { hogql } from '~/queries/utils'
+import { HogQLQueryString, escapePropertyAsHogQLIdentifier, hogql } from '~/queries/utils'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 import { SessionRecordingPropertiesType, SessionRecordingType } from '~/types'
 
+import { sessionRecordingPinnedPropertiesLogic } from '../player/player-meta/sessionRecordingPinnedPropertiesLogic'
 import type { sessionRecordingsListPropertiesLogicType } from './sessionRecordingsListPropertiesLogicType'
+
+// session properties the base query below always selects
+const ALWAYS_FETCHED_SESSION_PROPERTIES = ['$entry_referring_domain', '$entry_current_url']
+
+export function pinnedSessionProperties(pinnedProperties: string[]): string[] {
+    return pinnedProperties.filter(
+        (property) =>
+            property in CORE_FILTER_DEFINITIONS_BY_GROUP.session_properties &&
+            !ALWAYS_FETCHED_SESSION_PROPERTIES.includes(property)
+    )
+}
 
 // This logic is used to fetch properties for a list of recordings
 // It is used in a global way as the cached values can be re-used
@@ -17,6 +29,7 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
     path(() => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsListPropertiesLogic']),
     connect(() => ({
         actions: [sessionRecordingEventUsageLogic, ['reportRecordingsListPropertiesFetched']],
+        values: [sessionRecordingPinnedPropertiesLogic, ['pinnedProperties']],
     })),
 
     actions({
@@ -24,7 +37,7 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
         maybeLoadPropertiesForSessions: (sessions: SessionRecordingType[]) => ({ sessions }),
     }),
 
-    loaders(({ actions }) => ({
+    loaders(({ actions, values }) => ({
         recordingProperties: [
             [] as SessionRecordingPropertiesType[],
             {
@@ -37,7 +50,15 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                     const oldestTimestamp = sessions.map((x) => x.start_time).sort()[0]
                     const newestTimestamp = sessions.map((x) => x.end_time).sort()[sessions.length - 1]
 
-                    const query = hogql`
+                    const buildQuery = (sessionProperties: string[]): HogQLQueryString => {
+                        const extraSelects = sessionProperties
+                            .map((property) => {
+                                const identifier = escapePropertyAsHogQLIdentifier(property)
+                                return `, any(session.${identifier}) as ${identifier}`
+                            })
+                            .join('')
+
+                        return hogql`
                         SELECT
                             $session_id as session_id,
                             any(properties.$geoip_country_code) as $geoip_country_code,
@@ -48,7 +69,7 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                             any(session.$entry_referring_domain) as $entry_referring_domain,
                             any(properties.$geoip_subdivision_1_name) as $geoip_subdivision_1_name,
                             any(properties.$geoip_city_name) as $geoip_city_name,
-                            any(session.$entry_current_url) as $entry_current_url
+                            any(session.$entry_current_url) as $entry_current_url${hogql.raw(extraSelects)}
                         FROM events
                         WHERE event IN ${Object.keys(CORE_FILTER_DEFINITIONS_BY_GROUP['events'])}
                         AND session_id IN ${sessionIds}
@@ -59,28 +80,49 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                         AND timestamp >= ${dayjs(oldestTimestamp).subtract(1, 'day')}
                         AND timestamp <= ${dayjs(newestTimestamp).add(1, 'day')}
                         GROUP BY session_id`
+                    }
 
-                    const response = await api.queryHogQL(query, { scene: 'Replay', productKey: 'session_replay' })
+                    const extraSessionProperties = pinnedSessionProperties(values.pinnedProperties)
+                    let extrasQueried = true
+                    let response
+                    try {
+                        response = await api.queryHogQL(buildQuery(extraSessionProperties), {
+                            scene: 'Replay',
+                            productKey: 'session_replay',
+                        })
+                    } catch (e) {
+                        if (!extraSessionProperties.length) {
+                            throw e
+                        }
+                        // a pinned property may not exist on this project's session table version
+                        extrasQueried = false
+                        response = await api.queryHogQL(buildQuery([]), {
+                            scene: 'Replay',
+                            productKey: 'session_replay',
+                        })
+                    }
                     const loadTimeMs = performance.now() - startTime
 
                     actions.reportRecordingsListPropertiesFetched(loadTimeMs)
 
                     breakpoint()
                     return (response.results || []).map((x: any): SessionRecordingPropertiesType => {
-                        return {
-                            id: x[0],
-                            properties: {
-                                $geoip_country_code: x[1],
-                                $browser: x[2],
-                                $device_type: x[3],
-                                $os: x[4],
-                                $os_name: x[5],
-                                $entry_referring_domain: x[6],
-                                $geoip_subdivision_1_name: x[7],
-                                $geoip_city_name: x[8],
-                                $entry_current_url: x[9],
-                            },
+                        const properties: Record<string, any> = {
+                            $geoip_country_code: x[1],
+                            $browser: x[2],
+                            $device_type: x[3],
+                            $os: x[4],
+                            $os_name: x[5],
+                            $entry_referring_domain: x[6],
+                            $geoip_subdivision_1_name: x[7],
+                            $geoip_city_name: x[8],
+                            $entry_current_url: x[9],
                         }
+                        // null out extras that failed to load, so cached entries read as complete and don't refetch
+                        extraSessionProperties.forEach((property, index) => {
+                            properties[property] = extrasQueried ? x[10 + index] : null
+                        })
+                        return { id: x[0], properties }
                     })
                 },
             },
@@ -89,7 +131,11 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
 
     listeners(({ actions, values }) => ({
         maybeLoadPropertiesForSessions: ({ sessions }) => {
-            const newSessions = sessions.filter((session) => !values.recordingPropertiesById[session.id])
+            const wantedSessionProperties = pinnedSessionProperties(values.pinnedProperties)
+            const newSessions = sessions.filter((session) => {
+                const cached = values.recordingPropertiesById[session.id]
+                return !cached || wantedSessionProperties.some((property) => !(property in cached))
+            })
 
             if (newSessions.length > 0) {
                 actions.loadPropertiesForSessions(newSessions)

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -1,10 +1,11 @@
-import { actions, connect, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 
+import { QueryLogTags } from '~/queries/schema/schema-general'
 import { HogQLQueryString, escapePropertyAsHogQLIdentifier, hogql } from '~/queries/utils'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 import { SessionRecordingPropertiesType, SessionRecordingType } from '~/types'
@@ -12,15 +13,59 @@ import { SessionRecordingPropertiesType, SessionRecordingType } from '~/types'
 import { sessionRecordingPinnedPropertiesLogic } from '../player/player-meta/sessionRecordingPinnedPropertiesLogic'
 import type { sessionRecordingsListPropertiesLogicType } from './sessionRecordingsListPropertiesLogicType'
 
-// session properties the base query below always selects
-const ALWAYS_FETCHED_SESSION_PROPERTIES = ['$entry_referring_domain', '$entry_current_url']
+const QUERY_TAGS: QueryLogTags = { scene: 'Replay', productKey: 'session_replay' }
 
-export function pinnedSessionProperties(pinnedProperties: string[]): string[] {
+// [source table, property] pairs; order defines the result columns
+const BASE_QUERY_PROPERTIES: [string, string][] = [
+    ['properties', '$geoip_country_code'],
+    ['properties', '$browser'],
+    ['properties', '$device_type'],
+    ['properties', '$os'],
+    ['properties', '$os_name'],
+    ['session', '$entry_referring_domain'],
+    ['properties', '$geoip_subdivision_1_name'],
+    ['properties', '$geoip_city_name'],
+    ['session', '$entry_current_url'],
+]
+const BASE_PROPERTIES = BASE_QUERY_PROPERTIES.map(([, property]) => property)
+
+function pinnedSessionProperties(pinnedProperties: string[]): string[] {
     return pinnedProperties.filter(
         (property) =>
-            property in CORE_FILTER_DEFINITIONS_BY_GROUP.session_properties &&
-            !ALWAYS_FETCHED_SESSION_PROPERTIES.includes(property)
+            property in CORE_FILTER_DEFINITIONS_BY_GROUP.session_properties && !BASE_PROPERTIES.includes(property)
     )
+}
+
+function buildPropertiesQuery(
+    sessionIds: string[],
+    oldestTimestamp: string,
+    newestTimestamp: string | undefined,
+    extraSessionProperties: string[]
+): HogQLQueryString {
+    const selects = [
+        ...BASE_QUERY_PROPERTIES,
+        ...extraSessionProperties.map((property): [string, string] => ['session', property]),
+    ]
+        .map(([source, property]) => {
+            const identifier = escapePropertyAsHogQLIdentifier(property)
+            return `any(${source}.${identifier}) as ${identifier}`
+        })
+        .join(',\n                            ')
+
+    return hogql`
+                        SELECT
+                            $session_id as session_id,
+                            ${hogql.raw(selects)}
+                        FROM events
+                        WHERE event IN ${Object.keys(CORE_FILTER_DEFINITIONS_BY_GROUP['events'])}
+                        AND session_id IN ${sessionIds}
+                        -- the timestamp range here is only to avoid querying too much of the events table
+                        -- we don't really care about the absolute value,
+                        -- but we do care about whether timezones have an odd impact
+                        -- so, we extend the range by a day on each side so that timezones don't cause issues
+                        AND timestamp >= ${dayjs(oldestTimestamp).subtract(1, 'day')}
+                        AND timestamp <= ${dayjs(newestTimestamp).add(1, 'day')}
+                        GROUP BY session_id`
 }
 
 // This logic is used to fetch properties for a list of recordings
@@ -35,6 +80,7 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
     actions({
         loadPropertiesForSessions: (sessions: SessionRecordingType[]) => ({ sessions }),
         maybeLoadPropertiesForSessions: (sessions: SessionRecordingType[]) => ({ sessions }),
+        markExtraPropertiesUnqueryable: (properties: string[]) => ({ properties }),
     }),
 
     loaders(({ actions, values }) => ({
@@ -50,97 +96,46 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                     const oldestTimestamp = sessions.map((x) => x.start_time).sort()[0]
                     const newestTimestamp = sessions.map((x) => x.end_time).sort()[sessions.length - 1]
 
-                    const buildQuery = (sessionProperties: string[]): HogQLQueryString => {
-                        const extraSelects = sessionProperties
-                            .map((property) => {
-                                const identifier = escapePropertyAsHogQLIdentifier(property)
-                                return `, any(session.${identifier}) as ${identifier}`
-                            })
-                            .join('')
-
-                        return hogql`
-                        SELECT
-                            $session_id as session_id,
-                            any(properties.$geoip_country_code) as $geoip_country_code,
-                            any(properties.$browser) as $browser,
-                            any(properties.$device_type) as $device_type,
-                            any(properties.$os) as $os,
-                            any(properties.$os_name) as $os_name,
-                            any(session.$entry_referring_domain) as $entry_referring_domain,
-                            any(properties.$geoip_subdivision_1_name) as $geoip_subdivision_1_name,
-                            any(properties.$geoip_city_name) as $geoip_city_name,
-                            any(session.$entry_current_url) as $entry_current_url${hogql.raw(extraSelects)}
-                        FROM events
-                        WHERE event IN ${Object.keys(CORE_FILTER_DEFINITIONS_BY_GROUP['events'])}
-                        AND session_id IN ${sessionIds}
-                        -- the timestamp range here is only to avoid querying too much of the events table
-                        -- we don't really care about the absolute value,
-                        -- but we do care about whether timezones have an odd impact
-                        -- so, we extend the range by a day on each side so that timezones don't cause issues
-                        AND timestamp >= ${dayjs(oldestTimestamp).subtract(1, 'day')}
-                        AND timestamp <= ${dayjs(newestTimestamp).add(1, 'day')}
-                        GROUP BY session_id`
-                    }
-
-                    const extraSessionProperties = pinnedSessionProperties(values.pinnedProperties)
-                    let extrasQueried = true
+                    const extraSessionProperties = values.extraSessionProperties
                     let response
                     try {
-                        response = await api.queryHogQL(buildQuery(extraSessionProperties), {
-                            scene: 'Replay',
-                            productKey: 'session_replay',
-                        })
+                        response = await api.queryHogQL(
+                            buildPropertiesQuery(sessionIds, oldestTimestamp, newestTimestamp, extraSessionProperties),
+                            QUERY_TAGS
+                        )
                     } catch (e) {
                         if (!extraSessionProperties.length) {
                             throw e
                         }
-                        // a pinned property may not exist on this project's session table version
-                        extrasQueried = false
-                        response = await api.queryHogQL(buildQuery([]), {
-                            scene: 'Replay',
-                            productKey: 'session_replay',
-                        })
+                        // a pinned property may not exist on this project's session table version —
+                        // remember the failing set so subsequent batches skip the wide query
+                        response = await api.queryHogQL(
+                            buildPropertiesQuery(sessionIds, oldestTimestamp, newestTimestamp, []),
+                            QUERY_TAGS
+                        )
+                        actions.markExtraPropertiesUnqueryable(extraSessionProperties)
                     }
                     const loadTimeMs = performance.now() - startTime
 
                     actions.reportRecordingsListPropertiesFetched(loadTimeMs)
 
                     breakpoint()
-                    return (response.results || []).map((x: any): SessionRecordingPropertiesType => {
-                        const properties: Record<string, any> = {
-                            $geoip_country_code: x[1],
-                            $browser: x[2],
-                            $device_type: x[3],
-                            $os: x[4],
-                            $os_name: x[5],
-                            $entry_referring_domain: x[6],
-                            $geoip_subdivision_1_name: x[7],
-                            $geoip_city_name: x[8],
-                            $entry_current_url: x[9],
-                        }
-                        // null out extras that failed to load, so cached entries read as complete and don't refetch
-                        extraSessionProperties.forEach((property, index) => {
-                            properties[property] = extrasQueried ? x[10 + index] : null
+                    return (response.results || []).map((row: any[]): SessionRecordingPropertiesType => {
+                        const cachedProperties = values.recordingPropertiesById[row[0]]
+                        const properties: Record<string, any> = {}
+                        BASE_PROPERTIES.forEach((property, index) => {
+                            properties[property] = row[index + 1]
                         })
-                        return { id: x[0], properties }
+                        // fallback rows have no extra columns — keep cached values (or null) so entries read as complete
+                        extraSessionProperties.forEach((property, index) => {
+                            properties[property] =
+                                row[BASE_PROPERTIES.length + 1 + index] ?? cachedProperties?.[property] ?? null
+                        })
+                        return { id: row[0], properties }
                     })
                 },
             },
         ],
-    })),
-
-    listeners(({ actions, values }) => ({
-        maybeLoadPropertiesForSessions: ({ sessions }) => {
-            const wantedSessionProperties = pinnedSessionProperties(values.pinnedProperties)
-            const newSessions = sessions.filter((session) => {
-                const cached = values.recordingPropertiesById[session.id]
-                return !cached || wantedSessionProperties.some((property) => !(property in cached))
-            })
-
-            if (newSessions.length > 0) {
-                actions.loadPropertiesForSessions(newSessions)
-            }
-        },
     })),
 
     reducers({
@@ -162,5 +157,43 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                 },
             },
         ],
+        unqueryableExtraProperties: [
+            null as string[] | null,
+            {
+                markExtraPropertiesUnqueryable: (_, { properties }) => properties,
+            },
+        ],
     }),
+
+    selectors({
+        extraSessionProperties: [
+            (s) => [s.pinnedProperties, s.unqueryableExtraProperties],
+            (pinnedProperties, unqueryableExtraProperties): string[] => {
+                const extras = pinnedSessionProperties(pinnedProperties)
+                // while the pin set that failed to query is unchanged, don't retry it
+                if (
+                    unqueryableExtraProperties &&
+                    extras.length === unqueryableExtraProperties.length &&
+                    extras.every((property, index) => property === unqueryableExtraProperties[index])
+                ) {
+                    return []
+                }
+                return extras
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        maybeLoadPropertiesForSessions: ({ sessions }) => {
+            const wantedSessionProperties = values.extraSessionProperties
+            const newSessions = sessions.filter((session) => {
+                const cached = values.recordingPropertiesById[session.id]
+                return !cached || wantedSessionProperties.some((property) => !(property in cached))
+            })
+
+            if (newSessions.length > 0) {
+                actions.loadPropertiesForSessions(newSessions)
+            }
+        },
+    })),
 ])


### PR DESCRIPTION
## Problem

Pinning a session property like `$entry_utm_medium` or `$channel_type` on the recording overview tab always renders `-`.
The recording properties query only fetches a hardcoded set of nine properties, so other pinned session properties are never fetched.

## Changes

- The recording properties query now also selects pinned session properties (whitelisted against the session properties taxonomy, escaped as HogQL identifiers).
- Cached sessions missing a newly pinned session property are refetched.
- If the extended query fails (a pinned key can be absent on a project's session table version), the loader falls back to the base properties, preserves cached values, and remembers the failed pin set so it doesn't retry every batch.

## How did you test this code?

Added 3 cases to `sessionRecordingsListPropertiesLogic.test.ts`: pinned session properties are queried and mapped (the original bug), cached sessions refetch when a new property is pinned, and a failing extended query falls back without clobbering cached values or looping.
No manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a support ticket triage, then a multi-agent cleanup pass. Skills: `/writing-kea-logics`, `/writing-tests`. Key decision: static taxonomy whitelist plus runtime fallback instead of the version-aware property-definitions endpoint (deeper fix, deferred).