### PR TITLE
fix(dags): resolve ducklake schema via ducklake_schema join in fpv fix-up

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1777,9 +1777,11 @@ def _fixup_partition_values_for_added_files(
                     """
                     SELECT t.table_id, pi.partition_id
                     FROM public.ducklake_table t
+                    JOIN public.ducklake_schema s
+                      ON s.schema_id = t.schema_id AND s.end_snapshot IS NULL
                     JOIN public.ducklake_partition_info pi
                       ON pi.table_id = t.table_id AND pi.end_snapshot IS NULL
-                    WHERE t.schema_name = 'posthog'
+                    WHERE s.schema_name = 'posthog'
                       AND t.table_name = %s
                       AND t.end_snapshot IS NULL
                     """,
@@ -1861,7 +1863,7 @@ def _fixup_partition_values_for_added_files(
                                        array_agg(file_partition_value.partition_key_index
                                                  ORDER BY file_partition_value.partition_key_index)
                                        FILTER (WHERE file_partition_value.partition_key_index IS NOT NULL),
-                                       '{{}}'::int[]
+                                       '{{}}'::bigint[]
                                    ) AS indexes,
                                    COUNT(*) FILTER (WHERE file_partition_value.partition_value IS NULL) AS nulls
                             FROM public.ducklake_data_file df
@@ -1874,7 +1876,7 @@ def _fixup_partition_values_for_added_files(
                             GROUP BY df.data_file_id
                         )
                         SELECT
-                            COUNT(*) FILTER (WHERE indexes IS DISTINCT FROM %s::int[]) AS wrong_indexes,
+                            COUNT(*) FILTER (WHERE indexes IS DISTINCT FROM %s::bigint[]) AS wrong_indexes,
                             COUNT(*) FILTER (WHERE nulls > 0)                          AS null_values,
                             COUNT(*) AS total
                         FROM file_partition_value_state

--- a/posthog/dags/tests/test_events_backfill_to_duckling.py
+++ b/posthog/dags/tests/test_events_backfill_to_duckling.py
@@ -1,6 +1,9 @@
+import re
 import uuid
+from collections.abc import Iterator
 from contextlib import closing
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from unittest.mock import patch
@@ -93,16 +96,14 @@ _DUCKLAKE_CATALOG_DDL = [
 ]
 
 _DUCKLAKE_CATALOG_TABLES = [
-    "public.ducklake_schema",
-    "public.ducklake_table",
-    "public.ducklake_partition_info",
-    "public.ducklake_partition_column",
-    "public.ducklake_data_file",
-    "public.ducklake_file_partition_value",
+    match.group(1)
+    for stmt in _DUCKLAKE_CATALOG_DDL
+    for match in [re.search(r"CREATE TABLE (public\.\w+)", stmt)]
+    if match
 ]
 
 
-def _connect_test_db() -> psycopg.Connection:
+def _connect_test_db() -> psycopg.Connection[Any]:
     settings_dict = django_connection.settings_dict
     return psycopg.connect(
         host=settings_dict["HOST"] or "localhost",
@@ -114,24 +115,30 @@ def _connect_test_db() -> psycopg.Connection:
     )
 
 
+def _drop_catalog_tables(conn: psycopg.Connection[Any]) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {', '.join(_DUCKLAKE_CATALOG_TABLES)}")
+
+
 @pytest.fixture
-def ducklake_catalog(django_db_setup):
+def ducklake_catalog(django_db_setup: None) -> Iterator[psycopg.Connection[Any]]:
     with closing(_connect_test_db()) as conn:
+        # Pre-drop: leftovers from an interrupted run survive --reuse-db.
+        _drop_catalog_tables(conn)
         with conn.cursor() as cur:
             for stmt in _DUCKLAKE_CATALOG_DDL:
                 cur.execute(stmt)
         try:
             yield conn
         finally:
-            with conn.cursor() as cur:
-                cur.execute(f"DROP TABLE IF EXISTS {', '.join(_DUCKLAKE_CATALOG_TABLES)}")
+            _drop_catalog_tables(conn)
 
 
 class TestFixupPartitionValuesForAddedFiles:
     TABLE_ID = 10
     PARTITION_ID = 100
 
-    def _seed_catalog(self, conn: psycopg.Connection) -> None:
+    def _seed_catalog(self, conn: psycopg.Connection[Any]) -> None:
         with conn.cursor() as cur:
             # A dropped-and-recreated 'posthog' schema: only the live row may resolve.
             cur.executemany(
@@ -188,7 +195,7 @@ class TestFixupPartitionValuesForAddedFiles:
         return f"backfill/events/2/year=2025/month=01/day={day:02d}/part-00.parquet"
 
     @staticmethod
-    def _partition_values(conn: psycopg.Connection) -> set[tuple[int, int, int, str]]:
+    def _partition_values(conn: psycopg.Connection[Any]) -> set[tuple[int, int, int, str]]:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT data_file_id, table_id, partition_key_index, partition_value "
@@ -209,7 +216,7 @@ class TestFixupPartitionValuesForAddedFiles:
         ):
             _fixup_partition_values_for_added_files(build_asset_context(), target, "events", "events", file_paths)
 
-    def test_rebuilds_partition_values_from_paths(self, ducklake_catalog: psycopg.Connection) -> None:
+    def test_rebuilds_partition_values_from_paths(self, ducklake_catalog: psycopg.Connection[Any]) -> None:
         self._seed_catalog(ducklake_catalog)
 
         self._run_fixup([self._path(day=5), self._path(day=6)])

--- a/posthog/dags/tests/test_events_backfill_to_duckling.py
+++ b/posthog/dags/tests/test_events_backfill_to_duckling.py
@@ -1,10 +1,21 @@
+import uuid
+from contextlib import closing
 from dataclasses import dataclass
 
+import pytest
 from unittest.mock import patch
 
+from django.db import connection as django_connection
+
+import psycopg
+from dagster import build_asset_context
 from parameterized import parameterized
 
-from posthog.dags.events_backfill_to_duckling import _resolve_duckling_target
+from posthog.dags.events_backfill_to_duckling import (
+    DucklingTarget,
+    _fixup_partition_values_for_added_files,
+    _resolve_duckling_target,
+)
 
 
 @dataclass
@@ -64,7 +75,158 @@ class TestResolveDucklingTarget:
         ]
     )
     def test_raises_when_nothing_can_name_the_bucket(self, _name: str, server: "_FakeRow | None") -> None:
-        import pytest
-
         with pytest.raises(ValueError, match="No S3 bucket resolvable"):
             self._resolve(server=server, cp_bucket=None)
+
+
+# Verbatim from the DuckLake specification (docs/stable/specification/tables/overview.html),
+# limited to the tables the ducklake_file_partition_value fix-up touches. The fix-up's SQL is
+# validated against this real DDL — a query referencing a column the spec doesn't define
+# (the UndefinedColumn class of bug) fails here instead of in production.
+_DUCKLAKE_CATALOG_DDL = [
+    "CREATE TABLE public.ducklake_schema (schema_id BIGINT PRIMARY KEY, schema_uuid UUID, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)",
+    "CREATE TABLE public.ducklake_table (table_id BIGINT, table_uuid UUID, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)",
+    "CREATE TABLE public.ducklake_partition_info (partition_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT)",
+    'CREATE TABLE public.ducklake_partition_column (partition_id BIGINT, table_id BIGINT, partition_key_index BIGINT, column_id BIGINT, "transform" VARCHAR)',
+    "CREATE TABLE public.ducklake_data_file (data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)",
+    "CREATE TABLE public.ducklake_file_partition_value (data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)",
+]
+
+_DUCKLAKE_CATALOG_TABLES = [
+    "public.ducklake_schema",
+    "public.ducklake_table",
+    "public.ducklake_partition_info",
+    "public.ducklake_partition_column",
+    "public.ducklake_data_file",
+    "public.ducklake_file_partition_value",
+]
+
+
+def _connect_test_db() -> psycopg.Connection:
+    settings_dict = django_connection.settings_dict
+    return psycopg.connect(
+        host=settings_dict["HOST"] or "localhost",
+        port=int(settings_dict["PORT"] or 5432),
+        dbname=settings_dict["NAME"],
+        user=settings_dict["USER"],
+        password=settings_dict["PASSWORD"],
+        autocommit=True,
+    )
+
+
+@pytest.fixture
+def ducklake_catalog(django_db_setup):
+    with closing(_connect_test_db()) as conn:
+        with conn.cursor() as cur:
+            for stmt in _DUCKLAKE_CATALOG_DDL:
+                cur.execute(stmt)
+        try:
+            yield conn
+        finally:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {', '.join(_DUCKLAKE_CATALOG_TABLES)}")
+
+
+class TestFixupPartitionValuesForAddedFiles:
+    TABLE_ID = 10
+    PARTITION_ID = 100
+
+    def _seed_catalog(self, conn: psycopg.Connection) -> None:
+        with conn.cursor() as cur:
+            # A dropped-and-recreated 'posthog' schema: only the live row may resolve.
+            cur.executemany(
+                "INSERT INTO public.ducklake_schema VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                [
+                    (2, uuid.uuid4(), 1, 5, "posthog", "posthog/", True),
+                    (1, uuid.uuid4(), 5, None, "posthog", "posthog/", True),
+                ],
+            )
+            cur.execute(
+                "INSERT INTO public.ducklake_table VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                (self.TABLE_ID, uuid.uuid4(), 1, None, 1, "events", "events/", True),
+            )
+            # A superseded partition_info generation next to the live one.
+            cur.executemany(
+                "INSERT INTO public.ducklake_partition_info VALUES (%s, %s, %s, %s)",
+                [(99, self.TABLE_ID, 1, 5), (self.PARTITION_ID, self.TABLE_ID, 5, None)],
+            )
+            cur.executemany(
+                "INSERT INTO public.ducklake_partition_column VALUES (%s, %s, %s, %s, %s)",
+                [
+                    (self.PARTITION_ID, self.TABLE_ID, 0, 7, "year"),
+                    (self.PARTITION_ID, self.TABLE_ID, 1, 7, "month"),
+                    (self.PARTITION_ID, self.TABLE_ID, 2, 7, "day"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO public.ducklake_data_file "
+                "(data_file_id, table_id, begin_snapshot, end_snapshot, path, path_is_relative, partition_id) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                [
+                    (1000, self.TABLE_ID, 5, None, self._path(day=5), True, self.PARTITION_ID),
+                    (1001, self.TABLE_ID, 5, None, self._path(day=6), True, self.PARTITION_ID),
+                    (1002, self.TABLE_ID, 5, None, self._path(day=7), True, self.PARTITION_ID),
+                ],
+            )
+            # File 1000 carries the upstream bug's signature (every value piled onto the
+            # highest key index); file 1001 has no rows at all; file 1002 is untargeted
+            # and correct — it must survive the fix-up untouched.
+            cur.executemany(
+                "INSERT INTO public.ducklake_file_partition_value VALUES (%s, %s, %s, %s)",
+                [
+                    (1000, self.TABLE_ID, 2, "2025"),
+                    (1000, self.TABLE_ID, 2, "1"),
+                    (1000, self.TABLE_ID, 2, "5"),
+                    (1002, self.TABLE_ID, 0, "2025"),
+                    (1002, self.TABLE_ID, 1, "1"),
+                    (1002, self.TABLE_ID, 2, "7"),
+                ],
+            )
+
+    @staticmethod
+    def _path(day: int) -> str:
+        return f"backfill/events/2/year=2025/month=01/day={day:02d}/part-00.parquet"
+
+    @staticmethod
+    def _partition_values(conn: psycopg.Connection) -> set[tuple[int, int, int, str]]:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT data_file_id, table_id, partition_key_index, partition_value "
+                "FROM public.ducklake_file_partition_value"
+            )
+            return {tuple(row) for row in cur.fetchall()}
+
+    def _run_fixup(self, file_paths: list[str]) -> None:
+        target = DucklingTarget(
+            team_id=2,
+            organization_id="org-1",
+            bucket="test-bucket",
+            bucket_region="us-east-1",
+        )
+        with patch(
+            "posthog.dags.events_backfill_to_duckling._open_catalog_conn",
+            side_effect=lambda _target: _connect_test_db(),
+        ):
+            _fixup_partition_values_for_added_files(build_asset_context(), target, "events", "events", file_paths)
+
+    def test_rebuilds_partition_values_from_paths(self, ducklake_catalog: psycopg.Connection) -> None:
+        self._seed_catalog(ducklake_catalog)
+
+        self._run_fixup([self._path(day=5), self._path(day=6)])
+
+        expected = {
+            (1000, self.TABLE_ID, 0, "2025"),
+            (1000, self.TABLE_ID, 1, "1"),
+            (1000, self.TABLE_ID, 2, "5"),
+            (1001, self.TABLE_ID, 0, "2025"),
+            (1001, self.TABLE_ID, 1, "1"),
+            (1001, self.TABLE_ID, 2, "6"),
+            (1002, self.TABLE_ID, 0, "2025"),
+            (1002, self.TABLE_ID, 1, "1"),
+            (1002, self.TABLE_ID, 2, "7"),
+        }
+        assert self._partition_values(ducklake_catalog) == expected
+
+        # Re-running over the same paths must converge to the same state (retry contract).
+        self._run_fixup([self._path(day=5), self._path(day=6)])
+        assert self._partition_values(ducklake_catalog) == expected


