### PR TITLE
fix(toolbar): make clickmap element matching linear and position-aware

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/Users/paul/github/posthog/frontend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/paul/github/posthog/frontend/node_modules

--- a/frontend/src/lib/utils/actions.test.ts
+++ b/frontend/src/lib/utils/actions.test.ts
@@ -20,4 +20,31 @@ describe('elementToSelector', () => {
         const actual = elementToSelector(element, [])
         expect(actual).toEqual('.potato.soup')
     })
+
+    const dataAttributeValueCases = [
+        {
+            name: 'keeps dots unescaped so backend literal matching still works',
+            value: 'user.settings.save',
+            expected: '[data-attr="user.settings.save"]',
+        },
+        {
+            name: 'escapes quotes so a value cannot break out of the selector',
+            value: 'x"],[id="other',
+            expected: '[data-attr="x\\"],[id=\\"other"]',
+        },
+        {
+            name: 'escapes backslashes before quotes',
+            value: 'a\\"b',
+            expected: '[data-attr="a\\\\\\"b"]',
+        },
+    ]
+
+    it.each(dataAttributeValueCases)('$name', ({ value, expected }) => {
+        const element = {
+            attributes: { 'attr__data-attr': value },
+        } as unknown as ElementType
+
+        const actual = elementToSelector(element, ['data-attr'])
+        expect(actual).toEqual(expected)
+    })
 })

