### PR TITLE
fix(engineering_analytics): attribute CI log records to github-ci-logs

### DIFF
--- a/products/engineering_analytics/backend/logic/job_logs/activity.py
+++ b/products/engineering_analytics/backend/logic/job_logs/activity.py
@@ -38,6 +38,10 @@ class FetchJobLogInputs:
     run_id: int | None = None
     branch: str | None = None
     conclusion: str | None = None
+    job_name: str | None = None
+    workflow_name: str | None = None
+    run_attempt: int | None = None
+    head_sha: str | None = None
 
 
 def _resolve_credentials(team_id: int, integration_id: int) -> tuple[str, str, str]:
@@ -76,6 +80,13 @@ async def fetch_and_emit_job_log_activity(inputs: FetchJobLogInputs) -> dict[str
         "repo": inputs.repo,
         "branch": inputs.branch or "",
         "conclusion": inputs.conclusion or "",
+        # job_name/workflow_name make records readable in the Logs UI without a warehouse join;
+        # run_attempt disambiguates re-runs (all attempts share run_id, i.e. one trace); head_sha
+        # is the per-commit anchor (SPEC §7 — precision key only, never the attribution key).
+        "job_name": inputs.job_name or "",
+        "workflow_name": inputs.workflow_name or "",
+        "run_attempt": inputs.run_attempt or 0,
+        "head_sha": inputs.head_sha or "",
         # Total lines in the full log before thinning — the denominator for each line's orig_line.
         "orig_total": len(archive.splitlines()),
     }

