### PR TITLE
fix(warehouse): make stripe backfill resilient to heartbeat timeouts

### DIFF
--- a/posthog/temporal/common/shutdown.py
+++ b/posthog/temporal/common/shutdown.py
@@ -189,5 +189,3 @@ class ShutdownMonitor:
         if self.is_worker_shutdown():
             self.logger.debug("Worker is shutting down.")
             raise WorkerShuttingDownError.from_activity_context()
-
-        self.logger.debug("Worker is not shutting down.")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -65,6 +65,9 @@ DEFAULT_LIMIT = 100
 # genuinely transient cuts.
 SUBSCRIPTION_PAGE_LIMIT = 20
 
+# Small write batch so each chunk (and its durable `earliest` watermark) commits well inside the heartbeat window, letting a large backfill make progress every attempt.
+STRIPE_CHUNK_SIZE = 1000
+
 _JSON_WHITESPACE = frozenset(b" \t\n\r\f\v")
 _OPEN_BRACE = ord("{")
 _CLOSE_BRACE = ord("}")
@@ -266,6 +269,27 @@ class StripeResumeConfig:
     starting_after: str
 
 
+def _batch_and_yield(
+    objects: Any,
+    batcher: Batcher,
+    incremental_field_name: Optional[str] = None,
+    stop_at_or_before: Optional[int] = None,
+):
+    """Batch raw Stripe objects into pa.Tables and yield them, stopping early once we reach an object
+    we already have (`stop_at_or_before`). Yielding in small batches lets the pipeline write and
+    persist the incremental watermark frequently, so progress survives a heartbeat timeout or redeploy."""
+    for obj in objects:
+        if stop_at_or_before is not None and incremental_field_name is not None:
+            if obj[incremental_field_name] <= stop_at_or_before:
+                break
+        batcher.batch(obj)
+        while batcher.should_yield():
+            yield batcher.get_table()
+
+    while batcher.should_yield(include_incomplete_chunk=True):
+        yield batcher.get_table()
+
+
 def _build_resources(
     client: StripeClient, logger: Optional[FilteringBoundLogger] = None
 ) -> dict[str, Union[StripeResource, StripeNestedResource]]:
@@ -352,7 +376,7 @@ def get_rows(
     default_params = {"limit": DEFAULT_LIMIT}
     resources = _build_resources(client, logger=logger)
 
-    batcher = Batcher(logger=logger)
+    batcher = Batcher(logger=logger, chunk_size=STRIPE_CHUNK_SIZE)
 
     if endpoint in WEBHOOK_ONLY_ENDPOINTS:
         # Webhook-only resources (e.g. Discount) have no Stripe list endpoint — Discount
@@ -474,7 +498,7 @@ def get_rows(
                 f"created[lt]": db_incremental_field_earliest_value,
             },
         )
-        yield from stripe_objects.auto_paging_iter()
+        yield from _batch_and_yield(stripe_objects.auto_paging_iter(), batcher)
 
     # check for any objects more than the maximum object we already have
     if db_incremental_field_last_value is not None:
@@ -488,12 +512,12 @@ def get_rows(
                 f"created[gt]": db_incremental_field_last_value,
             },
         )
-        last_value_cursor = _coerce_incremental_cursor(db_incremental_field_last_value)
-        for obj in stripe_objects.auto_paging_iter():
-            if last_value_cursor is not None and obj[incremental_field_name] <= last_value_cursor:
-                break
-
-            yield obj
+        yield from _batch_and_yield(
+            stripe_objects.auto_paging_iter(),
+            batcher,
+            incremental_field_name=incremental_field_name,
+            stop_at_or_before=_coerce_incremental_cursor(db_incremental_field_last_value),
+        )
 
 
 def _webhook_table_transformer(table: pa.Table) -> pa.Table:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -93,7 +93,7 @@ class TestStripeGetRowsIncrementalCursor:
             "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.stripe._build_resources",
             return_value={"charge": resource},
         ):
