### PR TITLE
feat(mcp): add projects-find to resolve projects by name across orgs

### DIFF
--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6348,7 +6348,7 @@
         }
     },
     "projects-find": {
-        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Each result includes the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. Use this to resolve a project the user names when you don't already know its id.",
+        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Returns `projects`, each with the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. If any organization could not be searched, it is listed under `incomplete_organizations` so you can tell an empty result apart from an incomplete search. Use this to resolve a project the user names when you don't already know its id.",
         "category": "Organization & project management",
         "feature": "workspace",
         "summary": "Find projects by name across all your organizations.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6347,6 +6347,20 @@
             "readOnlyHint": false
         }
     },
+    "projects-find": {
+        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Each result includes the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. Use this to resolve a project the user names when you don't already know its id.",
+        "category": "Organization & project management",
+        "feature": "workspace",
+        "summary": "Find projects by name across all your organizations.",
+        "title": "Find projects",
+        "required_scopes": ["organization:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "projects-get": {
         "description": "Fetches projects that the user has access to in the current organization.",
         "category": "Organization & project management",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -381,7 +381,7 @@
         }
     },
     "projects-find": {
-        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Each result includes the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. Use this to resolve a project the user names when you don't already know its id.",
+        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Returns `projects`, each with the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. If any organization could not be searched, it is listed under `incomplete_organizations` so you can tell an empty result apart from an incomplete search. Use this to resolve a project the user names when you don't already know its id.",
         "category": "Organization & project management",
         "feature": "workspace",
         "summary": "Find projects by name across all your organizations.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -380,6 +380,20 @@
             "readOnlyHint": true
         }
     },
+    "projects-find": {
+        "description": "Find projects by name across ALL organizations you can access, not just the active one. Pass `name` for a case-insensitive substring match, or omit it to list every project. Each result includes the project `id` plus its `organization` id and name, so you can `switch-project` (and `switch-organization` if it lives in a different org) instead of guessing or enumerating project ids. Use this to resolve a project the user names when you don't already know its id.",
+        "category": "Organization & project management",
+        "feature": "workspace",
+        "summary": "Find projects by name across all your organizations.",
+        "title": "Find projects",
+        "required_scopes": ["organization:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "event-definition-update": {
         "description": "Update event definition metadata. Can update description, tags, mark status as verified or hidden. Use exact event name like '$pageview' or 'user_signed_up'.",
         "category": "Events & properties",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -533,6 +533,15 @@
             },
             "required": ["projectId"]
         },
