### PR TITLE
feat(logs): log transformations UI, templates, and test invocation

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -369,6 +369,7 @@ export const FEATURE_FLAGS = {
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
+    LOGS_TRANSFORMATIONS: 'logs-transformations', // owner: #team-logs
     MANAGED_MIGRATIONS_IAM_ROLE_AUTH: 'managed-migrations-iam-role-auth', // owner: #team-ingestion, gates IAM role auth for S3 batch imports
     MANAGED_MIGRATIONS_TRIAL_RUNS: 'managed-migrations-trial-runs', // owner: #team-ingestion, gates trial runs for managed migrations
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -63,9 +63,11 @@ const HOG_FUNCTION_SCENE_TABS = ['configuration', 'metrics', 'runs', 'invocation
 export type HogFunctionSceneTab = (typeof HOG_FUNCTION_SCENE_TABS)[number]
 
 const HogFunctionSceneMapping: Partial<
-    Record<HogFunctionTypeType, { scene: Scene; url: () => string; newKind: DataPipelinesNewSceneKind }>
+    Record<HogFunctionTypeType, { scene: Scene; url: () => string; newKind?: DataPipelinesNewSceneKind }>
 > = {
     transformation: { scene: Scene.Transformations, url: urls.transformations, newKind: 'transformation' },
+    // Log transformations have no /pipeline/new page; creation happens from the Logs scene
+    transformation_log: { scene: Scene.Logs, url: urls.logs },
     destination: { scene: Scene.Destinations, url: urls.destinations, newKind: 'destination' },
     site_destination: { scene: Scene.Destinations, url: urls.destinations, newKind: 'destination' },
     source_webhook: { scene: Scene.Sources, url: urls.sources, newKind: 'source' },
@@ -308,7 +310,10 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                         {
                             key: sceneMapping.scene,
                             name: capitalizeFirstLetter(humanizeHogFunctionType(type, true)),
-                            path: id ? sceneMapping.url() : urls.dataPipelinesNew(sceneMapping.newKind),
+                            path:
+                                id || !sceneMapping.newKind
+                                    ? sceneMapping.url()
+                                    : urls.dataPipelinesNew(sceneMapping.newKind),
                             iconType: 'data_pipeline',
                         },
                         finalCrumb,

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -201,12 +201,16 @@ export function HogFunctionConfiguration({
                                             disabled={loading}
                                             bordered
                                             fullWidth
-                                            label="Enable destination"
+                                            label={type === 'transformation_log' ? 'Enable' : 'Enable destination'}
                                             tooltip={
                                                 <>
-                                                    {value
-                                                        ? 'Enabled. Events will be processed.'
-                                                        : 'Disabled. Events will not be processed.'}
+                                                    {type === 'transformation_log'
+                                                        ? value
+                                                            ? 'Enabled. Log records will be processed.'
+                                                            : 'Disabled. Log records will not be processed.'
+                                                        : value
+                                                          ? 'Enabled. Events will be processed.'
+                                                          : 'Disabled. Events will not be processed.'}
                                                 </>
                                             }
                                         />
@@ -226,9 +230,19 @@ export function HogFunctionConfiguration({
                             {mightDropEvents && (
                                 <div>
                                     <LemonBanner type="info">
-                                        <b>Warning:</b> This transformation can filter out events, dropping them
-                                        irreversibly. Make sure to double check your configuration, and use filters to
-                                        limit the events that this transformation is applied to.
+                                        {type === 'transformation_log' ? (
+                                            <>
+                                                <b>Warning:</b> This transformation can drop log records irreversibly
+                                                (any record it returns null for is discarded). Double check your code
+                                                before enabling.
+                                            </>
+                                        ) : (
+                                            <>
+                                                <b>Warning:</b> This transformation can filter out events, dropping them
+                                                irreversibly. Make sure to double check your configuration, and use
+                                                filters to limit the events that this transformation is applied to.
+                                            </>
+                                        )}
                                     </LemonBanner>
                                 </div>
                             )}

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
@@ -202,7 +202,10 @@ export function HogFunctionTest(): JSX.Element {
                             <span>Testing</span>
                         </h2>
                         {inactive ? (
-                            <p>Click here to test your function with an example {isDataWarehouse ? 'row' : 'event'}</p>
+                            <p>
+                                Click here to test your function with an example{' '}
+                                {isDataWarehouse ? 'row' : type === 'transformation_log' ? 'record' : 'event'}
+                            </p>
                         ) : null}
                     </div>
 
@@ -375,7 +378,8 @@ export function HogFunctionTest(): JSX.Element {
                                           : 'Error'}
                                 </LemonBanner>
 
-                                {type === 'transformation' && testResult.status !== 'error' ? (
+                                {(type === 'transformation' || type === 'transformation_log') &&
+                                testResult.status !== 'error' ? (
                                     <>
                                         <div className="flex gap-2 justify-between items-center">
                                             <LemonLabel>Transformation result</LemonLabel>
@@ -392,14 +396,21 @@ export function HogFunctionTest(): JSX.Element {
                                                 />
                                             )}
                                         </div>
-                                        <p>Below you can see the event after the transformation has been applied.</p>
+                                        <p>
+                                            Below you can see the {type === 'transformation_log' ? 'record' : 'event'}{' '}
+                                            after the transformation has been applied.
+                                        </p>
                                         {testResult.result ? (
                                             <>
                                                 {!sortedTestsResult?.hasDiff && (
                                                     <LemonBanner type="info">
                                                         {testResult.status === 'skipped'
-                                                            ? 'The event was not modified as it did not match the filter criteria.'
-                                                            : 'The event was unmodified by the transformation.'}
+                                                            ? `The ${
+                                                                  type === 'transformation_log' ? 'record' : 'event'
+                                                              } was not modified as it did not match the filter criteria.`
+                                                            : `The ${
+                                                                  type === 'transformation_log' ? 'record' : 'event'
+                                                              } was unmodified by the transformation.`}
                                                     </LemonBanner>
                                                 )}
                                                 <CodeEditorResizeable

--- a/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
@@ -106,8 +106,9 @@ export function HogFunctionCode(): JSX.Element {
                             ) : null}
                             {mightDropEvents && (
                                 <LemonBanner type="warning" className="mt-2">
-                                    <b>Warning:</b> Returning null or undefined will drop the event. If this is
-                                    unintentional, return the event object instead.
+                                    <b>Warning:</b> Returning null or undefined will drop the{' '}
+                                    {type === 'transformation_log' ? 'record' : 'event'}. If this is unintentional,
+                                    return the {type === 'transformation_log' ? 'record' : 'event'} object instead.
                                 </LemonBanner>
                             )}
                             {type === 'source_webhook' && (

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
@@ -183,4 +183,36 @@ describe('hogFunctionConfigurationLogic', () => {
             }).toDispatchActions(['upsertHogFunction', 'submitConfigurationSuccess'])
         })
     })
+
+    describe('log transformation', () => {
+        const LOG_TEMPLATE: HogFunctionTemplateType = {
+            free: true,
+            status: 'stable',
+            id: 'template-log-transformation-default',
+            type: 'transformation_log',
+            name: 'Custom log transformation',
+            description: 'Start from scratch.',
+            code: 'return record',
+            code_language: 'hog',
+            inputs_schema: [],
+            filters: null,
+            masking: null,
+            icon_url: '/static/hedgehog/builder-hog-01.png',
+        }
+
+        beforeEach(() => {
+            initKeaTests()
+            mockApi.getTemplate.mockReturnValue(Promise.resolve(LOG_TEMPLATE))
+            logic = hogFunctionConfigurationLogic({ templateId: 'test' })
+            logic.mount()
+        })
+
+        it('seeds the inline tester with a sample record, not an event', async () => {
+            await expectLogic(logic).toDispatchActions(['loadTemplate', 'loadTemplateSuccess'])
+            const globals = logic.values.exampleInvocationGlobals
+            expect(globals.record).toBeTruthy()
+            expect(globals.record?.body).toContain('GET /api/users')
+            expect(globals.event).toBeUndefined()
+        })
+    })
 })

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -121,7 +121,7 @@ const NEW_FUNCTION_TEMPLATE: HogFunctionTemplateType = {
     status: 'stable',
 }
 
-export const TYPES_WITH_GLOBALS: HogFunctionTypeType[] = ['transformation', 'destination']
+export const TYPES_WITH_GLOBALS: HogFunctionTypeType[] = ['transformation', 'transformation_log', 'destination']
 export const TYPES_WITH_REAL_EVENTS: HogFunctionTypeType[] = ['destination', 'site_destination', 'transformation']
 export const TYPES_WITH_VOLUME_WARNING: HogFunctionTypeType[] = ['destination', 'site_destination']
 
@@ -129,7 +129,24 @@ const TYPE_TO_PRODUCT_KEY: Partial<Record<HogFunctionTypeType, ProductKey>> = {
     destination: ProductKey.PIPELINE_DESTINATIONS,
     site_destination: ProductKey.PIPELINE_DESTINATIONS,
     transformation: ProductKey.PIPELINE_TRANSFORMATIONS,
+    transformation_log: ProductKey.LOGS,
     site_app: ProductKey.SITE_APPS,
+}
+
+// Sample record shown in the log transformation testing UI (no events table to sample from).
+const EXAMPLE_LOG_RECORD: NonNullable<CyclotronJobInvocationGlobals['record']> = {
+    body: 'GET /api/users 200 in 42ms user=jane@example.com',
+    attributes: { 'http.method': 'GET', 'http.status_code': '200' },
+    resource_attributes: { 'service.name': 'api', 'k8s.namespace.name': 'production' },
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'api',
+    instrumentation_scope: 'http.server',
+    event_name: null,
+    timestamp: 1780000000000000000,
+    observed_timestamp: 1780000000000000000,
+    trace_id: null,
+    span_id: null,
 }
 
 export function sanitizeInputs(
@@ -1258,9 +1275,11 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                             ? 'Web scripts'
                             : type === 'transformation'
                               ? 'Transformations'
-                              : type === 'source_webhook'
-                                ? 'Sources'
-                                : 'Destinations'
+                              : type === 'transformation_log'
+                                ? 'Log transformations'
+                                : type === 'source_webhook'
+                                  ? 'Sources'
+                                  : 'Destinations'
                     payload._create_in_folder = `Unfiled/${typeFolder}`
                 }
                 await asyncActions.upsertHogFunction(payload as HogFunctionConfigurationType)
@@ -1373,6 +1392,18 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 contextId: HogFunctionConfigurationContextId,
                 survey: Survey | null
             ): CyclotronJobInvocationGlobals => {
+                // Log transformations are seeded with a sample record (no event), so the inline
+                // tester shows something useful to run against instead of an empty object.
+                if (configuration?.type === 'transformation_log') {
+                    return {
+                        project: {
+                            id: currentProject?.id ?? 0,
+                            name: currentProject?.name ?? '',
+                            url: `${window.location.origin}/project/${currentProject?.id}`,
+                        },
+                        record: EXAMPLE_LOG_RECORD,
+                    } as CyclotronJobInvocationGlobals
+                }
                 const currentUrl = window.location.href.split('#')[0]
                 const eventId = uuid()
                 const personId = uuid()
@@ -1520,6 +1551,17 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     return {
                         project: baseGlobals.project,
                         event: baseGlobals.event,
+                        inputs,
+                    }
+                }
+
+                // Log transformations receive `project` and `record` at runtime (see
+                // buildLogRecordGlobals). There is no event table to sample from, so show a
+                // representative record the user can edit.
+                if (configuration.type === 'transformation_log') {
+                    return {
+                        project: baseGlobals.project,
+                        record: EXAMPLE_LOG_RECORD,
                         inputs,
                     }
                 }
@@ -1776,7 +1818,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         mightDropEvents: [
             (s) => [s.configuration, s.type],
             (configuration: HogFunctionConfigurationType, type: HogFunctionTypeType) => {
-                if (type !== 'transformation') {
+                if (type !== 'transformation' && type !== 'transformation_log') {
                     return false
                 }
                 const hogCode = configuration.hog || ''
@@ -1848,14 +1890,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     return false
                 }
 
-                return ['source_webhook', 'transformation', 'destination'].includes(type)
+                return ['source_webhook', 'transformation', 'transformation_log', 'destination'].includes(type)
             },
         ],
 
         showTesting: [
             (s) => [s.type],
             (type: HogFunctionTypeType) => {
-                return ['destination', 'internal_destination', 'transformation'].includes(type)
+                return ['destination', 'internal_destination', 'transformation', 'transformation_log'].includes(type)
             },
         ],
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
@@ -367,6 +367,9 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 const event = convertToTransformationEvent(globals.event)
                 // Strip down to just the real values
                 actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
+            } else if (values.type === 'transformation_log') {
+                // Log transformations edit the record directly
+                actions.setTestInvocationValue('globals', JSON.stringify(globals.record ?? {}, null, 2))
             } else {
                 actions.setTestInvocationValue('globals', JSON.stringify(globals, null, 2))
             }
@@ -505,13 +508,13 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 configuration.template_id = values.templateId
                 configuration.hog = values.currentHogCode
 
-                // Transformations have a simpler UI just showing the event so we need to map it back to the event
+                // Transformations have a simpler UI just showing the event/record so we map it back
                 const globals =
                     values.type === 'transformation'
-                        ? {
-                              event: parsedData,
-                          }
-                        : parsedData
+                        ? { event: parsedData }
+                        : values.type === 'transformation_log'
+                          ? { record: parsedData }
+                          : parsedData
 
                 try {
                     const res = await api.hogFunctions.createTestInvocation(props.id ?? 'new', {
@@ -549,13 +552,20 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 output: string
                 hasDiff: boolean
             } | null => {
-                if (!testResult || configuration.type !== 'transformation') {
+                if (
+                    !testResult ||
+                    (configuration.type !== 'transformation' && configuration.type !== 'transformation_log')
+                ) {
                     return null
                 }
 
-                const rawInput = convertFromTransformationEvent(
-                    convertToTransformationEvent(JSON.parse(testInvocation.globals))
-                )
+                // Log transformations edit the record directly; events round-trip through the event shape
+                const rawInput =
+                    configuration.type === 'transformation_log'
+                        ? JSON.parse(testInvocation.globals)
+                        : convertFromTransformationEvent(
+                              convertToTransformationEvent(JSON.parse(testInvocation.globals))
+                          )
 
                 const input = JSON.stringify(rawInput, null, 2)
                 const output = JSON.stringify(testResult.result, null, 2)

--- a/frontend/src/scenes/hog-functions/hog-function-utils.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.ts
@@ -14,6 +14,9 @@ export function humanizeHogFunctionType(type: HogFunctionTypeType, plural: boole
     if (type === 'site_app') {
         return 'Web script' + (plural ? 's' : '')
     }
+    if (type === 'transformation_log') {
+        return 'log transformation' + (plural ? 's' : '')
+    }
     return type.replaceAll('_', ' ') + (plural ? 's' : '')
 }
 

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -288,7 +288,7 @@ export function HogFunctionList({
             })
         }
 
-        if (props.type === 'transformation') {
+        if (props.type === 'transformation' || props.type === 'transformation_log') {
             // insert it in the second column
             columns.splice(1, 0, {
                 title: 'Prio',

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -31,6 +31,7 @@ import { CdpApi } from './cdp-api'
 import { CdpConsumerBaseDeps } from './consumers/cdp-base.consumer'
 import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/posthog-filter-out-plugin/template'
 import { BASE_REDIS_KEY, HogWatcherState } from './services/monitoring/hog-watcher.service'
+import { compileHog } from './templates/compiler'
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 
 // Email MX validation runs on every email send, so without a mock the test-panel
@@ -622,6 +623,112 @@ describe('CDP API', () => {
             expect(res.status).toEqual(200)
             expect(res.body.logs.map((log: any) => log.message)).toMatchInlineSnapshot(`[]`)
             expect(res.body.result).toMatchInlineSnapshot(`null`)
+        })
+    })
+
+    describe('log transformations', () => {
+        let configuration: HogFunctionType
+
+        const logRecordGlobals = {
+            record: {
+                body: 'login ok password=hunter2',
+                severity_text: 'info',
+                severity_number: 9,
+                service_name: 'payments-api',
+                attributes: { 'http.method': 'POST' },
+                resource_attributes: { 'k8s.namespace.name': 'payments' },
+            },
+        }
+
+        beforeEach(async () => {
+            const hog = `
+                let r := record
+                if (r.severity_text == 'debug') {
+                    return null
+                }
+                if (r.body != null) {
+                    r.body := replaceAll(r.body, inputs.needle, '[REDACTED]')
+                }
+                r.attributes.transformed := 'true'
+                return r
+            `
+            configuration = createHogFunction({
+                type: 'transformation_log',
+                name: 'Test log transformation',
+                team_id: team.id,
+                enabled: true,
+                hog,
+                bytecode: await compileHog(hog),
+                inputs: { needle: { value: 'hunter2' } },
+            })
+        })
+
+        it('transforms a mock log record', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({ globals: logRecordGlobals, configuration })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.errors).toEqual([])
+            expect(res.body.result.body).toEqual('login ok password=[REDACTED]')
+            expect(res.body.result.severity_text).toEqual('info')
+            expect(res.body.result.attributes).toEqual({ 'http.method': 'POST', transformed: 'true' })
+        })
+
+        it('returns null result when the record is dropped', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: { record: { ...logRecordGlobals.record, severity_text: 'debug' } },
+                    configuration,
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.result).toEqual(null)
+            expect(res.body.logs.map((log: any) => log.message)).toContain('Record dropped by transformation.')
+        })
+
+        it('returns 400 when the record global is missing', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({ globals: {}, configuration })
+
+            expect(res.status).toEqual(400)
+            expect(res.body.error).toEqual('Missing record')
+        })
+
+        it('reports a malformed return value as an error', async () => {
+            // Returning a non-record, non-null value is a customer mistake the endpoint must surface
+            const hog = `return 42`
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: logRecordGlobals,
+                    configuration: { ...configuration, hog, bytecode: await compileHog(hog) },
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('error')
+            expect(res.body.errors.length).toBeGreaterThan(0)
+        })
+
+        it('captures print output from the transformation', async () => {
+            const hog = `
+                print('inspecting', record.service_name)
+                return record
+            `
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: logRecordGlobals,
+                    configuration: { ...configuration, hog, bytecode: await compileHog(hog) },
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.logs.map((log: any) => log.message)).toContain('inspecting, payments-api')
         })
     })
 

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -415,7 +415,7 @@ export class CdpApi {
 
             if (functionType === 'transformation_log') {
                 // Log transformations run against a log record, not an event
-                if (!globals?.record || typeof globals.record !== 'object') {
+                if (!globals?.record || typeof globals.record !== 'object' || Array.isArray(globals.record)) {
                     res.status(400).json({ error: 'Missing record' })
                     return
                 }
@@ -598,9 +598,13 @@ export class CdpApi {
                     })
                 }
 
-                const sensitiveValues = Object.values(compoundConfiguration.encrypted_inputs ?? {})
-                    .map((input) => input?.value)
-                    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+                // Derive from the resolved inputs (which merge inputs + encrypted_inputs) like the
+                // destination test path does — Django resolves stored secrets into `inputs`, so
+                // collecting from `encrypted_inputs` alone would leave them unredacted in test logs.
+                const sensitiveValues = this.hogExecutor.getSensitiveValues(
+                    compoundConfiguration,
+                    (hogGlobals.inputs ?? {}) as Record<string, any>
+                )
 
                 const outcome = executeLogTransformation(compoundConfiguration.bytecode, record, hogGlobals, {
                     sensitiveValues,

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -4,6 +4,13 @@ import express from 'ultimate-express'
 import { ModifiedRequest } from '~/common/api/router'
 import { logger } from '~/common/utils/logger'
 import { UUID, UUIDT, delay } from '~/common/utils/utils'
+import { LogRecord } from '~/logs/log-record-avro'
+import {
+    DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+    resolveLogTransformationInputs,
+} from '~/logs/transformations/hog-log-exec'
 import { PluginEvent } from '~/plugin-scaffold'
 
 import {
@@ -404,7 +411,15 @@ export class CdpApi {
                 ? convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.config.SITE_URL)
                 : globals
 
-            if (!globals || !globals.event) {
+            const functionType: string | undefined = configuration?.type ?? hogFunction?.type
+
+            if (functionType === 'transformation_log') {
+                // Log transformations run against a log record, not an event
+                if (!globals?.record || typeof globals.record !== 'object') {
+                    res.status(400).json({ error: 'Missing record' })
+                    return
+                }
+            } else if (!globals || !globals.event) {
                 res.status(400).json({ error: 'Missing event' })
                 return
             }
@@ -527,6 +542,97 @@ export class CdpApi {
                 res.json({
                     result: result,
                     status: errors.length > 0 ? 'error' : wasSkipped ? 'skipped' : 'success',
+                    errors: errors.map((e) => String(e)),
+                    logs: logs,
+                })
+            } else if (compoundConfiguration.type === 'transformation_log') {
+                const mock = globals.record as Record<string, unknown>
+
+                const toStringMap = (value: unknown): Record<string, string> => {
+                    const map: Record<string, string> = {}
+                    if (value && typeof value === 'object' && !Array.isArray(value)) {
+                        for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+                            if (entry !== null && entry !== undefined) {
+                                map[key] = typeof entry === 'string' ? entry : JSON.stringify(entry)
+                            }
+                        }
+                    }
+                    return map
+                }
+
+                // Mock log record from the request; trace/span ids stay null (they are
+                // read-only in transformations and not meaningful for a test run).
+                const record: LogRecord = {
+                    uuid: invocationID,
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: typeof mock.timestamp === 'number' ? mock.timestamp : DateTime.now().toMillis() * 1e6,
+                    observed_timestamp: typeof mock.observed_timestamp === 'number' ? mock.observed_timestamp : null,
+                    body: typeof mock.body === 'string' ? mock.body : null,
+                    severity_text: typeof mock.severity_text === 'string' ? mock.severity_text : null,
+                    severity_number: typeof mock.severity_number === 'number' ? mock.severity_number : null,
+                    service_name: typeof mock.service_name === 'string' ? mock.service_name : null,
+                    resource_attributes: toStringMap(mock.resource_attributes),
+                    instrumentation_scope:
+                        typeof mock.instrumentation_scope === 'string' ? mock.instrumentation_scope : null,
+                    event_name: typeof mock.event_name === 'string' ? mock.event_name : null,
+                    attributes: toStringMap(mock.attributes),
+                    bytes_uncompressed: null,
+                }
+
+                const hogGlobals = buildLogRecordGlobals(record, triggerGlobals.project, {})
+
+                try {
+                    hogGlobals.inputs = resolveLogTransformationInputs(
+                        compoundConfiguration,
+                        hogGlobals,
+                        DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS
+                    ).inputs
+                } catch (e) {
+                    return res.json({
+                        result: null,
+                        status: 'error',
+                        errors: [String(e)],
+                        logs,
+                    })
+                }
+
+                const sensitiveValues = Object.values(compoundConfiguration.encrypted_inputs ?? {})
+                    .map((input) => input?.value)
+                    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+
+                const outcome = executeLogTransformation(compoundConfiguration.bytecode, record, hogGlobals, {
+                    sensitiveValues,
+                })
+
+                logs = logs.concat(
+                    outcome.logs.map((message) => ({
+                        level: 'info' as const,
+                        timestamp: DateTime.now(),
+                        message,
+                    }))
+                )
+
+                if (outcome.status === 'failed') {
+                    errors.push(outcome.error)
+                } else if (outcome.status === 'dropped') {
+                    logs.push({
+                        level: 'info',
+                        timestamp: DateTime.now(),
+                        message: 'Record dropped by transformation.',
+                    })
+                }
+
+                // Same record shape the function saw (hex ids, string maps) — null when dropped
+                result =
+                    outcome.status === 'dropped'
+                        ? null
+                        : buildLogRecordGlobals(record, triggerGlobals.project, {}).record
+
+                res.json({
+                    result: result,
+                    status: errors.length > 0 ? 'error' : 'success',
                     errors: errors.map((e) => String(e)),
                     logs: logs,
                 })

--- a/nodejs/src/cdp/templates/_transformations/transformation-templates.test.ts
+++ b/nodejs/src/cdp/templates/_transformations/transformation-templates.test.ts
@@ -1,11 +1,16 @@
 import { HogFunctionTemplate } from '~/cdp/types'
 
-import { HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS, HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED } from '../index'
+import {
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
+} from '../index'
 
 describe('Transformation templates', () => {
     const allTransformationTemplates: HogFunctionTemplate[] = [
         ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
         ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+        ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
     ]
 
     it('should have free property set to true for all transformation templates', () => {

--- a/nodejs/src/cdp/templates/_transformations_log/default/default.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/default/default.template.ts
@@ -1,0 +1,26 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-default',
+    name: 'Custom log transformation',
+    description: 'Start from scratch. Mutate the log record and return it, or return null to drop it.',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+// Runs on every log record for your project.
+//
+// 'record' fields you can change: body, attributes, resource_attributes, severity_text
+// 'record' fields that are read-only: severity_number, service_name, instrumentation_scope,
+//          event_name, timestamp, observed_timestamp, trace_id, span_id
+//
+// Return the record to keep it (optionally mutated), or return null to drop it.
+// Note: severity_text is lowercased before this runs — compare against 'error', 'info', etc.
+
+return record
+`,
+    inputs_schema: [],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/drop-by-severity/drop-by-severity.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/drop-by-severity/drop-by-severity.template.ts
@@ -1,0 +1,34 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-drop-by-severity',
+    name: 'Drop logs by severity',
+    description: 'Drop noisy log records at the configured severity levels (for example debug and trace).',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+// severity_text is lowercased upstream, so normalise the configured list too.
+let drop := splitByString(',', lower(inputs.severitiesToDrop))
+for (let _, s in drop) {
+    if (record.severity_text == trim(s)) {
+        return null
+    }
+}
+return record
+`,
+    inputs_schema: [
+        {
+            key: 'severitiesToDrop',
+            type: 'string',
+            label: 'Severities to drop',
+            description: 'Comma-separated severity levels to drop, e.g. "debug,trace". Case-insensitive.',
+            default: 'debug,trace',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
@@ -1,0 +1,51 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-pii-scrub',
+    name: 'Scrub PII from log bodies',
+    description: 'Redact emails, API keys, and bearer tokens from the log body using regular expressions.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+let r := record
+if (r.body == null) {
+    return r
+}
+
+// Character classes ([.] [ ]) keep these readable — no backslash escaping needed.
+// Non-capturing groups (?:...) so the whole match is redacted, not a sub-group.
+let patterns := [
+    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z]{2,}',
+    '(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{8,}',
+    '[Bb]earer[ ]+[A-Za-z0-9._-]{10,}'
+]
+
+for (let _, pattern in patterns) {
+    let found := extractRegex(r.body, pattern)
+    // Each replaceAll clears one distinct match; guard caps work per record.
+    let guard := 0
+    while (notEmpty(found) and guard < 100) {
+        r.body := replaceAll(r.body, found, inputs.replacement)
+        found := extractRegex(r.body, pattern)
+        guard := guard + 1
+    }
+}
+
+return r
+`,
+    inputs_schema: [
+        {
+            key: 'replacement',
+            type: 'string',
+            label: 'Replacement text',
+            description: 'Replaces each matched value in the log body.',
+            default: '[REDACTED]',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
@@ -21,7 +21,7 @@ if (r.body == null) {
 let patterns := [
     '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z]{2,}',
     '(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{8,}',
-    '[Bb]earer[ ]+[A-Za-z0-9._-]{10,}'
+    '[Bb]earer[ ]+[A-Za-z0-9._~+/-]{10,}[=]*'
 ]
 
 for (let _, pattern in patterns) {

--- a/nodejs/src/cdp/templates/_transformations_log/redact-attributes/redact-attributes.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/redact-attributes/redact-attributes.template.ts
@@ -1,0 +1,47 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-redact-attributes',
+    name: 'Hash log attributes',
+    description: 'Replace the values of the configured log attributes with a SHA-256 hash to protect PII.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+let salt := inputs.salt
+if (salt == null) {
+    salt := ''
+}
+let r := record
+for (let _, key in splitByString(',', inputs.attributeKeys)) {
+    let k := trim(key)
+    if (notEmpty(k) and notEmpty(r.attributes[k])) {
+        r.attributes[k] := sha256Hex(concat(salt, r.attributes[k]))
+    }
+}
+return r
+`,
+    inputs_schema: [
+        {
+            key: 'attributeKeys',
+            type: 'string',
+            label: 'Attribute keys to hash',
+            description: 'Comma-separated attribute keys whose values are replaced with a SHA-256 hash.',
+            default: 'user.email,user.id',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'salt',
+            type: 'string',
+            label: 'Salt',
+            description:
+                'Prepended to the value before hashing. Strongly recommended: without a salt, hashes of low-entropy values like emails can be reversed by lookup tables.',
+            secret: true,
+            required: false,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
@@ -1,0 +1,130 @@
+import { parseJSON } from '~/common/utils/json-parse'
+import type { LogRecord } from '~/logs/log-record-avro'
+import {
+    LogTransformationOutcome,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+} from '~/logs/transformations/hog-log-exec'
+
+import { compileHog } from '../compiler'
+import { template as logDefaultTemplate } from './default/default.template'
+import { template as logDropBySeverityTemplate } from './drop-by-severity/drop-by-severity.template'
+import { template as logPiiScrubTemplate } from './pii-scrub/pii-scrub.template'
+import { template as logRedactAttributesTemplate } from './redact-attributes/redact-attributes.template'
+
+jest.setTimeout(30_000)
+
+const PROJECT = { id: 1, name: 'test', url: 'http://localhost:8010/project/1' }
+
+const createRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+    uuid: '0197a3f2-1111-7000-8000-000000000001',
+    trace_id: null,
+    span_id: null,
+    trace_flags: 0,
+    timestamp: 1_780_000_000_000_000_000,
+    observed_timestamp: 1_780_000_000_000_000_000,
+    body: 'user jane@example.com logged in',
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'auth-api',
+    resource_attributes: { 'k8s.namespace.name': 'auth' },
+    instrumentation_scope: 'auth.sessions',
+    event_name: null,
+    attributes: { 'http.method': 'POST' },
+    bytes_uncompressed: 120,
+    ...overrides,
+})
+
+const run = async (
+    code: string,
+    record: LogRecord,
+    inputs: Record<string, unknown> = {}
+): Promise<{ outcome: LogTransformationOutcome; record: LogRecord }> => {
+    const bytecode = await compileHog(code)
+    const globals = buildLogRecordGlobals(record, PROJECT, inputs)
+    const outcome = executeLogTransformation(bytecode, record, globals, {})
+    return { outcome, record }
+}
+
+describe('transformation_log templates', () => {
+    describe('default', () => {
+        it('returns the record unchanged', async () => {
+            const { outcome, record } = await run(logDefaultTemplate.code, createRecord())
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toEqual('user jane@example.com logged in')
+        })
+    })
+
+    describe('pii-scrub', () => {
+        it('redacts emails, API keys, and bearer tokens from the body', async () => {
+            const body = 'login jane@example.com key sk_live_abcdef123456 auth Bearer abcdef012345 done'
+            const { outcome, record } = await run(logPiiScrubTemplate.code, createRecord({ body }), {
+                replacement: '[REDACTED]',
+            })
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toEqual('login [REDACTED] key [REDACTED] auth [REDACTED] done')
+        })
+
+        it('honors a custom replacement value', async () => {
+            const { record } = await run(logPiiScrubTemplate.code, createRecord({ body: 'x jane@example.com y' }), {
+                replacement: '***',
+            })
+            expect(record.body).toEqual('x *** y')
+        })
+
+        it('leaves a null body untouched', async () => {
+            const { outcome, record } = await run(logPiiScrubTemplate.code, createRecord({ body: null }), {
+                replacement: '[REDACTED]',
+            })
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toBeNull()
+        })
+    })
+
+    describe('drop-by-severity', () => {
+        it('drops a configured severity', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'debug' }), {
+                severitiesToDrop: 'debug,trace',
+            })
+            expect(outcome.status).toEqual('dropped')
+        })
+
+        it('keeps severities not in the list', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'error' }), {
+                severitiesToDrop: 'debug,trace',
+            })
+            expect(outcome.status).toEqual('mutated')
+        })
+
+        it('matches case-insensitively against the lowercased severity', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'debug' }), {
+                severitiesToDrop: 'DEBUG',
+            })
+            expect(outcome.status).toEqual('dropped')
+        })
+    })
+
+    describe('redact-attributes', () => {
+        it('replaces configured attribute values with a sha256 hash', async () => {
+            const { outcome, record } = await run(
+                logRedactAttributesTemplate.code,
+                createRecord({ attributes: { user_email: '"jane@example.com"', keep: '"me"' } }),
+                { attributeKeys: 'user_email' }
+            )
+            expect(outcome.status).toEqual('mutated')
+            const attributes = record.attributes ?? {}
+            expect(parseJSON(attributes.user_email)).toMatch(/^[a-f0-9]{64}$/)
+            expect(attributes.keep).toEqual('"me"')
+        })
+
+        it('ignores attribute keys that are not present', async () => {
+            const { outcome, record } = await run(
+                logRedactAttributesTemplate.code,
+                createRecord({ attributes: { keep: '"me"' } }),
+                { attributeKeys: 'user_email,user.id' }
+            )
+            expect(outcome.status).toEqual('mutated')
+            expect(record.attributes).toEqual({ keep: '"me"' })
+        })
+    })
+})

--- a/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
@@ -65,6 +65,17 @@ describe('transformation_log templates', () => {
             expect(record.body).toEqual('login [REDACTED] key [REDACTED] auth [REDACTED] done')
         })
 
+        it('redacts a base64 bearer token, whose alphabet includes + / and =', async () => {
+            // Standard base64 credentials are the common case and were surviving: the
+            // token pattern stopped at the first character outside its class, leaving too
+            // few characters to meet the length floor, so nothing matched at all.
+            const body = 'auth Bearer YWJjZGVm+Z2hpamts/bW5vcHFy== done'
+            const { record } = await run(logPiiScrubTemplate.code, createRecord({ body }), {
+                replacement: '[REDACTED]',
+            })
+            expect(record.body).toEqual('auth [REDACTED] done')
+        })
+
         it('honors a custom replacement value', async () => {
             const { record } = await run(logPiiScrubTemplate.code, createRecord({ body: 'x jane@example.com y' }), {
                 replacement: '***',

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -53,6 +53,10 @@ import { template as piiHashingTemplate } from './_transformations/pii-hashing/p
 import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { template as urlMaskingTemplate } from './_transformations/url-masking/url-masking.template'
 import { template as urlNormalizationTemplate } from './_transformations/url-normalization/url-normalization.template'
+import { template as logDefaultTemplate } from './_transformations_log/default/default.template'
+import { template as logDropBySeverityTemplate } from './_transformations_log/drop-by-severity/drop-by-severity.template'
+import { template as logPiiScrubTemplate } from './_transformations_log/pii-scrub/pii-scrub.template'
+import { template as logRedactAttributesTemplate } from './_transformations_log/redact-attributes/redact-attributes.template'
 
 export const HOG_FUNCTION_TEMPLATES_COMING_SOON: HogFunctionTemplate[] = allComingSoonTemplates
 
@@ -108,6 +112,13 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     urlNormalizationTemplate,
 ]
 
+export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG: HogFunctionTemplate[] = [
+    logDefaultTemplate,
+    logPiiScrubTemplate,
+    logDropBySeverityTemplate,
+    logRedactAttributesTemplate,
+]
+
 export const NATIVE_HOG_FUNCTIONS: (HogFunctionTemplate & NativeTemplate)[] = [nativeWebhookTemplate].map((plugin) => ({
     ...plugin,
     code_language: 'javascript',
@@ -157,6 +168,7 @@ export const HOG_FUNCTION_TEMPLATES: HogFunctionTemplate[] = [
     ...HOG_FUNCTION_TEMPLATES_DESTINATIONS_DEPRECATED,
     ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
     ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+    ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
     ...HOG_FUNCTION_TEMPLATES_SOURCES,
     ...HOG_FUNCTION_TEMPLATES_COMING_SOON,
     ...NATIVE_HOG_FUNCTIONS,

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -18,6 +18,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
 import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
 import { LogsSqlEditor } from 'products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor'
+import { LogsTransformations } from 'products/logs/frontend/components/LogsTransformations/LogsTransformations'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
@@ -94,12 +95,14 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
     const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
+    const showTransformations = useFeatureFlag('LOGS_TRANSFORMATIONS')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
         ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
+        ...(showTransformations ? [{ key: 'transformations' as const, label: 'Transformations' }] : []),
         { key: 'configuration', label: 'Configuration' },
     ]
 
@@ -154,6 +157,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             )}
             {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
             {activeTab === 'sql' && showSqlView && <LogsSqlEditor id={LOGS_SCENE_VIEWER_ID} />}
+            {activeTab === 'transformations' && showTransformations && <LogsTransformations />}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}

--- a/products/logs/frontend/components/LogsTransformations/LogsTransformations.tsx
+++ b/products/logs/frontend/components/LogsTransformations/LogsTransformations.tsx
@@ -1,0 +1,28 @@
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
+import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
+
+const LOGS_TRANSFORMATIONS_LOGIC_KEY = 'logs-transformations'
+
+export function LogsTransformations(): JSX.Element {
+    return (
+        <SceneContent>
+            <LemonBanner type="info" dismissKey="logs-transformations-beta-banner" className="mb-3">
+                Transformations run on every log record as it is ingested. Use them to mutate, redact, or drop records.
+                They run in order, and a transformation that returns null drops the record.
+            </LemonBanner>
+            <SceneSection title="Transformations" description="Modify or drop log records as they are ingested.">
+                <HogFunctionList logicKey={LOGS_TRANSFORMATIONS_LOGIC_KEY} type="transformation_log" />
+            </SceneSection>
+            <SceneDivider />
+            <SceneSection title="Create a new transformation">
+                <HogFunctionTemplateList type="transformation_log" hideComingSoonByDefault />
+            </SceneSection>
+        </SceneContent>
+    )
+}

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -45,8 +45,15 @@ export const LOGS_SCENE_VIEWER_ID = `logs-scene-${window.POSTHOG_APP_CONTEXT?.cu
 
 const VALID_VIEW_MODES: LogsViewerViewMode[] = ['logs', 'patterns', 'group']
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'sql', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'transformations' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = [
+    'viewer',
+    'services',
+    'alerts',
+    'sql',
+    'transformations',
+    'configuration',
+]
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 const resolveActiveTabFromParams = (params: Params): LogsSceneActiveTab | null => {


### PR DESCRIPTION
## Problem

Layer 4 of the log transformations stack (on top of #67610). The backend can run log transformations but there's no way to create, test, or manage them.

## Changes

- Transformations tab on the logs scene, behind the `LOGS_TRANSFORMATIONS` feature flag, reusing the shared hog function list and template gallery — including the execution-order badge and drag-to-reorder modal, which now also show for `transformation_log` (the rearrange API already supported it).
- The hog function editor supports `transformation_log`: the events-based testing tab and sample-event loading are hidden (there's no events source), replaced by an inline tester seeded with a sample log record and backed by a new test-invocation path in the CDP API that mirrors production semantics, including the plain-vs-encoded attribute value handling from #67609.
- Starter templates: custom (blank), drop-by-severity, redact-attributes, pii-scrub.
- Copy fixes so the editor says "record" rather than "event" for log transformations.

Everything user-facing is behind the feature flag; without it the logs scene is unchanged.

## How did you test this code?

Automated: `nodejs/src/cdp/templates/_transformations_log/` and `nodejs/src/cdp/cdp-api.test.ts` (47 tests) pass locally, plus frontend typecheck on the touched scenes. I exercised the test-invocation endpoint against a locally running CDP API and confirmed a record-dropping function returns `status: success` with a "Record dropped by transformation." log. I did not do a full browser click-through of the tab — worth one manual pass before enabling the flag for the first team.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) rebased the original UI commits (#63848–#63851) and closed the UX parity gaps found by comparing against the event transformations surfaces: the reorder UI was gated to `type === 'transformation'` only, and one tester banner hardcoded "event". Skills invoked: pr-slicing, run-posthog.
