### PR TITLE
feat(billing): split usage gauge at billing limit with pay tooltips

### DIFF
--- a/frontend/src/scenes/billing/Billing.stories.tsx
+++ b/frontend/src/scenes/billing/Billing.stories.tsx
@@ -23,17 +23,6 @@ const billingJsonWithoutIconKeys: BillingType = {
     })),
 }
 
-// Product analytics usage has run past its billing limit — exercises the gauge's paid/over-limit
-// split (solid up to the limit, striped + desaturated above it), which no other fixture triggers.
-const billingJsonWithUsageOverLimit: BillingType = {
-    ...billingJson,
-    products: billingJson.products.map((product) =>
-        product.type === 'product_analytics'
-            ? { ...product, usage_limit: 400000, percentage_usage: 2.2, projected_usage: 1000000 }
-            : product
-    ),
-}
-
 const meta: Meta = {
     title: 'Scenes-Other/Billing',
     parameters: {
@@ -121,20 +110,6 @@ export const BillingWithCreditCTA: Story = {
                     email: 'test@posthog.com',
                     cc_last_four: '1234',
                     cc_brand: 'Visa',
-                },
-            },
-        })
-
-        return <Billing />
-    },
-}
-
-export const BillingWithUsageOverLimit: Story = {
-    render: () => {
-        useStorybookMocks({
-            get: {
-                '/api/billing/': {
-                    ...billingJsonWithUsageOverLimit,
                 },
             },
         })

--- a/frontend/src/scenes/billing/Billing.stories.tsx
+++ b/frontend/src/scenes/billing/Billing.stories.tsx
@@ -23,6 +23,17 @@ const billingJsonWithoutIconKeys: BillingType = {
     })),
 }
 
+// Product analytics usage has run past its billing limit — exercises the gauge's paid/over-limit
+// split (solid up to the limit, striped + desaturated above it), which no other fixture triggers.
+const billingJsonWithUsageOverLimit: BillingType = {
+    ...billingJson,
+    products: billingJson.products.map((product) =>
+        product.type === 'product_analytics'
+            ? { ...product, usage_limit: 400000, percentage_usage: 2.2, projected_usage: 1000000 }
+            : product
+    ),
+}
+
 const meta: Meta = {
     title: 'Scenes-Other/Billing',
     parameters: {
@@ -110,6 +121,20 @@ export const BillingWithCreditCTA: Story = {
                     email: 'test@posthog.com',
                     cc_last_four: '1234',
                     cc_brand: 'Visa',
+                },
+            },
+        })
+
+        return <Billing />
+    },
+}
+
+export const BillingWithUsageOverLimit: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/billing/': {
+                    ...billingJsonWithUsageOverLimit,
                 },
             },
         })

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -60,14 +60,16 @@
 
         // Actual usage above the billing limit — real, but not charged. Desaturated grey, and
         // angled the opposite way (135deg) to the projected/forecast stripes (-45deg) so the two
-        // striped bars never read as the same thing where they overlap.
+        // striped bars never read as the same thing where they overlap. Both stops must use defined
+        // tokens: a single undefined custom property makes the whole gradient invalid, which would
+        // silently drop the stripes to a transparent background.
         &--over-limit {
             background: repeating-linear-gradient(
                 135deg,
                 var(--muted),
                 var(--muted) 3px,
-                var(--color-border-primary-opaque) 3px,
-                var(--color-border-primary-opaque) 7px
+                var(--color-border-primary) 3px,
+                var(--color-border-primary) 7px
             );
             opacity: 0.7;
         }

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -38,6 +38,32 @@
         &.BillingGaugeItem--within-usage-limit {
             background: var(--brand-blue);
         }
