### PR TITLE
feat(llma): add ai-failures and online-evals skills

### DIFF
--- a/products/ai_observability/skills/creating-online-evaluations/SKILL.md
+++ b/products/ai_observability/skills/creating-online-evaluations/SKILL.md
@@ -92,7 +92,7 @@ posthog:llma-evaluation-create
   "name": "Output is valid JSON",
   "description": "Fails when the assistant message can't be parsed as JSON",
   "evaluation_type": "hog",
-  "evaluation_config": { "source": "try { jsonParseStr(event.properties.$ai_output_choices[1].content); return true; } catch { return false; }" },
+  "evaluation_config": { "source": "try { jsonParse(jsonParse(output)[1].message.content); return true; } catch { return false; }" },
   "output_type": "boolean",
   "output_config": { "allows_na": false },
   "conditions": [

--- a/products/ai_observability/skills/creating-online-evaluations/SKILL.md
+++ b/products/ai_observability/skills/creating-online-evaluations/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: creating-online-evaluations
+description: >
+  Author continuously-running online evaluations in PostHog AI observability, grounded in a real failure
+  mode you've identified. Use when the user wants an evaluation that automatically scores new
+  `$ai_generation` events going forward — "create an eval to catch X", "continuously check that responses
+  do Y", "turn this failure into an eval". Covers choosing the eval type (hog / llm_judge / sentiment),
+  gating on the team's provider key before an llm_judge eval, scoping which events fire via
+  conditions (property filters + rollout sampling), creating it disabled, verifying scope, and enabling.
+  Finding and ranking the failure modes worth evaluating is its own job — use exploring-ai-failures first.
+  To debug or manage evaluations that already exist, use exploring-llm-evaluations.
+---
+
+# Creating online evaluations
+
+An **online evaluation** scores `$ai_generation` events automatically as they arrive, forever, until
+disabled. A good eval comes from a real failure mode you've found in production traffic, not from a guess
+or a generic metric like "hallucination" or "helpfulness". This skill starts once that failure mode is
+identified and turns it into a scoped, continuously-running eval.
+
+**First, know what you're evaluating.** Finding and ranking the failure modes worth catching is a
+separate job. If the user doesn't specify what they want to evaluate, ask them. If they are still vague
+about it and don't refer to a specific failure mode, run `exploring-ai-failures` to scope a use case,
+find failing traces, and produce a ranked list of failure modes.
+
+For the mechanics of _writing and iterating_ an evaluator (Hog source vs LLM-judge prompt, dry-running,
+debugging a live eval), defer to `exploring-llm-evaluations`.
+
+## Tools
+
+| Tool                                   | Purpose                                                       |
+| -------------------------------------- | ------------------------------------------------------------- |
+| `posthog:llma-provider-key-list`       | Find a usable (`ok` state) provider key to pin (llm_judge)    |
+| `posthog:llma-evaluation-judge-models` | List valid provider+model combos                              |
+| `posthog:llma-evaluation-test-hog`     | Dry-run Hog source against recent generations before creating |
+| `posthog:llma-evaluation-create`       | Create the evaluation (always `enabled: false` first)         |
+| `posthog:llma-evaluation-run`          | Spot-run a draft eval against one generation                  |
+| `posthog:llma-evaluation-update`       | Iterate config, then flip `enabled: true`                     |
+| `posthog:execute-sql`                  | Verify a condition matches the events and volume you expect   |
+
+The full create payload (every field, the config schemas, the exact `conditions` shape) is in
+[references/evaluation-payload.md](references/evaluation-payload.md).
+
+## Phase 1 — Pick the failure mode to evaluate
+
+Start from a real, observed failure, not a metric you picked in advance. If you don't already have one,
+run `exploring-ai-failures` to scope a use case, find failing traces, and produce a ranked list of failure
+modes — then come back. With that list in hand, talk with the user to choose what to turn into an eval:
+
+- **Most frequent, most painful first.** A handful of modes usually cover the majority of failures.
+- **Pair obvious fixes with the eval, don't skip it.** If a prompt tweak would likely fix the failure, set
+  up the eval anyway and suggest the fix alongside it — a rising pass rate is how you confirm the fix landed.
+- **One mode per eval.** Three failure modes is three evals, not one prompt trying to catch everything.
+
+You should end with a single, crisp, checkable criterion — "the reply must stay on the user's topic", "the
+tool call must include an `order_id`". Then move to Phase 2.
+
+## Phase 2 — Build the online eval
+
+### 2.1 — Choose the eval type
+
+| Use…        | When the criterion is…                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `hog`       | Structural / rule-based (JSON parses, length, regex, tool-call shape). Cheap, deterministic, **no provider key needed.**              |
+| `llm_judge` | Subjective / fuzzy (tone, factuality, on-topic). Costs an LLM call per run; needs AI data-processing approval + a provider key.       |
+| `sentiment` | You want sentiment labels on user messages, not a pass/fail (unless very specifically asked for, usually not relevant to this skill). |
+
+Reach for `hog` first, escalate to `llm_judge` if there is no deterministic way to check for what we want to check.
+
+### 2.2 — Gate (llm_judge only)
+
+Before creating an `llm_judge` eval, confirm it can actually run, or it errors on first fire. Hog and
+sentiment skip this.
+
+```json
+posthog:llma-provider-key-list            // pick a key whose state == "ok"
+posthog:llma-evaluation-judge-models      // { "provider": "openai" } → valid models
+```
+
+Every `llm_judge` eval runs on a provider key. Pick an `ok`-state key from `llma-provider-key-list` and set
+it as `model_configuration.provider_key_id`.
+
+If there's no `ok` key, stop and ask the user to add/validate one in the UI — the agent can't create keys.
+
+### 2.3 — Create it disabled
+
+Create with `enabled: false` so nothing fires until the scope is verified. Minimal `hog` example:
+
+```json
+posthog:llma-evaluation-create
+{
+  "name": "Output is valid JSON",
+  "description": "Fails when the assistant message can't be parsed as JSON",
+  "evaluation_type": "hog",
+  "evaluation_config": { "source": "try { jsonParseStr(event.properties.$ai_output_choices[1].content); return true; } catch { return false; }" },
+  "output_type": "boolean",
+  "output_config": { "allows_na": false },
+  "conditions": [
+    { "id": "default", "rollout_percentage": 100, "properties": [{ "key": "$ai_model", "type": "event", "operator": "icontains", "value": "gpt" }] }
+  ],
+  "enabled": false
+}
+```
+
+For `llm_judge`, swap `evaluation_config` to `{ "prompt": "…" }` and add
+`"model_configuration": { "provider": "openai", "model": "gpt-5-mini", "provider_key_id": "<uuid of an ok-state key from llma-provider-key-list>" }`.
+Full field reference: [references/evaluation-payload.md](references/evaluation-payload.md).
+
+### 2.4 — Verify the scope before enabling
+
+`conditions` is where online evals go wrong: too broad and you evaluate (and bill) a firehose; too narrow
+and it never fires. Confirm the filter matches the events you expect, and roughly how many per day:
+
+```sql
+posthog:execute-sql
+SELECT count() AS matched, count() / 7 AS per_day
+FROM events
+WHERE event = '$ai_generation'
+    AND properties.$ai_model ILIKE '%gpt%'      -- mirror each condition property
+    AND timestamp >= now() - INTERVAL 7 DAY
+```
+
+If volume is high, set `rollout_percentage` below 100 to sample. Spot-check the evaluator with
+`llma-evaluation-test-hog` (hog) or `llma-evaluation-run` against one generation (llm_judge).
+
+> **Watch out:** some orgs reuse a single `$ai_trace_id` across 100k+ events. Scoping by trace-ID prefix
+> can match far more than expected — verify volume with the SQL above before enabling.
+
+### 2.5 — Enable, then close the loop
+
+```json
+posthog:llma-evaluation-update
+{ "evaluationId": "<uuid>", "enabled": true }
+```
+
+It now runs on every new matching `$ai_generation`. This isn't one-and-done: the user should be aware that
+they need to keep an eye on results and iterate if the outcome is not the expected one. To wire results
+into a Slack feed, see `feature-usage-feed`.
+
+## Scoping with conditions
+
+`conditions` is a **list** of condition sets — **OR between sets, AND within a set's `properties`**. Each
+set is `{ id, rollout_percentage, properties[] }`. There is no time window inside conditions; sampling is
+only `rollout_percentage` (0–100). Property filters use the standard PostHog shape
+(`key`, `type`, `operator`, `value`).
+
+```json
+"conditions": [
+  { "id": "openai",    "rollout_percentage": 100, "properties": [{"key": "$ai_provider", "type": "event", "operator": "exact", "value": "openai"}] },
+  { "id": "anthropic", "rollout_percentage": 25,  "properties": [{"key": "$ai_provider", "type": "event", "operator": "exact", "value": "anthropic"}] }
+]
+```
+
+## Constructing UI links
+
+- **Evaluations list:** `https://app.posthog.com/ai-evals/evaluations`
+- **Single evaluation:** `https://app.posthog.com/ai-evals/evaluations/<evaluation_id>`
+
+Surface the link after creating so the user can review and toggle it in the UI.
+
+## Tips
+
+- **Evals come from real failures, not generic metrics.** Start from a failure found in this product's
+  traffic (via `exploring-ai-failures`), not from "let's measure hallucination". A metric nobody traced
+  back to a real bad output is noise.
+- **One eval, one failure mode.** Different failure modes need different evals; don't make one eval try to
+  catch everything.
+- **Suggest changes along with the eval if possible.** If it's clear a prompt change would fix the issue, for
+  instance, set up the eval but also suggest to the user they change the prompt: they should soon see the eval
+  go from low pass rate to a higher pass rate.
+- **`hog` first.** No provider key, no AI approval, deterministic. Reach for `llm_judge` only when the
+  criterion genuinely can't be coded.
+- **Always create disabled, verify scope, then enable.** An eval firing on the wrong events is worse than
+  none — noise, and (for llm_judge) cost.
+- **Gate llm_judge before creating**, not after. A judge eval with no usable provider key errors on first run.
+- **`bytecode` is server-written** for hog evals — never pass it; send only `evaluation_config.source`.
+- For cluster-scoped evals, identify the cluster with `exploring-llm-clusters`, then translate its event
+  filter into `conditions`.

--- a/products/ai_observability/skills/creating-online-evaluations/references/evaluation-payload.md.j2
+++ b/products/ai_observability/skills/creating-online-evaluations/references/evaluation-payload.md.j2
@@ -103,7 +103,7 @@ and sample volume with `rollout_percentage`.
 {
   "name": "Reply is under 500 tokens",
   "evaluation_type": "hog",
-  "evaluation_config": { "source": "return event.properties.$ai_output_tokens < 500;" },
+  "evaluation_config": { "source": "return properties.$ai_output_tokens < 500;" },
   "output_type": "boolean",
   "output_config": { "allows_na": false },
   "conditions": [{ "id": "default", "rollout_percentage": 100, "properties": [] }],

--- a/products/ai_observability/skills/creating-online-evaluations/references/evaluation-payload.md.j2
+++ b/products/ai_observability/skills/creating-online-evaluations/references/evaluation-payload.md.j2
@@ -1,0 +1,128 @@
+# Evaluation create payload reference
+
+Full field reference for `posthog:llma-evaluation-create`. The `evaluation_config` and `output_config`
+schemas below are rendered from the backend Pydantic models at build time, so they can't drift.
+
+## Top-level fields
+
+| Field                 | Required | Notes                                                                       |
+| --------------------- | -------- | --------------------------------------------------------------------------- |
+| `name`                | yes      | Up to 400 chars.                                                            |
+| `description`         | no       | Defaults to `""`.                                                          |
+| `evaluation_type`     | yes      | `"hog"`, `"llm_judge"`, or `"sentiment"`.                                  |
+| `evaluation_config`   | yes      | Shape depends on `evaluation_type` (below).                                |
+| `output_type`         | yes      | `"boolean"` for `hog`/`llm_judge`; `"sentiment"` for `sentiment`.         |
+| `output_config`       | no       | `{ "allows_na": bool }` for boolean; `{}` for sentiment.                   |
+| `model_configuration` | llm_judge only | Provider/model/key. Rejected on `hog`/`sentiment`.                  |
+| `conditions`          | no       | List of trigger condition sets (below). Omit to evaluate all generations. |
+| `enabled`             | no       | Defaults to `false`. Create disabled, then flip with `llma-evaluation-update`. |
+
+Valid `(evaluation_type, output_type)` pairs: `(hog, boolean)`, `(llm_judge, boolean)`,
+`(sentiment, sentiment)`.
+
+## `evaluation_config` by type
+
+### `llm_judge`
+
+```json
+{{ pydantic_schema("products.ai_observability.backend.models.evaluation_configs.LLMJudgeConfig") }}
+```
+
+### `hog`
+
+```json
+{{ pydantic_schema("products.ai_observability.backend.models.evaluation_configs.HogEvalConfig") }}
+```
+
+`bytecode` is compiled and written by the server on save — never pass it. Send only `source`.
+
+### `sentiment`
+
+```json
+{{ pydantic_schema("products.ai_observability.backend.models.evaluation_configs.SentimentEvalConfig") }}
+```
+
+## `output_config`
+
+### boolean output
+
+```json
+{{ pydantic_schema("products.ai_observability.backend.models.evaluation_configs.BooleanOutputConfig") }}
+```
+
+`allows_na: true` lets the evaluator return N/A (skip) in addition to pass/fail.
+
+### sentiment output
+
+Empty object: `{}`.
+
+## `model_configuration` (llm_judge only)
+
+| Field             | Required | Notes                                                                          |
+| ----------------- | -------- | ------------------------------------------------------------------------------ |
+| `provider`        | yes      | One of `openai`, `anthropic`, `gemini`, `openrouter`, `fireworks`, `azure_openai`, `together_ai`. |
+| `model`           | yes      | Model id, e.g. `gpt-5-mini`. Validate against `llma-evaluation-judge-models`.  |
+| `provider_key_id` | yes      | UUID of an `ok`-state `LLMProviderKey` from `llma-provider-key-list`. |
+
+Pin `provider_key_id` to an `ok`-state key; the eval runs on that key.
+
+## `conditions`
+
+A **list** of condition sets. **OR between sets, AND within a set's `properties`.** Omitting `conditions`
+(or an empty list) evaluates every `$ai_generation`.
+
+| Field                | Required | Notes                                                                 |
+| -------------------- | -------- | --------------------------------------------------------------------- |
+| `id`                 | yes      | Stable string identifier for the set (e.g. `"default"`).             |
+| `rollout_percentage` | no       | 0–100, defaults to 100. The sampling rate the dispatcher reads.       |
+| `properties`         | no       | Flat list of PostHog property filters, AND-ed together.               |
+
+Each property filter: `{ "key": "...", "type": "event" | "person", "operator": "...", "value": ... }`.
+Common operators: `exact`, `is_not`, `icontains`, `not_icontains`, `regex`, `gt`, `lt`, `is_set`,
+`is_not_set`. There is no time/date field inside conditions — scope by event timestamp upstream if needed,
+and sample volume with `rollout_percentage`.
+
+```json
+"conditions": [
+  {
+    "id": "gpt-only",
+    "rollout_percentage": 50,
+    "properties": [
+      { "key": "$ai_model", "type": "event", "operator": "icontains", "value": "gpt" },
+      { "key": "$ai_is_error", "type": "event", "operator": "exact", "value": ["false"] }
+    ]
+  }
+]
+```
+
+## Full examples
+
+### Hog (no provider key required)
+
+```json
+{
+  "name": "Reply is under 500 tokens",
+  "evaluation_type": "hog",
+  "evaluation_config": { "source": "return event.properties.$ai_output_tokens < 500;" },
+  "output_type": "boolean",
+  "output_config": { "allows_na": false },
+  "conditions": [{ "id": "default", "rollout_percentage": 100, "properties": [] }],
+  "enabled": false
+}
+```
+
+### LLM judge
+
+```json
+{
+  "name": "Response stays on-topic",
+  "description": "Fails if the assistant changes topic from the user's question",
+  "evaluation_type": "llm_judge",
+  "evaluation_config": { "prompt": "Return true if the assistant's reply stays on the user's topic, false if it changes subject. Return N/A if the user did not ask a question." },
+  "output_type": "boolean",
+  "output_config": { "allows_na": true },
+  "model_configuration": { "provider": "openai", "model": "gpt-5-mini", "provider_key_id": "<ok-state key uuid from llma-provider-key-list>" },
+  "conditions": [{ "id": "default", "rollout_percentage": 100, "properties": [] }],
+  "enabled": false
+}
+```

--- a/products/ai_observability/skills/exploring-ai-failures/SKILL.md
+++ b/products/ai_observability/skills/exploring-ai-failures/SKILL.md
@@ -99,7 +99,7 @@ aren't there; it means you have to read.
 
 For each trace, note in plain language what went wrong — and jot down the trace's earliest-event timestamp
 alongside the note (it's right there in the trace you just read, and in `query-llm-traces-list`'s
-`first_timestamp`). That timestamp and the trace ID is all you need to build a resolvable deep link in Step 4,
+`createdAt`). That timestamp and the trace ID is all you need to build a resolvable deep link in Step 4,
 so capturing it now saves a second round-trip later.
 
 When a trace fails in a chain, record the _first_ thing that broke — the root failure usually causes the

--- a/products/ai_observability/skills/exploring-ai-failures/SKILL.md
+++ b/products/ai_observability/skills/exploring-ai-failures/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: exploring-ai-failures
+description: >
+  Find where an AI/LLM application is failing in production and surface the failure patterns, working from
+  real traces. Use when someone wants to understand what's going wrong with an AI feature, find and
+  categorize failure modes, triage errors, or investigate quality issues (wrong answers, ignored
+  instructions, hallucinations, tool misuse) — "what's failing in my agent", "surface error patterns",
+  "why are the responses bad", "find the common failure modes", "what should I fix next". Covers scoping
+  to one use case, finding failing traces by whichever signal fits the context (code errors, metric
+  outliers, trace-type slices, manual review, existing-eval spikes, clustering), and reading them into a
+  ranked failure taxonomy.
+---
+
+# Exploring AI failures
+
+The highest-value thing you can do with production AI traffic is look at where it fails and name the
+patterns. The catch: **most failures are silent.** The model returns a clean response — HTTP 200, no
+exception — that is wrong, off-topic, ignores an instruction, or misuses a tool. Those never raise an
+error, and they're usually the failures worth caring about.
+
+So this skill is about finding failures (loud _and_ silent), **reading them**, and grouping them into a
+**ranked set of failure modes** you can act on: fix a prompt, file a bug, prioritize work, or turn the
+top mode into an automatic eval (`creating-online-evaluations`).
+
+**Everything below serves one irreducible activity: reading real traces.** The queries only tell you
+_which_ traces to open — they are never the answer. If you report a list of problems without having
+opened traces, you've described the loud minority (the things that throw errors) and missed the job.
+
+This is bottom-up: the failure modes emerge from real traces, not from a list of generic metrics decided
+in advance. For reading a single trace in depth, lean on `exploring-llm-traces`; for emergent grouping at
+high volume, `exploring-llm-clusters`.
+
+## Tools
+
+| Tool                                     | Purpose                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------ |
+| `posthog:query-llm-traces-list`          | List candidate traces — filter by error, sort by a metric, scope by type |
+| `posthog:query-llm-trace`                | Read a trace in full to see what actually went wrong                     |
+| `posthog:execute-sql`                    | Find metric outliers, discover the trace taxonomy, count failure modes   |
+| `posthog:llma-evaluation-list`           | Find existing evals whose failures might reveal a new mode               |
+| `posthog:llma-evaluation-summary-create` | Summarize an existing eval's failures into patterns                      |
+
+Detailed queries for each strategy below are in
+[references/finding-traces.md](references/finding-traces.md). The full `$ai_*` event schema (and the
+`events` vs `ai_events` split for heavy content like `$ai_input`/`$ai_output_choices`) lives in
+`exploring-llm-traces/references/events-and-properties.md`.
+
+## Work with the user
+
+Collaborate on _scope and priorities_ — not on whether to do the work. Narrow with the user up front:
+which feature or use case? have they already seen something bad? is there a signal to follow (a
+thumbs-down, a ticket, a metric that looks off)? Once it's scoped, **go read traces and come back with
+coded failure modes** — don't stop to ask permission before the reading; that reading is the core
+activity, not an optional follow-up to offer. When the user doesn't know what to look for, drive the loop
+below and explain the reasoning as you go; keep the teaching opt-in.
+
+## Step 1 — Scope to one use case
+
+Apps have a _taxonomy_ of trace types, and each fails differently — a support chat hallucinates policy, a
+summarizer drops key points, an agent loops or misuses a tool. Evaluating or analyzing them together
+averages the signal away. **Pick one**, then find its filter (a `$ai_trace_id` prefix, a feature
+property, a model). If the user isn't sure how their traffic splits, discover the taxonomy first (query
+in [references/finding-traces.md](references/finding-traces.md)).
+
+## Step 2 — Pick which traces to read
+
+These are ways to _select which traces to open_ — not answers in themselves. The queryable ones (error
+counts, metric aggregates) tell you _where to look_; they are never the output. Choose by the context and
+signals you have, and combine them:
+
+- **Code errors (`$ai_is_error`)** — the cheapest sweep and the _least_ representative signal: it only
+  catches exceptions and API failures, not the silent quality failures that matter most. Use it to grab a
+  few traces to read, not as a tally of "the problems." Slightly more useful for structured-output or
+  tool-calling pipelines, where some failures do surface as parse/schema errors.
+- **Metric outliers** — sort by output/input tokens, message length, cost, or latency and open the
+  extremes. Runaway length, truncation, context bloat, and loops cluster at the tails.
+- **One trace-type slice** — narrow to a single kind of request so the traces you read share a taxonomy.
+- **Stratified sample** — when you have no specific signal (the common case), pull a mixed batch across
+  slices and outcomes and read it. This is the default, not the fallback.
+- **Existing-eval spikes** — when evals already run, a jump in an eval's failures points you at traces to
+  read (`llma-evaluation-list` + `llma-evaluation-summary-create`).
+- **Clustering** — at high volume, let groupings emerge to pick representative traces to read; see
+  `exploring-llm-clusters`.
+
+> **The trap.** It's tempting to `GROUP BY` error messages, produce a ranked table, and stop. That table
+> is the loud minority — failures that raise an exception. The failures that matter for most AI products
+> complete with HTTP 200 and only appear when a human reads the trace. **A ranking built from error or
+> metric counts you never opened is not the deliverable** — it's a pointer to what to read next. If a
+> query for silent failures comes back empty or awkward, that's a signal to _read traces_, not to give up
+> and report the loud ones.
+
+## Step 3 — Read a batch (this is the job)
+
+Open and actually read the traces you selected — plan on roughly 20–30 for a use case. This step is not
+optional, and nothing substitutes for it. You **cannot** find silent failures with `GROUP BY` or by
+grepping outputs for "refusal" / "sorry" language, because you don't yet know the patterns to search for —
+reading is how you discover them. A clever SQL proxy that returns nothing is not evidence the failures
+aren't there; it means you have to read.
+
+For each trace, note in plain language what went wrong — and jot down the trace's earliest-event timestamp
+alongside the note (it's right there in the trace you just read, and in `query-llm-traces-list`'s
+`first_timestamp`). That timestamp and the trace ID is all you need to build a resolvable deep link in Step 4,
+so capturing it now saves a second round-trip later.
+
+When a trace fails in a chain, record the _first_ thing that broke — the root failure usually causes the
+downstream symptoms, and fixing it clears them. Group the notes into a few named failure modes
+("ignores the date filter", "invents a policy", "drops the second question"); a later pass can help
+cluster your notes, but review the groupings yourself. Keep reading until new traces stop turning up
+new modes (tens of traces, not thousands — stop when it goes quiet).
+
+## Step 4 — Rank, link, and hand back to the user
+
+Rank the modes you found _by reading_, roughly by how often they showed up in your sample — a handful
+usually dominate. Present a short, ranked list of named failure modes. For each mode, include **one or two
+example trace deep links** on your own — don't wait to be asked, and don't make the user request them.
+
+You read these traces, but you can misread one — a trace that looks like a hallucination may be correct in
+context, and some of what you flag will be you misunderstanding the trace, not a real failure. So don't
+present the list as settled fact. Give the user a couple of linked examples per mode, ask them to open the
+links, then ask **which mode they want to focus on** next.
+
+(A list assembled from error messages or metric counts you never read is the loud subset, not this — go
+back to Step 3.)
+
+## When there's little to look at
+
+If the use case is new or low-volume and you can't find enough failures: widen the time window or loosen
+the slice first; then **stress-test** with inputs that deliberately probe the constraints you care about
+(edge cases, long or ambiguous inputs, adversarial phrasing); or **generate a small synthetic set** across
+the dimensions that matter (request type × user scenario), run it through the system, and read those
+traces. Treat synthetic results as a bootstrap, not ground truth — they're unreliable for high-stakes or
+niche domains.
+
+## Constructing UI links
+
+- **Traces list:** `https://app.posthog.com/ai-observability/traces` (filter to your use case)
+- **Single trace:** `https://app.posthog.com/ai-observability/traces/<trace_id>?timestamp=<url_encoded_timestamp>`.
+
+## Tips
+
+- **Reading is the job, not the last step.** Aggregates, error counts, and scores are clues for _which
+  traces to open_ — never a substitute. Read a first batch before reporting anything, and don't ask
+  permission to do it.
+- **Don't over-index on errors.** `$ai_is_error` is the loudest but least interesting signal; the
+  failures worth your time usually complete without one.
+- **The finding strategies are a menu for picking traces to read**, not a pipeline and not the answer.
+  Pick by context, combine freely, and don't force an order.
+- **One use case at a time.** Different trace types have different failure taxonomies — mixing them blurs
+  the result.
+- **Frequency over completeness.** The goal is the modes that happen most, not every conceivable failure.
+- **The output is a ranked list of named failure modes from traces you read** — that artifact is what
+  makes the next step (fix, prioritize, or eval) obvious.
+- **Hand back linked examples, then let the user steer.** Don't stop at a categorical table. Give one or
+  two resolvable trace links per mode unprompted, ask the user to eyeball a couple.

