### PR TITLE
fix(data-warehouse): detect repartition need pre-extraction so OOMing tables self-heal

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
@@ -179,11 +179,49 @@ class TestRepartitionActivity:
             ActivityEnvironment().run(maybe_repartition_table_activity, inputs)
         return capture
 
-    def test_noop_when_nothing_pending(self, team):
-        inputs = self._inputs(team, _make_schema(team, {}))
+    def test_noop_when_within_budget_measurement_recorded(self, team):
+        # The healthy common path: a within-budget `max_partition_bytes` from a prior post-load run
+        # short-circuits the cheap gate, so nothing pending means no delta read, no detection, no
+        # rewrite. Guards the gate that keeps every healthy sync free of the extra pre-extraction work.
+        schema = _make_schema(team, {"max_partition_bytes": 5})
         mocked = AsyncMock()
-        self._run(inputs, mocked)
+        with (
+            patch.object(repartition_table, "HeartbeaterSync"),
+            patch.object(repartition_table, "repartition_table_in_place", new=mocked),
+            patch.object(repartition_table, "capture_repartition_event"),
+            patch.object(repartition_table, "target_partition_bytes", return_value=10**12),
+            patch.object(repartition_table, "maybe_flag_for_repartition") as flag,
+        ):
+            ActivityEnvironment().run(maybe_repartition_table_activity, self._inputs(team, schema))
         mocked.assert_not_called()
+        flag.assert_not_called()
+
+    def test_pre_extraction_flags_over_budget_table_and_repartitions(self, team):
+        # No target was queued, but the on-disk partition is over budget: the activity must detect and
+        # rewrite it here, pre-extraction. This is the path that rescues a table whose merge OOMs every
+        # run and so never reaches post-load detection to flag itself — without it the activity is a noop.
+        schema = _make_schema(
+            team,
+            {"partitioning_enabled": True, "partition_mode": "md5", "partition_count": 2, "partitioning_keys": ["id"]},
+        )
+        mocked = AsyncMock(return_value={"outcome": "completed", "row_count": 4, "partition_mode_after": "md5"})
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_partitioned_delta(f"{d}/t", ["0", "0", "1", "1"])
+            with (
+                patch.object(repartition_table, "HeartbeaterSync"),
+                patch.object(repartition_table, "repartition_table_in_place", new=mocked),
+                patch.object(repartition_table, "capture_repartition_event") as capture,
+                patch.object(repartition_table.DeltaTableHelper, "get_delta_table", new=AsyncMock(return_value=delta)),
+                patch.object(ctrl, "target_partition_bytes", return_value=1),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "capture_repartition_event"),
+            ):
+                ActivityEnvironment().run(maybe_repartition_table_activity, self._inputs(team, schema))
+
+        mocked.assert_awaited_once()
+        emitted = [c.args[0] for c in capture.call_args_list]
+        assert "warehouse_repartition_started" in emitted
+        assert "warehouse_repartition_completed" in emitted
 
     def test_success_emits_completed(self, team):
         schema = _make_schema(team, {})

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -67,41 +67,45 @@ def _target_from_schema(schema: ExternalDataSchema) -> RepartitionTarget:
     )
 
 
+def _needs_pre_extraction_detection(schema: ExternalDataSchema) -> bool:
+    """Whether to measure the on-disk table for a repartition need, using only in-memory schema state.
+
+    Keeps the healthy no-op path free of any I/O (no job fetch, no delta-log read): we only fall through
+    to the on-disk measurement for a non-CDC table (CDC is excluded from the controller, matching the
+    post-load call site in load.py) whose last post-load measurement is over budget or was never
+    recorded. The never-recorded case covers a table whose merge OOMs every run, so post-load detection
+    never ran to record one — the chicken-and-egg this whole path exists to break.
+    """
+    if schema.sync_type == ExternalDataSchema.SyncType.CDC:
+        return False
+    last_measured = schema.max_partition_bytes
+    return last_measured is None or last_measured > target_partition_bytes()
+
+
 def _maybe_flag_pre_extraction(
     schema: ExternalDataSchema,
     job: ExternalDataJob,
     helper: DeltaTableHelper,
     logger: FilteringBoundLogger,
 ) -> dict[str, Any] | None:
