### PR TITLE
fix(logs): use decimal KB and guard non-array patterns in rule compile

### DIFF
--- a/nodejs/src/logs/sampling/compile-rules.ts
+++ b/nodejs/src/logs/sampling/compile-rules.ts
@@ -61,7 +61,11 @@ const MAX_LOGS_PER_SECOND = 1_000_000
 const MAX_BURST_LOGS = 10_000_000
 const MAX_KB_PER_SECOND = 1_000_000
 const MAX_BURST_KB = 10_000_000
-const BYTES_PER_KB = 1024
+// Decimal (SI) KB: the drop-rule form (UNIT_TO_KB_PER_S), the sparkline preview's
+// threshold line (KB/s × 1000), and the API validator ("1000000 = 1 GB/s") all use
+// 1 KB = 1000 bytes. The bucket must charge in the same unit, otherwise every cap
+// silently enforces ~2.4% above its label.
+const BYTES_PER_KB = 1000
 
 function parseRateLimitFromConfig(
     config: Record<string, unknown>
@@ -230,7 +234,9 @@ export function compileRuleSet(rows: SamplingRuleRow[]): CompiledRuleSet {
         let pathDropMatchAttributeKey: string | null = null
         let filterGroup: FilterGroupNode | null = null
         if (row.rule_type === 'path_drop') {
-            const patterns = (row.config.patterns as unknown[]) || []
+            // Array.isArray, not truthiness: a corrupt string value would otherwise be
+            // iterated per character into single-char regexes that match nearly everything.
+            const patterns = Array.isArray(row.config.patterns) ? (row.config.patterns as unknown[]) : []
             pathDropPatterns = []
             for (const p of patterns) {
                 if (typeof p !== 'string') {

--- a/nodejs/src/logs/sampling/evaluate.test.ts
+++ b/nodejs/src/logs/sampling/evaluate.test.ts
@@ -161,6 +161,41 @@ describe('evaluateLogRecord', () => {
         expect(elapsed).toBeLessThan(10_000)
     })
 
+    it('compileRuleSet converts kb_per_second to bytes using decimal KB', () => {
+        const rs = compileRuleSet([
+            {
+                id: 'rl-kb',
+                rule_type: 'rate_limit',
+                scope_service: null,
+                scope_path_pattern: null,
+                scope_attribute_filters: [],
+                config: { kb_per_second: 1, burst_kb: 2 },
+            },
+        ])
+        // The drop-rule UI (UNIT_TO_KB_PER_S), the preview threshold line (KB/s × 1000),
+        // and the API validator ("1000000 = 1 GB/s") all treat KB as decimal — the
+        // bucket must enforce the same unit or every cap runs above its label.
+        expect(rs.rules[0]?.rateLimit).toEqual({ refillPerSecond: 1000, poolMax: 2000, costUnit: 'bytes' })
+    })
+
+    it('path_drop with non-array patterns config matches nothing', () => {
+        const rules = compileRuleSet([
+            {
+                id: 'p-bad',
+                rule_type: 'path_drop',
+                scope_service: null,
+                scope_path_pattern: null,
+                scope_attribute_filters: [],
+                config: { patterns: 'abc' },
+            },
+        ])
+        // A corrupt non-array value must not be iterated per character into
+        // single-char regexes, each of which would match nearly every path.
+        const rec = baseRecord()
+        rec.attributes = { 'http.route': '/api/cart' }
+        expect(evaluateLogRecord(rules, rec).decision).not.toBe(SAMPLING_DECISION_DROP)
+    })
+
     it('compileRuleSet marks hasRateLimitRules for valid rate_limit config', () => {
         const rs = compileRuleSet([
             {


### PR DESCRIPTION
## Problem

Two correctness issues in the drop-rule compile step of the logs ingestion worker:

1. **Byte caps enforce ~2.4% above their label.** `kb_per_second` was converted to bytes at 1024 B/KB, while every other layer of the feature is decimal: the form's unit conversion (`UNIT_TO_KB_PER_S`, MB/s = 1000 KB/s), the sparkline preview's threshold line (`KB/s × 1000 = bytes/s`), and the API validator's documented range ("1000000 = 1 GB/s"). A rule labeled 1 MB/s enforced 1,024,000 B/s — and the preview plotted a threshold the bucket didn't enforce.
2. **A corrupt `patterns` value turns into a drop-everything rule.** `(row.config.patterns as unknown[]) || []` assumes an array; a string value is iterated per character, and each character compiles into a single-char regex that matches nearly every path. This is the one spot in the pipeline where malformed config over-drops instead of failing open (the API validates new writes, so only pre-validation or hand-edited rows can hit it — but the blast radius is total).

## Changes

- `BYTES_PER_KB` 1024 → 1000, with a comment pinning the unit contract to the form, preview, and validator.
- `Array.isArray` guard on `config.patterns`; non-array values compile to no patterns (match nothing), consistent with the fail-open posture everywhere else in the evaluator.

Behavior change for existing KB-mode rules: buckets refill ~2.4% slower, i.e. they now enforce exactly the labeled rate.

## How did you test this code?

Automated tests only (agent-authored, no manual testing):

- New `compileRuleSet converts kb_per_second to bytes using decimal KB` — observed before the fix: `kb_per_second: 1` compiled to `refillPerSecond: 1024, poolMax: 2048`; after: `1000/2000`. Catches any future regression of the unit contract in either direction.
- New `path_drop with non-array patterns config matches nothing` — observed before the fix: a record with path `/api/cart` was **dropped** by `config: { patterns: 'abc' }`; after: kept. No existing test covered non-array patterns.
- Full logs suite in `nodejs/`: 289 passed (including the ingestion-consumer end-to-end tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by the assignee. Skills invoked: `/writing-tests`. Found during an end-to-end audit of drop rules comparing worker enforcement against what the form, preview, and API docs promise. Considered aligning the UI to 1024 instead — rejected because the API help text and preview math already promise SI units, and billing measures decimal bytes.
