### PR TITLE
fix(mysql): retry Vitess vtgate dial-timeout on connect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -398,6 +398,27 @@ def _is_transient_packet_sequence_error(e: BaseException) -> bool:
     return any(_PACKET_SEQUENCE_ERROR_PHRASE in str(arg) for arg in e.args)
 
 
+# Vitess/PlanetScale vtgate surfaces a backend tablet it can't reach at connect time as pymysql
+# OperationalError(1815, 'internal connection error: dial tcp <addr>: connect: connection timed
+# out, after N attempts, reqid=...'): the vtgate handshake succeeds but dialing the tablet behind
+# it times out — a failover, a restart, or a momentary network blip that a fresh attempt recovers
+# from. 1815 is MySQL's generic ER_INTERNAL_ERROR, so key on the Go-network `dial tcp` +
+# `connection timed out` signature (no plain MySQL error carries the `dial tcp` token) rather than
+# the bare code; the volatile tablet address, attempt count, and reqid stay untouched. This is the
+# connect-time sibling of the `code = Unavailable` tablet-unavailable case, which instead lands on
+# the first query after connect (see `_is_transient_tablet_unavailable`).
+_VITESS_DIAL_TOKEN = "dial tcp"
+_VITESS_DIAL_TIMEOUT_TOKEN = "connection timed out"
+
+
+def _is_transient_vitess_dial_timeout(e: BaseException) -> bool:
+    """Return True if a Vitess vtgate timed out dialing its backend tablet — a transient blip."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    args_text = " ".join(str(arg) for arg in e.args)
+    return _VITESS_DIAL_TOKEN in args_text and _VITESS_DIAL_TIMEOUT_TOKEN in args_text
+
+
 def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
     """Open a pymysql connection, retrying a transient drop or timeout on connect.
 
@@ -416,6 +437,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 _is_transient_connect_drop(e)
                 or _is_transient_connect_timeout(e)
                 or _is_transient_packet_sequence_error(e)