--- a/products/ai_observability/skills/exploring-ai-failures/references/finding-traces.md
+++ b/products/ai_observability/skills/exploring-ai-failures/references/finding-traces.md
@@ -1,0 +1,101 @@
+# Finding failing traces — queries
+
+Concrete queries for each strategy in Step 2. Property names (`$ai_is_error`, `$ai_input_tokens`, …) are
+the standard AI event properties; confirm the exact ones for this project with `read-data-schema`, and
+see `exploring-llm-traces/references/events-and-properties.md` for the full schema and the `events` vs
+`ai_events` split (heavy content like `$ai_input` / `$ai_output_choices` lives on `ai_events`).
+
+## Discover the trace taxonomy
+
+When the user isn't sure how their traffic splits, find the use cases before scoping to one:
+
+```sql
+-- By trace-id prefix convention (many apps namespace trace ids like "support:", "summarize:")
+SELECT splitByChar(':', coalesce(properties.$ai_trace_id, ''))[1] AS kind, count() AS n
+FROM events
+WHERE event = '$ai_generation' AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY kind ORDER BY n DESC
+```
+
+Or group by whatever feature property the app sets (`ai_product`, `agent_mode`, a custom tag). Then scope
+every query below to one slice.
+
+## Code errors
+
+The cheap first sweep. Group the messages to see the error classes:
+
+```sql
+SELECT properties.$ai_error AS error, count() AS n
+FROM events
+WHERE event = '$ai_generation' AND properties.$ai_is_error = 'true'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY error ORDER BY n DESC
+```
+
+Remember this only catches exceptions/API failures. A trace can succeed (no `$ai_is_error`) and still be
+wrong — those silent failures need the other strategies.
+
+## Metric outliers
+
+Anomalies cluster around failures. Sort by a metric and read both extremes:
+
+```sql
+SELECT properties.$ai_trace_id AS trace_id,
+       properties.$ai_input_tokens AS in_tok,
+       properties.$ai_output_tokens AS out_tok,
+       properties.$ai_latency AS latency,
+       properties.$ai_total_cost_usd AS cost
+FROM events
+WHERE event = '$ai_generation' AND timestamp >= now() - INTERVAL 7 DAY
+ORDER BY out_tok DESC      -- also try in_tok, latency, cost; and ASC for truncation / empty outputs
+LIMIT 25
+```
+
+What the extremes tend to mean: huge output = runaway/repetition; tiny output = truncation or refusal;
+huge input = context bloat or a stuffed prompt; high latency/cost = inefficiency or a loop. Open the
+interesting ones with `query-llm-trace`.
+
+## Manual review of a stratified batch
+
+Pull a mixed batch (slices and outcomes, not all errors) and read each candidate end to end:
+
+```json
+posthog:query-llm-traces-list
+{ "dateRange": { "date_from": "-7d" }, "filterTestAccounts": true }
+```
+
+Then `query-llm-trace` on each. Reading ~20–30 across a use case usually surfaces the main modes.
+
+## Existing-eval spikes
+
+A jump in an existing eval's failures often exposes a new problem. Summarize the failures, then confirm
+the spike with a daily count:
+
+```json
+posthog:llma-evaluation-list { "enabled": true }
+posthog:llma-evaluation-summary-create { "evaluation_id": "<uuid>", "filter": "fail" }
+```
+
+```sql
+SELECT toDate(timestamp) AS day, count() AS fails
+FROM events
+WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<uuid>'
+    AND properties.$ai_evaluation_result = false AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day
+```
+
+`exploring-llm-evaluations` covers reading eval results in depth.
+
+## Counting failure modes
+
+After open-noting and grouping (Step 3), a quick frequency count over the traces you tagged makes the
+ranking concrete — e.g. tally by a label you wrote into a scratch list, or, when the mode maps to a
+property, count it directly:
+
+```sql
+SELECT properties.$ai_model AS model, count() AS n
+FROM events
+WHERE event = '$ai_generation' AND properties.$ai_is_error = 'true'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY model ORDER BY n DESC
+```

