### PR TITLE
fix(data-modeling): include endpoint nodes in v2 DAG executable set

### DIFF
--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -41,7 +41,7 @@ class DAG:
 def _get_dag_structure_async(team_id: int, dag_id: str) -> DAG:
     """Retrieve all nodes and edges for a DAG from the database."""
     nodes = Node.objects.filter(team_id=team_id, dag_id=dag_id)
-    executable_nodes = nodes.filter(type__in=[NodeType.VIEW, NodeType.MAT_VIEW])
+    executable_nodes = nodes.filter(type__in=[NodeType.VIEW, NodeType.MAT_VIEW, NodeType.ENDPOINT])
     ephemeral_nodes = executable_nodes.filter(type=NodeType.VIEW)
     edges = (
         Edge.objects.prefetch_related("source", "target")

--- a/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
@@ -146,6 +146,30 @@ class TestGetDagStructureActivity:
         assert len(dag.executable_nodes) == 0
         assert len(dag.edges) == 0
 
+    async def test_endpoint_nodes_are_executable(self, activity_environment, ateam, auser):
+        # endpoints on a v2 DAG schedule must materialize; dropping ENDPOINT from the
+        # executable filter silently stops their refresh (v1 frequency is cleared on migrate)
+        dag = await database_sync_to_async(DAG.objects.create)(team=ateam, name="test-endpoint-dag")
+        endpoint_query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+            team=ateam,
+            name="endpoint_executable_test",
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            created_by=auser,
+        )
+        endpoint_node = await database_sync_to_async(Node.objects.create)(
+            team=ateam,
+            dag=dag,
+            type=NodeType.ENDPOINT,
+            saved_query=endpoint_query,
+        )
+        inputs = GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(dag.id))
+        result = await activity_environment.run(get_dag_structure_activity, inputs)
+        assert str(endpoint_node.id) in result.executable_nodes
+        assert str(endpoint_node.id) not in result.ephemeral_nodes
+        await database_sync_to_async(endpoint_node.delete)()
+        await database_sync_to_async(dag.delete)()
+        await database_sync_to_async(endpoint_query.delete)()
+
     async def test_identifies_ephemeral_nodes(self, activity_environment, ateam, auser):
         """Test that ephemeral (VIEW) nodes are correctly identified."""
         dag = await database_sync_to_async(DAG.objects.create)(team=ateam, name="test-ephemeral-dag")


### PR DESCRIPTION
> Claude-written:

## Problem

Endpoint nodes on the v2 data-modeling backend silently stop refreshing. `ExecuteDAGWorkflow`'s structure activity filters executable nodes to `VIEW` and `MAT_VIEW` only, so an `ENDPOINT` node is never picked up by a DAG run. Migrating a team to a v2 DAG schedule also clears the endpoint's v1 per-query sync frequency, which leaves the endpoint with no refresh path at all - the schedule fires, the endpoint is skipped, and its materialized data goes stale indefinitely.

This also blocks upcoming per-node freshness scheduling (#67395): a cadence tier containing only endpoint nodes would fire forever and execute nothing.

## Changes

One line in `posthog/temporal/data_modeling/activities/get_dag_structure.py`: add `NodeType.ENDPOINT` to the executable-node filter. Endpoint nodes are materialized like matviews (they are not ephemeral views), so no other behavior changes.

## How did you test this code?

Added `test_endpoint_nodes_are_executable` to the existing `TestGetDagStructureActivity` suite - it creates an `ENDPOINT` node and asserts it lands in `executable_nodes` (and not in `ephemeral_nodes`). No existing test covered the `ENDPOINT` type in the executable filter, and this one fails against the unfixed code (verified by running it with the fix stashed). Full `TestGetDagStructureActivity` suite passes locally (6 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during a review session on the per-node freshness targets branch, where the missing `ENDPOINT` type surfaced as a hard prerequisite for tiered DAG scheduling. `/writing-tests` was invoked before adding the regression test; the test was verified to fail without the fix before opening this PR.