+        "ProjectsFindSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Case-insensitive substring matched against project names. Omit to list every project across all your organizations.",
+                    "type": "string"
+                }
+            }
+        },
         "PromptListInputSchema": {
             "type": "object",
             "properties": {

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -318,6 +318,15 @@ export const OrganizationSetActiveSchema = z.object({
 
 export const ProjectGetAllSchema = z.object({})
 
+export const ProjectsFindSchema = z.object({
+    name: z
+        .string()
+        .optional()
+        .describe(
+            'Case-insensitive substring matched against project names. Omit to list every project across all your organizations.'
+        ),
+})
+
 export const EventDefinitionUpdateInputSchema = z.object({
     description: z.string().optional().describe('Description explaining when the event is triggered'),
     tags: z

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -32,6 +32,7 @@ import {
     readDataWarehouseSchema,
 } from './posthogAiTools'
 // Projects
+import findProjects from './projects/findProjects'
 import getProjects from './projects/getProjects'
 import setActiveProject from './projects/setActive'
 import updateEventDefinition from './projects/updateEventDefinition'
@@ -60,6 +61,7 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Projects
     'projects-get': getProjects,
+    'projects-find': findProjects,
     'switch-project': setActiveProject,
     'event-definition-update': updateEventDefinition,
 

--- a/services/mcp/src/tools/projects/findProjects.ts
+++ b/services/mcp/src/tools/projects/findProjects.ts
@@ -13,7 +13,22 @@ interface FoundProject {
     organization_name: string
 }
 
-export const findProjectsHandler: ToolBase<typeof schema, FoundProject[]>['handler'] = async (
+interface IncompleteOrganization {
+    id: string
+    name: string
+    error: string
+}
+
+interface ProjectsFindResult {
+    projects: FoundProject[]
+    // Present only when one or more organizations could not be searched. Lets the
+    // caller tell "no such project" apart from "the search was incomplete" (a
+    // permission gap or a transient error), rather than reading a partial result
+    // as authoritative.
+    incomplete_organizations?: IncompleteOrganization[]
+}
+
+export const findProjectsHandler: ToolBase<typeof schema, ProjectsFindResult>['handler'] = async (
     context: Context,
     params: z.infer<typeof schema>
 ) => {
@@ -25,32 +40,46 @@ export const findProjectsHandler: ToolBase<typeof schema, FoundProject[]>['handl
     const needle = params.name?.trim().toLowerCase()
 
     const perOrg = await Promise.all(
-        orgsResult.data.map(async (org: Schemas.OrganizationBasic) => {
-            const projectsResult = await context.api.organizations().projects({ orgId: org.id }).list()
-            // Skip orgs we can't enumerate rather than failing the whole search — the
-            // caller still gets matches from the orgs they can access.
-            if (!projectsResult.success) {
-                return [] as FoundProject[]
+        orgsResult.data.map(
+            async (
+                org: Schemas.OrganizationBasic
+            ): Promise<{ projects: FoundProject[]; incomplete?: IncompleteOrganization }> => {
+                const projectsResult = await context.api.organizations().projects({ orgId: org.id }).list()
+                // Don't fail the whole search when one org can't be read — return its
+                // matches empty and record it so the caller knows the result is partial.
+                if (!projectsResult.success) {
+                    return {
+                        projects: [],
+                        incomplete: { id: org.id, name: org.name, error: projectsResult.error.message },
+                    }
+                }
+                const projects = projectsResult.data
+                    .filter(
+                        (project: Schemas.ProjectBackwardCompat) =>
+                            !needle || project.name?.toLowerCase().includes(needle)
+                    )
+                    .map(
+                        (project: Schemas.ProjectBackwardCompat): FoundProject => ({
+                            id: project.id,
+                            name: project.name,
+                            organization: org.id,
+                            organization_name: org.name,
+                        })
+                    )
+                return { projects }
             }
-            return projectsResult.data
-                .filter(
-                    (project: Schemas.ProjectBackwardCompat) => !needle || project.name?.toLowerCase().includes(needle)
-                )
-                .map(
-                    (project: Schemas.ProjectBackwardCompat): FoundProject => ({
-                        id: project.id,
-                        name: project.name,
-                        organization: org.id,
-                        organization_name: org.name,
-                    })
-                )
-        })
+        )
     )
 
-    return perOrg.flat()
+    const projects = perOrg.flatMap((result) => result.projects)
+    const incompleteOrganizations = perOrg.flatMap((result) => (result.incomplete ? [result.incomplete] : []))
+
+    return incompleteOrganizations.length > 0
+        ? { projects, incomplete_organizations: incompleteOrganizations }
+        : { projects }
 }
 
-const tool = (): ToolBase<typeof schema, FoundProject[]> => ({
+const tool = (): ToolBase<typeof schema, ProjectsFindResult> => ({
     name: 'projects-find',
     schema,
     handler: findProjectsHandler,

--- a/services/mcp/src/tools/projects/findProjects.ts
+++ b/services/mcp/src/tools/projects/findProjects.ts
@@ -1,0 +1,59 @@
+import type { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import { ProjectsFindSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ProjectsFindSchema
+
+interface FoundProject {
+    id: number
+    name: string | undefined
+    organization: string
+    organization_name: string
+}
+
+export const findProjectsHandler: ToolBase<typeof schema, FoundProject[]>['handler'] = async (
+    context: Context,
+    params: z.infer<typeof schema>
+) => {
+    const orgsResult = await context.api.organizations().list()
+    if (!orgsResult.success) {
+        throw new Error(`Failed to list organizations: ${orgsResult.error.message}`)
+    }
+
+    const needle = params.name?.trim().toLowerCase()
+
+    const perOrg = await Promise.all(
+        orgsResult.data.map(async (org: Schemas.OrganizationBasic) => {
+            const projectsResult = await context.api.organizations().projects({ orgId: org.id }).list()
+            // Skip orgs we can't enumerate rather than failing the whole search — the
+            // caller still gets matches from the orgs they can access.
+            if (!projectsResult.success) {
+                return [] as FoundProject[]
+            }
+            return projectsResult.data
+                .filter(
+                    (project: Schemas.ProjectBackwardCompat) => !needle || project.name?.toLowerCase().includes(needle)
+                )
+                .map(
+                    (project: Schemas.ProjectBackwardCompat): FoundProject => ({
+                        id: project.id,
+                        name: project.name,
+                        organization: org.id,
+                        organization_name: org.name,
+                    })
+                )
+        })
+    )
+
+    return perOrg.flat()
+}
+
+const tool = (): ToolBase<typeof schema, FoundProject[]> => ({
+    name: 'projects-find',
+    schema,
+    handler: findProjectsHandler,
+})
+
+export default tool

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/projects-find.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/projects-find.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "name": {
+            "description": "Case-insensitive substring matched against project names. Omit to list every project across all your organizations.",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/find-projects-handler.test.ts
+++ b/services/mcp/tests/unit/find-projects-handler.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { findProjectsHandler } from '@/tools/projects/findProjects'
+import type { Context } from '@/tools/types'
+
+function createContext(orgs: { list: () => Promise<any>; projectsByOrg: Record<string, () => Promise<any>> }): Context {
+    return {
+        api: {
+            organizations: () => ({
+                list: orgs.list,
+                projects: ({ orgId }: { orgId: string }) => ({
+                    list: orgs.projectsByOrg[orgId] ?? (async () => ({ success: true, data: [] })),
+                }),
+            }),
+        } as any,
+        stateManager: {} as any,
+        env: {} as any,
+        sessionManager: {} as any,
+        cache: {} as any,
+        getDistinctId: async () => 'test-distinct-id',
+        trackEvent: async () => {},
+    }
+}
+
+const ok = (data: unknown) => async () => ({ success: true, data })
+const fail = (message: string) => async () => ({ success: false, error: { message } })
+
+describe('projects-find handler', () => {
+    it('aggregates matching projects across every organization', async () => {
+        const context = createContext({
+            list: ok([
+                { id: 'org-a', name: 'Org A' },
+                { id: 'org-b', name: 'Org B' },
+            ]),
+            projectsByOrg: {
+                'org-a': ok([{ id: 1, name: 'Marketing site' }]),
+                'org-b': ok([{ id: 2, name: 'Marketing app' }]),
+            },
+        })
+
+        const result = await findProjectsHandler(context, { name: 'marketing' })
+
+        expect(result).toEqual([
+            { id: 1, name: 'Marketing site', organization: 'org-a', organization_name: 'Org A' },
+            { id: 2, name: 'Marketing app', organization: 'org-b', organization_name: 'Org B' },
+        ])
+    })
+
+    it('matches the name filter case-insensitively and drops non-matches', async () => {
+        const context = createContext({
+            list: ok([{ id: 'org-a', name: 'Org A' }]),
+            projectsByOrg: {
+                'org-a': ok([
+                    { id: 1, name: 'Checkout' },
+                    { id: 2, name: 'Billing' },
+                ]),
+            },
+        })
+
+        const result = await findProjectsHandler(context, { name: 'CHECK' })
+
+        expect(result).toEqual([{ id: 1, name: 'Checkout', organization: 'org-a', organization_name: 'Org A' }])
+    })
+
+    it('returns every project when no name filter is given', async () => {
+        const context = createContext({
+            list: ok([{ id: 'org-a', name: 'Org A' }]),
+            projectsByOrg: {
+                'org-a': ok([
+                    { id: 1, name: 'Checkout' },
+                    { id: 2, name: 'Billing' },
+                ]),
+            },
+        })
+
+        const result = await findProjectsHandler(context, {})
+
+        expect(result.map((p) => p.id)).toEqual([1, 2])
+    })
+
+    it('skips organizations whose project list fails instead of failing the whole search', async () => {
+        const context = createContext({
+            list: ok([
+                { id: 'org-a', name: 'Org A' },
+                { id: 'org-b', name: 'Org B' },
+            ]),
+            projectsByOrg: {
+                'org-a': fail('403 forbidden'),
+                'org-b': ok([{ id: 2, name: 'Billing' }]),
+            },
+        })
+
+        const result = await findProjectsHandler(context, {})
+
+        expect(result).toEqual([{ id: 2, name: 'Billing', organization: 'org-b', organization_name: 'Org B' }])
+    })
+
+    it('throws when the organization list itself fails', async () => {
+        const context = createContext({ list: fail('500 server error'), projectsByOrg: {} })
+
+        await expect(findProjectsHandler(context, {})).rejects.toThrow('Failed to list organizations: 500 server error')
+    })
+})

--- a/services/mcp/tests/unit/find-projects-handler.test.ts
+++ b/services/mcp/tests/unit/find-projects-handler.test.ts
@@ -40,10 +40,12 @@ describe('projects-find handler', () => {
 
         const result = await findProjectsHandler(context, { name: 'marketing' })
 
-        expect(result).toEqual([
+        expect(result.projects).toEqual([
             { id: 1, name: 'Marketing site', organization: 'org-a', organization_name: 'Org A' },
             { id: 2, name: 'Marketing app', organization: 'org-b', organization_name: 'Org B' },
         ])
+        // No org failed, so the caller sees no incompleteness signal.
+        expect(result.incomplete_organizations).toBeUndefined()
     })
 
     it('matches the name filter case-insensitively and drops non-matches', async () => {
@@ -59,7 +61,9 @@ describe('projects-find handler', () => {
 
         const result = await findProjectsHandler(context, { name: 'CHECK' })
 
-        expect(result).toEqual([{ id: 1, name: 'Checkout', organization: 'org-a', organization_name: 'Org A' }])
+        expect(result.projects).toEqual([
+            { id: 1, name: 'Checkout', organization: 'org-a', organization_name: 'Org A' },
+        ])
     })
 
     it('returns every project when no name filter is given', async () => {
@@ -75,24 +79,29 @@ describe('projects-find handler', () => {
 
         const result = await findProjectsHandler(context, {})
 
-        expect(result.map((p) => p.id)).toEqual([1, 2])
+        expect(result.projects.map((p) => p.id)).toEqual([1, 2])
     })
 
-    it('skips organizations whose project list fails instead of failing the whole search', async () => {
+    it('reports organizations it could not search instead of silently dropping them', async () => {
         const context = createContext({
             list: ok([
                 { id: 'org-a', name: 'Org A' },
                 { id: 'org-b', name: 'Org B' },
             ]),
             projectsByOrg: {
-                'org-a': fail('403 forbidden'),
+                'org-a': fail('503 service unavailable'),
                 'org-b': ok([{ id: 2, name: 'Billing' }]),
             },
         })
 
         const result = await findProjectsHandler(context, {})
 
-        expect(result).toEqual([{ id: 2, name: 'Billing', organization: 'org-b', organization_name: 'Org B' }])
+        expect(result.projects).toEqual([{ id: 2, name: 'Billing', organization: 'org-b', organization_name: 'Org B' }])
+        // The unreadable org surfaces so the caller can tell a partial search apart
+        // from a genuine "no match".
+        expect(result.incomplete_organizations).toEqual([
+            { id: 'org-a', name: 'Org A', error: '503 service unavailable' },
+        ])
     })
 
     it('throws when the organization list itself fails', async () => {


### PR DESCRIPTION
## Problem

Agents brute-force `project-get` with guessed ids because there's no good way to go from a project name to its id. `projects-get` only ever lists the *active* organization, so when the project the user means lives in a sibling org, the agent has to notice the miss, call `organizations-list`, `switch-organization`, then retry `projects-get` — and often just enumerates ids instead. This is a big chunk of the `project-get` failure rate flagged in [this inbox report](https://us.posthog.com/project/2/inbox/019f1fd6-0e0f-76a7-b264-b7dda72d556e).

The existing PR [#67560](https://github.com/PostHog/posthog/pull/67560) handles the other suggestions from that report (graceful degradation of `project-get` and classifying silent tool-result errors) plus a within-current-org name filter. This PR adds the piece that's genuinely missing: cross-organization name resolution.

## Changes

- New read-only `projects-find` tool. Pass `name` for a case-insensitive substring match, or omit it to list everything. It searches across *all* organizations the caller can access, so an agent resolves a named project in one call instead of walking orgs by hand.
- Each result carries the project `id` plus its `organization` id and name, so the agent knows whether it also needs to `switch-organization` before `switch-project`.
- Organizations whose project list can't be read are skipped rather than failing the whole search — the caller still gets matches from the orgs they can see. A failure to list organizations at all still propagates.

It's a distinct tool from `projects-get` on purpose: `projects-get` stays a plain "projects in the current org" list, and `projects-find` is the cross-org name resolver.

## How did you test this code?

Automated tests I (Claude, via the PostHog Slack app) ran locally, all passing:

- `tests/unit/find-projects-handler.test.ts` (new): cross-org aggregation, case-insensitive substring match with non-matches dropped, no-filter lists everything, an org whose project list errors is skipped (not fatal), and a failed org-list propagates. No existing test covered a cross-org project lookup.
- `tests/unit/tool-schema-snapshots.test.ts`: regenerated to add the `projects-find` schema snapshot.
- Re-ran the full `tests/unit` suite (1986 passing) plus `tool-filtering` and `generate-tools` to confirm the new tool registers cleanly.
- Regenerated `schema/tool-inputs.json` (via `generate-tool-schema`) and hand-added the `projects-find` entry to `schema/tool-definitions-all.json` to match what the merge produces — the `generate-tools` codegen couldn't run locally (no `frontend/tmp/openapi.json`), so CI's OpenAPI step will reconcile if anything drifts. Typecheck is clean for the changed files (the remaining `@posthog/quill` errors are pre-existing and unrelated — that workspace dep isn't built in this env).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Directed by Georgiy from a Slack thread on the inbox report, asking to implement just the "list" affordance since another PR already covers the report's other suggestions. Authored by the PostHog Slack app (Claude Code). Skill invoked: `/writing-tests` before adding the handler test.
- Decision: rather than duplicate #67560's within-org `name` filter on `projects-get`, I added a separate `projects-find` tool that searches across organizations — the capability #67560 doesn't provide and the actual cause of agents enumerating sibling/adjacent project ids. Kept it a new tool instead of changing `projects-get`'s semantics (and to avoid colliding with #67560's edits to the same handler).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782948155084049?thread_ts=1782948155.084049&cid=C0B89UWRJDP)*
