### PR TITLE
fix(persons): shrink team-delete batch size to clear personhog deadline storm

### DIFF
--- a/posthog/models/person/test/test_delete_personless_personhog.py
+++ b/posthog/models/person/test/test_delete_personless_personhog.py
@@ -45,4 +45,4 @@ class TestDeletePersonlessDistinctIdsForTeamsRPC(BaseTest):
             team_ids_called = {c.request.team_id for c in calls}
             assert self.team.pk in team_ids_called
             assert other_team.pk in team_ids_called
-            assert all(c.request.batch_size == 10000 for c in calls)
+            assert all(c.request.batch_size == 2000 for c in calls)

--- a/posthog/models/team/test_util_deletion.py
+++ b/posthog/models/team/test_util_deletion.py
@@ -99,7 +99,7 @@ class TestDeleteHashKeyOverridesForTeams(SimpleTestCase):
         assert mock_client.delete_hash_key_overrides_by_teams.call_count == 1
         req = mock_client.delete_hash_key_overrides_by_teams.call_args[0][0]
         assert list(req.team_ids) == [1, 2, 3]
-        assert req.batch_size == 10000
+        assert req.batch_size == 2000
 
     @patch(_CLIENT_PATCH)
     def test_loops_until_zero_deleted(self, mock_get_client):

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -13,6 +13,13 @@ from products.batch_exports.backend.service import BatchExportServiceScheduleNot
 
 logger = structlog.get_logger(__name__)
 
+# Batch size for the personhog batch-delete RPCs on the largest team-scoped tables
+# (personless distinct IDs, persons, hash-key-overrides). Kept well below 10000 so each
+# DELETE commits comfortably inside the personhog gRPC deadline on multi-billion-row
+# tables; otherwise a batch that overruns the deadline is rolled back wholesale and the
+# activity retries with zero forward progress.
+TEAM_DELETE_BATCH_SIZE = 2000
+
 actions_that_require_current_team = [
     "rotate_secret_token",
     "delete_secret_token_backup",
@@ -82,7 +89,7 @@ def _delete_hash_key_overrides_for_teams(team_ids: list[int]) -> None:
     def _fn() -> None:
         while True:
             resp = client.delete_hash_key_overrides_by_teams(
-                DeleteHashKeyOverridesByTeamsRequest(team_ids=team_ids, batch_size=10000)
+                DeleteHashKeyOverridesByTeamsRequest(team_ids=team_ids, batch_size=TEAM_DELETE_BATCH_SIZE)
             )
             if resp.deleted_count == 0:
                 break
@@ -115,7 +122,7 @@ def _delete_personless_distinct_ids_for_team_via_personhog(team_id: int) -> None
 
     while True:
         resp = client.delete_personless_distinct_ids_batch_for_team(
-            DeletePersonlessDistinctIdsBatchForTeamRequest(team_id=team_id, batch_size=10000)
+            DeletePersonlessDistinctIdsBatchForTeamRequest(team_id=team_id, batch_size=TEAM_DELETE_BATCH_SIZE)
         )
         if resp.deleted_count == 0:
             break
@@ -154,7 +161,9 @@ def _delete_persons_for_team_via_personhog(team_id: int) -> None:
     client = require_personhog_client()
 
     while True:
-        resp = client.delete_persons_batch_for_team(DeletePersonsBatchForTeamRequest(team_id=team_id, batch_size=10000))
+        resp = client.delete_persons_batch_for_team(
+            DeletePersonsBatchForTeamRequest(team_id=team_id, batch_size=TEAM_DELETE_BATCH_SIZE)
+        )
         if resp.deleted_count == 0:
             break
 


### PR DESCRIPTION
## Problem

Team deletion drives batched `DELETE`s on the persons DB through personhog RPCs. For the largest team-scoped tables the batch size was 10000, which on multi-billion-row tables can push a single batch past the personhog gRPC deadline. When that happens the batch is rolled back wholesale (`rows_affected=0`), the personhog call reraises, and the Temporal `delete-teams-data` activity retries and runs the exact same oversized batch again. The result is a lot of wasted I/O on the persons primary and little to no forward progress on the deletion.

This showed up in prod-eu as a persistently slow `DELETE FROM posthog_personlessdistinctid ... LIMIT $2 FOR UPDATE SKIP LOCKED` on the `posthog_personlessdistinctid` table (~23B rows, ~2.8 TB of indexes), with the personhog-replica logging repeated deadline overruns.

## Changes

Introduce `TEAM_DELETE_BATCH_SIZE = 2000` in `posthog/models/team/util.py` and use it for the three largest team-scoped delete loops:

- `_delete_personless_distinct_ids_for_team_via_personhog` (`posthog_personlessdistinctid`)
- `_delete_persons_for_team_via_personhog` (`posthog_person`)
- `_delete_hash_key_overrides_for_teams` (`posthog_featureflaghashkeyoverride`)

Groups and group-type-mappings stay at 10000 (small tables, no deadline pressure).

`batch_size` is caller-supplied and validated `1..=50000` on the personhog side, which passes it straight to the SQL `LIMIT`. So this is a caller-side (Temporal) change only. No proto, rust, migration, or shared-client change. Semantics are unchanged: still `FOR UPDATE SKIP LOCKED`, still loops until a batch returns zero. Smaller batches just mean more, faster, individually-committing RPC round-trips that stay inside the deadline.

The already-running deletion workflows re-enter their `while` loop fresh on each activity retry, so they pick up the smaller batch on the next retry after deploy and resume steady progress without manual intervention.

## How did you test this code?

I (Claude, agent-assisted) updated the two tests that pinned the old batch size (`test_delete_personless_personhog.py` and the hash-key-overrides assertion in `test_util_deletion.py`) to expect 2000; groups and group-type-mappings assertions stay at 10000. I did not run manual end-to-end team deletion against a real persons DB. Reviewers should rely on the existing unit tests plus the reasoning above; the value (2000) is a conservative pick that leaves comfortable headroom under the deadline and can be tuned later if needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Eli directed this work; I (Claude) investigated and implemented it. The investigation traced the prod-eu slow query end to end: the pganalyze fingerprint maps byte-for-byte to the SQL in `rust/personhog-replica/src/storage/postgres/person.rs`, whose `LIMIT` binds directly to the RPC `batch_size`, and the only production caller is `posthog/models/team/util.py`. That ruled out a personhog/global change and pointed at the caller-side batch size as the surgical fix.

We considered raising the personhog gRPC timeout instead, but rejected it: it is a shared client-wide setting and would leave long, lock-holding deletes in place rather than guaranteeing per-batch forward progress. We also considered 5000 (too close to the deadline the current 10000 already trips) and 1000 (more headroom, more round-trips), and settled on 2000 as the balance. No repo skills were required for this change.