### PR TITLE
fix(warehouse): drop stale Jira resume tokens minted for a different JQL

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/jira.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/jira.py
@@ -38,6 +38,8 @@ class JiraRetryableError(Exception):
 class JiraResumeConfig:
     next_page_token: Optional[str] = None
     start_at: Optional[int] = None
+    # The JQL the token was minted for — a token replayed against a different JQL is a 400.
+    jql: Optional[str] = None
 
 
 def is_valid_subdomain(subdomain: str) -> bool:
@@ -152,7 +154,15 @@ def get_rows(
     if config.pagination == "token":
         last_value = db_incremental_field_last_value if should_use_incremental_field else None
         jql = _build_issues_jql(incremental_field, last_value)
-        next_page_token = resume.next_page_token if resume else None
+
+        # The JQL moves between runs as the watermark advances. Dropping a stale token is safe:
+        # issues are scanned in incremental-field ASC order, so the watermark query resumes from
+        # where the interrupted run got to (modulo the lookback overlap, which merge dedupes).
+        next_page_token = resume.next_page_token if resume and resume.jql == jql else None
+        if resume and resume.next_page_token and not next_page_token:
+            logger.info(
+                f"Discarding Jira resume token minted for a different JQL: saved={resume.jql!r}, current={jql!r}"
+            )
 
         while True:
             params: dict[str, Any] = {"jql": jql, "maxResults": config.page_size, "fields": "*all"}
@@ -168,7 +178,7 @@ def get_rows(
             if not next_page_token or data.get("isLast"):
                 break
 
-            resumable_source_manager.save_state(JiraResumeConfig(next_page_token=next_page_token))
+            resumable_source_manager.save_state(JiraResumeConfig(next_page_token=next_page_token, jql=jql))
         return
 
     # offset pagination (startAt / maxResults)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/test_jira.py
@@ -193,13 +193,42 @@ class TestGetRows:
         )
         assert [row["id"] for batch in batches for row in batch] == ["1", "2"]
         # State is saved with the token for the *next* page after the first batch is yielded.
-        manager.save_state.assert_called_once_with(JiraResumeConfig(next_page_token="tok2"))
+        full_sync_jql = 'updated >= "1970-01-01 00:00" ORDER BY updated ASC'
+        manager.save_state.assert_called_once_with(JiraResumeConfig(next_page_token="tok2", jql=full_sync_jql))
 
-    def test_token_pagination_resumes_from_saved_token(self) -> None:
-        manager = _manager(JiraResumeConfig(next_page_token="tok2"))
-        pages = [{"issues": [{"id": "2", "fields": {"created": "c2", "updated": "u2"}}], "isLast": True}]
-        batches = self._run("issues", pages, manager, should_use_incremental_field=False)
+    @parameterized.expand(
+        [
+            ("matching_jql_reuses_token", 'updated >= "1970-01-01 00:00" ORDER BY updated ASC', True),
+            ("stale_jql_discards_token", 'updated >= "2026-02-11 09:07" ORDER BY updated ASC', False),
+            ("legacy_state_without_jql_discards_token", None, False),
+        ]
+    )
+    def test_token_pagination_resume_honors_saved_jql(
+        self, _name: str, saved_jql: str | None, expect_token_sent: bool
+    ) -> None:
+        manager = _manager(JiraResumeConfig(next_page_token="tok2", jql=saved_jql))
+        session = mock.MagicMock()
+        session.get.side_effect = [
+            _fake_response({"issues": [{"id": "2", "fields": {"created": "c2", "updated": "u2"}}], "isLast": True})
+        ]
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.jira.jira.make_tracked_session",
+            return_value=session,
+        ):
+            batches = list(
+                get_rows(
+                    config=JIRA_ENDPOINTS["issues"],
+                    subdomain="acme",
+                    email="e@x.com",
+                    api_token="token",
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                    should_use_incremental_field=False,
+                )
+            )
         assert [row["id"] for batch in batches for row in batch] == ["2"]
+        params = session.get.call_args.kwargs["params"]
+        assert params.get("nextPageToken") == ("tok2" if expect_token_sent else None)
 
     def test_token_pagination_applies_incremental_jql(self) -> None:
         manager = _manager()


### PR DESCRIPTION
## Problem

Follow-up to #67649. After that fix let the initial Jira full sync actually run, an interrupted run started 400ing on every retry:

```
400 Client Error: Bad Request for url: .../rest/api/3/search/jql?jql=updated+%3E%3D+%222026-02-11+09%3A07%22...&nextPageToken=Ckx1cGRhdGVk...
```

The cause is a stale resume token. Jira's `nextPageToken` embeds the exact JQL it was minted for (base64-decoding the token from the failing request shows `updated >= "1970-01-01 00:00" ORDER BY updated ASC` inside it), and the endpoint rejects a token replayed with a different `jql` param. Our issues JQL changes between runs as the incremental watermark advances, so this sequence poisons the sync:

1. Full sync runs with the epoch-floor JQL and saves a `nextPageToken` per page via the resumable source manager.
2. The run is interrupted partway, but enough rows committed that the watermark now exists.
3. The retry builds the watermark-bounded JQL, reattaches the saved token from the floor JQL, and Jira 400s. Every subsequent retry does the same.

## Changes

`JiraResumeConfig` now persists the JQL alongside the token, and `get_rows` discards the token when the current JQL doesn't match (with an info log).

Discarding is safe rather than lossy. Issues are scanned in incremental-field ASC order, so the watermark already points at where the interrupted run got to. The fresh watermark query resumes from effectively the same place, and the 1-day lookback overlap is deduped by merge.

Old saved states (no `jql` field) deserialize with `jql=None`, mismatch, and get discarded the same way, so no state migration is needed.

## How did you test this code?

Automated only, no manual run against a live Jira instance. I (Claude) ran the Jira source suite, 64 passed:

```
hogli test products/warehouse_sources/backend/temporal/data_imports/sources/jira/tests/
```

New parameterized test `test_token_pagination_resume_honors_saved_jql` covers matching JQL (token reused), stale JQL (token dropped), and legacy state without a jql field (token dropped). It guards the exact regression here: nothing previously asserted which JQL a resumed token was sent with. The existing `save_state` assertion was updated to expect the persisted JQL.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Luke) hit the 400 on a sync retry and had Claude (PostHog Code) diagnose it. Claude decoded the `nextPageToken` from the failing URL to confirm it embedded the old epoch-floor JQL, then implemented the persist-and-compare fix. The `/writing-tests` skill was invoked before test changes.

We considered reusing the saved JQL with the token to finish the original scan instead of discarding, but rejected it: the watermark already covers the resume point, and discarding keeps the state model simpler.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