--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -58,7 +58,7 @@ export function elementToSelector(element: ElementType, dataAttributes: string[]
     let selector = ''
     const attribute = matchesDataAttribute(element, dataAttributes)
     if (attribute) {
-        selector += `[${attribute}="${element.attributes[`attr__${attribute}`]}"]`
+        selector += `[${attribute}="${CSS.escape(element.attributes[`attr__${attribute}`])}"]`
         return selector
     }
     if (element.attr_id) {

--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -54,11 +54,15 @@ export function matchesDataAttribute(element: ElementType, dataAttributes: strin
     }
 }
 
+// not CSS.escape: the backend selector parser matches quoted values literally, so escaping
+// anything beyond \ and " (e.g. the dots in data-attr="user.settings.save") breaks server-side matching
+const escapeQuotedSelectorValue = (value: string): string => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
 export function elementToSelector(element: ElementType, dataAttributes: string[]): string {
     let selector = ''
     const attribute = matchesDataAttribute(element, dataAttributes)
     if (attribute) {
-        selector += `[${attribute}="${CSS.escape(element.attributes[`attr__${attribute}`])}"]`
+        selector += `[${attribute}="${escapeQuotedSelectorValue(element.attributes[`attr__${attribute}`])}"]`
         return selector
     }
     if (element.attr_id) {

--- a/frontend/src/toolbar/TELEMETRY.md
+++ b/frontend/src/toolbar/TELEMETRY.md
@@ -153,15 +153,21 @@ Fired when a toolbar mode is toggled on or off.
 
 ### `toolbar clickmap processed`
 
-Fired when the clickmap finishes matching loaded element stats to DOM elements.
+Fired when a clickmap matching run ends, including runs cancelled because a newer run superseded them (see `completed`).
+A user paginating emits one event per page with cumulative `event_count` — group by `trigger` when aggregating.
 
-| Property                | Type      | Description                                                                                                      |
-| ----------------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
-| `event_count`           | `number`  | Element stats rows processed                                                                                     |
-| `matched_element_count` | `number`  | Rows matched to a visible DOM element                                                                            |
-| `page_element_count`    | `number`  | Elements collected from the page for matching                                                                    |
-| `has_shadow_roots`      | `boolean` | Whether open shadow roots were detected; selects which fallback implementation runs, not whether a fallback runs |
-| `duration_ms`           | `number`  | Wall-clock processing time, including main-thread yields; DOM index build time is included only on a cold cache  |
+| Property                 | Type      | Description                                                                                                      |
+| ------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------- |
+| `event_count`            | `number`  | Element stats rows processed                                                                                     |
+| `matched_element_count`  | `number`  | Rows matched to a visible DOM element                                                                            |
+| `index_matched_count`    | `number`  | Rows matched via the DOM index fast path (before visibility trimming)                                            |
+| `fallback_matched_count` | `number`  | Rows matched via the selector fallback (before visibility trimming); rising values signal index drift            |
+| `page_element_count`     | `number`  | Elements collected from the page for matching                                                                    |
+| `has_shadow_roots`       | `boolean` | Whether open shadow roots were detected; selects which fallback implementation runs, not whether a fallback runs |
+| `duration_ms`            | `number`  | Wall-clock processing time, including main-thread yields; DOM index build time is included only on a cold cache  |
+| `trigger`                | `string`  | What started the run: `initial`, `pagination`, `refresh`, or `toggle`                                            |
+| `cache_hit`              | `boolean` | Whether the page-elements cache was warm (no collect + index rebuild)                                            |
+| `completed`              | `boolean` | False when the run was cancelled mid-processing by a newer run                                                   |
 
 **File:** `elements/heatmapToolbarMenuLogic.ts`
 

--- a/frontend/src/toolbar/TELEMETRY.md
+++ b/frontend/src/toolbar/TELEMETRY.md
@@ -149,6 +149,20 @@ Fired when a toolbar mode is toggled on or off.
 `actions/actionsTabLogic.tsx`, `experiments/experimentsTabLogic.tsx`,
 `product-tours/productToursLogic.ts`
 
+### `toolbar clickmap processed`
+
+Fired when the clickmap finishes matching loaded element stats to DOM elements.
+
+| Property                | Type      | Description                                                    |
+| ----------------------- | --------- | -------------------------------------------------------------- |
+| `event_count`           | `number`  | Element stats rows processed                                   |
+| `matched_element_count` | `number`  | Rows matched to a visible DOM element                          |
+| `page_element_count`    | `number`  | Elements collected from the page for matching                  |
+| `has_shadow_roots`      | `boolean` | Whether the page has shadow roots (forces the slower fallback) |
+| `duration_ms`           | `number`  | Total processing time including DOM index build                |
+
+**File:** `elements/heatmapToolbarMenuLogic.ts`
+
 ## Element inspection
 
 ### `toolbar selected HTML element`

--- a/frontend/src/toolbar/TELEMETRY.md
+++ b/frontend/src/toolbar/TELEMETRY.md
@@ -149,17 +149,19 @@ Fired when a toolbar mode is toggled on or off.
 `actions/actionsTabLogic.tsx`, `experiments/experimentsTabLogic.tsx`,
 `product-tours/productToursLogic.ts`
 
+## Heatmaps / clickmaps
+
 ### `toolbar clickmap processed`
 
 Fired when the clickmap finishes matching loaded element stats to DOM elements.
 
-| Property                | Type      | Description                                                    |
-| ----------------------- | --------- | -------------------------------------------------------------- |
-| `event_count`           | `number`  | Element stats rows processed                                   |
-| `matched_element_count` | `number`  | Rows matched to a visible DOM element                          |
-| `page_element_count`    | `number`  | Elements collected from the page for matching                  |
-| `has_shadow_roots`      | `boolean` | Whether the page has shadow roots (forces the slower fallback) |
-| `duration_ms`           | `number`  | Total processing time including DOM index build                |
+| Property                | Type      | Description                                                                                                      |
+| ----------------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
+| `event_count`           | `number`  | Element stats rows processed                                                                                     |
+| `matched_element_count` | `number`  | Rows matched to a visible DOM element                                                                            |
+| `page_element_count`    | `number`  | Elements collected from the page for matching                                                                    |
+| `has_shadow_roots`      | `boolean` | Whether open shadow roots were detected; selects which fallback implementation runs, not whether a fallback runs |
+| `duration_ms`           | `number`  | Wall-clock processing time, including main-thread yields; DOM index build time is included only on a cold cache  |
 
 **File:** `elements/heatmapToolbarMenuLogic.ts`
 

--- a/frontend/src/toolbar/elements/domElementIndex.test.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.test.ts
@@ -1,77 +1,8 @@
-import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
+import { collectAllElementsDeep } from 'query-selector-shadow-dom'
 
-import { elementToSelector } from 'lib/utils/actions'
+import { ElementsEventType } from '~/toolbar/types'
 
-import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-
-import { buildDOMIndex, matchEventToElementUsingIndex } from './domElementIndex'
-
-function matchEventToElementOriginal(
-    event: ElementsEventType,
-    dataAttributes: string[],
-    matchLinksByHref: boolean,
-    pageElements: HTMLElement[],
-    selectorCache: Record<string, HTMLElement[]>
-): CountedHTMLElement | null {
-    let lastSelector: string | undefined
-
-    for (let i = 0; i < event.elements.length; i++) {
-        const element = event.elements[i]
-        const selector =
-            elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
-        const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
-
-        try {
-            let domElements: HTMLElement[] | undefined = selectorCache[combinedSelector]
-            if (domElements === undefined) {
-                domElements = Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
-                selectorCache[combinedSelector] = domElements
-            }
-
-            if (domElements.length === 1) {
-                const e = event.elements[i]
-                const isTooSimple =
-                    i === 0 &&
-                    e.tag_name &&
-                    !e.attr_class &&
-                    !e.attr_id &&
-                    !e.href &&
-                    !e.text &&
-                    e.nth_child === 1 &&
-                    e.nth_of_type === 1 &&
-                    !e.attributes['attr__data-attr']
-
-                if (!isTooSimple) {
-                    return {
-                        element: domElements[0],
-                        count: event.count,
-                        selector: selector,
-                        hash: event.hash,
-                        type: event.type,
-                        clickCount: 0,
-                        rageclickCount: 0,
-                        deadclickCount: 0,
-                    }
-                }
-            }
-
-            if (domElements.length === 0) {
-                if (i === event.elements.length - 1) {
-                    return null
-                } else if (i > 0 && lastSelector) {
-                    lastSelector = `* > ${lastSelector}`
-                    continue
-                }
-            }
-        } catch {
-            break
-        }
-
-        lastSelector = combinedSelector
-    }
-
-    return null
-}
+import { buildDOMIndex, matchEventToElementUsingIndex, matchEventToElementUsingSelectors } from './domElementIndex'
 
 function createTestDOM(html: string): { container: HTMLElement; cleanup: () => void } {
     const container = document.createElement('div')
@@ -325,18 +256,49 @@ describe('domElementIndex', () => {
             }
         })
 
-        it('uses parent chain to disambiguate multiple candidates', () => {
-            const { container, cleanup } = createTestDOM(`
-                <div class="container-a"><button class="btn"></button></div>
-                <div class="container-b"><button class="btn" id="target"></button></div>
-            `)
-            try {
-                const index = buildDOMIndex(getAllElements(container))
-                const event = createEvent([
+        const parentChainCases = [
+            {
+                name: 'uses parent chain to disambiguate multiple candidates',
+                html: `
+                    <div class="container-a"><button class="btn"></button></div>
+                    <div class="container-b"><button class="btn" id="target"></button></div>
+                `,
+                event: [
                     { tag_name: 'button', attr_class: ['btn'] },
                     { tag_name: 'div', attr_class: ['container-b'] },
-                ])
-                const result = matchEventToElementUsingIndex(event, [], false, index)
+                ],
+            },
+            {
+                name: 'uses ancestor position to disambiguate repeated identical structures',
+                html: `
+                    <div class="row"><button class="btn"></button></div>
+                    <div class="row"><button class="btn" id="target"></button></div>
+                    <div class="row"><button class="btn"></button></div>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn'], nth_child: 1, nth_of_type: 1 },
+                    { tag_name: 'div', attr_class: ['row'], nth_child: 2, nth_of_type: 2 },
+                ],
+            },
+            {
+                name: 'walks one ancestor level per chain entry, not the parent repeatedly',
+                html: `
+                    <section class="outer-a"><div class="middle"><button class="btn"></button></div></section>
+                    <section class="outer-b"><div class="middle"><button class="btn" id="target"></button></div></section>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn'] },
+                    { tag_name: 'div', attr_class: ['middle'] },
+                    { tag_name: 'section', attr_class: ['outer-b'] },
+                ],
+            },
+        ]
+
+        it.each(parentChainCases)('$name', ({ html, event }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const result = matchEventToElementUsingIndex(createEvent(event), [], false, index)
 
                 expect(result).not.toBeNull()
                 expect(result?.element.id).toBe('target')
@@ -467,37 +429,67 @@ describe('domElementIndex', () => {
                 event: [{ tag_name: 'button', attributes: { 'attr__data-testid': 'cta-button' } }],
                 dataAttributes: ['data-testid'],
             },
+            {
+                name: 'matches within repeated identical structures via ancestor position',
+                html: `
+                    <div class="row"><a class="link" href="/one">One</a></div>
+                    <div class="row"><a class="link" href="/two">Two</a></div>
+                    <div class="row"><a class="link" href="/three">Three</a></div>
+                `,
+                event: [
+                    { tag_name: 'a', attr_class: ['link'], nth_child: 1, nth_of_type: 1 },
+                    { tag_name: 'div', attr_class: ['row'], nth_child: 3, nth_of_type: 3 },
+                ],
+            },
+            {
+                name: 'matches when only a grandparent disambiguates',
+                html: `
+                    <section class="outer-a"><div class="middle"><button class="btn">A</button></div></section>
+                    <section class="outer-b"><div class="middle"><button class="btn">B</button></div></section>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn'] },
+                    { tag_name: 'div', attr_class: ['middle'] },
+                    { tag_name: 'section', attr_class: ['outer-b'] },
+                ],
+            },
         ]
 
-        it.each(comparisonCases)('$name: both implementations agree', ({ html, event, dataAttributes = [] }) => {
-            const { cleanup } = createTestDOM(html)
-            try {
-                const pageElements = collectAllElementsDeep('*', document) as HTMLElement[]
-                const index = buildDOMIndex(pageElements)
-                const selectorCache: Record<string, HTMLElement[]> = {}
+        const shadowRootModes = [{ hasShadowRoots: true }, { hasShadowRoots: false }]
 
-                const eventObj = createEvent(event)
+        it.each(comparisonCases.flatMap((c) => shadowRootModes.map((mode) => ({ ...c, ...mode }))))(
+            '$name: both implementations agree (hasShadowRoots=$hasShadowRoots)',
+            ({ html, event, dataAttributes = [], hasShadowRoots }) => {
+                const { cleanup } = createTestDOM(html)
+                try {
+                    const pageElements = collectAllElementsDeep('*', document) as HTMLElement[]
+                    const index = buildDOMIndex(pageElements)
+                    const selectorCache: Record<string, HTMLElement[]> = {}
 
-                const indexResult = matchEventToElementUsingIndex(eventObj, dataAttributes, true, index)
-                const originalResult = matchEventToElementOriginal(
-                    eventObj,
-                    dataAttributes,
-                    true,
-                    pageElements,
-                    selectorCache
-                )
+                    const eventObj = createEvent(event)
 
-                if (originalResult === null) {
-                    expect(indexResult).toBeNull()
-                } else {
-                    expect(indexResult).not.toBeNull()
-                    expect(indexResult?.element).toBe(originalResult.element)
-                    expect(indexResult?.count).toBe(originalResult.count)
-                    expect(indexResult?.hash).toBe(originalResult.hash)
+                    const indexResult = matchEventToElementUsingIndex(eventObj, dataAttributes, true, index)
+                    const selectorResult = matchEventToElementUsingSelectors(
+                        eventObj,
+                        dataAttributes,
+                        true,
+                        pageElements,
+                        selectorCache,
+                        hasShadowRoots
+                    )
+
+                    if (selectorResult === null) {
+                        expect(indexResult).toBeNull()
+                    } else {
+                        expect(indexResult).not.toBeNull()
+                        expect(indexResult?.element).toBe(selectorResult.element)
+                        expect(indexResult?.count).toBe(selectorResult.count)
+                        expect(indexResult?.hash).toBe(selectorResult.hash)
+                    }
+                } finally {
+                    cleanup()
                 }
-            } finally {
-                cleanup()
             }
-        })
+        )
     })
 })

--- a/frontend/src/toolbar/elements/domElementIndex.test.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.test.ts
@@ -292,13 +292,43 @@ describe('domElementIndex', () => {
                     { tag_name: 'section', attr_class: ['outer-b'] },
                 ],
             },
+            {
+                name: 'ignores drifted sibling position when the ancestor is identified by id',
+                html: `
+                    <div class="injected-banner"></div>
+                    <div id="main-panel"><button class="btn" id="target"></button></div>
+                    <div class="other"><button class="btn"></button></div>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn'], nth_child: 1, nth_of_type: 1 },
+                    { tag_name: 'div', attr_id: 'main-panel', nth_child: 1, nth_of_type: 1 },
+                ],
+            },
+            {
+                name: 'ignores drifted sibling position when the ancestor is identified by a data attribute',
+                html: `
+                    <div class="injected-banner"></div>
+                    <div data-attr="main-panel"><button class="btn" id="target"></button></div>
+                    <div class="other"><button class="btn"></button></div>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn'], nth_child: 1, nth_of_type: 1 },
+                    {
+                        tag_name: 'div',
+                        attributes: { 'attr__data-attr': 'main-panel' },
+                        nth_child: 1,
+                        nth_of_type: 1,
+                    },
+                ],
+                dataAttributes: ['data-attr'],
+            },
         ]
 
-        it.each(parentChainCases)('$name', ({ html, event }) => {
+        it.each(parentChainCases)('$name', ({ html, event, dataAttributes = [] }) => {
             const { container, cleanup } = createTestDOM(html)
             try {
                 const index = buildDOMIndex(getAllElements(container))
-                const result = matchEventToElementUsingIndex(createEvent(event), [], false, index)
+                const result = matchEventToElementUsingIndex(createEvent(event), dataAttributes, false, index)
 
                 expect(result).not.toBeNull()
                 expect(result?.element.id).toBe('target')
@@ -464,7 +494,7 @@ describe('domElementIndex', () => {
                 try {
                     const pageElements = collectAllElementsDeep('*', document) as HTMLElement[]
                     const index = buildDOMIndex(pageElements)
-                    const selectorCache: Record<string, HTMLElement[]> = {}
+                    const selectorCache = new Map<string, HTMLElement[]>()
 
                     const eventObj = createEvent(event)
 

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -1,5 +1,8 @@
-import { matchesDataAttribute } from 'lib/utils/actions'
+import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 
+import { elementToSelector, matchesDataAttribute } from 'lib/utils/actions'
+
+import { toolbarLogger } from '~/toolbar/toolbarLogger'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
 import { ElementType } from '~/types'
 
@@ -8,6 +11,11 @@ interface ElementFingerprint {
     id: string | null
     classes: Set<string>
     dataAttrs: Map<string, string>
+    nthChild: number
+    nthOfType: number
+}
+
+interface ElementPosition {
     nthChild: number
     nthOfType: number
 }
@@ -30,17 +38,36 @@ function addToIndex(map: Map<string, HTMLElement[]>, key: string, element: HTMLE
     }
 }
 
-function createFingerprint(element: HTMLElement): ElementFingerprint {
+function getPosition(
+    element: HTMLElement,
+    positionsByParent: WeakMap<HTMLElement, Map<Element, ElementPosition>>
+): ElementPosition {
     const parent = element.parentElement
-    let nthChild = 1
-    let nthOfType = 1
-
-    if (parent) {
-        const siblings = Array.from(parent.children)
-        const elementIndex = siblings.indexOf(element)
-        nthChild = elementIndex + 1
-        nthOfType = siblings.filter((s, idx) => s.tagName === element.tagName && idx < elementIndex).length + 1
+    if (!parent) {
+        return { nthChild: 1, nthOfType: 1 }
     }
+
+    let positions = positionsByParent.get(parent)
+    if (!positions) {
+        positions = new Map()
+        const typeCounts = new Map<string, number>()
+        let nthChild = 0
+        for (const child of Array.from(parent.children)) {
+            nthChild += 1
+            const nthOfType = (typeCounts.get(child.tagName) ?? 0) + 1
+            typeCounts.set(child.tagName, nthOfType)
+            positions.set(child, { nthChild, nthOfType })
+        }
+        positionsByParent.set(parent, positions)
+    }
+    return positions.get(element) ?? { nthChild: 1, nthOfType: 1 }
+}
+
+function createFingerprint(
+    element: HTMLElement,
+    positionsByParent: WeakMap<HTMLElement, Map<Element, ElementPosition>>
+): ElementFingerprint {
+    const { nthChild, nthOfType } = getPosition(element, positionsByParent)
 
     const dataAttrs = new Map<string, string>()
     for (let i = 0; i < element.attributes.length; i++) {
@@ -69,9 +96,10 @@ export function buildDOMIndex(pageElements: HTMLElement[]): DOMIndex {
         byHref: new Map(),
         fingerprints: new WeakMap(),
     }
+    const positionsByParent = new WeakMap<HTMLElement, Map<Element, ElementPosition>>()
 
     for (const element of pageElements) {
-        const fingerprint = createFingerprint(element)
+        const fingerprint = createFingerprint(element, positionsByParent)
         index.fingerprints.set(element, fingerprint)
 
         if (fingerprint.id) {
@@ -162,34 +190,28 @@ function getCandidatesFromIndex(
     })
 }
 
-function matchesParent(candidate: HTMLElement, parentEvent: ElementType, index: DOMIndex): boolean {
-    const parent = candidate.parentElement
-    if (!parent) {
+function fingerprintMatchesEventElement(
+    fingerprint: ElementFingerprint | undefined,
+    eventElement: ElementType
+): boolean {
+    if (!fingerprint) {
         return false
     }
-
-    const fp = index.fingerprints.get(parent)
-    if (!fp) {
+    if (eventElement.tag_name && fingerprint.tagName !== eventElement.tag_name.toLowerCase()) {
         return false
     }
-
-    if (parentEvent.tag_name && fp.tagName !== parentEvent.tag_name.toLowerCase()) {
+    if (eventElement.attr_id && fingerprint.id !== eventElement.attr_id) {
         return false
     }
-    if (parentEvent.attr_id && fp.id !== parentEvent.attr_id) {
-        return false
-    }
-    if (parentEvent.attr_class?.length) {
-        for (const cls of parentEvent.attr_class) {
-            if (cls && !fp.classes.has(cls)) {
-                return false
-            }
+    for (const cls of eventElement.attr_class ?? []) {
+        if (cls && !fingerprint.classes.has(cls)) {
+            return false
         }
     }
-    return true
+    return matchesPosition(fingerprint, eventElement)
 }
 
-function isTooSimple(element: ElementType): boolean {
+export function isTooSimple(element: ElementType): boolean {
     return !!(
         element.tag_name &&
         !element.attr_class &&
@@ -213,19 +235,26 @@ export function matchEventToElementUsingIndex(
         return null
     }
 
-    let candidates = getCandidatesFromIndex(targetElement, dataAttributes, matchLinksByHref, index)
+    const candidates = getCandidatesFromIndex(targetElement, dataAttributes, matchLinksByHref, index)
 
     if (candidates.length === 0) {
         return null
     }
 
-    for (let i = 1; i < event.elements.length && candidates.length > 1; i++) {
-        candidates = candidates.filter((c) => matchesParent(c, event.elements[i], index))
+    let walkers = candidates.map((candidate) => ({ candidate, ancestor: candidate.parentElement }))
+    for (let i = 1; i < event.elements.length && walkers.length > 1; i++) {
+        const eventAncestor = event.elements[i]
+        walkers = walkers.flatMap(({ candidate, ancestor }) => {
+            if (!ancestor || !fingerprintMatchesEventElement(index.fingerprints.get(ancestor), eventAncestor)) {
+                return []
+            }
+            return [{ candidate, ancestor: ancestor.parentElement }]
+        })
     }
 
-    if (candidates.length === 1 && !isTooSimple(targetElement)) {
+    if (walkers.length === 1 && !isTooSimple(targetElement)) {
         return {
-            element: candidates[0],
+            element: walkers[0].candidate,
             count: event.count,
             selector: '',
             hash: event.hash,
@@ -234,6 +263,67 @@ export function matchEventToElementUsingIndex(
             rageclickCount: 0,
             deadclickCount: 0,
         }
+    }
+
+    return null
+}
+
+export function matchEventToElementUsingSelectors(
+    event: ElementsEventType,
+    dataAttributes: string[],
+    matchLinksByHref: boolean,
+    pageElements: HTMLElement[],
+    selectorCache: Record<string, HTMLElement[]>,
+    hasShadowRoots: boolean
+): CountedHTMLElement | null {
+    let lastSelector: string | undefined
+
+    for (let i = 0; i < event.elements.length; i++) {
+        const element = event.elements[i]
+        const selector =
+            elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
+        const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
+
+        try {
+            let domElements: HTMLElement[] | undefined = selectorCache[combinedSelector]
+            if (domElements === undefined) {
+                domElements = hasShadowRoots
+                    ? Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
+                    : Array.from(document.querySelectorAll<HTMLElement>(combinedSelector))
+                selectorCache[combinedSelector] = domElements
+            }
+
+            if (domElements.length === 1) {
+                if (!(i === 0 && isTooSimple(event.elements[i]))) {
+                    return {
+                        element: domElements[0],
+                        count: event.count,
+                        selector: selector,
+                        hash: event.hash,
+                        type: event.type,
+                        clickCount: 0,
+                        rageclickCount: 0,
+                        deadclickCount: 0,
+                    }
+                }
+            }
+
+            if (domElements.length === 0) {
+                if (i === event.elements.length - 1) {
+                    return null
+                } else if (i > 0 && lastSelector) {
+                    lastSelector = `* > ${lastSelector}`
+                    continue
+                }
+            }
+        } catch {
+            toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
+                selector: combinedSelector,
+            })
+            break
+        }
+
+        lastSelector = combinedSelector
     }
 
     return null

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -60,7 +60,7 @@ function getPosition(
         }
         positionsByParent.set(parent, positions)
     }
-    return positions.get(element) ?? { nthChild: 1, nthOfType: 1 }
+    return positions.get(element) ?? { nthChild: -1, nthOfType: -1 }
 }
 
 function createFingerprint(
@@ -294,7 +294,8 @@ export function matchEventToElementUsingSelectors(
             }
 
             if (domElements.length === 1) {
-                if (!(i === 0 && isTooSimple(event.elements[i]))) {
+                const firstAndTooSimple = i === 0 && isTooSimple(event.elements[i])
+                if (!firstAndTooSimple) {
                     return {
                         element: domElements[0],
                         count: event.count,

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -195,23 +195,23 @@ function getCandidatesFromIndex(
     return filterByPosition(candidates, eventElement, index)
 }
 
-function matchesEventDataAttribute(
-    fingerprint: ElementFingerprint,
+// derived once per chain level, not per candidate: matchesDataAttribute builds a RegExp per call
+function getMatchedDataAttribute(
     eventElement: ElementType,
     dataAttributes: string[]
-): boolean {
+): { name: string; value: string } | null {
     const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
     if (!matchedAttr) {
-        return false
+        return null
     }
     const value = eventElement.attributes?.[`attr__${matchedAttr}`]
-    return value !== undefined && fingerprint.dataAttrs.get(matchedAttr) === value
+    return value === undefined ? null : { name: matchedAttr, value }
 }
 
 function fingerprintMatchesEventElement(
     fingerprint: ElementFingerprint | undefined,
     eventElement: ElementType,
-    dataAttributes: string[]
+    matchedDataAttribute: { name: string; value: string } | null
 ): boolean {
     if (!fingerprint) {
         return false
@@ -232,7 +232,7 @@ function fingerprintMatchesEventElement(
     // mirroring elementToSelector, which early-returns on these without position
     const identifiedWithoutPosition =
         (!!eventElement.attr_id && fingerprint.id === eventElement.attr_id) ||
-        matchesEventDataAttribute(fingerprint, eventElement, dataAttributes)
+        (!!matchedDataAttribute && fingerprint.dataAttrs.get(matchedDataAttribute.name) === matchedDataAttribute.value)
     return identifiedWithoutPosition || matchesPosition(fingerprint, eventElement)
 }
 
@@ -269,10 +269,11 @@ export function matchEventToElementUsingIndex(
     let walkers = candidates.map((candidate) => ({ candidate, ancestor: candidate.parentElement }))
     for (let i = 1; i < event.elements.length && walkers.length > 1; i++) {
         const eventAncestor = event.elements[i]
+        const ancestorDataAttribute = getMatchedDataAttribute(eventAncestor, dataAttributes)
         walkers = walkers.flatMap(({ candidate, ancestor }) => {
             if (
                 !ancestor ||
-                !fingerprintMatchesEventElement(index.fingerprints.get(ancestor), eventAncestor, dataAttributes)
+                !fingerprintMatchesEventElement(index.fingerprints.get(ancestor), eventAncestor, ancestorDataAttribute)
             ) {
                 return []
             }

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -4,6 +4,7 @@ import { elementToSelector, matchesDataAttribute } from 'lib/utils/actions'
 
 import { toolbarLogger } from '~/toolbar/toolbarLogger'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
+import { TOOLBAR_ID } from '~/toolbar/utils'
 import { ElementType } from '~/types'
 
 interface ElementFingerprint {
@@ -27,6 +28,7 @@ export interface DOMIndex {
     byDataAttr: Map<string, Map<string, HTMLElement[]>>
     byHref: Map<string, HTMLElement[]>
     fingerprints: WeakMap<HTMLElement, ElementFingerprint>
+    hasShadowRoots: boolean
 }
 
 function addToIndex(map: Map<string, HTMLElement[]>, key: string, element: HTMLElement): void {
@@ -95,6 +97,7 @@ export function buildDOMIndex(pageElements: HTMLElement[]): DOMIndex {
         byDataAttr: new Map(),
         byHref: new Map(),
         fingerprints: new WeakMap(),
+        hasShadowRoots: false,
     }
     const positionsByParent = new WeakMap<HTMLElement, Map<Element, ElementPosition>>()
 
@@ -123,6 +126,10 @@ export function buildDOMIndex(pageElements: HTMLElement[]): DOMIndex {
         if (href) {
             addToIndex(index.byHref, href, element)
         }
+
+        if (element.shadowRoot && element.id !== TOOLBAR_ID) {
+            index.hasShadowRoots = true
+        }
     }
 
     return index
@@ -138,6 +145,13 @@ function matchesPosition(fingerprint: ElementFingerprint, eventElement: ElementT
     return true
 }
 
+function filterByPosition(candidates: HTMLElement[], eventElement: ElementType, index: DOMIndex): HTMLElement[] {
+    return candidates.filter((el) => {
+        const fp = index.fingerprints.get(el)
+        return fp && matchesPosition(fp, eventElement)
+    })
+}
+
 function getCandidatesFromIndex(
     eventElement: ElementType,
     dataAttributes: string[],
@@ -150,10 +164,7 @@ function getCandidatesFromIndex(
         if (value !== undefined) {
             const candidates = index.byDataAttr.get(matchedAttr)?.get(value) || []
             if (candidates.length) {
-                return candidates.filter((el) => {
-                    const fp = index.fingerprints.get(el)
-                    return fp && matchesPosition(fp, eventElement)
-                })
+                return filterByPosition(candidates, eventElement, index)
             }
         }
     }
@@ -161,14 +172,11 @@ function getCandidatesFromIndex(
     if (eventElement.attr_id) {
         const candidates = index.byId.get(eventElement.attr_id) || []
         if (candidates.length) {
-            return candidates.filter((el) => {
-                const fp = index.fingerprints.get(el)
-                return fp && matchesPosition(fp, eventElement)
-            })
+            return filterByPosition(candidates, eventElement, index)
         }
     }
 
-    let candidates = eventElement.tag_name ? [...(index.byTagName.get(eventElement.tag_name.toLowerCase()) || [])] : []
+    let candidates = eventElement.tag_name ? index.byTagName.get(eventElement.tag_name.toLowerCase()) || [] : []
 
     if (eventElement.attr_class?.length) {
         for (const cls of eventElement.attr_class) {
@@ -184,10 +192,7 @@ function getCandidatesFromIndex(
         candidates = candidates.filter((el) => hrefMatches.has(el))
     }
 
-    return candidates.filter((el) => {
-        const fp = index.fingerprints.get(el)
-        return fp && matchesPosition(fp, eventElement)
-    })
+    return filterByPosition(candidates, eventElement, index)
 }
 
 function fingerprintMatchesEventElement(

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -195,9 +195,23 @@ function getCandidatesFromIndex(
     return filterByPosition(candidates, eventElement, index)
 }
 
+function matchesEventDataAttribute(
+    fingerprint: ElementFingerprint,
+    eventElement: ElementType,
+    dataAttributes: string[]
+): boolean {
+    const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
+    if (!matchedAttr) {
+        return false
+    }
+    const value = eventElement.attributes?.[`attr__${matchedAttr}`]
+    return value !== undefined && fingerprint.dataAttrs.get(matchedAttr) === value
+}
+
 function fingerprintMatchesEventElement(
     fingerprint: ElementFingerprint | undefined,
-    eventElement: ElementType
+    eventElement: ElementType,
+    dataAttributes: string[]
 ): boolean {
     if (!fingerprint) {
         return false
@@ -213,7 +227,13 @@ function fingerprintMatchesEventElement(
             return false
         }
     }
-    return matchesPosition(fingerprint, eventElement)
+    // an id or configured data attribute identifies the ancestor on its own, so DOM drift that
+    // shifts sibling positions (cookie banners, injected wrappers) shouldn't kill the match —
+    // mirroring elementToSelector, which early-returns on these without position
+    const identifiedWithoutPosition =
+        (!!eventElement.attr_id && fingerprint.id === eventElement.attr_id) ||
+        matchesEventDataAttribute(fingerprint, eventElement, dataAttributes)
+    return identifiedWithoutPosition || matchesPosition(fingerprint, eventElement)
 }
 
 export function isTooSimple(element: ElementType): boolean {
@@ -250,7 +270,10 @@ export function matchEventToElementUsingIndex(
     for (let i = 1; i < event.elements.length && walkers.length > 1; i++) {
         const eventAncestor = event.elements[i]
         walkers = walkers.flatMap(({ candidate, ancestor }) => {
-            if (!ancestor || !fingerprintMatchesEventElement(index.fingerprints.get(ancestor), eventAncestor)) {
+            if (
+                !ancestor ||
+                !fingerprintMatchesEventElement(index.fingerprints.get(ancestor), eventAncestor, dataAttributes)
+            ) {
                 return []
             }
             return [{ candidate, ancestor: ancestor.parentElement }]
@@ -273,29 +296,34 @@ export function matchEventToElementUsingIndex(
     return null
 }
 
+// each chain level costs a selector query, so a single deep-chain event (legitimately deep DOM or a
+// forged chain) could otherwise hold the main thread for an unbounded uninterruptible stretch
+const MAX_SELECTOR_CHAIN_LEVELS = 10
+
 export function matchEventToElementUsingSelectors(
     event: ElementsEventType,
     dataAttributes: string[],
     matchLinksByHref: boolean,
     pageElements: HTMLElement[],
-    selectorCache: Record<string, HTMLElement[]>,
+    selectorCache: Map<string, HTMLElement[]>,
     hasShadowRoots: boolean
 ): CountedHTMLElement | null {
     let lastSelector: string | undefined
 
-    for (let i = 0; i < event.elements.length; i++) {
+    const chainDepth = Math.min(event.elements.length, MAX_SELECTOR_CHAIN_LEVELS)
+    for (let i = 0; i < chainDepth; i++) {
         const element = event.elements[i]
         const selector =
             elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
         const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
 
         try {
-            let domElements: HTMLElement[] | undefined = selectorCache[combinedSelector]
+            let domElements: HTMLElement[] | undefined = selectorCache.get(combinedSelector)
             if (domElements === undefined) {
                 domElements = hasShadowRoots
                     ? Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
                     : Array.from(document.querySelectorAll<HTMLElement>(combinedSelector))
-                selectorCache[combinedSelector] = domElements
+                selectorCache.set(combinedSelector, domElements)
             }
 
             if (domElements.length === 1) {
@@ -323,9 +351,14 @@ export function matchEventToElementUsingSelectors(
                 }
             }
         } catch {
-            toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
-                selector: combinedSelector,
-            })
+            // sentinel-cache the failing selector so repeated rows neither re-throw nor re-log,
+            // and truncate: event-derived selectors can embed long customer-page attribute values
+            if (!selectorCache.has(combinedSelector)) {
+                selectorCache.set(combinedSelector, [])
+                toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
+                    selector: combinedSelector.slice(0, 200),
+                })
+            }
             break
         }
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -417,12 +417,13 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
                 if (performance.now() - sliceStart > SLICE_BUDGET_MS) {
                     actions.setProcessingProgress(i + 1, totalEvents)
-                    breakpoint()
                     await yieldToMain()
+                    breakpoint()
                     sliceStart = performance.now()
                 }
             }
 
+            breakpoint()
             actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
             actions.startElementObservation()
             actions.setIsRefreshing(false)

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -20,7 +20,7 @@ import { toolbarApi } from '~/toolbar/toolbarApi'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { TOOLBAR_ID, elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
+import { elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
@@ -44,7 +44,6 @@ function yieldToMain(): Promise<void> {
 interface ElementProcessingCache {
     pageElements?: HTMLElement[]
     domIndex?: DOMIndex
-    hasShadowRoots?: boolean
     selectorToElements: Record<string, HTMLElement[]>
     lastHref?: string
     intersectionObserver?: IntersectionObserver
@@ -70,17 +69,16 @@ function getCachedPageElements(
         return {
             pageElements: cache.pageElements,
             domIndex: cache.domIndex,
-            hasShadowRoots: cache.hasShadowRoots ?? true,
+            hasShadowRoots: cache.domIndex.hasShadowRoots,
         }
     }
 
     cache.pageElements = collectAllElementsDeep('*', document)
     cache.domIndex = buildDOMIndex(cache.pageElements)
-    cache.hasShadowRoots = cache.pageElements.some((el) => !!el.shadowRoot && el.id !== TOOLBAR_ID)
     cache.lastHref = href
     cache.selectorToElements = {}
     cache.cacheInvalidated = false
-    return { pageElements: cache.pageElements, domIndex: cache.domIndex, hasShadowRoots: cache.hasShadowRoots }
+    return { pageElements: cache.pageElements, domIndex: cache.domIndex, hasShadowRoots: cache.domIndex.hasShadowRoots }
 }
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -20,7 +20,7 @@ import { toolbarApi } from '~/toolbar/toolbarApi'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
+import { TOOLBAR_ID, elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
@@ -41,10 +41,12 @@ function yieldToMain(): Promise<void> {
     })
 }
 
+export type ClickmapProcessingTrigger = 'initial' | 'pagination' | 'refresh' | 'toggle'
+
 interface ElementProcessingCache {
     pageElements?: HTMLElement[]
     domIndex?: DOMIndex
-    selectorToElements: Record<string, HTMLElement[]>
+    selectorToElements: Map<string, HTMLElement[]>
     lastHref?: string
     intersectionObserver?: IntersectionObserver
     visibilityCache: WeakMap<HTMLElement, boolean>
@@ -61,7 +63,7 @@ function invalidatePageElementsCache(cache: ElementProcessingCache): void {
 function getCachedPageElements(
     cache: ElementProcessingCache,
     href: string
-): { pageElements: HTMLElement[]; domIndex: DOMIndex; hasShadowRoots: boolean } {
+): { pageElements: HTMLElement[]; domIndex: DOMIndex; hasShadowRoots: boolean; cacheHit: boolean } {
     const hrefChanged = cache.lastHref !== href
     const cacheValid = cache.pageElements && !hrefChanged && !cache.cacheInvalidated
 
@@ -69,16 +71,24 @@ function getCachedPageElements(
         return {
             pageElements: cache.pageElements,
             domIndex: cache.domIndex,
-            hasShadowRoots: cache.domIndex.hasShadowRoots,
+            // attachShadow() emits no light-DOM mutation, so the build-time flag can go stale —
+            // recheck the snapshot on every run
+            hasShadowRoots: cache.pageElements.some((el) => el.shadowRoot && el.id !== TOOLBAR_ID),
+            cacheHit: true,
         }
     }
 
     cache.pageElements = collectAllElementsDeep('*', document)
     cache.domIndex = buildDOMIndex(cache.pageElements)
     cache.lastHref = href
-    cache.selectorToElements = {}
+    cache.selectorToElements = new Map()
     cache.cacheInvalidated = false
-    return { pageElements: cache.pageElements, domIndex: cache.domIndex, hasShadowRoots: cache.domIndex.hasShadowRoots }
+    return {
+        pageElements: cache.pageElements,
+        domIndex: cache.domIndex,
+        hasShadowRoots: cache.domIndex.hasShadowRoots,
+        cacheHit: false,
+    }
 }
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
@@ -142,7 +152,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         updateElementMetrics: (observedElements: [HTMLElement, boolean][]) => ({ observedElements }),
         startElementObservation: true,
         stopElementObservation: true,
-        processElements: true,
+        processElements: (trigger: ClickmapProcessingTrigger) => ({ trigger }),
         refreshClickmap: true,
         setIsRefreshing: (isRefreshing: boolean) => ({ isRefreshing }),
         setProcessedElements: (elements: CountedHTMLElement[]) => ({ elements }),
@@ -369,7 +379,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
     })),
     listeners(({ actions, values, cache }) => ({
-        processElements: async (_, breakpoint) => {
+        processElements: async ({ trigger }, breakpoint) => {
             const SLICE_BUDGET_MS = 10
             const startedAt = performance.now()
 
@@ -383,7 +393,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             cache.visibilityCache = cache.visibilityCache || new WeakMap<HTMLElement, boolean>()
             const cursorPointerCache = new WeakMap<HTMLElement, boolean>()
-            const { pageElements, domIndex, hasShadowRoots } = getCachedPageElements(
+            const { pageElements, domIndex, hasShadowRoots, cacheHit } = getCachedPageElements(
                 cache as ElementProcessingCache,
                 href
             )
@@ -391,48 +401,70 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             const totalEvents = eventsToProcess.length
 
             const allTrimmedElements: CountedHTMLElement[] = []
+            let indexMatchedCount = 0
+            let fallbackMatchedCount = 0
+            let completed = false
             let sliceStart = performance.now()
 
-            for (let i = 0; i < totalEvents; i++) {
-                const event = eventsToProcess[i]
-                const matched =
-                    matchEventToElementUsingIndex(event, dataAttributes, matchLinksByHref, domIndex) ||
-                    matchEventToElementUsingSelectors(
-                        event,
-                        dataAttributes,
-                        matchLinksByHref,
-                        pageElements,
-                        (cache as ElementProcessingCache).selectorToElements,
-                        hasShadowRoots
-                    )
+            try {
+                for (let i = 0; i < totalEvents; i++) {
+                    const event = eventsToProcess[i]
+                    let matched = matchEventToElementUsingIndex(event, dataAttributes, matchLinksByHref, domIndex)
+                    if (matched) {
+                        indexMatchedCount += 1
+                    } else {
+                        matched = matchEventToElementUsingSelectors(
+                            event,
+                            dataAttributes,
+                            matchLinksByHref,
+                            pageElements,
+                            (cache as ElementProcessingCache).selectorToElements,
+                            hasShadowRoots
+                        )
+                        if (matched) {
+                            fallbackMatchedCount += 1
+                        }
+                    }
 
-                if (matched) {
-                    const trimmed = trimElement(matched.element, { cursorPointerCache })
-                    if (trimmed && elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)) {
-                        allTrimmedElements.push({ ...matched, element: trimmed })
+                    if (matched) {
+                        const trimmed = trimElement(matched.element, { cursorPointerCache })
+                        if (
+                            trimmed &&
+                            elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)
+                        ) {
+                            allTrimmedElements.push({ ...matched, element: trimmed })
+                        }
+                    }
+
+                    if (performance.now() - sliceStart > SLICE_BUDGET_MS) {
+                        actions.setProcessingProgress(i + 1, totalEvents)
+                        await yieldToMain()
+                        breakpoint()
+                        sliceStart = performance.now()
                     }
                 }
 
-                if (performance.now() - sliceStart > SLICE_BUDGET_MS) {
-                    actions.setProcessingProgress(i + 1, totalEvents)
-                    await yieldToMain()
-                    breakpoint()
-                    sliceStart = performance.now()
-                }
+                breakpoint()
+                actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
+                actions.startElementObservation()
+                actions.setIsRefreshing(false)
+                completed = true
+            } finally {
+                // fire on cancelled runs too — the slow pages that get superseded are exactly
+                // the ones we most need to see
+                toolbarPosthogJS.capture('toolbar clickmap processed', {
+                    event_count: totalEvents,
+                    matched_element_count: allTrimmedElements.length,
+                    index_matched_count: indexMatchedCount,
+                    fallback_matched_count: fallbackMatchedCount,
+                    page_element_count: pageElements.length,
+                    has_shadow_roots: hasShadowRoots,
+                    duration_ms: Math.round(performance.now() - startedAt),
+                    trigger,
+                    cache_hit: cacheHit,
+                    completed,
+                })
             }
-
-            breakpoint()
-            actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
-            actions.startElementObservation()
-            actions.setIsRefreshing(false)
-
-            toolbarPosthogJS.capture('toolbar clickmap processed', {
-                event_count: totalEvents,
-                matched_element_count: allTrimmedElements.length,
-                page_element_count: pageElements.length,
-                has_shadow_roots: hasShadowRoots,
-                duration_ms: Math.round(performance.now() - startedAt),
-            })
         },
 
         enableHeatmap: () => {
@@ -510,7 +542,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 actions.stopElementObservation()
                 actions.resetElementStats()
                 cache.pageElements = undefined
-                cache.selectorToElements = {}
+                cache.selectorToElements = new Map()
                 cache.lastHref = undefined
                 cache.visibilityCache = new WeakMap()
             }
@@ -522,12 +554,12 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             }
         },
 
-        getElementStatsSuccess: () => {
-            actions.processElements()
+        getElementStatsSuccess: ({ elementStats }) => {
+            actions.processElements(elementStats?.previous ? 'pagination' : 'initial')
         },
 
         setMatchLinksByHref: () => {
-            actions.processElements()
+            actions.processElements('toggle')
         },
 
         refreshClickmap: () => {
@@ -536,7 +568,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             }
             actions.setIsRefreshing(true)
             invalidatePageElementsCache(cache as ElementProcessingCache)
-            actions.processElements()
+            actions.processElements('refresh')
         },
 
         patchHeatmapFilters: ({ filters }) => {
@@ -547,7 +579,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
     })),
     afterMount(({ actions, cache, values }) => {
-        cache.selectorToElements = {}
+        cache.selectorToElements = new Map()
         cache.visibilityCache = new WeakMap()
 
         cache.disposables.add(() => {
@@ -611,7 +643,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
     }),
     beforeUnmount(({ cache }) => {
         cache.pageElements = undefined
-        cache.selectorToElements = {}
+        cache.selectorToElements = new Map()
         cache.visibilityCache = new WeakMap()
         cache.lastHref = undefined
         cache.cacheInvalidated = false

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -27,7 +27,7 @@ import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
 
-export const ELEMENT_STATS_PAGE_LIMIT = 2000
+const ELEMENT_STATS_PAGE_LIMIT = 2000
 
 function yieldToMain(): Promise<void> {
     return new Promise((resolve) => {
@@ -373,6 +373,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
     listeners(({ actions, values, cache }) => ({
         processElements: async (_, breakpoint) => {
             const SLICE_BUDGET_MS = 10
+            const startedAt = performance.now()
 
             const { elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled } = values.processingInputs
 
@@ -425,6 +426,14 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
             actions.startElementObservation()
             actions.setIsRefreshing(false)
+
+            toolbarPosthogJS.capture('toolbar clickmap processed', {
+                event_count: totalEvents,
+                matched_element_count: allTrimmedElements.length,
+                page_element_count: pageElements.length,
+                has_shadow_roots: hasShadowRoots,
+                duration_ms: Math.round(performance.now() - startedAt),
+            })
         },
 
         enableHeatmap: () => {

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -3,26 +3,31 @@ import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 import { windowValues } from 'kea-window-values'
 import { PostHog } from 'posthog-js'
-import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
+import { collectAllElementsDeep } from 'query-selector-shadow-dom'
 
 import type { PaginatedResponse } from 'lib/api'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
-import { elementToSelector } from 'lib/utils/actions'
 import { createVersionChecker } from 'lib/utils/semver'
 
-import { DOMIndex, buildDOMIndex, matchEventToElementUsingIndex } from '~/toolbar/elements/domElementIndex'
+import {
+    DOMIndex,
+    buildDOMIndex,
+    matchEventToElementUsingIndex,
+    matchEventToElementUsingSelectors,
+} from '~/toolbar/elements/domElementIndex'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarApi } from '~/toolbar/toolbarApi'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
-import { toolbarLogger } from '~/toolbar/toolbarLogger'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
+import { TOOLBAR_ID, elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
+
+export const ELEMENT_STATS_PAGE_LIMIT = 2000
 
 function yieldToMain(): Promise<void> {
     return new Promise((resolve) => {
@@ -39,6 +44,7 @@ function yieldToMain(): Promise<void> {
 interface ElementProcessingCache {
     pageElements?: HTMLElement[]
     domIndex?: DOMIndex
+    hasShadowRoots?: boolean
     selectorToElements: Record<string, HTMLElement[]>
     lastHref?: string
     intersectionObserver?: IntersectionObserver
@@ -56,20 +62,25 @@ function invalidatePageElementsCache(cache: ElementProcessingCache): void {
 function getCachedPageElements(
     cache: ElementProcessingCache,
     href: string
-): { pageElements: HTMLElement[]; domIndex: DOMIndex } {
+): { pageElements: HTMLElement[]; domIndex: DOMIndex; hasShadowRoots: boolean } {
     const hrefChanged = cache.lastHref !== href
     const cacheValid = cache.pageElements && !hrefChanged && !cache.cacheInvalidated
 
     if (cacheValid && cache.pageElements && cache.domIndex) {
-        return { pageElements: cache.pageElements, domIndex: cache.domIndex }
+        return {
+            pageElements: cache.pageElements,
+            domIndex: cache.domIndex,
+            hasShadowRoots: cache.hasShadowRoots ?? true,
+        }
     }
 
     cache.pageElements = collectAllElementsDeep('*', document)
     cache.domIndex = buildDOMIndex(cache.pageElements)
+    cache.hasShadowRoots = cache.pageElements.some((el) => !!el.shadowRoot && el.id !== TOOLBAR_ID)
     cache.lastHref = href
     cache.selectorToElements = {}
     cache.cacheInvalidated = false
-    return { pageElements: cache.pageElements, domIndex: cache.domIndex }
+    return { pageElements: cache.pageElements, domIndex: cache.domIndex, hasShadowRoots: cache.hasShadowRoots }
 }
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
@@ -267,6 +278,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                                   date_to: values.commonFilters.date_to,
                                   paginate_response: true,
                                   sampling_factor: values.samplingFactor,
+                                  limit: ELEMENT_STATS_PAGE_LIMIT,
                               },
                               options
                           )
@@ -360,8 +372,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
     })),
     listeners(({ actions, values, cache }) => ({
         processElements: async (_, breakpoint) => {
-            const BATCH_SIZE = 200
-            const INITIAL_BATCH_SIZE = 50
+            const SLICE_BUDGET_MS = 10
 
             const { elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled } = values.processingInputs
 
@@ -373,45 +384,42 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             cache.visibilityCache = cache.visibilityCache || new WeakMap<HTMLElement, boolean>()
             const cursorPointerCache = new WeakMap<HTMLElement, boolean>()
-            const { pageElements, domIndex } = getCachedPageElements(cache as ElementProcessingCache, href)
+            const { pageElements, domIndex, hasShadowRoots } = getCachedPageElements(
+                cache as ElementProcessingCache,
+                href
+            )
             const eventsToProcess = elementStats.results
             const totalEvents = eventsToProcess.length
 
             const allTrimmedElements: CountedHTMLElement[] = []
-            let processedCount = 0
+            let sliceStart = performance.now()
 
-            while (processedCount < totalEvents) {
-                const batchSize = processedCount === 0 ? INITIAL_BATCH_SIZE : BATCH_SIZE
-                const batchEnd = Math.min(processedCount + batchSize, totalEvents)
+            for (let i = 0; i < totalEvents; i++) {
+                const event = eventsToProcess[i]
+                const matched =
+                    matchEventToElementUsingIndex(event, dataAttributes, matchLinksByHref, domIndex) ||
+                    matchEventToElementUsingSelectors(
+                        event,
+                        dataAttributes,
+                        matchLinksByHref,
+                        pageElements,
+                        (cache as ElementProcessingCache).selectorToElements,
+                        hasShadowRoots
+                    )
 
-                for (let i = processedCount; i < batchEnd; i++) {
-                    const event = eventsToProcess[i]
-                    const matched =
-                        matchEventToElementUsingIndex(event, dataAttributes, matchLinksByHref, domIndex) ||
-                        matchEventToElement(
-                            event,
-                            dataAttributes,
-                            matchLinksByHref,
-                            pageElements,
-                            cache as ElementProcessingCache
-                        )
-
-                    if (matched) {
-                        const trimmed = trimElement(matched.element, { cursorPointerCache })
-                        if (
-                            trimmed &&
-                            elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)
-                        ) {
-                            allTrimmedElements.push({ ...matched, element: trimmed })
-                        }
+                if (matched) {
+                    const trimmed = trimElement(matched.element, { cursorPointerCache })
+                    if (trimmed && elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)) {
+                        allTrimmedElements.push({ ...matched, element: trimmed })
                     }
                 }
 
-                processedCount = batchEnd
-                actions.setProcessingProgress(processedCount, totalEvents)
-
-                breakpoint()
-                await yieldToMain()
+                if (performance.now() - sliceStart > SLICE_BUDGET_MS) {
+                    actions.setProcessingProgress(i + 1, totalEvents)
+                    breakpoint()
+                    await yieldToMain()
+                    sliceStart = performance.now()
+                }
             }
 
             actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
@@ -601,73 +609,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         cache.cacheInvalidated = false
     }),
 ])
-
-function matchEventToElement(
-    event: ElementsEventType,
-    dataAttributes: string[],
-    matchLinksByHref: boolean,
-    pageElements: HTMLElement[],
-    cache: ElementProcessingCache
-): CountedHTMLElement | null {
-    let lastSelector: string | undefined
-
-    for (let i = 0; i < event.elements.length; i++) {
-        const element = event.elements[i]
-        const selector =
-            elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
-        const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
-
-        try {
-            let domElements: HTMLElement[] | undefined = cache.selectorToElements[combinedSelector]
-            if (domElements === undefined) {
-                domElements = Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
-                cache.selectorToElements[combinedSelector] = domElements
-            }
-
-            if (domElements.length === 1) {
-                const e = event.elements[i]
-                const isTooSimple =
-                    i === 0 &&
-                    e.tag_name &&
-                    !e.attr_class &&
-                    !e.attr_id &&
-                    !e.href &&
-                    !e.text &&
-                    e.nth_child === 1 &&
-                    e.nth_of_type === 1 &&
-                    !e.attributes['attr__data-attr']
-
-                if (!isTooSimple) {
-                    return {
-                        element: domElements[0],
-                        count: event.count,
-                        selector: selector,
-                        hash: event.hash,
-                        type: event.type,
-                    } as CountedHTMLElement
-                }
-            }
-
-            if (domElements.length === 0) {
-                if (i === event.elements.length - 1) {
-                    return null
-                } else if (i > 0 && lastSelector) {
-                    lastSelector = `* > ${lastSelector}`
-                    continue
-                }
-            }
-        } catch {
-            toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
-                selector: combinedSelector,
-            })
-            break
-        }
-
-        lastSelector = combinedSelector
-    }
-
-    return null
-}
 
 function aggregateAndSortElements(elements: CountedHTMLElement[]): CountedHTMLElement[] {
     const normalisedElements = new Map<HTMLElement, CountedHTMLElement>()

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -27,7 +27,7 @@ import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
 
-const ELEMENT_STATS_PAGE_LIMIT = 2000
+export const ELEMENT_STATS_PAGE_LIMIT = 5000
 
 function yieldToMain(): Promise<void> {
     return new Promise((resolve) => {
@@ -291,11 +291,11 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                     }
 
                     return {
-                        results: [
+                        results: dedupeByChainIdentity([
                             // if url is present we are paginating and merge results, otherwise we only use the new results
                             ...(url ? values.elementStats?.results || [] : []),
                             ...(result.data.results || []),
-                        ],
+                        ]),
                         next: result.data.next,
                         previous: result.data.previous,
                     } as PaginatedResponse<ElementsEventType>
@@ -617,6 +617,20 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         cache.cacheInvalidated = false
     }),
 ])
+
+function dedupeByChainIdentity(events: ElementsEventType[]): ElementsEventType[] {
+    const seen = new Set<string>()
+    const deduped: ElementsEventType[] = []
+    for (const event of events) {
+        const identity = `${event.type}:${event.hash}`
+        if (seen.has(identity)) {
+            continue
+        }
+        seen.add(identity)
+        deduped.push(event)
+    }
+    return deduped
+}
 
 function aggregateAndSortElements(elements: CountedHTMLElement[]): CountedHTMLElement[] {
     const normalisedElements = new Map<HTMLElement, CountedHTMLElement>()

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -18,7 +18,7 @@ import { urls } from 'scenes/urls'
 
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
-import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
+import { ELEMENT_STATS_PAGE_LIMIT, heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { joinWithUiHost } from '~/toolbar/utils'
 
@@ -270,6 +270,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                     type="secondary"
                                     size="small"
                                     onClick={loadMoreElementStats}
+                                    loading={elementStatsLoading}
                                     disabledReason={
                                         canLoadMoreElementStats ? undefined : 'Loaded all elements in this data range.'
                                     }
@@ -309,6 +310,12 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                     '!'
                                 )}
                             </div>
+                            {canLoadMoreElementStats && (
+                                <div className="mb-2 text-muted text-xs">
+                                    Showing the top {ELEMENT_STATS_PAGE_LIMIT.toLocaleString()} element groups by click
+                                    count — load more for the full data range.
+                                </div>
+                            )}
                             <div className="flex flex-col w-full h-full">
                                 {countedElements.length ? (
                                     countedElements.map(({ element, count }, index) => {


### PR DESCRIPTION
## Problem

The toolbar clickmap (autocapture click / rageclick / deadclick highlighting) has always been slow, and on data-heavy pages it freezes the browser once the element stats load and processing begins. Because it was slow we also avoided loading much data, which made the feature less useful.

Profiling (real matching code bundled into Chromium, driven against synthetic DOMs and live posthog.com pages, plus ClickHouse volume checks) found four compounding causes:

1. `buildDOMIndex` computed each element's `nth_child`/`nth_of_type` with a fresh sibling scan per element - quadratic in sibling count, and fully synchronous. Measured 9.6s at 40k elements and 44.6s at 80k, in one unyielding main-thread task.
2. The index matcher checked ancestor tag/id/class but not ancestor position, so on any repeated structure (rows, cards, nav lists) candidates never disambiguated. On the live posthog.com homepage only 42/500 events matched via the index - everything else fell through to the `querySelectorAllDeep` fallback at ~3ms per event, which manually walks every collected element calling `.matches()`. It also compared the candidate's immediate parent against every chain level instead of walking up one level per entry.
3. The toolbar requested `/api/element/stats/` with no `limit`, so the server default of 50,000 rows applied. For a high-traffic page that is a response carrying ~180MB of element chain text, and 82% of the rows are count=1 singletons.
4. Processing ran in fixed 200-event batches, so a batch of expensive events could block the main thread for 650ms at a time.

## Changes

All in `domElementIndex.ts`, `heatmapToolbarMenuLogic.ts`, and `HeatmapToolbarMenu.tsx` - the shared highlighting utilities (`trimElement`, `elementIsVisible`, `getRectForElement`, `getAllClickTargets`) used by inspect / actions / experiments / product tours are untouched.

- Compute sibling positions once per parent (one pass over `children`, cached in a `WeakMap`) instead of per element. Index build at 80k elements: 44.6s -> 117ms.
- Match ancestors by fingerprint including `nth_child`/`nth_of_type`, walking one ancestor level per chain entry. Index hit rate on posthog.com goes to 100% of matchable events; the selector fallback now only runs for genuinely stale chains. Ancestors identified by an id or configured data attribute skip the position check (mirroring `elementToSelector`, which early-returns on these), so injected DOM - cookie banners, A/B wrappers - that shifts sibling positions doesn't silently demote index matches to the fallback.
- Use native `document.querySelectorAll` in the selector fallback when the page has no shadow roots (detected at index build, and rechecked cheaply on warm cache hits since `attachShadow()` emits no light-DOM mutation to invalidate the cache). Measured 68x faster for identical selectors. Pages that do have shadow roots keep `querySelectorAllDeep`.
- Bound the selector fallback at 10 chain levels per event, so a single deep-chain event (legitimately deep DOM or a forged chain) can't hold the main thread for an unbounded uninterruptible stretch. The selector cache is a `Map` (immune to `__proto__`-style event-derived keys); failing selectors are sentinel-cached and their log line is truncated and deduped.
- Request element stats in pages of 5,000 rows instead of inheriting the 50,000 default. The server already sorts by count descending (top 500 rows cover ~50% of all clicks on the posthog.com homepage) and the existing load-more path still works for the long tail - which is now cheap to process. Paginated pages are deduped by chain identity (`type` + `hash`) so a chain reordered across pages by the live aggregation isn't double-counted when results are summed.
- Surface a truncation hint ("Showing the top 5,000 element groups by click count — load more for the full data range.") when more pages are available, and give the now-primary "Load more" button an in-flight loading guard.
- Yield to the main thread on a 10ms time budget instead of every 200 events.
- New `toolbar clickmap processed` telemetry event (documented in TELEMETRY.md) captures event count, match count, index vs fallback hit counts (the rollout canary for index drift), page element count, shadow-root presence, duration, what triggered the run (`initial`/`pagination`/`refresh`/`toggle`), whether the page-elements cache was warm, and a `completed` flag - it emits from a `finally` block so runs cancelled by a newer run (exactly the slow pages worth seeing) still report.
- The selector fallback moves from `heatmapToolbarMenuLogic.ts` to `domElementIndex.ts` unchanged, so the comparison test suite exercises the real implementation instead of a hand-maintained copy, and both matchers share one `isTooSimple`.

Measured end to end (same events, same pages, before -> after):

| scenario | before | after |
|---|---|---|
| index build, 80k elements | 44,647ms | 117ms |
| full pipeline, 40k element page, 750 events | 34,017ms | 1,085ms |
| 500 events on live posthog.com/pricing | 1,743ms | 33ms |
| 500 events on live posthog.com/docs | 843ms | 16ms |

## How did you test this code?

- `jest frontend/src/toolbar` - all 421 pass.
- New parameterized cases in `domElementIndex.test.ts`, each catching a regression nothing else did:
  - repeated identical structures disambiguated by ancestor position - fails on the old position-blind `matchesParent` (the production 42/500 hit-rate bug)
  - disambiguation that only resolves at grandparent depth - fails on the old code that compared the immediate parent against every chain level
  - ancestors identified by id / data attribute still match when their sibling position drifted (injected banner) - verified to fail on the position-strict walk before this fix
  - the index-vs-selector comparison suite now runs against the real exported fallback in both `hasShadowRoots` modes, so the native-`querySelectorAll` path is held to the same agreement contract as the shadow-DOM path
- Benchmarked the actual repo functions (esbuild bundle, Chromium via Playwright + CDP profiling) on synthetic DOMs at 4k-80k elements and on live posthog.com pages - numbers above.
- Revalidated the pipeline at 5,000 events vs 2,000 (matching code untouched by the page-size change): per-event matching cost is unchanged and total processing scales linearly, so the larger page stays non-blocking under the 10ms yield budget.
- I did not manually run the full toolbar against production with authenticated element stats data.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. The investigation used static analysis, jest, esbuild-bundled benchmark probes driven by Playwright + CDP against synthetic DOMs and live posthog.com pages, and ClickHouse queries to size real element-stats payloads.
- Skills invoked: /writing-tests.
- Decisions: kept the selector fallback (it still adds recall for stale chains where strict position matching fails) rather than deleting it; dropped an initially planned per-event match-result cache because matching became fast enough that reprocessing on pagination is tens of milliseconds - the cache would only have added invalidation state; chose 5,000 as the page size since the server sorts by count and load-more covers the tail; deduped paginated pages by chain identity client-side rather than reconciling server offsets.
- Known limitation: on pages that contain shadow roots the stale-chain fallback still pays the `querySelectorAllDeep` cost; the page limit bounds it.


