### PR TITLE
feat(mcp-analytics): source intent clustering corpus from event-level $mcp_intent

### DIFF
--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -86,6 +86,12 @@ class IntentRecord:
 # DEFAULT_TOP_N_INTENTS=500 a larger sample only adds long-tail singletons.
 MAX_CORPUS_SESSIONS = 2000
 
+# Event-sourced intents are free text written by the calling agent — clip them
+# so one oversized value can't blow up embedding requests (the worker's model
+# has a token ceiling) or bloat the snapshot blob. Real intents are one or two
+# sentences; anything past this length adds no clustering signal.
+MAX_INTENT_TEXT_LENGTH = 1000
+
 # First (chronological) $mcp_intent per session — the agent's opening task
 # statement, used as the session's representative intent unless an on-demand
 # LLM summary exists in Postgres. Ordering by cityHash64(session_id) is a
@@ -190,7 +196,7 @@ def fetch_intent_corpus(
     intent_by_session: dict[str, str] = {}
     for row in intent_response.results or []:
         session_id = str(row[0] or "")
-        text = str(row[1] or "").strip()
+        text = str(row[1] or "").strip()[:MAX_INTENT_TEXT_LENGTH]
         if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:
             continue
         intent_by_session[session_id] = text
@@ -203,7 +209,7 @@ def fetch_intent_corpus(
         "session_id", "intent"
     )
     for session_id, intent_text in session_rows:
-        text = (intent_text or "").strip()
+        text = (intent_text or "").strip()[:MAX_INTENT_TEXT_LENGTH]
         if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:
             continue
         intent_by_session[session_id] = text

--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -9,9 +9,11 @@ each stage as a pure function over numpy arrays / dataclasses makes the
 algorithm validatable without touching ClickHouse, Postgres, or the embedding
 service.
 
-Why ``$mcp_intent`` per-event for v1: a session-level summarised-intent table is
-being built in parallel. ``fetch_intent_corpus`` is the only function that needs
-to change when that table lands — swap its body to read from the new source.
+Intent sources: the corpus is built from the ``$mcp_intent`` recorded on tool-call
+events (the first intent of each session, sampled from ClickHouse), overlaid with
+the LLM-generated session summaries from ``posthog_mcp_session`` where those exist.
+Event intents give scale without any LLM dependency; summaries, generated on
+demand, win per session because they condense the whole session's intents.
 """
 
 import math
@@ -79,22 +81,47 @@ class IntentRecord:
 
 # Intent corpus -----------------------------------------------------------
 
-# Per-session tool stats: for each session_id we know about in Postgres, what
-# tools were called and how often. Joined in Python with the session→intent
-# map from Postgres so the same intent string can aggregate across sessions.
-# TODO(mcp-sessions): when the parallel-team posthog_mcp_session table ships,
-# change MCPSession.objects.filter(...) below to point at the real model.
+# Bound on sessions sampled from ClickHouse for the corpus. Keeps the IN-tuple
+# in the two per-session queries below at a sane size; with
+# DEFAULT_TOP_N_INTENTS=500 a larger sample only adds long-tail singletons.
+MAX_CORPUS_SESSIONS = 2000
+
+# First (chronological) $mcp_intent per session — the agent's opening task
+# statement, used as the session's representative intent unless an on-demand
+# LLM summary exists in Postgres. Ordering by cityHash64(session_id) is a
+# deterministic pseudo-random sample: unbiased across the window (newest-first
+# would collapse the corpus to the last few hours at production volume) and
+# stable across reruns, so repeat runs re-hit the embedding cache.
+# NB: `$session_id` is the materialised events column ('' when absent), NOT the
+# `properties.` accessor — same rationale as logic.py's session SQL.
+_SESSION_FIRST_INTENT_SQL = """
+SELECT
+    $session_id AS session_id,
+    argMin(toString(properties.$mcp_intent), timestamp) AS first_intent
+FROM events
+WHERE event = {event}
+    AND timestamp >= now() - INTERVAL {lookback_days} DAY
+    AND $session_id != ''
+    AND coalesce(toString(properties.$mcp_intent), '') != ''
+GROUP BY session_id
+ORDER BY cityHash64(session_id)
+LIMIT {max_sessions}
+"""
+
+# Per-session tool stats: for each session in the corpus, what tools were
+# called and how often. Joined in Python with the session→intent map so the
+# same intent string can aggregate across sessions.
 # TODO(intent-routing): chaining is by $session_id today; swap to
 # $mcp_session_id once tool calls carry it consistently.
 _SESSION_TOOL_STATS_SQL = """
 SELECT
-    properties.$session_id AS session_id,
+    $session_id AS session_id,
     toString(properties.$mcp_tool_name) AS tool_name,
     countIf(toString(properties.$mcp_is_error) NOT IN ('true', '1')) AS success_count,
     countIf(toString(properties.$mcp_is_error) IN ('true', '1')) AS error_count
 FROM events
 WHERE event = {event}
-    AND properties.$session_id IN {session_ids}
+    AND $session_id IN {session_ids}
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
     AND timestamp >= now() - INTERVAL {lookback_days} DAY
@@ -105,7 +132,7 @@ GROUP BY session_id, tool_name
 # arraySort on (timestamp, tool) tuples preserves call order.
 _SESSION_JOURNEY_SQL = """
 SELECT
-    properties.$session_id AS session_id,
+    $session_id AS session_id,
     arrayMap(
         x -> x.2,
         arraySort(
@@ -116,7 +143,7 @@ SELECT
     countIf(toString(properties.$mcp_is_error) IN ('true', '1')) > 0 AS had_error
 FROM events
 WHERE event = {event}
-    AND properties.$session_id IN {session_ids}
+    AND $session_id IN {session_ids}
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
     AND timestamp >= now() - INTERVAL {lookback_days} DAY
@@ -131,30 +158,50 @@ def fetch_intent_corpus(
 ) -> tuple[list[IntentRecord], dict[str, str]]:
     """Return ``(records, intent_by_session)`` for clustering.
 
-    The intent text comes from posthog_mcp_session (Postgres), one row per
-    MCP session. Tool stats come from ClickHouse $mcp_tool_call events joined
-    by session_id. Same intent string repeated across sessions aggregates.
+    Each session's intent text is the first ``$mcp_intent`` it recorded (sampled
+    from ClickHouse, capped at ``MAX_CORPUS_SESSIONS``), overridden by the
+    on-demand LLM summary from posthog_mcp_session where one exists — the
+    summary condenses the whole session, so it wins. Tool stats come from
+    ClickHouse $mcp_tool_call events joined by session_id. Same intent string
+    repeated across sessions aggregates.
 
     ``intent_by_session`` is exposed so callers can later join session-level
     data (e.g. journey aggregation) back to the cluster a session belongs to.
 