--- a/services/mcp/scripts/generate-orval-schemas.mjs
+++ b/services/mcp/scripts/generate-orval-schemas.mjs
@@ -26,7 +26,7 @@ import {
 } from '@posthog/openapi-codegen'
 
 import { discoverDefinitions, resolveSchemaPath } from './lib/definitions.mjs'
-import { stripEnumMinLength } from './lib/schema-transforms.mjs'
+import { stripEnumMinLength, stripUuidFormat } from './lib/schema-transforms.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const mcpRoot = path.resolve(__dirname, '..')
@@ -133,25 +133,6 @@ function stripReadOnlyFromRequired(obj) {
     }
     for (const value of Object.values(obj)) {
         stripReadOnlyFromRequired(value)
-    }
-}
-
-/**
- * Strip `format: "uuid"` from all string properties in the schema.
- * Zod 4's `.uuid()` enforces strict RFC 4122 version/variant bits,
- * which some PostHog UUID generation paths don't satisfy.
- * Since these are API response schemas, there's no value in
- * re-validating the UUID format client-side.
- */
-function stripUuidFormat(obj) {
-    if (!obj || typeof obj !== 'object') {
-        return
-    }
-    if (obj.type === 'string' && obj.format === 'uuid') {
-        delete obj.format
-    }
-    for (const value of Object.values(obj)) {
-        stripUuidFormat(value)
     }
 }
 

