### PR TITLE
fix(data-modeling): resolve cadence-tier schedule ids to their DAG id

### DIFF
--- a/products/data_modeling/backend/management/commands/delete_orphaned_saved_query_schedules.py
+++ b/products/data_modeling/backend/management/commands/delete_orphaned_saved_query_schedules.py
@@ -130,6 +130,11 @@ class Command(BaseCommand):
         valid_uuids: set[str] = set()
 
         for sid in target_ids:
+            if ":" in sid:
+                # "{dag_id}:{interval_seconds}" is a v2 cadence-tier execute-dag schedule,
+                # not a saved-query schedule — never sweep it as an orphan.
+                logger.warning("v2 cadence-tier schedule id, skipping", schedule_id=sid)
+                continue
             try:
                 UUID(sid)
                 valid_uuids.add(sid)

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -33,7 +33,8 @@ from products.data_modeling.backend.models import Node
 if TYPE_CHECKING:
     from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
-# v2 (DAG-based) schedules run this workflow; their schedule id is the DAG id. The v1 backend
+# v2 (DAG-based) schedules run this workflow; their schedule id is the bare DAG id, or
+# "{dag_id}:{interval_seconds}" for a per-cadence-tier schedule. The v1 backend
 # (`data-modeling-run`, one schedule per saved query) is frozen and being migrated away from.
 DATA_MODELING_EXECUTE_DAG_WORKFLOW = "data-modeling-execute-dag"
 
@@ -84,7 +85,9 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
             isinstance(action, ScheduleListActionStartWorkflow)
             and action.workflow == DATA_MODELING_EXECUTE_DAG_WORKFLOW
         ):
-            dag_ids.add(listing.id)
+            # A cadence-tier schedule id is "{dag_id}:{interval_seconds}"; a legacy id is the
+            # bare DAG id (no colon), which rsplit leaves untouched.
+            dag_ids.add(listing.id.rsplit(":", 1)[0])
     return dag_ids
 
 

--- a/products/data_modeling/backend/test/test_delete_orphaned_saved_query_schedules.py
+++ b/products/data_modeling/backend/test/test_delete_orphaned_saved_query_schedules.py
@@ -1,0 +1,11 @@
+from asgiref.sync import async_to_sync
+
+from products.data_modeling.backend.management.commands.delete_orphaned_saved_query_schedules import Command
+
+
+class TestFindOrphansFromIds:
+    def test_tier_schedule_ids_are_never_orphans(self):
+        # "{dag_id}:{seconds}" is a live v2 cadence-tier schedule; treating it as an orphan
+        # (the non-UUID fallback) would delete active DAG scheduling on operator input
+        orphans = async_to_sync(Command()._find_orphans_from_ids)({"018f2a00-0000-0000-0000-000000000000:900"})
+        assert orphans == set()

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -373,6 +373,32 @@ class TestGetV2ScheduledDagIds:
         assert captured["kwargs"]["query"] == "PostHogDagId IN ('dag-on-v2')"
         assert result == {"dag-on-v2"}
 
+    def test_tiered_schedule_ids_resolve_to_the_dag_id(self):
+        # cadence-tier schedules are "{dag_id}:{seconds}"; returning them raw would make every
+        # v2-detection consumer treat migrated DAGs as v1 and recreate v1 schedules
+        listings = [
+            self._listing("dag-a:900", "data-modeling-execute-dag"),
+            self._listing("dag-a:86400", "data-modeling-execute-dag"),
+            self._listing("dag-b", "data-modeling-execute-dag"),
+        ]
+
+        async def fake_list_schedules(*args, **kwargs):
+            async def gen():
+                for listing in listings:
+                    yield listing
+
+            return gen()
+
+        temporal = mock.Mock()
+        temporal.list_schedules = fake_list_schedules
+        with mock.patch(
+            "products.data_modeling.backend.schedule.async_connect",
+            new=mock.AsyncMock(return_value=temporal),
+        ):
+            result = get_v2_scheduled_dag_ids()
+
+        assert result == {"dag-a", "dag-b"}
+
     def test_empty_candidates_skips_temporal(self):
         connect = mock.AsyncMock()
         with mock.patch("products.data_modeling.backend.schedule.async_connect", new=connect):


### PR DESCRIPTION
> Claude-written:

## Problem

Per-node freshness scheduling (#67395) will replace the single per-DAG `data-modeling-execute-dag` schedule (schedule id == DAG id) with one schedule per cadence tier, id `{dag_id}:{interval_seconds}`. The v2-detection read side assumes schedule id == DAG id: `get_v2_scheduled_dag_ids` returns raw schedule ids. The moment a tiered schedule exists, a migrated DAG stops matching its own id and every consumer silently treats it as still-on-v1 - `schedule_materialization` recreates a v1 per-query schedule (with `trigger_immediately`), manual runs try to trigger a nonexistent v1 schedule, and `create_missing_saved_query_schedules` mass-recreates v1 schedules, undoing migration.

This lands separately from the wiring PR and must be deployed first, because it also has to survive a rollback of that PR: reverting the wiring while tiered schedules exist must not revert id resolution with it.

## Changes

- `get_v2_scheduled_dag_ids` parses the DAG id off the schedule id (`rsplit(":", 1)[0]`) - legacy bare ids contain no colon and pass through unchanged, so this is a no-op for every schedule that exists today.
- `delete_orphaned_saved_query_schedules --schedule-ids` treated any non-UUID id as a deletable orphan; a tier id passed by an operator would delete live DAG scheduling. Tier-shaped ids are now skipped with a warning.

## How did you test this code?

Automated only. Extended the existing `TestGetV2ScheduledDagIds` (mocked Temporal listing) with a case where tiered + bare ids resolve to their DAG ids - it fails against the old `listing.id` behavior. Added one test asserting the orphan sweeper never classifies a tier id as an orphan (the non-UUID fallback used to). Full `test_schedule.py` suite passes (48 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jovan directed this as part of planning the freshness-target wiring PR; I (Claude) wrote it. A design pressure-test surfaced that this read-side assumption was the single point where a rollback of the wiring PR would corrupt scheduling for migrated teams, which is why it ships standalone ahead of everything else.
