### PR TITLE
refactor(slack_app): consolidate feature flags into one aligned module

### DIFF
--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -1170,7 +1170,7 @@ class TestUserIntegrationSlackEndpoints(APIBaseTest):
         )
 
     def _enable_flag(self) -> Any:
-        return patch("posthog.api.user_integration.slack_oauth_link_enabled", return_value=True)
+        return patch("posthog.api.user_integration.is_slack_app_oauth_enabled", return_value=True)
 
     def _seed_workspace_integration(self) -> Integration:
         return Integration.objects.create(
@@ -1206,7 +1206,7 @@ class TestUserIntegrationSlackEndpoints(APIBaseTest):
 
     def test_slack_start_403_when_flag_off(self):
         self._seed_workspace_integration()
-        with patch("posthog.api.user_integration.slack_oauth_link_enabled", return_value=False):
+        with patch("posthog.api.user_integration.is_slack_app_oauth_enabled", return_value=False):
             response = self.client.post("/api/users/@me/integrations/slack/start/", data={}, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1239,7 +1239,7 @@ class TestUserIntegrationSlackEndpoints(APIBaseTest):
 
     def test_slack_linkable_skips_workspaces_with_flag_off(self):
         self._seed_workspace_integration()
-        with patch("posthog.api.user_integration.slack_oauth_link_enabled", return_value=False):
+        with patch("posthog.api.user_integration.is_slack_app_oauth_enabled", return_value=False):
             response = self.client.get("/api/users/@me/integrations/slack/linkable_workspaces/")
         self.assertEqual(response.json()["results"], [])
 

--- a/posthog/api/user_integration.py
+++ b/posthog/api/user_integration.py
@@ -51,7 +51,7 @@ from posthog.permissions import APIScopePermission
 from posthog.rate_limit import UserAuthenticationThrottle
 from posthog.user_permissions import UserPermissions
 
-from products.slack_app.backend.feature_flags import slack_oauth_link_enabled
+from products.slack_app.backend.feature_flags import is_slack_app_oauth_enabled
 from products.slack_app.backend.services.slack_user_oauth import build_invite_url
 
 logger = structlog.get_logger(__name__)
@@ -560,7 +560,7 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
                 continue
             # Feature-flag check per workspace so an org that hasn't rolled out
             # the flag yet doesn't show up in another org's picker.
-            if not slack_oauth_link_enabled(integration, integration.integration_id):
+            if not is_slack_app_oauth_enabled(integration, integration.integration_id):
                 continue
             # `(config or {}).get("team", {})` doesn't defend against an explicit
             # ``config["team"] = None`` — dict.get returns the literal None
@@ -618,7 +618,7 @@ class UserIntegrationViewSet(viewsets.GenericViewSet):
                 "This project has no Slack workspace connected. Ask an admin to install the Slack app first."
             )
 
-        if not slack_oauth_link_enabled(workspace, workspace.integration_id):
+        if not is_slack_app_oauth_enabled(workspace, workspace.integration_id):
             raise exceptions.PermissionDenied("Slack identity linking is not enabled for this organization.")
 
         if UserIntegration.objects.filter(

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -33,7 +33,6 @@ from posthog.models.integration import (
     validate_slack_request,
 )
 from posthog.models.organization import OrganizationMembership
-from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
 from posthog.temporal.ai.slack_app import (
@@ -52,7 +51,11 @@ from posthog.user_permissions import UserPermissions
 from posthog.utils import get_instance_region
 
 from products.slack_app.backend import inbox_channel, onboarding
-from products.slack_app.backend.feature_flags import slack_oauth_link_enabled
+from products.slack_app.backend.feature_flags import (
+    is_slack_app_assistant_enabled,
+    is_slack_app_oauth_enabled,
+    is_slack_app_untagged_thread_followups_enabled,
+)
 from products.slack_app.backend.models import SlackChannel, SlackThreadTaskMapping
 from products.slack_app.backend.services import inbox_interactivity
 from products.slack_app.backend.services.integration_resolver import (
@@ -314,7 +317,7 @@ def resolve_slack_user(
             candidate_org_ids={integration.team.organization_id},
         )
 
-        if linked_user is not None and slack_oauth_link_enabled(integration, slack_team_id):
+        if linked_user is not None and is_slack_app_oauth_enabled(integration, slack_team_id):
             user_permissions = UserPermissions(user=linked_user, team=integration.team)
             if user_permissions.current_team.effective_membership_level is None:
                 logger.warning(
@@ -397,7 +400,7 @@ def resolve_slack_user(
                     ),
                     prefer_thread_message=True,
                 )
-                if slack_oauth_link_enabled(integration, slack_team_id):
+                if is_slack_app_oauth_enabled(integration, slack_team_id):
                     invite_url = build_invite_url(
                         slack_user_id=slack_user_id,
                         slack_team_id=slack_team_id,
@@ -1109,14 +1112,6 @@ def _thread_message_ignore_reason(event: dict[str, Any]) -> str | None:
     return None
 
 
-# Feature flag that gates the untagged-thread followup path per org. Off by
-# default until rollout; turning it on for an org makes every message in a
-# tagged thread eligible for classification + forward, instead of requiring a
-# fresh ``@PostHog`` mention. Naming follows the ``posthog-slack-app-*`` prefix
-# the team uses for the Slack App's product flags.
-UNTAGGED_THREAD_FOLLOWUPS_FLAG = "posthog-slack-app-untagged-thread-followups"
-
-
 def _resolve_untagged_followup_mapping(
     *,
     candidates: list[Integration],
@@ -1147,7 +1142,7 @@ def _resolve_untagged_followup_mapping(
     )
     if mapping is None:
         return None
-    if not _untagged_thread_followups_enabled(mapping.integration, slack_team_id):
+    if not is_slack_app_untagged_thread_followups_enabled(mapping.integration, slack_team_id):
         logger.info(
             "slack_app_thread_message_feature_flag_off",
             slack_team_id=slack_team_id,
@@ -1157,30 +1152,6 @@ def _resolve_untagged_followup_mapping(
         )
         return None
     return mapping
-
-
-def _untagged_thread_followups_enabled(integration: Integration, slack_team_id: str) -> bool:
-    """Return True if the integration's org has the untagged-thread followup
-    flag enabled. Fail-closed on any error — a transient PostHog API outage
-    must not silently enable the feature for everyone.
-    """
-    try:
-        enabled = posthoganalytics.feature_enabled(
-            UNTAGGED_THREAD_FOLLOWUPS_FLAG,
-            f"slack_workspace:{slack_team_id}",
-            groups={"organization": str(integration.team.organization_id)},
-            person_properties={"region": get_instance_region() or "unknown"},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-        return bool(enabled)
-    except Exception:
-        logger.exception(
-            "slack_app_thread_message_feature_flag_check_failed",
-            slack_team_id=slack_team_id,
-            integration_id=integration.id,
-        )
-        return False
 
 
 def _notify_missing_slack_scopes(
@@ -1321,7 +1292,7 @@ def resolve_posthog_user_from_event(
         slack_team_id=slack_team_id,
         candidate_org_ids=org_ids,
     )
-    if linked_user is not None and slack_oauth_link_enabled(probe_integration, slack_team_id):
+    if linked_user is not None and is_slack_app_oauth_enabled(probe_integration, slack_team_id):
         return linked_user
 
     if slack_email is None:
@@ -1403,7 +1374,7 @@ def _post_user_resolution_failure_reply(
     # neither is redundant. Only `user_not_found` is link-recoverable;
     # `no_team_access` means the user *is* known but lacks project access.
     _post_slack_user_feedback(slack_client, channel, slack_user_id, thread_ts, text, prefer_thread_message=True)
-    if failure_reason == "user_not_found" and slack_oauth_link_enabled(probe, probe.integration_id):
+    if failure_reason == "user_not_found" and is_slack_app_oauth_enabled(probe, probe.integration_id):
         invite_url = build_invite_url(
             slack_user_id=slack_user_id,
             slack_team_id=probe.integration_id,
@@ -1447,7 +1418,6 @@ def _start_posthog_code_workflow(
     )
 
 
-_ASSISTANT_FEATURE_FLAG = "slack-app-assistant"
 _ASSISTANT_CONTEXT_TTL_SECONDS = 60 * 60
 _ASSISTANT_SUGGESTED_PROMPTS = [
     {"title": "Fix a bug", "message": "Open a PR to fix a bug in my connected repo"},
@@ -1466,25 +1436,6 @@ _ASSISTANT_UNAVAILABLE = (
     "I can only help PostHog org members whose project has a connected repo. Make sure your Slack "
     "email matches your PostHog account and that a repo is connected, then try again."
 )
-
-
-def _assistant_enabled(team: Team) -> bool:
-    # Evaluated on the workspace's team (a stable key) so the flag is a true kill-switch we can
-    # check before resolving the DMing user — i.e. the feature stays dark when off.
-    try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                _ASSISTANT_FEATURE_FLAG,
-                str(team.uuid),
-                groups={"organization": str(team.organization_id)},
-                person_properties={"region": get_instance_region() or "unknown"},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception:
-        logger.warning("assistant_feature_flag_eval_failed", exc_info=True)
-        return False
 
 
 def _assistant_event_fields(event: dict) -> tuple[str, str | None, str | None, str | None]:
@@ -1555,7 +1506,7 @@ def _post_assistant_unavailable(slack: SlackIntegration, channel_id: str, thread
 
 def send_assistant_install_welcome(integration: Integration) -> None:
     """DM the installing user the moment the app is added, when the assistant is enabled for their team."""
-    if not _assistant_enabled(integration.team):
+    if not is_slack_app_assistant_enabled(integration.team):
         return
     slack_user_id = ((integration.config or {}).get("authed_user") or {}).get("id")
     if not slack_user_id:
@@ -1649,7 +1600,7 @@ def _route_assistant_event(
     probe = result.integration if result.integration in result.candidates else result.candidates[0]
 
     # Kill-switch first: stay fully dark (no user resolution, no Slack reply) when the flag is off.
-    if not _assistant_enabled(probe.team):
+    if not is_slack_app_assistant_enabled(probe.team):
         return ROUTE_HANDLED_LOCALLY
 
     # Share the mention path's user resolution + access filter, so the DM only ever sees and runs

--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -1,8 +1,19 @@
 """Feature-flag checks for the Slack app backend.
 
-One module for all Slack-app flag checks so rollouts are easy to find and
-audit. Every check here is fail-closed: a flaky ``posthoganalytics.feature_enabled``
-call must not silently enable a feature for everyone.
+One module for every Slack-app flag check so rollouts are easy to find and audit.
+
+All gates share the same evaluation settings, so behaviour is uniform across the
+surfaces:
+
+- **Remote evaluation** (``only_evaluate_locally=False``) — no deployment needs a
+  local-evaluation personal API key for these to work; evaluation goes through
+  PostHog's flags endpoint with the project token.
+- **Region targeting** — the deployment region rides along as the ``region``
+  person property (via ``_region_properties``) so a flag rule like
+  ``region equals DEV`` can target a single Cloud region.
+- ``send_feature_flag_events=False`` — these are control checks, not analytics.
+- **Fail-closed** — any error returns ``False`` so a flaky flag call never
+  silently enables a feature for everyone.
 """
 
 from __future__ import annotations
@@ -11,6 +22,7 @@ import structlog
 import posthoganalytics
 
 from posthog.models.integration import Integration
+from posthog.models.team.team import Team
 from posthog.utils import get_instance_region
 
 logger = structlog.get_logger(__name__)
@@ -19,34 +31,30 @@ logger = structlog.get_logger(__name__)
 SLACK_APP_OAUTH_FLAG = "slack-app-oauth"
 SLACK_APP_HOME_FLAG = "slack-app-home"
 SLACK_APP_AGENT_DESIGN_FLAG = "slack-app-agent-design"
+SLACK_APP_ASSISTANT_FLAG = "slack-app-assistant"
+UNTAGGED_THREAD_FOLLOWUPS_FLAG = "posthog-slack-app-untagged-thread-followups"
 
 
-def slack_oauth_link_enabled(integration: Integration, slack_team_id: str) -> bool:
-    """Gate for the Slack user-identity OAuth link feature, covering both
-    backend (offering the invite button, accepting the link callback,
-    listing/starting from settings) and frontend (rendering the Slack card
-    in Personal integrations) decisions.
+def _region_properties() -> dict[str, str]:
+    """The deployment region as a person property, shared by every gate so a
+    ``region equals DEV`` rule targets one Cloud region. Falls back to ``dev``
+    when the region is unset (local), matching the value dev rules target."""
+    return {"region": get_instance_region() or "dev"}
 
-    Evaluated against the workspace's PostHog organization so we can roll
-    out org-by-org, with the deployment region carried as a person property
-    so a flag rule like ``region equals US`` targets a single Cloud region.
 
-    Fail-closed on any error: a flaky feature-flag check must not silently
-    enable the feature for everyone.
-    """
+def is_slack_app_oauth_enabled(integration: Integration, slack_team_id: str) -> bool:
+    """Gate for the Slack user-identity OAuth link feature, covering both backend
+    (offering the invite button, accepting the link callback, listing/starting
+    from settings) and frontend (rendering the Slack card in Personal
+    integrations) decisions. Keyed on the Slack workspace + PostHog org."""
     try:
         return bool(
             posthoganalytics.feature_enabled(
                 SLACK_APP_OAUTH_FLAG,
                 f"slack_workspace:{slack_team_id}",
                 groups={"organization": str(integration.team.organization_id)},
-                person_properties={"region": get_instance_region() or "unknown"},
-                # Hot path: every inbound Slack event (every @mention, link_shared,
-                # message-in-watched-channel) hits this. Local evaluation avoids a
-                # synchronous HTTPS call to PostHog's `decide` endpoint that would
-                # compete with Slack's 3s webhook ack deadline. The org-level rules
-                # and region person-property all evaluate fine locally.
-                only_evaluate_locally=True,
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
                 send_feature_flag_events=False,
             )
         )
@@ -59,44 +67,16 @@ def slack_oauth_link_enabled(integration: Integration, slack_team_id: str) -> bo
         return False
 
 
-def is_slack_app_agent_design_enabled(integration_id: int) -> bool:
-    """Fail-closed agent-design gate. Per-integration key + region targeting.
-    Local-only eval — see ``slack_oauth_link_enabled``."""
-    try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                SLACK_APP_AGENT_DESIGN_FLAG,
-                f"slack_integration:{integration_id}",
-                person_properties={"region": get_instance_region() or "unknown"},
-                only_evaluate_locally=True,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception:
-        logger.exception("slack_app_agent_design_feature_flag_check_failed", integration_id=integration_id)
-        return False
-
-
-def is_slack_app_home_enabled(integration: Integration, *, region: str | None = None) -> bool:
-    """Return True when the ``slack-app-home`` flag is on for this workspace.
-
-    The flag controls the App Home tab surface and the AI-settings resolver
-    that feeds Slack-triggered task runs. Keyed on Slack workspace id +
-    PostHog org so the same flag rule can target either dimension.
-
-    ``region`` overrides the auto-detected instance region — useful in dev
-    environments where ``get_instance_region()`` returns ``None``. The
-    default fallback is ``"dev"`` (not ``"unknown"``), so a flag rule
-    targeting ``region == "dev"`` opts local environments in without
-    leaking to prod.
-    """
+def is_slack_app_home_enabled(integration: Integration) -> bool:
+    """Gate for the App Home tab surface and the AI-settings resolver that feeds
+    Slack-triggered task runs. Keyed on the Slack workspace + PostHog org."""
     try:
         return bool(
             posthoganalytics.feature_enabled(
                 SLACK_APP_HOME_FLAG,
                 f"slack_workspace:{integration.integration_id}",
                 groups={"organization": str(integration.team.organization_id)},
-                person_properties={"region": region or get_instance_region() or "dev"},
+                person_properties=_region_properties(),
                 only_evaluate_locally=False,
                 send_feature_flag_events=False,
             )
@@ -106,4 +86,70 @@ def is_slack_app_home_enabled(integration: Integration, *, region: str | None = 
             "slack_app_home_feature_flag_check_failed",
             integration_id=integration.id,
         )
+        return False
+
+
+def is_slack_app_agent_design_enabled(integration: Integration) -> bool:
+    """Gate for the agent-design plan-block streaming surface on Slack task runs.
+    Keyed on the Slack workspace + PostHog org, matching ``is_slack_app_home_enabled``."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                SLACK_APP_AGENT_DESIGN_FLAG,
+                f"slack_workspace:{integration.integration_id}",
+                groups={"organization": str(integration.team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception(
+            "slack_app_agent_design_feature_flag_check_failed",
+            integration_id=integration.id,
+        )
+        return False
+
+
+def is_slack_app_untagged_thread_followups_enabled(integration: Integration, slack_team_id: str) -> bool:
+    """Gate for the untagged-thread followup path: when on, every message in a
+    tagged thread is eligible for classification + forward instead of requiring
+    a fresh ``@PostHog`` mention. Keyed on the Slack workspace + PostHog org."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                UNTAGGED_THREAD_FOLLOWUPS_FLAG,
+                f"slack_workspace:{slack_team_id}",
+                groups={"organization": str(integration.team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception(
+            "slack_app_thread_message_feature_flag_check_failed",
+            slack_team_id=slack_team_id,
+            integration_id=integration.id,
+        )
+        return False
+
+
+def is_slack_app_assistant_enabled(team: Team) -> bool:
+    """Kill-switch for the DM assistant. Evaluated on the workspace's team (a
+    stable key) so the feature can be checked before resolving the DMing user —
+    i.e. it stays dark when off."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                SLACK_APP_ASSISTANT_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("assistant_feature_flag_eval_failed")
         return False

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -30,7 +30,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
-from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, slack_oauth_link_enabled
+from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
@@ -527,7 +527,7 @@ def _project_section_blocks(state: ProjectState, *, is_admin: bool) -> list[dict
 def _account_section_blocks(account_state: AccountState) -> list[dict]:
     """Render the Sign-in-with-Slack account card.
 
-    Visible only when `slack_oauth_link_enabled` returned True. Linked
+    Visible only when `is_slack_app_oauth_enabled` returned True. Linked
     state mirrors the Claude home pattern: ✅ + email, with a danger-styled
     Disconnect button at the bottom.
     """
@@ -1123,7 +1123,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
         # Only act when the OAuth-link feature is on for this workspace —
         # otherwise the button shouldn't have been rendered, and a stale
         # cached view shouldn't be allowed to drive deletes.
-        if slack_oauth_link_enabled(integration, integration.integration_id):
+        if is_slack_app_oauth_enabled(integration, integration.integration_id):
             _unlink_user_account(integration, slack_user_id)
         _republish_home(integration, slack_user_id)
         return HttpResponse(status=200)
@@ -1603,7 +1603,7 @@ def _read_tasks_filters_from_payload(payload: dict) -> tuple[str | None, str | N
 
 def _resolve_account_state(integration: Integration, slack_user_id: str) -> AccountState:
     slack_team_id = integration.integration_id
-    if not slack_oauth_link_enabled(integration, slack_team_id):
+    if not is_slack_app_oauth_enabled(integration, slack_team_id):
         return AccountState(enabled=False)
 
     candidate_org_ids = _workspace_org_ids(slack_team_id)

--- a/products/slack_app/backend/tests/services/test_slack_user_oauth.py
+++ b/products/slack_app/backend/tests/services/test_slack_user_oauth.py
@@ -166,7 +166,7 @@ class TestResolveSlackUserWithLink:
     """
 
     @patch("posthog.models.integration.WebClient")
-    @patch("products.slack_app.backend.api.slack_oauth_link_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_oauth_enabled")
     def test_flag_off_falls_through_to_email_path_unchanged(
         self, mock_flag, mock_webclient_class, org_team_user, workspace_integration, link_user
     ):
@@ -188,7 +188,7 @@ class TestResolveSlackUserWithLink:
         assert result.slack_email == "dev@example.com"
 
     @patch("posthog.models.integration.WebClient")
-    @patch("products.slack_app.backend.api.slack_oauth_link_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_oauth_enabled")
     def test_flag_on_with_link_short_circuits_email_lookup(
         self, mock_flag, mock_webclient_class, org_team_user, workspace_integration, link_user
     ):
@@ -215,7 +215,7 @@ class TestResolveSlackUserWithLink:
 
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.post_link_invite_message")
-    @patch("products.slack_app.backend.api.slack_oauth_link_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_oauth_enabled")
     def test_flag_on_with_no_link_and_no_membership_posts_invite(
         self,
         mock_flag,
@@ -253,7 +253,7 @@ class TestResolveSlackUserWithLink:
 
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.post_link_invite_message")
-    @patch("products.slack_app.backend.api.slack_oauth_link_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_oauth_enabled")
     def test_flag_off_with_no_membership_does_not_post_invite(
         self,
         mock_flag,

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -1115,7 +1115,7 @@ class TestAssistantEvents(TestCase):
             else UserAndIntegrationsResolution(failure_reason="user_not_found")
         )
         resolve = patch("products.slack_app.backend.api.resolve_user_for_workspace", return_value=resolution)
-        enabled_p = patch("products.slack_app.backend.api._assistant_enabled", return_value=enabled)
+        enabled_p = patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=enabled)
         usp = patch("products.slack_app.backend.api._us_should_handle_instead", return_value=False)
         slack = patch("products.slack_app.backend.api.SlackIntegration")
         return load, resolve, enabled_p, usp, slack
@@ -1225,7 +1225,7 @@ class TestAssistantInstallWelcome(TestCase):
     def _run(self, *, enabled: bool):
         from products.slack_app.backend.api import _ASSISTANT_INSTALL_WELCOME, send_assistant_install_welcome
 
-        enabled_p = patch("products.slack_app.backend.api._assistant_enabled", return_value=enabled)
+        enabled_p = patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=enabled)
         slack = patch("products.slack_app.backend.api.SlackIntegration")
         with enabled_p, slack as slack_cls:
             send_assistant_install_welcome(self.integration)
@@ -1248,7 +1248,7 @@ class TestAssistantInstallWelcome(TestCase):
     def test_slack_error_is_swallowed(self):
         from products.slack_app.backend.api import send_assistant_install_welcome
 
-        enabled_p = patch("products.slack_app.backend.api._assistant_enabled", return_value=True)
+        enabled_p = patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
         slack = patch("products.slack_app.backend.api.SlackIntegration")
         with enabled_p, slack as slack_cls:
             slack_cls.return_value.client.chat_postMessage.side_effect = Exception("slack down")

--- a/products/slack_app/backend/tests/test_thread_message_routing.py
+++ b/products/slack_app/backend/tests/test_thread_message_routing.py
@@ -92,7 +92,9 @@ class TestRouteThreadMessage(TestCase):
         # All routing tests assume the per-org feature flag is on. The
         # dedicated ``test_feature_flag_off_dropped`` test stops the patcher
         # to exercise the off path.
-        self._ff_patcher = patch("products.slack_app.backend.api._untagged_thread_followups_enabled", return_value=True)
+        self._ff_patcher = patch(
+            "products.slack_app.backend.api.is_slack_app_untagged_thread_followups_enabled", return_value=True
+        )
         self._ff_patcher.start()
         self.addCleanup(self._ff_patcher.stop)
 
@@ -182,7 +184,7 @@ class TestRouteThreadMessage(TestCase):
 
         self._ff_patcher.stop()
         with (
-            patch("products.slack_app.backend.api._untagged_thread_followups_enabled", return_value=False),
+            patch("products.slack_app.backend.api.is_slack_app_untagged_thread_followups_enabled", return_value=False),
             patch("products.slack_app.backend.api.resolve_user_for_workspace") as mock_resolve,
             patch("products.slack_app.backend.api._start_mention_workflow") as mock_start,
         ):

--- a/products/slack_app/backend/tests/test_zz_resolve_slack_user_with_link_no_access.py
+++ b/products/slack_app/backend/tests/test_zz_resolve_slack_user_with_link_no_access.py
@@ -26,7 +26,7 @@ from products.slack_app.backend.tests.conftest import SLACK_USER_ID
 class TestResolveSlackUserAccessDenied:
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.UserPermissions")
-    @patch("products.slack_app.backend.api.slack_oauth_link_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_oauth_enabled")
     def test_flag_on_with_link_but_no_team_access_returns_none(
         self,
         mock_flag,

--- a/products/slack_app/backend/tests/views/test_slack_user_link.py
+++ b/products/slack_app/backend/tests/views/test_slack_user_link.py
@@ -69,7 +69,7 @@ class TestAuthorizeView:
             slack_team_id=SLACK_TEAM_ID,
             posthog_team_id=workspace_integration.team_id,
         ).encode()
-        with patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=False):
+        with patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=False):
             response = client.get(f"/complete/slack-link/start/?state={token}")
         self._assert_settings_redirect_error(response, "flag_off")
 
@@ -83,7 +83,7 @@ class TestAuthorizeView:
             thread_ts="1.2",
         ).encode()
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch(
                 "products.slack_app.backend.services.slack_user_oauth.get_instance_settings",
                 return_value={"SLACK_APP_CLIENT_ID": "cid", "SLACK_APP_CLIENT_SECRET": "csecret"},
@@ -169,7 +169,7 @@ class TestCallbackView:
         state = self._state_for(user, workspace_integration.team_id)
 
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch("products.slack_app.backend.views.slack_user_link.exchange_code", return_value=self._identity()),
             patch("posthog.models.integration.WebClient"),
         ):
@@ -189,7 +189,7 @@ class TestCallbackView:
         state = self._state_for(user, workspace_integration.team_id)
 
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch(
                 "products.slack_app.backend.views.slack_user_link.exchange_code",
                 return_value=self._identity(slack_team_id="T-DIFFERENT", slack_team_name=None, slack_email=None),
@@ -206,7 +206,7 @@ class TestCallbackView:
         state = self._state_for(user, workspace_integration.team_id)
 
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch(
                 "products.slack_app.backend.views.slack_user_link.exchange_code",
                 side_effect=SlackUserOAuthError("invalid_code"),
@@ -234,7 +234,7 @@ class TestCallbackView:
         state = self._state_for(attacker, workspace_integration.team_id)
 
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch("products.slack_app.backend.views.slack_user_link.exchange_code", return_value=self._identity()),
         ):
             response = client.get(f"/complete/slack-link/?code=abc&state={state}")
@@ -254,7 +254,7 @@ class TestCallbackView:
         state = self._state_for(outsider, workspace_integration.team_id)
 
         with (
-            patch("products.slack_app.backend.views.slack_user_link.slack_oauth_link_enabled", return_value=True),
+            patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch("products.slack_app.backend.views.slack_user_link.exchange_code", return_value=self._identity()),
         ):
             response = client.get(f"/complete/slack-link/?code=abc&state={state}")

--- a/products/slack_app/backend/views/slack_user_link.py
+++ b/products/slack_app/backend/views/slack_user_link.py
@@ -43,7 +43,7 @@ from posthog.models.user import User
 from posthog.models.user_integration import user_slack_integration_from_identity
 from posthog.views import login_required
 
-from products.slack_app.backend.feature_flags import slack_oauth_link_enabled
+from products.slack_app.backend.feature_flags import is_slack_app_oauth_enabled
 from products.slack_app.backend.services.slack_user_oauth import (
     CallbackState,
     InviteToken,
@@ -103,7 +103,7 @@ def slack_user_link_authorize(request: HttpRequest) -> HttpResponse:
     if workspace_integration is None:
         return _settings_redirect(error="workspace_not_found")
 
-    if not slack_oauth_link_enabled(workspace_integration, invite.slack_team_id):
+    if not is_slack_app_oauth_enabled(workspace_integration, invite.slack_team_id):
         return _settings_redirect(error="flag_off")
 
     callback_state = CallbackState(
@@ -152,7 +152,7 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
     workspace_integration = _load_workspace_integration(state.posthog_team_id, state.slack_team_id)
     if workspace_integration is None:
         return _settings_redirect(error="workspace_not_found")
-    if not slack_oauth_link_enabled(workspace_integration, state.slack_team_id):
+    if not is_slack_app_oauth_enabled(workspace_integration, state.slack_team_id):
         return _settings_redirect(error="flag_off")
 
     try:

--- a/products/tasks/backend/temporal/process_task/activities/feature_flags.py
+++ b/products/tasks/backend/temporal/process_task/activities/feature_flags.py
@@ -25,10 +25,18 @@ def is_slack_app_agent_design_enabled_for_task_activity(
 ) -> bool:
     """Flag check + persist to TaskRun.state so out-of-workflow callers (e.g.
     forward_pending_message) can read the decision without re-evaluating."""
+    from posthog.models.integration import Integration
+
     from products.slack_app.backend.feature_flags import is_slack_app_agent_design_enabled
     from products.tasks.backend.models import TaskRun
 
-    enabled = is_slack_app_agent_design_enabled(input.integration_id)
+    try:
+        integration = Integration.objects.select_related("team", "team__organization").get(id=input.integration_id)
+    except Integration.DoesNotExist:
+        logger.warning("slack_app_agent_design_integration_missing", integration_id=input.integration_id)
+        enabled = False
+    else:
+        enabled = is_slack_app_agent_design_enabled(integration)
 
     def _persist(state: dict[str, Any]) -> None:
         state[AGENT_DESIGN_STATE_KEY] = enabled


### PR DESCRIPTION
## Problem

The slack_app feature-flag gates were scattered — some in `feature_flags.py`, some inline in `api.py` — and evaluated with inconsistent settings (different eval modes, region fallbacks, and distinct_id/group keys). The `slack-app-agent-design` gate was the worst case: it used local evaluation, which needs a local-eval personal API key that isn't provisioned on the dev tasks worker, so it fail-closed on the dev region no matter how the flag was set — while the home tab and untagged-threading gates (remote eval) worked fine.

## Changes

- Moved every slack-app feature-flag gate into one module (`products/slack_app/backend/feature_flags.py`); the untagged-thread-followups and DM-assistant gates moved out of `api.py`.
- Named them all `is_slack_app_*_enabled`.
- Gave them one shared evaluation shape — remote eval (`only_evaluate_locally=False`) plus the deployment region as a person property via a single helper. No deployment needs a local-eval personal API key.
- Fixed `slack-app-agent-design`: it now evaluates remotely and is keyed on the Slack workspace + org (copying the App Home gate), so it behaves like the gates that already work on dev. The task activity loads the `Integration` to pass in.

## How did you test this code?

Tested locally: `hogli test products/slack_app/backend/tests posthog/api/test/test_user_integration.py` — 682 passed. `ruff` clean.

Model: Opus 4.8 (1M context) via Claude Code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a
