### PR TITLE
chore(warehouse-sources): document oauth2 auth in custom rest source skill

### DIFF
--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -65,7 +65,8 @@ The skeleton:
 
 **Secrets never go inline in the manifest.** `manifest_json` holds only the non-secret structure. The credential
 travels in a separate payload key chosen by the manifest's `client.auth.type`: `auth_token` (bearer), `auth_api_key`
-(api_key), `auth_password` (http_basic), or `auth_oauth2_client_secret` + `auth_oauth2_refresh_token` (oauth2). The
+(api_key), `auth_password` (http_basic), or `auth_oauth2_client_secret` for oauth2 (plus
+`auth_oauth2_refresh_token` for the refresh-token grant only). The
 engine injects it at run time, and PostHog redacts it from every response. Putting a token inline is rejected at
 validation.
 
@@ -167,9 +168,9 @@ After creation, call `external-data-schemas-list` to show the user the initial s
 - **Pick the cursor carefully.** Prefer an `updated_at`-style field over `created_at` (it catches edits), and set
   `cursor_type` when the cursor isn't a datetime (e.g. an integer id) so it's compared with the right type.
 - **OAuth2 secrets are adopted into a server-managed credential store** on the first db-schema / preview / create
-  call, and any rotated single-use refresh token is persisted server-side — so keep `client_id`, `token_url`, and
-  `grant_type` identical across those calls within one setup, and re-submit the same secrets each time. Changing them
-  mid-setup strands the stored rotation, and providers that rotate single-use refresh tokens will then reject the next
-  mint until the user fetches a fresh token. Never set `auth_oauth2_integration_id` yourself (it is server-owned); to
+  call, and any rotated single-use refresh token is persisted server-side — so keep the entire `client.auth` block
+  identical across those calls within one setup, and re-submit the same secrets each time. Changing any auth-block
+  field mid-setup discards the stored rotation, and providers that rotate single-use refresh tokens will then reject
+  the next mint until the user fetches a fresh token. Never set `auth_oauth2_integration_id` yourself (it is server-owned); to
   reconnect a source whose token broke, update it with re-entered `auth_oauth2_client_secret` /
   `auth_oauth2_refresh_token`. See the OAuth2 section of the manifest reference for the auth block fields.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -5,8 +5,9 @@ description: >
   per-source code. Use when the user points at an API that has no built-in PostHog connector — "import data from this
   REST API", "sync my internal API", "connect this API from its docs", "build a custom data warehouse source" — and
   gives a docs URL or a natural-language description of the endpoints. Walks through drafting the RESTAPIConfig manifest
-  (auth, pagination, record path, incremental cursor, parent/child fan-out), validating it, test-reading live rows to
-  verify the field mappings, and creating the source. If the API already has a native PostHog connector, use
+  (auth — bearer, API key, HTTP basic, or OAuth2 client credentials / refresh token — pagination, record path,
+  incremental cursor, parent/child fan-out), validating it, test-reading live rows to verify the field mappings, and
+  creating the source. If the API already has a native PostHog connector, use
   setting-up-a-data-warehouse-source instead — this skill checks the connector registry first and only handles APIs
   with no native connector.
 ---
@@ -64,8 +65,9 @@ The skeleton:
 
 **Secrets never go inline in the manifest.** `manifest_json` holds only the non-secret structure. The credential
 travels in a separate payload key chosen by the manifest's `client.auth.type`: `auth_token` (bearer), `auth_api_key`
-(api_key), or `auth_password` (http_basic). The engine injects it at run time, and PostHog redacts it from every
-response. Putting a token inline is rejected at validation.
+(api_key), `auth_password` (http_basic), or `auth_oauth2_client_secret` + `auth_oauth2_refresh_token` (oauth2). The
+engine injects it at run time, and PostHog redacts it from every response. Putting a token inline is rejected at
+validation.
 
 ## Available tools
 
@@ -97,7 +99,8 @@ Get either a **docs URL** (fetch it and read the auth scheme, the list endpoints
 pagination) or a **natural-language description** of the endpoints. You need, per resource you'll import:
 
 - the **path** (relative to a common `base_url`) and method (GET, or POST for query-style read endpoints),
