### PR TITLE
feat(error-tracking): surface missing source maps in system health

### DIFF
--- a/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
+++ b/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
@@ -1,6 +1,7 @@
 import { urls } from 'scenes/urls'
 
 import { DataModelingHealthTable } from '../components/DataModelingHealthTable'
+import { ErrorTrackingHealthTable } from '../components/ErrorTrackingHealthTable'
 import { IngestionWarningTable } from '../components/IngestionWarningTable'
 import { PipelineHealthTable } from '../components/PipelineHealthTable'
 import { WebAnalyticsHealthTable } from '../components/WebAnalyticsHealthTable'
@@ -53,5 +54,11 @@ export const CATEGORY_DETAIL_CONFIG: Partial<Record<HealthIssueCategory, Categor
         guidance: 'Materialized view failures may affect query performance and data freshness.',
         contentComponent: DataModelingDetailContent,
         tableComponent: DataModelingHealthTable,
+    },
+    error_tracking: {
+        docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
+        guidance: 'Without source maps, JavaScript stack traces show minified code instead of your original source.',
+        redirectUrl: urls.errorTracking({ activeTab: 'recommendations' }),
+        tableComponent: ErrorTrackingHealthTable,
     },
 }

--- a/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
+++ b/frontend/src/scenes/health/categoryDetail/categoryDetailConfig.ts
@@ -56,8 +56,8 @@ export const CATEGORY_DETAIL_CONFIG: Partial<Record<HealthIssueCategory, Categor
         tableComponent: DataModelingHealthTable,
     },
     error_tracking: {
-        docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
-        guidance: 'Without source maps, JavaScript stack traces show minified code instead of your original source.',
+        docsUrl: 'https://posthog.com/docs/error-tracking',
+        guidance: 'These checks ensure your error tracking setup captures exceptions with readable stack traces.',
         redirectUrl: urls.errorTracking({ activeTab: 'recommendations' }),
         tableComponent: ErrorTrackingHealthTable,
     },

