### PR TITLE
fix(agent-proxy): handle client disconnects during ingest

### DIFF
--- a/services/agent-proxy/src/hono/app.ts
+++ b/services/agent-proxy/src/hono/app.ts
@@ -49,9 +49,6 @@ export function createApp(redis: Redis, config: Config, publicKeys: CryptoKey[])
     const lifecycle: Lifecycle = { shuttingDown: false }
     const streamCapacity = new StreamCapacity(config.maxConcurrentStreams, config.maxStreamsPerRun)
 
-    // Hono's default onError writes a bare console.error stack with no request
-    // context. Log structured instead, and mirror the error onto the wide
-    // http.request line. The request logger is absent on probe paths.
     app.onError((err, c) => {
         const requestLogger: RequestLogger | undefined = c.get('requestLogger')
         requestLogger?.extend({ error: err.message })

--- a/services/agent-proxy/src/hono/app.ts
+++ b/services/agent-proxy/src/hono/app.ts
@@ -20,7 +20,7 @@ import type { Redis } from 'ioredis'
 
 import type { Config } from '../lib/config.js'
 import { validateStreamReadToken } from '../lib/jwt.js'
-import { logger } from '../lib/logging.js'
+import { logger, type RequestLogger } from '../lib/logging.js'
 import { getStreamKey } from '../lib/redis-stream.js'
 import { StreamCapacity } from '../lib/stream-capacity.js'
 import type { StreamReadTokenPayload } from '../lib/types.js'
@@ -29,14 +29,14 @@ import { observeStreamConnectionRejected } from './metrics.js'
 import { corsHeaders, corsPreflightHandler, httpMetrics, requestLog, securityHeaders } from './middleware.js'
 import { registerPublicRoutes } from './public-routes.js'
 import { streamTaskRunEvents } from './sse-handler.js'
-import type { Lifecycle } from './types.js'
+import type { HonoVariables, Lifecycle } from './types.js'
 
 // ---------------------------------------------------------------------------
 // Exported types
 // ---------------------------------------------------------------------------
 
 export interface App {
-    app: Hono
+    app: Hono<{ Variables: HonoVariables }>
     lifecycle: Lifecycle
 }
 
@@ -45,9 +45,25 @@ export interface App {
 // ---------------------------------------------------------------------------
 
 export function createApp(redis: Redis, config: Config, publicKeys: CryptoKey[]): App {
-    const app = new Hono()
+    const app = new Hono<{ Variables: HonoVariables }>()
     const lifecycle: Lifecycle = { shuttingDown: false }
     const streamCapacity = new StreamCapacity(config.maxConcurrentStreams, config.maxStreamsPerRun)
+
+    // Hono's default onError writes a bare console.error stack with no request
+    // context. Log structured instead, and mirror the error onto the wide
+    // http.request line. The request logger is absent on probe paths.
+    app.onError((err, c) => {
+        const requestLogger: RequestLogger | undefined = c.get('requestLogger')
+        requestLogger?.extend({ error: err.message })
+        logger.error('http.unhandled_error', {
+            requestId: requestLogger?.id,
+            method: c.req.method,
+            path: new URL(c.req.url).pathname,
+            error: err.message,
+            stack: err.stack,
+        })
+        return c.json({ error: 'Internal server error' }, 500)
+    })
 
     app.use('*', securityHeaders)
     app.use('*', corsHeaders(config))

--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -9,8 +9,7 @@
 //   401  missing / invalid JWT
 //   403  JWT claims don't match URL params
 //   405  wrong HTTP method
-//   408  client disconnected mid-body: {error, last_accepted_seq} (the
-//        response is undeliverable; the status exists for logs and metrics)
+//   408  client disconnected mid-body: {error, last_accepted_seq}
 //   409  SequenceGap / AlreadyCompleted / CompletionSequenceMismatch: {error, last_accepted_seq}
 //   413  payload too large: {error, last_accepted_seq}
 
@@ -120,10 +119,6 @@ export async function handleIngest(
         result = await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming)
     } catch (err: unknown) {
         if (err instanceof ClientDisconnected) {
-            // Sandbox teardown or connection reset mid-body is a normal client
-            // event, not a server error (mirrors event_ingest.py). Events
-            // accepted before the drop are already in Redis; the client
-            // resumes from last_accepted_seq with seq-based dedup.
             logger.info('ingest:client_disconnect', {
                 run: claims.runId,
                 accepted: err.accepted,
@@ -249,8 +244,6 @@ async function ingestEventLines(
             )
         }
     } catch (err: unknown) {
-        // The disconnect is raised by the body reader, which can't see ingest
-        // progress; attach it here so the handler can log and respond with it.
         if (err instanceof ClientDisconnected) {
             err.accepted = result.accepted
             err.duplicate = result.duplicate
@@ -410,9 +403,6 @@ async function* iterRequestLines(request: Request, run: string, timing: IngestBo
     }
 }
 
-// Node surfaces a client hanging up mid-body as an IncomingMessage abort:
-// Error('aborted') with code ECONNRESET (node:_http_server abortIncoming).
-// AbortError and premature-close cover the web-stream and pipeline variants.
 function isClientAbortError(err: unknown): boolean {
     if (!(err instanceof Error)) {
         return false

--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -115,25 +115,24 @@ export async function handleIngest(
         bytes: 0,
     }
 
-    // Caller-owned so the disconnect branch below can report partial progress.
-    const result: EventIngestResult = { accepted: 0, duplicate: 0, last_accepted_seq: 0 }
+    let result: EventIngestResult
     try {
-        await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming, result)
+        result = await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming)
     } catch (err: unknown) {
         if (err instanceof ClientDisconnected) {
-            // Sandbox teardown or connection reset mid-body — a normal client
+            // Sandbox teardown or connection reset mid-body is a normal client
             // event, not a server error (mirrors event_ingest.py). Events
             // accepted before the drop are already in Redis; the client
             // resumes from last_accepted_seq with seq-based dedup.
             logger.info('ingest:client_disconnect', {
                 run: claims.runId,
-                accepted: result.accepted,
-                duplicate: result.duplicate,
-                lastSeq: result.last_accepted_seq,
+                accepted: err.accepted,
+                duplicate: err.duplicate,
+                lastSeq: err.lastAcceptedSeq,
                 chunks: bodyTiming.chunks,
                 bodyBytes: bodyTiming.bytes,
             })
-            return c.json({ error: 'Client disconnected', last_accepted_seq: result.last_accepted_seq }, 408)
+            return c.json({ error: 'Client disconnected', last_accepted_seq: err.lastAcceptedSeq }, 408)
         }
         if (err instanceof EventIngestBadRequest) {
             return c.json({ error: err.message }, 400)
@@ -193,10 +192,13 @@ async function ingestEventLines(
     originalToken: string,
     config: Config,
     rawRequest: Request,
-    bodyTiming: IngestBodyTiming,
-    result: EventIngestResult
-): Promise<void> {
-    result.last_accepted_seq = await redisStream.getLastSequence()
+    bodyTiming: IngestBodyTiming
+): Promise<EventIngestResult> {
+    const result: EventIngestResult = {
+        accepted: 0,
+        duplicate: 0,
+        last_accepted_seq: await redisStream.getLastSequence(),
+    }
 
     let eventCount = 0
     let completionLineFinalSeq: number | null = null
@@ -247,6 +249,13 @@ async function ingestEventLines(
             )
         }
     } catch (err: unknown) {
+        // The disconnect is raised by the body reader, which can't see ingest
+        // progress; attach it here so the handler can log and respond with it.
+        if (err instanceof ClientDisconnected) {
+            err.accepted = result.accepted
+            err.duplicate = result.duplicate
+            err.lastAcceptedSeq = result.last_accepted_seq
+        }
         // Re-throw EventIngestPayloadTooLarge with the current last_accepted_seq
         // if the error didn't carry one (mirrors Python's except re-raise).
         if (err instanceof EventIngestPayloadTooLarge && result.last_accepted_seq > 0 && err.lastAcceptedSeq === 0) {
@@ -258,6 +267,8 @@ async function ingestEventLines(
     if (completionLineFinalSeq !== null) {
         await redisStream.markCompleteAfterSequence(completionLineFinalSeq)
     }
+
+    return result
 }
 
 // ---------------------------------------------------------------------------

--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -9,6 +9,8 @@
 //   401  missing / invalid JWT
 //   403  JWT claims don't match URL params
 //   405  wrong HTTP method
+//   408  client disconnected mid-body: {error, last_accepted_seq} (the
+//        response is undeliverable; the status exists for logs and metrics)
 //   409  SequenceGap / AlreadyCompleted / CompletionSequenceMismatch: {error, last_accepted_seq}
 //   413  payload too large: {error, last_accepted_seq}
 
@@ -28,6 +30,7 @@ import { logger } from '../lib/logging.js'
 import { TaskRunRedisStream, getStreamKey } from '../lib/redis-stream.js'
 import { heartbeatWorkflowIfNeeded } from '../lib/side-effects.js'
 import {
+    ClientDisconnected,
     EventIngestBadRequest,
     EventIngestPayloadTooLarge,
     TaskRunStreamSequenceGap,
@@ -112,10 +115,26 @@ export async function handleIngest(
         bytes: 0,
     }
 
-    let result: EventIngestResult
+    // Caller-owned so the disconnect branch below can report partial progress.
+    const result: EventIngestResult = { accepted: 0, duplicate: 0, last_accepted_seq: 0 }
     try {
-        result = await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming)
+        await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming, result)
     } catch (err: unknown) {
+        if (err instanceof ClientDisconnected) {
+            // Sandbox teardown or connection reset mid-body — a normal client
+            // event, not a server error (mirrors event_ingest.py). Events
+            // accepted before the drop are already in Redis; the client
+            // resumes from last_accepted_seq with seq-based dedup.
+            logger.info('ingest:client_disconnect', {
+                run: claims.runId,
+                accepted: result.accepted,
+                duplicate: result.duplicate,
+                lastSeq: result.last_accepted_seq,
+                chunks: bodyTiming.chunks,
+                bodyBytes: bodyTiming.bytes,
+            })
+            return c.json({ error: 'Client disconnected', last_accepted_seq: result.last_accepted_seq }, 408)
+        }
         if (err instanceof EventIngestBadRequest) {
             return c.json({ error: err.message }, 400)
         }
@@ -174,13 +193,10 @@ async function ingestEventLines(
     originalToken: string,
     config: Config,
     rawRequest: Request,
-    bodyTiming: IngestBodyTiming
-): Promise<EventIngestResult> {
-    const result: EventIngestResult = {
-        accepted: 0,
-        duplicate: 0,
-        last_accepted_seq: await redisStream.getLastSequence(),
-    }
+    bodyTiming: IngestBodyTiming,
+    result: EventIngestResult
+): Promise<void> {
+    result.last_accepted_seq = await redisStream.getLastSequence()
 
     let eventCount = 0
     let completionLineFinalSeq: number | null = null
@@ -242,8 +258,6 @@ async function ingestEventLines(
     if (completionLineFinalSeq !== null) {
         await redisStream.markCompleteAfterSequence(completionLineFinalSeq)
     }
-
-    return result
 }
 
 // ---------------------------------------------------------------------------
@@ -307,7 +321,9 @@ async function* iterRequestLines(request: Request, run: string, timing: IngestBo
 
     try {
         while (true) {
-            const { done, value } = await reader.read()
+            const { done, value } = await reader.read().catch((err: unknown) => {
+                throw isClientAbortError(err) ? new ClientDisconnected() : err
+            })
 
             if (value !== undefined && value.length > 0) {
                 const chunkAt = Date.now()
@@ -381,6 +397,20 @@ async function* iterRequestLines(request: Request, run: string, timing: IngestBo
     } finally {
         reader.releaseLock()
     }
+}
+
+// Node surfaces a client hanging up mid-body as an IncomingMessage abort:
+// Error('aborted') with code ECONNRESET (node:_http_server abortIncoming).
+// AbortError and premature-close cover the web-stream and pipeline variants.
+function isClientAbortError(err: unknown): boolean {
+    if (!(err instanceof Error)) {
+        return false
+    }
+    if (err.name === 'AbortError') {
+        return true
+    }
+    const code = (err as NodeJS.ErrnoException).code
+    return code === 'ECONNRESET' || code === 'ERR_STREAM_PREMATURE_CLOSE' || err.message === 'aborted'
 }
 
 // Decode bytes as UTF-8, mapping decode errors to EventIngestBadRequest.

--- a/services/agent-proxy/src/hono/public-routes.ts
+++ b/services/agent-proxy/src/hono/public-routes.ts
@@ -9,7 +9,7 @@
 // provisioned. Unset keeps the route open for in-cluster scrapes that have
 // no token configured.
 
-import type { Hono } from 'hono'
+import type { Env, Hono } from 'hono'
 import { createHash, timingSafeEqual } from 'node:crypto'
 
 import { register, shuttingDown as shuttingDownGauge } from './metrics.js'
@@ -26,7 +26,7 @@ function tokensMatch(provided: string, expected: string): boolean {
     return timingSafeEqual(providedDigest, expectedDigest)
 }
 
-export function registerPublicRoutes(app: Hono, lifecycle: Lifecycle, metricsToken: string): void {
+export function registerPublicRoutes<E extends Env>(app: Hono<E>, lifecycle: Lifecycle, metricsToken: string): void {
     app.get('/_health', (c) => c.json({ status: 'ok' }))
 
     app.get('/_readyz', (c) => {

--- a/services/agent-proxy/src/lib/logging.ts
+++ b/services/agent-proxy/src/lib/logging.ts
@@ -110,6 +110,12 @@ export class RequestLogger {
         this.data['requestId'] = this.requestId
     }
 
+    // Exposed so out-of-band log lines (e.g. app.onError) can correlate with
+    // the wide http.request line for the same request.
+    get id(): string {
+        return this.requestId
+    }
+
     // Merge additional fields into the accumulated record. Later calls win on
     // key conflicts — route handlers overwrite middleware-set placeholders.
     extend(data: Record<string, unknown>): void {

--- a/services/agent-proxy/src/lib/logging.ts
+++ b/services/agent-proxy/src/lib/logging.ts
@@ -110,8 +110,6 @@ export class RequestLogger {
         this.data['requestId'] = this.requestId
     }
 
-    // Exposed so out-of-band log lines (e.g. app.onError) can correlate with
-    // the wide http.request line for the same request.
     get id(): string {
         return this.requestId
     }

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -62,10 +62,6 @@ export class EventIngestPayloadTooLarge extends Error {
     }
 }
 
-// Raised when the client drops the connection mid-request-body. Matches the
-// Python ClientDisconnected in event_ingest.py: a normal client event, not a
-// server error. Carries partial ingest progress the same way
-// EventIngestPayloadTooLarge carries lastAcceptedSeq.
 export class ClientDisconnected extends Error {
     constructor(
         public accepted: number = 0,

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -64,9 +64,14 @@ export class EventIngestPayloadTooLarge extends Error {
 
 // Raised when the client drops the connection mid-request-body. Matches the
 // Python ClientDisconnected in event_ingest.py: a normal client event, not a
-// server error.
+// server error. Carries partial ingest progress the same way
+// EventIngestPayloadTooLarge carries lastAcceptedSeq.
 export class ClientDisconnected extends Error {
-    constructor() {
+    constructor(
+        public accepted: number = 0,
+        public duplicate: number = 0,
+        public lastAcceptedSeq: number = 0
+    ) {
         super('Client disconnected during event ingest')
         this.name = 'ClientDisconnected'
     }

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -62,6 +62,16 @@ export class EventIngestPayloadTooLarge extends Error {
     }
 }
 
+// Raised when the client drops the connection mid-request-body. Matches the
+// Python ClientDisconnected in event_ingest.py: a normal client event, not a
+// server error.
+export class ClientDisconnected extends Error {
+    constructor() {
+        super('Client disconnected during event ingest')
+        this.name = 'ClientDisconnected'
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Redis stream types
 // ---------------------------------------------------------------------------

--- a/services/agent-proxy/tests/hono/app.test.ts
+++ b/services/agent-proxy/tests/hono/app.test.ts
@@ -1,9 +1,3 @@
-// Tests for app-level error handling (app.onError in app.ts).
-//
-// Unexpected errors escaping a route handler (Redis failures, bugs) must
-// produce a structured error log with request context and a JSON 500 — not
-// Hono's default bare console.error with no run or request correlation.
-
 import type { Redis } from 'ioredis'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 

--- a/services/agent-proxy/tests/hono/app.test.ts
+++ b/services/agent-proxy/tests/hono/app.test.ts
@@ -1,0 +1,65 @@
+// Tests for app-level error handling (app.onError in app.ts).
+//
+// Unexpected errors escaping a route handler (Redis failures, bugs) must
+// produce a structured error log with request context and a JSON 500 — not
+// Hono's default bare console.error with no run or request correlation.
+
+import type { Redis } from 'ioredis'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { Config } from '@/lib/config.js'
+import { logger } from '@/lib/logging.js'
+
+vi.mock('@/lib/jwt.js', () => ({
+    validateSandboxEventIngestToken: vi.fn(),
+    validateStreamReadToken: vi.fn(),
+    loadPublicKeys: vi.fn(),
+}))
+
+import { createApp } from '@/hono/app.js'
+import { validateSandboxEventIngestToken } from '@/lib/jwt.js'
+
+const mockValidate = vi.mocked(validateSandboxEventIngestToken)
+
+function makeConfig(): Config {
+    return {
+        redisUrl: 'redis://localhost:6379',
+        sandboxJwtPublicKeysPem: [],
+        corsOrigins: new Set(),
+        djangoCallbackBaseUrl: '',
+        agentProxyCallbackSecret: '',
+        maxConcurrentStreams: 1000,
+        maxStreamsPerRun: 25,
+        metricsToken: '',
+        port: 8003,
+        host: '0.0.0.0',
+        shutdownGraceMs: 300_000,
+        shutdownPrestopDelayMs: 0,
+    }
+}
+
+describe('app onError', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockValidate.mockResolvedValue({ runId: 'run-123', taskId: 'task-abc', teamId: 42 })
+    })
+
+    it('logs unexpected route errors with request context and returns JSON 500', async () => {
+        const errorSpy = vi.spyOn(logger, 'error')
+        const failingRedis = { get: vi.fn().mockRejectedValue(new Error('redis exploded')) } as unknown as Redis
+        const { app } = createApp(failingRedis, makeConfig(), [])
+
+        const res = await app.request('/v1/runs/run-123/ingest', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer tok' },
+            body: JSON.stringify({ seq: 1, event: {} }) + '\n',
+        })
+
+        expect(res.status).toBe(500)
+        expect(await res.json()).toEqual({ error: 'Internal server error' })
+
+        const logged = errorSpy.mock.calls.find((c) => c[0] === 'http.unhandled_error')?.[1] as Record<string, unknown>
+        expect(logged).toMatchObject({ error: 'redis exploded', path: '/v1/runs/run-123/ingest', method: 'POST' })
+        expect(logged.requestId).toBeTruthy()
+    })
+})

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -883,15 +883,6 @@ describe('ingest-handler', () => {
         expect(res.status).toBe(400)
     })
 
-    // -----------------------------------------------------------------------
-    // Client disconnect mid-body (sandbox teardown, connection reset)
-    //
-    // Node surfaces this as Error('aborted') code=ECONNRESET from the request
-    // body reader. It must be classified as a client event — not rethrown as
-    // an unhandled error that becomes an opaque 500 — and events accepted
-    // before the drop must stay in Redis for the client's seq-based resume.
-    // -----------------------------------------------------------------------
-
     it.each([
         {
             variant: 'ECONNRESET code',

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -884,6 +884,47 @@ describe('ingest-handler', () => {
     })
 
     // -----------------------------------------------------------------------
+    // Client disconnect mid-body (sandbox teardown, connection reset)
+    //
+    // Node surfaces this as Error('aborted') code=ECONNRESET from the request
+    // body reader. It must be classified as a client event — not rethrown as
+    // an unhandled error that becomes an opaque 500 — and events accepted
+    // before the drop must stay in Redis for the client's seq-based resume.
+    // -----------------------------------------------------------------------
+
+    it('treats a mid-body connection reset as a client disconnect, not a server error', async () => {
+        const infoSpy = vi.spyOn(logger, 'info')
+        const config = makeConfig()
+        const enc = new TextEncoder()
+        const line = enc.encode(JSON.stringify({ seq: 1, event: { type: 'before-drop' } }) + '\n')
+        let sentFirstChunk = false
+        const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                if (!sentFirstChunk) {
+                    sentFirstChunk = true
+                    controller.enqueue(line)
+                    return
+                }
+                const abortError = new Error('aborted') as NodeJS.ErrnoException
+                abortError.code = 'ECONNRESET'
+                controller.error(abortError)
+            },
+        })
+
+        const res = await handleIngest(makeContext({ body }), fakeRedis as unknown as Redis, config, [] as CryptoKey[])
+
+        expect(res.status).toBe(408)
+        const responseBody = (await decodeJson(res)) as { last_accepted_seq: number }
+        expect(responseBody.last_accepted_seq).toBe(1)
+
+        const entries = await fakeRedis.xrange(getStreamKey(RUN_ID))
+        expect(entries).toHaveLength(1)
+
+        const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest:client_disconnect')?.[1] as Record<string, unknown>
+        expect(log).toMatchObject({ run: RUN_ID, accepted: 1, lastSeq: 1 })
+    })
+
+    // -----------------------------------------------------------------------
     // Empty body
     // -----------------------------------------------------------------------
 

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -892,7 +892,21 @@ describe('ingest-handler', () => {
     // before the drop must stay in Redis for the client's seq-based resume.
     // -----------------------------------------------------------------------
 
-    it('treats a mid-body connection reset as a client disconnect, not a server error', async () => {
+    it.each([
+        {
+            variant: 'ECONNRESET code',
+            makeError: (): Error => Object.assign(new Error('read failed'), { code: 'ECONNRESET' }),
+        },
+        { variant: 'aborted message', makeError: (): Error => new Error('aborted') },
+        {
+            variant: 'AbortError name',
+            makeError: (): Error => Object.assign(new Error('This operation was aborted'), { name: 'AbortError' }),
+        },
+        {
+            variant: 'premature close code',
+            makeError: (): Error => Object.assign(new Error('Premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }),
+        },
+    ])('treats a mid-body $variant as a client disconnect, not a server error', async ({ makeError }) => {
         const infoSpy = vi.spyOn(logger, 'info')
         const config = makeConfig()
         const enc = new TextEncoder()
@@ -905,9 +919,7 @@ describe('ingest-handler', () => {
                     controller.enqueue(line)
                     return
                 }
-                const abortError = new Error('aborted') as NodeJS.ErrnoException
-                abortError.code = 'ECONNRESET'
-                controller.error(abortError)
+                controller.error(makeError())
             },
         })
 

--- a/services/agent-proxy/tests/setup.ts
+++ b/services/agent-proxy/tests/setup.ts
@@ -13,8 +13,6 @@ const mockDec = vi.fn()
 const mockSet = vi.fn()
 const mockObserve = vi.fn()
 
-// Each metric type needs its own labels fn: a shared vi.fn() would let the
-// last mockReturnValue win for all three shapes.
 // Counters
 const mockCounter = { labels: vi.fn().mockReturnValue({ inc: mockInc }), inc: mockInc }
 // Gauges

--- a/services/agent-proxy/tests/setup.ts
+++ b/services/agent-proxy/tests/setup.ts
@@ -12,20 +12,21 @@ const mockInc = vi.fn()
 const mockDec = vi.fn()
 const mockSet = vi.fn()
 const mockObserve = vi.fn()
-const mockLabels = vi.fn()
 
+// Each metric type needs its own labels fn: a shared vi.fn() would let the
+// last mockReturnValue win for all three shapes.
 // Counters
-const mockCounter = { labels: mockLabels.mockReturnValue({ inc: mockInc }), inc: mockInc }
+const mockCounter = { labels: vi.fn().mockReturnValue({ inc: mockInc }), inc: mockInc }
 // Gauges
 const mockGauge = {
-    labels: mockLabels.mockReturnValue({ inc: mockInc, dec: mockDec, set: mockSet }),
+    labels: vi.fn().mockReturnValue({ inc: mockInc, dec: mockDec, set: mockSet }),
     inc: mockInc,
     dec: mockDec,
     set: mockSet,
 }
 // Histograms
 const mockHistogram = {
-    labels: mockLabels.mockReturnValue({ observe: mockObserve }),
+    labels: vi.fn().mockReturnValue({ observe: mockObserve }),
     observe: mockObserve,
     startTimer: vi.fn().mockReturnValue(vi.fn()),
 }


### PR DESCRIPTION
## Problem

`POST /v1/runs/:run/ingest` reads a long-lived chunked NDJSON upload (the sandbox can hold one open for a whole turn behind the `tasks-agent-proxy-keep-stream-open` flag). When the client drops mid-upload (sandbox teardown, connection reset), Node rejects the body read with `Error: aborted` (`ECONNRESET`). The handler only catches the typed protocol errors, so the abort escaped to Hono's default error handler: a bare `console.error` stack with no run or request context, plus a 500 in the access log.

Two problems fall out of that:

- client disconnects, which are normal events on a long-lived upload, pollute the 5xx rate and look like server errors
- any genuinely unexpected error (Redis failures included) is equally invisible because the service never registered an `onError` handler

The Python service this was ported from handled the disconnect case explicitly (`ClientDisconnected` in `event_ingest.py`); the Node port dropped it.

## Changes

- Translate body-read aborts (`ECONNRESET`, `aborted`, `AbortError`, premature close) into a typed `ClientDisconnected` error, mirroring the Python handler. It's logged at info as `ingest:client_disconnect` with partial progress (accepted, lastSeq, chunks, bodyBytes) and answered with 408. The response is undeliverable either way, so the status only classifies the request in logs and metrics, keeping disconnects out of 5xx and distinct from the protocol 400/409/413s. Events accepted before the drop are already in Redis and clients resume via `last_accepted_seq` with seq dedup, so nothing is lost.
- Add `app.onError`: unexpected errors now produce a structured `http.unhandled_error` log (requestId, method, path, message, stack) and a JSON 500, and the error message is mirrored onto the wide `http.request` line for correlation.
- Expose `RequestLogger.id` so the error line can carry the same requestId as the request summary line.
- Fix the metrics mock in `tests/setup.ts`: a single shared `labels` mock meant the last `mockReturnValue` won for all metric shapes, so any test exercising the `httpMetrics` middleware crashed on `.labels().inc`.
- Make `registerPublicRoutes` generic over the Hono env so the app can be typed with its context variables.

## How did you test this code?

`pnpm exec vitest run` in `services/agent-proxy`: 185 passed, including two new tests.

- `ingest-handler.test.ts`: a body stream that errors with `code: ECONNRESET` after one accepted line must yield 408, keep the accepted event in Redis and log `ingest:client_disconnect`. Catches the regression where the abort classification is removed and disconnects go back to being opaque 500s. No existing test exercised an erroring body stream.
- `app.test.ts`: a Redis failure during ingest must produce a JSON 500 and a `http.unhandled_error` log with request context. Catches removal of `app.onError`, which would revert to Hono's default contextless `console.error`.

`pnpm exec tsc --noEmit` is clean and `oxlint`/`oxfmt` pass (2 pre-existing warnings in an unrelated test are untouched). Not done: reproducing a live sandbox disconnect against a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed: the service docs don't enumerate ingest status codes. The status-code table in the `ingest-handler.ts` header comment is updated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @charlesvien after production logs showed repeated 500s on the ingest route alongside orphaned `Error: aborted` stacks. I (Claude) traced the abort to the request-body reader, compared against the Python predecessor's `ClientDisconnected` handling and ported it. Skills invoked: /writing-tests.

Decisions along the way: used 408 rather than nginx-style 499 because Hono's status types don't include unofficial codes and the response is undeliverable either way; kept the abort classification narrow (only body-read rejections) so genuine Redis or write errors still surface through the new `onError` logging instead of being masked as disconnects.
