### PR TITLE
fix(data-imports): don't fail queued runs in v3 lock takeover

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -42,6 +42,15 @@ LEASE_TTL_SECONDS = 300
 # gone by the time this matters.
 PARTITION_PRUNING_INTERVAL = "14 days"
 
+# Lock-takeover staleness windows (see get_run_activity_summary). A run whose
+# started batches last wrote a status row longer ago than this is considered
+# abandoned mid-processing.
+STALE_THRESHOLD_SECONDS = 30 * 60
+# Batches the consumer never picked up carry no status row, so status recency
+# can't judge them — a deep queue backlog legitimately holds them unstarted for
+# hours. They only count as abandoned after this much longer grace period.
+QUEUED_GRACE_SECONDS = 24 * 60 * 60
+
 
 def pending_batch_select_columns(status_alias: str) -> str:
     return f"""
@@ -633,12 +642,12 @@ class BatchQueue:
         the status view must be LEFT JOINed and a missing status counts as
         non-terminal. Status recency can't judge those batches either — a deep
         queue backlog holds them unstarted for hours while the run is perfectly
-        healthy — so queued batches get a much longer grace period before the
-        run is considered stale.
+        healthy — so queued batches get a much longer grace period
+        (QUEUED_GRACE_SECONDS) before the run is considered stale. The grace
+        only protects runs with no started work gone silent: a batch stuck
+        executing past STALE_THRESHOLD_SECONDS means the consumer died mid-run,
+        and a queued sibling must not mask that.
         """
-        STALE_THRESHOLD_SECONDS = 30 * 60  # 30 minutes
-        QUEUED_GRACE_SECONDS = 24 * 60 * 60  # 24 hours
-
         with conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 f"""
@@ -647,6 +656,9 @@ class BatchQueue:
                     COUNT(*) FILTER (
                         WHERE s.batch_id IS NULL OR s.job_state NOT IN ('succeeded', 'failed')
                     ) AS non_terminal_count,
+                    COUNT(*) FILTER (
+                        WHERE s.batch_id IS NOT NULL AND s.job_state NOT IN ('succeeded', 'failed')
+                    ) AS started_non_terminal_count,
                     MAX(s.created_at) AS latest_status_at,
                     MAX(b.created_at) FILTER (WHERE s.batch_id IS NULL) AS latest_queued_at
                 FROM {BATCH_TABLE} b
@@ -670,7 +682,11 @@ class BatchQueue:
         latest_queued_at: datetime | None = row["latest_queued_at"]
 
         consumer_active = latest_status_at is not None and _age_seconds(latest_status_at) <= STALE_THRESHOLD_SECONDS
-        queued_waiting = latest_queued_at is not None and _age_seconds(latest_queued_at) <= QUEUED_GRACE_SECONDS
+        queued_waiting = (
+            row["started_non_terminal_count"] == 0
+            and latest_queued_at is not None
+            and _age_seconds(latest_queued_at) <= QUEUED_GRACE_SECONDS
+        )
 
         return RunActivitySummary(
             has_batches=True,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -625,22 +625,32 @@ class BatchQueue:
         """Check the queue DB for batch activity belonging to a holder's run.
 
         Returns a summary indicating whether any non-terminal batches exist and
-        the age of the most recent status update. Used by the lock takeover
+        how recently the run showed signs of life. Used by the lock takeover
         decision matrix to distinguish genuinely stale RUNNING jobs from ones
         with active consumer processing.
+
+        Batches the consumer hasn't picked up yet have no status row at all, so
+        the status view must be LEFT JOINed and a missing status counts as
+        non-terminal. Status recency can't judge those batches either — a deep
+        queue backlog holds them unstarted for hours while the run is perfectly
+        healthy — so queued batches get a much longer grace period before the
+        run is considered stale.
         """
         STALE_THRESHOLD_SECONDS = 30 * 60  # 30 minutes
+        QUEUED_GRACE_SECONDS = 24 * 60 * 60  # 24 hours
 
         with conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 f"""
                 SELECT
+                    COUNT(*) AS batch_count,
                     COUNT(*) FILTER (
-                        WHERE s.job_state NOT IN ('succeeded', 'failed')
+                        WHERE s.batch_id IS NULL OR s.job_state NOT IN ('succeeded', 'failed')
                     ) AS non_terminal_count,
-                    MAX(s.created_at) AS latest_status_at
+                    MAX(s.created_at) AS latest_status_at,
+                    MAX(b.created_at) FILTER (WHERE s.batch_id IS NULL) AS latest_queued_at
                 FROM {BATCH_TABLE} b
-                JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
                 WHERE
                     b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                     AND b.job_id = %(job_id)s
@@ -650,15 +660,20 @@ class BatchQueue:
             )
             row = cur.fetchone()
 
-        if row is None or row["latest_status_at"] is None:
+        if row is None or row["batch_count"] == 0:
             return RunActivitySummary(has_batches=False, has_non_terminal=False, is_stale=True)
 
