### PR TITLE
fix(mcp): degrade project-get gracefully and classify silent errors

### DIFF
--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -457,6 +457,7 @@ tools:
         title: Get project
         description: |
             Retrieve a project and its settings. Omit the ID to get the caller's active project.
+            Don't guess the ID — if you only know the project by name, call `projects-get` first to list accessible projects (each with its `id` and `name`) and match by name.
         param_overrides:
             id:
                 description: Project ID. If omitted, returns the caller's active project.

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -455,9 +455,11 @@ tools:
             destructive: false
             idempotent: true
         title: Get project
-        description: |
+        description: >
             Retrieve a project and its settings. Omit the ID to get the caller's active project.
-            Don't guess the ID — if you only know the project by name, call `projects-get` first to list accessible projects (each with its `id` and `name`) and match by name.
+
+            Don't guess the ID — if you only know the project by name, call `projects-get` first to list accessible
+            projects (each with its `id` and `name`) and match by name.
         param_overrides:
             id:
                 description: Project ID. If omitted, returns the caller's active project.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5869,7 +5869,7 @@
         }
     },
     "project-get": {
-        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
+        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.\nDon't guess the ID — if you only know the project by name, call `projects-get` first to list accessible projects (each with its `id` and `name`) and match by name.",
         "category": "Core",
         "feature": "core",
         "summary": "Get project",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6320,7 +6320,7 @@
         }
     },
     "project-get": {
-        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
+        "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.\nDon't guess the ID — if you only know the project by name, call `projects-get` first to list accessible projects (each with its `id` and `name`) and match by name.",
         "category": "Core",
         "feature": "core",
         "summary": "Get project",
@@ -6348,10 +6348,10 @@
         }
     },
     "projects-get": {
-        "description": "Fetches projects that the user has access to in the current organization.",
+        "description": "Fetches projects that the user has access to in the current organization, each with its `id` and `name`. Use this to resolve a project by name — never guess a project id and pass it to `project-get`.",
         "category": "Organization & project management",
         "feature": "workspace",
-        "summary": "Fetches projects that the user has access to in the current organization.",
+        "summary": "Fetches projects that the user has access to in the current organization, each with its id and name.",
         "title": "Get projects",
         "required_scopes": ["organization:read"],
         "annotations": {

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -367,10 +367,10 @@
         }
     },
     "projects-get": {
-        "description": "Fetches projects that the user has access to in the current organization.",
+        "description": "Fetches projects that the user has access to in the current organization, each with its `id` and `name`. Use this to resolve a project by name — never guess a project id and pass it to `project-get`.",
         "category": "Organization & project management",
         "feature": "workspace",
-        "summary": "Fetches projects that the user has access to in the current organization.",
+        "summary": "Fetches projects that the user has access to in the current organization, each with its id and name.",
         "title": "Get projects",
         "required_scopes": ["organization:read"],
         "annotations": {

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -433,6 +433,7 @@ type ToolErrorType =
     | 'timeout'
     | 'rate_limited'
     | 'api_5xx'
+    | 'not_found'
     | 'api_4xx'
     | 'internal'
 
@@ -478,6 +479,12 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
     }
     if (apiError instanceof PostHogApiError && apiError.status >= 500) {
         return { errorType: 'api_5xx', status: apiError.status }
+    }
+    // Split 404 out of the generic 4xx bucket: for read/get tools it's usually a
+    // guessed id that misses, and keeping it distinct lets the dashboard see that
+    // "not found" churn separately from genuine bad-input errors.
+    if (apiError instanceof PostHogApiError && apiError.status === 404) {
+        return { errorType: 'not_found', status: apiError.status }
     }
     if (apiError instanceof PostHogApiError) {
         return { errorType: 'api_4xx', status: apiError.status }

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -439,11 +439,19 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
             recoverableApiError instanceof PostHogValidationError ||
             (recoverableApiError.status >= 400 && recoverableApiError.status < 500)
         if (isFourXx) {
+            // Most 4xx already carry an actionable detail, but a few (e.g. a 404
+            // for a guessed project id) leave the agent with no next step, so it
+            // retries the same shape of failing call. Append a targeted hint when
+            // one applies. Only PostHogApiError carries url/status to match on.
+            const recoveryHint =
+                recoverableApiError instanceof PostHogApiError
+                    ? getToolRecoveryHint({ url: recoverableApiError.url, status: recoverableApiError.status })
+                    : undefined
             return {
                 content: [
                     {
                         type: 'text',
-                        text: `Error: [${toolName}]: ${recoverableApiError.message}`,
+                        text: `Error: [${toolName}]: ${recoverableApiError.message}${recoveryHint ? `\n\n${recoveryHint}` : ''}`,
                     },
                 ],
                 isError: true,

--- a/services/mcp/src/lib/tool-error-hints.ts
+++ b/services/mcp/src/lib/tool-error-hints.ts
@@ -39,6 +39,31 @@ const LOGS_QUERY_URL_FRAGMENTS = [
     '/logs/sparkline/',
 ]
 
+/**
+ * A 404 from `project-get`/`project-settings-update` means the id doesn't exist
+ * in this org (or isn't accessible). Because there's no name-based project
+ * lookup, agents respond by guessing another id — each miss is another hard 404,
+ * which is the bulk of `project-get`'s error rate. Point them at `projects-get`
+ * (which returns every accessible project's `id` and `name`) so they resolve the
+ * project by name in one call instead of brute-forcing numbers.
+ */
+const PROJECT_NOT_FOUND_RECOVERY_HINT = [
+    "No project with that id exists in this organization, or you don't have access to it. Don't guess project ids by trying other numbers.",
+    '',
+    'To find the right project:',
+    '1. Call `projects-get` to list every project you can access — each result carries its `id` and `name`.',
+    '2. Match the one you want by `name`, then retry with that `id` (or call `switch-project { projectId: <id> }` to make it active).',
+].join('\n')
+
+/**
+ * Matches the project retrieve/update endpoint
+ * (`/api/organizations/<org>/projects/<id>/`). Deliberately anchored to the
+ * `organizations/.../projects/<id>` shape so it doesn't fire on the far more
+ * common `/api/projects/<id>/<sub-resource>/` URLs, whose 404s mean the
+ * sub-resource is missing, not the project.
+ */
+const PROJECT_RETRIEVE_URL_PATTERN = /\/organizations\/[^/]+\/projects\/[^/]+\/?$/
+
 interface RecoveryHintInput {
     /** The failed request URL (from `PostHogApiError.url`), if the error was an HTTP failure. */
     url?: string | undefined
@@ -50,12 +75,19 @@ interface RecoveryHintInput {
  * Returns an actionable recovery hint for a failed tool call, or `undefined`
  * when none applies.
  *
- * Only fires for server-side failures (5xx) or non-HTTP errors with no status —
- * 4xx responses already carry an actionable validation detail and must not be
- * buried under a generic hint.
+ * Most 4xx responses already carry an actionable validation detail and must not
+ * be buried under a generic hint, so hints default to server-side failures (5xx)
+ * and non-HTTP errors with no status. The one exception is a 404 on the project
+ * retrieve endpoint: a bare "not found" gives the agent nothing to route on, so
+ * it keeps guessing ids — that case gets a targeted name-lookup hint.
  */
 export function getToolRecoveryHint({ url, status }: RecoveryHintInput): string | undefined {
-    // 4xx is recoverable agent input, already surfaced verbatim upstream.
+    // Targeted 404: a missing project id, where the recovery is a name lookup
+    // rather than the "narrow and retry" shape the generic 4xx guard assumes.
+    if (status === 404 && url && PROJECT_RETRIEVE_URL_PATTERN.test(url)) {
+        return PROJECT_NOT_FOUND_RECOVERY_HINT
+    }
+    // Other 4xx is recoverable agent input, already surfaced verbatim upstream.
     if (status !== undefined && status < 500) {
         return undefined
     }

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -41,7 +41,7 @@ import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
-import { PostHogRateLimitError, wrapError } from '@/lib/errors'
+import { PostHogApiError, PostHogRateLimitError, wrapError } from '@/lib/errors'
 
 const mockTrackToolCall = vi.mocked(trackToolCall)
 
@@ -222,6 +222,28 @@ describe('ToolExecutor metrics', () => {
             await executor.handleToolCall({ name: 'execute-sql', arguments: {} }, makeState([{ name: 'execute-sql' }]))
 
             expect(mockToolErrorsInc).toHaveBeenCalledWith({ tool: 'execute-sql', error_type: 'rate_limited' })
+        })
+
+        it('classifies a 404 as not_found, split out from the generic api_4xx bucket', async () => {
+            vi.spyOn(catalog, 'getToolByName').mockReturnValue(
+                makeFakeTool('project-get', async () => {
+                    throw new PostHogApiError({
+                        status: 404,
+                        statusText: 'Not Found',
+                        body: '{"detail":"Not found."}',
+                        url: 'https://us.posthog.com/api/organizations/abc/projects/999999/',
+                        method: 'GET',
+                    })
+                }) as any
+            )
+
+            await executor.handleToolCall({ name: 'project-get', arguments: {} }, makeState([{ name: 'project-get' }]))
+
+            expect(mockToolErrorsInc).toHaveBeenCalledWith({ tool: 'project-get', error_type: 'not_found' })
+            expect(trackToolCallExtras('project-get')).toMatchObject({
+                $mcp_error_type: 'not_found',
+                $mcp_error_status: 404,
+            })
         })
 
         it('records validation_error without starting a timer', async () => {

--- a/services/mcp/tests/unit/tool-error-hints.test.ts
+++ b/services/mcp/tests/unit/tool-error-hints.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/posthog', () => ({
 }))
 
 const LOGS_QUERY_URL = 'https://us.posthog.com/api/projects/2/logs/query/'
+const PROJECT_RETRIEVE_URL = 'https://us.posthog.com/api/organizations/abc-123/projects/999999/'
 
 describe('getToolRecoveryHint', () => {
     it('returns the narrow-and-retry hint for a 5xx on a logs query endpoint', () => {
@@ -41,6 +42,28 @@ describe('getToolRecoveryHint', () => {
 
     it('fires when status is unknown but the URL is a logs query endpoint', () => {
         expect(getToolRecoveryHint({ url: LOGS_QUERY_URL })).not.toBeUndefined()
+    })
+
+    it('returns the name-lookup hint for a 404 on the project retrieve endpoint', () => {
+        const hint = getToolRecoveryHint({ url: PROJECT_RETRIEVE_URL, status: 404 })
+
+        expect(hint).not.toBeUndefined()
+        expect(hint).toContain('projects-get')
+        expect(hint).toContain("Don't guess project ids")
+    })
+
+    it.each([
+        // A project sub-resource 404 means the sub-resource is missing, not the
+        // project — the name-lookup hint would be misleading noise there.
+        'https://us.posthog.com/api/projects/2/insights/999/',
+        // A 5xx on the project endpoint is a server bug, not a missing id.
+    ])('does not fire the name-lookup hint for %s', (url: string) => {
+        expect(getToolRecoveryHint({ url, status: 404 })).toBeUndefined()
+    })
+
+    it('does not fire the name-lookup hint for a 5xx on the project retrieve endpoint', () => {
+        // Falls through to the logs check, which this URL doesn't match either.
+        expect(getToolRecoveryHint({ url: PROJECT_RETRIEVE_URL, status: 500 })).toBeUndefined()
     })
 })
 
@@ -76,6 +99,23 @@ describe('handleToolError recovery hints', () => {
         const [content] = result.content as Array<{ type: string; text: string }>
 
         expect(content?.text).toContain('logs-count-ranges')
+    })
+
+    it('appends the name-lookup hint to a 404 from project-get so the agent stops guessing ids', () => {
+        const error = new PostHogApiError({
+            status: 404,
+            statusText: 'Not Found',
+            body: '{"detail":"Not found."}',
+            url: PROJECT_RETRIEVE_URL,
+            method: 'GET',
+        })
+
+        const result = handleToolError(error, 'project-get')
+        const [content] = result.content as Array<{ type: string; text: string }>
+
+        expect(content?.text).toContain('[project-get]')
+        expect(content?.text).toContain('Status Code: 404')
+        expect(content?.text).toContain('projects-get')
     })
 
     it('does not append a hint for a 4xx (no noise on recoverable input errors)', () => {

--- a/services/mcp/tests/unit/tool-error-hints.test.ts
+++ b/services/mcp/tests/unit/tool-error-hints.test.ts
@@ -52,13 +52,12 @@ describe('getToolRecoveryHint', () => {
         expect(hint).toContain("Don't guess project ids")
     })
 
-    it.each([
-        // A project sub-resource 404 means the sub-resource is missing, not the
-        // project — the name-lookup hint would be misleading noise there.
-        'https://us.posthog.com/api/projects/2/insights/999/',
-        // A 5xx on the project endpoint is a server bug, not a missing id.
-    ])('does not fire the name-lookup hint for %s', (url: string) => {
-        expect(getToolRecoveryHint({ url, status: 404 })).toBeUndefined()
+    it('does not fire the name-lookup hint for a 404 on a project sub-resource', () => {
+        // A sub-resource 404 means the sub-resource is missing, not the project —
+        // the name-lookup hint would be misleading noise there.
+        expect(
+            getToolRecoveryHint({ url: 'https://us.posthog.com/api/projects/2/insights/999/', status: 404 })
+        ).toBeUndefined()
     })
 
     it('does not fire the name-lookup hint for a 5xx on the project retrieve endpoint', () => {


### PR DESCRIPTION
## Problem

Agents hit a high error rate on the MCP `project-get` tool. The root cause: there's no way to find a project by name, so agents guess numeric ids. Every miss returns a bare 404 with no next step, so the agent just tries another number, and those misses pile up as the bulk of the tool's error rate. This was surfaced by a Signals scout report.

## Changes

- **Graceful degradation:** a 404 from the project retrieve endpoint now gets a targeted recovery hint that points the agent at `projects-get` (which lists every accessible project with its `id` and `name`) so it resolves the project by name in one call instead of brute-forcing ids. The hint is anchored to the `/organizations/<org>/projects/<id>/` URL shape so it does not fire on the far more common `/api/projects/<id>/<sub-resource>/` 404s, where a miss means the sub-resource is gone, not the project.
- **Classify silent errors:** 404s are now bucketed as a distinct `not_found` error type instead of being lumped into the generic `api_4xx` bucket, so the dashboard can see the "not found" churn separately from genuine bad-input errors.
- **Discoverability:** the `project-get` and `projects-get` tool descriptions now steer agents to the name-lookup path.

## How did you test this code?

Added automated tests (all run locally, green):

- `tests/unit/tool-error-hints.test.ts` — the name-lookup hint fires for a 404 on the project retrieve endpoint, does not fire for a 404 on a project sub-resource, does not fire for a 5xx there, and `handleToolError` appends it to a project-get 404. Catches a regression where the hint stops firing or fires too broadly.
- `tests/hono/tool-executor-metrics.test.ts` — a 404 classifies as `not_found` (not `api_4xx`) and stamps `$mcp_error_type` / `$mcp_error_status` on the analytics event. Catches a regression that folds 404 back into the generic bucket.

I (Claude, via the PostHog Slack app) could not exercise this against a live MCP client; verification is the automated tests plus typecheck and lint on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @skoob13 from a Slack thread on a Signals scout inbox item, asking to implement the report's suggestions. Authored by Claude via the PostHog Slack app.

Invoked the `/implementing-mcp-tools` skill (MCP tool/definition change) and the `/writing-tests` skill (before adding tests). Key decisions:

- The generated `project-get` handler is codegen output, so the graceful-degradation logic lives in the shared error-handling layer (`tool-error-hints.ts` + `handleToolError`) rather than the handler. This also covers `project-settings-update`, which 404s the same way.
- Deliberately broadened `getToolRecoveryHint` to fire on one specific 404 (project retrieve) while keeping the "no hints on generic 4xx" default, since a bare project-not-found gives the agent nothing to route on.
- Regenerated `generated-tool-definitions.json` by hand-mirroring the YAML description edit (the full `hogli build:openapi-schema` needs a running Django backend that wasn't available); the generator only trims and copies the description string, so the result is byte-identical to what codegen would produce.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782948155084049?thread_ts=1782948155.084049&cid=C0B89UWRJDP)*
