### PR TITLE
fix(tasks): mount directory resume snapshots at the workspace only

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -12,8 +12,14 @@ SnapshotKind = Literal["filesystem", "directory"]
 SNAPSHOT_KIND_FILESYSTEM: SnapshotKind = "filesystem"
 SNAPSHOT_KIND_DIRECTORY: SnapshotKind = "directory"
 DEFAULT_SANDBOX_WORKING_DIR = "/tmp/workspace"
-DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH = "/tmp"
-DEFAULT_RESUME_SNAPSHOT_MOUNT_PATH = DEFAULT_SANDBOX_WORKING_DIR
+# Directory resume snapshots capture a directory and re-mount it into the next sandbox. The mount
+# REPLACES the target directory in the running sandbox, so only the quiescent workspace dir is safe:
+# mounting over a live system directory (the old "/tmp" default) rips scratch space and sockets out
+# from under Modal's in-sandbox helpers and kills the sandbox on its first filesystem operation.
+# A snapshot's content layout matches the path it was captured from, so snapshots created for a
+# path outside this allowlist cannot be remapped — they must be invalidated on resume instead.
+DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH = DEFAULT_SANDBOX_WORKING_DIR
+ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS: frozenset[str] = frozenset({DEFAULT_SANDBOX_WORKING_DIR})
 
 ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]
 CodexPermissionMode = Literal["auto", "read-only", "full-access"]

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -33,7 +33,11 @@ from posthog.event_usage import groups
 from posthog.models import User
 from posthog.models.integration import Integration
 