-            rows = list(
+            tables = list(
                 get_rows(
                     api_key="sk_test_123",
                     endpoint="charge",
@@ -106,7 +106,39 @@ class TestStripeGetRowsIncrementalCursor:
                 )
             )
 
-        assert [obj["id"] for obj in rows] == ["ch_2"]
+        rows = [row for table in tables for row in table.to_pylist()]
+        assert [row["id"] for row in rows] == ["ch_2"]
+
+    def test_backfill_branch_yields_all_earlier_objects_in_bounded_chunks(self):
+        # The created[lt] backfill must yield every earlier object AND batch them into bounded chunks:
+        # each yielded chunk is what makes the pipeline persist the `earliest` watermark, so a large
+        # backfill checkpoints progress mid-attempt instead of restarting the whole scan on a
+        # heartbeat timeout. A single giant batch (the previous behaviour) never checkpoints.
+        objects = [{"id": f"ch_{i}", "created": 1700000000 - i} for i in range(5)]
+        resource = StripeResource(method=lambda params: cast(ListObject[Any], _FakeStripeList(objects)))
+        resumable_source_manager = mock.MagicMock()
+        resumable_source_manager.can_resume.return_value = False
+
+        with (
+            mock.patch.object(stripe_module, "STRIPE_CHUNK_SIZE", 2),
+            mock.patch.object(stripe_module, "_build_resources", return_value={"charge": resource}),
+        ):
+            tables = list(
+                get_rows(
+                    api_key="sk_test_123",
+                    endpoint="charge",
+                    account_id=None,
+                    db_incremental_field_last_value=None,
+                    db_incremental_field_earliest_value=1700000100,
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=resumable_source_manager,
+                    should_use_incremental_field=True,
+                )
+            )
+
+        rows = [row for table in tables for row in table.to_pylist()]
+        assert [row["id"] for row in rows] == [f"ch_{i}" for i in range(5)]
+        assert len(tables) > 1
 
 
 class TestStripeSource:
@@ -361,12 +393,11 @@ class TestStripeBatcherDrainsSplitChunks:
         resumable_source_manager.can_resume.return_value = False
 
         # Tiny caps force every 2-row buffer flush to split into single-row chunks.
-        splitting_batcher = functools.partial(
-            stripe_module.Batcher, chunk_size=2, max_table_bytes=1, max_column_offset_bytes=1
-        )
+        splitting_batcher = functools.partial(stripe_module.Batcher, max_table_bytes=1, max_column_offset_bytes=1)
 
         with (
             patch.object(stripe_module, "StripeClient"),
+            patch.object(stripe_module, "STRIPE_CHUNK_SIZE", 2),
             patch.object(stripe_module, "Batcher", splitting_batcher),
             patch.object(stripe_module, "_build_resources", return_value={"charge": resource}),
         ):
@@ -390,11 +421,12 @@ class TestStripeBatcherDrainsSplitChunks:
         def nested_method(customer=None, params=None):
             return _list_object(nested_objects)
 
-        splitting_batcher = functools.partial(
-            stripe_module.Batcher, chunk_size=2, max_table_bytes=1, max_column_offset_bytes=1
-        )
+        splitting_batcher = functools.partial(stripe_module.Batcher, max_table_bytes=1, max_column_offset_bytes=1)
 
-        with patch.object(stripe_module, "Batcher", splitting_batcher):
+        with (
+            patch.object(stripe_module, "STRIPE_CHUNK_SIZE", 2),
+            patch.object(stripe_module, "Batcher", splitting_batcher),
+        ):
             rows = _run_nested_get_rows(nested_method, parent_objects=[{"id": "cus_1"}])
 
         assert [row["id"] for row in rows] == [f"cbt_{i}" for i in range(6)]
@@ -409,12 +441,11 @@ class TestStripeBatcherDrainsSplitChunks:
         resumable_source_manager = MagicMock()
         resumable_source_manager.can_resume.return_value = False
 
-        splitting_batcher = functools.partial(
-            stripe_module.Batcher, chunk_size=100, max_table_bytes=1, max_column_offset_bytes=1
-        )
+        splitting_batcher = functools.partial(stripe_module.Batcher, max_table_bytes=1, max_column_offset_bytes=1)
 
         with (
             patch.object(stripe_module, "StripeClient"),
+            patch.object(stripe_module, "STRIPE_CHUNK_SIZE", 100),
             patch.object(stripe_module, "Batcher", splitting_batcher),
             patch.object(stripe_module, "_build_resources", return_value={"charge": resource}),
         ):


### PR DESCRIPTION
## Problem

A Stripe `charges` schema has been failing to sync since mid-November, stuck in a perpetual "activity Heartbeat timeout" loop. It never completes, and fires a failure digest on every scheduled run.

The account has a large charges history. Each Stripe page (`limit=100`) is ~300 KB and takes a few seconds, so a 5000-row batch takes ~135s to assemble before the pipeline writes it to delta and persists the durable `earliest` watermark. That exceeds the 2-minute activity heartbeat, so on a large account **no batch ever commits within an attempt**, the `earliest` watermark never advances, and every retry (and every scheduled run) restarts the exact same descending scan. It can never finish.

The `earliest` watermark is already a durable, per-batch, Postgres-backed checkpoint that the activity re-reads on each retry, so the fix is not new checkpointing machinery. It's making the durable unit small enough to actually commit inside the heartbeat window.

## Changes

- Add `STRIPE_CHUNK_SIZE = 1000` and use it for the Stripe source batcher. A batch of 1000 charges commits in well under the heartbeat window, so the `earliest` watermark advances every attempt regardless of how large the account is. The number of durable units scales with size, but each one is bounded.
- Route the `created[lt]` backfill and `created[gt]` delta branches through the same batcher (via a small `_batch_and_yield` helper) so they yield bounded `pa.Table` chunks like the full-refresh branch, instead of streaming raw objects with no batch boundary. Previously these two branches never yielded on a boundary that triggered a watermark write.
- Drop the unconditional per-row `logger.debug("Worker is not shutting down.")` in `ShutdownMonitor.raise_if_is_worker_shutdown` (called once per row during a sync). At tens of thousands of calls it floods stdout and the Kafka log queue on the event-loop thread, which can starve the background heartbeater — a second, independent contributor to the timeout.

Smaller batches also bound per-batch memory, which is aligned with reducing the wide-table loader memory spikes seen on this fleet.

## How did you test this code?

Automated tests I (Claude) actually ran, both green locally via `hogli test`:

- `products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py` (52 passed). Added `test_backfill_branch_yields_all_earlier_objects_in_bounded_chunks` — it feeds 5 objects with `STRIPE_CHUNK_SIZE` patched to 2 and asserts every object is yielded across more than one chunk. It catches a regression where the `created[lt]` backfill drops rows or reverts to a single unbounded batch (the bug this PR fixes). Updated `test_get_rows_handles_string_incremental_watermark` to drain tables since branches B/C now yield tables, and adjusted three existing split tests to patch the new constant instead of passing `chunk_size` into the `Batcher` partial.
- `posthog/temporal/tests/test_shutdown.py` (2 passed) to confirm removing the debug line doesn't affect shutdown detection.

I did not run this against a live large Stripe account. Suggested prod validation for the affected schema: trigger a resync and confirm from the worker logs that the `created` windows advance, the `earliest` watermark moves monotonically, and the job reaches Completed instead of the attempt-15 heartbeat timeout.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Estefania directed this investigation and fix; I (Claude, via PostHog Code) did the analysis and implementation.

The root cause came from reading production worker logs in Grafana Loki (the schema 404s under the project-scoped MCP, so I traced it by schema id across the data-warehouse temporal worker namespace) plus the source code. Key evidence: every charges request returns 200 in ~2.4-3.3s at ~300 KB, the pod logs continuously across the whole window (so it's alive and grinding, not OOM-dead), yet it still dies at the 2-minute heartbeat and retries to attempt 15.

I first drafted a heavier fix that added Redis `starting_after` checkpointing to the backfill/delta branches. I dropped that after confirming the `earliest` watermark is already persisted to Postgres per written batch and re-read on each retry, which makes it the real durable checkpoint. The Redis cursor is keyed per `job_id` and useless across retries anyway. That collapsed the fix to "shrink the batch so a commit lands inside the heartbeat" plus the log-flood removal.

Skills invoked: `/writing-tests` (test value gate), `/implementing-warehouse-sources` (source conventions).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
