### PR TITLE
fix(google-sheets): map Sheets API errors to an actionable message

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -102,6 +102,22 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
                 False,
                 "Permissions missing from spreadsheet. View documentation at https://posthog.com/docs/cdp/sources/google-sheets",
             )
+        except gspread.exceptions.APIError as e:
+            # gspread stringifies these as "APIError: [<code>]: <message>", which isn't actionable.
+            # The common case is an uploaded Office file (.xlsx) the Sheets API can't read.
+            api_message = str(e.error.get("message", "")) if isinstance(e.error, dict) else ""
+            if "Office file" in api_message:
+                return (
+                    False,
+                    "This spreadsheet is an uploaded Office file (e.g. .xlsx), which the Google Sheets API "
+                    "can't read. Open it in Google Sheets, use File → Save as Google Sheets, and connect the "
+                    "converted sheet instead.",
+                )
+            return (
+                False,
+                "Google Sheets could not open this spreadsheet. Please check the URL and that it is shared "
+                "with our service account as described at https://posthog.com/docs/cdp/sources/google-sheets",
+            )
         except Exception as e:
             return False, str(e)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -494,3 +494,31 @@ def test_google_sheets_client_sets_request_timeout():
 
     assert client.http_client.timeout == _REQUEST_TIMEOUT_SECONDS
     assert client.http_client.timeout is not None
+
+
+@pytest.mark.parametrize(
+    "api_message,expected_fragment",
+    [
+        # The reported case: an uploaded .xlsx the Sheets API refuses to open.
+        (
+            "This operation is not supported for this document. The document must not be an Office file.",
+            "Save as Google Sheets",
+        ),
+        # Any other 400 from the Sheets API falls back to a clean, actionable message.
+        ("Some other bad request", "shared with our service account"),
+    ],
+)
+def test_validate_credentials_maps_api_error_to_friendly_message(api_message, expected_fragment):
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.source.google_sheets_client"
+    ) as mock_client:
+        mock_client.return_value.open_by_url.side_effect = _api_error(
+            400, message=api_message, status="INVALID_ARGUMENT"
+        )
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+        is_valid, error_message = GoogleSheetsSource().validate_credentials(config, team_id=1)
+
+    assert is_valid is False
+    assert expected_fragment in (error_message or "")
+    # The raw gspread "APIError: [400]: ..." dump must not reach the user.
+    assert "APIError" not in (error_message or "")


### PR DESCRIPTION
## Problem

Connecting a spreadsheet the Google Sheets API refuses to open surfaced a raw internal string in the new-source wizard, of the shape `APIError: [400]: <google's message>`. The most common trigger is an uploaded Office file (.xlsx), which the Sheets API can't read at all.

`GoogleSheetsSource.validate_credentials` handled `SpreadsheetNotFound` (404) and `PermissionError` (403) with friendly messages, but any other gspread `APIError` fell through to the bare `except Exception` and returned `str(e)` verbatim.

## Changes

Catch `gspread.exceptions.APIError` before the generic handler:

- Office-file case (message contains `Office file`): tell the user to open it in Google Sheets, use File → Save as Google Sheets, and connect the converted sheet.
- Any other API error: a clean fallback pointing at the URL and service-account sharing docs, instead of the raw gspread dump.

## How did you test this code?

Added a parameterized test `test_validate_credentials_maps_api_error_to_friendly_message` driving `open_by_url` with an Office-file `APIError` and a generic 400 `APIError`, asserting the actionable message is returned and the raw `APIError` string never leaks. Guards the exact regression fixed here (no existing test exercised `validate_credentials`'s `APIError` path). Ran it locally: 2 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging a batch of data-warehouse source-creation failures. Invoked the `/writing-tests` skill before adding the test. I (Claude) extracted the message via gspread's `APIError.error["message"]` rather than string-slicing `str(e)`, matching how the source's other handlers branch on known conditions.