-from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, is_blocked_sandbox_env_key
+from products.tasks.backend.constants import (
+    RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS,
+    SNAPSHOT_KIND_DIRECTORY,
+    is_blocked_sandbox_env_key,
+)
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
 from products.tasks.backend.models import (
@@ -3335,11 +3339,16 @@ def run_task(
         extra_state = extra_state or {}
         extra_state["resume_from_run_id"] = str(resume_from_run_id)
         if prev_state.snapshot_external_id:
-            extra_state["snapshot_external_id"] = prev_state.snapshot_external_id
-            extra_state["snapshot_kind"] = prev_state.resume_snapshot_kind()
+            snapshot_kind = prev_state.resume_snapshot_kind()
             snapshot_mount_path = prev_state.resume_snapshot_mount_path()
-            if snapshot_mount_path is not None:
-                extra_state["snapshot_mount_path"] = snapshot_mount_path
+            # A directory snapshot whose stored mount path is no longer allowed (e.g. legacy
+            # "/tmp" captures) is unusable — don't carry it into the new run's state, or the
+            # missing path would get re-defaulted downstream and mount mismatched content.
+            if snapshot_kind != SNAPSHOT_KIND_DIRECTORY or snapshot_mount_path is not None:
+                extra_state["snapshot_external_id"] = prev_state.snapshot_external_id
+                extra_state["snapshot_kind"] = snapshot_kind
+                if snapshot_mount_path is not None:
+                    extra_state["snapshot_mount_path"] = snapshot_mount_path
 
         if prev_state.sandbox_environment_id and sandbox_environment_id is None:
             sandbox_environment_id = prev_state.sandbox_environment_id

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -33,11 +33,7 @@ from posthog.event_usage import groups
 from posthog.models import User
 from posthog.models.integration import Integration
 
-from products.tasks.backend.constants import (
-    RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS,
-    SNAPSHOT_KIND_DIRECTORY,
-    is_blocked_sandbox_env_key,
-)
+from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, is_blocked_sandbox_env_key
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
 from products.tasks.backend.models import (
@@ -3338,17 +3334,15 @@ def run_task(
         prev_state = parse_run_state(previous_run.state)
         extra_state = extra_state or {}
         extra_state["resume_from_run_id"] = str(resume_from_run_id)
-        if prev_state.snapshot_external_id:
-            snapshot_kind = prev_state.resume_snapshot_kind()
+        # An unusable directory snapshot (see RunState.resume_snapshot_is_usable) must not be
+        # carried into the new run's state — the stripped mount path would get re-defaulted
+        # downstream and mount mismatched content.
+        if prev_state.snapshot_external_id and prev_state.resume_snapshot_is_usable():
+            extra_state["snapshot_external_id"] = prev_state.snapshot_external_id
+            extra_state["snapshot_kind"] = prev_state.resume_snapshot_kind()
             snapshot_mount_path = prev_state.resume_snapshot_mount_path()
-            # A directory snapshot whose stored mount path is no longer allowed (e.g. legacy
-            # "/tmp" captures) is unusable — don't carry it into the new run's state, or the
-            # missing path would get re-defaulted downstream and mount mismatched content.
-            if snapshot_kind != SNAPSHOT_KIND_DIRECTORY or snapshot_mount_path is not None:
-                extra_state["snapshot_external_id"] = prev_state.snapshot_external_id
-                extra_state["snapshot_kind"] = snapshot_kind
-                if snapshot_mount_path is not None:
-                    extra_state["snapshot_mount_path"] = snapshot_mount_path
+            if snapshot_mount_path is not None:
+                extra_state["snapshot_mount_path"] = snapshot_mount_path
 
         if prev_state.sandbox_environment_id and sandbox_environment_id is None:
             sandbox_environment_id = prev_state.sandbox_environment_id

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -33,7 +33,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.settings import CLOUD_DEPLOYMENT
 
 from products.tasks.backend.constants import (
-    DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+    ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS,
     SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS,
     SNAPSHOT_KIND_DIRECTORY,
     SNAPSHOT_KIND_FILESYSTEM,
@@ -407,7 +407,10 @@ class ModalSandbox(SandboxBase):
             config.snapshot_restored = False
             snapshot_external_id: str | None = None
             snapshot_kind = _normalize_snapshot_kind(config.snapshot_kind)
-            snapshot_mount_path = config.snapshot_mount_path or DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+            # No default-fill: a directory snapshot must arrive with an explicit allowed mount
+            # path, or the mount below is refused. Defaulting here would silently re-target a
+            # snapshot that upstream validation invalidated (mount path stripped).
+            snapshot_mount_path: str | None = config.snapshot_mount_path
             snapshot_image: modal.Image | None = None
             used_snapshot_image = False
 
@@ -483,7 +486,19 @@ class ModalSandbox(SandboxBase):
                     config.snapshot_restored = False
 
             if snapshot_kind == SNAPSHOT_KIND_DIRECTORY and snapshot_image is not None:
-                if not hasattr(sb, "mount_image"):
+                # The mount REPLACES the target directory in the running sandbox — over a live
+                # system path (the legacy "/tmp" default) that kills Modal's in-sandbox helpers,
+                # and a snapshot's content only fits the path it was captured from. Last-line
+                # guard for snapshot rows whose stored mount path bypassed normalization.
+                if snapshot_mount_path not in ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS:
+                    logger.warning(
+                        "Refusing to mount directory snapshot at unsupported path; falling back to base image",
+                        extra={
+                            "snapshot_external_id": snapshot_external_id,
+                            "snapshot_mount_path": snapshot_mount_path,
+                        },
+                    )
+                elif not hasattr(sb, "mount_image"):
                     logger.warning(
                         "Modal sandbox does not support directory snapshot restore; falling back to base image",
                         extra={

--- a/products/tasks/backend/logic/services/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/test_modal_sandbox.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
+from products.tasks.backend.constants import DEFAULT_SANDBOX_WORKING_DIR, SNAPSHOT_KIND_DIRECTORY
 from products.tasks.backend.logic.services.modal_sandbox import ModalSandbox
 from products.tasks.backend.logic.services.sandbox import SandboxConfig, SandboxTemplate
 
@@ -37,3 +38,39 @@ class TestModalSandboxVmRuntime:
             assert "experimental_options" not in kwargs
         else:
             assert kwargs["experimental_options"] == expected_experimental_options
+
+
+class TestModalSandboxDirectorySnapshotMount:
+    @pytest.mark.parametrize(
+        "mount_path, expect_mounted",
+        [
+            (DEFAULT_SANDBOX_WORKING_DIR, True),
+            # Legacy captures of the system temp dir: re-mounting replaces the live /tmp and
+            # kills Modal's in-sandbox helpers — must never reach mount_image again.
+            ("/tmp", False),
+            # Upstream validation strips a disallowed path; the missing path must not be
+            # re-defaulted into a mount of mismatched content.
+            (None, False),
+        ],
+    )
+    def test_directory_snapshot_mount_guard(self, patched_modal, mocker, mount_path, expect_mounted):
+        snapshot_image = MagicMock()
+        mocker.patch("modal.Image.from_id", return_value=snapshot_image)
+        fake_sandbox = patched_modal.return_value
+
+        sandbox = ModalSandbox.create(
+            SandboxConfig(
+                name="test",
+                template=SandboxTemplate.DEFAULT_BASE,
+                snapshot_external_id="im-dir",
+                snapshot_kind=SNAPSHOT_KIND_DIRECTORY,
+                snapshot_mount_path=mount_path,
+            )
+        )
+
+        if expect_mounted:
+            fake_sandbox.mount_image.assert_called_once_with(mount_path, snapshot_image)
+            assert sandbox.config.snapshot_restored is True
+        else:
+            fake_sandbox.mount_image.assert_not_called()
+            assert sandbox.config.snapshot_restored is False

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -8,11 +8,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.constants import (
-    SNAPSHOT_KIND_DIRECTORY,
-    SNAPSHOT_KIND_FILESYSTEM,
-    filter_user_sandbox_env_vars,
-)
+from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM, filter_user_sandbox_env_vars
 from products.tasks.backend.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.logic.services.connection_token import (
     SANDBOX_JWT_STATE_KID_KEY,
@@ -128,9 +124,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
                 snapshot_lookup_timer.set_used_snapshot(used_snapshot)
             if snapshot is not None:
                 snapshot_metadata = get_sandbox_snapshot_metadata(snapshot)
-                if snapshot_metadata.kind == SNAPSHOT_KIND_DIRECTORY and snapshot_metadata.mount_path is None:
-                    # Directory snapshot with a disallowed mount path (e.g. legacy "/tmp"): its
-                    # content layout matches that path, so it can't be remapped. Provision fresh.
+                if not snapshot_metadata.is_usable:
                     snapshot = None
                     used_snapshot = False
                 else:
@@ -231,11 +225,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         # Check for resume snapshot (takes priority over integration-level snapshots)
         resume_snapshot_ext_id = run_state.snapshot_external_id
         if resume_snapshot_ext_id:
-            resume_snapshot_kind = run_state.resume_snapshot_kind()
-            resume_snapshot_mount_path = run_state.resume_snapshot_mount_path()
-            if resume_snapshot_kind == SNAPSHOT_KIND_DIRECTORY and resume_snapshot_mount_path is None:
-                # Same invalidation as the repository-snapshot branch above, for directory
-                # snapshots referenced from run state (e.g. legacy "/tmp" captures).
+            if not run_state.resume_snapshot_is_usable():
                 emit_agent_log(
                     ctx.run_id,
                     "debug",
@@ -245,8 +235,8 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
             else:
                 used_snapshot = True
                 snapshot_source = "resume"
-                snapshot_kind = resume_snapshot_kind
-                snapshot_mount_path = resume_snapshot_mount_path
+                snapshot_kind = run_state.resume_snapshot_kind()
+                snapshot_mount_path = run_state.resume_snapshot_mount_path()
 
         provider = getattr(settings, "SANDBOX_PROVIDER", None)
         image_source_label = _get_image_source_label(

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -8,7 +8,11 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM, filter_user_sandbox_env_vars
+from products.tasks.backend.constants import (
+    SNAPSHOT_KIND_DIRECTORY,
+    SNAPSHOT_KIND_FILESYSTEM,
+    filter_user_sandbox_env_vars,
+)
 from products.tasks.backend.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.logic.services.connection_token import (
     SANDBOX_JWT_STATE_KID_KEY,
@@ -123,10 +127,16 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
                 used_snapshot = snapshot is not None
                 snapshot_lookup_timer.set_used_snapshot(used_snapshot)
             if snapshot is not None:
-                snapshot_source = "repository"
                 snapshot_metadata = get_sandbox_snapshot_metadata(snapshot)
-                snapshot_kind = snapshot_metadata.kind
-                snapshot_mount_path = snapshot_metadata.mount_path
+                if snapshot_metadata.kind == SNAPSHOT_KIND_DIRECTORY and snapshot_metadata.mount_path is None:
+                    # Directory snapshot with a disallowed mount path (e.g. legacy "/tmp"): its
+                    # content layout matches that path, so it can't be remapped. Provision fresh.
+                    snapshot = None
+                    used_snapshot = False
+                else:
+                    snapshot_source = "repository"
+                    snapshot_kind = snapshot_metadata.kind
+                    snapshot_mount_path = snapshot_metadata.mount_path
         elif not has_repo:
             emit_agent_log(ctx.run_id, "debug", "Creating environment without repository")
 
@@ -221,10 +231,22 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         # Check for resume snapshot (takes priority over integration-level snapshots)
         resume_snapshot_ext_id = run_state.snapshot_external_id
         if resume_snapshot_ext_id:
-            used_snapshot = True
-            snapshot_source = "resume"
-            snapshot_kind = run_state.resume_snapshot_kind()
-            snapshot_mount_path = run_state.resume_snapshot_mount_path()
+            resume_snapshot_kind = run_state.resume_snapshot_kind()
+            resume_snapshot_mount_path = run_state.resume_snapshot_mount_path()
+            if resume_snapshot_kind == SNAPSHOT_KIND_DIRECTORY and resume_snapshot_mount_path is None:
+                # Same invalidation as the repository-snapshot branch above, for directory
+                # snapshots referenced from run state (e.g. legacy "/tmp" captures).
+                emit_agent_log(
+                    ctx.run_id,
+                    "debug",
+                    "Previous session snapshot is unusable; resuming with a fresh sandbox",
+                )
+                resume_snapshot_ext_id = None
+            else:
+                used_snapshot = True
+                snapshot_source = "resume"
+                snapshot_kind = resume_snapshot_kind
+                snapshot_mount_path = resume_snapshot_mount_path
 
         provider = getattr(settings, "SANDBOX_PROVIDER", None)
         image_source_label = _get_image_source_label(

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -8,11 +8,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.constants import (
-    SNAPSHOT_KIND_DIRECTORY,
-    SNAPSHOT_KIND_FILESYSTEM,
-    filter_user_sandbox_env_vars,
-)
+from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM, filter_user_sandbox_env_vars
 from products.tasks.backend.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.logic.services.agentsh import ENV_FILE, INFRASTRUCTURE_DOMAINS, _get_debug_only_domains
 from products.tasks.backend.logic.services.connection_token import (
@@ -310,10 +306,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                 snapshot_lookup_timer.set_used_snapshot(used_snapshot)
             if snapshot is not None:
                 snapshot_metadata = get_sandbox_snapshot_metadata(snapshot)
-                if snapshot_metadata.kind == SNAPSHOT_KIND_DIRECTORY and snapshot_metadata.mount_path is None:
-                    # Directory snapshot with a mount path that is no longer allowed (e.g. the
-                    # legacy "/tmp" default): its content layout matches that path, so it can't
-                    # be remapped. Provision fresh instead of restoring it.
+                if not snapshot_metadata.is_usable:
                     snapshot = None
                     used_snapshot = False
                 else:
@@ -367,11 +360,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         # kind of new snapshot created after this run.
         resume_snapshot_external_id = run_state.snapshot_external_id
         if resume_snapshot_external_id:
-            resume_snapshot_kind = run_state.resume_snapshot_kind()
-            resume_snapshot_mount_path = run_state.resume_snapshot_mount_path()
-            if resume_snapshot_kind == SNAPSHOT_KIND_DIRECTORY and resume_snapshot_mount_path is None:
-                # Same invalidation as the repository-snapshot branch above, for directory
-                # snapshots referenced from run state (e.g. legacy "/tmp" captures).
+            if not run_state.resume_snapshot_is_usable():
                 emit_agent_log(
                     ctx.run_id,
                     "debug",
@@ -381,8 +370,8 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
             else:
                 used_snapshot = True
                 snapshot_source = "resume"
-                snapshot_kind = resume_snapshot_kind
-                snapshot_mount_path = resume_snapshot_mount_path
+                snapshot_kind = run_state.resume_snapshot_kind()
+                snapshot_mount_path = run_state.resume_snapshot_mount_path()
 
         activity.logger.info(
             "resume_decision",

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -8,7 +8,11 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM, filter_user_sandbox_env_vars
+from products.tasks.backend.constants import (
+    SNAPSHOT_KIND_DIRECTORY,
+    SNAPSHOT_KIND_FILESYSTEM,
+    filter_user_sandbox_env_vars,
+)
 from products.tasks.backend.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.logic.services.agentsh import ENV_FILE, INFRASTRUCTURE_DOMAINS, _get_debug_only_domains
 from products.tasks.backend.logic.services.connection_token import (
@@ -305,10 +309,17 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                 used_snapshot = snapshot is not None
                 snapshot_lookup_timer.set_used_snapshot(used_snapshot)
             if snapshot is not None:
-                snapshot_source = "repository"
                 snapshot_metadata = get_sandbox_snapshot_metadata(snapshot)
-                snapshot_kind = snapshot_metadata.kind
-                snapshot_mount_path = snapshot_metadata.mount_path
+                if snapshot_metadata.kind == SNAPSHOT_KIND_DIRECTORY and snapshot_metadata.mount_path is None:
+                    # Directory snapshot with a mount path that is no longer allowed (e.g. the
+                    # legacy "/tmp" default): its content layout matches that path, so it can't
+                    # be remapped. Provision fresh instead of restoring it.
+                    snapshot = None
+                    used_snapshot = False
+                else:
+                    snapshot_source = "repository"
+                    snapshot_kind = snapshot_metadata.kind
+                    snapshot_mount_path = snapshot_metadata.mount_path
         elif not has_repo:
             emit_agent_log(ctx.run_id, "debug", "Creating environment without repository")
 
@@ -356,10 +367,22 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         # kind of new snapshot created after this run.
         resume_snapshot_external_id = run_state.snapshot_external_id
         if resume_snapshot_external_id:
-            used_snapshot = True
-            snapshot_source = "resume"
-            snapshot_kind = run_state.resume_snapshot_kind()
-            snapshot_mount_path = run_state.resume_snapshot_mount_path()
+            resume_snapshot_kind = run_state.resume_snapshot_kind()
+            resume_snapshot_mount_path = run_state.resume_snapshot_mount_path()
+            if resume_snapshot_kind == SNAPSHOT_KIND_DIRECTORY and resume_snapshot_mount_path is None:
+                # Same invalidation as the repository-snapshot branch above, for directory
+                # snapshots referenced from run state (e.g. legacy "/tmp" captures).
+                emit_agent_log(
+                    ctx.run_id,
+                    "debug",
+                    "Previous session snapshot is unusable; resuming with a fresh sandbox",
+                )
+                resume_snapshot_external_id = None
+            else:
+                used_snapshot = True
+                snapshot_source = "resume"
+                snapshot_kind = resume_snapshot_kind
+                snapshot_mount_path = resume_snapshot_mount_path
 
         activity.logger.info(
             "resume_decision",

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -37,10 +37,18 @@ class TestRunStateSnapshotPaths(TestCase):
                 {"snapshot_kind": SNAPSHOT_KIND_DIRECTORY, "snapshot_mount_path": DEFAULT_SANDBOX_WORKING_DIR},
                 DEFAULT_SANDBOX_WORKING_DIR,
             ),
+            # A disallowed stored path invalidates the snapshot (None) — it must NOT be remapped
+            # to the default: the snapshot's content layout only fits the path it was captured
+            # from. "/tmp" is the legacy default whose re-mount killed the sandbox.
+            (
+                "legacy_tmp_directory_snapshot",
+                {"snapshot_kind": SNAPSHOT_KIND_DIRECTORY, "snapshot_mount_path": "/tmp"},
+                None,
+            ),
             (
                 "unsupported_directory_snapshot_path",
                 {"snapshot_kind": SNAPSHOT_KIND_DIRECTORY, "snapshot_mount_path": "/tmp/agent-env"},
-                DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+                None,
             ),
             ("filesystem_snapshot", {"snapshot_kind": "filesystem"}, None),
         ]

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -270,6 +270,13 @@ class RunState(BaseModel, extra="allow"):
             return None
         return normalize_directory_resume_snapshot_mount_path(self.snapshot_mount_path)
 
+    def resume_snapshot_is_usable(self) -> bool:
+        """A directory snapshot whose stored mount path was invalidated (e.g. legacy "/tmp"
+        captures) can't be restored anywhere — callers must provision fresh instead."""
+        return not (
+            self.resume_snapshot_kind() == SNAPSHOT_KIND_DIRECTORY and self.resume_snapshot_mount_path() is None
+        )
+
 
 def parse_run_state(state: dict[str, Any] | None) -> RunState:
     return RunState.model_validate(state or {})
@@ -279,6 +286,11 @@ def parse_run_state(state: dict[str, Any] | None) -> RunState:
 class SnapshotMetadata:
     kind: SnapshotKind
     mount_path: str | None
+
+    @property
+    def is_usable(self) -> bool:
+        """See ``RunState.resume_snapshot_is_usable`` — same invalidation rule."""
+        return not (self.kind == SNAPSHOT_KIND_DIRECTORY and self.mount_path is None)
 
 
 def get_sandbox_snapshot_metadata(snapshot: SandboxSnapshot) -> SnapshotMetadata:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -16,8 +16,8 @@ from posthog.temporal.oauth import TOKEN_EXPIRATION_SECONDS, PosthogMcpScopes, h
 
 from products.mcp_store.backend.facade.api import get_active_installations
 from products.tasks.backend.constants import (
+    ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS,
     DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
-    DEFAULT_SANDBOX_WORKING_DIR,
     SNAPSHOT_KIND_DIRECTORY,
     SNAPSHOT_KIND_FILESYSTEM,
     InitialPermissionMode,
@@ -32,13 +32,6 @@ if TYPE_CHECKING:
     from products.tasks.backend.models import SandboxSnapshot, Task
 
 logger = logging.getLogger(__name__)
-
-_ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS = frozenset(
-    {
-        DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
-        DEFAULT_SANDBOX_WORKING_DIR,
-    }
-)
 
 
 class PrAuthorshipMode(StrEnum):
@@ -219,17 +212,24 @@ def get_reasoning_effort_error(
     )
 
 
-def normalize_directory_resume_snapshot_mount_path(snapshot_mount_path: object) -> str:
+def normalize_directory_resume_snapshot_mount_path(snapshot_mount_path: object) -> str | None:
+    """Resolve where a directory resume snapshot may be mounted; ``None`` means "don't use it".
+
+    A snapshot's content layout matches the path it was captured from, so a stored path outside
+    the allowlist (notably the legacy "/tmp" default, whose mount replaced the live system temp
+    dir and killed the sandbox) cannot be remapped to a safe path — the snapshot is unusable and
+    the resume must fall back to a fresh sandbox.
+    """
     if not snapshot_mount_path:
         return DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
-    if isinstance(snapshot_mount_path, str) and snapshot_mount_path in _ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS:
+    if isinstance(snapshot_mount_path, str) and snapshot_mount_path in ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS:
         return snapshot_mount_path
 
     logger.warning(
-        "Ignoring unsupported directory resume snapshot mount path",
+        "Directory resume snapshot has an unsupported mount path; invalidating the snapshot",
         extra={"snapshot_mount_path": snapshot_mount_path},
     )
-    return DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+    return None
 
 
 class RunState(BaseModel, extra="allow"):

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -210,6 +210,50 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertEqual(stale.status, TaskRun.Status.FAILED.value)
         self.assertEqual(stale.error_message, "boom")
 
+    @parameterized.expand(
+        [
+            # A directory snapshot captured at a still-allowed path is carried into the new run.
+            ("workspace_path", "/tmp/workspace", True),
+            # A legacy "/tmp" capture is unusable (its content only fits that path, and mounting
+            # over the live /tmp killed sandboxes) — resuming must drop it, not carry it forward
+            # with the path stripped, or downstream defaulting would remount mismatched content.
+            ("legacy_tmp_path", "/tmp", False),
+        ]
+    )
+    def test_run_task_resume_carries_only_usable_directory_snapshots(
+        self, _name: str, prior_mount_path: str, expect_carried: bool
+    ):
+        task = self._make_task()
+        previous_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={
+                "snapshot_external_id": "im-dir",
+                "snapshot_kind": "directory",
+                "snapshot_mount_path": prior_mount_path,
+            },
+        )
+
+        with patch("products.tasks.backend.facade.api._trigger_task_processing_workflow"):
+            result = facade.run_task(
+                task.id,
+                self.team.id,
+                self.user.id,
+                validated_data={"mode": "interactive", "resume_from_run_id": str(previous_run.id)},
+            )
+
+        assert result is not None and result.error is None
+        new_run = task.runs.exclude(id=previous_run.id).get()
+        if expect_carried:
+            self.assertEqual(new_run.state.get("snapshot_external_id"), "im-dir")
+            self.assertEqual(new_run.state.get("snapshot_kind"), "directory")
+            self.assertEqual(new_run.state.get("snapshot_mount_path"), prior_mount_path)
+        else:
+            self.assertNotIn("snapshot_external_id", new_run.state)
+            self.assertNotIn("snapshot_kind", new_run.state)
+            self.assertNotIn("snapshot_mount_path", new_run.state)
+
     def test_stale_queued_created_at_hard_cap(self):
         task = self._make_task()
         now = django_timezone.now()


### PR DESCRIPTION
## Problem

Directory resume snapshots (behind `tasks-modal-directory-resume-snapshots`) captured the whole `/tmp` of an interactive sandbox at run end and re-mounted that image over `/tmp` on resume (`DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH = "/tmp"`).

## Changes

Capture and mount at `/tmp/workspace` and invalidate legacy captures everywhere they could resurface