--- a/services/mcp/scripts/lib/schema-transforms.mjs
+++ b/services/mcp/scripts/lib/schema-transforms.mjs
@@ -21,3 +21,26 @@ export function stripEnumMinLength(obj) {
         stripEnumMinLength(value)
     }
 }
+
+/**
+ * Strip `format: "uuid"` from all string schemas.
+ * Zod 4's `.uuid()` enforces strict RFC 4122 version/variant bits, which some
+ * PostHog UUID generation paths don't satisfy (e.g. provider key ids with a
+ * `-0000-` version group). These are request/response schemas, so there's no
+ * value in re-validating the UUID format client-side.
+ *
+ * Nullable fields (allow_null=True) serialize as `type: ["string", "null"]`,
+ * so match both the scalar and array forms.
+ */
+export function stripUuidFormat(obj) {
+    if (!obj || typeof obj !== 'object') {
+        return
+    }
+    const isStringType = obj.type === 'string' || (Array.isArray(obj.type) && obj.type.includes('string'))
+    if (isStringType && obj.format === 'uuid') {
+        delete obj.format
+    }
+    for (const value of Object.values(obj)) {
+        stripUuidFormat(value)
+    }
+}

--- a/services/mcp/src/generated/agent_platform/api.ts
+++ b/services/mcp/src/generated/agent_platform/api.ts
@@ -159,7 +159,7 @@ export const AgentApplicationsRevisionsCreateParams = /* @__PURE__ */ zod.object
 export const agentApplicationsRevisionsCreateBodyBundleUriDefault = ``
 
 export const AgentApplicationsRevisionsCreateBody = /* @__PURE__ */ zod.object({
-    parent_revision: zod.uuid().nullish(),
+    parent_revision: zod.string().nullish(),
     bundle_uri: zod
         .string()
         .default(agentApplicationsRevisionsCreateBodyBundleUriDefault)
@@ -244,7 +244,7 @@ export const AgentApplicationsRevisionsPartialUpdateParams = /* @__PURE__ */ zod
 })
 
 export const AgentApplicationsRevisionsPartialUpdateBody = /* @__PURE__ */ zod.object({
-    parent_revision: zod.uuid().nullish(),
+    parent_revision: zod.string().nullish(),
     bundle_uri: zod
         .string()
         .optional()

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -261,7 +261,7 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                         ),
                     model: zod.string().max(evaluationsCreateBodyModelConfigurationOneModelMax),
                     provider_key_id: zod
-                        .uuid()
+                        .string()
                         .nullish()
                         .describe(
                             'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
@@ -433,7 +433,7 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         ),
                     model: zod.string().max(evaluationsPartialUpdateBodyModelConfigurationOneModelMax),
                     provider_key_id: zod
-                        .uuid()
+                        .string()
                         .nullish()
                         .describe(
                             'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
@@ -1475,7 +1475,7 @@ export const LlmAnalyticsTraceReviewsCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 definition_id: zod.string().describe('Stable scorer definition ID.'),
                 definition_version_id: zod
-                    .uuid()
+                    .string()
                     .nullish()
                     .describe("Optional immutable scorer version ID. Defaults to the scorer's current version."),
                 categorical_values: zod
@@ -1493,7 +1493,7 @@ export const LlmAnalyticsTraceReviewsCreateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe('Full desired score set for this review. Omit scorers you want to leave blank.'),
     queue_id: zod
-        .uuid()
+        .string()
         .nullish()
         .describe(
             'Optional review queue ID for queue-context saves. When provided, the matching pending queue item is cleared after the review is saved. If omitted, any pending queue item for the same trace is cleared.'
@@ -1538,7 +1538,7 @@ export const LlmAnalyticsTraceReviewsPartialUpdateBody = /* @__PURE__ */ zod.obj
             zod.object({
                 definition_id: zod.string().describe('Stable scorer definition ID.'),
                 definition_version_id: zod
-                    .uuid()
+                    .string()
                     .nullish()
                     .describe("Optional immutable scorer version ID. Defaults to the scorer's current version."),
                 categorical_values: zod
@@ -1558,7 +1558,7 @@ export const LlmAnalyticsTraceReviewsPartialUpdateBody = /* @__PURE__ */ zod.obj
         .optional()
         .describe('Full desired score set for this review. Omit scorers you want to leave blank.'),
     queue_id: zod
-        .uuid()
+        .string()
         .nullish()
         .describe(
             'Optional review queue ID for queue-context saves. When provided, the matching pending queue item is cleared after the review is saved. If omitted, any pending queue item for the same trace is cleared.'
@@ -1855,7 +1855,7 @@ export const TaggersCreateBody = /* @__PURE__ */ zod.object({
                     .max(taggersCreateBodyModelConfigurationOneModelMax)
                     .describe('Provider model identifier to use for this tagger.'),
                 provider_key_id: zod
-                    .uuid()
+                    .string()
                     .nullish()
                     .describe(
                         'Existing LLM provider key UUID for the current project. Do not invent this value; use a real provider key ID returned by PostHog, or omit/null when no provider key should be pinned.'

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -942,7 +942,7 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                 .nullish()
                 .describe('Execution priority for transformations. Lower values run first.'),
             _create_in_folder: zod.string().optional(),
-            batch_export_id: zod.uuid().nullish(),
+            batch_export_id: zod.string().nullish(),
             search_match_type: zod
                 .union([zod.enum(['exact', 'similar']), zod.null()])
                 .optional()

--- a/services/mcp/src/generated/data_warehouse/api.ts
+++ b/services/mcp/src/generated/data_warehouse/api.ts
@@ -207,10 +207,10 @@ export const WarehouseSavedQueriesCreateBody = /* @__PURE__ */ zod
                 "How often to materialize this view. One of '15min', '30min', '1hour', '6hour', '12hour', '24hour', '7day', '30day', or 'never' to pause scheduled materialization. 15min is the fastest cadence available.\n\n* `never` - never\n* `15min` - 15min\n* `30min` - 30min\n* `1hour` - 1hour\n* `6hour` - 6hour\n* `12hour` - 12hour\n* `24hour` - 24hour\n* `7day` - 7day\n* `30day` - 30day"
             ),
         folder_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe('Optional folder ID used to organize this view in the SQL editor sidebar.'),
-        dag_id: zod.uuid().nullish().describe('Optional DAG to place this view into'),
+        dag_id: zod.string().nullish().describe('Optional DAG to place this view into'),
         is_test: zod.boolean().optional().describe('Whether this view is for testing only and will auto-expire.'),
     })
     .describe(
@@ -277,14 +277,14 @@ export const WarehouseSavedQueriesPartialUpdateBody = /* @__PURE__ */ zod
                 "How often to materialize this view. One of '15min', '30min', '1hour', '6hour', '12hour', '24hour', '7day', '30day', or 'never' to pause scheduled materialization. 15min is the fastest cadence available.\n\n* `never` - never\n* `15min` - 15min\n* `30min` - 30min\n* `1hour` - 1hour\n* `6hour` - 6hour\n* `12hour` - 12hour\n* `24hour` - 24hour\n* `7day` - 7day\n* `30day` - 30day"
             ),
         folder_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe('Optional folder ID used to organize this view in the SQL editor sidebar.'),
         edited_history_id: zod
             .string()
             .nullish()
             .describe('Activity log ID from the last known edit. Used for conflict detection.'),
-        dag_id: zod.uuid().nullish().describe('Optional DAG to place this view into'),
+        dag_id: zod.string().nullish().describe('Optional DAG to place this view into'),
         is_test: zod.boolean().optional().describe('Whether this view is for testing only and will auto-expire.'),
     })
     .describe(
@@ -350,7 +350,7 @@ export const WarehouseSavedQueriesMaterializeCreateBody = /* @__PURE__ */ zod
                 "How often to materialize this view. One of '15min', '30min', '1hour', '6hour', '12hour', '24hour', '7day', '30day', or 'never' to pause scheduled materialization. 15min is the fastest cadence available.\n\n* `never` - never\n* `15min` - 15min\n* `30min` - 30min\n* `1hour` - 1hour\n* `6hour` - 6hour\n* `12hour` - 12hour\n* `24hour` - 24hour\n* `7day` - 7day\n* `30day` - 30day"
             ),
         folder_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe('Optional folder ID used to organize this view in the SQL editor sidebar.'),
         edited_history_id: zod
@@ -361,7 +361,7 @@ export const WarehouseSavedQueriesMaterializeCreateBody = /* @__PURE__ */ zod
             .boolean()
             .nullish()
             .describe('If true, skip column inference and validation. For saving drafts.'),
-        dag_id: zod.uuid().nullish().describe('Optional DAG to place this view into'),
+        dag_id: zod.string().nullish().describe('Optional DAG to place this view into'),
         is_test: zod.boolean().optional().describe('Whether this view is for testing only and will auto-expire.'),
     })
     .describe(
@@ -418,7 +418,7 @@ export const WarehouseSavedQueriesRevertMaterializationCreateBody = /* @__PURE__
                 "How often to materialize this view. One of '15min', '30min', '1hour', '6hour', '12hour', '24hour', '7day', '30day', or 'never' to pause scheduled materialization. 15min is the fastest cadence available.\n\n* `never` - never\n* `15min` - 15min\n* `30min` - 30min\n* `1hour` - 1hour\n* `6hour` - 6hour\n* `12hour` - 12hour\n* `24hour` - 24hour\n* `7day` - 7day\n* `30day` - 30day"
             ),
         folder_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe('Optional folder ID used to organize this view in the SQL editor sidebar.'),
         edited_history_id: zod
@@ -429,7 +429,7 @@ export const WarehouseSavedQueriesRevertMaterializationCreateBody = /* @__PURE__
             .boolean()
             .nullish()
             .describe('If true, skip column inference and validation. For saving drafts.'),
-        dag_id: zod.uuid().nullish().describe('Optional DAG to place this view into'),
+        dag_id: zod.string().nullish().describe('Optional DAG to place this view into'),
         is_test: zod.boolean().optional().describe('Whether this view is for testing only and will auto-expire.'),
     })
     .describe(
@@ -483,7 +483,7 @@ export const WarehouseSavedQueriesRunCreateBody = /* @__PURE__ */ zod
                 "How often to materialize this view. One of '15min', '30min', '1hour', '6hour', '12hour', '24hour', '7day', '30day', or 'never' to pause scheduled materialization. 15min is the fastest cadence available.\n\n* `never` - never\n* `15min` - 15min\n* `30min` - 30min\n* `1hour` - 1hour\n* `6hour` - 6hour\n* `12hour` - 12hour\n* `24hour` - 24hour\n* `7day` - 7day\n* `30day` - 30day"
             ),
         folder_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe('Optional folder ID used to organize this view in the SQL editor sidebar.'),
         edited_history_id: zod
@@ -494,7 +494,7 @@ export const WarehouseSavedQueriesRunCreateBody = /* @__PURE__ */ zod
             .boolean()
             .nullish()
             .describe('If true, skip column inference and validation. For saving drafts.'),
-        dag_id: zod.uuid().nullish().describe('Optional DAG to place this view into'),
+        dag_id: zod.string().nullish().describe('Optional DAG to place this view into'),
         is_test: zod.boolean().optional().describe('Whether this view is for testing only and will auto-expire.'),
     })
     .describe(

--- a/services/mcp/src/generated/email_templates/api.ts
+++ b/services/mcp/src/generated/email_templates/api.ts
@@ -112,7 +112,7 @@ export const MessagingTemplatesCreateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe("Message channel of the template. Currently 'email'."),
     message_category: zod
-        .uuid()
+        .string()
         .nullish()
         .describe('Message category ID to file the template under. Must belong to the same project.'),
     deleted: zod.boolean().optional().describe('Soft-delete flag. Set true to remove the template from the library.'),
@@ -220,7 +220,7 @@ export const MessagingTemplatesPartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe("Message channel of the template. Currently 'email'."),
     message_category: zod
-        .uuid()
+        .string()
         .nullish()
         .describe('Message category ID to file the template under. Must belong to the same project.'),
     deleted: zod.boolean().optional().describe('Soft-delete flag. Set true to remove the template from the library.'),

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -372,7 +372,7 @@ export const VisionScannersEstimateCreateBody = /* @__PURE__ */ zod
             .default(visionScannersEstimateCreateBodySamplingRateDefault)
             .describe('0..1 downsample applied to matched sessions. Defaults to 1.0 (no downsampling).'),
         scanner_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe(
                 "The scanner being edited, excluded from `other_enabled_scanners_monthly` so its stored estimate isn't double-counted in the forecast. Omit (or null) when estimating a brand-new scanner."

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -1047,7 +1047,7 @@ export const SignalsScoutScratchpadRememberBody = /* @__PURE__ */ zod
             .max(signalsScoutScratchpadRememberBodyContentMax)
             .describe('Prose to write. Read verbatim into future prompts.'),
         run_id: zod
-            .uuid()
+            .string()
             .nullish()
             .describe(
                 "Run that authored this memory; persisted as `created_by_run_id` for lineage. Best-effort — a `run_id` that isn't a run on this project is dropped (lineage left null), not rejected, so the memory write is never lost."

--- a/services/mcp/src/generated/user_interviews/api.ts
+++ b/services/mcp/src/generated/user_interviews/api.ts
@@ -489,7 +489,7 @@ export const UserInterviewsSearchCreateBody = /* @__PURE__ */ zod.object({
             'Which document types to search across. Omit to default to both `transcript` and `summary`. Pass a non-empty subset to restrict the search.'
         ),
     topic_id: zod
-        .uuid()
+        .string()
         .nullish()
         .describe('Optional. Restrict results to interviews belonging to a specific UserInterviewTopic.'),
     classifications: zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-create.json
@@ -12,8 +12,6 @@
         "parent_revision": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-partial-update.json
@@ -15,8 +15,6 @@
         "parent_revision": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -18,8 +18,6 @@
                 "batch_export_id": {
                     "anyOf": [
                         {
-                            "format": "uuid",
-                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                             "type": "string"
                         },
                         {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
@@ -116,8 +116,6 @@
                         "provider_key_id": {
                             "anyOf": [
                                 {
-                                    "format": "uuid",
-                                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                                     "type": "string"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
@@ -120,8 +120,6 @@
                         "provider_key_id": {
                             "anyOf": [
                                 {
-                                    "format": "uuid",
-                                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                                     "type": "string"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-tagger-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-tagger-create.json
@@ -66,8 +66,6 @@
                         "provider_key_id": {
                             "anyOf": [
                                 {
-                                    "format": "uuid",
-                                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                                     "type": "string"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-trace-review-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-trace-review-create.json
@@ -15,8 +15,6 @@
         "queue_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -63,8 +61,6 @@
                     "definition_version_id": {
                         "anyOf": [
                             {
-                                "format": "uuid",
-                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                                 "type": "string"
                             },
                             {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-trace-review-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-trace-review-update.json
@@ -19,8 +19,6 @@
         "queue_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -67,8 +65,6 @@
                     "definition_version_id": {
                         "anyOf": [
                             {
-                                "format": "uuid",
-                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                                 "type": "string"
                             },
                             {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-remember.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-remember.json
@@ -15,8 +15,6 @@
         "run_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-create.json
@@ -4,8 +4,6 @@
         "dag_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -17,8 +15,6 @@
         "folder_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-materialize.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-materialize.json
@@ -4,8 +4,6 @@
         "dag_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -38,8 +36,6 @@
         "folder_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-run.json
@@ -4,8 +4,6 @@
         "dag_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -38,8 +36,6 @@
         "folder_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-unmaterialize.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-unmaterialize.json
@@ -4,8 +4,6 @@
         "dag_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -38,8 +36,6 @@
         "folder_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/view-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/view-update.json
@@ -4,8 +4,6 @@
         "dag_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {
@@ -28,8 +26,6 @@
         "folder_id": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create-email-template.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create-email-template.json
@@ -107,8 +107,6 @@
         "message_category": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update-email-template.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update-email-template.json
@@ -111,8 +111,6 @@
         "message_category": {
             "anyOf": [
                 {
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/schema-transforms.test.ts
+++ b/services/mcp/tests/unit/schema-transforms.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { stripEnumMinLength } from '../../scripts/lib/schema-transforms.mjs'
+import { stripEnumMinLength, stripUuidFormat } from '../../scripts/lib/schema-transforms.mjs'
 
 describe('stripEnumMinLength', () => {
     it('removes minLength from a schema with enum', () => {
@@ -147,5 +147,57 @@ describe('stripEnumMinLength', () => {
 
         expect(spec.a.b.c).not.toHaveProperty('minLength')
         expect(spec.a.b.c.enum).toEqual(['X', 'Y'])
+    })
+})
+
+describe('stripUuidFormat', () => {
+    it('strips format from a scalar string uuid field', () => {
+        const schema = { type: 'string', format: 'uuid' }
+
+        stripUuidFormat(schema)
+
+        expect(schema).not.toHaveProperty('format')
+        expect(schema.type).toBe('string')
+    })
+
+    it('strips format from a nullable uuid field with array-form type', () => {
+        const schema = { type: ['string', 'null'], format: 'uuid' }
+
+        stripUuidFormat(schema)
+
+        expect(schema).not.toHaveProperty('format')
+        expect(schema.type).toEqual(['string', 'null'])
+    })
+
+    it('leaves non-uuid formats untouched', () => {
+        const schema = { type: 'string', format: 'date-time' }
+
+        stripUuidFormat(schema)
+
+        expect(schema.format).toBe('date-time')
+    })
+
+    it('strips uuid format from a nested nullable provider key field', () => {
+        const spec = {
+            components: {
+                schemas: {
+                    ModelConfiguration: {
+                        type: 'object',
+                        properties: {
+                            provider_key_id: { type: ['string', 'null'], format: 'uuid' },
+                        },
+                    },
+                },
+            },
+        }
+
+        stripUuidFormat(spec)
+
+        expect(spec.components.schemas.ModelConfiguration.properties.provider_key_id).not.toHaveProperty('format')
+    })
+
+    it('is a no-op for null and undefined', () => {
+        expect(() => stripUuidFormat(null)).not.toThrow()
+        expect(() => stripUuidFormat(undefined)).not.toThrow()
     })
 })


### PR DESCRIPTION
## Changes

Adds two new skills, bundled in a single commit because they have a dependency and I tested them together:
- `exploring-ai-failures` explores the failure space of AI traces and sample and understands what goes wrong with existing traces, creating a taxonomy of failures (based on current best practices)
- `creating-online-evaluations` sets up new evals in an evidence based manner, that fit the user's domain. Leverages the `exploring-ai-failures` skill when the user is not clear on what to focus the evaluation on

It additionally bundles a fix that prevented the evaluation creation tools from working by being too strict with UUID input validation.

Sample run of the skill, which I used to create [this eval](https://us.posthog.com/project/2/ai-evals/evaluations/019f2226-2a45-0000-a198-22aeca92b303) and [this other eval](https://us.posthog.com/project/2/ai-evals/evaluations/019f2226-16bd-0000-c1fb-4e008f33fb1e):

```
 ▐▛███▜▌   Claude Code v2.1.198
▝▜█████▛▘  Opus 4.8 · Claude Max
  ▘▘ ▝▝    ~/Code/posthog

 ▎ Fable 5 is back.
 ▎ Until July 7, you can use up to 50% of your plan's weekly usage limit on Fable 5. If you hit your limit, you can continue on Fable 5 with usage credits. Fable 5 draws down usage faster than Opus 4.8. Learn more
   +1 more · /status

❯ Help me create one or two evals for my LLMs                                   

⏺ I'll invoke the skill that's designed exactly for this. It grounds evals in a
  real failure mode, so it'll also point me at finding failures first.

⏺ Skill(creating-online-evaluations)
  ⎿  Successfully loaded skill

⏺ The skill is grounded in a real, observed failure mode — not a generic metric.
  Since you haven't named a specific failure yet, I want to anchor on that
  before writing anything. A couple of quick decisions:

⏺ User answered Claude's questions:
  ⎿  · Which AI product/use case should these evals cover, and where's its data?
     → This project (PostHog prod, id 2)
     · How should we pick the failure mode to evaluate? → Explore failures first
     (Recommended)

⏺ Good — this project (PostHog prod), and we'll explore failures first. Let me
  pull in the exploration skill.

⏺ Skill(exploring-ai-failures)
  ⎿  Successfully loaded skill

⏺ Let me load the PostHog MCP tools so I can query the production LLM traffic.

⏺ Let me read the finding-traces reference and inspect the key tools in
  parallel.

  Read 1 file, called posthog-prod 2 times (ctrl+o to expand)
  ⎿  Loaded .claude/rules/semantic-line-breaks.md

⏺ Now let me discover the LLM trace taxonomy in this project — volume, and how
  traffic splits.

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ Massive volume — ~[redacted] generations/week. The named traffic is clearly Max AI
  (PostHog's product assistant): MaxChatAnthropic (~[redacted]/wk) and MaxChatOpenAI
  (~[redacted]/wk). There's also a huge unnamed bucket ([redacted]). Let me quickly see what
  that unnamed bucket is before scoping.

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ The unnamed bucket is a grab-bag across ~[redacted] models (gpt-4.1-nano at [redacted],
  gemini, various claudes) — many different internal features mixed together,
  not one use case. Max AI chat is the coherent, flagship target: mostly
  claude-sonnet-4-6 (~[redacted]) and gpt-4.1 (~[redacted]), with a very low error rate
  (~[redacted]) — meaning the failures that matter here are silent.

  Let me scope to Max and pull traces to read: a random sample plus the error
  ones and any with negative user feedback.

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ The random-sample list came back huge (full conversation states inline). I'll
  have a subagent read that file so it stays out of my context. Meanwhile, [redacted]
  feedback events in 30 days — all with text — is a high-yield failure signal.
  Let me pull those and kick off the trace reading in parallel.

  Called posthog-prod (ctrl+o to expand)

⏺ Agent(Read Max AI random trace sample)
  ⎿  Done (10 tool uses · 55.6k tokens · 2m 21s)
  (ctrl+o to expand)

⏺ Two key findings. First, the traces-list only returned span telemetry — the
  actual prompt/response content lives on posthog.ai_events and needs
  query-llm-trace per trace. Second, and more valuable: the [redacted] feedback texts 
  are a strong, real failure signal, and clear patterns already jump out.
  Reading them as a reviewer:

  - A large "failed to generate an answer" / not working / crashing cluster
  around 2026-06-09 — looks like an infra incident (loud, not a good eval
  target).
  - Recurring "0 days" complaints from many separate users (8b0079b0, 7b2c89ad,
  f36f4b9c, ad397c2a, 6921109d…) — Max reporting a 0-day / empty window.
  - Wrong property selected — "Used wrong property", "$entry_utm_source instead
  of $utm_source".
  - Wrong tools / nonexistent slash commands — "calling the wrong tools and
  passing wrong arguments", proposes /ticket that doesn't exist.
  - Hallucinated / false claims about data — "completely false claim… not
  supported by the session it references", "it's false, I can see 4 matching
  people".
  - Specific formatting bug — "Always creates charts with %% as the postfix".

  The skill is firm that I confirm by reading real traces, not trust the labels.
  Let me check query-llm-trace's shape, then have subagents deep-read the
  traces behind the most checkable modes.

  Called posthog-prod (ctrl+o to expand)
⏺ Now I'll deep-read the traces behind the most promising, checkable failure
  modes — in parallel, so the heavy trace content stays out of my context and
  each subagent returns only coded notes with verbatim quotes and a checkability
  verdict.

⏺ 4 agents finished (ctrl+o to expand)
   ├ Read Max "0 days" traces · 10 tool uses · 65.7k tokens
   │ ⎿  Done
   ├ Read Max wrong-property traces
   ├ Read Max wrong-tool traces · 10 tool uses · 65.8k tokens
   │ ⎿  Done
   └ Read Max hallucination traces · 10 tool uses · 66.0k tokens
     ⎿  Done

⏺ Agent "Read Max wrong-property traces" finished · 5m 26s

⏺ I've now deep-read the traces behind each candidate mode. The reads corrected 
  several of my initial labels — which is exactly why the skill insists on
  reading. Here's the confirmed, ranked picture (setting aside the loud infra
  incident around 2026‑06‑09 — a wave of "failed to generate an answer" — and
  the /ticket handler SynchronousOnlyOperation crash; those are bugs to file, 
  not evals).

  Confirmed failure modes (from reading real traces)

  1. Ungrounded / hallucinated claims — highest pain, most recurring. Max takes
  clean tool output and asserts a confident conclusion the data doesn't support.
  Confirmed across every trace I read for it:
  - cf8447ee — invented a causal mechanism: "The app is programmatically 
  relaunching the language modal every time it comes to the foreground… 
  preference is not being persisted" — the session events show the locale
  persisted throughout.
  - 23495fe0 — over-attribution: "Found it. Your person record has the email 
  [redacted-email]" — one of 10 unrelated rows from a query with no
  identity filter.
  - 0989bf06 — quoted a funnel "6→6→3 (50%)" that no query in the trace ever 
  ran.
  - bd2294ae — fabricated that gpt‑5.4 "maps to" gpt‑4.1, then advised on the
  wrong model.

  The grounding data (tool results) sits in the same generation's input, so an
  llm_judge can actually verify it. Not hog-checkable.

  2. Generated query doesn't match the user's intent — the "0 days" and "wrong 
  property" complaints collapse into this. The reads killed my mechanical
  hypotheses (no zero-length windows exist; every property Max used does exist
  in the taxonomy). The real defect is subtler:
  - 73e8e29a — "users in Brentwood area" → built $pageview DAU instead of a
  person count → returned 0.
  - fe93479d — session-scoped question got an event-scoped breakdown
  ($referring_domain, type event) instead of $entry_utm_source, type session.
  - 8b0079b0 / f36f4b9c — dropped the user's established time window / omitted
  the requested time series ("0 days" = "no time dimension").

  Needs an llm_judge (a hog proxy misfires on legitimately all-time questions).

  3. Invented capabilities / wrong app URLs — partly deterministic but brittle.
  b82aee76: wrong routes (/activity/live-events vs /activity/live), and handed
  the user JavaScript for a Hog editor. The "invented slash command" angle
  turned out weaker — /ticket is actually a real command that crashed, not a
  hallucination. A hog regex over emitted URL paths is possible but needs a
  hand-maintained known-bad list.

  ---
  Per the skill, evals should be one mode each, and it's your call which to turn
  into evals. My recommendation: build #1 (groundedness) as an llm_judge — it's
  the biggest, most painful, and cleanly judgeable — and pair it with one more.
  Which would you like?

⏺ User answered Claude's questions:
  ⎿  · Which failure mode(s) should I turn into online evals? (one eval each) → 
     Groundedness (llm_judge) — Recommended, Query matches intent (llm_judge)

⏺ Both are llm_judge, so I need a usable provider key first. Let me read the
  exact payload reference and run the gate checks (provider keys + valid judge
  models) in parallel.

  Read 1 file, called posthog-prod 2 times (ctrl+o to expand)

⏺ The key-list tool is named differently here. The config tools are
  llma-evaluation-config-get (active/available keys) and
  llma-evaluation-judge-models. Let me inspect and call both.

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ Now the gate calls:

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ There's an active OpenAI key in ok state
  (019b217f-bcc7-0000-664b-e229e01ded70, "Production key", created by you). Note
  the trial eval quota is exhausted (trial_evals_remaining: 0), but that's fine
  — with a real active key, evals run on your own key, not the trial. Valid
  judge models include gpt-5-mini (good balance for judging).

  Before creating, let me confirm the scope volume so I can pick a sane sampling
  rate — Max chat is high-traffic and each llm_judge call bills against that
  key.

  Called posthog-prod (ctrl+o to expand)

⏺ ~[redacted] Max chat generations/day — far too many to judge at 100%. I'll create
  both disabled with a conservative 1% sample (~[redacted] judged/day each), scoped to
  Max chat generations excluding errors, and we'll confirm the rate before
  enabling.

  Creating the two evals now:

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ The key's UUID (019b217f-bcc7-0000-...) has a 0000 version group that the
  tool's strict UUID validator rejects. That's fine — the active team key is
  that same "Production key", so omitting provider_key_id falls back to exactly
  it. Recreating without the pin:

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ Both created and disabled (status: paused):
  - Groundedness — 019f2226-16bd-0000-c1fb-4e008f33fb1e
  - Query matches intent — 019f2226-2a45-0000-a198-22aeca92b303

  Before proposing we enable, let me spot-run each judge against a known-failing
  generation to confirm it fires and returns a sensible verdict. Let me check
  how llma-evaluation-run takes its target.

  Called posthog-prod (ctrl+o to expand)

⏺ llma-evaluation-run needs a specific generation event UUID + timestamp. Let me
  grab the generation events for two known-failing traces — cf8447ee
  (hallucinated causal claim, for groundedness) and 73e8e29a (Brentwood
  DAU-vs-person-count, for query-intent) — so I can target the spot-runs. This
  also validates a real scoping concern: whether the query Max generates
  actually lives on the MaxChat generation my conditions target.

  Called posthog-prod (ctrl+o to expand)

⏺ out_len is null because the heavy output lives on ai_events, not
  events.properties — expected; the eval engine reads it from there. Each trace
  has many MaxChat generations (the tool-calling loop); the last is the final
  answer. Let me spot-run both judges against the relevant generation and then
  read the $ai_evaluation results. This is the real end-to-end check — including
  a genuine open question: whether the query-intent judge can see the generated
  query from the orchestrator MaxChat turn (Max may generate queries in an
  unlabeled sub-agent turn my scope doesn't catch).

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ Both spot-run workflows started (async). Let me give them a moment and query
  the resulting $ai_evaluation events.

  Ran 1 shell command (ctrl+o to expand)

⏺ While that runs, let me confirm the $ai_evaluation result event's property
  names so I query the right fields.

  Called posthog-prod (ctrl+o to expand)
⏺ The result event carries $ai_evaluation_result, $ai_evaluation_applicable (the
  N/A signal), and $ai_evaluation_reasoning. Let me query the two spot-run
  verdicts.

  Called posthog-prod (ctrl+o to expand)

⏺ Both judges validated correctly against the known-bad generations:

  Eval: Groundedness
  Target: cf8447ee (hallucinated modal cause)
  Verdict: Fail (applicable)
  Judge's reasoning: "unsupported causal claims about why the modal reopens, why
   
    RTL fails… none directly established by the provided data"
  ────────────────────────────────────────
  Eval: Query matches intent
  Target: 73e8e29a (Brentwood)
  Verdict: Fail (applicable)
  Judge's reasoning: "defaulted to 'last 30 days' … $pageview with DAU … 
  measures
     active pageview users, not the total distinct persons in  Brentwood… the 
    measured entity diverges"

  Both caught the real failure with accurate reasoning and correctly marked it
  applicable (not N/A). Importantly, this resolves my scoping worry: the
  query-intent judge could see and assess the generated query from the MaxChat
  generation, so scoping to MaxChatAnthropic/MaxChatOpenAI works — I don't need
  to chase the unlabeled sub-agent turns.

  Where things stand:
  - Both evals exist, disabled, validated, judge gpt-5-mini, scoped to 1% of 
  non-error Max chat generations (~[redacted]/day → ~[redacted] judged/day each).
  - One thing to flag: you already have an eval "PostHog AI - product-fact 
  answers: grounding triage" running. Mine is broader (every Max claim vs. its
  in-context tool results, not just product-fact answers) — worth deciding later
  whether they're redundant.

  I've deliberately not enabled them — that's the last step, it fires on live
  prod and bills your key, and you're mid-fixing the keys. How do you want to
  proceed?

⏺ User answered Claude's questions:
  ⎿  · How should I handle enabling the two evals? → Enable both now at 1%

⏺ Enabling both now at 1%.

  Called posthog-prod 2 times (ctrl+o to expand)

⏺ Both are now live (status: active), pinned to your Production key
  (019b217f-…), judge model gpt-5-mini.

  Done — two online evals live on Max AI

  Both scoped to a 1% sample of non-error MaxChatAnthropic/MaxChatOpenAI
  generations (~[redacted] judged/day each), allows_na: true:

  - Max answer is grounded in tool results — eval — catches the
  hallucination/unsupported-claim class (the top failure mode from your
  feedback).
  - Max query matches the user's intent — eval — catches the "0 days" /
  wrong-property / DAU-vs-person-count class.

  They'll now score new matching generations going forward, emitting
  $ai_evaluation events ($ai_evaluation_result = pass/fail, plus reasoning).

  What to keep an eye on

  - First 24h: confirm they're firing and not erroring — a quick check is the
  pass/fail/N/A split. If almost everything is N/A, the scope is catching too
  many non-applicable turns and we should tighten conditions.
  - Rollout: 1% was a conservative exploration rate. Once you see the fail rate,
  dial rollout up (more signal) or down (less cost).
  - Overlap: decide whether my groundedness eval supersedes the existing
  "product-fact answers: grounding triage" one, or if they serve different
  purposes.
  - Pair with fixes: these came from real, unaddressed failures — as the
  underlying prompt/tooling improves, the pass rate rising is your confirmation
  the fix landed.

  Not evals — bugs to file separately

  The exploration also surfaced two loud issues that are bugs, not eval targets:
  the 2026‑06‑09 "failed to generate an answer" wave, and the /ticket handler 
  crashing with SynchronousOnlyOperation (a real command, async-context bug).

  Want me to draft the query for a quick daily pass/fail dashboard, or leave it
  here?

✻ Worked for 3m 31s

※ recap: Goal: create online evals for Max AI from real failures. Both are built, validated, and live at 1% sampling: a groundedness judge and a query-intent judge. Next: watch the first 24h of results to confirm they fire and check the fail/N/A split. (disable recaps in /config)
```

## How did you test this code?

Automated tests I actually ran:
- Added unit tests for `stripUuidFormat` in `schema-transforms.test.ts`, including the nullable array-form `type: ["string","null"]` case that this fix targets. Ran vitest — all pass.
- Regenerated schemas with `hogli build:openapi-schema` + `hogli build:openapi-mcp` and confirmed `provider_key_id` now generates as `.string()`, with the diff limited to `.uuid()` → `.string()` on nullable fields.
- MCP typecheck (`tsgo --noEmit`) passes; oxlint clean on the changed source.

The skills themselves are markdown plus a Jinja reference template, so there's no runtime path to exercise beyond authoring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Skills only, no posthog.com docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this; Claude Code (Opus 4.8) did the code. The skills were authored first (this branch's original `wip`). The MCP fix came out of debugging why pinning a provider key failed during a spot-run of the eval skill.

Claude root-caused the rejection to `stripUuidFormat`'s exact-string `type` check missing the nullable array form, rather than to the serializer. It chose to relocate the transform into the shared `schema-transforms.mjs` lib (next to `stripEnumMinLength`) instead of patching it inline, so it could be unit-tested. Skills invoked: `/writing-tests` (gate for the new unit test).
