### PR TITLE
fix(hogql): keep shared CTE columns demanded by sibling union branches

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -209,6 +209,9 @@ def prepare_ast_for_printing(
     if context.modifiers.optimizeProjections:
         with context.timings.measure("projection_pushdown"):
             node = pushdown_projections(node, context)
+        # Pushdown mutates SelectQueryType.columns, staling cached CTE tables. Drop them so a
+        # wrongly pruned column fails loudly at compile time instead of emitting broken SQL.
+        context.cte_database_table_cache.clear()
 
     if dialect in SQL_TARGET_DIALECTS:
         with context.timings.measure("resolve_lazy_tables"):

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -776,8 +776,6 @@ class TestResolver(BaseTest):
     def test_star_cte_shared_by_union_branches_projects_all_columns(self):
         # Regression: pushdown pruned a `SELECT *` CTE to the first UNION branch's column, and
         # the cached CTE table (built pre-prune) masked the failure into silently broken SQL.
-        from posthog.schema import HogQLQueryModifiers
-
         query = self._select(
             "with base as (select * from (select 1 as a, 2 as b, 3 as d)) "
             "select a as v from base "

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -773,6 +773,33 @@ class TestResolver(BaseTest):
         assert len(build_ids) == len(set(build_ids))
         assert len(set(build_ids)) == 4
 
+    def test_star_cte_shared_by_union_branches_projects_all_columns(self):
+        # Regression: pushdown pruned a `SELECT *` CTE to the first UNION branch's column, and
+        # the cached CTE table (built pre-prune) masked the failure into silently broken SQL.
+        from posthog.schema import HogQLQueryModifiers
+
+        query = self._select(
+            "with base as (select * from (select 1 as a, 2 as b, 3 as d)) "
+            "select a as v from base "
+            "union all select b as v from base "
+            "union all select d as v from base"
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            modifiers=HogQLQueryModifiers(optimizeProjections=True),
+        )
+        _, prepared = prepare_and_print_ast(query, context, "clickhouse")
+
+        # The single shared CTE must project every column referenced across the branches.
+        assert isinstance(prepared, ast.SelectSetQuery)
+        first_branch = prepared.initial_select_query
+        assert isinstance(first_branch, ast.SelectQuery) and first_branch.ctes is not None
+        base_cte = first_branch.ctes["base"].expr
+        assert isinstance(base_cte, ast.SelectQuery)
+        cte_cols = {col.alias if isinstance(col, ast.Alias) else col.chain[-1] for col in base_cte.select}
+        assert cte_cols == {"a", "b", "d"}, f"CTE dropped columns referenced by sibling UNION branches: got {cte_cols}"
+
     def test_ctes_with_aliases_in_joins(self):
         self.assertEqual(
             self._print_hogql(

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -11,6 +11,8 @@ from django.test import override_settings
 
 from parameterized import parameterized
 
+from posthog.schema import HogQLQueryModifiers
+
 import posthog.hogql.resolver_utils as resolver_utils
 from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
@@ -776,11 +778,17 @@ class TestResolver(BaseTest):
     def test_star_cte_shared_by_union_branches_projects_all_columns(self):
         # Regression: pushdown pruned a `SELECT *` CTE to the first UNION branch's column, and
         # the cached CTE table (built pre-prune) masked the failure into silently broken SQL.
-        query = self._select(
-            "with base as (select * from (select 1 as a, 2 as b, 3 as d)) "
-            "select a as v from base "
-            "union all select b as v from base "
-            "union all select d as v from base"
+        query = cast(
+            ast.SelectSetQuery,
+            clone_expr(
+                parse_select(
+                    "with base as (select * from (select 1 as a, 2 as b, 3 as d)) "
+                    "select a as v from base "
+                    "union all select b as v from base "
+                    "union all select d as v from base"
+                ),
+                clear_locations=True,
+            ),
         )
         context = HogQLContext(
             team_id=self.team.pk,

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -803,7 +803,10 @@ class TestResolver(BaseTest):
         assert isinstance(first_branch, ast.SelectQuery) and first_branch.ctes is not None
         base_cte = first_branch.ctes["base"].expr
         assert isinstance(base_cte, ast.SelectQuery)
-        cte_cols = {col.alias if isinstance(col, ast.Alias) else col.chain[-1] for col in base_cte.select}
+        cte_cols: set[str] = set()
+        for col in base_cte.select:
+            assert isinstance(col, ast.Alias | ast.Field)
+            cte_cols.add(col.alias if isinstance(col, ast.Alias) else str(col.chain[-1]))
         assert cte_cols == {"a", "b", "d"}, f"CTE dropped columns referenced by sibling UNION branches: got {cte_cols}"
 
     def test_ctes_with_aliases_in_joins(self):

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -13,19 +13,31 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
 
     Algorithm Overview:
     ──────────────────
-    This optimizer works in a single top-down pass through the query tree:
+    This optimizer makes two top-down passes through the query tree: the first only collects
+    demands, the second prunes with the complete demand set. A CTE can be consumed by nodes
+    visited after it — notably sibling UNION branches — so pruning must wait for the full walk.
+
+    Each pass runs these phases per query:
 
     Phase 1 - Register: Map subquery types to AST nodes for demand tracking
     Phase 2 - Collect: Gather column demands from WHERE/GROUP BY/ORDER BY/etc
     Phase 3 - Propagate: For demanded columns, visit their source to propagate to child queries
     Phase 4 - Recurse: Visit child subqueries (repeat phases 1-4)
-    Phase 5 - Prune: Remove unreferenced asterisk columns from this query
+    Phase 5 - Prune: Remove unreferenced asterisk columns from this query (second pass only)
     """
 
     def __init__(self):
         super().__init__()
         self.demands: dict[int, set[str]] = defaultdict(set)
         self.subquery_map: dict[int, ast.SelectQuery | ast.SelectSetQuery] = {}
+        # True during the first pass; gates pruning to the second (see class docstring)
+        self.collecting: bool = False
+
+    def optimize(self, node: ast.SelectQuery | ast.SelectSetQuery) -> ast.SelectQuery | ast.SelectSetQuery:
+        self.collecting = True
+        self.visit(node)
+        self.collecting = False
+        return cast(ast.SelectQuery | ast.SelectSetQuery, self.visit(node))
 
     def visit_select_query(self, node: ast.SelectQuery) -> ast.SelectQuery:
         # Phase 1: Register subqueries and CTEs for demand tracking
@@ -68,10 +80,11 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         if node.select_from:
             self.visit(node.select_from)
 
-        # Phase 5: Prune unreferenced asterisk columns from this query and CTEs
-        self._prune_columns(node)
-        if node.ctes:
-            self._prune_cte_columns(node.ctes)
+        # Phase 5: Prune unreferenced asterisk columns from this query and CTEs (second pass only)
+        if not self.collecting:
+            self._prune_columns(node)
+            if node.ctes:
+                self._prune_cte_columns(node.ctes)
 
         return node
 
@@ -290,4 +303,4 @@ def pushdown_projections(node: _T_AST, context: HogQLContext) -> _T_AST:
     if not isinstance(node, (ast.SelectQuery, ast.SelectSetQuery)):
         return node
     optimizer = ProjectionPushdownOptimizer()
-    return cast(_T_AST, optimizer.visit(node))
+    return cast(_T_AST, optimizer.optimize(node))

--- a/posthog/hogql/transforms/test/test_projection_pushdown.py
+++ b/posthog/hogql/transforms/test/test_projection_pushdown.py
@@ -593,3 +593,21 @@ class TestProjectionPushdown(BaseTest):
         }, f"Expected event, timestamp, and person_id but got {base_cols}"
 
         assert optimized.to_hogql() == self.snapshot
+
+    def test_cte_shared_by_union_branches_keeps_all_demanded_columns(self):
+        # The WITH lives on the first UNION branch but every sibling branch consumes it, so
+        # pruning before all branches register their demands drops columns the siblings need.
+        optimized = self._optimize(
+            "WITH base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)) "
+            "SELECT a FROM base "
+            "UNION ALL SELECT b FROM base "
+            "UNION ALL SELECT d FROM base"
+        )
+
+        first_branch = optimized.initial_select_query
+        assert isinstance(first_branch, ast.SelectQuery)
+        assert first_branch.ctes is not None
+        base_cte = first_branch.ctes["base"].expr
+        assert isinstance(base_cte, ast.SelectQuery)
+        base_cols = {self._col_name(col) for col in base_cte.select}
+        assert base_cols == {"a", "b", "d"}, f"CTE dropped columns demanded by sibling branches: got {base_cols}"


### PR DESCRIPTION
## Problem

A `SELECT *` CTE consumed by multiple `UNION ALL` branches compiles to broken SQL. With projection pushdown on (the default), the CTE gets pruned to only the columns the **first** branch demands, so later branches reference columns the CTE no longer projects:

```sql
WITH endpoints AS (SELECT * FROM some_view)
SELECT round(countIf(a = 'x') * 100.0 / count(), 2) FROM endpoints
UNION ALL
SELECT round(countIf(b = 1) * 100.0 / count(), 2) FROM endpoints
```

compiles the CTE down to `SELECT a FROM ...`, and ClickHouse rejects the query with `Identifier 'endpoints.b' cannot be resolved from subquery`.

Root cause is in `ProjectionPushdownOptimizer`. The `WITH` clause lives on the first union branch, and the optimizer pruned the CTE's asterisk columns at the end of that branch's visit, before the sibling branches (visited afterwards) registered their demands.

The bug is old but used to fail loudly at compile time (`Field "b" not found on table Table`). #66147 made it silent: the CTE table cached during type resolution still held the pre-prune columns, so resolution succeeded and the broken SQL shipped to ClickHouse. Verified both ways by reverting #66147 and re-running the repro.

## Changes

- `ProjectionPushdownOptimizer` now runs two passes: the first collects column demands across the whole tree with pruning disabled, the second prunes with the complete demand set. Demands were already accumulated correctly per CTE, only the pruning timing was wrong.
- After pushdown mutates `SelectQueryType.columns`, `prepare_ast_for_printing` clears the CTE table cache from #66147. The cache stays effective within each phase, but a wrongly pruned column now fails loudly at compile time again instead of emitting broken SQL.

## How did you test this code?

Automated tests only (no manual UI testing):

- `test_projection_pushdown.py::test_cte_shared_by_union_branches_keeps_all_demanded_columns` – transform-level: a star CTE shared by union branches that demand different columns keeps all of them. Existing tests only covered CTEs consumed within one query (joins) or unions where every branch demands the same columns, so this failure shipped undetected.
- `test_resolver.py::test_star_cte_shared_by_union_branches_projects_all_columns` – end-to-end through `prepare_and_print_ast` with `optimizeProjections=True`, catching the cache-masking variant of the same regression.
- Full `test_projection_pushdown.py` + `test_resolver.py` + `test_printer.py`: 1035 passed, 233 snapshots unchanged.
- Verified the loud-failure tripwire: with the pruning bug temporarily re-introduced and the cache clear in place, compilation raises instead of emitting broken SQL.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A – internal query compiler fix, no user-facing behavior change beyond the bug going away.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: investigated a user-reported dashboard query failure, reproduced it live, bisected the cause with a four-config matrix (with/without #66147, with/without this fix), then wrote failing tests before the fix. Skills invoked: /writing-tests.
- Considered and rejected a deferred-CTE-queue design with a fixpoint loop in favor of the simpler two-pass traversal – identical test results, much less machinery.
- The cache clear was added deliberately after discussing failure modes: pushdown always stales the cache, and without the clear any future pruning bug would again surface as silently wrong results instead of a compile error.