-    ``lookback_days`` bounds both stores to the same window: session intent
-    rows are filtered by ``created_at`` (when the intent was generated, since
-    intents are produced on demand), and the joined ClickHouse query filters by
-    event timestamp.
+    ``lookback_days`` bounds both stores to the same window: event queries
+    filter by timestamp, and session intent rows are filtered by ``created_at``
+    (when the intent was generated, since intents are produced on demand).
     """
-    window_start = timezone.now() - timedelta(days=lookback_days)
-    session_rows = list(
-        MCPSession.objects.filter(team=team, created_at__gte=window_start).values_list("session_id", "intent")
+    intent_query = parse_select(
+        _SESSION_FIRST_INTENT_SQL,
+        placeholders={
+            "event": ast.Constant(value=MCP_TOOL_CALL_EVENT),
+            "lookback_days": ast.Constant(value=lookback_days),
+            "max_sessions": ast.Constant(value=MAX_CORPUS_SESSIONS),
+        },
     )
-    if not session_rows:
-        return [], {}
+    with tags_context(product=Product.MCP, feature=Feature.QUERY, team_id=team.id):
+        intent_response = execute_hogql_query(query=intent_query, team=team)
 
-    # Map session_id -> intent_text (last write wins per session).
-    # Skip the summariser's "no intents recorded" placeholder — clustering
-    # it produces a meaningless pseudo-cluster of sessions with nothing in
-    # common except that their tool calls had no $mcp_intent property.
+    # Map session_id -> intent_text. Skip the summariser's "no intents
+    # recorded" placeholder — clustering it produces a meaningless
+    # pseudo-cluster of sessions with nothing in common except that their
+    # tool calls had no $mcp_intent property.
     intent_by_session: dict[str, str] = {}
+    for row in intent_response.results or []:
+        session_id = str(row[0] or "")
+        text = str(row[1] or "").strip()
+        if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:
+            continue
+        intent_by_session[session_id] = text
+
+    # Overlay LLM-generated session summaries, and include summarised sessions
+    # the event sample missed (e.g. generated for a session whose events sit
+    # just outside the sampled set).
+    window_start = timezone.now() - timedelta(days=lookback_days)
+    session_rows = MCPSession.objects.filter(team=team, created_at__gte=window_start).values_list(
+        "session_id", "intent"
+    )
     for session_id, intent_text in session_rows:
         text = (intent_text or "").strip()
         if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -24,6 +24,7 @@ from products.mcp_analytics.backend import intent_clustering
 from products.mcp_analytics.backend.intent_clustering import (
     DEFAULT_DISTANCE_THRESHOLD,
     EMBEDDING_MODEL,
+    MAX_INTENT_TEXT_LENGTH,
     NO_INTENT_RECORDED_FALLBACK,
     IntentRecord,
     _content_hash,
@@ -381,6 +382,17 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
 
         assert intent_by_session == {"session-a": "Condensed LLM summary of the session"}
         assert [r.intent_text for r in records] == ["Condensed LLM summary of the session"]
+
+    def test_oversized_event_intent_is_clipped(self) -> None:
+        # Agents control the intent text — an unbounded value would flow into
+        # embedding requests and the snapshot blob.
+        self._seed_tool_call("session-big", "execute_sql", intent="x" * (MAX_INTENT_TEXT_LENGTH * 5))
+        flush_persons_and_events()
+
+        records, intent_by_session = fetch_intent_corpus(self.team)
+
+        assert intent_by_session == {"session-big": "x" * MAX_INTENT_TEXT_LENGTH}
+        assert [len(r.intent_text) for r in records] == [MAX_INTENT_TEXT_LENGTH]
 
     @parameterized.expand(
         [

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -253,18 +253,28 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
         # created_at is auto_now_add, so override it directly to position the row in the lookback window.
         MCPSession.objects.filter(pk=session.pk).update(created_at=datetime.now(tz=UTC) + created_at_offset)
 
-    def _seed_tool_call(self, session_id: str, tool_name: str, is_error: bool = False) -> None:
+    def _seed_tool_call(
+        self,
+        session_id: str,
+        tool_name: str,
+        is_error: bool = False,
+        intent: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        properties: dict[str, Any] = {
+            "$session_id": session_id,
+            "$mcp_tool_name": tool_name,
+            "$mcp_is_error": is_error,
+        }
+        if intent is not None:
+            properties["$mcp_intent"] = intent
         _create_event(
             event_uuid=uuid.uuid4(),
             event="$mcp_tool_call",
             team=self.team,
             distinct_id="seed",
-            timestamp=datetime.now(tz=UTC) - timedelta(hours=1),
-            properties={
-                "$session_id": session_id,
-                "$mcp_tool_name": tool_name,
-                "$mcp_is_error": is_error,
-            },
+            timestamp=timestamp or (datetime.now(tz=UTC) - timedelta(hours=1)),
+            properties=properties,
         )
 
     def test_returns_empty_when_no_sessions(self) -> None:
@@ -331,6 +341,67 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
         records, _ = fetch_intent_corpus(self.team, lookback_days=lookback_days)
 
         assert [r.intent_text for r in records] == expected_intents
+
+    def test_builds_corpus_from_event_intents_without_session_rows(self) -> None:
+        # Two intents in one session: the chronologically first one represents it.
+        self._seed_tool_call(
+            "session-a",
+            "execute_sql",
+            intent="find slow queries",
+            timestamp=datetime.now(tz=UTC) - timedelta(hours=2),
+        )
+        self._seed_tool_call("session-a", "query_trends", intent="chart the slow queries")
+        # Calls without an intent still count toward the session's tool stats.
+        self._seed_tool_call("session-a", "insight_create")
+        self._seed_tool_call("session-b", "feature_flag_get", intent="check flag rollout", is_error=True)
+        # Sessionless intent events must not enter the corpus.
+        self._seed_tool_call("", "execute_sql", intent="orphan intent")
+        flush_persons_and_events()
+
+        records, intent_by_session = fetch_intent_corpus(self.team)
+
+        assert intent_by_session == {
+            "session-a": "find slow queries",
+            "session-b": "check flag rollout",
+        }
+        by_text = {r.intent_text: r for r in records}
+        assert by_text["find slow queries"].tool_counts == {
+            "execute_sql": 1,
+            "query_trends": 1,
+            "insight_create": 1,
+        }
+        assert by_text["check flag rollout"].error_counts == {"feature_flag_get": 1}
+
+    def test_llm_summary_overrides_event_intent(self) -> None:
+        self._seed_tool_call("session-a", "execute_sql", intent="raw first intent")
+        flush_persons_and_events()
+        self._seed_session("session-a", "Condensed LLM summary of the session")
+
+        records, intent_by_session = fetch_intent_corpus(self.team)
+
+        assert intent_by_session == {"session-a": "Condensed LLM summary of the session"}
+        assert [r.intent_text for r in records] == ["Condensed LLM summary of the session"]
+
+    @parameterized.expand(
+        [
+            ("default_7_excludes_old", 7, {}),
+            ("override_30_includes_old", 30, {"session-old": "old event intent"}),
+        ]
+    )
+    def test_event_intents_respect_lookback_window(
+        self, _name: str, lookback_days: int, expected: dict[str, str]
+    ) -> None:
+        self._seed_tool_call(
+            "session-old",
+            "execute_sql",
+            intent="old event intent",
+            timestamp=datetime.now(tz=UTC) - timedelta(days=10),
+        )
+        flush_persons_and_events()
+
+        _, intent_by_session = fetch_intent_corpus(self.team, lookback_days=lookback_days)
+
+        assert intent_by_session == expected
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

The intent clustering corpus reads only `posthog_mcp_session.intent`, which is populated on demand by the LLM summarizer. Most sessions never get a summary, so the daily clustering workflow has almost nothing to cluster - even though `$mcp_tool_call` events themselves now carry `$mcp_intent` on most calls (restored in #64586).

## Changes

- `fetch_intent_corpus` now samples each session's first recorded `$mcp_intent` from ClickHouse (deterministic `cityHash64` sample, capped at `MAX_CORPUS_SESSIONS`) and overlays the on-demand LLM session summaries where they exist. The summary condenses the whole session, so it wins per session.
- Session-id filters in the corpus and journey queries moved from the `properties.$session_id` JSON accessor to the materialised `$session_id` column, matching the rationale documented in `logic.py`.
- Removed stale TODOs referencing the pre-`MCPSession` world.

Downstream stages (embedding, clustering, journey aggregation, snapshot shape) are untouched - each session still maps to exactly one intent text.

## How did you test this code?

- `pytest products/mcp_analytics/backend/ posthog/temporal/mcp_analytics/` - 201 passed locally.
- New tests, each tied to a regression no existing test caught: event-derived corpus with no Postgres rows (the new ClickHouse query breaking would silently empty the corpus), LLM summary precedence over the raw event intent (overlay ordering flipping is a silent quality downgrade), and the lookback bound on the new query (dropping the timestamp clause would scan full history). Lookback variations are parameterized.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by Daniel. Skills invoked: /pr-slicing, /writing-tests, /get-stamp.
- I (Claude) considered clustering every unique event intent (the original v1 shape) but kept one representative intent per session so `intent_by_session` stays 1:1 and the journey aggregation downstream is untouched. The first chronological intent represents the session because the agent's opening task statement best describes its goal.
- Deterministic hash sampling was chosen over newest-first (which collapses the corpus to the most recent hours at volume) and over random sampling (stable resampling re-hits the embedding cache).
