### PR TITLE
feat(max): add PostHog AI capability badges to homepage and /ai

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6481,13 +6481,13 @@ snapshots:
     scenes-app-posthog-ai-hands-free-surface--with-error--light:
         hash: v1.k794b7964.adc72ce96c288856a6c829cb40bbbe745d769b2039c380447385ca780f7dc3ee.gd16WryQO9Bxv44QjAnFCh6tAlzqwNNzcf7uJEFKbGw
     scenes-app-project-homepage--no-primary-dashboard--dark:
-        hash: v1.k794b7964.05e7bbc357febe22dfaa9241cb67690c18d9a35be02078cd9fa93c3c6f448159.JQiS1v2vU1OgTzHK0cD3AaIvNQ09Qp5x6Hub70JSBcY
+        hash: v1.k794b7964.69eaa870e5e73e74dfa0a3702acc826122e3fae884ddc9929cd1f1988ca11f22.Vh-3AcJRV9i-IAF3z1yQjpRpHlg0rOUh_cQRFWx2kZY
     scenes-app-project-homepage--no-primary-dashboard--light:
-        hash: v1.k794b7964.eacf4d029cf5acf69aa33f039cf7b58df48324a25c07a232d3e68182cf2963ec.OIgGCE-nIEfpyd3JzzFkyvbf0qlUYj8APFVdrSVIrU8
+        hash: v1.k794b7964.49458fde00f2a3c98a2052ebc7b6b87db519eaf9bb139b53a536739c9176bd2d.gq1nFiwmuWTo9Yandi0hnTk282J1scVvCRVya-vReQM
     scenes-app-project-homepage--project-homepage--dark:
-        hash: v1.k794b7964.05e7bbc357febe22dfaa9241cb67690c18d9a35be02078cd9fa93c3c6f448159.nJY9sqBszcQpgYRsJoUuBns50rA3wUj-QZqbf7NZbOQ
+        hash: v1.k794b7964.69eaa870e5e73e74dfa0a3702acc826122e3fae884ddc9929cd1f1988ca11f22.ttCP7MmvWFSmGKkFUvG-5tqmQHcnMWrmSkeHbuvei0I
     scenes-app-project-homepage--project-homepage--light:
-        hash: v1.k794b7964.853928313ecadc1d9daf77ddf3779f4dc42c14853b28ed9bb91dffeb5a751bbf.knbN_bMGgzgR-EoNShaqPQYhnEiWBS7_pLFWcxnka7c
+        hash: v1.k794b7964.dfcc82e2f861ae5715947a5792c0f78ea52c88ceef1a49c1a45e0440470345ec.8KBCrZFFDXR1ig6xGNCgCJVyhikgwaHTyYMrxg16Dn8
     scenes-app-replay-vision--scanners-list--dark:
         hash: v1.k794b7964.0e18ee716502a431a1b52f43413ecca3b2b40bb96172279d0e9e557f87ac6c61.Qq-IoYFbMhHW5FkdNyVTkhx5vf_g_4fowvmyQtcO8p4
     scenes-app-replay-vision--scanners-list--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -374,6 +374,7 @@ export const FEATURE_FLAGS = {
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
     MAX_HANDS_FREE: 'max-hands-free', // owner: #team-posthog-ai
+    MAX_HOMEPAGE_CAPABILITIES: 'max-homepage-capabilities', // owner: @rafaeelaudibert #team-posthog-ai multivariate=control,behaviors,products — /home capability badges grouped by behavior vs product
     MAX_WEB_ANALYTICS_NUDGE: 'posthog-ai-web-analytics-nudge', // owner: @jordanm-posthog #team-web-analytics
     MCP_ANALYTICS: 'mcp-analytics', // owner: #project-mcp-analytics
     MCP_ANALYTICS_INTENT_ROUTING: 'mcp-analytics-intent-routing', // owner: #project-mcp-analytics

--- a/frontend/src/scenes/max/components/CapabilityBadges.tsx
+++ b/frontend/src/scenes/max/components/CapabilityBadges.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef } from 'react'
+
+import { IconCode } from '@posthog/icons'
+import { LemonButton, LemonTag } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { FileSystemIconType } from '~/queries/schema/schema-general'
+
+import { CODE_CAPABILITY, Capability, CapabilitySuggestion } from '../maxCapabilities'
+import { nextTypingDelayMs } from '../utils/typing'
+
+// Colors the product icons (via iconForType's ProductIconWrapper). Applied inside the components so
+// they look identical on every surface, not only where an ancestor happens to set it (e.g. /home).
+const COLORFUL_ICONS = 'group/colorful-product-icons colorful-product-icons-true'
+
+/**
+ * Height of the suggestion-cards / recents-grid swap area. Set once on the outer container by each
+ * surface; the cards and the homepage recents grid both fill it with `h-full`, so the two can never
+ * differ and swapping between them (or between capabilities) never shifts layout.
+ */
+export const CAPABILITY_CARDS_HEIGHT_PX = 184
+
+function badgeIcon(capability: Capability): JSX.Element {
+    return capability.icon ?? iconForType(capability.iconType)
+}
+
+export interface CapabilityBadgesProps {
+    capabilities: Capability[]
+    selectedKey: string | null
+    onSelect: (key: string | null) => void
+    className?: string
+}
+
+/** Row of PostHog AI capability badges (+ the Code beta badge). Selection is owned by the parent. */
+export function CapabilityBadges({
+    capabilities,
+    selectedKey,
+    onSelect,
+    className,
+}: CapabilityBadgesProps): JSX.Element | null {
+    if (!capabilities.length) {
+        return null
+    }
+
+    return (
+        <div
+            className={cn('flex flex-wrap items-center justify-center gap-1.5 w-full px-3', COLORFUL_ICONS, className)}
+        >
+            {capabilities.map((capability) => (
+                <LemonButton
+                    key={capability.key}
+                    size="small"
+                    type="secondary"
+                    active={selectedKey === capability.key}
+                    icon={badgeIcon(capability)}
+                    onClick={() => onSelect(selectedKey === capability.key ? null : capability.key)}
+                    data-attr={`capability-badge-${capability.key}`}
+                >
+                    {capability.label}
+                </LemonButton>
+            ))}
+            <LemonButton
+                size="small"
+                type="secondary"
+                to={CODE_CAPABILITY.to}
+                icon={<IconCode />}
+                data-attr="capability-badge-code"
+            >
+                <span className="flex items-center gap-1.5">
+                    {CODE_CAPABILITY.label}
+                    <LemonTag type="completion" size="small">
+                        Beta
+                    </LemonTag>
+                </span>
+            </LemonButton>
+        </div>
+    )
+}
+
+export interface CapabilitySuggestionsProps {
+    capability: Capability
+    /** Called per keystroke of the typewriter animation, and once more with the full prompt. */
+    onType: (text: string) => void
+    /** Send the fully typed prompt to PostHog AI. */
+    onSubmit: (text: string) => void
+    /** Fired after a fill-in prompt is typed in — the parent shows `hint` as a postfix cue + focuses. */
+    onFillIn: (hint: string) => void
+    className?: string
+}
+
+/**
+ * The 4 suggestion cards for a selected capability. Fills its parent's height (`h-full`) — the
+ * parent sets the fixed height (see `CAPABILITY_CARDS_HEIGHT_PX`), and the 4 cards split it evenly.
+ */
+export function CapabilitySuggestions({
+    capability,
+    onType,
+    onSubmit,
+    onFillIn,
+    className,
+}: CapabilitySuggestionsProps): JSX.Element {
+    // Cancels an in-flight typewriter animation (new click, or unmount).
+    const cancelTypingRef = useRef<(() => void) | null>(null)
+    useEffect(() => () => cancelTypingRef.current?.(), [])
+
+    // Type the prompt at a human pace, then either send it, or — for a fill-in prompt — add a
+    // trailing space and hand the hint to the parent so it can show the postfix cue.
+    const runSuggestion = (suggestion: CapabilitySuggestion): void => {
+        cancelTypingRef.current?.()
+        const { content, requiresUserInput, hint } = suggestion
+        let cancelled = false
+        let timer: ReturnType<typeof setTimeout> | undefined
+        cancelTypingRef.current = () => {
+            cancelled = true
+            if (timer) {
+                clearTimeout(timer)
+            }
+        }
+        const finish = (): void => {
+            if (cancelled) {
+                return
+            }
+            if (requiresUserInput) {
+                onType(`${content} `)
+                onFillIn(hint ?? 'the details')
+            } else {
+                onSubmit(content)
+            }
+        }
+        const typeTo = (i: number): void => {
+            if (cancelled) {
+                return
+            }
+            onType(content.slice(0, i))
+            if (i >= content.length) {
+                timer = setTimeout(finish, 250)
+                return
+            }
+            timer = setTimeout(() => typeTo(i + 1), nextTypingDelayMs(content[i - 1] ?? '', content[i]))
+        }
+        typeTo(1)
+    }
+
+    // Docs-style: a plain question list (like production's Docs suggestions), reading as an
+    // explanation rather than an action. Card-style: icon + bold title + description.
+    const isDocs = capability.variant === 'docs'
+    return (
+        <div
+            className={cn('w-full h-full px-3 flex flex-col gap-px', COLORFUL_ICONS, className)}
+            data-attr="capability-suggestions"
+        >
+            {capability.suggestions.map((suggestion) => {
+                const iconType: FileSystemIconType = suggestion.iconType ?? capability.iconType
+                return (
+                    <LemonButton
+                        key={suggestion.content}
+                        className="flex-1 min-h-0"
+                        fullWidth
+                        type={isDocs ? 'tertiary' : undefined}
+                        onClick={() => runSuggestion(suggestion)}
+                        icon={isDocs ? undefined : iconForType(iconType)}
+                        data-attr={`capability-suggestion-${capability.key}`}
+                    >
+                        {isDocs ? (
+                            <span className="text-sm font-normal text-left truncate w-full">{suggestion.content}</span>
+                        ) : (
+                            <div className="flex flex-col text-left leading-tight min-w-0">
+                                <span className="text-sm font-semibold truncate">{suggestion.title}</span>
+                                <span className="text-xs text-secondary font-normal truncate">
+                                    {suggestion.description}
+                                </span>
+                            </div>
+                        )}
+                    </LemonButton>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/FillInHint.tsx
+++ b/frontend/src/scenes/max/components/FillInHint.tsx
@@ -1,0 +1,19 @@
+/**
+ * Inline postfix cue for a fill-in suggestion. The suggestion's prefix has been typed into the
+ * input as real text; this overlays an invisible mirror of that text (so the cue lands right after
+ * it) followed by a wide blinking caret and a faded hint (e.g. "insert feature flag name").
+ *
+ * Rendered as an overlay positioned at the input's text origin; the parent hides the native caret
+ * while it shows. `text` is the current input value (the typed prefix); `hint` is the postfix.
+ */
+export function FillInHint({ text, hint }: { text: string; hint: string }): JSX.Element {
+    return (
+        <span className="flex items-center text-sm whitespace-pre" data-attr="capability-fill-in-hint" aria-hidden>
+            {/* Invisible copy of the typed text reserves its exact width so the caret sits after it. */}
+            <span className="invisible">{text}</span>
+            {/* Wide blinking caret (hogqlx-blink is the shared 1s blinking-cursor keyframe). */}
+            <span className="hogqlx-blink ml-2 inline-block w-2 h-[1.15rem] rounded-[1px] bg-accent" />
+            <span className="text-accent/60 ml-2 font-normal">{hint}</span>
+        </span>
+    )
+}

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -24,6 +24,7 @@ import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
 import { MAX_SLASH_COMMANDS } from '../slash-commands'
+import { FillInHint } from './FillInHint'
 import { HandsFreeButton } from './HandsFreeButton'
 import { HandsFreeSurface } from './HandsFreeSurface'
 import { SlashCommandAutocomplete } from './SlashCommandAutocomplete'
@@ -145,8 +146,8 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     ref
 ) {
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
-    const { question, panelId: maxPanelId } = useValues(maxLogic)
-    const { setQuestion } = useActions(maxLogic)
+    const { question, panelId: maxPanelId, fillInHint } = useValues(maxLogic)
+    const { setQuestion, setFillInHint } = useActions(maxLogic)
     const { user } = useValues(userLogic)
     const {
         conversation,
@@ -214,6 +215,10 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
 
     const handleQuestionChange = (value: string): void => {
         setInputValue(value)
+        // The user typing their own text ends the fill-in cue.
+        if (fillInHint) {
+            setFillInHint(null)
+        }
         if (value.startsWith('/')) {
             // Slash commands drive the autocomplete off kea's `question`, so sync immediately.
             debouncedSetQuestion.cancel()
@@ -227,10 +232,15 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         // askMax reads the prompt arg directly and clears `question` afterwards, so drop any
         // pending debounce to stop it from re-populating the just-sent text.
         debouncedSetQuestion.cancel()
+        if (fillInHint) {
+            setFillInHint(null)
+        }
         askMax(prompt)
     }
 
     const hasQuestion = inputValue.trim().length > 0
+    // A fill-in suggestion typed its prefix in and is waiting for the user to complete it.
+    const showFillInHint = !!fillInHint
     const isQueueingSubmission = queueingEnabled && threadLoading && hasQuestion
     const showStopButton = threadLoading && !isQueueingSubmission && !cancelLoading
 
@@ -372,6 +382,12 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                             )}
                                         </div>
                                     )}
+                                    {/* Postfix cue after a fill-in suggestion's typed-in prefix. */}
+                                    {showFillInHint && (
+                                        <div className="absolute top-4 left-4 right-4 overflow-hidden pointer-events-none">
+                                            <FillInHint text={inputValue} hint={fillInHint} />
+                                        </div>
+                                    )}
                                     <LemonTextArea
                                         aria-describedby={!inputValue ? 'textarea-hint' : undefined}
                                         id="question-input"
@@ -432,7 +448,9 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         maxRows={10}
                                         className={cn(
                                             '!border-none !bg-transparent min-h-16 py-2 pl-2 resize-none',
-                                            handsFreeFlagEnabled ? 'pr-20' : 'pr-12'
+                                            handsFreeFlagEnabled ? 'pr-20' : 'pr-12',
+                                            // Hide the native caret so only the enlarged fill-in caret shows.
+                                            showFillInHint && 'caret-transparent'
                                         )}
                                         hideFocus
                                     />

--- a/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
@@ -5,14 +5,18 @@ import { useState } from 'react'
 import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
 import { MaxMemorySettings } from 'scenes/settings/environment/MaxMemorySettings'
 import { maxSettingsLogic } from 'scenes/settings/environment/maxSettingsLogic'
 
 import { AgentMode } from '~/queries/schema/schema-assistant-messages'
 
+import { capabilitiesForGrouping, capabilityGroupingFromVariant } from '../maxCapabilities'
 import { QUESTION_SUGGESTIONS_DATA, RESEARCH_SUGGESTIONS_DATA, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
+import { CAPABILITY_CARDS_HEIGHT_PX, CapabilityBadges, CapabilitySuggestions } from './CapabilityBadges'
 import { FloatingSuggestionsDisplay } from './FloatingSuggestionsDisplay'
 import { SidebarQuestionInput } from './SidebarQuestionInput'
 
@@ -22,15 +26,25 @@ export function SidebarQuestionInputWithSuggestions({
     hideSuggestions?: boolean
 }): JSX.Element {
     const { dataProcessingAccepted, dataProcessingApprovalDisabledReason, activeSuggestionGroup } = useValues(maxLogic)
-    const { setActiveGroup } = useActions(maxLogic)
+    const { setActiveGroup, setQuestion, focusInput, setFillInHint } = useActions(maxLogic)
     const { agentMode } = useValues(maxThreadLogic)
+    const { askMax } = useActions(maxThreadLogic)
     const { coreMemory, coreMemoryLoading } = useValues(maxSettingsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const [settingsModalOpen, setSettingsModalOpen] = useState(false)
+    const [selectedCapability, setSelectedCapability] = useState<string | null>(null)
 
     const handleSettingsClick = (): void => {
         setSettingsModalOpen(true)
     }
+
+    // Capability badges (same experiment as the homepage) replace the pills — except in Research
+    // mode, which keeps its own tailored suggestions.
+    const grouping = capabilityGroupingFromVariant(featureFlags[FEATURE_FLAGS.MAX_HOMEPAGE_CAPABILITIES])
+    const showBadges = !!grouping && agentMode !== AgentMode.Research
+    const capabilities = grouping ? capabilitiesForGrouping(grouping) : []
+    const selectedCapabilityData = capabilities.find((capability) => capability.key === selectedCapability) ?? null
 
     const tip =
         !coreMemoryLoading && !coreMemory?.text
@@ -46,6 +60,7 @@ export function SidebarQuestionInputWithSuggestions({
                 if (activeSuggestionGroup) {
                     setActiveGroup(null)
                 }
+                setSelectedCapability(null)
             }}
         >
             <SidebarQuestionInput />
@@ -57,24 +72,50 @@ export function SidebarQuestionInputWithSuggestions({
                 )}
             >
                 <h3 className="text-center text-xs font-medium mb-0 text-secondary">{tip}</h3>
-                <FloatingSuggestionsDisplay
-                    type="secondary"
-                    dataProcessingAccepted={dataProcessingAccepted}
-                    dataProcessingApprovalDisabledReason={dataProcessingApprovalDisabledReason}
-                    suggestionsData={
-                        agentMode === AgentMode.Research ? RESEARCH_SUGGESTIONS_DATA : QUESTION_SUGGESTIONS_DATA
-                    }
-                    additionalSuggestions={[
-                        <LemonButton
-                            key="edit-max-memory"
-                            onClick={handleSettingsClick}
-                            size="xsmall"
-                            type="secondary"
-                            icon={<IconGear />}
-                            tooltip="Edit PostHog AI memory"
-                        />,
-                    ]}
-                />
+                {showBadges ? (
+                    <div className="flex flex-col gap-6 w-full">
+                        <CapabilityBadges
+                            capabilities={capabilities}
+                            selectedKey={selectedCapability}
+                            onSelect={(key) => {
+                                setFillInHint(null)
+                                setSelectedCapability(key)
+                            }}
+                        />
+                        {selectedCapabilityData && (
+                            <div className="w-full overflow-hidden" style={{ height: CAPABILITY_CARDS_HEIGHT_PX }}>
+                                <CapabilitySuggestions
+                                    capability={selectedCapabilityData}
+                                    onType={setQuestion}
+                                    onSubmit={(text) => askMax(text)}
+                                    onFillIn={(hint) => {
+                                        setFillInHint(hint)
+                                        focusInput()
+                                    }}
+                                />
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <FloatingSuggestionsDisplay
+                        type="secondary"
+                        dataProcessingAccepted={dataProcessingAccepted}
+                        dataProcessingApprovalDisabledReason={dataProcessingApprovalDisabledReason}
+                        suggestionsData={
+                            agentMode === AgentMode.Research ? RESEARCH_SUGGESTIONS_DATA : QUESTION_SUGGESTIONS_DATA
+                        }
+                        additionalSuggestions={[
+                            <LemonButton
+                                key="edit-max-memory"
+                                onClick={handleSettingsClick}
+                                size="xsmall"
+                                type="secondary"
+                                icon={<IconGear />}
+                                tooltip="Edit PostHog AI memory"
+                            />,
+                        ]}
+                    />
+                )}
             </div>
             <LemonModal
                 title="PostHog AI memory"

--- a/frontend/src/scenes/max/maxCapabilities.tsx
+++ b/frontend/src/scenes/max/maxCapabilities.tsx
@@ -370,33 +370,6 @@ export const BEHAVIOR_CAPABILITIES: Capability[] = [
         ],
     },
     {
-        key: 'understand',
-        label: 'Understand',
-        iconType: 'survey',
-        suggestions: [
-            {
-                title: 'Ask users a question',
-                description: 'Launch an NPS, CSAT, or custom survey',
-                content: 'Create a survey to collect NPS responses from users',
-            },
-            {
-                title: 'Measure product-market fit',
-                description: 'Ask how users would feel without your product',
-                content: 'Create a survey to measure product market fit',
-            },
-            {
-                title: 'Summarize feedback',
-                description: 'Common themes across recent responses',
-                content: 'Analyze survey responses to prioritize key features our users are interested in',
-            },
-            {
-                title: 'Learn from interviews',
-                description: 'Key themes across user interviews',
-                content: 'Analyze my user interviews and summarize the key themes',
-            },
-        ],
-    },
-    {
         key: 'ship',
         label: 'Ship',
         iconType: 'feature_flag',
@@ -425,6 +398,33 @@ export const BEHAVIOR_CAPABILITIES: Capability[] = [
                 title: 'Plan a release',
                 description: 'Draft a safe gradual rollout',
                 content: 'Help me plan a safe gradual rollout for a new feature',
+            },
+        ],
+    },
+    {
+        key: 'understand',
+        label: 'Understand',
+        iconType: 'survey',
+        suggestions: [
+            {
+                title: 'Ask users a question',
+                description: 'Launch an NPS, CSAT, or custom survey',
+                content: 'Create a survey to collect NPS responses from users',
+            },
+            {
+                title: 'Measure product-market fit',
+                description: 'Ask how users would feel without your product',
+                content: 'Create a survey to measure product market fit',
+            },
+            {
+                title: 'Summarize feedback',
+                description: 'Common themes across recent responses',
+                content: 'Analyze survey responses to prioritize key features our users are interested in',
+            },
+            {
+                title: 'Learn from interviews',
+                description: 'Key themes across user interviews',
+                content: 'Analyze my user interviews and summarize the key themes',
             },
         ],
     },

--- a/frontend/src/scenes/max/maxCapabilities.tsx
+++ b/frontend/src/scenes/max/maxCapabilities.tsx
@@ -1,0 +1,443 @@
+import { IconBook } from '@posthog/icons'
+
+import { urls } from 'scenes/urls'
+
+import { FileSystemIconType } from '~/queries/schema/schema-general'
+
+/** One suggestion inside a capability. `content` is the prompt sent to PostHog AI. */
+export interface CapabilitySuggestion {
+    /**
+     * The prompt sent to PostHog AI. For `requiresUserInput` cards this is the instruction prefix
+     * (no trailing "…"); the input shows it as a hint and the user's text is appended on send.
+     * For docs-style capabilities this is also the text shown in the list.
+     */
+    content: string
+    /** Card-style display; omit for docs-style capabilities (which render `content` as plain text). */
+    title?: string
+    description?: string
+    /**
+     * When set, this is a fill-in prompt: `content` is typed into the input, then this hint is shown
+     * as a faded postfix (e.g. "insert feature flag name") after a wide caret, prompting the user to
+     * complete it. `requiresUserInput` must also be true.
+     */
+    requiresUserInput?: boolean
+    hint?: string
+    /** Icon override for the card; falls back to the capability's icon. */
+    iconType?: FileSystemIconType
+}
+
+export interface Capability {
+    key: string
+    label: string
+    iconType: FileSystemIconType
+    /** Badge icon override (e.g. for Learn, which has no product icon). */
+    icon?: JSX.Element
+    /**
+     * 'cards' (default): icon + title + description cards. 'docs': a plain question list (like
+     * production's Docs suggestions) so it reads as an explanation, not an action. Card-style
+     * capabilities should have exactly 4 suggestions so every block is the same height.
+     */
+    variant?: 'cards' | 'docs'
+    suggestions: CapabilitySuggestion[]
+}
+
+/** Shared across both experiment arms — routes to the PostHog Code beta in the inbox. */
+export const CODE_CAPABILITY = {
+    key: 'code',
+    label: 'Code',
+    to: urls.inbox(),
+    beta: true as const,
+}
+
+/**
+ * A few docs prompts included in every arm so newcomers can learn about PostHog. Rendered as a
+ * plain question list (docs variant), matching the Docs suggestions we show in production.
+ */
+const LEARN_CAPABILITY: Capability = {
+    key: 'learn',
+    label: 'Learn',
+    iconType: 'default_icon_type',
+    icon: <IconBook />,
+    variant: 'docs',
+    suggestions: [
+        { content: 'How can I create a feature flag?' },
+        { content: 'Where do I watch session replays?' },
+        { content: 'Help me set up an experiment' },
+        { content: 'Explain autocapture' },
+        { content: 'How can I capture an exception?' },
+    ],
+}
+
+/**
+ * Product-based grouping — mirrors PostHog's products. Prompt content is drawn from the
+ * existing `QUESTION_SUGGESTIONS_DATA` on the PostHog AI scene so the two surfaces stay in sync.
+ */
+export const PRODUCT_CAPABILITIES: Capability[] = [
+    {
+        key: 'analytics',
+        label: 'Analytics',
+        iconType: 'product_analytics',
+        suggestions: [
+            {
+                title: 'Run a funnel analysis',
+                description: 'Conversion and drop-off across the Pirate Metrics (AARRR)',
+                content: 'Create a funnel of the Pirate Metrics (AARRR)',
+            },
+            {
+                title: 'Check retention',
+                description: 'How many users came back over the last two weeks',
+                content: 'What is the retention in the last two weeks?',
+            },
+            {
+                title: 'Find popular pages',
+                description: 'Your most visited pages and screens',
+                content: 'What are the most popular pages or screens?',
+            },
+            {
+                title: 'See top referrers',
+                description: 'Where your traffic is coming from',
+                content: 'What are the top referring domains?',
+            },
+        ],
+    },
+    {
+        key: 'sql',
+        label: 'SQL',
+        iconType: 'sql_editor',
+        suggestions: [
+            {
+                title: 'Write a SQL query',
+                description: 'Query any of your data with HogQL',
+                content: 'Write an SQL query to',
+                requiresUserInput: true,
+                hint: 'type a question you have about your data',
+            },
+            {
+                title: 'Explore your warehouse',
+                description: 'Query your synced external data sources',
+                content: 'Show me the tables available in my data warehouse',
+            },
+            {
+                title: 'Find your top events',
+                description: 'Your most frequent events this week',
+                content: 'Write a SQL query for my most frequent events in the last 7 days',
+            },
+            {
+                title: 'Count active users',
+                description: 'Weekly active users with SQL',
+                content: 'Write a SQL query to count my weekly active users',
+            },
+        ],
+    },
+    {
+        key: 'session_replay',
+        label: 'Session replay',
+        iconType: 'session_replay',
+        suggestions: [
+            {
+                title: 'Find recordings',
+                description: 'Filter replays by user or action',
+                content: 'Find recordings for',
+                requiresUserInput: true,
+                hint: 'type a specific user or behavior you wanna find recordings for',
+            },
+            {
+                title: 'Summarize sessions',
+                description: 'What happened across recent replays',
+                content: 'Summarize recent session recordings and highlight anything notable',
+            },
+            {
+                title: 'Spot friction',
+                description: 'Rage-clicks, dead-clicks, and confusion',
+                content: 'Find session replays showing common user pain points or confusion',
+            },
+            {
+                title: 'Watch error sessions',
+                description: 'Replays where users hit an error',
+                content: 'Find session recordings where users ran into errors',
+                iconType: 'error_tracking',
+            },
+        ],
+    },
+    {
+        key: 'error_tracking',
+        label: 'Error tracking',
+        iconType: 'error_tracking',
+        suggestions: [
+            {
+                title: 'Find impactful errors',
+                description: 'The exceptions hitting the most users',
+                content: 'What are the most impactful errors affecting my users right now?',
+            },
+            {
+                title: 'Triage new issues',
+                description: 'Errors first seen this week',
+                content: 'Show me new error issues from the last 7 days',
+            },
+            {
+                title: 'Explain an error',
+                description: 'Likely cause and where it fires',
+                content: 'Explain the most common error in my app and where it happens',
+            },
+            {
+                title: 'See error replays',
+                description: 'Watch sessions where users hit an error',
+                content: 'Find session recordings where users ran into errors',
+                iconType: 'session_replay',
+            },
+        ],
+    },
+    {
+        key: 'feature_flags',
+        label: 'Feature flags',
+        iconType: 'feature_flag',
+        suggestions: [
+            {
+                title: 'Roll out a feature',
+                description: 'Gradually release a feature behind a flag',
+                content: 'Create a flag to gradually roll out',
+                requiresUserInput: true,
+                hint: "type the feature you're launching",
+            },
+            {
+                title: 'Create a multivariate flag',
+                description: 'Test several variants of a feature',
+                content: 'Create a multivariate flag for',
+                requiresUserInput: true,
+                hint: "type the feature you're testing",
+            },
+            {
+                title: 'Audit your flags',
+                description: 'Find stale or risky feature flags',
+                content: 'Audit my feature flags for issues',
+            },
+            {
+                title: 'Review flag usage',
+                description: 'Which flags are still being evaluated',
+                content: 'Which of my feature flags are still being evaluated?',
+            },
+        ],
+    },
+    {
+        key: 'experiments',
+        label: 'Experiments',
+        iconType: 'experiment',
+        suggestions: [
+            {
+                title: 'Design an A/B test',
+                description: 'Set up an experiment to test a change',
+                content: 'Create an experiment to test',
+                requiresUserInput: true,
+                hint: 'type a change you have in mind',
+            },
+            {
+                title: 'Review a running test',
+                description: 'Check your experiments are set up correctly',
+                content: 'Check if my running experiments are set up correctly',
+            },
+            {
+                title: 'Interpret results',
+                description: 'Significance and what to do next',
+                content: 'Summarize the results of my most recent experiment and what to do next',
+            },
+            {
+                title: 'Size an experiment',
+                description: 'How long it needs to run for significance',
+                content: 'How long should my experiment run to reach significance?',
+            },
+        ],
+    },
+    {
+        key: 'surveys',
+        label: 'Surveys',
+        iconType: 'survey',
+        suggestions: [
+            {
+                title: 'Launch an NPS survey',
+                description: 'Collect Net Promoter Score from your users',
+                content: 'Create a survey to collect NPS responses from users',
+            },
+            {
+                title: 'Run a CSAT survey',
+                description: 'Measure customer satisfaction',
+                content: 'Create a survey to collect CSAT responses from users',
+            },
+            {
+                title: 'Measure product-market fit',
+                description: 'Ask how users would feel without your product',
+                content: 'Create a survey to measure product market fit',
+            },
+            {
+                title: 'Analyze survey responses',
+                description: 'Surface themes to prioritize what to build',
+                content: 'Analyze survey responses to prioritize key features our users are interested in',
+            },
+        ],
+    },
+    LEARN_CAPABILITY,
+]
+
+/**
+ * Behavior-based grouping — organized around what people come to PostHog to *do*, rather than
+ * which product a task lives in. Same underlying prompts, regrouped by job-to-be-done.
+ */
+export const BEHAVIOR_CAPABILITIES: Capability[] = [
+    {
+        key: 'analyze',
+        label: 'Analyze',
+        iconType: 'product_analytics',
+        suggestions: [
+            {
+                title: 'Run a feature analysis',
+                description: 'Adoption, engagement, and retention of a feature',
+                content: 'Run a feature analysis covering adoption, engagement, and retention',
+            },
+            {
+                title: 'Summarize product usage',
+                description: 'Top events, active users, and key funnels',
+                content: 'Summarize our product usage: top events, active users, and key funnels',
+            },
+            {
+                title: 'Check retention',
+                description: 'How many users came back over the last two weeks',
+                content: 'What is the retention in the last two weeks?',
+            },
+            {
+                title: 'Query with SQL',
+                description: 'Ask anything of your data with HogQL',
+                content: 'Write an SQL query to',
+                requiresUserInput: true,
+                hint: 'type a question you have about your data',
+                iconType: 'sql_editor',
+            },
+        ],
+    },
+    {
+        key: 'debug',
+        label: 'Debug',
+        iconType: 'error_tracking',
+        suggestions: [
+            {
+                title: 'Find impactful errors',
+                description: 'The exceptions hitting the most users',
+                content: 'What are the most impactful errors affecting my users right now?',
+            },
+            {
+                title: 'Investigate a drop',
+                description: 'Root-cause a recent change in a metric',
+                content: 'Investigate why one of my key metrics dropped last week',
+            },
+            {
+                title: 'Watch error sessions',
+                description: 'Replays where users ran into a problem',
+                content: 'Find session recordings where users ran into errors',
+                iconType: 'session_replay',
+            },
+            {
+                title: 'Explain an error',
+                description: 'Likely cause and where it fires',
+                content: 'Explain the most common error in my app and where it happens',
+            },
+        ],
+    },
+    {
+        key: 'monitor',
+        label: 'Monitor',
+        iconType: 'session_replay',
+        suggestions: [
+            {
+                title: 'Summarize recent sessions',
+                description: 'Common patterns across recent replays',
+                content: 'Summarize recent session recordings and highlight anything notable',
+            },
+            {
+                title: 'Spot friction',
+                description: 'Where users hesitate, rage-click, or churn',
+                content: 'Find session replays showing common user pain points or confusion',
+            },
+            {
+                title: 'Review conversion',
+                description: 'How your main funnel performed this week',
+                content: 'How is my main conversion funnel performing this week?',
+            },
+            {
+                title: 'Watch a user journey',
+                description: 'Replays for a specific segment or action',
+                content: 'Find recordings for',
+                requiresUserInput: true,
+                hint: 'type a specific user or behavior you wanna find recordings for',
+            },
+        ],
+    },
+    {
+        key: 'understand',
+        label: 'Understand',
+        iconType: 'survey',
+        suggestions: [
+            {
+                title: 'Ask users a question',
+                description: 'Launch an NPS, CSAT, or custom survey',
+                content: 'Create a survey to collect NPS responses from users',
+            },
+            {
+                title: 'Measure product-market fit',
+                description: 'Ask how users would feel without your product',
+                content: 'Create a survey to measure product market fit',
+            },
+            {
+                title: 'Summarize feedback',
+                description: 'Common themes across recent responses',
+                content: 'Analyze survey responses to prioritize key features our users are interested in',
+            },
+            {
+                title: 'Learn from interviews',
+                description: 'Key themes across user interviews',
+                content: 'Analyze my user interviews and summarize the key themes',
+            },
+        ],
+    },
+    {
+        key: 'ship',
+        label: 'Ship',
+        iconType: 'feature_flag',
+        suggestions: [
+            {
+                title: 'Roll out a feature',
+                description: 'Gradually release behind a flag',
+                content: 'Create a flag to gradually roll out',
+                requiresUserInput: true,
+                hint: "type the feature you're launching",
+            },
+            {
+                title: 'Run an A/B test',
+                description: 'Experiment to measure the impact of a change',
+                content: 'Create an experiment to test',
+                requiresUserInput: true,
+                hint: 'type a change you have in mind',
+                iconType: 'experiment',
+            },
+            {
+                title: 'Audit your flags',
+                description: 'Find stale or risky feature flags',
+                content: 'Audit my feature flags for issues',
+            },
+            {
+                title: 'Plan a release',
+                description: 'Draft a safe gradual rollout',
+                content: 'Help me plan a safe gradual rollout for a new feature',
+            },
+        ],
+    },
+    LEARN_CAPABILITY,
+]
+
+export type CapabilityGrouping = 'behaviors' | 'products'
+
+export function capabilitiesForGrouping(grouping: CapabilityGrouping): Capability[] {
+    return grouping === 'behaviors' ? BEHAVIOR_CAPABILITIES : PRODUCT_CAPABILITIES
+}
+
+/** Maps the `MAX_HOMEPAGE_CAPABILITIES` experiment variant to a grouping (null = control). */
+export function capabilityGroupingFromVariant(variant: string | boolean | undefined): CapabilityGrouping | null {
+    return variant === 'behaviors' || variant === 'products' ? variant : null
+}

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -214,6 +214,8 @@ export const maxLogic = kea<maxLogicType>([
         setBackScreen: (screen: 'history') => ({ screen }),
         focusInput: true,
         setActiveGroup: (group: SuggestionGroup | null) => ({ group }),
+        // Postfix hint shown after a fill-in capability suggestion's typed-in prefix.
+        setFillInHint: (hint: string | null) => ({ hint }),
         incrActiveStreamingThreads: true,
         decrActiveStreamingThreads: true,
         setAutoRun: (autoRun: boolean) => ({ autoRun }),
@@ -292,6 +294,14 @@ export const maxLogic = kea<maxLogicType>([
             {
                 setActiveGroup: (_, { group }) => group,
                 setQuestion: (state, { question }) => (question === '' ? null : state),
+            },
+        ],
+
+        fillInHint: [
+            null as string | null,
+            {
+                setFillInHint: (_, { hint }) => hint,
+                startNewConversation: () => null,
             },
         ],
 

--- a/frontend/src/scenes/max/utils/typing.ts
+++ b/frontend/src/scenes/max/utils/typing.ts
@@ -1,0 +1,25 @@
+/**
+ * Human-feeling delay (ms) before the next keystroke of the typewriter animation.
+ *
+ * Real typing isn't metronomic: it speeds up mid-word, slows at word boundaries, and pauses
+ * noticeably after punctuation, with the occasional hesitation. `justTyped` is the character we
+ * just committed; `nextChar` is what's coming, letting us keep letter runs quick.
+ */
+export function nextTypingDelayMs(justTyped: string, nextChar?: string): number {
+    const rand = Math.random()
+    let delay = 17 + rand * 23 // 17-40ms base keystroke
+
+    if (/[.!?]/.test(justTyped)) {
+        delay += 120 + Math.random() * 110 // full stop — noticeable pause
+    } else if (/[,;:]/.test(justTyped)) {
+        delay += 60 + Math.random() * 60 // clause break
+    } else if (justTyped === ' ') {
+        delay += 10 + Math.random() * 35 // between words
+    } else if (rand < 0.05) {
+        delay += 60 + Math.random() * 90 // occasional hesitation
+    } else if (/[a-z]/i.test(justTyped) && nextChar && /[a-z]/i.test(nextChar)) {
+        delay *= 0.8 // fast letter runs within a word
+    }
+
+    return delay
+}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -7,8 +7,10 @@ import { IconArrowRight, IconClock, IconInfo, IconLock, IconMicrophone, IconPin,
 import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { Search } from 'lib/components/Search/Search'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
@@ -291,6 +293,7 @@ function getStoredSkeletonCounts(): Record<string, number> | null {
 function IdleGrid(): JSX.Element {
     const { gridItems, query, dashboardsLoading, recentItemsLoading, starredItemsLoading } =
         useValues(aiFirstHomepageLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     // [col, row] position of the highlighted item, null = nothing highlighted
     const [highlight, setHighlight] = useState<[number, number] | null>(null)
@@ -298,7 +301,9 @@ function IdleGrid(): JSX.Element {
 
     const [skeletonCounts, setSkeletonCounts] = useState(getStoredSkeletonCounts)
 
-    const hasExtraMarginTop = useFeatureFlag('MAX_HOMEPAGE_CAPABILITIES', 'control')
+    const hasExtraMarginTop =
+        !!featureFlags[FEATURE_FLAGS.MAX_HOMEPAGE_CAPABILITIES] ||
+        featureFlags[FEATURE_FLAGS.MAX_HOMEPAGE_CAPABILITIES] === 'control'
 
     const columns = useMemo(() => {
         return GRID_COLUMNS.map((col) => ({

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -291,11 +291,14 @@ function getStoredSkeletonCounts(): Record<string, number> | null {
 function IdleGrid(): JSX.Element {
     const { gridItems, query, dashboardsLoading, recentItemsLoading, starredItemsLoading } =
         useValues(aiFirstHomepageLogic)
-    const gridRef = useRef<HTMLDivElement>(null)
+
     // [col, row] position of the highlighted item, null = nothing highlighted
     const [highlight, setHighlight] = useState<[number, number] | null>(null)
+    const gridRef = useRef<HTMLDivElement>(null)
 
     const [skeletonCounts, setSkeletonCounts] = useState(getStoredSkeletonCounts)
+
+    const hasExtraMarginTop = useFeatureFlag('MAX_HOMEPAGE_CAPABILITIES', 'control')
 
     const columns = useMemo(() => {
         return GRID_COLUMNS.map((col) => ({
@@ -445,7 +448,10 @@ function IdleGrid(): JSX.Element {
             data-attr="homepage-grid"
             // Fills the fixed-height swap container (see HomepageInput) so the recents grid and the
             // capability cards are always the same height. Only shown at @xl+ where columns sit in a row.
-            className="flex flex-col @xl/main-content:flex-row gap-8 @xl/main-content:gap-2 w-full px-3 outline-none h-full"
+            className={cn(
+                'flex flex-col @xl/main-content:flex-row gap-8 @xl/main-content:gap-2 w-full px-3 outline-none h-full',
+                hasExtraMarginTop && 'mt-2'
+            )}
             tabIndex={-1}
             onFocus={(e) => {
                 // Only auto-highlight when focused via keyboard (ArrowDown from input)

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -12,7 +12,14 @@ import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
+import { cn } from 'lib/utils/css-classes'
 import { uuid } from 'lib/utils/dom'
+import {
+    CAPABILITY_CARDS_HEIGHT_PX,
+    CapabilityBadges,
+    CapabilitySuggestions,
+} from 'scenes/max/components/CapabilityBadges'
+import { FillInHint } from 'scenes/max/components/FillInHint'
 import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
 import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { Intro } from 'scenes/max/Intro'
@@ -28,26 +35,33 @@ import { HomepageGridItem, HomepageGridItemKind, aiFirstHomepageLogic } from './
 import { HOMEPAGE_TAB_ID } from './constants'
 
 function IdleInput(): JSX.Element {
-    const { query } = useValues(aiFirstHomepageLogic)
-    const { setQuery, submitQuery, enterAiMode, startHandsFreeChat } = useActions(aiFirstHomepageLogic)
+    const { query, fillInHint } = useValues(aiFirstHomepageLogic)
+    const { setQuery, submitQuery, enterAiMode, startHandsFreeChat, setFillInHint } = useActions(aiFirstHomepageLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
     const handsFreeFlag = useFeatureFlag('MAX_HANDS_FREE')
     const { canUseHandsFree } = useValues(handsFreeLogic({ panelId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const handsFreeAvailable = handsFreeFlag && canUseHandsFree && dataProcessingAccepted
+    // A fill-in suggestion typed its prefix in and is waiting for the user to complete it.
+    const showFillInHint = !!fillInHint
 
     useEffect(() => {
         const timer = setTimeout(() => inputRef.current?.focus(), 100)
         return () => clearTimeout(timer)
     }, [])
 
+    const submitAi = (): void => {
+        if (!query.trim()) {
+            return
+        }
+        posthog.capture('homepage query submitted', { mode: 'ai' })
+        submitQuery('ai')
+    }
+
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault()
-        if (query.trim()) {
-            posthog.capture('homepage query submitted', { mode: 'ai' })
-            submitQuery('ai')
-        }
+        submitAi()
     }
 
     return (
@@ -57,12 +71,18 @@ function IdleInput(): JSX.Element {
                 className="min-h-[40px] group input-like flex flex-col items-start relative w-full bg-fill-input border border-primary focus-within:ring-primary rounded-lg justify-stretch overflow-hidden"
             >
                 <div className="flex w-full py-1 px-1 max-h-[300px] items-end gap-1">
-                    {!query && (
+                    {!query && !fillInHint && (
                         <span className="text-tertiary pointer-events-none absolute left-2.5 top-2 flex items-center gap-1">
                             <span className="text-tertiary">What can I help you with?</span>
                             <span className="text-tertiary opacity-50 contrast-more:opacity-100 hidden @xl/main-content:inline">
                                 / for commands
                             </span>
+                        </span>
+                    )}
+                    {/* Postfix cue after the typed-in prefix (aligned to the textarea text origin). */}
+                    {fillInHint && (
+                        <span className="pointer-events-none absolute left-2 top-2 right-2 overflow-hidden">
+                            <FillInHint text={query} hint={fillInHint} />
                         </span>
                     )}
                     <TextareaPrimitive
@@ -79,6 +99,10 @@ function IdleInput(): JSX.Element {
                                 enterAiMode(value)
                                 return
                             }
+                            // The user typing their own text ends the fill-in cue.
+                            if (fillInHint) {
+                                setFillInHint(null)
+                            }
                             setQuery(value)
                         }}
                         onKeyDown={(e) => {
@@ -94,14 +118,12 @@ function IdleInput(): JSX.Element {
                                 }
                                 // Prevent newline, let form submit handle it
                                 e.preventDefault()
-                                if (query.trim()) {
-                                    posthog.capture('homepage query submitted', { mode: 'ai' })
-                                    submitQuery('ai')
-                                }
+                                submitAi()
                             }
-                            if (e.key === 'Escape' && query.trim()) {
+                            if (e.key === 'Escape' && (query.trim() || fillInHint)) {
                                 e.preventDefault()
                                 setQuery('')
+                                setFillInHint(null)
                             }
                             // When input is empty, ArrowDown moves focus to the grid
                             if (e.key === 'ArrowDown' && !query.trim()) {
@@ -114,7 +136,11 @@ function IdleInput(): JSX.Element {
                             }
                         }}
                         autoComplete="off"
-                        className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
+                        className={cn(
+                            'w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent',
+                            // Hide the native caret so only the enlarged fill-in caret shows.
+                            showFillInHint && 'caret-transparent'
+                        )}
                         autoFocus
                     />
                     <div className="flex items-end shrink-0">
@@ -404,115 +430,104 @@ function IdleGrid(): JSX.Element {
         }
     }, [highlight])
 
-    const isCollapsed = !!query.trim()
     const loadingByKind: Record<HomepageGridItemKind, boolean> = {
         dashboard: dashboardsLoading,
         recent: recentItemsLoading,
         starred: starredItemsLoading,
     }
 
+    // Collapse-on-typing is handled by the shared wrapper in HomepageInput, so this renders the
+    // grid content directly (no self-collapse) — keeping the badges and grid in one animated box.
     return (
         <div
-            className="w-full px-3 grid transition-[grid-template-rows] duration-200 ease-out mt-2"
-            style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
+            ref={gridRef}
+            role="grid"
+            data-attr="homepage-grid"
+            // Fills the fixed-height swap container (see HomepageInput) so the recents grid and the
+            // capability cards are always the same height. Only shown at @xl+ where columns sit in a row.
+            className="flex flex-col @xl/main-content:flex-row gap-8 @xl/main-content:gap-2 w-full px-3 outline-none h-full"
+            tabIndex={-1}
+            onFocus={(e) => {
+                // Only auto-highlight when focused via keyboard (ArrowDown from input)
+                if (!highlight && e.currentTarget.dataset.keyboardFocus === 'true') {
+                    delete e.currentTarget.dataset.keyboardFocus
+                    const firstCol = columns.findIndex((c) => c.items.length > 0)
+                    if (firstCol !== -1) {
+                        setHighlight([firstCol, 0])
+                    }
+                }
+            }}
+            onKeyDown={handleGridKeyDown}
         >
-            <div className="overflow-hidden">
+            {columns.map((col, colIndex) => (
                 <div
-                    ref={gridRef}
-                    role="grid"
-                    data-attr="homepage-grid"
-                    className="flex flex-col @xl/main-content:flex-row gap-8 @xl/main-content:gap-2 w-full mt-3 outline-none min-h-[174px]"
-                    tabIndex={-1}
-                    aria-hidden={isCollapsed}
-                    onFocus={(e) => {
-                        // Only auto-highlight when focused via keyboard (ArrowDown from input)
-                        if (!highlight && e.currentTarget.dataset.keyboardFocus === 'true') {
-                            delete e.currentTarget.dataset.keyboardFocus
-                            const firstCol = columns.findIndex((c) => c.items.length > 0)
-                            if (firstCol !== -1) {
-                                setHighlight([firstCol, 0])
-                            }
-                        }
-                    }}
-                    onKeyDown={handleGridKeyDown}
+                    key={col.kind}
+                    role="rowgroup"
+                    className="flex-1 min-w-0 flex flex-col gap-px"
+                    data-attr={`homepage-grid-column-${col.kind}`}
                 >
-                    {columns.map((col, colIndex) => (
+                    <Label className="px-2 mb-1 flex items-center gap-1" intent="menu">
+                        {col.icon}
+                        {col.label}
+                    </Label>
+                    {loadingByKind[col.kind] &&
+                    col.items.length === 0 &&
+                    (skeletonCounts === null || (skeletonCounts[col.kind] ?? 0) > 0) ? (
+                        Array.from({ length: skeletonCounts?.[col.kind] ?? 3 }).map((_, i) => (
+                            <div key={`skeleton-${i}`}>
+                                <LemonSkeleton className="h-[30px]" />
+                            </div>
+                        ))
+                    ) : col.items.length === 0 ? (
                         <div
-                            key={col.kind}
-                            role="rowgroup"
-                            aria-labelledby={`homepage-grid-column-label-${col.kind}`}
-                            className="flex-1 min-w-0 flex flex-col gap-px"
-                            data-attr={`homepage-grid-column-${col.kind}`}
+                            className="px-3 py-2 border border-dashed rounded text-xs text-tertiary"
+                            data-attr={`homepage-grid-empty-${col.kind}`}
                         >
-                            {/* Static section caption — the surrounding grid is menu-styled, so
-                                mark it non-interactive (no text/selection cue) to avoid reading as a clickable header */}
-                            <Label
-                                id={`homepage-grid-column-label-${col.kind}`}
-                                className="px-2 mb-1 flex items-center gap-1 cursor-default select-none"
-                                intent="menu"
-                            >
-                                {col.icon}
-                                {col.label}
-                            </Label>
-                            {loadingByKind[col.kind] &&
-                            col.items.length === 0 &&
-                            (skeletonCounts === null || (skeletonCounts[col.kind] ?? 0) > 0) ? (
-                                Array.from({ length: skeletonCounts?.[col.kind] ?? 3 }).map((_, i) => (
-                                    <div key={`skeleton-${i}`}>
-                                        <LemonSkeleton className="h-[30px]" />
-                                    </div>
-                                ))
-                            ) : col.items.length === 0 ? (
-                                <div
-                                    className="px-3 py-2 border border-dashed rounded text-xs text-tertiary"
-                                    data-attr={`homepage-grid-empty-${col.kind}`}
-                                >
-                                    {col.emptyLabel}{' '}
-                                    <Tooltip title={col.emptyTooltip} delayMs={0}>
-                                        <IconInfo
-                                            className="size-3 text-tertiary"
-                                            data-attr={`homepage-grid-empty-tooltip-${col.kind}`}
-                                        />
-                                    </Tooltip>
-                                </div>
-                            ) : (
-                                col.items.map((item, rowIndex) => (
-                                    <div key={item.id} role="row">
-                                        <Link
-                                            to={item.href}
-                                            role="gridcell"
-                                            title={item.label}
-                                            buttonProps={{
-                                                menuItem: true,
-                                                fullWidth: true,
-                                                className: 'truncate -outline-offset-2',
-                                            }}
-                                            data-attr={`homepage-grid-${item.kind}`}
-                                            data-highlighted={
-                                                highlight?.[0] === colIndex && highlight?.[1] === rowIndex
-                                                    ? 'true'
-                                                    : undefined
-                                            }
-                                            onMouseEnter={() => setHighlight([colIndex, rowIndex])}
-                                            onMouseLeave={() => setHighlight(null)}
-                                        >
-                                            <GridItemIcon item={item} />
-                                            <span className="truncate">{item.label}</span>
-                                        </Link>
-                                    </div>
-                                ))
-                            )}
+                            {col.emptyLabel}{' '}
+                            <Tooltip title={col.emptyTooltip} delayMs={0}>
+                                <IconInfo
+                                    className="size-3 text-tertiary"
+                                    data-attr={`homepage-grid-empty-tooltip-${col.kind}`}
+                                />
+                            </Tooltip>
                         </div>
-                    ))}
+                    ) : (
+                        col.items.map((item, rowIndex) => (
+                            <div key={item.id} role="row">
+                                <Link
+                                    to={item.href}
+                                    role="gridcell"
+                                    title={item.label}
+                                    buttonProps={{
+                                        menuItem: true,
+                                        fullWidth: true,
+                                        className: 'truncate -outline-offset-2',
+                                    }}
+                                    data-attr={`homepage-grid-${item.kind}`}
+                                    data-highlighted={
+                                        highlight?.[0] === colIndex && highlight?.[1] === rowIndex ? 'true' : undefined
+                                    }
+                                    onMouseEnter={() => setHighlight([colIndex, rowIndex])}
+                                    onMouseLeave={() => setHighlight(null)}
+                                >
+                                    <GridItemIcon item={item} />
+                                    <span className="truncate">{item.label}</span>
+                                </Link>
+                            </div>
+                        ))
+                    )}
                 </div>
-            </div>
+            ))}
         </div>
     )
 }
 
 export function HomepageInput(): JSX.Element {
-    const { mode } = useValues(aiFirstHomepageLogic)
+    const { mode, query, capabilities, selectedCapability } = useValues(aiFirstHomepageLogic)
+    const { setQuery, submitQuery, setSelectedCapability, setFillInHint } = useActions(aiFirstHomepageLogic)
     const { user } = useValues(userLogic)
+
+    const selectedCapabilityData = capabilities.find((capability) => capability.key === selectedCapability) ?? null
 
     return (
         <div className="w-full max-w-180 mx-auto py-2 ">
@@ -520,7 +535,47 @@ export function HomepageInput(): JSX.Element {
                 <div className="flex flex-col items-center gap-3 pb-(--scene-layout-header-height)">
                     <Intro forceHeadline={`Hello ${user?.first_name || 'there'}`} forceSubheadline={null} />
                     <IdleInput />
-                    <IdleGrid />
+                    {/* Badges + (cards | recents grid) collapse together as a single box when the user
+                        starts typing / leaves idle. Hidden on mobile — only shown at @xl, where the grid
+                        lays its columns in a row. */}
+                    <div
+                        className="w-full hidden @xl/main-content:grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:duration-0"
+                        style={{ gridTemplateRows: query.trim() ? '0fr' : '1fr' }}
+                        aria-hidden={!!query.trim()}
+                    >
+                        {/* shrink-0 on the children so collapsing just clips them away (top-down) rather
+                            than squeezing their heights, which would reflow the cards/grid mid-animation.
+                            gap-6 spaces the badges from the row below — it's part of the flex column's
+                            laid-out height, so it's counted in the collapse and the vertical centering. */}
+                        <div className="overflow-hidden flex flex-col gap-6">
+                            <CapabilityBadges
+                                className="shrink-0"
+                                capabilities={capabilities}
+                                selectedKey={selectedCapability}
+                                onSelect={setSelectedCapability}
+                            />
+                            {/* Single fixed-height swap area — the cards and the recents grid both fill
+                                it (h-full), so switching never changes height. */}
+                            <div
+                                className="w-full shrink-0 overflow-hidden"
+                                style={{ height: CAPABILITY_CARDS_HEIGHT_PX }}
+                            >
+                                {selectedCapabilityData ? (
+                                    <CapabilitySuggestions
+                                        capability={selectedCapabilityData}
+                                        onType={setQuery}
+                                        onSubmit={() => submitQuery('ai')}
+                                        onFillIn={(hint) => {
+                                            setFillInHint(hint)
+                                            document.querySelector<HTMLElement>('#homepage-input')?.focus()
+                                        }}
+                                    />
+                                ) : (
+                                    <IdleGrid />
+                                )}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             )}
             {mode === 'ai' && <HomepageAiInput />}

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -2,8 +2,16 @@ import { actions, afterMount, connect, kea, listeners, path, reducers, selectors
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
 import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
+import {
+    Capability,
+    CapabilityGrouping,
+    capabilitiesForGrouping,
+    capabilityGroupingFromVariant,
+} from 'scenes/max/maxCapabilities'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -90,6 +98,8 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['shortcutData as cachedStarred', 'shortcutDataHasLoaded'],
             tabUiStateLogic,
             ['chatDraftFor'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [
             maxLogic({ panelId: HOMEPAGE_TAB_ID }),
@@ -112,6 +122,9 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         returnToIdle: true,
         setPreviousHomepage: (tab: SceneTab | null) => ({ tab }),
         revertToPreviousHomepage: true,
+        setSelectedCapability: (key: string | null) => ({ key }),
+        // Postfix hint shown after a fill-in suggestion's typed-in prefix (e.g. "insert feature name").
+        setFillInHint: (hint: string | null) => ({ hint }),
     }),
 
     reducers({
@@ -159,6 +172,23 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
                 setPreviousHomepage: (_, { tab }) => tab,
             },
         ],
+        selectedCapability: [
+            null as string | null,
+            {
+                setSelectedCapability: (_, { key }) => key,
+                submitQuery: () => null,
+                returnToIdle: () => null,
+            },
+        ],
+        fillInHint: [
+            null as string | null,
+            {
+                setFillInHint: (_, { hint }) => hint,
+                setSelectedCapability: () => null,
+                submitQuery: () => null,
+                returnToIdle: () => null,
+            },
+        ],
     }),
 
     selectors({
@@ -177,6 +207,16 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         ],
         mode: [(s) => [s.layoutState], (layoutState): HomepageMode => layoutState.mode],
         animationPhase: [(s) => [s.layoutState], (layoutState): AnimationPhase => layoutState.animationPhase],
+        capabilityGrouping: [
+            (s) => [s.featureFlags],
+            (featureFlags): CapabilityGrouping | null =>
+                capabilityGroupingFromVariant(featureFlags[FEATURE_FLAGS.MAX_HOMEPAGE_CAPABILITIES]),
+        ],
+        capabilities: [
+            (s) => [s.capabilityGrouping],
+            (capabilityGrouping): Capability[] =>
+                capabilityGrouping ? capabilitiesForGrouping(capabilityGrouping) : [],
+        ],
         pinnedDashboardItems: [
             (s) => [s.pinnedDashboards],
             (pinnedDashboards): HomepageGridItem[] =>


### PR DESCRIPTION
## Problem

The `/home` (AI-first homepage) landing shows a hero, an input, and a recents/starred grid, but nothing that tells people what PostHog AI can actually do. Conversion from landing on the page to actually using PostHog AI is lower than we'd like. This surfaces the product's capabilities directly, so people can discover and kick off an analysis, a flag, an experiment, a survey, etc. in one click.

## Changes

Adds a row of PostHog AI capability badges above the recents/starred grid on `/home`, and the same badges in place of the suggestion pills on the `/ai` scene. All of it is behind an experiment (`max-homepage-capabilities`) with three arms:

- **control** – today's experience, unchanged.
- **behaviors** – grouped by what you do: Analysis, Debug, Monitor, Understand, Ship.
- **products** – grouped by product: Analytics, SQL, Session replay, Error tracking, Feature flags, Experiments, Surveys.

Both treatment arms also include a **Learn** badge (a plain docs-style question list, matching the Docs suggestions we show elsewhere) and a **Code** badge with a Beta tag that links to `/inbox`.

Behavior:

- Clicking a badge swaps the recents/starred grid for that capability's suggestion cards. The grid and the cards share one fixed-height container, so switching never shifts layout.
- Clicking a suggestion types the prompt into the input at a human-feeling pace, then sends it.
- For fill-in prompts (e.g. "Create a flag to gradually roll out"), it types the prefix in, then shows a faded postfix cue ("the feature you're launching") after a wide blinking caret, and sends the full thing once you complete it.
- The whole section is hidden on mobile and collapses when you start typing.

Shared, presentational components (`CapabilityBadges`, `CapabilitySuggestions`) drive both surfaces so they stay identical.

I also created the experiment in prod as a draft: [Homepage PostHog AI capability badges (380454)](https://us.posthog.com/project/2/experiments/380454). It has no metric yet and is not launched, so no users are exposed. Whoever owns this should add a primary activation metric before launching.

<img width="844" height="560" alt="image" src="https://github.com/user-attachments/assets/3ac6277b-6028-4a6a-8085-e4aea05799da" />
<img width="804" height="277" alt="image" src="https://github.com/user-attachments/assets/58c20ed7-7e0b-4389-926e-0de4a96bc2dc" />



## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` and `oxlint` are clean for all touched files.
- I (Claude) did **not** run the app or verify in a browser. The layout/animation behavior (centering, no-shift on badge switch, the fill-in caret, mobile hiding) has not been visually confirmed by me and should be eyeballed before this is marked ready.
- No automated tests added. The logic here is UI-and-animation heavy and best confirmed visually; happy to add a focused `aiFirstHomepageLogic` test if reviewers want coverage of the experiment-arm selection.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) – Rafael directed the work and is the DRI.

Built with Claude Code (Opus 4.8). No repo skills were invoked; the change is confined to frontend scene code, so the mandatory skill areas (DRF, migrations, generated API types) didn't apply.

A few decisions worth flagging for review:

- **Centering vs the layout shift.** Clicking a badge changed the section height and, because the idle content is vertically centered, that re-centered everything and caused a jump. I first tried top-anchoring the content with a fixed top margin, then reverted to the original centering and instead gave the grid and the cards one shared fixed-height container (both fill it with `h-full`), which removes the shift without changing the page's feel.
- **The fill-in cue went through a couple of iterations.** It started as an empty box with the prompt shown as a placeholder, then flipped to the current approach: type the prefix in as real text, then show a natural-language postfix hint after a wide blinking caret. The prefix is real input now, so there's no prepend-on-send logic.
- **Avoiding duplication.** The fixed height lives once as `CAPABILITY_CARDS_HEIGHT_PX`; the grid and cards inherit it, so they can't drift out of sync.
- The caret reuses the existing `hogqlx-blink` keyframe; product-icon coloring is applied inside the shared components (`colorful-product-icons`) so they render the same on every surface, not just where an ancestor happens to set it.
