### PR TITLE
fix(metrics): correct fingerprint doc, pin little-endian prefixes

### DIFF
--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -371,9 +371,10 @@ fn compute_series_fingerprint(
     hasher.finish() as i64
 }
 
-/// Length-prefixed so e.g. {"ab":"c"} and {"a":"bc"} can never collide.
+/// Length-prefixed so e.g. {"ab":"c"} and {"a":"bc"} can never collide. Lengths are
+/// written little-endian (not native `write_u64`) so the id is identical on any host.
 fn hash_str(hasher: &mut SipHasher13, s: &str) {
-    hasher.write_u64(s.len() as u64);
+    hasher.write(&(s.len() as u64).to_le_bytes());
     hasher.write(s.as_bytes());
 }
 
@@ -381,7 +382,7 @@ fn hash_str(hasher: &mut SipHasher13, s: &str) {
 fn hash_sorted_map(hasher: &mut SipHasher13, map: &HashMap<String, String>) {
     let mut pairs: Vec<(&str, &str)> = map.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
     pairs.sort_unstable();
-    hasher.write_u64(pairs.len() as u64);
+    hasher.write(&(pairs.len() as u64).to_le_bytes());
     for (key, value) in pairs {
         hash_str(hasher, key);
         hash_str(hasher, value);

--- a/rust/capture-logs/src/metrics_avro_schema.rs
+++ b/rust/capture-logs/src/metrics_avro_schema.rs
@@ -121,7 +121,7 @@ pub const METRICS_AVRO_SCHEMA: &str = r#"
     "name": "series_fingerprint",
     "type": ["null", "long"],
     "default": null,
-    "doc": "Stable per-series identity assigned at ingest (hash of metric_name + sorted resource/data-point attributes). Stored verbatim by ClickHouse, never recomputed. u64 bits carried as a signed long."
+    "doc": "Stable per-series identity assigned at ingest (hash of metric_name, metric_type, service_name, and sorted resource/data-point attributes). Stored verbatim by ClickHouse, never recomputed. u64 bits carried as a signed long."
     }
 ]
 }"#;


### PR DESCRIPTION
## Problem

The ingest `series_fingerprint` work (#67195, merged) left two small snags a future debugger would trip on.

The Avro schema doc for `series_fingerprint` says the hash covers "metric_name + sorted resource/data-point attributes".
That is stale: the id also includes `metric_type` and `service_name`.
Someone chasing a `metric_series` ↔ `metric_samples` join mismatch would trust that doc and look in the wrong place.

The label length prefixes were hashed with `Hasher::write_u64`, which is native-endian.
Our fleet is little-endian and the golden test pins the value, so the id is correct everywhere it runs today.
But the encoding is host-defined rather than explicit, so a big-endian host would silently compute a different id.

## Changes

- Avro `series_fingerprint` doc now lists all identity components: metric_name, metric_type, service_name, and the sorted resource/data-point attributes.
- `hash_str` / `hash_sorted_map` write the u64 length prefixes with `to_le_bytes` instead of `write_u64`, so the id is platform-defined.

No behavior change on the little-endian fleet: the golden fingerprint test value is unchanged, because `write_u64` already emits little-endian bytes there.

## How did you test this code?

I (Claude) ran the `capture-logs` fingerprint unit tests locally: `cargo test -p capture-logs --lib metric_record::tests::test_series_fingerprint`.
All six pass, including the pinned golden (`test_series_fingerprint_is_pinned`), which is unchanged — that is what confirms the endianness edit is a pure refactor on this host.
`cargo fmt` and `cargo clippy -p capture-logs --lib --tests` are clean.
I did not run anything against a real ClickHouse cluster or Kafka.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. Internal doc-comment only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel flagged both nits while reviewing the fingerprint stack; I (Claude, via PostHog Code) made the changes.
The substantive fingerprint work already merged in #67195, so these follow-ups go in a fresh PR off master rather than through the ClickHouse PR (#67196), which is deliberately ClickHouse-only.

The one judgment call was whether `to_le_bytes` would move the golden fingerprint.
It does not on a little-endian host (`write_u64` defaults to `to_ne_bytes`, which equals `to_le_bytes` there), so the change is safe and the pinned test still holds.
No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
