### PR TITLE
fix(reddit_ads): stop capturing missing-integration errors during credential validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
@@ -118,6 +118,11 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
             self.get_oauth_integration(config.reddit_integration_id, team_id)
             return True, None
         except Exception as e:
+            if isinstance(e, ValueError) and "Integration not found" in str(e):
+                # The integration was deleted/disconnected while the source still references it —
+                # an expected user state, not an error worth reporting (get_oauth_integration raises
+                # ValueError("Integration not found: <id>")).
+                return False, "Reddit Ads integration not found. Please reconnect your Reddit Ads integration."
             capture_exception(e)
             return False, f"Failed to validate Reddit Ads credentials: {str(e)}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -97,21 +97,37 @@ class TestRedditAdsSource:
         assert error_message is None
         mock_get_oauth_integration.assert_called_once_with(self.config.reddit_integration_id, self.team_id)
 
+    @pytest.mark.parametrize(
+        "side_effect,expected_error_fragment,expect_capture_called",
+        [
+            # A deleted/disconnected integration is an expected user state — surface a clean
+            # "reconnect" message and do NOT report it to error tracking.
+            (ValueError("Integration not found: 154683"), "Reddit Ads integration not found", False),
+            # Anything else is genuinely unexpected and must still be captured.
+            (Exception("OAuth error"), "Failed to validate Reddit Ads credentials", True),
+        ],
+    )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration"
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.reddit_ads.source.capture_exception")
-    def test_validate_credentials_integration_error(self, mock_capture_exception, mock_get_oauth_integration):
-        """Test credential validation with integration error."""
-        mock_get_oauth_integration.side_effect = Exception("Integration not found")
+    def test_validate_credentials_oauth_failures(
+        self,
+        mock_capture_exception,
+        mock_get_oauth_integration,
+        side_effect,
+        expected_error_fragment,
+        expect_capture_called,
+    ):
+        """Validation distinguishes an expected missing integration from a genuine error."""
+        mock_get_oauth_integration.side_effect = side_effect
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is False
         assert error_message is not None
-        assert "Failed to validate Reddit Ads credentials" in error_message
-        assert "Integration not found" in error_message
-        mock_capture_exception.assert_called_once()
+        assert expected_error_fragment in error_message
+        assert mock_capture_exception.called is expect_capture_called
 
     @pytest.mark.parametrize(
         "observed_error",


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ValueError: Integration not found: <id>` originating in the Reddit Ads source's `validate_credentials` ([error-tracking issue](https://us.posthog.com/project/2/error_tracking/019f2180-0e57-7ad2-921a-1592b92d6624)).

The exception is a **handled** capture (not a crash) that fires from the source-setup/validation flow (`external_data_sources/database_schema`), not the import pipeline. It happens when a source still references a Reddit integration that has since been deleted or disconnected: `get_oauth_integration` raises `ValueError("Integration not found: <id>")`, and `validate_credentials` catches it, returns a friendly failure, but *also* calls `capture_exception`.

A missing integration is an expected user state - the user needs to reconnect. Reporting it to error tracking is just noise. The import pipeline side of this is already handled (the string is in `get_non_retryable_errors`), but that mechanism doesn't gate the validation path's `capture_exception`.

## Changes

In `validate_credentials`, detect the missing-integration `ValueError`, return a clean "reconnect" message, and skip `capture_exception`. Genuinely unexpected errors are still captured as before.

This mirrors the convention already used by `bing_ads` and `linkedin_ads`, which special-case the same missing-integration state.

## How did you test this code?

Refactored the existing `test_validate_credentials_integration_error` into a parameterized `test_validate_credentials_oauth_failures` with two cases:

- `ValueError("Integration not found: ...")` → friendly reconnect message, `capture_exception` **not** called. This is the regression the fix guards: revert the guard and a deleted/disconnected integration is captured to error tracking again. No prior test covered the not-captured path.
- generic `Exception` → generic failure message, `capture_exception` **still** called (unexpected-error branch stays intact).

Ran the full source test file locally: 21 passed. I (Claude) did not perform manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude. I confirmed the issue in error tracking, read the full stack trace (top in-app frame `validate_credentials` in `reddit_ads/source.py`, raise site `get_oauth_integration` in the shared `OAuthMixin`), and checked that the failure genuinely originates in this source's code path.

Decision: this is a user/upstream state (integration deleted/disconnected). The pipeline retry path already treats "Integration not found" as non-retryable, so I did not touch `get_non_retryable_errors`. The remaining problem was the validation path capturing the expected state as an exception. I rejected extending `NonRetryableErrors` (no-op for this path) and instead fixed the capture, following the existing `bing_ads`/`linkedin_ads` pattern rather than inventing a new abstraction. Scoped strictly to `reddit_ads`.

Skills invoked: `/writing-tests`.
