### PR TITLE
fix(tasks): support claude-sonnet-5 reasoning effort

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -70,6 +70,7 @@ def validated_request(
     deprecated: bool = False,
     strict_request_validation: bool = True,
     strict_response_validation: bool = False,
+    include_serializer_context: bool = False,
     **extend_schema_kwargs,
 ) -> Callable:
     """
@@ -89,6 +90,12 @@ def validated_request(
             # request.validated_query_data contains validated query params (if query_serializer provided)
             body_field = request.validated_data["field"]
             query_param = request.validated_query_data["param"]
+
+    By default the request/query serializers are constructed with no context, unlike DRF's
+    own `get_serializer()` (which always includes `request`/`view`/`format`). Pass
+    `include_serializer_context=True` to opt a view into the standard context — needed when a
+    serializer's `validate()` reads `self.context["request"]` or `self.context["team"]` (e.g. to
+    attribute a rejected request to the calling user/team).
     """
 
     def decorator(view_func: Callable) -> Callable:
@@ -111,13 +118,19 @@ def validated_request(
             validated_request = cast(ValidatedRequest, request)
             validated_request.validated_query_data = {}
 
+            serializer_context = (
+                {"request": request, "view": self, "team": getattr(self, "team", None)}
+                if include_serializer_context
+                else {}
+            )
+
             if query_serializer is not None:
-                query_serializer_instance = query_serializer(data=request.query_params)
+                query_serializer_instance = query_serializer(data=request.query_params, context=serializer_context)
                 query_serializer_instance.is_valid(raise_exception=True)
                 validated_request.validated_query_data = query_serializer_instance.validated_data
 
             if request_serializer is not None:
-                serializer = request_serializer(data=request.data)
+                serializer = request_serializer(data=request.data, context=serializer_context)
                 req_validation_result = serializer.is_valid(raise_exception=strict_request_validation)
 
                 if not req_validation_result and settings.DEBUG:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1,14 +1,17 @@
 import base64
+import logging
 import binascii
 from typing import Any, cast
 from zoneinfo import available_timezones
 
+import posthoganalytics
 from croniter import croniter
 from drf_spectacular.utils import PolymorphicProxySerializer
 from rest_framework import serializers
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
+from posthog.event_usage import groups
 from posthog.models.integration import Integration
 from posthog.models.user_integration import UserIntegration
 
@@ -32,6 +35,51 @@ from products.tasks.backend.facade.run_config import (
     RuntimeAdapter,
     get_reasoning_effort_error,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _capture_rejected_reasoning_effort(
+    context: dict[str, Any],
+    *,
+    runtime_adapter: str | None,
+    model: str | None,
+    reasoning_effort: str | None,
+    error: str,
+) -> None:
+    """Record a rejected runtime_adapter/model/reasoning_effort combination server-side.
+
+    This validation only ever reached the caller as a 400 response body, so recurring
+    misconfigurations (e.g. a model missing from the supported-effort map) were invisible
+    beyond individual client-side error toasts.
+    """
+    team = context.get("team")
+    logger.warning(
+        "Rejected task run reasoning_effort/model combination",
+        extra={
+            "team_id": getattr(team, "id", None),
+            "runtime_adapter": runtime_adapter,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+        },
+    )
+
+    request = context.get("request")
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated or not user.distinct_id:
+        return
+
+    posthoganalytics.capture(
+        distinct_id=str(user.distinct_id),
+        event="task run reasoning effort rejected",
+        properties={
+            "runtime_adapter": runtime_adapter,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+            "error": error,
+        },
+        groups=groups(team=team),
+    )
 
 
 class TaskUserBasicInfoSerializer(DataclassSerializer):
@@ -1167,6 +1215,13 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         )
         if reasoning_effort_error is not None:
             errors["reasoning_effort"] = reasoning_effort_error
+            _capture_rejected_reasoning_effort(
+                self.context,
+                runtime_adapter=attrs.get("runtime_adapter"),
+                model=attrs.get("model"),
+                reasoning_effort=attrs.get("reasoning_effort"),
+                error=reasoning_effort_error,
+            )
 
         if errors:
             raise serializers.ValidationError(errors)
@@ -1306,6 +1361,13 @@ class TaskRunBootstrapCreateRequestSerializer(serializers.Serializer):
         )
         if reasoning_effort_error is not None:
             errors["reasoning_effort"] = reasoning_effort_error
+            _capture_rejected_reasoning_effort(
+                self.context,
+                runtime_adapter=attrs.get("runtime_adapter"),
+                model=attrs.get("model"),
+                reasoning_effort=attrs.get("reasoning_effort"),
+                error=reasoning_effort_error,
+            )
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -514,6 +514,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         },
         summary="Run task",
         description="Create a new task run and kick off the workflow.",
+        include_serializer_context=True,
     )
     @action(detail=True, methods=["post"], url_path="run", required_scopes=["task:write"])
     def run(self, request, pk=None, **kwargs):
@@ -826,6 +827,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         },
         summary="Create task run",
         description="Create a new run for a specific task without starting execution.",
+        include_serializer_context=True,
     )
     def create(self, request, *args, **kwargs):
         task_id = self._task_id()

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -130,6 +130,11 @@ CLAUDE_REASONING_EFFORTS_BY_MODEL: dict[str, tuple[ReasoningEffort, ...]] = {
         ReasoningEffort.MEDIUM,
         ReasoningEffort.HIGH,
     ),