-        non_terminal_count: int = row["non_terminal_count"]
-        latest_status_at: datetime = row["latest_status_at"]
-        age_seconds = (datetime.now(latest_status_at.tzinfo) - latest_status_at).total_seconds()
+        def _age_seconds(ts: datetime) -> float:
+            return (datetime.now(ts.tzinfo) - ts).total_seconds()
+
+        latest_status_at: datetime | None = row["latest_status_at"]
+        latest_queued_at: datetime | None = row["latest_queued_at"]
+
+        consumer_active = latest_status_at is not None and _age_seconds(latest_status_at) <= STALE_THRESHOLD_SECONDS
+        queued_waiting = latest_queued_at is not None and _age_seconds(latest_queued_at) <= QUEUED_GRACE_SECONDS
 
         return RunActivitySummary(
             has_batches=True,
-            has_non_terminal=non_terminal_count > 0,
-            is_stale=age_seconds > STALE_THRESHOLD_SECONDS,
+            has_non_terminal=row["non_terminal_count"] > 0,
+            is_stale=not (consumer_active or queued_waiting),
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -637,8 +637,7 @@ def _summary(db_url: str, *, job_id: str = "job-1", workflow_run_id: str = "wf-1
 
 @pytest.mark.django_db(transaction=True)
 class TestGetRunActivitySummary:
-    @pytest.mark.asyncio
-    async def test_no_batches_reports_stale(self, conn, _db_url):
+    def test_no_batches_reports_stale(self, _db_url):
         assert _summary(_db_url) == RunActivitySummary(has_batches=False, has_non_terminal=False, is_stale=True)
 
     @pytest.mark.asyncio
@@ -658,18 +657,28 @@ class TestGetRunActivitySummary:
         assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=expected_stale)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("status_age,expected_stale", [("5 minutes", False), ("2 hours", True)])
-    async def test_started_batch_staleness_follows_latest_status(self, conn, _db_url, status_age, expected_stale):
+    @pytest.mark.parametrize("status_age_seconds,expected_stale", [(300, False), (7200, True)])
+    async def test_started_batch_staleness_follows_latest_status(
+        self, conn, _db_url, status_age_seconds, expected_stale
+    ):
         bid = await _insert_batch(conn, metadata={"workflow_run_id": "wf-1"})
-        await conn.execute(
-            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) "
-            f"VALUES (%s, 'executing', 1, now() - interval '{status_age}')",
-            [bid],
-        )
+        await _insert_backdated_executing(conn, batch_id=bid, age_seconds=status_age_seconds)
 
         summary = _summary(_db_url)
 
         assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=expected_stale)
+
+    @pytest.mark.asyncio
+    async def test_stalled_started_batch_not_masked_by_queued_sibling(self, conn, _db_url):
+        # Consumer died mid-run: batch 0 stuck executing past the stale threshold.
+        # The still-queued batch 1 must not shield the run from takeover.
+        stuck = await _insert_batch(conn, batch_index=0, metadata={"workflow_run_id": "wf-1"})
+        await _insert_backdated_executing(conn, batch_id=stuck, age_seconds=7200)
+        await _insert_batch(conn, batch_index=1, metadata={"workflow_run_id": "wf-1"})
+
+        summary = _summary(_db_url)
+
+        assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=True)
 
     @pytest.mark.asyncio
     async def test_mixed_processed_and_queued_batches_still_waiting(self, conn, _db_url):
@@ -688,11 +697,15 @@ class TestGetRunActivitySummary:
         assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=False)
 
     @pytest.mark.asyncio
-    async def test_all_terminal_batches_report_no_non_terminal(self, conn, _db_url):
+    @pytest.mark.parametrize("status_age,expected_stale", [("5 seconds", False), ("2 hours", True)])
+    async def test_all_terminal_batches_report_no_non_terminal(self, conn, _db_url, status_age, expected_stale):
         bid = await _insert_batch(conn, metadata={"workflow_run_id": "wf-1"})
-        await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+        await conn.execute(
+            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) "
+            f"VALUES (%s, 'succeeded', 1, now() - interval '{status_age}')",
+            [bid],
+        )
 
         summary = _summary(_db_url)
 
-        assert summary.has_batches is True
-        assert summary.has_non_terminal is False
+        assert summary == RunActivitySummary(has_batches=True, has_non_terminal=False, is_stale=expected_stale)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -12,6 +12,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     STATUS_VIEW,
     BatchQueue,
     PendingBatch,
+    RunActivitySummary,
 )
 
 # Distinct per-pod identities for the group-lease tests.
@@ -627,3 +628,71 @@ class TestPendingBatchToExportSignal:
         assert signal["data_folder"] == "/tmp/data"
         assert signal["primary_keys"] == ["id"]
         assert signal["cdc_write_mode"] == "upsert"