-- the **auth scheme** (bearer token / API key in header or query / HTTP basic),
+- the **auth scheme** (bearer token / API key in header or query / HTTP basic / OAuth2 with a customer-owned client —
+  `client_credentials` or a pre-obtained refresh token; the interactive `authorization_code` flow is not supported),
 - the **record path** — where the array of records sits in the JSON response (e.g. `data`, `results`, `items`),
 - how the API **paginates** (next-URL, link header, cursor, offset, page number, or single page),
 - a **primary key** field, and
@@ -118,7 +121,8 @@ fan-out example. Keep it to one level of nesting.
 
 Call `external-data-sources-db-schema` with `{ source_type: "Custom", manifest_json: "<stringified manifest>",
 auth_token: "<credential>" }`. The credential key is **not literally `auth_*`** — use the one for your auth type:
-`auth_token` (bearer), `auth_api_key` (api_key), or `auth_password` (http_basic). It validates the manifest structure,
+`auth_token` (bearer), `auth_api_key` (api_key), `auth_password` (http_basic), or `auth_oauth2_client_secret` (+
+`auth_oauth2_refresh_token` for the refresh-token grant). It validates the manifest structure,
 the fan-out graph, and the credential (a bounded live probe),
 then returns one table entry per resource with `detected_primary_keys` and `incremental_fields`. If it returns a 400,
 the `message` is plain English (e.g. `resources[0].endpoint.path: must not be empty`) — fix the manifest and retry.
@@ -162,3 +166,10 @@ After creation, call `external-data-schemas-list` to show the user the initial s
   source API.
 - **Pick the cursor carefully.** Prefer an `updated_at`-style field over `created_at` (it catches edits), and set
   `cursor_type` when the cursor isn't a datetime (e.g. an integer id) so it's compared with the right type.
+- **OAuth2 secrets are adopted into a server-managed credential store** on the first db-schema / preview / create
+  call, and any rotated single-use refresh token is persisted server-side — so keep `client_id`, `token_url`, and
+  `grant_type` identical across those calls within one setup, and re-submit the same secrets each time. Changing them
+  mid-setup strands the stored rotation, and providers that rotate single-use refresh tokens will then reject the next
+  mint until the user fetches a fresh token. Never set `auth_oauth2_integration_id` yourself (it is server-owned); to
+  reconnect a source whose token broke, update it with re-entered `auth_oauth2_client_secret` /
+  `auth_oauth2_refresh_token`. See the OAuth2 section of the manifest reference for the auth block fields.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
@@ -27,13 +27,13 @@ real engine behavior. Only the fields the engine reads are documented here; unkn
 The auth **type** lives in the manifest; the secret value travels in a separate payload key and is injected at run
 time. Never put the secret in the manifest.
 
-| `client.auth` block                                                | Secret payload key(s)                                    | Sends                                         |
-| ------------------------------------------------------------------ | -------------------------------------------------------- | --------------------------------------------- |
-| `{ "type": "bearer" }`                                             | `auth_token`                                             | `Authorization: Bearer <token>`               |
-| `{ "type": "api_key", "name": "X-Api-Key", "location": "header" }` | `auth_api_key`                                           | the key in header / query param `name`        |
-| `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`                                           | `?api_key=<key>`                              |
-| `{ "type": "http_basic", "username": "user" }`                     | `auth_password`                                          | HTTP Basic with the given username + password |
-| `{ "type": "oauth2", ... }` (see below)                            | `auth_oauth2_client_secret`, `auth_oauth2_refresh_token` | `Authorization: Bearer <minted access token>` |
+| `client.auth` block                                                | Secret payload key(s)                                                                          | Sends                                         |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `{ "type": "bearer" }`                                             | `auth_token`                                                                                   | `Authorization: Bearer <token>`               |
+| `{ "type": "api_key", "name": "X-Api-Key", "location": "header" }` | `auth_api_key`                                                                                 | the key in header / query param `name`        |
+| `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`                                                                                 | `?api_key=<key>`                              |
+| `{ "type": "http_basic", "username": "user" }`                     | `auth_password`                                                                                | HTTP Basic with the given username + password |
+| `{ "type": "oauth2", ... }` (see below)                            | `auth_oauth2_client_secret` (+ `auth_oauth2_refresh_token` for the `refresh_token` grant only) | `Authorization: Bearer <minted access token>` |
 
 `location` is one of `header`, `query`, `param`, `cookie`. `query` and `param` are **synonyms** — both append
 `name=<key>` to the URL query string, so use either (prefer `query`); they differ only in spelling, not behavior. For