+
+        // When split at the billing limit, the two sections below paint the bar instead.
+        &.BillingGaugeItem--split {
+            background: transparent;
+        }
+    }
+
+    .BillingGaugeItem__section {
+        // Usage at or below the billing limit — what the user actually pays for.
+        &--paid {
+            background: var(--brand-blue);
+        }
+
+        // Usage above the billing limit — not charged, so shown striped and desaturated.
+        &--over-limit {
+            background:
+                repeating-linear-gradient(
+                    -45deg,
+                    var(--brand-blue),
+                    var(--brand-blue) 4px,
+                    transparent 4px,
+                    transparent 8px
+                ),
+                var(--color-border-primary-opaque);
+            opacity: 0.5;
+        }
     }
 
     &.BillingGaugeItem--projected_usage {

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -1,21 +1,20 @@
 .BillingGaugeItem {
-    animation: BillingGaugeItem__expand 800ms cubic-bezier(0.15, 0.15, 0.2, 1) forwards;
-
     // Bars are absolutely-positioned siblings that stack by DOM order (higher-value bars paint
     // on top), so a bar above would otherwise intercept hover for the label/sections beneath it.
     // Only the interactive children opt back into pointer events.
     pointer-events: none;
+    animation: BillingGaugeItem__expand 800ms cubic-bezier(0.15, 0.15, 0.2, 1) forwards;
 
     .BillingGaugeItem__info {
         position: absolute;
         bottom: 100%;
         left: 100%;
-        pointer-events: auto;
         padding: 0 0.25rem 0.5rem;
         margin-left: -1px;
         font-size: 0.8rem;
         line-height: 1rem;
         white-space: nowrap;
+        pointer-events: auto;
         background-color: var(--color-bg-light);
         border-left: 1px solid var(--border-light);
 

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -58,18 +58,18 @@
             background: var(--brand-blue);
         }
 
-        // Usage above the billing limit — not charged, so shown striped and desaturated.
+        // Actual usage above the billing limit — real, but not charged. Desaturated grey, and
+        // angled the opposite way (135deg) to the projected/forecast stripes (-45deg) so the two
+        // striped bars never read as the same thing where they overlap.
         &--over-limit {
-            background:
-                repeating-linear-gradient(
-                    -45deg,
-                    var(--brand-blue),
-                    var(--brand-blue) 4px,
-                    transparent 4px,
-                    transparent 8px
-                ),
-                var(--color-border-primary-opaque);
-            opacity: 0.5;
+            background: repeating-linear-gradient(
+                135deg,
+                var(--muted),
+                var(--muted) 3px,
+                var(--color-border-primary-opaque) 3px,
+                var(--color-border-primary-opaque) 7px
+            );
+            opacity: 0.7;
         }
     }
 

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -1,10 +1,16 @@
 .BillingGaugeItem {
     animation: BillingGaugeItem__expand 800ms cubic-bezier(0.15, 0.15, 0.2, 1) forwards;
 
+    // Bars are absolutely-positioned siblings that stack by DOM order (higher-value bars paint
+    // on top), so a bar above would otherwise intercept hover for the label/sections beneath it.
+    // Only the interactive children opt back into pointer events.
+    pointer-events: none;
+
     .BillingGaugeItem__info {
         position: absolute;
         bottom: 100%;
         left: 100%;
+        pointer-events: auto;
         padding: 0 0.25rem 0.5rem;
         margin-left: -1px;
         font-size: 0.8rem;
@@ -46,6 +52,8 @@
     }
 
     .BillingGaugeItem__section {
+        pointer-events: auto;
+
         // Usage at or below the billing limit — what the user actually pays for.
         &--paid {
             background: var(--brand-blue);

--- a/frontend/src/scenes/billing/BillingGauge.stories.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.stories.tsx
@@ -1,0 +1,106 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { screen } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
+import billingJsonWithBillingLimits from '~/mocks/fixtures/_billing_with_billing_limits.json'
+import { BillingProductV2Type, BillingType } from '~/types'
+
+import { createGaugeItems } from './billing-utils'
+import { BillingGauge } from './BillingGauge'
+
+// These stories render the usage gauge in isolation so the bar treatments (and their hover
+// tooltips) are easy to review without the noise of the whole billing page.
+//
+// Everything is derived from the real `_billing_with_billing_limits.json` demo payload rather than
+// hand-picked numbers: product analytics there has a $500 billing limit, which the API maps to a
+// usage limit of ~3.46M events (well above the 1M free tier — a limit can never sit below the free
+// tier). Each scenario only varies current/projected usage within valid ranges; the tiers, pricing
+// and limit stay real, so "what you'll pay" tooltips show genuine amounts.
+const billing = billingJsonWithBillingLimits as unknown as BillingType
+const productAnalytics = billing.products.find(
+    (product) => product.type === 'product_analytics'
+) as BillingProductV2Type
+const USAGE_LIMIT = productAnalytics.usage_limit ?? 0
+
+function GaugeDemo({ currentUsage, projectedUsage }: { currentUsage: number; projectedUsage: number }): JSX.Element {
+    const product: BillingProductV2Type = {
+        ...productAnalytics,
+        current_usage: currentUsage,
+        projected_usage: projectedUsage,
+        percentage_usage: USAGE_LIMIT ? currentUsage / USAGE_LIMIT : 0,
+    }
+    const items = createGaugeItems(product, { billing, billingLimitAsUsage: USAGE_LIMIT })
+    return (
+        <div className="w-[900px] p-8">
+            <BillingGauge items={items} product={product} billing={billing} />
+        </div>
+    )
+}
+
+// The section tooltips render into a portal on document.body, so we query via `screen` (global)
+// rather than the story canvas. Awaiting the tooltip copy both proves it opened and holds the
+// snapshot until it's on screen.
+async function hoverSectionAndWaitForTooltip(selector: string, tooltipText: RegExp): Promise<void> {
+    const section = document.querySelector(selector)
+    if (!section) {
+        throw new Error(`Could not find gauge section "${selector}"`)
+    }
+    await userEvent.hover(section)
+    await screen.findByText(tooltipText, undefined, { timeout: 3000 })
+}
+
+const meta: Meta<typeof BillingGauge> = {
+    title: 'Scenes-Other/Billing/BillingGauge',
+    component: BillingGauge,
+}
+export default meta
+
+type Story = StoryObj<typeof BillingGauge>
+
+// Current and projected both below the limit: solid blue usage, blue forecast stripes, and the free
+// tier + billing limit tick markers all sit apart.
+export const WithinLimit: Story = {
+    render: () => <GaugeDemo currentUsage={1_800_000} projectedUsage={2_900_000} />,
+}
+
+// Current below the limit but forecast to blow past it: the forecast stripes carry on past the
+// billing limit marker, so the overshoot is obvious.
+export const ForecastExceedsLimit: Story = {
+    render: () => <GaugeDemo currentUsage={1_800_000} projectedUsage={4_500_000} />,
+}
+
+// The full mix: usage is already over the limit (solid blue up to the limit, desaturated grey
+// stripes above it), with the forecast layered on top in the opposite-angle stripes.
+export const UsageExceedsLimit: Story = {
+    render: () => <GaugeDemo currentUsage={4_200_000} projectedUsage={4_900_000} />,
+}
+
+export const UsageExceedsLimitPaidHovered: Story = {
+    render: () => <GaugeDemo currentUsage={4_200_000} projectedUsage={4_900_000} />,
+    play: async () => {
+        await hoverSectionAndWaitForTooltip(
+            '.BillingGaugeItem__section--paid',
+            /What you'll pay for Product analytics/i
+        )
+    },
+}
+
+export const UsageExceedsLimitOverLimitHovered: Story = {
+    render: () => <GaugeDemo currentUsage={4_200_000} projectedUsage={4_900_000} />,
+    play: async () => {
+        await hoverSectionAndWaitForTooltip(
+            '.BillingGaugeItem__section--over-limit',
+            /won't be charged for usage above your billing limit/i
+        )
+    },
+}
+
+export const UsageExceedsLimitForecastHovered: Story = {
+    render: () => <GaugeDemo currentUsage={4_200_000} projectedUsage={4_900_000} />,
+    play: async () => {
+        await hoverSectionAndWaitForTooltip(
+            '.BillingGaugeItem--projected_usage .BillingGaugeItem__section',
+            /Projected usage by the end/i
+        )
+    },
+}

--- a/frontend/src/scenes/billing/BillingGauge.test.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.test.tsx
@@ -55,24 +55,55 @@ describe('BillingGauge', () => {
         expect(forecast?.style.left).toBe('50%')
     })
 
-    it('does not split the bar when usage is below the billing limit', () => {
-        const { container } = render(
-            <BillingGauge items={usageItems(2, 3)} product={makeProduct({ percentage_usage: 2 / 3 })} />
-        )
+    it.each([
+        {
+            name: 'usage is below the billing limit',
+            items: usageItems(2, 3),
+            product: makeProduct({ percentage_usage: 2 / 3 }),
+        },
+        {
+            // Monetary items carry a `$` prefix — usage-based paid/not-charged semantics don't apply.
+            name: 'the gauge is monetary ($) even when over the limit',
+            items: [
+                { type: BillingGaugeItemKind.BillingLimit, text: 'Billing limit', value: 3, prefix: '$' },
+                { type: BillingGaugeItemKind.CurrentUsage, text: 'Current', value: 8, prefix: '$' },
+            ] as BillingGaugeItemType[],
+            product: makeProduct({ unit: '$', percentage_usage: 8 / 3 }),
+        },
+        {
+            // Free/unsubscribed products carry a usage_limit (~free allocation) with tiers: null — with no
+            // pricing we can't say what's "paid", so the bar must not split.
+            name: 'the product has no tier pricing',
+            items: [
+                { type: BillingGaugeItemKind.BillingLimit, text: 'Billing limit', value: 3 },
+                { type: BillingGaugeItemKind.FreeTier, text: 'Free tier limit', value: 3 },
+                { type: BillingGaugeItemKind.CurrentUsage, text: 'Current', value: 8 },
+            ] as BillingGaugeItemType[],
+            product: makeProduct({ tiers: null, percentage_usage: 8 / 3 }),
+        },
+    ])('does not split the current usage bar when $name', ({ items, product }) => {
+        const { container } = render(<BillingGauge items={items} product={product} />)
 
         expect(container.querySelector('.BillingGaugeItem__section--paid')).not.toBeInTheDocument()
         expect(container.querySelector('.BillingGaugeItem__section--over-limit')).not.toBeInTheDocument()
     })
 
-    it('does not split the monetary ($) gauge even when over the limit', () => {
+    it('does not render the usage forecast section on a monetary ($) gauge', () => {
+        // Forecast math divides usage units by the projected value; on a $ gauge that would mix units,
+        // so the projected section (and its "Projected usage" copy) must not render.
         const items: BillingGaugeItemType[] = [
-            { type: BillingGaugeItemKind.BillingLimit, text: 'Billing limit', value: 3, prefix: '$' },
             { type: BillingGaugeItemKind.CurrentUsage, text: 'Current', value: 8, prefix: '$' },
+            { type: BillingGaugeItemKind.ProjectedUsage, text: 'Projected', value: 16, prefix: '$' },
         ]
         const { container } = render(
-            <BillingGauge items={items} product={makeProduct({ unit: '$', percentage_usage: 8 / 3 })} />
+            <BillingGauge
+                items={items}
+                product={makeProduct({ unit: '$', current_usage: 8, percentage_usage: 8 / 3 })}
+            />
         )
 
-        expect(container.querySelector('.BillingGaugeItem__section--paid')).not.toBeInTheDocument()
+        expect(
+            container.querySelector('.BillingGaugeItem--projected_usage .BillingGaugeItem__section')
+        ).not.toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/billing/BillingGauge.test.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render } from '@testing-library/react'
+
+import { BillingProductV2Type } from '~/types'
+
+import { BillingGauge } from './BillingGauge'
+import { BillingGaugeItemKind, BillingGaugeItemType } from './types'
+
+const makeProduct = (overrides: Partial<BillingProductV2Type> = {}): BillingProductV2Type =>
+    ({
+        type: 'product_analytics',
+        tiers: [{ up_to: null, unit_amount_usd: '0.5', flat_amount_usd: '0', current_amount_usd: '0' }],
+        percentage_usage: 0,
+        ...overrides,
+    }) as BillingProductV2Type
+
+const usageItems = (current: number, limit: number): BillingGaugeItemType[] => [
+    { type: BillingGaugeItemKind.BillingLimit, text: 'Billing limit', value: limit },
+    { type: BillingGaugeItemKind.CurrentUsage, text: 'Current', value: current },
+]
+
+describe('BillingGauge', () => {
+    afterEach(cleanup)
+
+    it('splits the current usage bar at the billing limit when over it', () => {
+        // usage 8 over a limit of 3 -> paid section covers 3/8 = 37.5% of the bar, rest is not charged
+        const { container } = render(
+            <BillingGauge items={usageItems(8, 3)} product={makeProduct({ percentage_usage: 8 / 3 })} />
+        )
+
+        const paid = container.querySelector<HTMLElement>('.BillingGaugeItem__section--paid')
+        const overLimit = container.querySelector<HTMLElement>('.BillingGaugeItem__section--over-limit')
+
+        expect(paid).toBeInTheDocument()
+        expect(overLimit).toBeInTheDocument()
+        expect(paid?.style.width).toBe('37.5%')
+        expect(overLimit?.style.left).toBe('37.5%')
+    })
+
+    it('does not split the bar when usage is below the billing limit', () => {
+        const { container } = render(
+            <BillingGauge items={usageItems(2, 3)} product={makeProduct({ percentage_usage: 2 / 3 })} />
+        )
+
+        expect(container.querySelector('.BillingGaugeItem__section--paid')).not.toBeInTheDocument()
+        expect(container.querySelector('.BillingGaugeItem__section--over-limit')).not.toBeInTheDocument()
+    })
+
+    it('does not split the monetary ($) gauge even when over the limit', () => {
+        const items: BillingGaugeItemType[] = [
+            { type: BillingGaugeItemKind.BillingLimit, text: 'Billing limit', value: 3, prefix: '$' },
+            { type: BillingGaugeItemKind.CurrentUsage, text: 'Current', value: 8, prefix: '$' },
+        ]
+        const { container } = render(
+            <BillingGauge items={items} product={makeProduct({ unit: '$', percentage_usage: 8 / 3 })} />
+        )
+
+        expect(container.querySelector('.BillingGaugeItem__section--paid')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/billing/BillingGauge.test.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.test.tsx
@@ -38,6 +38,23 @@ describe('BillingGauge', () => {
         expect(overLimit?.style.left).toBe('37.5%')
     })
 
+    it('confines the projected forecast hover to the span beyond current usage', () => {
+        // projected 16 over current 8 -> forecast section starts at 8/16 = 50%, leaving the paid/
+        // over-limit sections (0..current) reachable underneath instead of occluded by a full overlay.
+        const items: BillingGaugeItemType[] = [
+            ...usageItems(8, 3),
+            { type: BillingGaugeItemKind.ProjectedUsage, text: 'Projected', value: 16 },
+        ]
+        const { container } = render(
+            <BillingGauge items={items} product={makeProduct({ current_usage: 8, percentage_usage: 8 / 3 })} />
+        )
+
+        const forecast = container.querySelector<HTMLElement>(
+            '.BillingGaugeItem--projected_usage .BillingGaugeItem__section'
+        )
+        expect(forecast?.style.left).toBe('50%')
+    })
+
     it('does not split the bar when usage is below the billing limit', () => {
         const { container } = render(
             <BillingGauge items={usageItems(2, 3)} product={makeProduct({ percentage_usage: 2 / 3 })} />

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -64,8 +64,12 @@ const BillingGaugeItem = ({
 
     // Split the current usage bar at the billing limit: the part at or below the limit is what the
     // user pays for (solid), the part above is not charged (striped + desaturated). We only do this on
-    // usage gauges (not the monetary `$` gauge, which carries a `prefix`) where a limit is actually set.
-    const hasLimit = item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit
+    // usage gauges (not the monetary `$` gauge, which carries a `prefix`) where a limit is actually set
+    // AND we can price the usage. Free/unsubscribed products carry a `usage_limit` (often equal to the
+    // free allocation) with `tiers: null` — without tiers we can't price anything, so we must not
+    // invent paid/not-charged semantics.
+    const hasLimit =
+        item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit && !!product?.tiers?.length
     const isOverLimit = hasLimit && item.value > (billingLimit as number)
     const paidUsage = hasLimit ? Math.min(item.value, billingLimit as number) : item.value
     const paidAmountUsd = hasLimit ? getPaidAmountUsd(paidUsage, product, discountPercent) : null
@@ -81,9 +85,11 @@ const BillingGaugeItem = ({
     // The projected/forecast bar spans 0..projected and paints over the current-usage bar. We only
     // want its explanatory hover on the *incremental* part beyond current usage — the rest must stay
     // transparent to pointer events so the paid/over-limit tooltips underneath remain reachable.
-    const isProjected = item.type === BillingGaugeItemKind.ProjectedUsage
+    // Only usage gauges get the forecast hover: `currentUsage` is in usage units, so dividing it by a
+    // monetary (`$`-prefixed) projected value would mix units and mislabel dollars as "usage".
+    const isProjectedUsage = item.type === BillingGaugeItemKind.ProjectedUsage && !item.prefix
     const currentUsage = product?.current_usage ?? 0
-    const projectedForecastFraction = isProjected && item.value > 0 ? Math.min(currentUsage / item.value, 1) : 0
+    const projectedForecastFraction = isProjectedUsage && item.value > 0 ? Math.min(currentUsage / item.value, 1) : 0
 
     return (
         <div
@@ -115,7 +121,7 @@ const BillingGaugeItem = ({
                         />
                     </Tooltip>
                 </>
-            ) : isProjected ? (
+            ) : isProjectedUsage ? (
                 <Tooltip title="Projected usage by the end of your billing period">
                     <div
                         className="BillingGaugeItem__section absolute top-0 bottom-0 right-0"

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -65,7 +65,8 @@ const BillingGaugeItem = ({
     // Split the current usage bar at the billing limit: the part at or below the limit is what the
     // user pays for (solid), the part above is not charged (striped + desaturated). We only do this on
     // usage gauges (not the monetary `$` gauge, which carries a `prefix`) where a limit is actually set.
-    const hasLimit = item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit && billingLimit > 0
+    const hasLimit =
+        item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit && billingLimit > 0
     const isOverLimit = hasLimit && item.value > (billingLimit as number)
     const paidUsage = hasLimit ? Math.min(item.value, billingLimit as number) : item.value
     const paidAmountUsd = hasLimit ? getPaidAmountUsd(paidUsage, product, discountPercent) : null

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -4,11 +4,33 @@ import clsx from 'clsx'
 import { useMemo } from 'react'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { humanFriendlyCurrency } from 'lib/utils/numbers'
 
-import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
+import { BillingProductV2AddonType, BillingProductV2Type, BillingType } from '~/types'
 
-import { createProductValueFormatter, formatDisplayUsage, hasDisplayFormatting } from './billing-utils'
-import { BillingGaugeItemType } from './types'
+import {
+    convertUsageToAmount,
+    createProductValueFormatter,
+    formatDisplayUsage,
+    hasDisplayFormatting,
+} from './billing-utils'
+import { BillingGaugeItemKind, BillingGaugeItemType } from './types'
+
+/**
+ * The USD amount a user will actually be charged for `usage` units of a tiered product,
+ * i.e. the cost of the portion of usage that sits at or below their billing limit.
+ * Returns null when we can't price the usage (non-tiered products).
+ */
+const getPaidAmountUsd = (
+    usage: number,
+    product?: BillingProductV2Type | BillingProductV2AddonType,
+    discountPercent?: number
+): number | null => {
+    if (!product?.tiers) {
+        return null
+    }
+    return parseFloat(convertUsageToAmount(usage, [product.tiers], discountPercent))
+}
 
 /*
  * Billing Gauge Item: Individual bars on the billing gauge.
@@ -19,6 +41,9 @@ type BillingGaugeItemProps = {
     isWithinUsageLimit: boolean
     isTop: boolean
     product?: BillingProductV2Type | BillingProductV2AddonType
+    /** Usage value of the billing limit, when the product has one set. */
+    billingLimit?: number
+    discountPercent?: number
 }
 
 const BillingGaugeItem = ({
@@ -27,6 +52,8 @@ const BillingGaugeItem = ({
     isWithinUsageLimit,
     isTop,
     product,
+    billingLimit,
+    discountPercent,
 }: BillingGaugeItemProps): JSX.Element => {
     const width = `${(item.value / maxValue) * 100}%`
 
@@ -35,18 +62,60 @@ const BillingGaugeItem = ({
     const tooltipValue =
         product && hasDisplayFormatting(product) ? formatDisplayUsage(item.value, product) : item.value.toLocaleString()
 
+    // Split the current usage bar at the billing limit: the part at or below the limit is what the
+    // user pays for (solid), the part above is not charged (striped + desaturated). We only do this on
+    // usage gauges (not the monetary `$` gauge, which carries a `prefix`) where a limit is actually set.
+    const hasLimit = item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit && billingLimit > 0
+    const isOverLimit = hasLimit && item.value > (billingLimit as number)
+    const paidUsage = hasLimit ? Math.min(item.value, billingLimit as number) : item.value
+    const paidAmountUsd = hasLimit ? getPaidAmountUsd(paidUsage, product, discountPercent) : null
+    // Fraction of this bar (which spans 0..item.value) that sits at or below the limit.
+    const paidFraction = isOverLimit ? (billingLimit as number) / item.value : 1
+
     return (
         <div
             className={clsx(
                 `BillingGaugeItem BillingGaugeItem--${item.type}`,
                 {
                     'BillingGaugeItem--within-usage-limit': isWithinUsageLimit,
+                    'BillingGaugeItem--split': isOverLimit,
                 },
                 'absolute top-0 left-0 bottom-0 h-2'
             )}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ '--billing-gauge-item-width': width } as React.CSSProperties}
         >
+            {isOverLimit ? (
+                <>
+                    <Tooltip
+                        title={
+                            paidAmountUsd !== null
+                                ? `What you'll pay: ${humanFriendlyCurrency(paidAmountUsd)}`
+                                : 'Usage you pay for'
+                        }
+                    >
+                        <div
+                            className="BillingGaugeItem__section BillingGaugeItem__section--paid absolute top-0 bottom-0 left-0"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ width: `${paidFraction * 100}%` }}
+                        />
+                    </Tooltip>
+                    <Tooltip title="You won't be charged for usage above your billing limit">
+                        <div
+                            className="BillingGaugeItem__section BillingGaugeItem__section--over-limit absolute top-0 bottom-0 right-0"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ left: `${paidFraction * 100}%` }}
+                        />
+                    </Tooltip>
+                </>
+            ) : (
+                hasLimit &&
+                paidAmountUsd !== null && (
+                    <Tooltip title={`What you'll pay: ${humanFriendlyCurrency(paidAmountUsd)}`}>
+                        <div className="absolute inset-0" />
+                    </Tooltip>
+                )
+            )}
             <div className="absolute right-0 w-px h-full bg-surface-primary" />
             <Tooltip title={item.prefix ? `${item.prefix}${tooltipValue}` : tooltipValue} placement="right">
                 <div
@@ -68,9 +137,10 @@ const BillingGaugeItem = ({
 export type BillingGaugeProps = {
     items: BillingGaugeItemType[]
     product: BillingProductV2Type | BillingProductV2AddonType
+    billing?: BillingType | null
 }
 
-export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element {
+export function BillingGauge({ items, product, billing }: BillingGaugeProps): JSX.Element {
     const maxValue = useMemo(() => {
         return Math.max(100, ...items.map((item) => item.value)) * 1.3
     }, [items])
@@ -79,6 +149,12 @@ export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element
     const sortedItems = useMemo(() => {
         return [...items].sort((a, b) => a.value - b.value)
     }, [items])
+
+    const billingLimit = useMemo(
+        () => items.find((item) => item.type === BillingGaugeItemKind.BillingLimit)?.value,
+        [items]
+    )
+    const discountPercent = billing?.discount_percent || undefined
 
     return (
         <div className="relative h-2 bg-border-light my-16">
@@ -90,6 +166,8 @@ export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element
                     isWithinUsageLimit={isWithinUsageLimit}
                     isTop={i % 2 !== 0}
                     product={product}
+                    billingLimit={billingLimit}
+                    discountPercent={discountPercent}
                 />
             ))}
         </div>

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -65,8 +65,7 @@ const BillingGaugeItem = ({
     // Split the current usage bar at the billing limit: the part at or below the limit is what the
     // user pays for (solid), the part above is not charged (striped + desaturated). We only do this on
     // usage gauges (not the monetary `$` gauge, which carries a `prefix`) where a limit is actually set.
-    const hasLimit =
-        item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit && billingLimit > 0
+    const hasLimit = item.type === BillingGaugeItemKind.CurrentUsage && !item.prefix && !!billingLimit
     const isOverLimit = hasLimit && item.value > (billingLimit as number)
     const paidUsage = hasLimit ? Math.min(item.value, billingLimit as number) : item.value
     const paidAmountUsd = hasLimit ? getPaidAmountUsd(paidUsage, product, discountPercent) : null
@@ -155,7 +154,7 @@ export function BillingGauge({ items, product, billing }: BillingGaugeProps): JS
         () => items.find((item) => item.type === BillingGaugeItemKind.BillingLimit)?.value,
         [items]
     )
-    const discountPercent = billing?.discount_percent || undefined
+    const discountPercent = billing?.discount_percent ?? undefined
 
     return (
         <div className="relative h-2 bg-border-light my-16">

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -73,6 +73,12 @@ const BillingGaugeItem = ({
     // Fraction of this bar (which spans 0..item.value) that sits at or below the limit.
     const paidFraction = isOverLimit ? (billingLimit as number) / item.value : 1
 
+    // Scoped to this product because we price only its tiers, not any addons folded into the total.
+    const paidLabel =
+        paidAmountUsd !== null
+            ? `What you'll pay for ${product?.name ?? 'this'}: ${humanFriendlyCurrency(paidAmountUsd)}`
+            : 'Usage you pay for'
+
     return (
         <div
             className={clsx(
@@ -88,13 +94,7 @@ const BillingGaugeItem = ({
         >
             {isOverLimit ? (
                 <>
-                    <Tooltip
-                        title={
-                            paidAmountUsd !== null
-                                ? `What you'll pay: ${humanFriendlyCurrency(paidAmountUsd)}`
-                                : 'Usage you pay for'
-                        }
-                    >
+                    <Tooltip title={paidLabel}>
                         <div
                             className="BillingGaugeItem__section BillingGaugeItem__section--paid absolute top-0 bottom-0 left-0"
                             // eslint-disable-next-line react/forbid-dom-props
@@ -112,8 +112,8 @@ const BillingGaugeItem = ({
             ) : (
                 hasLimit &&
                 paidAmountUsd !== null && (
-                    <Tooltip title={`What you'll pay: ${humanFriendlyCurrency(paidAmountUsd)}`}>
-                        <div className="absolute inset-0" />
+                    <Tooltip title={paidLabel}>
+                        <div className="BillingGaugeItem__section absolute inset-0" />
                     </Tooltip>
                 )
             )}

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -78,6 +78,13 @@ const BillingGaugeItem = ({
             ? `What you'll pay for ${product?.name ?? 'this'}: ${humanFriendlyCurrency(paidAmountUsd)}`
             : 'Usage you pay for'
 
+    // The projected/forecast bar spans 0..projected and paints over the current-usage bar. We only
+    // want its explanatory hover on the *incremental* part beyond current usage — the rest must stay
+    // transparent to pointer events so the paid/over-limit tooltips underneath remain reachable.
+    const isProjected = item.type === BillingGaugeItemKind.ProjectedUsage
+    const currentUsage = product?.current_usage ?? 0
+    const projectedForecastFraction = isProjected && item.value > 0 ? Math.min(currentUsage / item.value, 1) : 0
+
     return (
         <div
             className={clsx(
@@ -108,6 +115,14 @@ const BillingGaugeItem = ({
                         />
                     </Tooltip>
                 </>
+            ) : isProjected ? (
+                <Tooltip title="Projected usage by the end of your billing period">
+                    <div
+                        className="BillingGaugeItem__section absolute top-0 bottom-0 right-0"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ left: `${projectedForecastFraction * 100}%` }}
+                    />
+                </Tooltip>
             ) : (
                 hasLimit &&
                 paidAmountUsd !== null && (

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -233,6 +233,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                     <BillingGauge
                                         items={combinedMonetaryGaugeItems}
                                         product={{ ...product, unit: '$' }}
+                                        billing={billing}
                                     />
                                 </div>
                                 <Tooltip
@@ -333,6 +334,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                                                     : createGaugeItems(variant.product)
                                                             }
                                                             product={variant.product}
+                                                            billing={billing}
                                                         />
                                                     </div>
                                                     <BillingProductPricingTable product={variant.product} />
@@ -361,7 +363,11 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                             <h4 className="font-bold">{variant.displayName}</h4>
                                             <div className="sm:flex w-full items-center gap-x-8">
                                                 <div className="grow -my-4">
-                                                    <BillingGauge items={variantGaugeItems} product={variant.product} />
+                                                    <BillingGauge
+                                                        items={variantGaugeItems}
+                                                        product={variant.product}
+                                                        billing={billing}
+                                                    />
                                                 </div>
                                             </div>
                                         </div>
@@ -396,7 +402,11 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                         {isTemporaryFreeProduct ? (
                                             <div className="grow">
                                                 <div className="grow">
-                                                    <BillingGauge items={billingGaugeItems} product={product} />
+                                                    <BillingGauge
+                                                        items={billingGaugeItems}
+                                                        product={product}
+                                                        billing={billing}
+                                                    />
                                                 </div>
                                                 {/* TODO: rms: remove this notice after August 8 2024 */}
                                                 {product.type == ProductKey.DATA_WAREHOUSE &&
@@ -429,7 +439,11 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                                         />
                                                     )}
                                                     <div className="grow">
-                                                        <BillingGauge items={billingGaugeItems} product={product} />
+                                                        <BillingGauge
+                                                            items={billingGaugeItems}
+                                                            product={product}
+                                                            billing={billing}
+                                                        />
                                                     </div>
                                                 </div>
                                                 {product.subscribed ? (


### PR DESCRIPTION
## Problem

On the billing limits page, the usage gauge renders the whole current-usage bar in one color and just flips it red once usage crosses the limit. When a user goes over their billing limit, that over-limit usage isn't actually charged, but nothing on the bar makes that obvious. Users can't tell which part of their usage they'll pay for and which part is free.

Raised in a Slack thread: https://posthog.slack.com/archives/C09SK2PAGKF/p1782987174942569?thread_ts=1782987174.942569&cid=C09SK2PAGKF

## Changes

- The current-usage bar now splits at the billing limit: the portion at or below the limit stays solid (what you pay for), and the portion above is striped and desaturated (not charged).
- Hovering each section shows a tooltip. The paid section shows "What you'll pay: $X" (priced from the product tiers and any account discount), and the over-limit section explains that usage above the billing limit isn't charged.
- When usage is under the limit, hovering the bar still shows the "What you'll pay" amount.
- This applies only to usage gauges where a billing limit is set. The monetary `$` gauge and gauges without a limit (e.g. free-tier / credits) are unchanged.
- The pay tooltip is scoped to the product name ("What you'll pay for X"), since it prices only that product's tiers, not addons folded into the account total.
- Gauge bars are now `pointer-events: none` with the interactive labels/sections opted back in. Bars are absolutely-positioned siblings that stack by DOM order, so a higher-value bar (projected usage, or the limit/free-tier markers) was painting on top of the current-usage bar and intercepting hover - which would have made the new tooltips unreachable. Side benefit: existing gauge labels are now individually hoverable regardless of stacking.

## How did you test this code?

- Added `BillingGauge.test.tsx`, a render smoke test with 3 cases: over-limit usage splits the bar into a paid section (width = limit/usage) and a not-charged section, under-limit usage doesn't split, and the monetary `$` gauge is excluded from the split. All 3 pass.
- Ran oxlint + oxfmt on the changed files (clean).
- Ran the TypeScript check: no errors in the billing files touched here. (The full-repo check reports pre-existing errors in unrelated files that are just missing kea typegen artifacts in a fresh checkout - CI regenerates those.)

I have not done a manual visual check in a running app. Still worth a look on the billing page for a product over its limit, one under its limit, and the monetary variants gauge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marce asked for this from Slack after noticing a user went well over their billing limit without being charged, and that the existing bar was hard to parse. I (the PostHog Slack app, via Claude) made the changes.

Approach: I kept the split logic inside `BillingGaugeItem` rather than reshaping the gauge item list, so `createGaugeItems` and its other callers stay untouched. The billing limit value is read from the existing `BillingLimit` gauge item, and the discount comes from a new optional `billing` prop threaded through `BillingGauge`. Paid amounts reuse `convertUsageToAmount` from `billing-utils`. I scoped the behavior to usage gauges (skipping the `$` monetary gauge) to avoid the subtleties of discounted-dollar limits there.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782987174942569?thread_ts=1782987174.942569&cid=C09SK2PAGKF)*