### PR DESCRIPTION
## Problem

The `ducklake_file_partition_value` fix-up added in #67168 resolves the target catalog table with `WHERE t.schema_name = 'posthog'` on `ducklake_table`.
Per the DuckLake spec, `ducklake_table` only carries a `schema_id` FK. `schema_name` lives on `ducklake_schema`.
Since the fix-up defaults to enabled, every `duckling_events_backfill` run that registers files dies with:

```
psycopg.errors.UndefinedColumn: column t.schema_name does not exist
```

## Changes

- Resolve the table by joining `ducklake_schema` (live rows only, `end_snapshot IS NULL`) and filtering on `s.schema_name = 'posthog'`.
- Fix a second latent bug right behind it, surfaced by the new test. `partition_key_index` is `BIGINT` in the catalog, so the post-condition's `indexes IS DISTINCT FROM %s::int[]` comparison raises `UndefinedFunction` (no `bigint[]` vs `integer[]` operator). Both casts are now `::bigint[]`. Production never reached this statement because the first query always failed.
- Add a regression test that creates the real DuckLake catalog DDL (verbatim from the spec) in the test Postgres and runs `_fixup_partition_values_for_added_files` end-to-end against it.

## How did you test this code?

Ran `pytest posthog/dags/tests/test_events_backfill_to_duckling.py` locally, 8 passed.

The new test catches a regression class no existing test did. Nothing previously executed the fix-up's catalog SQL against the actual DuckLake schema, so column references were never validated (which is exactly how both bugs shipped). The test seeds a catalog with superseded schema and partition_info generations plus three data files (bug-signature rows, no rows, untargeted-correct rows), asserts the rebuilt `ducklake_file_partition_value` rows, and re-runs to assert convergence. With the fix reverted, it reproduces the production `UndefinedColumn` error verbatim.

I wasn't able to test against a real duckling deployment. The catalog DDL in the test comes from the DuckLake spec rather than a live catalog dump.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored the fix and test from a Dagster stack trace I provided.
Skills invoked: /systematic-debugging, /writing-tests, /setup-web-tests.
The root cause was confirmed against the DuckLake specification docs before any code change.
The test deliberately runs against real Postgres with the spec's DDL instead of mocking the connection, since mocked tests are what allowed the bad column reference to ship. That choice immediately paid off by catching the `int[]`/`bigint[]` cast bug in the post-condition query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)