### PR TITLE
fix(warehouse): bound Jira full-sync JQL to avoid 400

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/jira.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/jira.py
@@ -63,11 +63,16 @@ def _format_jql_datetime(value: Any) -> str:
     return (dt - INCREMENTAL_LOOKBACK).strftime(JQL_DATETIME_FORMAT)
 
 
+# The enhanced ``/search/jql`` endpoint rejects unbounded queries (400 "Unbounded JQL queries are not
+# allowed here"). On a full sync there's no watermark, so anchor to an epoch floor to keep the query bounded
+# while still scanning every issue.
+JQL_FLOOR_DATETIME = "1970-01-01 00:00"
+
+
 def _build_issues_jql(incremental_field: str | None, last_value: Any) -> str:
     field = incremental_field or "updated"
-    where = f'{field} >= "{_format_jql_datetime(last_value)}"' if last_value else ""
-    order = f"ORDER BY {field} ASC"
-    return f"{where} {order}".strip()
+    since = _format_jql_datetime(last_value) if last_value else JQL_FLOOR_DATETIME
+    return f'{field} >= "{since}" ORDER BY {field} ASC'
 
 
 def _extract_items(data: Any, data_key: str | None) -> list[dict[str, Any]]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira.py
@@ -72,8 +72,9 @@ class TestFormatJqlDatetime:
 
 
 class TestBuildIssuesJql:
-    def test_no_last_value_orders_ascending(self) -> None:
-        assert _build_issues_jql("updated", None) == "ORDER BY updated ASC"
+    def test_no_last_value_bounds_with_epoch_floor(self) -> None:
+        # ``/search/jql`` 400s on unbounded queries, so a full sync must still carry a lower bound.
+        assert _build_issues_jql("updated", None) == 'updated >= "1970-01-01 00:00" ORDER BY updated ASC'
 
     def test_with_last_value_filters_and_orders(self) -> None:
         jql = _build_issues_jql("updated", datetime(2026, 3, 4, 2, 58))
@@ -84,7 +85,7 @@ class TestBuildIssuesJql:
         assert jql == 'created >= "2026-03-03 02:58" ORDER BY created ASC'
 
     def test_none_field_defaults_to_updated(self) -> None:
-        assert _build_issues_jql(None, None) == "ORDER BY updated ASC"
+        assert _build_issues_jql(None, None) == 'updated >= "1970-01-01 00:00" ORDER BY updated ASC'
 
 
 class TestExtractItems:


### PR DESCRIPTION
## Problem

Jira imports 400 on the initial full sync. The enhanced `/rest/api/3/search/jql` endpoint (which replaced the now-removed legacy `/search`) rejects unbounded queries with `Unbounded JQL queries are not allowed here. Please add a search restriction to your query.`

Our full-sync path built a bare `ORDER BY updated ASC` with no `WHERE` clause, so it was unbounded and 400'd every time. Incremental syncs were fine because they carry an `updated >= "…"` watermark, which bounds the query.

Atlassian's KB on the error: https://support.atlassian.com/jira/kb/how-to-handle-http-400-bad-request-errors-on-jira-search-rest-api-endpoint/

## Changes

`_build_issues_jql` now always emits a lower bound. On incremental runs that's the stored watermark (unchanged). On a full sync it falls back to an epoch floor (`1970-01-01 00:00`), which keeps the query bounded while still scanning every issue.

I chose an epoch floor rather than bounding by project because bounding by project would break the "import everything" contract. The floor date is the minimal change that satisfies the endpoint's restriction requirement.

## How did you test this code?

Automated only, no manual testing against a live Jira instance. I (Claude) ran the existing suite:

```
hogli test products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira.py
```

42 passed. Two existing assertions that expected the old unbounded `ORDER BY updated ASC` output were updated to expect the bounded form — these guard the regression that started the 400 (full sync must carry a lower bound).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Luke) hit a `400 Bad Request` on a Jira sync and had Claude (PostHog Code) diagnose it. Claude traced the request back to `_build_issues_jql`, confirmed via Atlassian docs that the new `/search/jql` endpoint rejects unbounded JQL, and applied the epoch-floor fix plus the test updates.

One thing we noted but deliberately did not address: there are community reports of `nextPageToken` pagination looping on this endpoint (`isLast` never returning true, tracked in JRACLOUD-94632). Our loop breaks on `not next_page_token or data.get("isLast")`. We decided to wait until that actually becomes a problem rather than pre-emptively guarding against it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
