### PR TITLE
fix(bigquery): retry transient job-not-found in temp-table copy query

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -11,6 +11,7 @@ credentials.
 from __future__ import annotations
 
 import math
+import time
 import typing
 import contextlib
 import collections
@@ -770,6 +771,66 @@ def _get_query(
     return f"SELECT {select_clause} FROM {table_ref}", query_parameters
 
 
+# BigQuery's job-metadata store is eventually consistent: `client.query()` inserts a job and then
+# reads it straight back. When the auto-retried `jobs.insert` loses its first response, the retry
+# hits a 409 whose recovery `get_job` momentarily 404s for the job it just created (surfacing as
+# `NotFound: ... Not found: Job <project>:<id>`). The race clears within moments, so retry a few
+# times before surfacing the error.
+_JOB_NOT_FOUND_MAX_ATTEMPTS = 4
+_JOB_NOT_FOUND_RETRY_BACKOFF_SECONDS = 0.5
+
+
+def _is_transient_job_not_found(error: NotFound) -> bool:
+    """True for BigQuery's transient "Job ... not found" lookup race.
+
+    Must be distinguished from a genuine `NotFound` — a missing dataset/table, or a dataset absent
+    from the queried region — that no retry can fix (and which is deliberately treated as
+    non-retryable elsewhere), so match only the job-lookup wording, never "Not found: Dataset" /
+    "Not found: Table" / "was not found in location".
+    """
+    message = str(error)
+    return "Not found: Job" in message or "Job not found" in message
+
+
+def _run_destination_query_with_job_retry(
+    client: bigquery.Client,
+    query: str,
+    *,
+    destination_table: bigquery.Table,
+    query_parameters: list[bigquery.ScalarQueryParameter],
+    project: str,
+) -> None:
+    """Run a copy-into-temp-table query, retrying BigQuery's transient job-metadata race.
+
+    The 404 is raised from inside `client.query()` (its post-insert `get_job` reload), so recovering
+    means creating a fresh job — retrying `job.result()` alone can't. Re-running writes the same
+    temp table, so `WRITE_TRUNCATE` keeps a retry — or a stale table left behind by a lost first
+    attempt — idempotent instead of tripping the default empty-table check.
+    """
+    job_config = QueryJobConfig(
+        destination=destination_table,
+        query_parameters=query_parameters,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+    attempt = 0
+    while True:
+        try:
+            job = client.query(query, job_config=job_config, project=project)
+            _ = job.result()
+            return
+        except NotFound as e:
+            attempt += 1
+            if not _is_transient_job_not_found(e) or attempt >= _JOB_NOT_FOUND_MAX_ATTEMPTS:
+                raise
+            structlog.get_logger().warning(
+                "Retrying BigQuery copy query after transient job-not-found (attempt %s/%s): %s",
+                attempt,
+                _JOB_NOT_FOUND_MAX_ATTEMPTS,
+                e,
+            )
+            time.sleep(_JOB_NOT_FOUND_RETRY_BACKOFF_SECONDS * attempt)
+
+
 class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigquery.Client, Any]):
     """BigQuery driver implementation paired with `BigQuerySource`.
 
@@ -1142,9 +1203,13 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                     )
 
                     destination_table = bigquery.Table(bq_destination_table_id)
-                    job_config = QueryJobConfig(destination=destination_table, query_parameters=query_parameters)
-                    job = bq_client.query(query, job_config=job_config, project=bq_table.project)
-                    _ = job.result()
+                    _run_destination_query_with_job_retry(
+                        bq_client,
+                        query,
+                        destination_table=destination_table,
+                        query_parameters=query_parameters,
+                        project=bq_table.project,
+                    )
 
                     bq_table = bq_client.get_table(destination_table)
 
@@ -1165,9 +1230,13 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                     )
 
                     destination_table = bigquery.Table(bq_destination_table_id)
-                    job_config = QueryJobConfig(destination=destination_table, query_parameters=query_parameters)
-                    job = bq_client.query(query, job_config=job_config, project=bq_table.project)
-                    _ = job.result()
+                    _run_destination_query_with_job_retry(
+                        bq_client,
+                        query,
+                        destination_table=destination_table,
+                        query_parameters=query_parameters,
+                        project=bq_table.project,
+                    )
 
                     bq_table = bq_client.get_table(destination_table)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1084,6 +1084,27 @@ def test_run_destination_query_does_not_retry_genuine_not_found(mock_sleep):
     mock_sleep.assert_not_called()
 
 
+@mock.patch(
+    "products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery._JOB_NOT_FOUND_MAX_ATTEMPTS",
+    4,
+)
+@mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery.time.sleep")
+def test_run_destination_query_gives_up_after_max_attempts(mock_sleep):
+    """The race almost always clears within moments, but a persistent job-not-found must still stop
+    at the attempt cap and surface the error instead of retrying forever."""
+    client = mock.MagicMock()
+    client.query.side_effect = [NotFound("404 Not found: Job prj:US.abc") for _ in range(4)]
+
+    with pytest.raises(NotFound):
+        _run_destination_query_with_job_retry(
+            client, "SELECT 1", destination_table=mock.MagicMock(), query_parameters=[], project="prj"
+        )
+
+    assert client.query.call_count == 4
+    # No back-off after the final, failed attempt.
+    assert mock_sleep.call_count == 3
+
+
 @pytest.mark.parametrize(
     "location",
     ["US", "EU", "asia-northeast1"],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -25,11 +25,13 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     _get_query,
     _get_rows_to_sync,
     _has_duplicate_primary_keys,
+    _is_transient_job_not_found,
     _resolve_dataset_id,
     _resolve_dataset_project_id,
     _resolve_project_id,
     _resolve_query_project,
     _resolve_region,
+    _run_destination_query_with_job_retry,
     delete_all_temp_destination_tables,
     validate_bigquery_credentials,
 )
@@ -1019,6 +1021,67 @@ def test_bigquery_get_primary_keys_for_table_passes_job_retry():
     _get_primary_keys_for_table(table, client)
 
     assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "404 GET https://bigquery.googleapis.com/.../jobs/abc?projection=full: Not found: Job prj:US.abc",
+        "Not found: Job prj:EU.job_xyz",
+        "Job not found: job_xyz",
+    ],
+)
+def test_is_transient_job_not_found_matches_job_race(message):
+    assert _is_transient_job_not_found(NotFound(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # A missing dataset/table (or a dataset absent from the queried region) is genuinely
+        # non-retryable and must not be mistaken for the job race, even though the raw dataset 404
+        # can carry a trailing "Job ID:".
+        "404 Not found: Dataset prj:ds was not found in location US Job ID: b3abc342-16a7",
+        "404 Not found: Table prj:ds.tbl",
+    ],
+)
+def test_is_transient_job_not_found_ignores_other_not_found(message):
+    assert _is_transient_job_not_found(NotFound(message)) is False
+
+
+@mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery.time.sleep")
+def test_run_destination_query_retries_transient_job_not_found(mock_sleep):
+    """The copy-into-temp-table query is where the production sync crashed on BigQuery's job-metadata
+    race; a transient job-not-found must be retried with a fresh job instead of aborting the import."""
+    client = mock.MagicMock()
+    ok_job = mock.MagicMock()
+    client.query.side_effect = [NotFound("404 Not found: Job prj:US.abc"), ok_job]
+
+    _run_destination_query_with_job_retry(
+        client, "SELECT 1", destination_table=mock.MagicMock(), query_parameters=[], project="prj"
+    )
+
+    assert client.query.call_count == 2
+    ok_job.result.assert_called_once()
+    mock_sleep.assert_called_once()
+    # WRITE_TRUNCATE keeps the re-run idempotent against a temp table a lost first attempt populated.
+    assert client.query.call_args.kwargs["job_config"].write_disposition == "WRITE_TRUNCATE"
+
+
+@mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery.time.sleep")
+def test_run_destination_query_does_not_retry_genuine_not_found(mock_sleep):
+    """A genuine `NotFound` (missing dataset/table) is not the job race, so it surfaces immediately
+    rather than looping until the attempt cap."""
+    client = mock.MagicMock()
+    client.query.side_effect = NotFound("404 Not found: Table prj:ds.tbl")
+
+    with pytest.raises(NotFound):
+        _run_destination_query_with_job_retry(
+            client, "SELECT 1", destination_table=mock.MagicMock(), query_parameters=[], project="prj"
+        )
+
+    assert client.query.call_count == 1
+    mock_sleep.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

BigQuery imports occasionally crash with:

```
NotFound: GET https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/jobs/<redacted>?projection=full&prettyPrint=false: Not found: Job <redacted>
```

surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019f2245-e02e-7e93-8780-20ba9478a146

The stack lands in `get_rows` in `bigquery.py`, on the copy-into-temp-table query that incremental syncs (and view / row-filter syncs) run before streaming rows via the Storage Read API.

This is BigQuery's eventually-consistent job-metadata store. `client.query()` inserts a job and then reads it straight back. When the library's auto-retried `jobs.insert` loses its first response, the retry hits a 409 Conflict, and the recovery `get_job` momentarily 404s for the job it just created. The `NotFound` escapes `client.query()` and aborts the activity. The race clears within moments, so the next attempt succeeds - but the whole activity has to retry from scratch and it spams error tracking in the meantime.

## Changes

Wrap the two copy queries in `get_rows` in a bounded retry (`_run_destination_query_with_job_retry`) that re-runs on the transient job-not-found and backs off between attempts.

- The match (`_is_transient_job_not_found`) keys on the stable `Not found: Job` / `Job not found` wording only. It deliberately does **not** match `Not found: Dataset`, `Not found: Table`, or `was not found in location` - those are genuinely non-retryable and are handled as such elsewhere, so a false match there would swallow a real error.
- The 404 is raised from inside `client.query()`, so recovering means creating a fresh job - retrying `job.result()` alone can't. Re-running writes the same single-use temp table, so the jobs now use `WRITE_TRUNCATE` to keep a retry (or a stale table left behind by a lost first attempt) idempotent instead of tripping the default empty-table check. `WRITE_TRUNCATE` is a no-op on the normal first run (the temp table is freshly deleted beforehand), so it doesn't change happy-path behavior.

This complements #66534 (draft), which added the same job-not-found retry to the read-only primary-key probes. That PR does not touch the copy path where this production error actually fired, and the copy path needs the extra `WRITE_TRUNCATE` handling to be safe to retry.

Scoped strictly to the two destination-writing copy queries. Transient job errors elsewhere stay retryable at the Temporal activity level; nothing is added to `NonRetryableErrors`.

## How did you test this code?

Automated only (I'm an agent - no manual/live BigQuery run). Added 4 cases to `test_source.py`:

- `_is_transient_job_not_found` matches the job-race 404 wording and ignores dataset / table / wrong-region 404s. Guards against a regression that would either stop retrying the race or, worse, start retrying a genuinely non-retryable missing-dataset error.
- `_run_destination_query_with_job_retry` retries the transient job-not-found with a fresh job (and asserts `WRITE_TRUNCATE`), and surfaces a genuine `NotFound` immediately without looping.

Ran the full `bigquery/tests/test_source.py` suite (108 passed) plus `ruff check` / `ruff format --check` on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above by Claude. I confirmed the failing frame (`get_rows`, the copy query, not the read-only PK probes), traced the `NotFound` to the `client.query()` insert-conflict / `get_job` race in google-cloud-bigquery's `query_jobs_insert`, and checked open PRs for duplicates - #66534 covers the sibling PK-probe path but not this one.

Decision notes: this is a transient infra race, so it stays out of `NonRetryableErrors`. I considered leaving it entirely to the existing activity-level Temporal retry (which already recovers it), but chose an in-place retry to avoid re-copying the whole temp table on every occurrence. The one non-obvious call was `WRITE_TRUNCATE`: without it, a retry after the insert-conflict would fail the default empty-table check against the temp table the lost job populated. Skills invoked: `/writing-tests`.