--- a/frontend/src/scenes/health/components/ErrorTrackingHealthTable.tsx
+++ b/frontend/src/scenes/health/components/ErrorTrackingHealthTable.tsx
@@ -16,7 +16,7 @@ function missingSourceMapsDescription(issue: HealthIssue): string {
             : ''
     return `${percent}% of JavaScript stack frames${frames} were unresolved in the last ${
         Number(lookback_hours) || 24
-    } hours. Upload source maps so stack traces show your original source code.`
+    } hours. Unresolved frames also degrade issue grouping. Upload source maps so stack traces show your original source code and errors group correctly.`
 }
 
 export function ErrorTrackingHealthTable({

--- a/frontend/src/scenes/health/components/ErrorTrackingHealthTable.tsx
+++ b/frontend/src/scenes/health/components/ErrorTrackingHealthTable.tsx
@@ -1,0 +1,54 @@
+import { Link } from '@posthog/lemon-ui'
+
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+
+import type { HealthIssue } from '../types'
+import { dismissActionColumn, severityColumn } from './healthTableColumns'
+
+const SOURCE_MAPS_DOCS_URL = 'https://posthog.com/docs/error-tracking/upload-source-maps'
+
+function missingSourceMapsDescription(issue: HealthIssue): string {
+    const { unresolved_pct, unresolved_frames, total_frames, lookback_hours } = issue.payload
+    const percent = Math.round((Number(unresolved_pct) || 0) * 100)
+    const frames =
+        unresolved_frames != null && total_frames != null
+            ? ` (${Number(unresolved_frames).toLocaleString()} of ${Number(total_frames).toLocaleString()})`
+            : ''
+    return `${percent}% of JavaScript stack frames${frames} were unresolved in the last ${
+        Number(lookback_hours) || 24
+    } hours. Upload source maps so stack traces show your original source code.`
+}
+
+export function ErrorTrackingHealthTable({
+    issues,
+    onDismiss,
+    onUndismiss,
+}: {
+    issues: HealthIssue[]
+    onDismiss: (id: string) => void
+    onUndismiss: (id: string) => void
+}): JSX.Element {
+    const columns: LemonTableColumns<HealthIssue> = [
+        {
+            title: 'Check',
+            key: 'check',
+            render: function Render(_, issue: HealthIssue) {
+                return (
+                    <div className="py-1">
+                        <div className="flex items-center gap-2">
+                            <span className="font-medium">Source maps</span>
+                            <Link to={SOURCE_MAPS_DOCS_URL} className="text-xs text-muted">
+                                Docs
+                            </Link>
+                        </div>
+                        <div className="text-xs text-muted mt-0.5">{missingSourceMapsDescription(issue)}</div>
+                    </div>
+                )
+            },
+        },
+        severityColumn(),
+        dismissActionColumn(onDismiss, onUndismiss),
+    ]
+
+    return <LemonTable dataSource={issues} columns={columns} embedded size="small" rowClassName="group" />
+}

--- a/frontend/src/scenes/health/healthCategories.tsx
+++ b/frontend/src/scenes/health/healthCategories.tsx
@@ -1,6 +1,13 @@
-import { IconCode, IconDatabase, IconDecisionTree, IconPulse, IconTrending, IconWarning } from '@posthog/icons'
+import { IconBug, IconCode, IconDatabase, IconDecisionTree, IconPulse, IconTrending, IconWarning } from '@posthog/icons'
 
-export type HealthIssueCategory = 'ingestion' | 'sdk' | 'web_analytics' | 'data_modeling' | 'pipelines' | 'other'
+export type HealthIssueCategory =
+    | 'ingestion'
+    | 'sdk'
+    | 'web_analytics'
+    | 'data_modeling'
+    | 'pipelines'
+    | 'error_tracking'
+    | 'other'
 
 export type HealthIssueKind =
     | 'no_live_events'
@@ -15,6 +22,7 @@ export type HealthIssueKind =
     | 'sdk_outdated'
     | 'materialized_view_failure'
     | 'external_data_failure'
+    | 'error_tracking_missing_source_maps'
 
 export interface CategoryConfig {
     label: string
@@ -60,6 +68,13 @@ export const HEALTH_CATEGORY_CONFIG: Record<HealthIssueCategory, CategoryConfig>
         icon: <IconDecisionTree className="size-5" />,
         showInSummary: true,
     },
+    error_tracking: {
+        label: 'Error tracking',
+        description: 'Exception capture and stack trace resolution',
+        healthyDescription: 'Stack traces resolving',
+        icon: <IconBug className="size-5" />,
+        showInSummary: true,
+    },
     other: {
         label: 'Other',
         description: 'Other health issues',
@@ -81,6 +96,9 @@ const KIND_TO_CATEGORY: Record<HealthIssueKind, HealthIssueCategory> = {
 
     // SDKs
     sdk_outdated: 'sdk',
+
+    // Error tracking
+    error_tracking_missing_source_maps: 'error_tracking',
 
     // Web analytics
     no_live_events: 'web_analytics',
@@ -105,6 +123,7 @@ export const KIND_LABELS: Record<HealthIssueKind, string> = {
     ingestion_warning: 'Ingestion warning',
     sdk_outdated: 'SDK outdated',
     materialized_view_failure: 'Materialized view failure',
+    error_tracking_missing_source_maps: 'Missing source maps',
 }
 
 export const categoryForKind = (kind: string): HealthIssueCategory => {
@@ -123,5 +142,6 @@ export const CATEGORY_ORDER: HealthIssueCategory[] = [
     'web_analytics',
     'data_modeling',
     'pipelines',
+    'error_tracking',
     'other',
 ]

--- a/frontend/src/scenes/health/healthCategories.tsx
+++ b/frontend/src/scenes/health/healthCategories.tsx
@@ -70,8 +70,8 @@ export const HEALTH_CATEGORY_CONFIG: Record<HealthIssueCategory, CategoryConfig>
     },
     error_tracking: {
         label: 'Error tracking',
-        description: 'Exception capture and stack trace resolution',
-        healthyDescription: 'Stack traces resolving',
+        description: 'Error tracking setup and configuration',
+        healthyDescription: 'All healthy',
         icon: <IconBug className="size-5" />,
         showInSummary: true,
     },

--- a/posthog/temporal/health_checks/registry.py
+++ b/posthog/temporal/health_checks/registry.py
@@ -24,6 +24,7 @@ HEALTH_CHECK_MODULES = [
     "products.web_analytics.backend.temporal.health_checks.reverse_proxy",
     "products.web_analytics.backend.temporal.health_checks.partial_proxy",
     "products.web_analytics.backend.temporal.health_checks.web_vitals",
+    "products.error_tracking.backend.temporal.health_checks.missing_source_maps",
 ]
 
 _registry_loaded = False

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -1,0 +1,87 @@
+from posthog.clickhouse.query_tagging import Product
+from posthog.dags.common.owners import JobOwners
+from posthog.models.health_issue import HealthIssue
+from posthog.temporal.health_checks.detectors import HealthExecutionPolicy
+from posthog.temporal.health_checks.framework import AlertContent, HealthCheck, Remediation
+from posthog.temporal.health_checks.models import HealthCheckResult
+
+from products.error_tracking.backend.logic.recommendations.source_maps import SourceMapsRecommendation
+from products.error_tracking.backend.models import ErrorTrackingRecommendation
+
+RECOMMENDATIONS_PATH = "/error_tracking?activeTab=recommendations"
+SOURCE_MAPS_DOCS_URL = "https://posthog.com/docs/error-tracking/upload-source-maps"
+
+
+class MissingSourceMapsCheck(HealthCheck):
+    """Flags teams whose JavaScript stack traces are mostly unresolved for lack of source maps.
+
+    Reads the persisted `source_maps` recommendation rows rather than recomputing, so the
+    Health page and the error tracking recommendations tab can never disagree — clicking
+    through from a health issue always lands on a recommendation showing the same state.
+    Rows are kept fresh (≤6h stale) by the recommendations background sweep; teams without
+    a computed row yet are skipped until the sweep covers them.
+    """
+
+    name = "error_tracking_missing_source_maps"
+    kind = "error_tracking_missing_source_maps"
+    owner = JobOwners.TEAM_ERROR_TRACKING
+    product = Product.ERROR_TRACKING
+    policy = HealthExecutionPolicy(batch_size=250, max_concurrent=2)
+    schedule = "0 7 * * *"
+    remediation = Remediation(
+        human=f"""
+            Upload source maps for your JavaScript builds so stack traces show your original
+            source code. Open Error tracking → Recommendations for the "Missing source maps"
+            card — it includes an AI wizard that sets up uploads for your build pipeline — or
+            follow the docs at {SOURCE_MAPS_DOCS_URL}. Once uploads are in place, new
+            exceptions resolve against your original sources and this issue clears on the
+            next check run.
+        """,
+        agent=f"""
+            Read this issue with `health-issues-get` — the payload has `unresolved_pct`,
+            `total_frames`, and `lookback_hours` describing how many recent JavaScript stack
+            frames could not be resolved. Then fix it in the user's codebase: add source map
+            upload to their build following {SOURCE_MAPS_DOCS_URL} — typically installing
+            `posthog-cli` (or the PostHog bundler plugin for webpack/vite/rollup) and running
+            `posthog-cli sourcemap inject` + `posthog-cli sourcemap upload` against the build
+            output in their CI/deploy step, authenticated with a PostHog personal API key.
+            The issue clears on the next check run once newly ingested frames resolve.
+        """,
+    )
+
+    @classmethod
+    def render_alert(cls, issue: HealthIssue) -> AlertContent:
+        pct = round((issue.payload.get("unresolved_pct") or 0) * 100)
+        lookback_hours = issue.payload.get("lookback_hours") or 24
+        return AlertContent(
+            title="Missing source maps",
+            summary=(
+                f"{pct}% of JavaScript stack frames were unresolved in the last {lookback_hours} hours. "
+                "Upload source maps so stack traces show your original source code."
+            ),
+            link=RECOMMENDATIONS_PATH,
+        )
+
+    def detect(self, team_ids: list[int]) -> dict[int, list[HealthCheckResult]]:
+        recommendation = SourceMapsRecommendation()
+        # A dismissed recommendation means the user opted out of this nudge — don't
+        # resurface it as a health issue; the issue auto-resolves on the next run.
+        rows = ErrorTrackingRecommendation.objects.filter(
+            team_id__in=team_ids,
+            type=SourceMapsRecommendation.type,
+            computed_at__isnull=False,
+            dismissed_at__isnull=True,
+        )
+
+        issues: dict[int, list[HealthCheckResult]] = {}
+        for row in rows:
+            if recommendation.is_completed(row.meta):
+                continue
+            issues[row.team_id] = [
+                HealthCheckResult(
+                    severity=HealthIssue.Severity.WARNING,
+                    payload=row.meta,
+                    hash_keys=[],
+                )
+            ]
+        return issues

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -4,15 +4,18 @@ from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck, Remediation
 from posthog.temporal.health_checks.models import HealthCheckResult
+from posthog.utils import get_instance_region
 
 from products.error_tracking.backend.logic.recommendations.source_maps import SourceMapsRecommendation
 from products.error_tracking.backend.models import ErrorTrackingRecommendation
 
 RECOMMENDATIONS_PATH = "/error_tracking?activeTab=recommendations"
 SOURCE_MAPS_DOCS_URL = "https://posthog.com/docs/error-tracking/upload-source-maps"
-# Same command the source maps fix wizard modal shows (sourceMapsFixWizardLogic.wizardCommand);
-# remediation is a static per-kind constant, so the EU region flag is a note rather than interpolated.
-WIZARD_COMMAND = "npx -y @posthog/wizard@latest upload-source-maps"
+# Same command the source maps fix wizard modal shows (sourceMapsFixWizardLogic.wizardCommand),
+# including the region flag — the region is per-deployment, so import time is fine.
+WIZARD_COMMAND = "npx -y @posthog/wizard@latest upload-source-maps" + (
+    " --region eu" if get_instance_region() == "EU" else ""
+)
 
 
 class MissingSourceMapsCheck(HealthCheck):
@@ -33,12 +36,12 @@ class MissingSourceMapsCheck(HealthCheck):
     schedule = "0 7 * * *"
     remediation = Remediation(
         human=f"""
-            Run the source maps wizard in your project: `{WIZARD_COMMAND}` (add `--region eu`
-            on EU Cloud), or follow the docs at {SOURCE_MAPS_DOCS_URL}.
+            Run the source maps wizard in your project: `{WIZARD_COMMAND}`,
+            or follow the docs at {SOURCE_MAPS_DOCS_URL}.
         """,
         agent=f"""
-            Run `{WIZARD_COMMAND}` in the user's project (add `--region eu` if the project is
-            on EU Cloud), or set up uploads manually following {SOURCE_MAPS_DOCS_URL}.
+            Run `{WIZARD_COMMAND}` in the user's project, or set up uploads
+            manually following {SOURCE_MAPS_DOCS_URL}.
         """,
     )
 

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -40,7 +40,8 @@ class MissingSourceMapsCheck(HealthCheck):
             or follow the docs at {SOURCE_MAPS_DOCS_URL}.
         """,
         agent=f"""
-            Run `{WIZARD_COMMAND}` in the user's project, or set up uploads
+            Tell the user to run `{WIZARD_COMMAND}` in their project — the wizard is
+            interactive, so don't run it yourself. Alternatively, set up uploads
             manually following {SOURCE_MAPS_DOCS_URL}.
         """,
     )

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -54,7 +54,8 @@ class MissingSourceMapsCheck(HealthCheck):
             title="Missing source maps",
             summary=(
                 f"{pct}% of JavaScript stack frames were unresolved in the last {lookback_hours} hours. "
-                "Upload source maps so stack traces show your original source code."
+                "Unresolved frames also degrade issue grouping. Upload source maps so stack traces "
+                "show your original source code and errors group correctly."
             ),
             link=RECOMMENDATIONS_PATH,
         )

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -64,8 +64,6 @@ class MissingSourceMapsCheck(HealthCheck):
 
     def detect(self, team_ids: list[int]) -> dict[int, list[HealthCheckResult]]:
         recommendation = SourceMapsRecommendation()
-        # A dismissed recommendation means the user opted out of this nudge — don't
-        # resurface it as a health issue; the issue auto-resolves on the next run.
         rows = ErrorTrackingRecommendation.objects.filter(
             team_id__in=team_ids,
             type=SourceMapsRecommendation.type,

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -10,6 +10,9 @@ from products.error_tracking.backend.models import ErrorTrackingRecommendation
 
 RECOMMENDATIONS_PATH = "/error_tracking?activeTab=recommendations"
 SOURCE_MAPS_DOCS_URL = "https://posthog.com/docs/error-tracking/upload-source-maps"
+# Same command the source maps fix wizard modal shows (sourceMapsFixWizardLogic.wizardCommand);
+# remediation is a static per-kind constant, so the EU region flag is a note rather than interpolated.
+WIZARD_COMMAND = "npx -y @posthog/wizard@latest upload-source-maps"
 
 
 class MissingSourceMapsCheck(HealthCheck):
@@ -30,22 +33,12 @@ class MissingSourceMapsCheck(HealthCheck):
     schedule = "0 7 * * *"
     remediation = Remediation(
         human=f"""
-            Upload source maps for your JavaScript builds so stack traces show your original
-            source code. Open Error tracking → Recommendations for the "Missing source maps"
-            card — it includes an AI wizard that sets up uploads for your build pipeline — or
-            follow the docs at {SOURCE_MAPS_DOCS_URL}. Once uploads are in place, new
-            exceptions resolve against your original sources and this issue clears on the
-            next check run.
+            Run the source maps wizard in your project: `{WIZARD_COMMAND}` (add `--region eu`
+            on EU Cloud), or follow the docs at {SOURCE_MAPS_DOCS_URL}.
         """,
         agent=f"""
-            Read this issue with `health-issues-get` — the payload has `unresolved_pct`,
-            `total_frames`, and `lookback_hours` describing how many recent JavaScript stack
-            frames could not be resolved. Then fix it in the user's codebase: add source map
-            upload to their build following {SOURCE_MAPS_DOCS_URL} — typically installing
-            `posthog-cli` (or the PostHog bundler plugin for webpack/vite/rollup) and running
-            `posthog-cli sourcemap inject` + `posthog-cli sourcemap upload` against the build
-            output in their CI/deploy step, authenticated with a PostHog personal API key.
-            The issue clears on the next check run once newly ingested frames resolve.
+            Run `{WIZARD_COMMAND}` in the user's project (add `--region eu` if the project is
+            on EU Cloud), or set up uploads manually following {SOURCE_MAPS_DOCS_URL}.
         """,
     )
 


### PR DESCRIPTION
Clicking on a tile takes you to error tracking recommendations

<img width="1714" height="807" alt="image" src="https://github.com/user-attachments/assets/af2b353d-104f-475a-b980-d370620889ec" />
