### PR TITLE
fix(replay): make email redaction linear to stop quadratic scrub blowups

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/text.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/text.test.ts
@@ -1,5 +1,5 @@
 import { defaultAllowLists } from './default-dict'
-import { scrubText } from './text'
+import { redactEmails, scrubText } from './text'
 
 describe('anonymize/text', () => {
     const allow = defaultAllowLists()
@@ -55,5 +55,26 @@ describe('anonymize/text', () => {
         // `to`/`in` are stop-words the tokenizer would keep, but the email pass nukes the address first.
         expect(scrub('to jane.doe@in.example.com')).toBe('to ' + '*'.repeat('jane.doe@in.example.com'.length))
         expect(scrub('email a@b.co')).not.toContain('a@b.co')
+    })
+
+    test.each([
+        ['a@.co', 'a@.co'],
+        ['a@b.c', 'a@b.c'],
+        ['a@b.co', '******'],
+        ['user@example.com2', '****************2'],
+        ['a@b@c.com', 'a@*******'],
+        ['first@a.com second@b.org', '*********** ************'],
+        ['user@example.co.uk', '******************'],
+        ['trailing@dot.com...', '****************...'],
+    ])('redactEmails boundary semantics: %s', (input, expected) => {
+        expect(redactEmails(input).value).toBe(expected)
+    })
+
+    it('scales linearly on a long unbroken email-charset run (no regex backtracking)', () => {
+        // A backtracking email regex is O(n²) here: ~35s at this size vs ~10ms linear.
+        const run = 'A1b2C3d4'.repeat((256 * 1024) / 8)
+        const start = performance.now()
+        scrub(run)
+        expect(performance.now() - start).toBeLessThan(5000)
     })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/text.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/text.ts
@@ -10,17 +10,75 @@ export interface ScrubResult {
 // A "word" is a maximal run of word chars: Unicode letters/numbers, `_`, `'`, `’`.
 const WORD_RE = /[\p{L}\p{N}_'’]+/gu
 
-// Guaranteed email-PII pass, run over all text
-const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g
-
-/** Redact any email addresses in `input` (length-preserving). Safe to run anywhere. */
+// Guaranteed email-PII pass, run over all text. Hand-rolled scan (expand around each `@`,
+// equivalent to /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g) because that regex
+// backtracks quadratically on long unbroken charset runs (base64 bodies: minutes per event).
 export function redactEmails(input: string): ScrubResult {
+    let at = input.indexOf('@')
+    if (at === -1) {
+        return { value: input, changed: false }
+    }
+    let out = ''
+    let last = 0
     let changed = false
-    const value = input.replace(EMAIL_RE, (m) => {
-        changed = true
-        return REDACT_CHAR.repeat(codePointLength(m))
-    })
-    return { value, changed }
+    while (at !== -1) {
+        let start = at
+        while (start > last && isLocalChar(input.charCodeAt(start - 1))) {
+            start--
+        }
+        let scanEnd = at + 1
+        while (scanEnd < input.length && isDomainChar(input.charCodeAt(scanEnd))) {
+            scanEnd++
+        }
+        const end = trimDomainToTld(input, at + 1, scanEnd)
+        if (start < at && end !== -1) {
+            out += input.slice(last, start) + REDACT_CHAR.repeat(codePointLength(input.slice(start, end)))
+            last = end
+            changed = true
+            at = input.indexOf('@', end)
+        } else {
+            at = input.indexOf('@', at + 1)
+        }
+    }
+    if (!changed) {
+        return { value: input, changed: false }
+    }
+    return { value: out + input.slice(last), changed }
+}
+
+/** Longest `end` in (domainStart, scanEnd] where the domain ends with `.` + ≥2 letters, or -1. */
+function trimDomainToTld(input: string, domainStart: number, scanEnd: number): number {
+    let i = scanEnd
+    while (i > domainStart) {
+        let letters = 0
+        while (i > domainStart && isAsciiLetter(input.charCodeAt(i - 1))) {
+            i--
+            letters++
+        }
+        if (letters >= 2 && i - 1 > domainStart && input.charCodeAt(i - 1) === 0x2e /* . */) {
+            return i + letters
+        }
+        i-- // skip the non-letter (or short-TLD dot) and keep looking left
+    }
+    return -1
+}
+
+function isAsciiLetter(c: number): boolean {
+    return (c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a)
+}
+
+function isAsciiAlphanumeric(c: number): boolean {
+    return isAsciiLetter(c) || (c >= 0x30 && c <= 0x39)
+}
+
+// [A-Za-z0-9._%+-]
+function isLocalChar(c: number): boolean {
+    return isAsciiAlphanumeric(c) || c === 0x2e || c === 0x5f || c === 0x25 || c === 0x2b || c === 0x2d
+}
+
+// [A-Za-z0-9.-]
+function isDomainChar(c: number): boolean {
+    return isAsciiAlphanumeric(c) || c === 0x2e || c === 0x2d
 }
 
 export function scrubText(ctx: ScrubContext, input: string): ScrubResult {


### PR DESCRIPTION
## Problem

The ml-mirror anonymizer's email pass used a regex that backtracks quadratically on long unbroken email-charset runs (e.g. base64 request bodies in `rrweb/network@1` payloads). Single events took 10–76s of synchronous scrub time in prod (confirmed via the `anonymize_slow_breakdown` instrumentation from #67340), blocking the event loop and feeding the liveness-kill/rebalance churn on the mirror lane.

## Changes

- Replace `EMAIL_RE` in `redactEmails` with an equivalent linear scan: find each `@`, expand over local/domain charsets, trim the domain back to a valid `.tld` tail.
- Output is byte-identical to the old regex (verified with a differential harness: edge cases, real captured payloads, 20k fuzz inputs — 0 mismatches).

## How did you test this code?

- Captured slow prod messages replayed locally: worst case dropped from ~18s to ~9ms.
- New `test.each` locks the scan's boundary semantics (invalid domains, TLD trim-back, multi-`@`, adjacent emails) — regressions a future edit to the hand-rolled scan could introduce.
- New scaling test fails on any quadratic implementation (the existing suite passed with the bug in).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused from prod slow-message locators (#67444); fix verified against captured payloads locally.