### PR TITLE
fix(postgres): give schema-permission denials a USAGE-oriented message

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -361,6 +361,19 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "crypto_aead_det_decrypt). Grant the connecting role EXECUTE on that function, or remove the "
                 "view that uses it from the sync, then re-enable the sync."
             ),
+            # A selected table lives in a schema the connecting role can't access (SQLSTATE 42501,
+            # "permission denied for schema <name>") — most often a non-public schema like `extensions`
+            # holding an extension's objects. USAGE on the schema is a prerequisite for reading anything
+            # inside it, so granting SELECT on the table alone won't help — distinct from the table/view
+            # SELECT denial below, and it must precede the generic "permission denied for" so this
+            # USAGE-oriented message is the one selected.
+            "permission denied for schema": (
+                "PostHog's database role isn't allowed to access a schema that contains one or more of the "
+                'tables you selected to sync (PostgreSQL reported "permission denied for schema"). Grant the '
+                "connecting role USAGE on that schema and SELECT on the tables in it (for example: "
+                "GRANT USAGE ON SCHEMA <schema> TO <role>), or remove those tables from the sync, then "
+                "re-enable the sync."
+            ),
             "permission denied for": (
                 "PostHog's database role isn't allowed to read one or more of the tables you selected to sync "
                 '(PostgreSQL reported "permission denied"). Grant the connecting role SELECT on those tables '

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -720,6 +720,30 @@ class TestPostgresSourceNonRetryableErrors:
         "error_msg",
         [
             # Raw psycopg message (what the activity-level check sees via str(e)).
+            "permission denied for schema extensions",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "InsufficientPrivilege: permission denied for schema extensions",
+        ],
+    )
+    def test_permission_denied_for_schema_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Permission-denied-for-schema error should be non-retryable: {error_msg}"
+
+    def test_permission_denied_for_schema_returns_usage_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = "permission denied for schema extensions"
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Permission-denied-for-schema error should surface an actionable message"
+        # The schema-USAGE message must win over the generic table-SELECT message and advise USAGE
+        # rather than the misleading "GRANT SELECT ON <table>".
+        assert "USAGE" in friendly[0]
+        assert "GRANT SELECT" not in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
             'materialized view "mv_dayplan_blocks" has not been populated\nHINT:  Use the REFRESH MATERIALIZED VIEW command.',
             # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
             'ObjectNotInPrerequisiteState: materialized view "mv_dayplan_blocks" has not been populated',


### PR DESCRIPTION
## Problem

A Postgres warehouse import keeps failing when the connecting role can't access a schema that holds one of the selected tables.
Postgres raises `InsufficientPrivilege` (SQLSTATE 42501) with `permission denied for schema <name>` while reading rows through the server-side cursor in `get_rows` (`products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`).

The error is already treated as non-retryable, so it isn't the retry loop that's wrong — it's the customer-facing message.
`get_non_retryable_errors` matched this on the generic `permission denied for` entry, whose remedy is "Grant the connecting role SELECT on those tables (`GRANT SELECT ON <table>`)".
That's misleading here: a missing schema `USAGE` grant is the blocker, and `GRANT SELECT` on the table alone won't unblock it. The role needs `GRANT USAGE ON SCHEMA <schema>`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f21e5-084b-7602-a21e-d1b187500137

## Changes

Add a dedicated `permission denied for schema` entry to the Postgres source's `get_non_retryable_errors`, placed ahead of the generic `permission denied for` so its message wins (same first-match ordering the existing `permission denied for function` entry relies on).
The new message advises `GRANT USAGE ON SCHEMA <schema>` plus SELECT on the tables inside it, rather than the misleading table-only SELECT grant.

This is a user/upstream permission issue with nothing for us to retry, so it stays non-retryable — the only change is a more accurate remedy.

## How did you test this code?

Added two tests to `test_postgres.py`, mirroring the existing `permission denied for function` tests:

- `test_permission_denied_for_schema_errors_are_non_retryable` — covers both the raw psycopg message and the Temporal-wrapped `InsufficientPrivilege:` form.
- `test_permission_denied_for_schema_returns_usage_message` — locks in that the schema entry wins over the generic table-SELECT entry and advises `USAGE` rather than `GRANT SELECT`. No existing test covered the schema case; this guards against a reordering or removal that would resurface the misleading remedy.

Ran the Postgres source test file locally (`permission_denied`/`non_retryable`/`friendly` selection): 92 passed. Ruff check and format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres warehouse source. I (Claude) confirmed the issue via the PostHog error-tracking MCP tools: the real `InsufficientPrivilege` frame originates in `postgres.py` `get_rows`, and traced how `str(e.cause.cause)` (the raw psycopg message, no class name) reaches the friendly-message selection in `external_data_job.py`, where first-match dict order decides the message shown.

Decision: user/upstream permission error, already non-retryable, so the fix is message accuracy rather than retry behavior. Chose to mirror the established `permission denied for function` split (own message, placed before the generic entry) rather than widening or reordering the generic entry. Checked open PRs (including the maintainer's) for a duplicate — none touch schema-permission denials.

Invoked the `/writing-tests` skill before adding tests.
