### PR TITLE
chore(quill-charts): dedupe time-series chart wiring into shared hooks

### DIFF
--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
 import type {
@@ -15,13 +15,7 @@ import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { TrendLineOverlay } from '../../overlays/TrendLineOverlay'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import type { GoalLineConfig } from '../../utils/goal-lines'
-import {
-    buildYAxes,
-    normalizeYAxisList,
-    primaryYAxisConfig,
-    type XAxisConfig,
-    type YAxisConfig,
-} from '../../utils/use-axis-formatters'
+import type { XAxisConfig, YAxisConfig } from '../../utils/use-axis-formatters'
 import { BarChart } from '../BarChart/BarChart'
 import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
 import { useGoalLines, useTimeSeries } from '../utils/use-time-series'
@@ -99,10 +93,6 @@ export function TimeSeriesBarChart<Meta = unknown>({
         legend,
         trendLines,
     } = config ?? {}
-    const axisList = useMemo(() => normalizeYAxisList(yAxis), [yAxis])
-    const primaryYAxis = useMemo<YAxisConfig | undefined>(() => primaryYAxisConfig(axisList), [axisList])
-    const yAxes = useMemo(() => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined), [yAxis, axisList])
-
     const {
         xTickFormatter,
         yTickFormatter,
@@ -111,7 +101,9 @@ export function TimeSeriesBarChart<Meta = unknown>({
         chartSeries,
         valueLabelsConfig,
         valueLabelFormatter,
-    } = useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+        primaryYAxis,
+        yAxes,
+    } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
 
     // `axisOrientation` flows through `barChartConfig` into chart context, so `ReferenceLine`
     // reads it automatically — no need to stamp each line here.

--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
-import { useChartLegend } from '../../components/Legend/useChartLegend'
 import type {
     BarChartConfig,
     BarFillStyle,
@@ -15,23 +14,18 @@ import type {
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { TrendLineOverlay } from '../../overlays/TrendLineOverlay'
 import { ValueLabels } from '../../overlays/ValueLabels'
-import { buildGoalLineReferenceLines, goalLineValueDomain, type GoalLineConfig } from '../../utils/goal-lines'
+import type { GoalLineConfig } from '../../utils/goal-lines'
 import {
     buildYAxes,
     normalizeYAxisList,
     primaryYAxisConfig,
-    useXTickFormatter,
-    useYTickFormatter,
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
 import { BarChart } from '../BarChart/BarChart'
-import { buildTrendLineSeries, type TrendLineConfig } from '../TimeSeriesLineChart/utils/derived-series'
-import {
-    resolveValueLabelsConfig,
-    useSeriesWithValueLabelAllowlist,
-    type ValueLabelsConfig,
-} from '../utils/use-value-labels'
+import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
+import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export interface TimeSeriesBarChartConfig {
     xAxis?: XAxisConfig
@@ -109,40 +103,21 @@ export function TimeSeriesBarChart<Meta = unknown>({
     const primaryYAxis = useMemo<YAxisConfig | undefined>(() => primaryYAxisConfig(axisList), [axisList])
     const yAxes = useMemo(() => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined), [yAxis, axisList])
 
-    const xTickFormatter = useXTickFormatter(xAxis, labels)
-    const yTickFormatter = useYTickFormatter(primaryYAxis)
-
-    const { visibleSeries, legendProps } = useChartLegend(series, theme, legend)
-
-    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
-    const seriesAfterValueLabels = useSeriesWithValueLabelAllowlist(visibleSeries, valueLabelsConfig?.seriesKeys)
-
-    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
+    const {
+        xTickFormatter,
+        yTickFormatter,
+        legendProps,
+        visibleSeries,
+        chartSeries,
+        valueLabelsConfig,
+        valueLabelFormatter,
+    } = useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
     // `axisOrientation` flows through `barChartConfig` into chart context, so `ReferenceLine`
     // reads it automatically — no need to stamp each line here.
-    const referenceLines = useMemo(
-        () => buildGoalLineReferenceLines(goalLines, seriesAfterValueLabels),
-        [goalLines, seriesAfterValueLabels]
-    )
+    const { referenceLines, valueDomain } = useGoalLines(goalLines, chartSeries)
 
-    // Extend the value axis to cover goal lines that sit above (or below) the data, so a goal
-    // line off the data's natural scale still renders inside the plot. Memoized so the `{ include }`
-    // object stays referentially stable and doesn't re-trigger scale recomputation each render.
-    const valueDomain = useMemo(() => goalLineValueDomain(referenceLines), [referenceLines])
-
-    const trendSeries = useMemo(() => {
-        if (!trendLines?.length) {
-            return []
-        }
-        const byKey = new Map(visibleSeries.map((s) => [s.key, s]))
-        return trendLines.flatMap((tl) => {
-            const source = byKey.get(tl.seriesKey)
-            return source
-                ? [buildTrendLineSeries({ sourceSeries: source, kind: tl.kind, label: tl.label, fitUpTo: tl.fitUpTo, excluded: source.visibility?.excluded })]
-                : []
-        })
-    }, [trendLines, visibleSeries])
+    const trendSeries = useTrendLineSeries(visibleSeries, trendLines)
 
     const barChartConfig: BarChartConfig = {
         yScaleType: primaryYAxis?.scale,
@@ -171,7 +146,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
     return (
         <ChartLegend {...legendProps} legendDataAttr="hog-chart-timeseries-bar-legend">
             <BarChart
-                series={seriesAfterValueLabels}
+                series={chartSeries}
                 labels={labels}
                 config={barChartConfig}
                 theme={theme}

--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../utils/use-axis-formatters'
 import { BarChart } from '../BarChart/BarChart'
 import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
-import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import { useGoalLines, useTimeSeries } from '../utils/use-time-series'
 import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export interface TimeSeriesBarChartConfig {
@@ -111,7 +111,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
         chartSeries,
         valueLabelsConfig,
         valueLabelFormatter,
-    } = useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+    } = useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
     // `axisOrientation` flows through `barChartConfig` into chart context, so `ReferenceLine`
     // reads it automatically — no need to stamp each line here.

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
-import { useChartLegend } from '../../components/Legend/useChartLegend'
 import type {
     ChartLegendConfig,
     ChartTheme,
@@ -15,23 +14,18 @@ import type {
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { TrendLineOverlay } from '../../overlays/TrendLineOverlay'
 import { ValueLabels } from '../../overlays/ValueLabels'
-import { buildGoalLineReferenceLines, goalLineValueDomain, type GoalLineConfig } from '../../utils/goal-lines'
+import type { GoalLineConfig } from '../../utils/goal-lines'
 import {
     buildYAxes,
     normalizeYAxisList,
     primaryYAxisConfig,
-    useXTickFormatter,
-    useYTickFormatter,
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
 import { ComboChart } from '../ComboChart/ComboChart'
-import { buildTrendLineSeries, type TrendLineConfig } from '../TimeSeriesLineChart/utils/derived-series'
-import {
-    resolveValueLabelsConfig,
-    useSeriesWithValueLabelAllowlist,
-    type ValueLabelsConfig,
-} from '../utils/use-value-labels'
+import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
+import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export interface TimeSeriesComboChartConfig {
     xAxis?: XAxisConfig
@@ -104,38 +98,19 @@ export function TimeSeriesComboChart<Meta = unknown>({
     const primaryYAxis = useMemo<YAxisConfig | undefined>(() => primaryYAxisConfig(axisList), [axisList])
     const yAxes = useMemo(() => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined), [yAxis, axisList])
 
-    const xTickFormatter = useXTickFormatter(xAxis, labels)
-    const yTickFormatter = useYTickFormatter(primaryYAxis)
+    const {
+        xTickFormatter,
+        yTickFormatter,
+        legendProps,
+        visibleSeries,
+        chartSeries,
+        valueLabelsConfig,
+        valueLabelFormatter,
+    } = useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
-    const { visibleSeries, legendProps } = useChartLegend(series, theme, legend)
+    const { referenceLines, valueDomain } = useGoalLines(goalLines, chartSeries)
 
-    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
-    const seriesAfterValueLabels = useSeriesWithValueLabelAllowlist(visibleSeries, valueLabelsConfig?.seriesKeys)
-
-    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
-
-    const referenceLines = useMemo(
-        () => buildGoalLineReferenceLines(goalLines, seriesAfterValueLabels),
-        [goalLines, seriesAfterValueLabels]
-    )
-
-    // Extend the value axis to cover goal lines that sit outside the data range, so a goal line
-    // off the data's natural scale still renders inside the plot. Memoized so the `{ include }`
-    // object stays referentially stable and doesn't re-trigger scale recomputation each render.
-    const valueDomain = useMemo(() => goalLineValueDomain(referenceLines), [referenceLines])
-
-    const trendSeries = useMemo(() => {
-        if (!trendLines?.length) {
-            return []
-        }
-        const byKey = new Map(visibleSeries.map((s) => [s.key, s]))
-        return trendLines.flatMap((tl) => {
-            const source = byKey.get(tl.seriesKey)
-            return source
-                ? [buildTrendLineSeries({ sourceSeries: source, kind: tl.kind, label: tl.label, fitUpTo: tl.fitUpTo, excluded: source.visibility?.excluded })]
-                : []
-        })
-    }, [trendLines, visibleSeries])
+    const trendSeries = useTrendLineSeries(visibleSeries, trendLines)
 
     const comboChartConfig: ComboChartConfig = {
         yScaleType: primaryYAxis?.scale,
@@ -159,7 +134,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
     return (
         <ChartLegend {...legendProps} legendDataAttr="hog-chart-timeseries-combo-legend">
             <ComboChart
-                series={seriesAfterValueLabels}
+                series={chartSeries}
                 labels={labels}
                 config={comboChartConfig}
                 theme={theme}

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../utils/use-axis-formatters'
 import { ComboChart } from '../ComboChart/ComboChart'
 import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
-import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import { useGoalLines, useTimeSeries } from '../utils/use-time-series'
 import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export interface TimeSeriesComboChartConfig {
@@ -106,7 +106,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         chartSeries,
         valueLabelsConfig,
         valueLabelFormatter,
-    } = useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+    } = useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
     const { referenceLines, valueDomain } = useGoalLines(goalLines, chartSeries)
 

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
 import type {
@@ -15,13 +15,7 @@ import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { TrendLineOverlay } from '../../overlays/TrendLineOverlay'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import type { GoalLineConfig } from '../../utils/goal-lines'
-import {
-    buildYAxes,
-    normalizeYAxisList,
-    primaryYAxisConfig,
-    type XAxisConfig,
-    type YAxisConfig,
-} from '../../utils/use-axis-formatters'
+import type { XAxisConfig, YAxisConfig } from '../../utils/use-axis-formatters'
 import { ComboChart } from '../ComboChart/ComboChart'
 import { useTrendLineSeries, type TrendLineConfig } from '../utils/use-derived-series'
 import { useGoalLines, useTimeSeries } from '../utils/use-time-series'
@@ -94,10 +88,6 @@ export function TimeSeriesComboChart<Meta = unknown>({
         legend,
         trendLines,
     } = config ?? {}
-    const axisList = useMemo(() => normalizeYAxisList(yAxis), [yAxis])
-    const primaryYAxis = useMemo<YAxisConfig | undefined>(() => primaryYAxisConfig(axisList), [axisList])
-    const yAxes = useMemo(() => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined), [yAxis, axisList])
-
     const {
         xTickFormatter,
         yTickFormatter,
@@ -106,7 +96,9 @@ export function TimeSeriesComboChart<Meta = unknown>({
         chartSeries,
         valueLabelsConfig,
         valueLabelFormatter,
-    } = useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+        primaryYAxis,
+        yAxes,
+    } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
 
     const { referenceLines, valueDomain } = useGoalLines(goalLines, chartSeries)
 

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
-import { useChartLegend } from '../../components/Legend/useChartLegend'
 import type {
     ChartLegendConfig,
     ChartTheme,
@@ -15,28 +14,23 @@ import type {
 } from '../../core/types'
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
-import { buildGoalLineReferenceLines, goalLineValueDomain, type GoalLineConfig } from '../../utils/goal-lines'
+import type { GoalLineConfig } from '../../utils/goal-lines'
 import {
     buildYAxes,
     normalizeYAxisList,
     primaryYAxisConfig,
-    useXTickFormatter,
-    useYTickFormatter,
     type XAxisConfig,
     type YAxisConfig,
 } from '../../utils/use-axis-formatters'
 import { LineChart } from '../LineChart/LineChart'
 import {
-    resolveValueLabelsConfig,
-    useSeriesWithValueLabelAllowlist,
-    type ValueLabelsConfig,
-} from '../utils/use-value-labels'
-import {
     useDerivedSeries,
     type ConfidenceIntervalConfig,
     type MovingAverageConfig,
     type TrendLineConfig,
-} from './utils/use-derived-series'
+} from '../utils/use-derived-series'
+import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export type { ConfidenceIntervalConfig, MovingAverageConfig, TrendLineConfig }
 
@@ -119,31 +113,18 @@ export function TimeSeriesLineChart<Meta = unknown>({
         [yAxis, axisList]
     )
 
-    const xTickFormatter = useXTickFormatter(xAxis, labels)
-    const yTickFormatter = useYTickFormatter(primaryYAxis)
+    const { xTickFormatter, yTickFormatter, legendProps, chartSeries, valueLabelsConfig, valueLabelFormatter } =
+        useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
-    // Toggling works off the raw series so the legend lists the user's series (not derived trend
-    // lines / CI bands); hidden ones flow through the derived pipeline already excluded.
-    const { visibleSeries, legendProps } = useChartLegend(series, theme, legend)
-
-    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
-    const seriesAfterValueLabels = useSeriesWithValueLabelAllowlist(visibleSeries, valueLabelsConfig?.seriesKeys)
-
-    const finalSeries = useDerivedSeries(seriesAfterValueLabels, {
+    const finalSeries = useDerivedSeries(chartSeries, {
         confidenceIntervals,
         movingAverage,
         trendLines,
         comparisonOf,
     })
 
-    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
-
-    const referenceLines = useMemo(() => buildGoalLineReferenceLines(goalLines, finalSeries), [goalLines, finalSeries])
-
-    // Extend the value axis to cover goal lines that sit outside the data range, so a goal line
-    // off the data's natural scale still renders inside the plot. Memoized so the `{ include }`
-    // object stays referentially stable and doesn't re-trigger scale recomputation each render.
-    const valueDomain = useMemo(() => goalLineValueDomain(referenceLines), [referenceLines])
+    // Goal lines scale against the drawn (post-derived) series, unlike bar/combo.
+    const { referenceLines, valueDomain } = useGoalLines(goalLines, finalSeries)
 
     // `startAtZero === false` floats the primary axis to its data range; the default (undefined/true)
     // keeps the baseline clamped to 0. A log scale has no zero baseline to clamp, so it's a no-op there.

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
 import type {
@@ -10,18 +10,11 @@ import type {
     Series,
     TooltipConfig,
     TooltipContext,
-    YAxis,
 } from '../../core/types'
 import { ReferenceLines } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import type { GoalLineConfig } from '../../utils/goal-lines'
-import {
-    buildYAxes,
-    normalizeYAxisList,
-    primaryYAxisConfig,
-    type XAxisConfig,
-    type YAxisConfig,
-} from '../../utils/use-axis-formatters'
+import type { XAxisConfig, YAxisConfig } from '../../utils/use-axis-formatters'
 import { LineChart } from '../LineChart/LineChart'
 import {
     useDerivedSeries,
@@ -102,19 +95,16 @@ export function TimeSeriesLineChart<Meta = unknown>({
         tooltip: tooltipConfig,
         legend,
     } = config ?? {}
-    const axisList = useMemo(() => normalizeYAxisList(yAxis), [yAxis])
-    // Scalar y-config describes the primary (left) axis — drives single-axis rendering, the default
-    // value-label formatter, and the left gutter when a right-axis series is present.
-    const primaryYAxis = useMemo<YAxisConfig | undefined>(() => primaryYAxisConfig(axisList), [axisList])
-    // Per-axis configs only when the caller passed an array — a single object keeps the existing
-    // single-axis path untouched (no `yAxes` on the LineChart config).
-    const yAxes = useMemo<YAxis[] | undefined>(
-        () => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined),
-        [yAxis, axisList]
-    )
-
-    const { xTickFormatter, yTickFormatter, legendProps, chartSeries, valueLabelsConfig, valueLabelFormatter } =
-        useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+    const {
+        xTickFormatter,
+        yTickFormatter,
+        legendProps,
+        chartSeries,
+        valueLabelsConfig,
+        valueLabelFormatter,
+        primaryYAxis,
+        yAxes,
+    } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
 
     const finalSeries = useDerivedSeries(chartSeries, {
         confidenceIntervals,

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -29,7 +29,7 @@ import {
     type MovingAverageConfig,
     type TrendLineConfig,
 } from '../utils/use-derived-series'
-import { useGoalLines, useTimeSeriesChrome } from '../utils/use-time-series-chrome'
+import { useGoalLines, useTimeSeries } from '../utils/use-time-series'
 import type { ValueLabelsConfig } from '../utils/use-value-labels'
 
 export type { ConfidenceIntervalConfig, MovingAverageConfig, TrendLineConfig }
@@ -114,7 +114,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
     )
 
     const { xTickFormatter, yTickFormatter, legendProps, chartSeries, valueLabelsConfig, valueLabelFormatter } =
-        useTimeSeriesChrome(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
+        useTimeSeries(series, labels, theme, { xAxis, yAxis: primaryYAxis, valueLabels, legend })
 
     const finalSeries = useDerivedSeries(chartSeries, {
         confidenceIntervals,

--- a/packages/quill/packages/charts/src/charts/utils/derived-series.test.ts
+++ b/packages/quill/packages/charts/src/charts/utils/derived-series.test.ts
@@ -1,4 +1,4 @@
-import type { Series } from '../../../core/types'
+import type { Series } from '../../core/types'
 import { buildConfidenceIntervalSeries, buildMovingAverageSeries, buildTrendLineSeries } from './derived-series'
 
 const SOURCE: Series = {

--- a/packages/quill/packages/charts/src/charts/utils/derived-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/derived-series.ts
@@ -1,6 +1,6 @@
-import type { Series } from '../../../core/types'
-import { dimHex } from '../../../utils/comparison-dimming'
-import { linearRegression, movingAverage, trendLine } from '../../../utils/statistics'
+import type { Series } from '../../core/types'
+import { dimHex } from '../../utils/comparison-dimming'
+import { linearRegression, movingAverage, trendLine } from '../../utils/statistics'
 
 export type { TrendLineConfig } from './use-derived-series'
 

--- a/packages/quill/packages/charts/src/charts/utils/use-derived-series.test.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-derived-series.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 
-import type { Series } from '../../../core/types'
+import type { Series } from '../../core/types'
 import { useDerivedSeries } from './use-derived-series'
 
 const SOURCE: Series[] = [

--- a/packages/quill/packages/charts/src/charts/utils/use-derived-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-derived-series.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
-import type { Series } from '../../../core/types'
-import { applyComparisonDimming } from '../../../utils/comparison-dimming'
+import type { Series } from '../../core/types'
+import { applyComparisonDimming } from '../../utils/comparison-dimming'
 import { buildConfidenceIntervalSeries, buildMovingAverageSeries, buildTrendLineSeries } from './derived-series'
 
 export interface ConfidenceIntervalConfig {
@@ -130,6 +130,42 @@ export function useDerivedSeries<Meta>(source: Series<Meta>[], options: DerivedS
         // raw refs are intentionally absent so inline-config callers don't bust the cache.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [source, ciSignature, maSignature, tlSignature, cmpSignature])
+}
+
+/** Trend-line series for charts that render trends as an SVG overlay ({@link TrendLineOverlay})
+ *  instead of folding them into the drawn series the way {@link useDerivedSeries} does — the
+ *  bar-based time-series charts. Same construction and memo-signature rules as the trend-line
+ *  slice of {@link useDerivedSeries}. */
+export function useTrendLineSeries<Meta>(
+    source: Series<Meta>[],
+    trendLines: TrendLineConfig[] | undefined
+): Series<Meta>[] {
+    const tlSignature = tlSig(trendLines)
+    return useMemo(() => {
+        if (!trendLines?.length) {
+            return []
+        }
+        const sourceByKey = new Map(source.map((s) => [s.key, s]))
+        const tlSeries: Series<Meta>[] = []
+        for (const tl of trendLines) {
+            const found = sourceByKey.get(tl.seriesKey)
+            if (!found) {
+                continue
+            }
+            tlSeries.push(
+                buildTrendLineSeries<Meta>({
+                    sourceSeries: found,
+                    kind: tl.kind,
+                    label: tl.label,
+                    fitUpTo: tl.fitUpTo,
+                    excluded: found.visibility?.excluded,
+                })
+            )
+        }
+        return tlSeries
+        // tlSignature stands in for the reference-typed `trendLines` (see useDerivedSeries).
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [source, tlSignature])
 }
 
 function ciSig(ci: ConfidenceIntervalConfig[] | undefined): string {

--- a/packages/quill/packages/charts/src/charts/utils/use-time-series-chrome.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-time-series-chrome.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+
+import { useChartLegend, type ChartLegendRenderProps } from '../../components/Legend/useChartLegend'
+import type { ChartLegendConfig, ChartTheme, Series, ValueDomain } from '../../core/types'
+import type { ReferenceLineProps } from '../../overlays/ReferenceLine'
+import type { ValueLabelFormatter } from '../../overlays/ValueLabels'
+import { buildGoalLineReferenceLines, goalLineValueDomain, type GoalLineConfig } from '../../utils/goal-lines'
+import {
+    useXTickFormatter,
+    useYTickFormatter,
+    type XAxisConfig,
+    type YAxisConfig,
+} from '../../utils/use-axis-formatters'
+import { resolveValueLabelsConfig, useSeriesWithValueLabelAllowlist, type ValueLabelsConfig } from './use-value-labels'
+
+export interface TimeSeriesChromeConfig {
+    xAxis?: XAxisConfig
+    /** The primary y-axis config — drives the default y-tick and value-label formatters. */
+    yAxis?: YAxisConfig
+    valueLabels?: boolean | ValueLabelsConfig
+    legend?: ChartLegendConfig
+}
+
+export interface TimeSeriesChrome<Meta> {
+    xTickFormatter: ((value: string, index: number) => string | null) | undefined
+    yTickFormatter: ((value: number) => string) | undefined
+    /** Spread onto the wrapping `<ChartLegend>`. */
+    legendProps: ChartLegendRenderProps
+    /** Series with legend toggling applied (hidden ones excluded) — before the value-label
+     *  allowlist. Derived overlays (e.g. trend lines) resolve their sources against this. */
+    visibleSeries: Series<Meta>[]
+    /** `visibleSeries` with the value-label allowlist applied — what the chart should draw,
+     *  or feed into the derived-series pipeline first. */
+    chartSeries: Series<Meta>[]
+    valueLabelsConfig: ValueLabelsConfig | null
+    /** Formatter for the `<ValueLabels>` overlay. Undefined when value labels are off. */
+    valueLabelFormatter: ValueLabelFormatter | undefined
+}
+
+/** The shared chrome preamble of the TimeSeries* wrappers — date-aware x ticks, y ticks, the
+ *  built-in click-to-toggle legend, and value-label config — kept in one place so the line/bar/
+ *  combo wrappers can't drift. Legend toggling works off the raw `series` so the legend lists the
+ *  user's series (not derived trend lines / CI bands); hidden ones flow onward already excluded.
+ *  Chart-specific concerns (scales, layouts, derived series, goal-line resolution) stay in each
+ *  wrapper. */
+export function useTimeSeriesChrome<Meta>(
+    series: Series<Meta>[],
+    labels: string[],
+    theme: ChartTheme,
+    config: TimeSeriesChromeConfig
+): TimeSeriesChrome<Meta> {
+    const { xAxis, yAxis, valueLabels, legend } = config
+    const xTickFormatter = useXTickFormatter(xAxis, labels)
+    const yTickFormatter = useYTickFormatter(yAxis)
+    const { visibleSeries, legendProps } = useChartLegend(series, theme, legend)
+    const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
+    const chartSeries = useSeriesWithValueLabelAllowlist(visibleSeries, valueLabelsConfig?.seriesKeys)
+    const valueLabelFormatter = valueLabelsConfig ? (valueLabelsConfig.formatter ?? yTickFormatter) : undefined
+    return {
+        xTickFormatter,
+        yTickFormatter,
+        legendProps,
+        visibleSeries,
+        chartSeries,
+        valueLabelsConfig,
+        valueLabelFormatter,
+    }
+}
+
+/** Goal lines resolved against the series they should scale with — the drawn (post-derived)
+ *  series for the line chart, the chrome series for bar/combo. `valueDomain` extends the value
+ *  axis to cover goal lines outside the data range, so an off-scale goal still renders on-plot;
+ *  both results are referentially stable so they don't re-trigger scale recomputation. */
+export function useGoalLines<Meta>(
+    goalLines: GoalLineConfig[] | undefined,
+    series: Series<Meta>[]
+): { referenceLines: ReferenceLineProps[]; valueDomain: ValueDomain | undefined } {
+    const referenceLines = useMemo(() => buildGoalLineReferenceLines(goalLines, series), [goalLines, series])
+    const valueDomain = useMemo(() => goalLineValueDomain(referenceLines), [referenceLines])
+    return { referenceLines, valueDomain }
+}

--- a/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
@@ -24,7 +24,6 @@ export interface UseTimeSeriesConfig {
 export interface UseTimeSeriesResult<Meta> {
     xTickFormatter: ((value: string, index: number) => string | null) | undefined
     yTickFormatter: ((value: number) => string) | undefined
-    /** Spread onto the wrapping `<ChartLegend>`. */
     legendProps: ChartLegendRenderProps
     /** Series with legend toggling applied (hidden ones excluded) — before the value-label
      *  allowlist. Derived overlays (e.g. trend lines) resolve their sources against this. */

--- a/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
@@ -1,11 +1,14 @@
 import { useMemo } from 'react'
 
 import { useChartLegend, type ChartLegendRenderProps } from '../../components/Legend/useChartLegend'
-import type { ChartLegendConfig, ChartTheme, Series, ValueDomain } from '../../core/types'
+import type { ChartLegendConfig, ChartTheme, Series, ValueDomain, YAxis } from '../../core/types'
 import type { ReferenceLineProps } from '../../overlays/ReferenceLine'
 import type { ValueLabelFormatter } from '../../overlays/ValueLabels'
 import { buildGoalLineReferenceLines, goalLineValueDomain, type GoalLineConfig } from '../../utils/goal-lines'
 import {
+    buildYAxes,
+    normalizeYAxisList,
+    primaryYAxisConfig,
     useXTickFormatter,
     useYTickFormatter,
     type XAxisConfig,
@@ -15,8 +18,10 @@ import { resolveValueLabelsConfig, useSeriesWithValueLabelAllowlist, type ValueL
 
 export interface UseTimeSeriesConfig {
     xAxis?: XAxisConfig
-    /** The primary y-axis config — drives the default y-tick and value-label formatters. */
-    yAxis?: YAxisConfig
+    /** Single object for one y-axis; array for multi-axis charts (one entry per axis, `id`
+     *  matching `Series.yAxisId`). The primary (left) entry drives the default y-tick and
+     *  value-label formatters. */
+    yAxis?: YAxisConfig | YAxisConfig[]
     valueLabels?: boolean | ValueLabelsConfig
     legend?: ChartLegendConfig
 }
@@ -34,14 +39,21 @@ export interface UseTimeSeriesResult<Meta> {
     valueLabelsConfig: ValueLabelsConfig | null
     /** Formatter for the `<ValueLabels>` overlay. Undefined when value labels are off. */
     valueLabelFormatter: ValueLabelFormatter | undefined
+    /** The primary (left) axis config — drives the base chart's scalar y fields
+     *  (`yScaleType`/`hideYAxis`/`yAxisLabel`/`showGrid`) and the left gutter when a
+     *  right-axis series is present. */
+    primaryYAxis: YAxisConfig | undefined
+    /** Per-axis configs for the base chart, only when the caller passed a `yAxis` array — a
+     *  single object keeps the existing single-axis path untouched (no `yAxes` on the config). */
+    yAxes: YAxis[] | undefined
 }
 
-/** The shared preamble of the TimeSeries* wrappers — date-aware x ticks, y ticks, the
- *  built-in click-to-toggle legend, and value-label config — kept in one place so the line/bar/
- *  combo wrappers can't drift. Legend toggling works off the raw `series` so the legend lists the
- *  user's series (not derived trend lines / CI bands); hidden ones flow onward already excluded.
- *  Chart-specific concerns (scales, layouts, derived series, goal-line resolution) stay in each
- *  wrapper. */
+/** The shared preamble of the TimeSeries* wrappers — date-aware x ticks, y ticks (primary +
+ *  multi-axis resolution), the built-in click-to-toggle legend, and value-label config — kept in
+ *  one place so the line/bar/combo wrappers can't drift. Legend toggling works off the raw
+ *  `series` so the legend lists the user's series (not derived trend lines / CI bands); hidden
+ *  ones flow onward already excluded. Chart-specific concerns (scales, layouts, derived series,
+ *  goal-line resolution) stay in each wrapper. */
 export function useTimeSeries<Meta>(
     series: Series<Meta>[],
     labels: string[],
@@ -49,8 +61,11 @@ export function useTimeSeries<Meta>(
     config: UseTimeSeriesConfig
 ): UseTimeSeriesResult<Meta> {
     const { xAxis, yAxis, valueLabels, legend } = config
+    const axisList = useMemo(() => normalizeYAxisList(yAxis), [yAxis])
+    const primaryYAxis = useMemo(() => primaryYAxisConfig(axisList), [axisList])
+    const yAxes = useMemo(() => (Array.isArray(yAxis) ? buildYAxes(axisList) : undefined), [yAxis, axisList])
     const xTickFormatter = useXTickFormatter(xAxis, labels)
-    const yTickFormatter = useYTickFormatter(yAxis)
+    const yTickFormatter = useYTickFormatter(primaryYAxis)
     const { visibleSeries, legendProps } = useChartLegend(series, theme, legend)
     const valueLabelsConfig = resolveValueLabelsConfig(valueLabels)
     const chartSeries = useSeriesWithValueLabelAllowlist(visibleSeries, valueLabelsConfig?.seriesKeys)
@@ -63,6 +78,8 @@ export function useTimeSeries<Meta>(
         chartSeries,
         valueLabelsConfig,
         valueLabelFormatter,
+        primaryYAxis,
+        yAxes,
     }
 }
 

--- a/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/use-time-series.ts
@@ -13,7 +13,7 @@ import {
 } from '../../utils/use-axis-formatters'
 import { resolveValueLabelsConfig, useSeriesWithValueLabelAllowlist, type ValueLabelsConfig } from './use-value-labels'
 
-export interface TimeSeriesChromeConfig {
+export interface UseTimeSeriesConfig {
     xAxis?: XAxisConfig
     /** The primary y-axis config — drives the default y-tick and value-label formatters. */
     yAxis?: YAxisConfig
@@ -21,7 +21,7 @@ export interface TimeSeriesChromeConfig {
     legend?: ChartLegendConfig
 }
 
-export interface TimeSeriesChrome<Meta> {
+export interface UseTimeSeriesResult<Meta> {
     xTickFormatter: ((value: string, index: number) => string | null) | undefined
     yTickFormatter: ((value: number) => string) | undefined
     /** Spread onto the wrapping `<ChartLegend>`. */
@@ -37,18 +37,18 @@ export interface TimeSeriesChrome<Meta> {
     valueLabelFormatter: ValueLabelFormatter | undefined
 }
 
-/** The shared chrome preamble of the TimeSeries* wrappers — date-aware x ticks, y ticks, the
+/** The shared preamble of the TimeSeries* wrappers — date-aware x ticks, y ticks, the
  *  built-in click-to-toggle legend, and value-label config — kept in one place so the line/bar/
  *  combo wrappers can't drift. Legend toggling works off the raw `series` so the legend lists the
  *  user's series (not derived trend lines / CI bands); hidden ones flow onward already excluded.
  *  Chart-specific concerns (scales, layouts, derived series, goal-line resolution) stay in each
  *  wrapper. */
-export function useTimeSeriesChrome<Meta>(
+export function useTimeSeries<Meta>(
     series: Series<Meta>[],
     labels: string[],
     theme: ChartTheme,
-    config: TimeSeriesChromeConfig
-): TimeSeriesChrome<Meta> {
+    config: UseTimeSeriesConfig
+): UseTimeSeriesResult<Meta> {
     const { xAxis, yAxis, valueLabels, legend } = config
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
@@ -68,7 +68,7 @@ export function useTimeSeriesChrome<Meta>(
 }
 
 /** Goal lines resolved against the series they should scale with — the drawn (post-derived)
- *  series for the line chart, the chrome series for bar/combo. `valueDomain` extends the value
+ *  series for the line chart, the hook's `chartSeries` for bar/combo. `valueDomain` extends the value
  *  axis to cover goal lines outside the data range, so an off-scale goal still renders on-plot;
  *  both results are referentially stable so they don't re-trigger scale recomputation. */
 export function useGoalLines<Meta>(

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -146,7 +146,7 @@ export { computeVisibleXLabels } from './overlays/AxisLabels'
 
 export { AnomalyPointsLayer } from './overlays/AnomalyPointsLayer'
 export type { AnomalyMarker } from './overlays/AnomalyPointsLayer'
-export { movingAverageKey } from './charts/TimeSeriesLineChart/utils/derived-series'
+export { movingAverageKey } from './charts/utils/derived-series'
 
 // Timeseries utils
 export { createXAxisTickCallback } from './utils/dates'


### PR DESCRIPTION
## Problem

The three TimeSeries* wrappers (line, bar, combo) each repeated a near-verbatim preamble: date-aware x-tick formatter, y-tick formatter, click-to-toggle legend wiring, value-label allowlist and formatter, and the goal-line reference-lines + value-domain memo pair. On top of that, TimeSeriesBarChart and TimeSeriesComboChart carried a byte-for-byte identical trendSeries memo, and both reached into the line chart's private utils dir for `buildTrendLineSeries`, which made shared derived-series infrastructure look line-chart-owned. Three copies of the same wiring means three places for them to drift.

## Changes

- New `useTimeSeries` hook in `charts/utils/use-time-series.ts` owning the shared preamble; each wrapper's setup collapses to one hook call
- New `useGoalLines` hook for the duplicated referenceLines + valueDomain memos. It takes the series explicitly because the divergence is real: the line chart resolves goal lines against the drawn (post-derived) series, bar/combo against the hook's `chartSeries`
- New `useTrendLineSeries` hook replacing the identical trendSeries memos in bar/combo, reusing the same memo-signature machinery as `useDerivedSeries` so inline `trendLines` configs no longer bust the memo every render
- Moved `derived-series.ts` / `use-derived-series.ts` (+ tests) from `TimeSeriesLineChart/utils/` to the shared `charts/utils/`, since three charts depend on them

No behavior change intended, including the subtle bits: goal-line series source stays per-chart, and trend overlays still resolve their sources against the pre-allowlist visible series.

## How did you test this code?

I'm an agent, so no manual testing. Automated checks run locally:

- Full charts package jest suite via the frontend jest config: 59 suites, 1501 tests, all passing
- Package-scoped `tsc -p tsconfig.build.json --noEmit`: clean

No new tests: this is a pure extraction refactor and the existing TimeSeries* chart tests already cover the moved behavior (goal lines, legend toggling, trend overlays, value labels).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing API change, so no docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam asked for a thorough quality review of quill-charts (Claude Code / PostHog Code session); this PR ships the top finding from that review. Six parallel review agents swept the package, and the duplicated time-series wiring was the highest-leverage structural item.

Decisions along the way: kept `useGoalLines` series-parameterized rather than folding it into `useTimeSeries`, because the line chart genuinely feeds it different series than bar/combo. Skipped extracting the shared JSX render tail (ReferenceLines/TrendLineOverlay/ValueLabels) as a component - at 3 declarative lines per chart it did not earn the indirection. The hook was first named `useTimeSeriesChrome` after the existing "time-series chrome" wording in this package's docs; Sam preferred plain `useTimeSeries`, so it was renamed in a follow-up commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*