### PR TITLE
chore(logs): drop stale patterns write from drop-rule form payload

### DIFF
--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
@@ -19,7 +19,24 @@ const rateLimitForm = (overrides: Partial<LogsSamplingFormType> = {}): LogsSampl
     ...overrides,
 })
 
-describe('logsSamplingFormLogic rate-limit serialization', () => {
+describe('logsSamplingFormLogic serialization', () => {
+    it('serializes a path_drop rule into filter_group-only config', () => {
+        const innerGroup = {
+            type: FilterLogicalOperator.And,
+            values: [{ key: 'service.name', operator: 'exact', value: 'api', type: 'log_resource_attribute' }],
+        } as LogsSamplingFormType['filter_group']
+
+        const config = buildSamplingConfigPayload(
+            rateLimitForm({ rule_type: RuleTypeEnumApi.PathDrop, filter_group: innerGroup })
+        )
+
+        // The whole config is the wrapped filter group — the worker evaluates
+        // config.filter_group directly, and nothing else belongs in the payload.
+        expect(config).toEqual({
+            filter_group: { type: FilterLogicalOperator.And, values: [innerGroup] },
+        })
+    })
+
     it.each([
         ['1', 'MB/s', 1000],
         ['50', 'KB/s', 50],

--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
@@ -156,12 +156,7 @@ export function buildSamplingConfigPayload(form: LogsSamplingFormType): Record<s
             filter_group: wrapFilterGroup(form.filter_group),
         }
     }
-    // `patterns: []` keeps the existing path_drop config validator happy.
-    // Backend filter_group evaluation is wired in the follow-up PR; today the
-    // worker reads `patterns` only, so rules saved through the new UI are
-    // no-ops on the ingestion path until that lands.
     return {
-        patterns: [],
         filter_group: wrapFilterGroup(form.filter_group),
     }
 }


### PR DESCRIPTION
## Problem

`buildSamplingConfigPayload` still carried a comment claiming that backend `filter_group` evaluation "is wired in the follow-up PR; today the worker reads `patterns` only, so rules saved through the new UI are no-ops on the ingestion path". That has been false since #58924 — the worker evaluates `filter_group` for path_drop (and #59533 for rate_limit). The comment actively misleads anyone auditing whether drop rules work, and the `patterns: []` write it justified is dead weight: the API validator treats absent `patterns` the same as an empty list, and so does the worker's compile step.

## Changes

- Remove the stale comment and the `patterns: []` write; path_drop payloads are now `{ filter_group }` only.
- No behavior change: saving a rule through the UI replaces `config` wholesale either way, so legacy `patterns` on old rules were already cleared on re-save.

## How did you test this code?

Automated tests only (agent-authored, no manual testing):

- New `serializes a path_drop rule into filter_group-only config` asserting the exact payload shape. Observed before the change: payload contained `patterns: []` (test failed); after: exact `{ filter_group }` match. No existing test covered the path_drop payload at all — the suite only asserted rate-limit serialization.
- Full `LogsSampling` frontend jest suite: 9 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by the assignee, as part of an end-to-end drop-rules audit (companion PRs: #67596, #67597). Skills invoked: `/writing-tests`.
