### PR TITLE
chore(agents): add PR workflow skills

### DIFF
--- a/.agents/skills/getting-prs-approved/SKILL.md
+++ b/.agents/skills/getting-prs-approved/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: getting-prs-approved
+description: >
+  Gets a PostHog/posthog PR approved and merged with minimal waiting. Checks stamphog
+  auto-approval eligibility with the local gates dry-run, fixes what blocks it (size
+  ceiling, deny-list categories, title words, unresolved bot findings), manages the
+  stamphog label lifecycle, and routes gated PRs to the fastest human approval path
+  (priority-review label, owner-targeted asks). Use when a PR needs a stamp, review,
+  or approval, when stamphog refused or removed its label, when deciding whether a PR
+  can be auto-approved, or before opening a PR to make it stampable.
+---
+
+# Getting PRs approved
+
+PostHog/posthog has two review tracks: **stamphog** (the auto-approval agent, triggered by the `stamphog` label) typically approves eligible PRs within the hour, while human review commonly takes half a day to several days depending on reviewer availability. Aim every PR at the stamphog track when eligible; when gated, escalate deliberately instead of waiting.
+
+## Step 1 — check the gates locally (no LLM call, seconds)
+
+```bash
+uv run tools/pr-approval-agent/review_pr.py <PR_NUMBER> --dry-run
+```
+
+Runs stamphog's deterministic gates only (prerequisites, deny-list, size, tier). Requires `gh` auth. Do this **before** applying the label — it reports exactly why a PR would be refused.
+
+## Stamphog policy summary
+
+Source of truth is `tools/pr-approval-agent/gates.py` and its README — re-check there if behavior surprises you.
+
+**Hard prerequisites:** not a draft, no merge conflicts, no outstanding changes-requested review, human author (bot-authored PRs are always refused).
+
+**Size ceiling:** ≤500 changed lines (additions + deletions) and ≤20 files. Generated files count.
+
+**Deny categories** — any match forces human review. Matching runs on **file paths and the PR title**, so a title word alone can trip a category:
+
+| Category       | Trips on                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| auth           | auth/login/signup/oauth/saml/sso/oidc/credential/password/2fa/mfa (title or path); `permission` paths                                       |
+| crypto_secrets | crypto/encrypt/decrypt/vault; paths containing secret, api_key, private_key, `.env`, `.pem`                                                 |
+| migrations     | any `migrations/` path — see the analyzer bypass below                                                                                      |
+| infra_cicd     | `.github/workflows`, dockerfile, docker-compose, deploy, k8s paths; terraform/kubernetes/helm in the title                                  |
+| billing        | billing/payment/stripe/invoice/subscription/pricing — title counts                                                                          |
+| public_api     | openapi, api_schema, swagger, public_api — a title like "regenerate openapi types" trips it                                                 |
+| deps_toolchain | package.json, lockfiles (pnpm-lock, Cargo.lock, uv.lock…), pyproject.toml, requirements.txt, go.mod, Makefile, Dockerfile, tsconfig, .nvmrc |
+
+**Bot findings:** stamphog independently verifies confirmed reviewer-bot findings (e.g. greptile P1s) in source and escalates instead of approving. Resolve or explicitly rebut them before labeling.
+
+**Migrations bypass:** the Backend CI migration analyzer marks safe migrations (the `stamphog:v1` marker), which stamphog then ignores for deny purposes. If the PR's only deny hit is safe migrations, **wait for the Backend CI migration check to finish before labeling** — labeling early returns "Migration risk check pending; re-label after it completes."
+
+## Step 2 — make it stampable (often a 5-minute restructure)
+
+1. **Quarantine deny files.** A lockfile bump, workflow edit, or migration inside a feature PR drags the whole PR onto the human track. Move them to their own minimal PR.
+2. **Fix the title.** Strip deny words (billing, openapi, auth, deploy…) from titles when the change isn't actually in that domain.
+3. **Trim below 500 lines / 20 files** — but don't over-split; see `slicing-prs`.
+4. **Resolve confirmed bot findings** with a fix or a rebuttal comment.
+
+## Step 3 — apply the label and understand its lifecycle
+
+```bash
+gh pr edit <PR> --add-label stamphog
+```
+
+- **APPROVED** → the label stays on (marks the PR as stamphog'd). The approval comes from github-actions[bot] and counts for branch protection.
+- **REFUSE / ESCALATE** → the label is stripped. Address the feedback, then **re-apply the label** — it does not retry on its own.
+- **ERROR** (LLM backend outage) → the label stays and the review retries on the next push.
+- **New pushes:** trivial deltas (tests/docs/lockfile/generated paths, clean merges from the base branch) retain the approval; anything else dismisses it and auto re-reviews. Avoid pushing cosmetic changes onto an already-approved PR.
+
+## Step 4 — human track (when genuinely gated)
+
+Most stamphog denials still end in a human approval — a denial mostly means added latency, so escalate immediately rather than waiting passively:
+
+1. **Apply the `priority-review` label** — it auto-posts the PR to #dev-stamp-exchange (`gh pr edit <PR> --add-label priority-review`). Costs nothing, do it first.
+2. **Ask a specific likely approver.** Find the owning team with the `establishing-code-ownership` skill, then check who recently approved merged PRs touching the same paths (`gh pr view <n> --json reviews` on a few of them). A targeted ask to someone currently online resolves in minutes; untargeted channel posts often need a follow-up ping. Offering a reciprocal review speeds things up.
+3. **Team-channel group ping** for team-owned code (migrations, ClickHouse, cross-team files) with a one-line risk summary — these never pass stamphog, and generic stamp-exchange posts for them tend to go unanswered.
+
+**Timing:** review capacity clusters in reviewer timezones. Post asks early in your overlap window, and pre-announce PRs that will be ready late in your day so a reviewer expects them.
+
+**Other repos:** stamphog only runs in PostHog/posthog. PRs in sibling repos (charts, cloud infra) are always human-track — batch them, post early, and name a reviewer.

--- a/.agents/skills/preflighting-pushes/SKILL.md
+++ b/.agents/skills/preflighting-pushes/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: preflighting-pushes
+description: >
+  Runs CI-matching validation locally before pushing a PostHog branch so the first
+  push is green — regenerates generated artifacts (OpenAPI types, query and MCP
+  snapshots), lints, formats, typechecks, and checks Django/ClickHouse migration
+  numbering against master. Use before pushing, before opening a PR, after rebasing
+  or restacking a branch, or when asked to "make sure CI passes" before push.
+---
+
+# Preflighting pushes
+
+Follow-up commits that only regenerate artifacts or appease linters are among the most common commits pushed after a PR opens, and each one costs a full CI round trip.
+Run exactly what the diff needs locally, then push once.
+
+## Step 1 — scope the diff
+
+```bash
+git fetch origin master
+git diff --name-only origin/master...HEAD
+```
+
+Everything below is conditional on what appears in that list; skip sections whose trigger paths aren't touched.
+
+## Step 2 — regenerate what CI will validate
+
+| Touched                                                            | Run                                                                        | Why                                                                                                                                                                         |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Any DRF serializer/viewset (`posthog/api/`, `products/*/backend/`) | `hogli build:openapi`                                                      | the "Validate OpenAPI types" check fails on drift; regenerated files under `frontend/src/generated/` and `products/*/frontend/generated/` must be committed with the change |
+| HogQL / query runners / ClickHouse SQL                             | rerun the touched backend tests with snapshot update (`--snapshot-update`) | query snapshots drift with any SQL change                                                                                                                                   |
+| MCP `tools.yaml`, tool schemas, or MCP-exposed serializers         | rerun the MCP unit tests with snapshot update                              | tool-schema snapshots drift with any schema change                                                                                                                          |
+
+Commit regenerated artifacts in the same commit as the source change — never as a follow-up.
+
+**Stacked branches:** regenerate only on the layer about to merge; regen commits on upper layers are invalidated by every restack.
+
+## Step 3 — lint, format, typecheck
+
+- Python touched: `ruff check . --fix && ruff format .`; verify new and changed functions carry full type annotations — mypy runs only in CI, so a missing annotation is a deferred CI failure.
+- Frontend touched: `pnpm --filter=@posthog/frontend format` and `pnpm --filter=@posthog/frontend typescript:check`.
+- Rust touched: `cargo fmt` and `cargo clippy` in the touched crate; proto files have their own lint job.
+
+## Step 4 — migration numbering check
+
+Long-lived branches race master's migration counter; a numbering collision blocks review.
+For each app with a new migration in the diff:
+
+```bash
+git ls-tree origin/master --name-only <app>/migrations/ | sort | tail -3
+ls <app>/migrations/ | sort | tail -3
+```
+
+If master reached or passed your number, renumber before pushing — see the `django-migrations` skill for the safe rebase procedure.
+Apply the same check to ClickHouse migrations under `posthog/clickhouse/migrations/`.
+
+## Step 5 — targeted tests, then one push
+
+Run the tests nearest the change (`hogli test <file_or_dir>` or `hogli test --changed`), then push a single time with everything included.
+If the PR is headed for auto-approval, a clean push also avoids dismissing an existing stamphog approval with a non-trivial delta — see `getting-prs-approved`.

--- a/.agents/skills/slicing-prs/SKILL.md
+++ b/.agents/skills/slicing-prs/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: slicing-prs
+description: >
+  Decides how to slice a change into PostHog PRs before building or opening them —
+  auto-approval track vs human review track, when to stack vs collapse into one PR,
+  quarantining deny-listed files (dependencies, migrations, workflows) into their own
+  PRs, and validating direction with the DRI before large speculative builds. Use
+  when planning a feature's PR structure, splitting a large diff, opening a stack,
+  or asking "should this be one PR or several?".
+---
+
+# Slicing PRs
+
+A large share of never-merged PRs die to structure, not content: stacks that get collapsed because reviewers wanted one PR, fragments split purely to duck a size limit, and fully-built features abandoned when priorities shift.
+Slice deliberately up front instead of restructuring under review.
+
+## Rule 1 — aim every PR at the auto-approval track
+
+A PR stamphog can take merges in about an hour; one that needs a human commonly waits half a day to several days.
+Stampable means: ≤500 changed lines, ≤20 files, no deny-category files or title words (auth, billing, migrations, lockfiles/deps, `.github/workflows`, openapi/swagger — full list in `getting-prs-approved`), not a draft, no confirmed bot findings.
+
+## Rule 2 — don't over-split
+
+Splitting below the size reviewers actually consume creates pure overhead: coupled fragments get re-assembled into one PR anyway, and each fragment pays its own CI, regeneration, and rebase tax.
+
+- One coherent feature under 500 lines → **one PR**, even if it has several conceptual parts.
+- Split only along **independently shippable seams** — each PR must be mergeable and revertable alone, with a one-line purpose a reviewer understands without reading the sibling PRs.
+- Never split purely to duck the size ceiling; a 600-line coherent change on the human track beats two coupled 300-line PRs that must land together.
+
+## Rule 3 — quarantine deny-listed files
+
+Lockfile or dependency bumps, Django/ClickHouse migrations, and workflow edits each force everything sharing their PR onto the human track:
+
+- dependency bump → standalone PR (human-track regardless; keep it minimal with one line of intent)
+- migration → standalone PR when possible; the Backend CI migration analyzer can clear safe migrations for stamphog, but only when the rest of the PR passes the other gates
+- feature code → stampable PR(s) referencing the above
+
+## Rule 4 — stacks: shallow, land-as-you-go
+
+Deep stacks rot: bottom layers wait on review while upper layers accumulate rebases, migration-number collisions, and invalidated regenerated artifacts.
+
+- Keep roughly **three live layers maximum**; land the bottom before cutting a fourth.
+- Make each layer independently stampable when possible — a stack where every layer needs a human serializes days of latency.
+- Regenerate artifacts (OpenAPI types, snapshots) only on the layer about to merge — see `preflighting-pushes`.
+- Migrations go in the bottom layer or their own PR; expect renumbering at land time.
+- Delete local branches as layers land — see `sweeping-open-prs`.
+
+## Rule 5 — DRI check before speculative builds
+
+Fully-built multi-PR features abandoned as drafts are a recurring failure mode; the validation happened at PR time instead of before build time.
+Before building anything that will exceed roughly two PRs or a thousand lines:
+
+1. Write five lines: problem, approach, expected PR plan (count, rough sizes, which need human review).
+2. Get an explicit go-ahead from the DRI or owning team.
+3. Only then build. If the answer is "not now", file the five lines as an issue and move on — that is the cheap version of an abandoned ten-PR stack.
+
+## Rule 6 — plan human-track PRs around reviewer availability
+
+Any PR that will need a human (sibling repos without stamphog, migrations, cross-team files): open it early in your overlap window with reviewers, name a reviewer, and pre-announce anything that lands late in your day — per the `getting-prs-approved` ladder.

--- a/.agents/skills/sweeping-open-prs/SKILL.md
+++ b/.agents/skills/sweeping-open-prs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: sweeping-open-prs
+description: >
+  Sweeps the user's open PostHog PRs and unsticks each one — merges approved-and-green
+  PRs, classifies red CI, chases missing reviews, forces ship-or-close decisions on
+  stale drafts, and deletes local branches already squash-merged. Use for "check my
+  PRs", "babysit my PRs", a recurring morning PR sweep, or when PRs sit approved but
+  unmerged.
+---
+
+# Sweeping open PRs
+
+Approval is not the finish line: approved PRs routinely sit unmerged for days behind red CI shards, stack ordering, or plain inattention — accumulating conflicts and losing stamphog approvals to dismissal on the next push.
+This sweep converts every open PR from "waiting" into one explicit action.
+
+## Step 1 — inventory
+
+```bash
+gh pr list --repo PostHog/posthog --author @me --state open \
+  --json number,title,isDraft,createdAt,reviewDecision,mergeable,labels,headRefName,additions,deletions,statusCheckRollup
+```
+
+Include sibling repos the user works in (e.g. charts, cloud infra) when relevant.
+
+## Step 2 — triage every PR into exactly one action
+
+Work oldest-first. For each PR take the FIRST matching row:
+
+| State                                | Action                                                                                                                                                                                                                                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Approved + checks green + mergeable  | **Merge now** (or `gh pr merge <n> --auto --squash`). Sitting invites conflicts and stamphog-approval dismissal.                                                                                                                                                                            |
+| Approved + red checks                | Classify before touching anything: generated-artifact drift (Validate OpenAPI types, query/MCP snapshots) → regenerate locally per `preflighting-pushes` and push; suspected flake or master break → `debugging-ci-failures` (start with `hogli ci:insights`); real failure → fix it today. |
+| Approved + blocked by a downstack PR | Land the stack bottom-up first. If reviewers approved several layers, consider collapsing the remaining layers into one PR.                                                                                                                                                                 |
+| No review yet + auto-approvable      | `getting-prs-approved` (gates dry-run, then the `stamphog` label).                                                                                                                                                                                                                          |
+| No review yet + gated to humans      | `priority-review` label plus a targeted ask per the `getting-prs-approved` escalation ladder. Re-ping anything quiet for more than a day.                                                                                                                                                   |
+| Changes requested                    | Address or rebut every comment today, re-request review, and re-apply the `stamphog` label if it was stripped.                                                                                                                                                                              |
+| Merge conflicts                      | Rebase or update the branch now, before the conflict grows.                                                                                                                                                                                                                                 |
+| Draft, older than a week             | Decide: promote to ready this week, or close with a one-line comment saying why (superseded, deprioritized, parked — see issue). Old drafts rarely land; closing one recovers attention, and the branch still exists.                                                                       |
+
+## Step 3 — local branch hygiene
+
+Squash-merge makes `git branch --merged` useless. Match local branches against merged PR head refs instead:
+
+```bash
+gh pr list --repo PostHog/posthog --author @me --state merged --limit 200 \
+  --json headRefName --jq '.[].headRefName' > /tmp/merged-refs.txt
+git for-each-ref refs/heads --format='%(refname:short)' | grep -Fxf /tmp/merged-refs.txt
+```
+
+Delete those local branches (`git branch -D`) after confirming none is checked out or carries unpushed commits (`git log origin/<branch>..<branch>` is empty).
+Flag — don't delete — never-landed branches older than a month; list them for an explicit keep-or-kill decision.
+
+## Step 4 — report
+
+End with a compact table: PR → one-line status → action taken → what's still needed and from whom (a named person or team, not "someone").
+Put anything approved for more than a day and still unmerged at the top.


### PR DESCRIPTION
## Problem

Getting a PR from open to merged in this repo relies on knowledge that lives in code and tribal memory: stamphog's exact gates and label lifecycle, the priority-review path, which regeneration follow-ups CI forces, and how PR structure affects review latency. Agents and engineers rediscover it session by session, and the symptoms are familiar: regen-only fix commits, approved PRs sitting unmerged, stacks collapsed mid-review, and stamp requests that wait on the wrong channel.

## Changes

Adds four dev skills under `.agents/skills/` covering the PR lifecycle:

- **getting-prs-approved** – stamphog policy summary (size ceiling, deny categories, migration analyzer bypass), the local gates dry-run, label lifecycle, and the human-track escalation ladder (priority-review label, owner-targeted asks)
- **sweeping-open-prs** – a triage matrix turning every open PR into one explicit action, plus local branch cleanup that works with squash merges
- **preflighting-pushes** – diff-scoped local validation before pushing: OpenAPI type regen, snapshot updates, lint/format/typecheck, and a migration numbering check against master
- **slicing-prs** – deciding PR structure up front: aiming at the auto-approval track, when to stack vs collapse, quarantining deny-listed files, and a DRI check before large speculative builds

Markdown only, no production code. The skills are picked up automatically via the existing `.claude/skills` symlink.

## How did you test this code?

No automated tests (markdown-only). Policy claims were verified against their sources in this repo: `tools/pr-approval-agent/gates.py` (size ceiling and deny categories), `tools/pr-approval-agent/README.md` (verdict handling and dry-run), `.github/workflows/pr-approval-agent.yml` (label lifecycle, delta retention), and `.github/workflows/pr-priority-review.yml` (priority-review notifications). Claude Code confirmed the new skills register from `.agents/skills/` in a live session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal agent skills only, no public docs impact (`skip-inkeep-docs` applied).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude Code to analyze where my PRs lose time and encode the fixes as reusable skills. Claude authored the four skills, sourcing the policy content from `tools/pr-approval-agent/` and the workflow files rather than from memory, and invoked the repo `/writing-skills` skill for naming and structure conventions. We chose `.agents/skills/` over `products/*/skills/` because these target engineers working in the monorepo, not product agents, and generalized the drafts to remove anything person-specific before committing.