@@ -68,10 +68,12 @@ PostHog **adopts the OAuth2 secrets into a server-managed credential store** on 
 create call — they are never kept in the source's stored config, and any rotated single-use refresh token the provider
 returns is persisted server-side. Two practical consequences:
 
-- **Keep `client_id`, `token_url`, and `grant_type` identical across the db-schema → preview → create calls of one
-  setup.** Retries and the final create reuse the same stored credential (with its rotated refresh token) only when
-  those three match; changing them mid-setup strands the rotation and providers with single-use refresh tokens will
-  reject the next mint until the user fetches a fresh token.
+- **Keep the entire `client.auth` block identical across the db-schema → preview → create calls of one setup.**
+  The stored credential is found again by matching `client_id` + `token_url` + `grant_type`, but changing _any_
+  auth-block field (`scopes`, token-request knobs, `client_auth_method`, …) makes PostHog treat the re-submitted
+  refresh token as a deliberately new credential and discard the stored rotation — with a single-use-rotating
+  provider the next mint then fails with `invalid_grant`. Only change the auth block mid-setup together with a
+  freshly issued refresh token.
 - **`auth_oauth2_integration_id`** may appear in a stored source's config — it is the server-owned pointer to the
   credential store. Never set or copy it yourself; on create it is ignored, and to reconnect a broken credential you
   update the source with re-entered `auth_oauth2_client_secret` / `auth_oauth2_refresh_token` instead.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
@@ -27,16 +27,54 @@ real engine behavior. Only the fields the engine reads are documented here; unkn
 The auth **type** lives in the manifest; the secret value travels in a separate payload key and is injected at run
 time. Never put the secret in the manifest.
 
-| `client.auth` block                                                | Secret payload key | Sends                                         |
-| ------------------------------------------------------------------ | ------------------ | --------------------------------------------- |
-| `{ "type": "bearer" }`                                             | `auth_token`       | `Authorization: Bearer <token>`               |
-| `{ "type": "api_key", "name": "X-Api-Key", "location": "header" }` | `auth_api_key`     | the key in header / query param `name`        |
-| `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`     | `?api_key=<key>`                              |
-| `{ "type": "http_basic", "username": "user" }`                     | `auth_password`    | HTTP Basic with the given username + password |
+| `client.auth` block                                                | Secret payload key(s)                                    | Sends                                         |
+| ------------------------------------------------------------------ | -------------------------------------------------------- | --------------------------------------------- |
+| `{ "type": "bearer" }`                                             | `auth_token`                                             | `Authorization: Bearer <token>`               |
+| `{ "type": "api_key", "name": "X-Api-Key", "location": "header" }` | `auth_api_key`                                           | the key in header / query param `name`        |
+| `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`                                           | `?api_key=<key>`                              |
+| `{ "type": "http_basic", "username": "user" }`                     | `auth_password`                                          | HTTP Basic with the given username + password |
+| `{ "type": "oauth2", ... }` (see below)                            | `auth_oauth2_client_secret`, `auth_oauth2_refresh_token` | `Authorization: Bearer <minted access token>` |
 
 `location` is one of `header`, `query`, `param`, `cookie`. `query` and `param` are **synonyms** — both append
 `name=<key>` to the URL query string, so use either (prefer `query`); they differ only in spelling, not behavior. For
 an API with no auth, omit `auth` entirely.