--- a/products/engineering_analytics/backend/logic/job_logs/coordinator.py
+++ b/products/engineering_analytics/backend/logic/job_logs/coordinator.py
@@ -56,7 +56,8 @@ def _query_failed_jobs(team: Team, prefix: str, cutoff_iso: str) -> list[dict[st
     # suffix); user values flow through the placeholder, never the f-string.
     table = f"{prefix}github_workflow_jobs"
     sql = f"""
-        SELECT id AS job_id, run_id, head_branch AS branch, conclusion
+        SELECT id AS job_id, run_id, head_branch AS branch, conclusion,
+               name AS job_name, workflow_name, run_attempt, head_sha
         FROM {table}
         WHERE conclusion = 'failure' AND completed_at > {{cutoff}}
         ORDER BY completed_at DESC
@@ -141,6 +142,10 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
                             run_id=row.get("run_id"),
                             branch=row.get("branch"),
                             conclusion=row.get("conclusion"),
+                            job_name=row.get("job_name"),
+                            workflow_name=row.get("workflow_name"),
+                            run_attempt=row.get("run_attempt"),
+                            head_sha=row.get("head_sha"),
                         )
                     )
                 )

--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -101,7 +101,9 @@ class JobLogsEmitter:
             self._provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
         else:
             logger.warning("github_ci_logs_emit_disabled", detail="no endpoint/token configured; skipping export")
-        self._logger = self._provider.get_logger(_SERVICE_NAME)
+        # capture-logs stores the scope as "{name}@{version}"; without a version the stored value
+        # ends in a dangling "@".
+        self._logger = self._provider.get_logger(_SERVICE_NAME, version="1")
 
     def emit_log_archive(
         self,

--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -79,7 +79,13 @@ class JobLogsEmitter:
     def __init__(
         self, *, endpoint: str | None = None, token: str | None = None, exporter: LogExporter | None = None
     ) -> None:
-        self._provider = LoggerProvider(resource=Resource.create({"service.name": _SERVICE_NAME}))
+        # This resource must ALSO be passed to every hand-built LogRecord below: Logger.emit(record)
+        # attaches only the instrumentation scope, and a record constructed without resource= defaults
+        # to Resource.create({}) — i.e. the pod's OTEL_SERVICE_NAME/OTEL_RESOURCE_ATTRIBUTES env, which
+        # on the worker is the k8s workload name. Records then land under that service.name and the
+        # failure-logs read filter (service.name = github-ci-logs) never matches them.
+        self._resource = Resource.create({"service.name": _SERVICE_NAME})
+        self._provider = LoggerProvider(resource=self._resource)
         if exporter is None and endpoint and token:
             # capture-logs is in-cluster (a private ClusterIP). The worker's HTTP_PROXY/HTTPS_PROXY
             # point at the Smokescreen egress proxy, which denies private-range hosts (407) — so the
@@ -148,6 +154,7 @@ class JobLogsEmitter:
                     severity_number=severity_number,
                     body=body,
                     attributes=attrs,
+                    resource=self._resource,
                 )
             )
             emitted += 1

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_activity.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_activity.py
@@ -9,11 +9,23 @@ from products.engineering_analytics.backend.logic.job_logs.activity import (
 )
 
 _INPUTS = FetchJobLogInputs(
-    team_id=1, integration_id=2, repo="PostHog/posthog", job_id=3, run_id=4, branch="main", conclusion="failure"
+    team_id=1,
+    integration_id=2,
+    repo="PostHog/posthog",
+    job_id=3,
+    run_id=4,
+    branch="main",
+    conclusion="failure",
+    job_name="backend-tests",
+    workflow_name="Backend CI",
+    run_attempt=2,
+    head_sha="abc1234",
 )
 
 
 class _FakeEmitter:
+    last_kwargs: dict = {}
+
     def __init__(self, *_args, **_kwargs):
         self.archive = None
 
@@ -23,8 +35,9 @@ class _FakeEmitter:
     def __exit__(self, *_args):
         return None
 
-    def emit_log_archive(self, lines, **_kwargs):
+    def emit_log_archive(self, lines, **kwargs):
         self.lines = lines
+        _FakeEmitter.last_kwargs = kwargs
         return len(lines)
 
 
@@ -45,6 +58,13 @@ async def test_emits_and_returns_line_count(monkeypatch):
     _patch(monkeypatch, archive="line one\nline two")
     result = await fetch_and_emit_job_log_activity(_INPUTS)
     assert result == {"status": "emitted", "job_id": 3, "lines": 2}
+    # The job identity attributes must reach the emitter — dropping one here silently strips it
+    # from every stored record, and it can't be backfilled (GitHub logs expire).
+    attrs = _FakeEmitter.last_kwargs["attributes"]
+    assert attrs["job_name"] == "backend-tests"
+    assert attrs["workflow_name"] == "Backend CI"
+    assert attrs["run_attempt"] == 2
+    assert attrs["head_sha"] == "abc1234"
 
 
 async def test_raises_and_skips_fetch_when_budget_exhausted(monkeypatch):

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_activity.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_activity.py
@@ -28,6 +28,7 @@ class _FakeEmitter:
 
     def __init__(self, *_args, **_kwargs):
         self.archive = None
+        _FakeEmitter.last_kwargs = {}
 
     def __enter__(self):
         return self

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
@@ -151,3 +151,14 @@ def test_noop_when_token_missing():
     # the records would be lost), and a half-configured lane shouldn't crash the worker.
     emitter = JobLogsEmitter(endpoint="http://localhost:8010/i/v1/logs", token=None)
     assert emitter.emit_log_archive(_lines("2026-06-25T09:14:02.000000Z x"), attributes=_ATTRS) == 0
+
+
+def test_records_carry_ci_logs_service_name_despite_pod_otel_env():
+    # The worker pod sets OTEL_SERVICE_NAME to its own workload name, and a hand-built LogRecord
+    # defaults its resource from that env — Logger.emit(record) never attaches the provider's
+    # resource. Without pinning the resource on each record, every line lands under the pod's
+    # service.name and the failure-logs read filter (service.name = github-ci-logs) matches nothing.
+    env = {"OTEL_SERVICE_NAME": "temporal-worker-general-purpose"}
+    with patch.dict("os.environ", env):
+        _, records = _emit("2026-06-25T09:14:02.000000Z hello")
+    assert [r.resource.attributes["service.name"] for r in records] == ["github-ci-logs"]

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
@@ -158,7 +158,7 @@ def test_records_carry_ci_logs_service_name_despite_pod_otel_env():
     # defaults its resource from that env — Logger.emit(record) never attaches the provider's
     # resource. Without pinning the resource on each record, every line lands under the pod's
     # service.name and the failure-logs read filter (service.name = github-ci-logs) matches nothing.
-    env = {"OTEL_SERVICE_NAME": "temporal-worker-general-purpose"}
+    env = {"OTEL_SERVICE_NAME": "temporal-worker-general-purpose", "OTEL_RESOURCE_ATTRIBUTES": ""}
     with patch.dict("os.environ", env):
         _, records = _emit("2026-06-25T09:14:02.000000Z hello")
     assert [r.resource.attributes["service.name"] for r in records] == ["github-ci-logs"]


### PR DESCRIPTION
## Problem

CI failure logs finally land in the Logs product (after #67310 fixed the egress-proxy 407s), but every record arrives under the worker pod's `service.name` (`temporal-worker-general-purpose`) instead of `github-ci-logs` — so the `ci_failure_logs` endpoint, which filters on exactly that service name, matches nothing.

The emitter sets the intended resource on its `LoggerProvider`, but that only covers records the logger itself constructs. This emitter hand-builds SDK `LogRecord`s, and `Logger.emit(record)` attaches only the instrumentation scope — a record built without `resource=` defaults to `Resource.create({})`, which resolves `service.name` from the pod's `OTEL_SERVICE_NAME`/`OTEL_RESOURCE_ATTRIBUTES` env. Verified against the SDK source (1.33.1) and reproduced: same provider, one record without explicit resource lands under the env identity, one with it lands under `github-ci-logs`.

While in here, the records also carried too little identity: only the numeric `job_id`, so the Logs UI can't tell which job or workflow a line belongs to without a warehouse join, and re-run attempts are indistinguishable (all attempts share `run_id`, and `run_id` is the trace id, while job_ids change per attempt).

## Changes

- Build the `Resource` once and pass it both to the `LoggerProvider` and as `resource=` on every hand-built `LogRecord`, so records actually ship with `service.name = github-ci-logs`.
- Thread `job_name`, `workflow_name`, `run_attempt`, and `head_sha` from the coordinator's discovery query through `FetchJobLogInputs` into the emitted attributes. All four are existing columns on the `github_workflow_jobs` table — no new ingestion. `pr_number` deliberately stays out: per SPEC §7, PR attribution happens read-side via the run's `pull_requests` association.
- Pass a scope version to `get_logger` so capture-logs stops storing the scope as `github-ci-logs@` with a dangling separator (it renders `{name}@{version}`).

## How did you test this code?

- New regression test monkeypatches `OTEL_SERVICE_NAME` to the pod's workload name and asserts every exported record's resource carries `github-ci-logs`. Verified it fails against the unfixed emitter and passes with the fix. No existing test could catch this: they all inject an in-memory exporter in a clean env, so the pod-realistic env path never ran (the same gap that let the two earlier emit-path bugs ship).
- Extended the existing activity emit test to assert the four new identity attributes reach the emitter — dropping one silently strips it from every stored record, and it can't be backfilled since GitHub logs expire.
- Full job_logs suite: 45 passed. Targeted mypy on the module: clean (one pre-existing unrelated error in `personhog_client`).

I (well, Claude) could not verify end-to-end in production — that needs this deployed, then checking Logs for `service.name = github-ci-logs` and the `ci_failure_logs` tool returning lines.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal emit-path behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused and written with Claude Code. The tell was that `instrumentation_scope` survived ingestion while `service.name` showed the pod identity — scope is attached by `Logger.emit`, resource is not. An earlier session verified "explicit `Resource.create` beats env vars", which is true but was the wrong question: the provider's resource never reaches hand-built records at all. Confirmed by reading the installed SDK source and reproducing with an in-memory exporter under a pod-like env. The trace/span id encoding was also audited on live data and is correct end to end (`run_id` → 16-byte trace id, `job_id` → 8-byte span id, base64 stored, hex rendered by the query runner) — the zero-padding just looks unusual around small GitHub integers. `/writing-tests` guidelines applied to the test additions.
