### PR TITLE
fix(appsflyer): treat 416 report rejection as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
@@ -54,6 +54,10 @@ class AppsFlyerSource(SimpleSource[AppsFlyerSourceConfig]):
             "401 Client Error: Unauthorized for url: https://hq1.appsflyer.com": "AppsFlyer authentication failed. Please check your API token (V2).",
             "403 Client Error: Forbidden for url: https://hq1.appsflyer.com": "AppsFlyer denied access. Please check that your account's subscription includes the aggregate Pull API and the app id is correct.",
             "404 Client Error: Not Found for url: https://hq1.appsflyer.com": "AppsFlyer app not found. Please check the app id.",
+            # AppsFlyer overloads 416 as a catch-all for request/authorization validation failures on
+            # the aggregate Pull API (e.g. the account isn't authorized for this report or app id). The
+            # request shape is fixed, so retrying the identical call can never satisfy it.
+            "416 Client Error: Requested Range Not Satisfiable for url: https://hq1.appsflyer.com": "AppsFlyer rejected the report request. Please check that your account's subscription is authorized for this report and that the app id is correct.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
@@ -56,6 +56,7 @@ class TestAppsFlyerSource:
             "401 Client Error: Unauthorized for url: https://hq1.appsflyer.com/api/agg-data/export/app/id123/daily_report/v5",
             "403 Client Error: Forbidden for url: https://hq1.appsflyer.com/api/agg-data/export/app/id123/geo_by_date_report/v5",
             "404 Client Error: Not Found for url: https://hq1.appsflyer.com/api/agg-data/export/app/nope/daily_report/v5",
+            "416 Client Error: Requested Range Not Satisfiable for url: https://hq1.appsflyer.com/api/agg-data/export/app/id123/geo_by_date_report/v5?from=2024-01-01&to=2024-01-05",
         ],
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):


### PR DESCRIPTION
## Problem

The AppsFlyer data-warehouse source retries HTTP 416 responses from the aggregate Pull API forever, even though they can never succeed on retry.

Error tracking surfaced this on the `geo_by_date_report` endpoint: [HTTPError 416 issue](https://us.posthog.com/project/2/error_tracking/019f217c-23cd-7f23-93f1-df14a1165943). The stack trace is genuinely in our code — `fetch_report` at `products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/appsflyer.py:174`, where `response.raise_for_status()` raises on a 416 that isn't caught by the retryable (429/5xx) branch:

```
416 Client Error: Requested Range Not Satisfiable for url: https://hq1.appsflyer.com/api/agg-data/export/app/<redacted>/geo_by_date_report/v5?from=<redacted>&to=<redacted>
```

AppsFlyer overloads 416 on the aggregate Pull API as a catch-all for request/authorization validation failures — "please select authorized app-id", wrong API fields, non-UTC time range, and similar. It is not a byte-range error. In this case the request is well-formed (the `daily_report` endpoint uses the identical shape and works, and our unit tests pin the URL), so the most likely cause is that the account's subscription isn't authorized for this particular report. Either way, the request we send is fixed per report, so retrying the same call every sync will always get 416.

## Changes

Added the 416 signature to `AppsFlyerSource.get_non_retryable_errors` so a 416 stops the sync retry loop and surfaces an actionable message instead of burning the full retry budget on an unfixable rejection.

The key mirrors the existing 401/403/404 entries: it matches the stable `requests` status text plus the AppsFlyer host prefix (`... for url: https://hq1.appsflyer.com`), not the volatile app id, report slug, or date query string. That keeps it scoped to AppsFlyer and low-false-positive — transient 5xx responses and other vendors' 416s do not match, so they stay retryable.

This follows the same user/upstream-error pattern as the recent `fix(mollie): treat 400 Bad Request as non-retryable` and `fix(delighted): treat 410 Gone as non-retryable` changes.

## How did you test this code?

I (Claude) could not run the Python suite in this environment — the checkout's virtualenv has no pytest/Django installed, so I could not execute `pytest`.

What I did do:
- Extended the existing parametrized `test_non_retryable_errors_match_auth_failures` with a 416 case using a redacted-shape error string. Regression it catches: if the 416 key is removed or its text drifts, the AppsFlyer 416 silently becomes retryable again and loops on an unfixable upstream rejection — no existing case covered 416.
- The companion `test_non_retryable_errors_does_not_match_unrelated` already asserts a transient `500 ... hq1.appsflyer.com` and a Stripe 401 do not match, guarding against over-matching.
- Verified the substring-match logic standalone: the real observed error and the test fixture match the new key, while the transient 500 and a non-AppsFlyer 416 do not.
- `ruff check` and `ruff format --check` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking webhook by Claude (Claude Code). Skills invoked: `/writing-tests` (to gate the test change — landed on extending the existing parametrized test rather than adding a new function).

Decision path: confirmed the failure originates in `appsflyer.py` (not just serialized log context), read the source to see 416 falls through the retryable branch into `raise_for_status`, then classified it. Considered whether it was a fixable request bug (missing `groupings`, non-UTC dates) and rejected that — preset aggregate reports take only `from`/`to`, and `daily_report` works with the same shape, so the request is correct and 416 is an upstream authorization/validation rejection. Matched on the stable status text + host prefix rather than the per-request URL to avoid leaking customer values and to stay low-false-positive.
