### PR TITLE
fix(reddit-ads): surface reconnect prompt instead of leaking integration id

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/source.py
@@ -119,7 +119,18 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
             return True, None
         except Exception as e:
             capture_exception(e)
-            return False, f"Failed to validate Reddit Ads credentials: {str(e)}"
+            # A deleted/disconnected integration surfaces as OAuthMixin's
+            # "Integration not found: <id>" ValueError, which echoes an internal id the
+            # user can't act on. Surface the same reconnect prompt the other OAuth sources use.
+            if "Integration not found" in str(e):
+                return (
+                    False,
+                    "The Reddit Ads connection for this source no longer exists. Please reconnect your Reddit Ads account.",
+                )
+            return (
+                False,
+                "Could not validate your Reddit Ads credentials. Please reconnect your Reddit Ads account and try again.",
+            )
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -102,15 +102,15 @@ class TestRedditAdsSource:
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.reddit_ads.source.capture_exception")
     def test_validate_credentials_integration_error(self, mock_capture_exception, mock_get_oauth_integration):
-        """Test credential validation with integration error."""
-        mock_get_oauth_integration.side_effect = Exception("Integration not found")
+        """A missing integration surfaces a reconnect prompt without leaking the internal id."""
+        mock_get_oauth_integration.side_effect = ValueError("Integration not found: 154683")
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is False
         assert error_message is not None
-        assert "Failed to validate Reddit Ads credentials" in error_message
-        assert "Integration not found" in error_message
+        assert "reconnect your Reddit Ads account" in error_message
+        assert "154683" not in error_message
         mock_capture_exception.assert_called_once()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When a Reddit Ads data warehouse source's OAuth integration has been deleted or disconnected, the new-source wizard showed a raw internal error of the shape `Failed to validate Reddit Ads credentials: Integration not found: <id>`.

`RedditAdsSource.validate_credentials` looks the integration up via `OAuthMixin.get_oauth_integration`, which raises `ValueError("Integration not found: <id>")` when the row is gone. The bare `except Exception` echoed `str(e)` straight into the toast, exposing an internal integration id the user can't act on.

## Changes

Match the pattern the sync path (`get_non_retryable_errors`) and the other OAuth sources (Google Ads, Google Search Console) already use: catch the missing-integration case and return a clean "reconnect your Reddit Ads account" message. Other unexpected validation failures now return a generic reconnect prompt instead of dumping `str(e)`.

## How did you test this code?

Updated the existing `test_validate_credentials_integration_error` to drive `get_oauth_integration` with a `ValueError("Integration not found: <id>")` and assert the reconnect message is returned and the internal id does not leak. This guards the exact regression fixed here (the old test asserted the leaky behavior). Ran it locally: 1 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging a batch of data-warehouse source-creation failures. Invoked the `/writing-tests` skill before altering the test. I (Claude) verified the fix against the existing Google Ads / Google Search Console handling for the same missing-integration case and kept the message wording consistent with them.