+
+### OAuth2
+
+For APIs where the customer brings their own OAuth2 client, the engine mints access tokens itself from the token
+endpoint declared in the manifest:
+
+```json
+{
+  "type": "oauth2",
+  "client_id": "my-client-id",
+  "token_url": "https://auth.example.com/oauth/token",
+  "grant_type": "refresh_token",
+  "scopes": "read:orders read:users"
+}
+```
+
+- **`grant_type`** — `client_credentials` (machine-to-machine; default) or `refresh_token` (the user supplies a
+  pre-obtained refresh token). The interactive `authorization_code` flow is **not supported** — for providers that
+  only issue tokens that way, the user must obtain a refresh token out of band first.
+- **Secrets** travel in `auth_oauth2_client_secret` (the client secret) and, for the `refresh_token` grant,
+  `auth_oauth2_refresh_token`. Never inline them in the manifest.
+- **Optional knobs** for non-standard token endpoints: `access_token_name` / `expires_in_name` (response fields when
+  they aren't `access_token` / `expires_in`), `expiry_date_format` (strptime format for absolute-datetime expiries),
+  `extra_token_request_params` (extra form params, e.g. `audience`), `token_request_headers`, and
+  `client_auth_method` (`body`, the default, or `basic` for HTTP Basic client auth).
+
+PostHog **adopts the OAuth2 secrets into a server-managed credential store** on the first validation, preview, or
+create call — they are never kept in the source's stored config, and any rotated single-use refresh token the provider
+returns is persisted server-side. Two practical consequences:
+
+- **Keep `client_id`, `token_url`, and `grant_type` identical across the db-schema → preview → create calls of one
+  setup.** Retries and the final create reuse the same stored credential (with its rotated refresh token) only when
+  those three match; changing them mid-setup strands the rotation and providers with single-use refresh tokens will
+  reject the next mint until the user fetches a fresh token.
+- **`auth_oauth2_integration_id`** may appear in a stored source's config — it is the server-owned pointer to the
+  credential store. Never set or copy it yourself; on create it is ignored, and to reconnect a broken credential you
+  update the source with re-entered `auth_oauth2_client_secret` / `auth_oauth2_refresh_token` instead.
 
 ## Endpoint fields
 
@@ -197,6 +235,36 @@ Credential: `auth_api_key`.
 ```
 
 Credential: `auth_password`.
+
+### OAuth2 refresh-token grant + page-number pagination
+
+```json
+{
+  "client": {
+    "base_url": "https://api.example.com/v2",
+    "auth": {
+      "type": "oauth2",
+      "client_id": "warehouse-import",
+      "token_url": "https://auth.example.com/oauth/token",
+      "grant_type": "refresh_token"
+    }
+  },
+  "resources": [
+    {
+      "name": "invoices",
+      "primary_key": "id",
+      "endpoint": {
+        "path": "/invoices",
+        "data_selector": "items",
+        "paginator": { "type": "page_number", "page_param": "page", "total_path": "total_pages" },
+        "incremental": { "cursor_path": "updated_at", "start_param": "modified_since" }
+      }
+    }
+  ]
+}
+```
+
+Credentials: `auth_oauth2_client_secret` + `auth_oauth2_refresh_token`.
 
 ### Bearer + cursor pagination + incremental
 


### PR DESCRIPTION
## Problem

The `setting-up-a-custom-rest-source` MCP skill documents bearer, API-key, and HTTP-basic auth, but says nothing about OAuth2 — even though the Custom source supports it and the two PRs downstack make its credential handling server-managed. An agent following the skill today can't set up an OAuth2-backed API, and worse, could strand a rotating single-use refresh token by changing the client config between preview and create, or by trying to set the server-owned `auth_oauth2_integration_id` itself.

## Changes

Docs only — no code:

- `references/manifest-reference.md`: OAuth2 row in the auth table, a new OAuth2 section (grant types, secret payload keys, non-standard token-endpoint knobs, `authorization_code` explicitly unsupported), the server-managed credential-store semantics (keep `client_id`/`token_url`/`grant_type` identical across db-schema → preview → create; never set `auth_oauth2_integration_id`; reconnect by re-entering secrets), and a worked refresh-token-grant example.
- `SKILL.md`: OAuth2 added to the secret-key lists in the workflow steps, the auth-scheme checklist, the frontmatter trigger description, and an Important-notes bullet on rotation-safe setup.

## How did you test this code?

`hogli lint:skills` and `hogli build:skills` pass. Content cross-checked against the engine (`OAuth2Auth` kwargs, `_oauth2_row_config` matching keys) and the adoption behavior introduced downstack in #66792.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Conductor session); skills invoked: `/writing-skills`. Scoped to the one skill that owns the custom REST source job — the generic `setting-up-a-data-warehouse-source` skill only mentions OAuth for native connectors and needed no change.
