### PR TITLE
fix(postgres): advise USAGE for schema-level permission denials

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -361,6 +361,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "crypto_aead_det_decrypt). Grant the connecting role EXECUTE on that function, or remove the "
                 "view that uses it from the sync, then re-enable the sync."
             ),
+            # A selected table/view lives in a schema the connecting role has no USAGE privilege on
+            # (SQLSTATE 42501, "permission denied for schema <name>") — common with Supabase's internal
+            # `auth`/`storage` schemas when their tables are picked for sync. Distinct from the table/view
+            # SELECT denial below: granting SELECT on the tables won't help without USAGE on the schema, so
+            # it needs its own message and must precede the generic "permission denied for" so this one wins.
+            "permission denied for schema": (
+                "PostHog's database role isn't allowed to access one or more of the schemas that contain "
+                'the tables you selected to sync (PostgreSQL reported "permission denied for schema"). Grant '
+                "the connecting role USAGE on those schemas (for example: GRANT USAGE ON SCHEMA <schema> TO "
+                "<role>), along with SELECT on the tables, then re-enable the sync."
+            ),
             "permission denied for": (
                 "PostHog's database role isn't allowed to read one or more of the tables you selected to sync "
                 '(PostgreSQL reported "permission denied"). Grant the connecting role SELECT on those tables '

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -732,6 +732,7 @@ class TestPostgresSourceNonRetryableErrors:
         # The schema-permission message must win over the generic table-SELECT message and advise
         # USAGE ON SCHEMA rather than the misleading "GRANT SELECT ON <table>".
         assert "USAGE ON SCHEMA" in friendly[0]
+        assert "GRANT SELECT" not in friendly[0]
 
     @pytest.mark.parametrize(
         "error_msg",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -720,6 +720,23 @@ class TestPostgresSourceNonRetryableErrors:
         "error_msg",
         [
             # Raw psycopg message (what the activity-level check sees via str(e)).
+            "permission denied for schema analytics",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "InsufficientPrivilege: permission denied for schema analytics",
+        ],
+    )
+    def test_permission_denied_for_schema_returns_usage_message(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Permission-denied-for-schema error should surface an actionable message"
+        # The schema-permission message must win over the generic table-SELECT message and advise
+        # USAGE ON SCHEMA rather than the misleading "GRANT SELECT ON <table>".
+        assert "USAGE ON SCHEMA" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
             'materialized view "mv_dayplan_blocks" has not been populated\nHINT:  Use the REFRESH MATERIALIZED VIEW command.',
             # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
             'ObjectNotInPrerequisiteState: materialized view "mv_dayplan_blocks" has not been populated',


### PR DESCRIPTION
## Problem

PostHog error tracking flagged a recurring `InsufficientPrivilege` from the Postgres import source:

```
InsufficientPrivilege: permission denied for schema <redacted>
LINE 1: ..._auth.identities" CURSOR FOR SELECT * FROM ...
```

It fires in `get_rows` (`postgres.py`) when the connecting role has no `USAGE` privilege on a schema whose tables were selected for sync. This is common with Supabase, where the internal `auth` and `storage` schemas get picked but the sync role can't access them.

This is a user/upstream config issue, not a PostHog bug — nothing to do but stop and tell the customer how to fix it.

The retry side was already handled: the message matches the existing generic `"permission denied for"` non-retryable key (and `InsufficientPrivilege` at the workflow layer), so we already stop retrying. The problem is the remediation message we surface to the customer. The generic entry tells them to `GRANT SELECT ON <table>`, which won't fix a schema-`USAGE` denial — granting SELECT on the tables is useless if the role can't even use the schema.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f21e4-5341-7a53-806c-c16c73c406f4

## Changes

Added a `"permission denied for schema"` key to `PostgresSource.get_non_retryable_errors`, placed before the generic `"permission denied for"` so its message wins. It advises `GRANT USAGE ON SCHEMA <schema> TO <role>` (plus SELECT on the tables). This mirrors the existing `"permission denied for function"` entry, which exists for the same reason — the generic table-SELECT message is wrong for that case too.

Retry classification is unchanged. This only improves the actionable message the customer sees.

## How did you test this code?

Automated only (I'm Claude, an agent — no manual testing). Added `test_permission_denied_for_schema_returns_usage_message` (raw and Temporal-wrapped forms), mirroring the function-permission test. It guards the regression that no existing test caught: if the schema key is dropped or reordered after the generic key, the customer would again be told to `GRANT SELECT ON <table>` instead of `GRANT USAGE ON SCHEMA`. Existing permission tests only cover table/view/function.

Ran locally:

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k "non_retryable or permission"
# 70 passed
```

`ruff check` and `ruff format --check` clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude Code. I confirmed the issue in PostHog error tracking (133 occurrences, real stack originating in `get_rows` at `postgres.py:3352`; the `delete_teams`/personhog strings in the frame's serialized locals are unrelated noise from a shared thread pool, not the failure). Traced the capture path through `import_data_sync._handle_import_error` → `extract.handle_non_retryable_error` and the activity interceptor in `posthog/temporal/common/posthog_client.py`.

Key decision: this was already non-retryable via the generic key, so I did not touch retry behavior — a no-op there. The genuine gap was the remediation message in `external_data_job.py`, which surfaces `friendly_errors[0]` to the customer. I followed the established `permission denied for function` precedent (specific message ordered before the generic one) rather than inventing a new mechanism. Invoked the `/writing-tests` skill before adding the test.
