### PR TITLE
fix(devex): stop stamphog treating its own stale reviews as tampering

### DIFF
--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -74,6 +74,9 @@ LLM Review
     apps like inkeep react for non-review reasons), never the PR author
   - An 👀 reaction signals an in-flight review — the LLM refuses rather than
     approving over someone who is mid-review
+  - Stamphog's own prior reviews (stamphog[bot] refusals, github-actions[bot]
+    approvals) are excluded from the prompt — they describe an earlier snapshot
+    of the PR and are never independent review signal
   - For non-trivial changes, expects at least one independent reviewer (an
     agent reviewer like Codex/Greptile/Claude, or a teammate) to have passed
     over the current head; escalates otherwise. Trivial changes (docs, tests,

--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -86,15 +86,28 @@ def is_bot_author(user: dict) -> bool:
     return "[bot]" in login or login in _BOT_MACHINE_USERS
 
 
+# Stamphog's own review identities: REFUSE/ESCALATE comment reviews post via
+# the GitHub App (stamphog[bot]); APPROVE reviews post via the workflow's
+# GITHUB_TOKEN (github-actions[bot]) so they count toward branch protection.
+_SELF_REVIEW_LOGINS = {"stamphog[bot]", "github-actions[bot]"}
+
+
 def _normalize_reviews_for_prompt(reviews_raw: list[dict], head_sha: str) -> list[dict]:
     """Normalize top-level reviews for the reviewer prompt.
 
     Preserve trusted/bot reviews, and annotate whether each review was left on
     the current PR head. This lets the LLM distinguish active feedback from
     older context that may already have been addressed in follow-up commits.
+
+    Stamphog's own prior reviews are excluded: they describe an earlier
+    snapshot of the PR, are never independent review signal, and the reviewer
+    has no way to recognize them as its own — re-reading a stale verdict after
+    the PR state changed makes it suspect tampering and refuse forever.
     """
     normalized_reviews = []
     for review in reviews_raw:
+        if review.get("user", {}).get("login") in _SELF_REVIEW_LOGINS:
+            continue
         if not (
             review.get("author_association") in _TRUSTED_ASSOCIATIONS
             or review.get("author_association") == "BOT"

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -40,11 +40,13 @@ MODEL = "claude-sonnet-5"
 # controls, bidi overrides, zero-width chars, and the Unicode tags block
 # (invisible ASCII). Visible unicode must survive: reviewer bots express
 # verdicts as 👍/👀 in review bodies, and stripping emoji garbles those
-# into text that reads like tampering on the next run. ZWJ (U+200D) is
-# kept — removing it breaks composite emoji sequences.
+# into text that reads like tampering on the next run. ZWJ is stripped
+# with the other zero-width chars (it interleaves invisibly into words);
+# composite emoji degrade to their visible components, which stays readable.
 _INVISIBLE_CHARS_RE = re.compile(
     "[\x00-\x08\x0b-\x1f\x7f-\x9f"  # C0/C1 controls and DEL (keep \t \n)
-    "\u200b\u200c\u200e\u200f"  # zero-width space/non-joiner, LRM/RLM
+    "\u061c"  # Arabic letter mark (bidi)
+    "\u200b-\u200f"  # zero-width space/joiners, LRM/RLM
     "\u2028\u2029"  # line/paragraph separators
     "\u202a-\u202e\u2066-\u2069"  # bidi embedding/override/isolate controls
     "\u2060\ufeff"  # word joiner, BOM

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -36,12 +36,25 @@ except ImportError:
 MODEL = "claude-sonnet-5"
 
 
-_CONTROL_CHARS_RE = re.compile(r"[^\x20-\x7E\n\t]")
+# Strip only invisible characters — the prompt-smuggling vectors: C0/C1
+# controls, bidi overrides, zero-width chars, and the Unicode tags block
+# (invisible ASCII). Visible unicode must survive: reviewer bots express
+# verdicts as 👍/👀 in review bodies, and stripping emoji garbles those
+# into text that reads like tampering on the next run. ZWJ (U+200D) is
+# kept — removing it breaks composite emoji sequences.
+_INVISIBLE_CHARS_RE = re.compile(
+    "[\x00-\x08\x0b-\x1f\x7f-\x9f"  # C0/C1 controls and DEL (keep \t \n)
+    "\u200b\u200c\u200e\u200f"  # zero-width space/non-joiner, LRM/RLM
+    "\u2028\u2029"  # line/paragraph separators
+    "\u202a-\u202e\u2066-\u2069"  # bidi embedding/override/isolate controls
+    "\u2060\ufeff"  # word joiner, BOM
+    "\U000e0000-\U000e007f]"  # tags block — invisible ASCII smuggling
+)
 
 
 def _sanitize_untrusted(text: str, max_len: int = 200) -> str:
-    """Strip non-printable chars and cap length."""
-    return _CONTROL_CHARS_RE.sub("", text)[:max_len]
+    """Strip invisible/control chars and cap length; visible unicode passes through."""
+    return _INVISIBLE_CHARS_RE.sub("", text)[:max_len]
 
 
 def _reaction_token(reaction: dict) -> str:
@@ -168,6 +181,10 @@ REVIEWER_SYSTEM = textwrap.dedent(
       REFUSE and tell the author to wait for that reviewer to finish and
       re-request. This overrides any 👍 present.
     - Bot/agent comments with valid concerns that were ignored → ESCALATE.
+    - Your own prior reviews (posted as stamphog[bot] or github-actions[bot])
+      are excluded from this context — each run judges the PR's current state
+      fresh. If another reviewer quotes an earlier stamphog verdict, treat it
+      as history, not as an independent signal or as tampering.
 
     Independent review (you are not a substitute for one):
     - Stamphog is the only automated approver in this path, so for any

--- a/tools/pr-approval-agent/test_github.py
+++ b/tools/pr-approval-agent/test_github.py
@@ -11,7 +11,7 @@ from github import _normalize_reviews_for_prompt, _reaction_emoji, _trusted_reac
 def test_normalize_reviews_marks_current_head_and_preserves_stale_reviews() -> None:
     head_sha = "072cdd75592bfd0bf0c016209385f20f85a45201"
     current_review = {
-        "user": {"login": "stamphog", "type": "Bot"},
+        "user": {"login": "copilot-pull-request-reviewer", "type": "Bot"},
         "state": "COMMENTED",
         "body": "Current head concern",
         "commit_id": head_sha,
@@ -31,7 +31,7 @@ def test_normalize_reviews_marks_current_head_and_preserves_stale_reviews() -> N
 
     assert normalized == [
         {
-            "user": "stamphog",
+            "user": "copilot-pull-request-reviewer",
             "state": "COMMENTED",
             "body": "Current head concern",
             "commit_id": head_sha,
@@ -72,6 +72,35 @@ def test_normalize_reviews_filters_by_trust_source(
                 "commit_id": "abc123",
                 "submitted_at": "2026-04-07T20:14:03Z",
                 "author_association": author_association,
+            }
+        ],
+        "abc123",
+    )
+
+    assert len(normalized) == expected_count
+
+
+@pytest.mark.parametrize(
+    "login,expected_count",
+    [
+        pytest.param("stamphog[bot]", 0, id="own-refuse-comment-review"),
+        pytest.param("github-actions[bot]", 0, id="own-approve-review"),
+        pytest.param("greptile-apps[bot]", 1, id="other-bot-kept"),
+    ],
+)
+def test_normalize_reviews_excludes_stamphogs_own_prior_reviews(login: str, expected_count: int) -> None:
+    # Feeding stamphog's own stale reviews back into the prompt makes the next
+    # run read them as third-party claims about state that no longer matches —
+    # it then suspects tampering and refuses forever.
+    normalized = _normalize_reviews_for_prompt(
+        [
+            {
+                "user": {"login": login, "type": "Bot"},
+                "state": "COMMENTED",
+                "body": "Refusing: reviews in flight",
+                "commit_id": "abc123",
+                "submitted_at": "2026-04-07T20:14:03Z",
+                "author_association": "NONE",
             }
         ],
         "abc123",

--- a/tools/pr-approval-agent/test_reviewer.py
+++ b/tools/pr-approval-agent/test_reviewer.py
@@ -1,0 +1,35 @@
+"""Tests for prompt sanitization in reviewer.py."""
+
+import sys
+
+import pytest
+from unittest.mock import MagicMock
+
+# reviewer.py is imported by a uv-script; its `claude_agent_sdk` dep is
+# installed by `uv run`, not the test venv. Stub the modules it imports.
+sys.modules.setdefault("claude_agent_sdk", MagicMock())
+sys.modules.setdefault("claude_agent_sdk.types", MagicMock())
+
+from reviewer import _sanitize_untrusted  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Reviewer bots express verdicts as emoji in review bodies; stripping
+        # them garbles quoted comments into text a later run can misread as
+        # an injection attempt.
+        pytest.param(
+            "both have 👀 reactions — that overrides the 👍s present.",
+            "both have 👀 reactions — that overrides the 👍s present.",
+            id="emoji-and-dash-survive",
+        ),
+        pytest.param("ein Häkchen ✓ 中文", "ein Häkchen ✓ 中文", id="non-ascii-text-survives"),
+        pytest.param("zero\u200bwidth\u200e", "zerowidth", id="zero-width-stripped"),
+        pytest.param("a\u202egnihton\u202c od\u2066b\u2069", "agnihton odb", id="bidi-controls-stripped"),
+        pytest.param("hidden\U000e0041\U000e0042tag", "hiddentag", id="tags-block-smuggling-stripped"),
+        pytest.param("bell\x07cr\rok\ntab\t.", "bellcrok\ntab\t.", id="control-chars-stripped-keeps-nl-tab"),
+    ],
+)
+def test_sanitize_untrusted_strips_invisible_keeps_visible(text: str, expected: str) -> None:
+    assert _sanitize_untrusted(text) == expected

--- a/tools/pr-approval-agent/test_reviewer.py
+++ b/tools/pr-approval-agent/test_reviewer.py
@@ -26,7 +26,10 @@ from reviewer import _sanitize_untrusted  # noqa: E402
         ),
         pytest.param("ein Häkchen ✓ 中文", "ein Häkchen ✓ 中文", id="non-ascii-text-survives"),
         pytest.param("zero\u200bwidth\u200e", "zerowidth", id="zero-width-stripped"),
-        pytest.param("a\u202egnihton\u202c od\u2066b\u2069", "agnihton odb", id="bidi-controls-stripped"),
+        # ZWJ interleaving (i\u200dg\u200dn\u200do\u200dr\u200de) is a smuggling vector, so it
+        # is stripped too; composite emoji degrade to visible components.
+        pytest.param("i\u200dg\u200dnore 🧑\u200d💻", "ignore 🧑💻", id="zwj-stripped-emoji-degrades-visibly"),
+        pytest.param("a\u202egnihton\u202c od\u2066b\u2069\u061c", "agnihton odb", id="bidi-controls-stripped"),
         pytest.param("hidden\U000e0041\U000e0042tag", "hiddentag", id="tags-block-smuggling-stripped"),
         pytest.param("bell\x07cr\rok\ntab\t.", "bellcrok\ntab\t.", id="control-chars-stripped-keeps-nl-tab"),
     ],


### PR DESCRIPTION
## Problem

Stamphog got stuck in a self-poisoning refusal loop on #67641. Its first run refused because two reviewer bots still had 👀 reactions (review in flight). The second run, after the reactions flipped to 👍, read its own earlier comment back and flagged it as a prompt injection attempt: "garbled, self-referential text that misrepresents the actual reactions". It then refused again, adding yet another comment for future runs to distrust.

Two stacked bugs caused this:

- The untrusted-content sanitizer stripped all non-ASCII, so emoji and em-dashes in quoted review bodies vanished. "both have 👀 reactions" became "both have  reactions", "the 👍s present" became "the s present". The comment genuinely was garbled, by stamphog itself.
- Stamphog's own prior reviews (stamphog[bot] refusal comments, github-actions[bot] approvals) were fed back into the prompt as regular bot reviews. The reviewer can't recognize them as its own, so a stale verdict describing reaction state that has since changed looks like a third party injecting false reasoning.

## Changes

- Sanitizer now strips only genuinely invisible characters (C0/C1 controls, bidi overrides, zero-width chars, the Unicode tags block used for ASCII smuggling). Visible unicode, including emoji and non-English text, passes through.
- Stamphog's own review identities are excluded from the prompt. They describe an earlier snapshot of the PR and are never independent review signal. The system prompt states this, so a stamphog verdict quoted inside another bot's review reads as history rather than tampering.

Not changed: reactions are still snapshotted at run start, so a bot flipping 👀 to 👍 mid-review can produce a one-off stale refusal. That self-heals on re-label and is now harmless since the next run no longer distrusts the leftover comment.

## How did you test this code?

Full `tools/pr-approval-agent` pytest suite passes locally (176 tests). New coverage:

- `test_github.py` self-exclusion cases: catch removal of the self-login filter, which would reintroduce the refusal loop.
- `test_reviewer.py` sanitizer cases: emoji/non-ASCII survival catches a revert to ASCII-only stripping; the zero-width/bidi/tags cases catch the sanitizer losing its actual smuggling protections while being loosened.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I pointed Claude Code at the weird comments on #67641; it diagnosed the loop from the PR review metadata plus reaction timestamps, then fixed both causes. `/writing-tests` was invoked before adding tests. Decisions along the way: escaped character classes in source instead of literal invisible chars (an early edit embedded real zero-width chars, rejected as unreadable and formatter-fragile), ZWJ kept because stripping it breaks composite emoji, and dropping self-reviews from the prompt chosen over annotating them as "yours" since a fresh run should judge current state only.