+    "claude-sonnet-5": (
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+    ),
 }
 
 CODEX_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from typing import Any, ClassVar, cast
 from urllib.parse import quote
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from django.conf import settings
 from django.db import connection
@@ -2240,8 +2240,9 @@ class TestTaskAPI(BaseTaskAPITest):
         }
         mock_workflow.assert_not_called()
 
+    @patch("products.tasks.backend.presentation.serializers.posthoganalytics.capture")
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_run_endpoint_rejects_unsupported_claude_reasoning_effort(self, mock_workflow):
+    def test_run_endpoint_rejects_unsupported_claude_reasoning_effort(self, mock_workflow, mock_capture):
         task = self.create_task()
 
         response = self.client.post(
@@ -2265,6 +2266,24 @@ class TestTaskAPI(BaseTaskAPITest):
             "attr": "reasoning_effort",
         }
         mock_workflow.assert_not_called()
+
+        # The rejection used to be visible only in the client's 400 response; it must also
+        # be captured server-side so recurring bad model/effort combos are queryable.
+        # assert_any_call because create_task() itself fires a "task_created" capture.
+        mock_capture.assert_any_call(
+            distinct_id=str(self.user.distinct_id),
+            event="task run reasoning effort rejected",
+            properties={
+                "runtime_adapter": "claude",
+                "model": "claude-sonnet-4-5",
+                "reasoning_effort": "high",
+                "error": (
+                    "Reasoning effort 'high' is not supported for runtime_adapter 'claude' "
+                    "and model 'claude-sonnet-4-5'. Supported values: none."
+                ),
+            },
+            groups=ANY,
+        )
 
     @parameterized.expand(
         [
@@ -2295,6 +2314,82 @@ class TestTaskAPI(BaseTaskAPITest):
         assert task_run.state["model"] == "claude-fable-5"
         assert task_run.state["reasoning_effort"] == reasoning_effort
         mock_workflow.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("low",),
+            ("medium",),
+            ("high",),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_accepts_claude_sonnet_5_reasoning_effort(self, reasoning_effort, mock_workflow):
+        # claude-sonnet-5 was missing from the supported-model map, so every reasoning_effort
+        # (including these valid ones) was rejected with "Supported values: none."
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "runtime_adapter": "claude",
+                "model": "claude-sonnet-5",
+                "reasoning_effort": reasoning_effort,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        latest_run = response.json()["latest_run"]
+        task_run = TaskRun.objects.get(id=latest_run["id"])
+        assert task_run.state["model"] == "claude-sonnet-5"
+        assert task_run.state["reasoning_effort"] == reasoning_effort
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.presentation.serializers.posthoganalytics.capture")
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_unsupported_claude_sonnet_5_reasoning_effort(self, mock_workflow, mock_capture):
+        # claude-sonnet-5 supports low/medium/high (unlike claude-sonnet-4-5, which supports
+        # none) - this pins the "Supported values: <non-empty list>" message and confirms the
+        # rejection capture also fires for a model that has some supported efforts.
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "runtime_adapter": "claude",
+                "model": "claude-sonnet-5",
+                "reasoning_effort": "xhigh",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "invalid_input",
+            "detail": (
+                "Reasoning effort 'xhigh' is not supported for runtime_adapter 'claude' "
+                "and model 'claude-sonnet-5'. Supported values: low, medium, high."
+            ),
+            "attr": "reasoning_effort",
+        }
+        mock_workflow.assert_not_called()
+
+        # assert_any_call because create_task() itself fires a "task_created" capture.
+        mock_capture.assert_any_call(
+            distinct_id=str(self.user.distinct_id),
+            event="task run reasoning effort rejected",
+            properties={
+                "runtime_adapter": "claude",
+                "model": "claude-sonnet-5",
+                "reasoning_effort": "xhigh",
+                "error": (
+                    "Reasoning effort 'xhigh' is not supported for runtime_adapter 'claude' "
+                    "and model 'claude-sonnet-5'. Supported values: low, medium, high."
+                ),
+            },
+            groups=ANY,
+        )
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_run_endpoint_derives_provider_from_runtime_adapter(self, mock_workflow):


### PR DESCRIPTION
## Problem

`claude-sonnet-5` was already an approved model in the LLM gateway's `posthog_code` product config, but the Tasks backend's own `runtime_adapter='claude'` model map never got a matching entry. Every run request against `claude-sonnet-5` was rejected regardless of the reasoning effort requested, with `Reasoning effort '<any>' is not supported for runtime_adapter 'claude' and model 'claude-sonnet-5'. Supported values: none.`

Separately, that validation only ever surfaced as a 400 response body to the caller. There was no server-side record of it, so we couldn't tell when it started, when it stopped, or which user hit it without guessing.

## Changes

- Add `claude-sonnet-5` to `CLAUDE_REASONING_EFFORTS_BY_MODEL` in `products/tasks/backend/temporal/process_task/utils.py`, supporting `low`/`medium`/`high` (same tier as `claude-sonnet-4-6`).
- Add `_capture_rejected_reasoning_effort()` in `products/tasks/backend/presentation/serializers.py`, called from both `TaskRunCreateRequestSerializer.validate()` and `TaskRunBootstrapCreateRequestSerializer.validate()` whenever a run request is rejected for an unsupported reasoning effort. It logs a warning and captures a `task run reasoning effort rejected` PostHog event (with team/user context), so these are now queryable going forward.