### PR TITLE
fix(replay): memoize image blurs within a Kafka message

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
@@ -5,7 +5,7 @@ import { RRWebEventSource, RRWebEventType } from '~/ingestion/pipelines/sessionr
 
 import { runBlurJobs } from './blur'
 import { scrubCanvasMutation } from './canvas'
-import { BlurJob, ScrubContext, ScrubTiming, isObject } from './config'
+import { BlurCache, BlurJob, ScrubContext, ScrubTiming, isObject } from './config'
 import { scrubCompressedFullSnapshot, scrubCompressedMutation } from './cv'
 import { scrubFullSnapshot, scrubMutation } from './dom'
 import { scrubText } from './text'
@@ -30,8 +30,10 @@ export async function anonymizeParsedMessage(
     parsedMessage: ParsedMessageData
 ): Promise<{ failed: boolean }> {
     const blurJobs: BlurJob[] = []
+    // One memo per Kafka message: identical images across its rrweb events share a single sharp call.
+    const blurCache: BlurCache = new Map()
     const timing: ScrubTiming = { decompressMs: 0, recompressMs: 0 }
-    const ctx: ScrubContext = { ...scrubContext, blurJobs, timing }
+    const ctx: ScrubContext = { ...scrubContext, blurJobs, blurCache, timing }
 
     const scrubStart = performance.now()
     let eventCount = 0

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/assets.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/assets.ts
@@ -1,5 +1,5 @@
 /** Media detection + placeholder/blur dispatch. */
-import { BLANK_IMAGE_DATA_URI, blurImageDataUri, isImageDataUri } from './blur'
+import { BLANK_IMAGE_DATA_URI, blurImageDataUri, isImageDataUri, memoizedBlur } from './blur'
 import { ScrubContext } from './config'
 import { scrubUrl } from './url'
 
@@ -48,7 +48,7 @@ export function blurInlineImageAttr(ctx: ScrubContext, attrs: Record<string, unk
     const original = value
     attrs[name] = BLANK_IMAGE_DATA_URI
     ctx.blurJobs?.push(async () => {
-        const blurred = await blurImageDataUri(original)
+        const blurred = await memoizedBlur(ctx.blurCache, original, () => blurImageDataUri(original))
         if (blurred !== null) {
             attrs[name] = blurred
         }
@@ -66,7 +66,7 @@ export function applyBlur(ctx: ScrubContext, attrs: Record<string, unknown>): vo
         if (isImageDataUri(existing)) {
             attrs[key] = PLACEHOLDER_SRC
             ctx.blurJobs?.push(async () => {
-                const blurred = await blurImageDataUri(existing)
+                const blurred = await memoizedBlur(ctx.blurCache, existing, () => blurImageDataUri(existing))
                 if (blurred !== null) {
                     attrs[key] = blurred
                 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/blur.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/blur.test.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp'
 
-import { blurImageDataUri, isImageDataUri, runBlurJobs } from './blur'
+import { blurImageDataUri, isImageDataUri, memoizedBlur, runBlurJobs } from './blur'
+import { BlurCache } from './config'
 
 // A small patterned PNG (portable across libvips/libpng builds; a bare 1x1 is rejected by some,
 // and a solid color blurs to identical bytes, so we use a checkerboard the blur visibly changes).
@@ -58,6 +59,36 @@ describe('anonymize/blur', () => {
         }
         await runBlurJobs([bump, bump])
         expect(ran).toBe(2)
+    })
+
+    it('memoizedBlur runs compute once per key and shares the result (the in-batch dedup)', async () => {
+        const cache: BlurCache = new Map()
+        let calls = 0
+        const compute = () => {
+            calls++
+            return Promise.resolve('blurred')
+        }
+        // The regression this guards: without dedup, one image repeated N times in a message
+        // blurs N times. Same key must collapse to a single compute.
+        const [a, b] = await Promise.all([memoizedBlur(cache, 'img', compute), memoizedBlur(cache, 'img', compute)])
+        expect(calls).toBe(1)
+        expect(a).toBe('blurred')
+        expect(b).toBe('blurred')
+
+        // A distinct key is a distinct image — it recomputes.
+        await memoizedBlur(cache, 'other', compute)
+        expect(calls).toBe(2)
+    })
+
+    it('memoizedBlur without a cache always computes (dedup is opt-in via the cache)', async () => {
+        let calls = 0
+        const compute = () => {
+            calls++
+            return Promise.resolve('blurred')
+        }
+        await memoizedBlur(undefined, 'img', compute)
+        await memoizedBlur(undefined, 'img', compute)
+        expect(calls).toBe(2)
     })
 
     it('runBlurJobs swallows a job that throws (already-blanked image is left as-is)', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/blur.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/blur.ts
@@ -1,7 +1,7 @@
 /** Downsample + blur media/canvas images — scene stays legible, faces/text don't. Run deferred. */
 import sharp from 'sharp'
 
-import { BlurJob } from './config'
+import { BlurCache, BlurJob } from './config'
 
 const DOWNSAMPLE_RATIO = 0.12
 const BLUR_SIGMA = 2.34
@@ -87,6 +87,30 @@ export async function pixelateRawRgba(base64: string, width: number, height: num
     } catch {
         return null
     }
+}
+
+/**
+ * In-batch blur memo: within one Kafka message the same image often recurs thousands of times across
+ * its rrweb events (a canvas redrawing one sprite, a repeated background), and both blur functions are
+ * pure in their input. Sharing one settled Promise per distinct input collapses that fan-out to a
+ * single sharp call. Neither producer rejects (both catch and return null), so a cached entry never
+ * poisons its consumers. Scope is one Kafka message — the map is discarded when its blur jobs finish.
+ */
+export function memoizedBlur(
+    cache: BlurCache | undefined,
+    key: string,
+    compute: () => Promise<string | null>
+): Promise<string | null> {
+    if (!cache) {
+        return compute()
+    }
+    const existing = cache.get(key)
+    if (existing !== undefined) {
+        return existing
+    }
+    const pending = compute()
+    cache.set(key, pending)
+    return pending
 }
 
 /** Run deferred blur jobs concurrently. A job that throws is swallowed — the image was already

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/canvas.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/canvas.ts
@@ -13,7 +13,14 @@
  * Images are neutralized synchronously (fail-safe) and the real downsampled/blurred
  * result is swapped in by the deferred blur job on success.
  */
-import { BLANK_IMAGE_DATA_URI, BLANK_PNG_BASE64, blurImageDataUri, isImageDataUri, pixelateRawRgba } from './blur'
+import {
+    BLANK_IMAGE_DATA_URI,
+    BLANK_PNG_BASE64,
+    blurImageDataUri,
+    isImageDataUri,
+    memoizedBlur,
+    pixelateRawRgba,
+} from './blur'
 import { ScrubContext, isObject } from './config'
 import { scrubText } from './text'
 import { scrubUrl } from './url'
@@ -160,7 +167,7 @@ function blurBlobImage(ctx: ScrubContext, blob: Record<string, unknown>): boolea
 
 function queueImageBlur(ctx: ScrubContext, dataUri: string, apply: (blurred: string) => void): void {
     ctx.blurJobs?.push(async () => {
-        const blurred = await blurImageDataUri(dataUri)
+        const blurred = await memoizedBlur(ctx.blurCache, dataUri, () => blurImageDataUri(dataUri))
         if (blurred !== null) {
             apply(blurred)
         }
@@ -212,8 +219,11 @@ function blurImageData(ctx: ScrubContext, imageData: Record<string, unknown>): b
                 const blanked = Buffer.from(full)
                 blanked.fill(0, loc.start, loc.start + loc.length)
                 loc.ab.base64 = blanked.toString('base64')
+                // Key on dims too: pixelateRawRgba's output depends on width/height, and the `raw:`
+                // prefix keeps it from colliding with the `data:`-prefixed data-URI blur keys.
+                const cacheKey = `raw:${width}x${height}:${rgba}`
                 ctx.blurJobs?.push(async () => {
-                    const out = await pixelateRawRgba(rgba, width, height)
+                    const out = await memoizedBlur(ctx.blurCache, cacheKey, () => pixelateRawRgba(rgba, width, height))
                     if (out === null) {
                         return
                     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/config.ts
@@ -8,6 +8,9 @@ export const NUMBER_CHAR = '#'
 /** A deferred image-blur job: an async closure that blurs its image and writes the result back in place. */
 export type BlurJob = () => Promise<void>
 
+/** In-batch blur memo (input → settled blur): one per Kafka message, so an image recurring across its rrweb events blurs once. */
+export type BlurCache = Map<string, Promise<string | null>>
+
 /** Diagnostic accumulator (ms) for the cv gzip de/recompression sub-steps. */
 export interface ScrubTiming {
     decompressMs: number
@@ -19,6 +22,8 @@ export interface ScrubContext {
     allow: AllowLists
     /** Optional collector for deferred image-blur jobs (see {@link BlurJob}). */
     blurJobs?: BlurJob[]
+    /** Optional per-Kafka-message memo shared across those jobs so identical images blur once (see {@link BlurCache}). */
+    blurCache?: BlurCache
     /** Optional diagnostic timing accumulator (see {@link ScrubTiming}). */
     timing?: ScrubTiming
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/css.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/css.ts
@@ -1,5 +1,5 @@
 /** Blur inline `url(data:image/...;base64,...)` backgrounds in CSS */
-import { BLANK_IMAGE_DATA_URI, blurImageDataUri } from './blur'
+import { BLANK_IMAGE_DATA_URI, blurImageDataUri, memoizedBlur } from './blur'
 import { ScrubContext } from './config'
 
 const URL_DATA_IMAGE_RE = /url\(\s*(['"]?)(data:image\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+)\1\s*\)/gi
@@ -21,7 +21,7 @@ export function scrubCssImages(ctx: ScrubContext, container: Record<string, unkn
         // its own image back independently; on blur failure it just stays the blank.
         const placeholder = `${BLANK_IMAGE_DATA_URI}#a${n++}`
         ctx.blurJobs?.push(async () => {
-            const blurred = await blurImageDataUri(original)
+            const blurred = await memoizedBlur(ctx.blurCache, original, () => blurImageDataUri(original))
             const cur = container[key]
             if (typeof cur === 'string') {
                 container[key] = cur.replace(placeholder, () => blurred ?? BLANK_IMAGE_DATA_URI)


### PR DESCRIPTION
## Problem

The ml-mirror anonymizer blurs every image in a session recording so faces and text don't leak into the unencrypted ML bucket. The blur work runs off-thread via `sharp`, but the same image recurs many times within a single Kafka message: a canvas redrawing one sprite across frames, a repeated CSS background, the same `<img>` inlined in successive snapshots. Each reference queued its own deferred blur job, so identical bytes went through `sharp` over and over. A sampled worst case blurred one image ~2200 times, turning ~3ms of real work into ~10s and starving the event loop.

This is the duplication half of the slow-scrub problem. The regex half was fixed separately in #67540. The fuller cross-message, cross-pod dedup stays for the dedicated image pipeline. This PR does just the in-batch (one Kafka message) memoization so the current consumer can keep up.

## Changes

Both blur functions (`blurImageDataUri`, `pixelateRawRgba`) are pure in their input, so repeats are pure waste. I added a `BlurCache` (`Map<input, Promise<result>>`) scoped to one `anonymizeParsedMessage` call, which is exactly one Kafka message, discarded when its blur jobs finish. A new `memoizedBlur(cache, key, compute)` returns a single shared settled promise per distinct input, so N identical blurs collapse to one `sharp` call.

- `blur.ts`: `memoizedBlur` helper.
- `config.ts`: `BlurCache` type plus `blurCache?` on `ScrubContext`.
- `anonymize-event.ts`: one cache per message, passed in `ctx`.
- `canvas.ts` / `assets.ts` / `css.ts`: the five blur-job sites route through the memo. Data-URI jobs key on the URI (`data:...`); raw-pixel jobs key on `raw:${w}x${h}:${rgba}` so dimensions are part of the key and can't collide with data-URI keys.

Why it stays correct:

- Both producers catch internally and return `null`, never reject, so a cached promise can't poison its consumers.
- For raw pixels only the pure `(rgba, w, h) -> blurred RGBA` step is shared. Each location still does its own per-buffer merge at its own offset, so dedup doesn't cross-contaminate output.
- Memory is bounded per message and freed when jobs finish. No cross-message or cross-pod state.

## How did you test this code?

I (Claude) ran the affected Jest suites locally: `blur`, `canvas`, `assets`, `css`, and `anonymize-event` all pass, and typecheck is clean for the changed files. I did not do any manual or production testing.

Added two `memoizedBlur` cases in `blur.test.ts` at the pure-function level. They catch the exact regression this PR fixes: if the memo breaks, one image repeated N times computes N times again (the 2200x blowup). One case locks same-key-computes-once plus distinct-key-recomputes; the other locks that no cache means always compute (dedup is opt-in). No existing test exercised the dedup path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie directed this off a prod sample showing one batch blurring the same image ~2200 times. I (Claude Code, Opus 4.8) explored the anonymize pipeline, confirmed the "batch" scope is one Kafka message (`ParsedMessageData` in and out of `anonymizeParsedMessage`), and implemented per-message memoization mirroring the sibling scrub fix in #67540.

Skills invoked: `/writing-tests` (to gate the new test cases).

Considered memoizing inside the blur functions with a module-level cache, but that would be inter-batch/unbounded and belongs to the separate image pipeline. Chose a per-message cache on `ScrubContext` instead so memory is bounded and there's no cross-message state.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
