### PR TITLE
fix(toolbar): key clickmap dedupe on chain content, not the null api hash

### DIFF
--- a/frontend/src/toolbar/TELEMETRY.md
+++ b/frontend/src/toolbar/TELEMETRY.md
@@ -167,7 +167,7 @@ A user paginating emits one event per page with cumulative `event_count` — gro
 | `duration_ms`            | `number`  | Wall-clock processing time, including main-thread yields; DOM index build time is included only on a cold cache  |
 | `trigger`                | `string`  | What started the run: `initial`, `pagination`, `refresh`, or `toggle`                                            |
 | `cache_hit`              | `boolean` | Whether the page-elements cache was warm (no collect + index rebuild)                                            |
-| `completed`              | `boolean` | False when the run was cancelled mid-processing by a newer run                                                   |
+| `completed`              | `boolean` | False when the run did not finish — superseded by a newer run, or failed mid-processing                          |
 
 **File:** `elements/heatmapToolbarMenuLogic.ts`
 

--- a/frontend/src/toolbar/elements/domElementIndex.test.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.test.ts
@@ -293,6 +293,24 @@ describe('domElementIndex', () => {
                 ],
             },
             {
+                name: 'uses position to pick between siblings sharing a data attribute',
+                html: `
+                    <div>
+                        <button data-attr="cta"></button>
+                        <button data-attr="cta" id="target"></button>
+                    </div>
+                `,
+                event: [
+                    {
+                        tag_name: 'button',
+                        attributes: { 'attr__data-attr': 'cta' },
+                        nth_child: 2,
+                        nth_of_type: 2,
+                    },
+                ],
+                dataAttributes: ['data-attr'],
+            },
+            {
                 name: 'ignores drifted sibling position when the clicked element is identified by id',
                 html: `
                     <div class="injected-banner"></div>

--- a/frontend/src/toolbar/elements/domElementIndex.test.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.test.ts
@@ -293,6 +293,30 @@ describe('domElementIndex', () => {
                 ],
             },
             {
+                name: 'ignores drifted sibling position when the clicked element is identified by id',
+                html: `
+                    <div class="injected-banner"></div>
+                    <button id="target" class="btn"></button>
+                `,
+                event: [{ tag_name: 'button', attr_id: 'target', nth_child: 1, nth_of_type: 1 }],
+            },
+            {
+                name: 'ignores drifted sibling position when the clicked element is identified by a data attribute',
+                html: `
+                    <div class="injected-banner"></div>
+                    <button data-attr="cta" id="target"></button>
+                `,
+                event: [
+                    {
+                        tag_name: 'button',
+                        attributes: { 'attr__data-attr': 'cta' },
+                        nth_child: 1,
+                        nth_of_type: 1,
+                    },
+                ],
+                dataAttributes: ['data-attr'],
+            },
+            {
                 name: 'ignores drifted sibling position when the ancestor is identified by id',
                 html: `
                     <div class="injected-banner"></div>

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -89,6 +89,10 @@ function createFingerprint(
     }
 }
 
+export function hasNonToolbarShadowRoots(pageElements: HTMLElement[]): boolean {
+    return pageElements.some((el) => !!el.shadowRoot && el.id !== TOOLBAR_ID)
+}
+
 export function buildDOMIndex(pageElements: HTMLElement[]): DOMIndex {
     const index: DOMIndex = {
         byId: new Map(),
@@ -152,27 +156,40 @@ function filterByPosition(candidates: HTMLElement[], eventElement: ElementType, 
     })
 }
 