+
+
+def _summary(db_url: str, *, job_id: str = "job-1", workflow_run_id: str = "wf-1") -> RunActivitySummary:
+    with psycopg.Connection.connect(db_url, autocommit=True) as sync_conn:
+        return BatchQueue.get_run_activity_summary(sync_conn, job_id=job_id, workflow_run_id=workflow_run_id)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestGetRunActivitySummary:
+    @pytest.mark.asyncio
+    async def test_no_batches_reports_stale(self, conn, _db_url):
+        assert _summary(_db_url) == RunActivitySummary(has_batches=False, has_non_terminal=False, is_stale=True)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("batch_age,expected_stale", [("1 hour", False), ("25 hours", True)])
+    async def test_queued_batch_without_status_rows(self, conn, _db_url, batch_age, expected_stale):
+        # A batch the consumer hasn't picked up has no status row at all. It must
+        # still count as non-terminal activity, or the lock takeover falsely fails
+        # healthy jobs whenever the consumer backlog exceeds the sync interval.
+        bid = await _insert_batch(conn, metadata={"workflow_run_id": "wf-1"})
+        await conn.execute(
+            f"UPDATE {BATCH_TABLE} SET created_at = now() - interval '{batch_age}' WHERE id = %s",
+            [bid],
+        )
+
+        summary = _summary(_db_url)
+
+        assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=expected_stale)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_age,expected_stale", [("5 minutes", False), ("2 hours", True)])
+    async def test_started_batch_staleness_follows_latest_status(self, conn, _db_url, status_age, expected_stale):
+        bid = await _insert_batch(conn, metadata={"workflow_run_id": "wf-1"})
+        await conn.execute(
+            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) "
+            f"VALUES (%s, 'executing', 1, now() - interval '{status_age}')",
+            [bid],
+        )
+
+        summary = _summary(_db_url)
+
+        assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=expected_stale)
+
+    @pytest.mark.asyncio
+    async def test_mixed_processed_and_queued_batches_still_waiting(self, conn, _db_url):
+        # Batch 0 finished over the stale threshold ago, batch 1 is still queued:
+        # the run is waiting on the consumer, not abandoned.
+        done = await _insert_batch(conn, batch_index=0, metadata={"workflow_run_id": "wf-1"})
+        await conn.execute(
+            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) "
+            f"VALUES (%s, 'succeeded', 1, now() - interval '2 hours')",
+            [done],
+        )
+        await _insert_batch(conn, batch_index=1, metadata={"workflow_run_id": "wf-1"})
+
+        summary = _summary(_db_url)
+
+        assert summary == RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=False)
+
+    @pytest.mark.asyncio
+    async def test_all_terminal_batches_report_no_non_terminal(self, conn, _db_url):
+        bid = await _insert_batch(conn, metadata={"workflow_run_id": "wf-1"})
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+
+        summary = _summary(_db_url)
+
+        assert summary.has_batches is True
+        assert summary.has_non_terminal is False


### PR DESCRIPTION
## Problem

When the v3 batch consumer runs behind, a sync's batches can sit in the queue unstarted for longer than the schema's sync interval. The next scheduled run's lock takeover check (`get_run_activity_summary`) inner-joins the batch table to the status view, but status rows only exist once the consumer picks a batch up. Queued-but-unstarted batches are therefore invisible to it, so the takeover concludes "no batches, stale", marks the healthy RUNNING job as failed, and starts a duplicate run.

This repeats every cycle while the backlog lasts: failure digests fire, the schema shows `latest_error: "Lock takeover: workflow terminated but job was stuck in RUNNING"`, and each duplicate extract piles more work onto the already-deep queue. Observed in production on an hourly source: a run wrote its first batch, and one hour later the takeover for that same job logged `has_batches: false` and failed it.

## Changes

- LEFT JOIN the status view. The claim query already treats `s.batch_id IS NULL` as pending work, this makes the summary query consistent with it.
- Count status-less batches as non-terminal.
- Never-started batches get a 24h grace period before the run counts as stale. Started batches keep the existing 30 minute rule on the latest status row.

Staleness now means "processing started and then stopped". Dead-consumer recovery still works through the 24h cap, and ultimately the 7 day Redis lock TTL.

Follow-ups deliberately not in this PR: the summary query can hang under queue pressure (the `metadata->>'workflow_run_id'` filter has no index to help it), and there's a small residual race when a job has finished its last batch but hasn't been marked completed yet.

## How did you test this code?

Added `TestGetRunActivitySummary` to the real-Postgres queue harness in `test_jobs_db.py`. The existing takeover tests mock this function entirely, so its SQL had no coverage. Each case catches a regression nothing caught before:

- queued batch with no status row reports non-terminal and not stale (the production bug)
- queued batch older than the 24h grace reports stale (keeps dead-consumer recovery working)
- started batch staleness follows the latest status row age, both sides of the threshold
- mixed run (batch 0 finished long ago, batch 1 still queued) is not stale
- all-terminal and no-batches cases keep their existing semantics

Ran the full `test_jobs_db.py` and `test_acquire_v3_lock.py` suites locally: 55 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal pipeline behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused and written with Claude Code. The investigation traced a stale source through Loki: extracts and loads were healthy, but every takeover logged `has_batches: false` for jobs whose batches were verifiably written an hour earlier. The inner join was the only consistent explanation, confirmed against the enqueue path (batch insert writes no initial status row). `/writing-tests` was invoked for the test additions. One design alternative was considered and rejected: folding enqueue time into the existing 30 minute activity threshold would re-trigger the false failure whenever consumer lag exceeds 30 minutes, so never-started batches got their own, much longer grace period instead.
