### PR TITLE
fix(agent-proxy): address review comments from #67555

### DIFF
--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -411,6 +411,7 @@ function isClientAbortError(err: unknown): boolean {
         return true
     }
     const code = (err as NodeJS.ErrnoException).code
+    // 'aborted' is undici's body-read abort message; it carries no error code, unlike the others.
     return code === 'ECONNRESET' || code === 'ERR_STREAM_PREMATURE_CLOSE' || err.message === 'aborted'
 }
 

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -63,11 +63,11 @@ export class EventIngestPayloadTooLarge extends Error {
 }
 
 export class ClientDisconnected extends Error {
-    constructor(
-        public accepted: number = 0,
-        public duplicate: number = 0,
-        public lastAcceptedSeq: number = 0
-    ) {
+    accepted = 0
+    duplicate = 0
+    lastAcceptedSeq = 0
+
+    constructor() {
         super('Client disconnected during event ingest')
         this.name = 'ClientDisconnected'
     }

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -899,6 +899,7 @@ describe('ingest-handler', () => {
         },
     ])('treats a mid-body $variant as a client disconnect, not a server error', async ({ makeError }) => {
         const infoSpy = vi.spyOn(logger, 'info')
+        const errorSpy = vi.spyOn(logger, 'error')
         const config = makeConfig()
         const enc = new TextEncoder()
         const line = enc.encode(JSON.stringify({ seq: 1, event: { type: 'before-drop' } }) + '\n')
@@ -925,6 +926,7 @@ describe('ingest-handler', () => {
 
         const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest:client_disconnect')?.[1] as Record<string, unknown>
         expect(log).toMatchObject({ run: RUN_ID, accepted: 1, lastSeq: 1 })
+        expect(errorSpy).not.toHaveBeenCalledWith('http.unhandled_error', expect.anything())
     })
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

#67555 was merged before three review comments on it were addressed.

## Changes

- `ClientDisconnected` no longer takes constructor params that no call site passed; the progress fields are plain field declarations and the only call site keeps assigning them after the throw, matching the `EventIngestPayloadTooLarge` pattern.
- Added the requested one-line comment in `isClientAbortError` explaining the bare `'aborted'` message check, which unlike the other branches has no error code to match on.
- The client-disconnect test now also asserts `http.unhandled_error` is not logged, so a future change that classifies the disconnect but still logs it as an error can't pass silently.

## How did you test this code?

`pnpm exec vitest run` in `services/agent-proxy` (188 passed) plus `tsc --noEmit` and `oxlint`/`oxfmt`. The test change extends the existing parameterized disconnect test with one assertion rather than adding a new test; it guards double-logging of disconnects at error level, which nothing covered before.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @charlesvien. This applies the three post-merge review comments from #67555 as suggested by the reviewer, with no behavior changes beyond the extra test assertion. Skills invoked earlier in the session and still governing the test change: /writing-tests.