-    """Detect an over-budget partition against the on-disk table before extraction, and flag it.
+    """Measure the on-disk table before extraction and flag a repartition if it's over budget.
 
     The post-load detector (`maybe_flag_for_repartition`) only runs after a merge completes, so a table
     whose merge OOMs every run can never flag itself for repair — the classic chicken-and-egg. Running
     the same detection (same feature-flag, budget, and cooldown gating) here, pre-extraction, closes
     that gap: the on-disk table already reflects the over-budget layout, so we can flag and — in this
     same run — rewrite it before the merge that would OOM. Returns the pending target set by detection,
-    or None if nothing was flagged. Never raises.
+    or None if nothing was flagged (or the table couldn't be measured). Never raises.
     """
-    # CDC tables are excluded from the controller, matching the post-load call site in load.py.
-    if schema.sync_type == ExternalDataSchema.SyncType.CDC:
-        return None
-
-    # Cheap in-memory gate: skip the extra delta-log read on the healthy path. The post-load detector
-    # records `max_partition_bytes` after every successful merge, so a table with a known within-budget
-    # measurement can't need repair. We only reach the full on-disk measurement when the last recording
-    # was over budget or never happened — the latter covering a table whose merge always OOMs (so
-    # post-load never ran to record it).
-    last_measured = schema.max_partition_bytes
-    if last_measured is not None and last_measured <= target_partition_bytes():
-        return None
-
     try:
         delta_table = async_to_sync(helper.get_delta_table)()
         if delta_table is None:
+            logger.debug("repartition: no delta table on disk, cannot measure for repartition")
             return None
         async_to_sync(maybe_flag_for_repartition)(schema, schema.source, job, delta_table, logger)
     except Exception as e:
         # Detection is best-effort; a failure here must not block the sync.
+        logger.warning("repartition: pre-extraction detection failed", exc_info=True)
         capture_exception(e)
         return None
     return schema.repartition_pending
@@ -121,6 +125,15 @@ def maybe_repartition_table_activity(inputs: RepartitionActivityInputs) -> None:
         logger.warning("repartition: schema not found, skipping activity", schema_id=inputs.schema_id)
         return
 
+    pending = schema.repartition_pending
+    swap = schema.repartition_swap
+
+    # Fast no-op path: nothing queued and the in-memory gate says no on-disk measurement is needed.
+    # Return here — before fetching the job — so the common healthy invocation stays a single DB query.
+    if pending is None and swap is None and not _needs_pre_extraction_detection(schema):
+        logger.debug("repartition: nothing queued and no detection needed, nothing to do")
+        return
+
     try:
         job = ExternalDataJob.objects.get(id=inputs.job_id)
     except ExternalDataJob.DoesNotExist:
@@ -129,15 +142,13 @@ def maybe_repartition_table_activity(inputs: RepartitionActivityInputs) -> None:
 
     helper = DeltaTableHelper(resource_name=schema.name, job=job, logger=logger)
 
-    pending = schema.repartition_pending
-    swap = schema.repartition_swap
     if pending is None and swap is None:
-        # Nothing was queued by a prior run's post-load detection. Measure the on-disk table now and
-        # self-flag if it's over budget — the only path that can rescue a table which OOMs its merge
-        # every run (and so never reaches post-load detection to flag itself).
+        # Nothing was queued by a prior run's post-load detection, but the gate flagged the table for an
+        # on-disk measurement. Measure now and self-flag if it's over budget — the only path that can
+        # rescue a table which OOMs its merge every run (and so never reaches post-load detection).
         pending = _maybe_flag_pre_extraction(schema, job, helper, logger)
         if pending is None:
-            logger.debug("repartition: nothing queued and table within budget, nothing to do")
+            logger.debug("repartition: pre-extraction measurement found no repartition needed")
             return
 
     target = RepartitionTarget.from_dict(pending) if pending is not None else _target_from_schema(schema)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -16,6 +16,7 @@ from django.db import close_old_connections
 import structlog
 from asgiref.sync import async_to_sync
 from structlog.contextvars import bind_contextvars
+from structlog.types import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.exceptions_capture import capture_exception
@@ -35,6 +36,8 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     MAX_REPARTITION_ATTEMPTS,
     base_event_props,
     capture_repartition_event,
+    maybe_flag_for_repartition,
+    target_partition_bytes,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.metrics import (
     DELTA_REPARTITION_DURATION_SECONDS,
@@ -64,6 +67,46 @@ def _target_from_schema(schema: ExternalDataSchema) -> RepartitionTarget:
     )
 
 
+def _maybe_flag_pre_extraction(
+    schema: ExternalDataSchema,
+    job: ExternalDataJob,
+    helper: DeltaTableHelper,
+    logger: FilteringBoundLogger,
+) -> dict[str, Any] | None:
+    """Detect an over-budget partition against the on-disk table before extraction, and flag it.
+
+    The post-load detector (`maybe_flag_for_repartition`) only runs after a merge completes, so a table
+    whose merge OOMs every run can never flag itself for repair — the classic chicken-and-egg. Running
+    the same detection (same feature-flag, budget, and cooldown gating) here, pre-extraction, closes
+    that gap: the on-disk table already reflects the over-budget layout, so we can flag and — in this
+    same run — rewrite it before the merge that would OOM. Returns the pending target set by detection,
+    or None if nothing was flagged. Never raises.
+    """
+    # CDC tables are excluded from the controller, matching the post-load call site in load.py.
+    if schema.sync_type == ExternalDataSchema.SyncType.CDC:
+        return None
+
+    # Cheap in-memory gate: skip the extra delta-log read on the healthy path. The post-load detector
+    # records `max_partition_bytes` after every successful merge, so a table with a known within-budget
+    # measurement can't need repair. We only reach the full on-disk measurement when the last recording
+    # was over budget or never happened — the latter covering a table whose merge always OOMs (so
+    # post-load never ran to record it).
+    last_measured = schema.max_partition_bytes
+    if last_measured is not None and last_measured <= target_partition_bytes():
+        return None
+
+    try:
+        delta_table = async_to_sync(helper.get_delta_table)()
+        if delta_table is None:
+            return None
+        async_to_sync(maybe_flag_for_repartition)(schema, schema.source, job, delta_table, logger)
+    except Exception as e:
+        # Detection is best-effort; a failure here must not block the sync.
+        capture_exception(e)
+        return None
+    return schema.repartition_pending
+
+
 @activity.defn
 def maybe_repartition_table_activity(inputs: RepartitionActivityInputs) -> None:
     # Sync activity (runs in the worker's thread pool) so its ORM access is safe off the event loop;
@@ -75,22 +118,30 @@ def maybe_repartition_table_activity(inputs: RepartitionActivityInputs) -> None:
     try:
         schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
     except ExternalDataSchema.DoesNotExist:
+        logger.warning("repartition: schema not found, skipping activity", schema_id=inputs.schema_id)
         return
-
-    pending = schema.repartition_pending
-    swap = schema.repartition_swap
-    if pending is None and swap is None:
-        return  # Nothing queued — cheap common path.
 
     try:
         job = ExternalDataJob.objects.get(id=inputs.job_id)
     except ExternalDataJob.DoesNotExist:
+        logger.warning("repartition: job not found, skipping activity", job_id=inputs.job_id)
         return
+
+    helper = DeltaTableHelper(resource_name=schema.name, job=job, logger=logger)
+
+    pending = schema.repartition_pending
+    swap = schema.repartition_swap
+    if pending is None and swap is None:
+        # Nothing was queued by a prior run's post-load detection. Measure the on-disk table now and
+        # self-flag if it's over budget — the only path that can rescue a table which OOMs its merge
+        # every run (and so never reaches post-load detection to flag itself).
+        pending = _maybe_flag_pre_extraction(schema, job, helper, logger)
+        if pending is None:
+            logger.debug("repartition: nothing queued and table within budget, nothing to do")
+            return
 
     target = RepartitionTarget.from_dict(pending) if pending is not None else _target_from_schema(schema)
     trigger_reason = (pending or {}).get("trigger_reason", "resume")
-
-    helper = DeltaTableHelper(resource_name=schema.name, job=job, logger=logger)
 
     started_props = base_event_props(schema, schema.source, inputs.job_id)
     started_props["trigger_reason"] = trigger_reason


### PR DESCRIPTION
## Problem

The automated in-place repartition controller has two halves in different phases of the sync workflow:

- **Detection** (`maybe_flag_for_repartition`) runs post-merge, at the end of `common/load.py`. It measures partition sizes and, if a partition is over the memory-safe budget, records a `repartition_pending` target on the schema. This is the only place `repartition_pending` is ever set.
- **Execution** (`maybe_repartition_table_activity`) runs pre-extraction on the next run, reads `repartition_pending`, and does the rewrite.

That ordering has a chicken-and-egg problem. A table whose incremental merge OOMs the worker every run never reaches post-load detection, so it can never flag itself for repair. Turning on the rollout flag does nothing for exactly the tables that need it most, because the flag only gates the detection half, and detection requires a merge that completes. The pre-extraction activity just hits `if pending is None and swap is None: return` and exits silently every run.

## Changes

Run the same detection pre-extraction, against the on-disk table, inside `maybe_repartition_table_activity`. When nothing is queued, measure the current table and self-flag if it is over budget, reusing `maybe_flag_for_repartition` verbatim so the flag, budget, and cooldown gating are identical to the post-load path. The on-disk table already reflects the over-budget layout, so an over-budget table gets flagged and rewritten in the same run, before the merge that would OOM.

Two safety choices worth calling out:

- **Flag-safe rollout.** Because it reuses `maybe_flag_for_repartition`, a target is only set when the flag is on, the table is over budget, and it is not in cooldown. Tables without the flag are unaffected.
- **Cheap hot-path gate.** A cheap in-memory check (`schema.max_partition_bytes` vs budget, no I/O) short-circuits the healthy path, so we only pay the extra delta-log read when the last recorded measurement was over budget or was never recorded. The never-recorded case is exactly the OOMing table, which never reached post-load to record one.

Also logged the three previously-silent early returns (schema missing, job missing, nothing to do), so "ran and decided to no-op" is distinguishable from "never ran" in the logs. That gap is what made this hard to diagnose in the first place.

## How did you test this code?

Automated tests in `test_repartition_controller.py`:

- Replaced `test_noop_when_nothing_pending`, which was passing only incidentally because `get_delta_table` errored in the harness, with `test_noop_when_within_budget_measurement_recorded`. It deterministically locks in the cheap gate: a within-budget recorded measurement means no delta read, no detection, no rewrite. Catches someone removing or inverting the `max_partition_bytes` gate so healthy syncs start doing extra work.
- Added `test_pre_extraction_flags_over_budget_table_and_repartitions`. Nothing queued plus an on-disk partition over budget must detect and rewrite in the same run. This is the regression guard for the fix itself: revert the pre-extraction detection and an OOMing table goes back to never repartitioning.

I (Claude) could not run the DB-backed tests locally: this checkout's conftest dies in `create_clickhouse_tables()` on a `typing_extensions` incompatibility that hits before any test code runs, unrelated to this change. I verified the edited modules import cleanly under Django (no circular imports), ruff is clean, and reviewed the logic. The tests will run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code) wrote the code. Starting point was an OOMing schema that would not repartition despite the rollout flag being enabled. Claude traced it to the detection/execution split described above rather than a bug in the rewrite itself.

Decisions along the way: we considered a manual one-off seed of `repartition_pending` to unblock the specific schema, but chose the structural fix so the class of problem is handled for every table. We debated whether to run detection unconditionally pre-extraction versus gating it, and chose the in-memory `max_partition_bytes` gate to keep the healthy sync path free of an extra delta-log read while still catching the OOM case (whose last measurement is over budget or absent). Skipped a dedicated CDC-exclusion test since that guard just mirrors the existing post-load call site.

Skills invoked: `/writing-tests` (to gate and shape the two test changes).
