### PR TITLE
fix(signals): raise scout report telemetry summary cap to 10k

### DIFF
--- a/products/signals/backend/scout_harness/tools/report.py
+++ b/products/signals/backend/scout_harness/tools/report.py
@@ -381,7 +381,12 @@ async def _maybe_autostart_report(*, team_id: int, report_id: str) -> None:
 # scout never authored. These fields are the opposite: a curated, scout-authored report title/summary —
 # the deliberate product output — not an arbitrary nested blob. They're forwarded by name (no blob
 # passthrough) and length-capped here, which is what makes carrying them acceptable.
-_MAX_TELEMETRY_SUMMARY_LEN = 2000
+#
+# The summary cap must comfortably exceed what CDP forwards deliver downstream — a Slack forward posts
+# the event's `summary` verbatim, so a cap below the authored length silently cuts the message mid-content
+# (this happened at 2000). 10000 bounds the payload while leaving digest-style summaries intact; the
+# report row itself allows up to MAX_REPORT_SUMMARY_LENGTH.
+_MAX_TELEMETRY_SUMMARY_LEN = 10000
 _MAX_TELEMETRY_TEXT_LEN = 1000
 
 


### PR DESCRIPTION
## Problem

The `$scout_report_emitted` lifecycle event carries the report's `summary` so internal consumers (dashboards, alerts, CDP forwards) can act on a report's substance.
That property is clipped to 2000 chars (`_MAX_TELEMETRY_SUMMARY_LEN`), which is below what report-channel scouts actually author (the report row allows up to 20000).

The clip is a hard slice with no ellipsis, so any downstream consumer that renders the property verbatim gets cut mid-content.
Concretely: a Slack CDP forward of a daily digest report posted a message that ended mid-URL, because the digest was ~2800 chars and the event only carried the first 2000.

## Changes

- Bump `_MAX_TELEMETRY_SUMMARY_LEN` from 2000 to 10000 in `products/signals/backend/scout_harness/tools/report.py`.
- Extend the comment to record why the cap must exceed what CDP forwards deliver downstream.

10000 keeps the event payload bounded (half the report-level `MAX_REPORT_SUMMARY_LENGTH` of 20000) while comfortably covering digest-style summaries, including what a Slack forward can realistically render across blocks.

## How did you test this code?

Constant-only change. `ruff check` and `ruff format --check` pass on the touched file.
No test pins the old value (the only clip-length assertion in the signals tests targets the signal channel's separate `_MAX_TELEMETRY_STR_LEN`), and a test asserting the new constant would just restate it.
Verified the failure mode against production data: the emitted event's `summary` property measured exactly 2000 chars while the report row held the full ~2800-char summary, matching where the forwarded Slack message cut off.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal telemetry constant.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in an interactive session, directed by @andrewm4894 after we traced a truncated Slack digest message to this clip rather than to Slack's own limits.
- Diagnosis path: compared the report row's summary length against the `$scout_report_emitted` event property via HogQL, then located the `_clip` call site.
- Considered removing the cap entirely or matching `MAX_REPORT_SUMMARY_LENGTH` (20000), and rejected both to keep a deliberate telemetry payload bound; 10000 gives 5x headroom over the observed failure.