+// derived once per chain level, not per candidate: matchesDataAttribute builds a RegExp per call
+function getMatchedDataAttribute(
+    eventElement: ElementType,
+    dataAttributes: string[]
+): { name: string; value: string } | null {
+    const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
+    if (!matchedAttr) {
+        return null
+    }
+    const value = eventElement.attributes?.[`attr__${matchedAttr}`]
+    return value === undefined ? null : { name: matchedAttr, value }
+}
+
 function getCandidatesFromIndex(
     eventElement: ElementType,
     dataAttributes: string[],
     matchLinksByHref: boolean,
     index: DOMIndex
 ): HTMLElement[] {
-    const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
-    if (matchedAttr && eventElement.attributes) {
-        const value = eventElement.attributes[`attr__${matchedAttr}`]
-        if (value !== undefined) {
-            const candidates = index.byDataAttr.get(matchedAttr)?.get(value) || []
-            if (candidates.length) {
-                return filterByPosition(candidates, eventElement, index)
-            }
+    // a configured data attribute or an id identifies the element on its own — mirroring
+    // elementToSelector, which early-returns on these — so sibling-position drift from injected
+    // DOM must not exclude these candidates; the ancestor walk still disambiguates duplicates
+    const matchedDataAttribute = getMatchedDataAttribute(eventElement, dataAttributes)
+    if (matchedDataAttribute) {
+        const candidates = index.byDataAttr.get(matchedDataAttribute.name)?.get(matchedDataAttribute.value) || []
+        if (candidates.length) {
+            return candidates
         }
     }
 
     if (eventElement.attr_id) {
         const candidates = index.byId.get(eventElement.attr_id) || []
         if (candidates.length) {
-            return filterByPosition(candidates, eventElement, index)
+            return candidates
         }
     }
 
@@ -193,19 +210,6 @@ function getCandidatesFromIndex(
     }
 
     return filterByPosition(candidates, eventElement, index)
-}
-
-// derived once per chain level, not per candidate: matchesDataAttribute builds a RegExp per call
-function getMatchedDataAttribute(
-    eventElement: ElementType,
-    dataAttributes: string[]
-): { name: string; value: string } | null {
-    const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
-    if (!matchedAttr) {
-        return null
-    }
-    const value = eventElement.attributes?.[`attr__${matchedAttr}`]
-    return value === undefined ? null : { name: matchedAttr, value }
 }
 
 function fingerprintMatchesEventElement(
@@ -229,9 +233,10 @@ function fingerprintMatchesEventElement(
     }
     // an id or configured data attribute identifies the ancestor on its own, so DOM drift that
     // shifts sibling positions (cookie banners, injected wrappers) shouldn't kill the match —
-    // mirroring elementToSelector, which early-returns on these without position
+    // mirroring elementToSelector, which early-returns on these without position; the id guard
+    // above already established id equality
     const identifiedWithoutPosition =
-        (!!eventElement.attr_id && fingerprint.id === eventElement.attr_id) ||
+        !!eventElement.attr_id ||
         (!!matchedDataAttribute && fingerprint.dataAttrs.get(matchedDataAttribute.name) === matchedDataAttribute.value)
     return identifiedWithoutPosition || matchesPosition(fingerprint, eventElement)
 }
@@ -306,7 +311,7 @@ export function matchEventToElementUsingSelectors(
     dataAttributes: string[],
     matchLinksByHref: boolean,
     pageElements: HTMLElement[],
-    selectorCache: Map<string, HTMLElement[]>,
+    selectorCache: Map<string, HTMLElement[] | null>,
     hasShadowRoots: boolean
 ): CountedHTMLElement | null {
     let lastSelector: string | undefined
@@ -318,8 +323,14 @@ export function matchEventToElementUsingSelectors(
             elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
         const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
 
+        // null marks a selector that previously threw — repeat encounters bail out exactly like
+        // the original failure did
+        let domElements = selectorCache.get(combinedSelector)
+        if (domElements === null) {
+            break
+        }
+
         try {
-            let domElements: HTMLElement[] | undefined = selectorCache.get(combinedSelector)
             if (domElements === undefined) {
                 domElements = hasShadowRoots
                     ? Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
@@ -354,12 +365,10 @@ export function matchEventToElementUsingSelectors(
         } catch {
             // sentinel-cache the failing selector so repeated rows neither re-throw nor re-log,
             // and truncate: event-derived selectors can embed long customer-page attribute values
-            if (!selectorCache.has(combinedSelector)) {
-                selectorCache.set(combinedSelector, [])
-                toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
-                    selector: combinedSelector.slice(0, 200),
-                })
-            }
+            selectorCache.set(combinedSelector, null)
+            toolbarLogger.warn('heatmap', 'Failed to resolve heatmap element with selector', {
+                selector: combinedSelector.slice(0, 200),
+            })
             break
         }
 

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -156,6 +156,16 @@ function filterByPosition(candidates: HTMLElement[], eventElement: ElementType, 
     })
 }
 
+// position disambiguates siblings that share an identifier, but must not exclude a sole
+// candidate (or all candidates) whose sibling position drifted since capture
+function preferPositionMatches(candidates: HTMLElement[], eventElement: ElementType, index: DOMIndex): HTMLElement[] {
+    if (candidates.length <= 1) {
+        return candidates
+    }
+    const positioned = filterByPosition(candidates, eventElement, index)
+    return positioned.length ? positioned : candidates
+}
+
 // derived once per chain level, not per candidate: matchesDataAttribute builds a RegExp per call
 function getMatchedDataAttribute(
     eventElement: ElementType,
@@ -177,19 +187,20 @@ function getCandidatesFromIndex(
 ): HTMLElement[] {
     // a configured data attribute or an id identifies the element on its own — mirroring
     // elementToSelector, which early-returns on these — so sibling-position drift from injected
-    // DOM must not exclude these candidates; the ancestor walk still disambiguates duplicates
+    // DOM must not exclude a uniquely identified candidate; position still breaks ties between
+    // siblings that share the identifier
     const matchedDataAttribute = getMatchedDataAttribute(eventElement, dataAttributes)
     if (matchedDataAttribute) {
         const candidates = index.byDataAttr.get(matchedDataAttribute.name)?.get(matchedDataAttribute.value) || []
         if (candidates.length) {
-            return candidates
+            return preferPositionMatches(candidates, eventElement, index)
         }
     }
 
     if (eventElement.attr_id) {
         const candidates = index.byId.get(eventElement.attr_id) || []
         if (candidates.length) {
-            return candidates
+            return preferPositionMatches(candidates, eventElement, index)
         }
     }
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -1,0 +1,45 @@
+import { ElementsEventType } from '~/toolbar/types'
+
+import { dedupeByChainIdentity } from './heatmapToolbarMenuLogic'
+
+function statsRow(overrides: Partial<ElementsEventType>): ElementsEventType {
+    return {
+        count: 1,
+        hash: null,
+        type: '$autocapture',
+        elements: [{ tag_name: 'button', attr_class: ['btn'], nth_child: 1, nth_of_type: 1, attributes: {} }],
+        ...overrides,
+    } as ElementsEventType
+}
+
+describe('dedupeByChainIdentity', () => {
+    const cases = [
+        {
+            name: 'keeps distinct chains even though the API returns hash null for every row',
+            events: [
+                statsRow({ elements: [{ tag_name: 'button', attributes: {} }] as ElementsEventType['elements'] }),
+                statsRow({ elements: [{ tag_name: 'a', attributes: {} }] as ElementsEventType['elements'] }),
+            ],
+            expectedCount: 2,
+        },
+        {
+            name: 'drops a chain repeated across paginated pages, keeping the first occurrence',
+            events: [statsRow({ count: 10 }), statsRow({ count: 3 })],
+            expectedCount: 1,
+        },
+        {
+            name: 'keeps identical chains that differ by event type',
+            events: [statsRow({ type: '$autocapture' }), statsRow({ type: '$rageclick' })],
+            expectedCount: 2,
+        },
+    ]
+
+    it.each(cases)('$name', ({ events, expectedCount }) => {
+        expect(dedupeByChainIdentity(events)).toHaveLength(expectedCount)
+    })
+
+    it('keeps the first occurrence of a duplicated chain', () => {
+        const [kept] = dedupeByChainIdentity([statsRow({ count: 10 }), statsRow({ count: 3 })])
+        expect(kept.count).toBe(10)
+    })
+})

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -12,6 +12,7 @@ import { createVersionChecker } from 'lib/utils/semver'
 import {
     DOMIndex,
     buildDOMIndex,
+    hasNonToolbarShadowRoots,
     matchEventToElementUsingIndex,
     matchEventToElementUsingSelectors,
 } from '~/toolbar/elements/domElementIndex'
@@ -20,14 +21,14 @@ import { toolbarApi } from '~/toolbar/toolbarApi'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { TOOLBAR_ID, elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
+import { elementIsVisible, invalidateZoomCache, trimElement } from '~/toolbar/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
 
-export const ELEMENT_STATS_PAGE_LIMIT = 5000
+const ELEMENT_STATS_PAGE_LIMIT = 5000
 
 function yieldToMain(): Promise<void> {
     return new Promise((resolve) => {
@@ -46,7 +47,7 @@ export type ClickmapProcessingTrigger = 'initial' | 'pagination' | 'refresh' | '
 interface ElementProcessingCache {
     pageElements?: HTMLElement[]
     domIndex?: DOMIndex
-    selectorToElements: Map<string, HTMLElement[]>
+    selectorToElements: Map<string, HTMLElement[] | null>
     lastHref?: string
     intersectionObserver?: IntersectionObserver
     visibilityCache: WeakMap<HTMLElement, boolean>
@@ -68,13 +69,16 @@ function getCachedPageElements(
     const cacheValid = cache.pageElements && !hrefChanged && !cache.cacheInvalidated
 
     if (cacheValid && cache.pageElements && cache.domIndex) {
-        return {
-            pageElements: cache.pageElements,
-            domIndex: cache.domIndex,
-            // attachShadow() emits no light-DOM mutation, so the build-time flag can go stale —
-            // recheck the snapshot on every run
-            hasShadowRoots: cache.pageElements.some((el) => el.shadowRoot && el.id !== TOOLBAR_ID),
-            cacheHit: true,
+        // attachShadow() emits no light-DOM mutation, so shadow roots can appear without
+        // invalidating the cache; when that happens the snapshot predates the shadow content,
+        // so rebuild rather than just flipping the flag over stale data
+        if (hasNonToolbarShadowRoots(cache.pageElements) === cache.domIndex.hasShadowRoots) {
+            return {
+                pageElements: cache.pageElements,
+                domIndex: cache.domIndex,
+                hasShadowRoots: cache.domIndex.hasShadowRoots,
+                cacheHit: true,
+            }
         }
     }
 
@@ -301,11 +305,13 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                     }
 
                     return {
-                        results: dedupeByChainIdentity([
-                            // if url is present we are paginating and merge results, otherwise we only use the new results
-                            ...(url ? values.elementStats?.results || [] : []),
-                            ...(result.data.results || []),
-                        ]),
+                        // if url is present we are paginating and merge results, otherwise we only use the new results
+                        results: url
+                            ? dedupeByChainIdentity([
+                                  ...(values.elementStats?.results || []),
+                                  ...(result.data.results || []),
+                              ])
+                            : result.data.results || [],
                         next: result.data.next,
                         previous: result.data.previous,
                     } as PaginatedResponse<ElementsEventType>
@@ -324,6 +330,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             },
         ],
         elementCount: [(s) => [s.countedElements], (countedElements) => countedElements.length],
+        loadedElementStatsCount: [(s) => [s.elementStats], (elementStats) => elementStats?.results?.length ?? 0],
         clickCount: [
             (s) => [s.countedElements],
             (countedElements) => (countedElements ? countedElements.map((e) => e.count).reduce((a, b) => a + b, 0) : 0),
@@ -650,11 +657,13 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
     }),
 ])
 
-function dedupeByChainIdentity(events: ElementsEventType[]): ElementsEventType[] {
+export function dedupeByChainIdentity(events: ElementsEventType[]): ElementsEventType[] {
     const seen = new Set<string>()
     const deduped: ElementsEventType[] = []
     for (const event of events) {
-        const identity = `${event.type}:${event.hash}`
+        // /api/element/stats returns hash as null for every row, so the chain content is the
+        // only usable row identity
+        const identity = `${event.type}:${JSON.stringify(event.elements)}`
         if (seen.has(identity)) {
             continue
         }

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -18,7 +18,7 @@ import { urls } from 'scenes/urls'
 
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
-import { ELEMENT_STATS_PAGE_LIMIT, heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
+import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { joinWithUiHost } from '~/toolbar/utils'
 
@@ -91,6 +91,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         commonFilters,
         heatmapFilters,
         canLoadMoreElementStats,
+        loadedElementStatsCount,
         viewportRange,
         rawHeatmapLoading,
         elementStatsLoading,
@@ -310,9 +311,9 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                     '!'
                                 )}
                             </div>
-                            {canLoadMoreElementStats && (
+                            {canLoadMoreElementStats && loadedElementStatsCount > 0 && (
                                 <div className="mb-2 text-muted text-xs">
-                                    Showing the top {ELEMENT_STATS_PAGE_LIMIT.toLocaleString()} element groups by click
+                                    Showing the top {loadedElementStatsCount.toLocaleString()} element groups by click
                                     count — load more for the full data range.
                                 </div>
                             )}

--- a/frontend/src/toolbar/types.ts
+++ b/frontend/src/toolbar/types.ts
@@ -5,7 +5,7 @@ import { FragileSelectorResult } from './utils/selectorQuality'
 export type ElementsEventType = {
     count: number
     elements: ElementType[]
-    hash: string
+    hash: string | null
     type: '$autocapture' | '$rageclick'
 }
 
@@ -38,7 +38,7 @@ export interface CountedHTMLElement {
     rageclickCount: number
     deadclickCount: number
     element: HTMLElement
-    hash: string
+    hash: string | null
     selector: string
     position?: number
     actionStep?: ActionStepType


### PR DESCRIPTION
## Problem

#67549 added `dedupeByChainIdentity` to guard the clickmap's paginated element-stats merge against double-counted chains, keyed on `${event.type}:${event.hash}`. But `/api/element/stats/` has hardcoded `"hash": None` for every row since 2021 (`posthog/api/element.py:142`), so every row of a given event type shares the identity `"$autocapture:null"` — and because the dedupe wrapped initial loads too, every clickmap load collapses to at most one element group per event type. The toolbar clickmap is effectively broken on master.

Caught by an automated qa-swarm delta review of the follow-up commits; the PR merged via automerge while that review round was in flight, so this lands as a fast-follow.

## Changes

- Key the dedupe on `event.type` + the serialized element chain — the only usable row identity given the API's null hash — and only run it when actually paginating (a single page can't contain duplicates; the server aggregates by chain).
- Make the `hash` fields on `ElementsEventType` / `CountedHTMLElement` honest: `string | null`.
- Address the same review round's other findings:
  - rebuild the page-elements cache when the shadow-root state flips, instead of flipping the flag over a pre-`attachShadow()` snapshot that can't contain the shadow content (shared `hasNonToolbarShadowRoots` predicate)
  - skip the position filter for index candidates identified by id or a configured data attribute, so target-level DOM drift (injected banners) no longer demotes those matches to the selector fallback — matching the ancestor behavior and `elementToSelector` semantics
  - cache failing selectors as a `null` sentinel so repeat encounters bail out exactly like the original failure, instead of escalating a known-bad selector
  - the truncation hint now shows the loaded row count (not the page-size constant, which went stale after one "Load more") and only renders once data has arrived
  - document that `completed: false` in the `toolbar clickmap processed` event also covers mid-processing failures, not just supersedes

## How did you test this code?

- `jest frontend/src/toolbar` — 427/427 pass on this branch (rebased on master).
- New `dedupeByChainIdentity` tests: distinct chains with null hashes must both survive (fails on the hash-keyed version — the exact regression), duplicated chains collapse keeping the first occurrence, identical chains with different event types stay separate.
- New parameterized `domElementIndex` cases: target elements identified by id / data attribute match despite drifted sibling position — verified to fail before the candidate-lookup change.
- Re-ran the matching pipeline benchmark (esbuild bundle of this branch, Chromium via Playwright): per-event cost and hit/miss counts unchanged vs the merged PR's validated numbers (index build 118ms @ 80k elements; 1.8ms/event pathological, 0.03-0.25ms/event realistic shapes).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code as a fast-follow to #67549. The regression was found by a multi-agent qa-swarm review (qa-team, paul-reviewer, xp-reviewer, security-audit) of the merged PR's final commits; the backend's null hash was verified directly against `posthog/api/element.py` before fixing.
- Skills invoked: /writing-tests, /review-triage, /qa-swarm.
- Decisions: keyed dedupe on the serialized chain client-side rather than adding a real hash to the API response (smaller blast radius, no API change); restricted dedupe to pagination merges since single pages are already unique; rebuilt the cache on shadow-root flips rather than tracking partial staleness.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
