### PR TITLE
fix(custom): clean up probe timeout and connection error messages

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -12,7 +12,7 @@ from django.db import IntegrityError
 import structlog
 from jsonpath_ng.exceptions import JSONPathError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
-from requests import PreparedRequest, Response
+from requests import PreparedRequest, Response, Timeout
 from urllib3.util.retry import Retry
 
 from posthog.schema import (
@@ -931,8 +931,19 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
                     timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
                     stream=True,
                 )
-            except Exception as exc:
-                return False, f"Resource {resource['name']!r}: could not reach {url}: {exc}"
+            except Timeout:
+                # str(exc) here is the raw urllib3 "HTTPSConnectionPool(...): Read timed out" dump,
+                # which isn't actionable — surface the configured timeouts instead.
+                return False, (
+                    f"Resource {resource['name']!r}: timed out reaching {url} "
+                    f"(connect timeout {PROBE_CONNECT_TIMEOUT}s, read timeout {PROBE_READ_TIMEOUT}s). "
+                    "The endpoint may be slow or temporarily unreachable — check the URL and try again."
+                )
+            except Exception:
+                return False, (
+                    f"Resource {resource['name']!r}: could not reach {url}. "
+                    "Check that the URL is correct and the endpoint is reachable."
+                )
 
             # Only an auth rejection (401/403) is a credential problem. Other
             # statuses — 404 (resource not yet provisioned), 405, 429 (rate

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -1388,18 +1388,32 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
 
         assert mock_session.call_args.kwargs["redact_values"] == ("sk_live_leaky",)
 
+    @parameterized.expand(
+        [
+            # A connection-level failure surfaces a clean "could not reach" message.
+            ("connection", requests.exceptions.ConnectionError("boom at 10.0.0.1"), "could not reach", "boom"),
+            # A read timeout surfaces the configured timeouts, not the raw urllib3 dump.
+            (
+                "timeout",
+                requests.Timeout("HTTPSConnectionPool(host='x'): Read timed out. (read timeout=10)"),
+                "timed out",
+                "HTTPSConnectionPool",
+            ),
+        ]
+    )
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.custom.source.make_tracked_session")
-    def test_returns_false_on_network_error(self, mock_session):
-        # A connection-level failure (DNS, TLS, timeout) must surface as a
-        # credential validation error pointing at the offending resource.
-        mock_session.return_value.request.side_effect = ConnectionError("boom")
+    def test_returns_false_on_network_error(self, _name, side_effect, expected_fragment, leaked_text, mock_session):
+        # A connection-level failure (DNS, TLS, timeout) must surface as a credential validation
+        # error pointing at the offending resource, without leaking the raw requests exception.
+        mock_session.return_value.request.side_effect = side_effect
 
         source = CustomSource()
         config = CustomSourceConfig(manifest_json=json.dumps(_minimal_manifest()), auth_token="abc")
         ok, err = source.validate_credentials(config, team_id=999)
         assert not ok
-        assert "could not reach" in (err or "")
+        assert expected_fragment in (err or "")
         assert "users" in (err or "")
+        assert leaked_text not in (err or "")
 
     def test_returns_false_on_invalid_manifest(self):
         source = CustomSource()


### PR DESCRIPTION
## Problem

When the custom REST source's credential probe can't reach a configured endpoint, the new-source wizard showed a raw urllib3 exception dump of the shape `Resource '<name>': could not reach <url>: HTTPSConnectionPool(host=...): Read timed out. (read timeout=10)`.

`validate_credentials` caught bare `Exception` and appended `str(exc)` verbatim, so the internal connection-pool traceback text reached the user with nothing actionable in it.

## Changes

Split the probe's exception handling:

- Timeout (`requests.Timeout`, covering connect and read timeouts): report the configured connect/read timeouts and note the endpoint may be slow or temporarily unreachable.
- Any other connection-level failure: a clean "could not reach `<url>`, check that the URL is correct and the endpoint is reachable" message.

Neither branch echoes the raw requests exception. The configured URL is still surfaced (the user typed it, and the existing 401/403 branch already echoes it).

## How did you test this code?

Parameterized the existing `test_returns_false_on_network_error` over a connection error and a read timeout, asserting the actionable fragment is present, the resource name is present, and the raw exception text (`boom` / `HTTPSConnectionPool`) does not leak. Guards the exact regression fixed here. Ran it locally: 2 passed. Note: the DB-backed OAuth2 wiring tests in this file need Postgres and error out in this sandbox; the probe/validation tests I touched run without a DB and pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging a batch of data-warehouse source-creation failures. Invoked the `/writing-tests` skill before altering the test. I (Claude) kept the URL in the message for consistency with the source's existing 401/403 branch, and narrowed only the timeout case out of the generic handler rather than enumerating every requests exception type.