+                or _is_transient_vitess_dial_timeout(e)
             ):
                 raise
             structlog.get_logger().warning(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -28,6 +28,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_transient_connect_timeout,
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
+    _is_transient_vitess_dial_timeout,
     _release_streaming_cursor,
     _retry_on_transient_tablet_unavailable,
     _safe_convert_date,
@@ -961,6 +962,42 @@ class TestIsTransientPacketSequenceError:
         assert not _is_transient_packet_sequence_error(pymysql.err.InternalError())
 
 
+class TestIsTransientVitessDialTimeout:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The shape a Vitess/PlanetScale vtgate surfaces at connect time when it can't dial the
+            # backend tablet in time — the tablet address, attempt count, and reqid all vary, the
+            # Go `dial tcp ... connection timed out` signature is the stable signal.
+            "internal connection error: dial tcp 10.0.0.1:8083: connect: connection timed out, "
+            "after 1 attempts, reqid=csYTzBMNB2hB8111yzcg4A",
+            "internal connection error: dial tcp 192.0.2.5:3306: connect: connection timed out",
+        ],
+    )
+    def test_matches_dial_timeout(self, message):
+        assert _is_transient_vitess_dial_timeout(pymysql.err.OperationalError(1815, message))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            # A refused dial returns immediately and is more often a persistent config problem, so
+            # it must not be absorbed here — only the timeout flavour above is treated as transient.
+            (1815, "internal connection error: dial tcp 10.0.0.1:8083: connect: connection refused"),
+            # Config/credential errors stay untouched, even when they mention a timeout.
+            (2003, "Can't connect to MySQL server on 'db.example.com' (timed out)"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_non_dial_timeout_errors(self, code, message):
+        assert not _is_transient_vitess_dial_timeout(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_vitess_dial_timeout(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_vitess_dial_timeout(ValueError("dial tcp 10.0.0.1: connection timed out"))
+
+
 class TestConnectTransientRetry:
     @pytest.mark.parametrize(
         "fail_count,expected_sleeps",
@@ -1016,6 +1053,28 @@ class TestConnectTransientRetry:
             "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
             side_effect=[
                 pymysql.err.OperationalError(2003, "Can't connect to MySQL server on 'host' (timed out)"),
+                conn,
+            ],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
+    def test_retries_vitess_dial_timeout_then_succeeds(self, mocker):
+        sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[
+                pymysql.err.OperationalError(
+                    1815,
+                    "internal connection error: dial tcp 10.0.0.1:8083: connect: connection timed out, "
+                    "after 1 attempts, reqid=csYTzBMNB2hB8111yzcg4A",
+                ),
                 conn,
             ],
         )


### PR DESCRIPTION
## Problem

Error tracking surfaced a MySQL import failure: `OperationalError (2013, 'Lost connection to MySQL server during query')`. Reading the full event, the 2013 was a mid-stream `fetchmany` drop that the source already handles (it triggers the FORCE INDEX fallback). The chained cause is the real story: the fallback opened a probe connection and `pymysql.connect` failed with

```
OperationalError(1815, 'internal connection error: dial tcp <redacted-addr>: connect: connection timed out, after N attempts, reqid=<redacted>')
```

That is a Vitess/PlanetScale vtgate telling us it couldn't dial its backend tablet in time. The vtgate handshake succeeded, but the tablet behind it was momentarily unreachable (a failover, a restart, or a brief network blip). This is transient — a fresh attempt lands on a healthy tablet.

`_connect_with_transient_retry` already absorbs this class of blip in-process (the 2013 drop, the 2003 connect timeout, packet-sequence desyncs) precisely so a single hiccup doesn't surface as error-tracking noise, and there's a sibling retry for the Vitess `code = Unavailable` tablet-unavailable case. But error 1815 is MySQL's generic `ER_INTERNAL_ERROR`, so it matched none of the existing predicates and re-raised on the first attempt.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f2154-bf90-7713-afa0-b17c6fef4420

## Changes

This is a transient infrastructure error, so it stays retryable — nothing added to `get_non_retryable_errors`. Instead I taught the connect-retry helper to recognise it.

- New `_is_transient_vitess_dial_timeout` predicate matching the stable Go-network `dial tcp` + `connection timed out` signature. No plain MySQL error carries the `dial tcp` token, so it's tightly scoped; the volatile tablet address, attempt count, and reqid aren't matched. A refused dial (returns fast, more often a persistent config problem) is deliberately not absorbed.
- Wired it into the `_connect_with_transient_retry` OR-chain alongside the existing transient-connect predicates, so a dial timeout now retries with the same bounded backoff before giving up.

Scoped to the connect layer, where the error was observed.

## How did you test this code?

Automated only — I (Claude) can't drive a real Vitess endpoint from here.

- Added `TestIsTransientVitessDialTimeout`: locks in that the observed 1815 dial-timeout is recognised as transient, and that a dial `connection refused`, a 2003 connect timeout, a 1045 access-denied, an args-less error, and a non-`OperationalError` are all rejected. Guards against the predicate silently widening or narrowing.
- Added `test_retries_vitess_dial_timeout_then_succeeds` to `TestConnectTransientRetry`: proves the predicate is actually wired into the connect retry — a dial timeout followed by a success reconnects instead of raising. This is the regression that would fire if someone dropped the predicate from the OR-chain; no existing test exercised 1815.
- Ran the full `test_mysql.py` (187 passed) plus `ruff check` and `ruff format --check` on both changed files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Opus 4.8) via Claude Code. Used the PostHog error-tracking MCP tools to pull the issue and a representative event, read the full chained stack trace to confirm the failure originates in `sources/mysql/mysql.py` (the FORCE INDEX fallback's probe connect), and mapped it to the module's existing transient-connect-retry pattern.

Decision: the error is transient infra, not a user/upstream config problem, so I did not extend `NonRetryableErrors` (which would wrongly stop retrying). The in-keeping fix is to add it to the in-process connect retry, mirroring the sibling `code = Unavailable` handling. Matched on `dial tcp` + `connection timed out` rather than the bare 1815 code (which is a generic catch-all) to keep false positives near zero, and left `connection refused` out to avoid absorbing persistent config errors. Invoked the `/writing-tests` skill before adding tests.
