### PR TITLE
fix(csp): buffer capture-forward off the request path

### DIFF
--- a/posthog/api/report.py
+++ b/posthog/api/report.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -6,6 +7,7 @@ from rest_framework import status
 
 from posthog.api.capture import CaptureInternalError, capture_batch_internal, capture_internal
 from posthog.api.csp import process_csp_report
+from posthog.api.report_buffer import csp_report_buffer
 from posthog.api.utils import get_token
 from posthog.exceptions import generate_exception_response
 from posthog.exceptions_capture import capture_exception
@@ -57,6 +59,24 @@ def get_csp_event(request):
         token = get_token(csp_report, request)
         if not token:
             token = ""
+
+        if settings.CSP_REPORT_BUFFERED_FORWARD:
+            # Missing token would fail capture-side validation; without the synchronous
+            # round-trip that has to be surfaced before enqueueing.
+            if not token:
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "csp_report_capture",
+                        f"Failed to submit CSP report",
+                        code="capture_error",
+                        type="capture_error",
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                    ),
+                )
+            events = csp_report if isinstance(csp_report, list) else [csp_report]
+            csp_report_buffer.enqueue(events, token=token)
+            return cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
         if isinstance(csp_report, list):
             result = capture_batch_internal(

--- a/posthog/api/report.py
+++ b/posthog/api/report.py
@@ -61,8 +61,8 @@ def get_csp_event(request):
             token = ""
 
         if settings.CSP_REPORT_BUFFERED_FORWARD:
-            # Missing token would fail capture-side validation; without the synchronous
-            # round-trip that has to be surfaced before enqueueing.
+            # Buffered mode never makes the synchronous capture call that would
+            # reject an empty token, so reject it here before enqueueing.
             if not token:
                 return cors_response(
                     request,

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -8,7 +8,8 @@ sender thread batches events to ``capture_batch_internal``.
 
 CSP reporting is best-effort by contract: oversized events and events beyond a
 token's fair share of the buffer are dropped, on count or byte overflow the
-oldest queued events are evicted, and buffered events are lost if the process
+oldest queued events are evicted, events still unsent when a flush exceeds its
+wall-clock deadline are dropped, and buffered events are lost if the process
 dies before the final drain (all drops counted in ``csp_report_buffer_dropped``).
 Browsers never read report responses, so callers get no delivery guarantee
 either way.
@@ -18,6 +19,7 @@ from __future__ import annotations
 
 import os
 import json
+import time
 import queue
 import atexit
 import threading
@@ -31,6 +33,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.settings.ingestion import (
     CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
     CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+    CSP_REPORT_BUFFER_FLUSH_MAX_SECONDS,
     CSP_REPORT_BUFFER_MAX_BYTES,
     CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     CSP_REPORT_BUFFER_MAX_EVENTS,
@@ -69,12 +72,14 @@ class CspReportBuffer:
         maxsize: int = CSP_REPORT_BUFFER_MAX_EVENTS,
         flush_interval: float = CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
         flush_max_events: int = CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+        flush_max_seconds: float = CSP_REPORT_BUFFER_FLUSH_MAX_SECONDS,
         max_token_share: float = CSP_REPORT_BUFFER_MAX_TOKEN_SHARE,
         max_bytes: int = CSP_REPORT_BUFFER_MAX_BYTES,
         max_event_bytes: int = CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     ) -> None:
         self.flush_interval = flush_interval
         self.flush_max_events = flush_max_events
+        self.flush_max_seconds = flush_max_seconds
         self.max_bytes = max_bytes
         self.max_event_bytes = max_event_bytes
         # maxsize=0 makes queue.Queue unbounded, which silently removes the count
@@ -220,7 +225,27 @@ class CspReportBuffer:
         by_token: dict[str, list[dict[str, Any]]] = {}
         for token, event, _ in items:
             by_token.setdefault(token, []).append(event)
-        for token, events in by_token.items():
+        # Token groups are submitted serially and tokens are attacker-controlled
+        # (only capture-rs validates them), so a flood of distinct tokens against
+        # a slow capture-rs would otherwise multiply the per-call transport
+        # budget by up to flush_max_events groups — stalling the sender while
+        # the queue evicts everything behind it. The deadline bounds the whole
+        # flush; only the last group started before it can overshoot (by one
+        # call's transport budget). Groups past the deadline are dropped and
+        # counted, matching the buffer's best-effort contract.
+        deadline = time.monotonic() + self.flush_max_seconds
+        groups = list(by_token.items())
+        for index, (token, events) in enumerate(groups):
+            if time.monotonic() > deadline:
+                remaining = sum(len(group_events) for _, group_events in groups[index:])
+                CSP_BUFFER_DROPPED.labels(reason="flush_deadline").inc(remaining)
+                logger.warning(
+                    "csp_report_buffer_flush_deadline",
+                    dropped=remaining,
+                    groups_left=len(groups) - index,
+                    flush_max_seconds=self.flush_max_seconds,
+                )
+                break
             try:
                 # max_attempts=1: token groups are submitted serially, so a
                 # degraded capture-rs must not multiply its timeout by resubmit
@@ -255,9 +280,10 @@ class CspReportBuffer:
                 )
 
     def _drain_on_exit(self) -> None:
-        # Best-effort final flush of at most one batch. The capture call itself can
-        # still take its full timeout/retry budget — that has to fit inside the
-        # pod's termination grace, it is not bounded here.
+        # Best-effort final flush of at most one batch, bounded by the same flush
+        # deadline as regular flushes — flush_max_seconds (plus one call's
+        # transport budget of overshoot) has to fit inside the pod's termination
+        # grace.
         items: list[tuple[str, dict[str, Any], int]] = []
         while len(items) < self.flush_max_events:
             try:

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -6,16 +6,18 @@ retry budget), which starves bounded worker pools when capture-rs degrades. This
 buffer decouples the two: the view enqueues and returns immediately, a background
 sender thread batches events to ``capture_batch_internal``.
 
-CSP reporting is best-effort by contract: events beyond a token's fair share of
-the buffer are dropped, on overflow the oldest queued events are evicted, and
-buffered events are lost if the process dies before the final drain (all drops
-counted in ``csp_report_buffer_dropped``). Browsers never read report responses,
-so callers get no delivery guarantee either way.
+CSP reporting is best-effort by contract: oversized events and events beyond a
+token's fair share of the buffer are dropped, on count or byte overflow the
+oldest queued events are evicted, and buffered events are lost if the process
+dies before the final drain (all drops counted in ``csp_report_buffer_dropped``).
+Browsers never read report responses, so callers get no delivery guarantee
+either way.
 """
 
 from __future__ import annotations
 
 import os
+import json
 import queue
 import atexit
 import threading
@@ -29,6 +31,8 @@ from posthog.exceptions_capture import capture_exception
 from posthog.settings.ingestion import (
     CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
     CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+    CSP_REPORT_BUFFER_MAX_BYTES,
+    CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     CSP_REPORT_BUFFER_MAX_EVENTS,
 )
 
@@ -64,10 +68,14 @@ class CspReportBuffer:
         flush_interval: float = CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
         flush_max_events: int = CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
         max_token_share: float = 0.5,
+        max_bytes: int = CSP_REPORT_BUFFER_MAX_BYTES,
+        max_event_bytes: int = CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     ) -> None:
         self.flush_interval = flush_interval
         self.flush_max_events = flush_max_events
-        self._queue: queue.Queue[tuple[str, dict[str, Any]]] = queue.Queue(maxsize=maxsize)
+        self.max_bytes = max_bytes
+        self.max_event_bytes = max_event_bytes
+        self._queue: queue.Queue[tuple[str, dict[str, Any], int]] = queue.Queue(maxsize=maxsize)
         self._lock = threading.Lock()
         self._sender: threading.Thread | None = None
         # Sender threads don't survive fork, so remember which process started ours.
@@ -81,32 +89,43 @@ class CspReportBuffer:
         # events on overflow.
         self._token_cap = max(1, int(maxsize * max_token_share))
         self._token_counts: dict[str, int] = {}
+        # Byte accounting: the count cap alone doesn't bound memory, events carry
+        # the raw report body. Guarded by _counts_lock like the token counts.
+        self._total_bytes = 0
         self._counts_lock = threading.Lock()
 
     def enqueue(self, events: list[dict[str, Any]], *, token: str) -> None:
         """Add events to the buffer without ever blocking the caller.
 
-        A token over its share drops its own incoming events; on overflow the
-        globally oldest events are evicted so fresh reports win across tokens.
+        Oversized events and a token over its share drop the incoming event; on
+        count or byte overflow the globally oldest events are evicted so fresh
+        reports win across tokens.
         """
         self._ensure_sender()
         accepted = 0
         for event in events:
+            # Serialized length bounds both the single event (request bodies can
+            # be far larger than any legitimate CSP report) and, summed, the
+            # buffer's total memory footprint.
+            size = len(json.dumps(event, default=str))
+            if size > self.max_event_bytes:
+                CSP_BUFFER_DROPPED.labels(reason="oversized").inc()
+                continue
             if not self._reserve_slot(token):
                 CSP_BUFFER_DROPPED.labels(reason="token_share").inc()
                 continue
             while True:
                 try:
-                    self._queue.put_nowait((token, event))
-                    accepted += 1
+                    self._queue.put_nowait((token, event, size))
                     break
                 except queue.Full:
-                    try:
-                        evicted_token, _ = self._queue.get_nowait()
-                        self._release_slot(evicted_token)
-                        CSP_BUFFER_DROPPED.labels(reason="overflow").inc()
-                    except queue.Empty:
-                        continue
+                    self._evict_oldest("overflow")
+            with self._counts_lock:
+                self._total_bytes += size
+            accepted += 1
+            while self._total_bytes > self.max_bytes:
+                if not self._evict_oldest("bytes_overflow"):
+                    break
         CSP_BUFFER_ENQUEUED.inc(accepted)
         CSP_BUFFER_DEPTH.set(self._queue.qsize())
 
@@ -124,6 +143,17 @@ class CspReportBuffer:
                 self._token_counts[token] = remaining
             else:
                 self._token_counts.pop(token, None)
+
+    def _evict_oldest(self, reason: str) -> bool:
+        try:
+            token, _, size = self._queue.get_nowait()
+        except queue.Empty:
+            return False
+        self._release_slot(token)
+        with self._counts_lock:
+            self._total_bytes -= size
+        CSP_BUFFER_DROPPED.labels(reason=reason).inc()
+        return True
 
     def _ensure_sender(self) -> None:
         if self._sender is not None and self._sender.is_alive() and self._sender_pid == os.getpid():
@@ -149,9 +179,9 @@ class CspReportBuffer:
             except Exception:
                 logger.exception("csp_report_buffer_sender_error")
 
-    def _collect(self) -> list[tuple[str, dict[str, Any]]]:
+    def _collect(self) -> list[tuple[str, dict[str, Any], int]]:
         """Wait up to ``flush_interval`` for work, then drain up to ``flush_max_events``."""
-        items: list[tuple[str, dict[str, Any]]] = []
+        items: list[tuple[str, dict[str, Any], int]] = []
         try:
             items.append(self._queue.get(timeout=self.flush_interval))
         except queue.Empty:
@@ -161,22 +191,29 @@ class CspReportBuffer:
                 items.append(self._queue.get_nowait())
             except queue.Empty:
                 break
-        for token, _ in items:
+        for token, _, _ in items:
             self._release_slot(token)
+        with self._counts_lock:
+            self._total_bytes -= sum(size for _, _, size in items)
         return items
 
-    def _flush(self, items: list[tuple[str, dict[str, Any]]]) -> None:
+    def _flush(self, items: list[tuple[str, dict[str, Any], int]]) -> None:
         CSP_BUFFER_DEPTH.set(self._queue.qsize())
         by_token: dict[str, list[dict[str, Any]]] = {}
-        for token, event in items:
+        for token, event, _ in items:
             by_token.setdefault(token, []).append(event)
         for token, events in by_token.items():
             try:
+                # max_attempts=1: token groups are submitted serially, so a
+                # degraded capture-rs must not multiply its timeout by resubmit
+                # rounds across every group in the flush — drop and count
+                # instead of stalling the sender for minutes.
                 result = capture_batch_internal(
                     events=events,
                     token=token,
                     event_source="get_csp_report",
                     process_person_profile=False,
+                    max_attempts=1,
                 )
                 result.raise_for_status()
                 CSP_BUFFER_SUBMITTED.inc(len(events))
@@ -189,14 +226,16 @@ class CspReportBuffer:
         # Best-effort final flush of at most one batch. The capture call itself can
         # still take its full timeout/retry budget — that has to fit inside the
         # pod's termination grace, it is not bounded here.
-        items: list[tuple[str, dict[str, Any]]] = []
+        items: list[tuple[str, dict[str, Any], int]] = []
         while len(items) < self.flush_max_events:
             try:
                 items.append(self._queue.get_nowait())
             except queue.Empty:
                 break
-        for token, _ in items:
+        for token, _, _ in items:
             self._release_slot(token)
+        with self._counts_lock:
+            self._total_bytes -= sum(size for _, _, size in items)
         if items:
             self._flush(items)
 

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -1,0 +1,157 @@
+"""Bounded in-process buffer for the CSP report capture-forward.
+
+The /report/ endpoint forwards every accepted report to capture-rs. Doing that
+synchronously ties request-worker hold time to capture-rs latency (including its
+retry budget), which starves bounded worker pools when capture-rs degrades. This
+buffer decouples the two: the view enqueues and returns immediately, a background
+sender thread batches events to ``capture_batch_internal``.
+
+CSP reporting is best-effort by contract: on overflow the buffer drops the oldest
+events (counted in ``csp_report_buffer_dropped``), and buffered events are lost if
+the process dies before the final drain. Browsers never read report responses, so
+callers get no delivery guarantee either way.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import atexit
+import threading
+from typing import Any
+
+import structlog
+from prometheus_client import Counter, Gauge
+
+from posthog.api.capture import capture_batch_internal
+from posthog.exceptions_capture import capture_exception
+from posthog.settings.ingestion import (
+    CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
+    CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+    CSP_REPORT_BUFFER_MAX_EVENTS,
+)
+
+logger = structlog.get_logger(__name__)
+
+CSP_BUFFER_ENQUEUED = Counter(
+    "csp_report_buffer_enqueued",
+    "CSP report events accepted into the forward buffer.",
+)
+CSP_BUFFER_DROPPED = Counter(
+    "csp_report_buffer_dropped",
+    "CSP report events dropped from the forward buffer.",
+    labelnames=["reason"],
+)
+CSP_BUFFER_SUBMITTED = Counter(
+    "csp_report_buffer_submitted",
+    "CSP report events successfully forwarded to capture.",
+)
+CSP_BUFFER_FAILED = Counter(
+    "csp_report_buffer_failed",
+    "CSP report events whose forward to capture failed.",
+)
+CSP_BUFFER_DEPTH = Gauge(
+    "csp_report_buffer_depth",
+    "Current number of events waiting in the forward buffer.",
+)
+
+
+class CspReportBuffer:
+    def __init__(
+        self,
+        maxsize: int = CSP_REPORT_BUFFER_MAX_EVENTS,
+        flush_interval: float = CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
+        flush_max_events: int = CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+    ) -> None:
+        self.flush_interval = flush_interval
+        self.flush_max_events = flush_max_events
+        self._queue: queue.Queue[tuple[str, dict[str, Any]]] = queue.Queue(maxsize=maxsize)
+        self._lock = threading.Lock()
+        self._sender: threading.Thread | None = None
+        # Sender threads don't survive fork, so remember which process started ours.
+        self._sender_pid: int | None = None
+
+    def enqueue(self, events: list[dict[str, Any]], *, token: str) -> None:
+        """Add events to the buffer without ever blocking the caller.
+
+        On overflow the oldest queued events are evicted so fresh reports win.
+        """
+        self._ensure_sender()
+        for event in events:
+            while True:
+                try:
+                    self._queue.put_nowait((token, event))
+                    break
+                except queue.Full:
+                    try:
+                        self._queue.get_nowait()
+                        CSP_BUFFER_DROPPED.labels(reason="overflow").inc()
+                    except queue.Empty:
+                        continue
+        CSP_BUFFER_ENQUEUED.inc(len(events))
+        CSP_BUFFER_DEPTH.set(self._queue.qsize())
+
+    def _ensure_sender(self) -> None:
+        if self._sender is not None and self._sender.is_alive() and self._sender_pid == os.getpid():
+            return
+        with self._lock:
+            if self._sender is not None and self._sender.is_alive() and self._sender_pid == os.getpid():
+                return
+            self._sender_pid = os.getpid()
+            self._sender = threading.Thread(target=self._run, name="csp-report-buffer-sender", daemon=True)
+            self._sender.start()
+            atexit.register(self._drain_on_exit)
+
+    def _run(self) -> None:
+        while True:
+            batch = self._collect()
+            if batch:
+                self._flush(batch)
+
+    def _collect(self) -> list[tuple[str, dict[str, Any]]]:
+        """Wait up to ``flush_interval`` for work, then drain up to ``flush_max_events``."""
+        items: list[tuple[str, dict[str, Any]]] = []
+        try:
+            items.append(self._queue.get(timeout=self.flush_interval))
+        except queue.Empty:
+            return items
+        while len(items) < self.flush_max_events:
+            try:
+                items.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return items
+
+    def _flush(self, items: list[tuple[str, dict[str, Any]]]) -> None:
+        CSP_BUFFER_DEPTH.set(self._queue.qsize())
+        by_token: dict[str, list[dict[str, Any]]] = {}
+        for token, event in items:
+            by_token.setdefault(token, []).append(event)
+        for token, events in by_token.items():
+            try:
+                result = capture_batch_internal(
+                    events=events,
+                    token=token,
+                    event_source="get_csp_report",
+                    process_person_profile=False,
+                )
+                result.raise_for_status()
+                CSP_BUFFER_SUBMITTED.inc(len(events))
+            except Exception as exc:
+                CSP_BUFFER_FAILED.inc(len(events))
+                capture_exception(exc, {"capture-pathway": "csp_report_buffer", "ph-team-token": token})
+                logger.warning("csp_report_buffer_flush_failed", batch_size=len(events), error=str(exc))
+
+    def _drain_on_exit(self) -> None:
+        # Best-effort final flush, bounded to one batch so shutdown can't hang.
+        items: list[tuple[str, dict[str, Any]]] = []
+        while len(items) < self.flush_max_events:
+            try:
+                items.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        if items:
+            self._flush(items)
+
+
+csp_report_buffer = CspReportBuffer()

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -6,10 +6,11 @@ retry budget), which starves bounded worker pools when capture-rs degrades. This
 buffer decouples the two: the view enqueues and returns immediately, a background
 sender thread batches events to ``capture_batch_internal``.
 
-CSP reporting is best-effort by contract: on overflow the buffer drops the oldest
-events (counted in ``csp_report_buffer_dropped``), and buffered events are lost if
-the process dies before the final drain. Browsers never read report responses, so
-callers get no delivery guarantee either way.
+CSP reporting is best-effort by contract: events beyond a token's fair share of
+the buffer are dropped, on overflow the oldest queued events are evicted, and
+buffered events are lost if the process dies before the final drain (all drops
+counted in ``csp_report_buffer_dropped``). Browsers never read report responses,
+so callers get no delivery guarantee either way.
 """
 
 from __future__ import annotations
@@ -62,6 +63,7 @@ class CspReportBuffer:
         maxsize: int = CSP_REPORT_BUFFER_MAX_EVENTS,
         flush_interval: float = CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
         flush_max_events: int = CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
+        max_token_share: float = 0.5,
     ) -> None:
         self.flush_interval = flush_interval
         self.flush_max_events = flush_max_events
@@ -73,26 +75,55 @@ class CspReportBuffer:
         # atexit doesn't deduplicate handlers, so register once per process even
         # if the sender thread gets restarted.
         self._atexit_pid: int | None = None
+        # Fairness: no single token may occupy more than its share of the buffer,
+        # so one team's report storm (or a bogus token — tokens are public and
+        # only capture-rs truly validates them) cannot evict other tokens'
+        # events on overflow.
+        self._token_cap = max(1, int(maxsize * max_token_share))
+        self._token_counts: dict[str, int] = {}
+        self._counts_lock = threading.Lock()
 
     def enqueue(self, events: list[dict[str, Any]], *, token: str) -> None:
         """Add events to the buffer without ever blocking the caller.
 
-        On overflow the oldest queued events are evicted so fresh reports win.
+        A token over its share drops its own incoming events; on overflow the
+        globally oldest events are evicted so fresh reports win across tokens.
         """
         self._ensure_sender()
+        accepted = 0
         for event in events:
+            if not self._reserve_slot(token):
+                CSP_BUFFER_DROPPED.labels(reason="token_share").inc()
+                continue
             while True:
                 try:
                     self._queue.put_nowait((token, event))
+                    accepted += 1
                     break
                 except queue.Full:
                     try:
-                        self._queue.get_nowait()
+                        evicted_token, _ = self._queue.get_nowait()
+                        self._release_slot(evicted_token)
                         CSP_BUFFER_DROPPED.labels(reason="overflow").inc()
                     except queue.Empty:
                         continue
-        CSP_BUFFER_ENQUEUED.inc(len(events))
+        CSP_BUFFER_ENQUEUED.inc(accepted)
         CSP_BUFFER_DEPTH.set(self._queue.qsize())
+
+    def _reserve_slot(self, token: str) -> bool:
+        with self._counts_lock:
+            if self._token_counts.get(token, 0) >= self._token_cap:
+                return False
+            self._token_counts[token] = self._token_counts.get(token, 0) + 1
+            return True
+
+    def _release_slot(self, token: str) -> None:
+        with self._counts_lock:
+            remaining = self._token_counts.get(token, 0) - 1
+            if remaining > 0:
+                self._token_counts[token] = remaining
+            else:
+                self._token_counts.pop(token, None)
 
     def _ensure_sender(self) -> None:
         if self._sender is not None and self._sender.is_alive() and self._sender_pid == os.getpid():
@@ -130,6 +161,8 @@ class CspReportBuffer:
                 items.append(self._queue.get_nowait())
             except queue.Empty:
                 break
+        for token, _ in items:
+            self._release_slot(token)
         return items
 
     def _flush(self, items: list[tuple[str, dict[str, Any]]]) -> None:
@@ -162,6 +195,8 @@ class CspReportBuffer:
                 items.append(self._queue.get_nowait())
             except queue.Empty:
                 break
+        for token, _ in items:
+            self._release_slot(token)
         if items:
             self._flush(items)
 

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -185,7 +185,10 @@ class CspReportBuffer:
             try:
                 batch = self._collect()
                 if batch:
-                    self._flush(batch)
+                    try:
+                        self._flush(batch)
+                    finally:
+                        self._release_bytes(batch)
             except Exception:
                 logger.exception("csp_report_buffer_sender_error")
 
@@ -203,9 +206,14 @@ class CspReportBuffer:
                 break
         for token, _, _ in items:
             self._release_slot(token)
+        # Bytes stay reserved until the flush finishes (_release_bytes) — the
+        # in-flight batch still holds the memory, so releasing here would let
+        # the queue refill a full budget on top of it.
+        return items
+
+    def _release_bytes(self, items: list[tuple[str, dict[str, Any], int]]) -> None:
         with self._counts_lock:
             self._total_bytes -= sum(size for _, _, size in items)
-        return items
 
     def _flush(self, items: list[tuple[str, dict[str, Any], int]]) -> None:
         CSP_BUFFER_DEPTH.set(self._queue.qsize())
@@ -225,12 +233,26 @@ class CspReportBuffer:
                     process_person_profile=False,
                     max_attempts=1,
                 )
-                result.raise_for_status()
-                CSP_BUFFER_SUBMITTED.inc(len(events))
             except Exception as exc:
                 CSP_BUFFER_FAILED.inc(len(events))
                 capture_exception(exc, {"capture-pathway": "csp_report_buffer", "ph-team-token": token})
                 logger.warning("csp_report_buffer_flush_failed", batch_size=len(events), error=str(exc))
+                continue
+            # Count per-event outcomes: a partial failure must not mark events
+            # capture already accepted as lost — these counters are the only
+            # delivery visibility in a fire-and-forget design, so
+            # enqueued ≈ submitted + failed + dropped + depth has to hold.
+            accepted = len(result.ok) + len(result.warnings)
+            failed = len(result.dropped) + len(result.retried) + len(result.unaccounted)
+            CSP_BUFFER_SUBMITTED.inc(accepted)
+            if failed:
+                CSP_BUFFER_FAILED.inc(failed)
+                logger.warning(
+                    "csp_report_buffer_flush_partial",
+                    batch_size=len(events),
+                    failed=failed,
+                    error=result.error,
+                )
 
     def _drain_on_exit(self) -> None:
         # Best-effort final flush of at most one batch. The capture call itself can
@@ -244,10 +266,11 @@ class CspReportBuffer:
                 break
         for token, _, _ in items:
             self._release_slot(token)
-        with self._counts_lock:
-            self._total_bytes -= sum(size for _, _, size in items)
         if items:
-            self._flush(items)
+            try:
+                self._flush(items)
+            finally:
+                self._release_bytes(items)
 
 
 csp_report_buffer = CspReportBuffer()

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -34,6 +34,7 @@ from posthog.settings.ingestion import (
     CSP_REPORT_BUFFER_MAX_BYTES,
     CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     CSP_REPORT_BUFFER_MAX_EVENTS,
+    CSP_REPORT_BUFFER_MAX_TOKEN_SHARE,
 )
 
 logger = structlog.get_logger(__name__)
@@ -58,6 +59,7 @@ CSP_BUFFER_FAILED = Counter(
 CSP_BUFFER_DEPTH = Gauge(
     "csp_report_buffer_depth",
     "Current number of events waiting in the forward buffer.",
+    multiprocess_mode="livesum",
 )
 
 
@@ -67,7 +69,7 @@ class CspReportBuffer:
         maxsize: int = CSP_REPORT_BUFFER_MAX_EVENTS,
         flush_interval: float = CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS,
         flush_max_events: int = CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS,
-        max_token_share: float = 0.5,
+        max_token_share: float = CSP_REPORT_BUFFER_MAX_TOKEN_SHARE,
         max_bytes: int = CSP_REPORT_BUFFER_MAX_BYTES,
         max_event_bytes: int = CSP_REPORT_BUFFER_MAX_EVENT_BYTES,
     ) -> None:
@@ -75,6 +77,9 @@ class CspReportBuffer:
         self.flush_max_events = flush_max_events
         self.max_bytes = max_bytes
         self.max_event_bytes = max_event_bytes
+        # maxsize=0 makes queue.Queue unbounded, which silently removes the count
+        # bound — the opposite of what zeroing the knob looks like it should do.
+        maxsize = max(1, maxsize)
         self._queue: queue.Queue[tuple[str, dict[str, Any], int]] = queue.Queue(maxsize=maxsize)
         self._lock = threading.Lock()
         self._sender: threading.Thread | None = None
@@ -123,6 +128,11 @@ class CspReportBuffer:
             with self._counts_lock:
                 self._total_bytes += size
             accepted += 1
+            # _total_bytes is incremented after put and decremented after remove,
+            # matched per item, so the unlocked read below is safe under the GIL:
+            # it can only read a transiently stale total, never tear, and the count
+            # self-corrects. Worst case is one over- or under-eviction, tolerable
+            # for a best-effort buffer.
             while self._total_bytes > self.max_bytes:
                 if not self._evict_oldest("bytes_overflow"):
                     break

--- a/posthog/api/report_buffer.py
+++ b/posthog/api/report_buffer.py
@@ -70,6 +70,9 @@ class CspReportBuffer:
         self._sender: threading.Thread | None = None
         # Sender threads don't survive fork, so remember which process started ours.
         self._sender_pid: int | None = None
+        # atexit doesn't deduplicate handlers, so register once per process even
+        # if the sender thread gets restarted.
+        self._atexit_pid: int | None = None
 
     def enqueue(self, events: list[dict[str, Any]], *, token: str) -> None:
         """Add events to the buffer without ever blocking the caller.
@@ -100,13 +103,20 @@ class CspReportBuffer:
             self._sender_pid = os.getpid()
             self._sender = threading.Thread(target=self._run, name="csp-report-buffer-sender", daemon=True)
             self._sender.start()
-            atexit.register(self._drain_on_exit)
+            if self._atexit_pid != os.getpid():
+                atexit.register(self._drain_on_exit)
+                self._atexit_pid = os.getpid()
 
     def _run(self) -> None:
         while True:
-            batch = self._collect()
-            if batch:
-                self._flush(batch)
+            # A crashed sender would silently strand queued events until the next
+            # enqueue restarts it — never let an exception escape the loop.
+            try:
+                batch = self._collect()
+                if batch:
+                    self._flush(batch)
+            except Exception:
+                logger.exception("csp_report_buffer_sender_error")
 
     def _collect(self) -> list[tuple[str, dict[str, Any]]]:
         """Wait up to ``flush_interval`` for work, then drain up to ``flush_max_events``."""
@@ -143,7 +153,9 @@ class CspReportBuffer:
                 logger.warning("csp_report_buffer_flush_failed", batch_size=len(events), error=str(exc))
 
     def _drain_on_exit(self) -> None:
-        # Best-effort final flush, bounded to one batch so shutdown can't hang.
+        # Best-effort final flush of at most one batch. The capture call itself can
+        # still take its full timeout/retry budget — that has to fit inside the
+        # pod's termination grace, it is not bounded here.
         items: list[tuple[str, dict[str, Any]]] = []
         while len(items) < self.flush_max_events:
             try:

--- a/posthog/api/test/test_report_buffer.py
+++ b/posthog/api/test/test_report_buffer.py
@@ -9,7 +9,7 @@ from django.test.client import Client
 
 from rest_framework import status
 
-from posthog.api.report_buffer import CSP_BUFFER_FAILED, CSP_BUFFER_SUBMITTED, CspReportBuffer
+from posthog.api.report_buffer import CSP_BUFFER_DROPPED, CSP_BUFFER_FAILED, CSP_BUFFER_SUBMITTED, CspReportBuffer
 
 
 def _capture_result(ok=(), dropped=(), retried=(), unaccounted=(), warnings=()):
@@ -90,11 +90,13 @@ class TestCspReportBufferLogic(SimpleTestCase):
         max_token_share: float = 1.0,
         max_bytes: int = 1_000_000,
         max_event_bytes: int = 100_000,
+        flush_max_seconds: float = 5.0,
     ) -> CspReportBuffer:
         return CspReportBuffer(
             maxsize=maxsize,
             flush_interval=0.01,
             flush_max_events=100,
+            flush_max_seconds=flush_max_seconds,
             max_token_share=max_token_share,
             max_bytes=max_bytes,
             max_event_bytes=max_event_bytes,
@@ -199,3 +201,31 @@ class TestCspReportBufferLogic(SimpleTestCase):
         buf._flush([("token-1", {"event": "a"}, 20)])
         assert mock_capture.call_count == 1
         assert mock_capture_exception.call_count == 1
+
+    # Regression: token groups are submitted serially, so a flood of distinct
+    # tokens against a slow capture-rs could stall the sender for the sum of
+    # every group's transport budget while the queue evicted everything behind
+    # it. The flush deadline must cut the loop and count unsent events.
+    @patch("posthog.api.report_buffer.time.monotonic")
+    @patch("posthog.api.report_buffer.capture_batch_internal")
+    def test_flush_stops_at_deadline_and_drops_remaining_groups(self, mock_capture, mock_monotonic) -> None:
+        mock_capture.return_value = _capture_result(ok=["u1"])
+        # monotonic calls: deadline anchor (0.0), group-1 check (0.5, within
+        # budget), group-2 check (10.0, past it) — groups 2 and 3 never submit.
+        mock_monotonic.side_effect = [0.0, 0.5, 10.0]
+        buf = self._buffer(flush_max_seconds=1.0)
+        dropped_before = CSP_BUFFER_DROPPED.labels(reason="flush_deadline")._value.get()
+
+        buf._flush(
+            [
+                ("token-1", {"event": "a"}, 10),
+                ("token-2", {"event": "b"}, 10),
+                ("token-2", {"event": "c"}, 10),
+                ("token-3", {"event": "d"}, 10),
+            ]
+        )
+
+        assert mock_capture.call_count == 1
+        assert mock_capture.call_args.kwargs["token"] == "token-1"
+        dropped = CSP_BUFFER_DROPPED.labels(reason="flush_deadline")._value.get() - dropped_before
+        assert dropped == 3

--- a/posthog/api/test/test_report_buffer.py
+++ b/posthog/api/test/test_report_buffer.py
@@ -9,7 +9,19 @@ from django.test.client import Client
 
 from rest_framework import status
 
-from posthog.api.report_buffer import CspReportBuffer
+from posthog.api.report_buffer import CSP_BUFFER_FAILED, CSP_BUFFER_SUBMITTED, CspReportBuffer
+
+
+def _capture_result(ok=(), dropped=(), retried=(), unaccounted=(), warnings=()):
+    return MagicMock(
+        ok=list(ok),
+        dropped=list(dropped),
+        retried=list(retried),
+        unaccounted=list(unaccounted),
+        warnings=list(warnings),
+        error=None,
+    )
+
 
 CSP_PAYLOAD = {
     "csp-report": {
@@ -92,7 +104,7 @@ class TestCspReportBufferLogic(SimpleTestCase):
     @patch.object(CspReportBuffer, "_ensure_sender")
     @patch("posthog.api.report_buffer.capture_batch_internal")
     def test_flush_groups_events_by_token(self, mock_capture, _mock_sender) -> None:
-        mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
+        mock_capture.return_value = _capture_result(ok=["u1"])
         buf = self._buffer()
         buf.enqueue([{"event": "a"}, {"event": "b"}], token="token-1")
         buf.enqueue([{"event": "c"}], token="token-2")
@@ -141,6 +153,33 @@ class TestCspReportBufferLogic(SimpleTestCase):
 
         contents = [buf._queue.get_nowait() for _ in range(buf._queue.qsize())]
         assert [e["event"] for _, e, _s in contents] == ["small"]
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_bytes_stay_reserved_while_batch_in_flight(self, _mock_sender) -> None:
+        buf = self._buffer(max_bytes=250, max_event_bytes=200)
+        buf.enqueue([{"event": "0", "raw": "x" * 100}], token="token-1")
+        in_flight = buf._collect()
+        assert len(in_flight) == 1
+
+        buf.enqueue([{"event": "1", "raw": "x" * 100}, {"event": "2", "raw": "x" * 100}], token="token-1")
+        assert buf._queue.qsize() == 1
+
+        buf._release_bytes(in_flight)
+        buf.enqueue([{"event": "3", "raw": "x" * 100}], token="token-1")
+        assert buf._queue.qsize() == 2
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    @patch("posthog.api.report_buffer.capture_batch_internal")
+    def test_partial_batch_failure_splits_submitted_and_failed(self, mock_capture, _mock_sender) -> None:
+        mock_capture.return_value = _capture_result(ok=["u1"], dropped=["u2"])
+        buf = self._buffer()
+        submitted_before = CSP_BUFFER_SUBMITTED._value.get()
+        failed_before = CSP_BUFFER_FAILED._value.get()
+
+        buf._flush([("token-1", {"event": "a"}, 10), ("token-1", {"event": "b"}, 10)])
+
+        assert CSP_BUFFER_SUBMITTED._value.get() - submitted_before == 1
+        assert CSP_BUFFER_FAILED._value.get() - failed_before == 1
 
     @patch.object(CspReportBuffer, "_ensure_sender")
     def test_byte_budget_evicts_oldest(self, _mock_sender) -> None:

--- a/posthog/api/test/test_report_buffer.py
+++ b/posthog/api/test/test_report_buffer.py
@@ -72,8 +72,10 @@ class TestCspReportBufferedView(BaseTest):
 
 
 class TestCspReportBufferLogic(SimpleTestCase):
-    def _buffer(self, maxsize: int = 10) -> CspReportBuffer:
-        return CspReportBuffer(maxsize=maxsize, flush_interval=0.01, flush_max_events=100)
+    def _buffer(self, maxsize: int = 10, max_token_share: float = 1.0) -> CspReportBuffer:
+        return CspReportBuffer(
+            maxsize=maxsize, flush_interval=0.01, flush_max_events=100, max_token_share=max_token_share
+        )
 
     # _ensure_sender is patched out so no sender thread runs — collect/flush are driven synchronously.
     @patch.object(CspReportBuffer, "_ensure_sender")
@@ -94,12 +96,32 @@ class TestCspReportBufferLogic(SimpleTestCase):
     @patch.object(CspReportBuffer, "_ensure_sender")
     def test_enqueue_on_full_buffer_drops_oldest_without_blocking(self, _mock_sender) -> None:
         buf = self._buffer(maxsize=2)
-        buf.enqueue([{"event": "a"}, {"event": "b"}, {"event": "c"}], token="token-1")
+        buf.enqueue([{"event": "a"}, {"event": "b"}], token="token-1")
+        buf.enqueue([{"event": "c"}], token="token-2")
 
-        remaining = [buf._queue.get_nowait()[1]["event"] for _ in range(2)]
-        assert remaining == ["b", "c"]
+        remaining = [(t, e["event"]) for t, e in (buf._queue.get_nowait() for _ in range(2))]
+        assert remaining == [("token-1", "b"), ("token-2", "c")]
         with self.assertRaises(queue.Empty):
             buf._queue.get_nowait()
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_one_token_cannot_evict_other_tokens_events(self, _mock_sender) -> None:
+        buf = self._buffer(maxsize=4, max_token_share=0.5)
+        buf.enqueue([{"event": f"noisy-{i}"} for i in range(4)], token="token-noisy")
+        buf.enqueue([{"event": "quiet-1"}, {"event": "quiet-2"}], token="token-quiet")
+
+        contents = [buf._queue.get_nowait() for _ in range(4)]
+        assert [e["event"] for t, e in contents if t == "token-noisy"] == ["noisy-0", "noisy-1"]
+        assert [e["event"] for t, e in contents if t == "token-quiet"] == ["quiet-1", "quiet-2"]
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_collect_frees_token_share_for_new_events(self, _mock_sender) -> None:
+        buf = self._buffer(maxsize=4, max_token_share=0.5)
+        buf.enqueue([{"event": "a"}, {"event": "b"}, {"event": "c"}], token="token-1")
+        assert len(buf._collect()) == 2
+
+        buf.enqueue([{"event": "d"}], token="token-1")
+        assert [e["event"] for _, e in buf._collect()] == ["d"]
 
     @patch("posthog.api.report_buffer.capture_exception")
     @patch("posthog.api.report_buffer.capture_batch_internal", side_effect=Exception("capture down"))

--- a/posthog/api/test/test_report_buffer.py
+++ b/posthog/api/test/test_report_buffer.py
@@ -1,0 +1,110 @@
+import json
+import queue
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, override_settings
+from django.test.client import Client
+
+from rest_framework import status
+
+from posthog.api.report_buffer import CspReportBuffer
+
+CSP_PAYLOAD = {
+    "csp-report": {
+        "document-uri": "https://example.com/foo/bar",
+        "violated-directive": "default-src self",
+        "effective-directive": "img-src",
+        "original-policy": "default-src 'self'; img-src 'self' https://img.example.com",
+        "disposition": "enforce",
+        "blocked-uri": "https://evil.com/malicious-image.png",
+    }
+}
+
+
+class TestCspReportBufferedView(BaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client(enforce_csrf_checks=True)
+
+    @override_settings(CSP_REPORT_BUFFERED_FORWARD=True)
+    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.csp_report_buffer")
+    def test_buffered_mode_enqueues_instead_of_calling_capture(self, mock_buffer, mock_capture) -> None:
+        resp = self.client.post(
+            f"/report/?token={self.team.api_token}",
+            data=json.dumps(CSP_PAYLOAD),
+            content_type="application/csp-report",
+        )
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert mock_capture.call_count == 0
+        assert mock_buffer.enqueue.call_count == 1
+        events = mock_buffer.enqueue.call_args.args[0]
+        assert len(events) == 1
+        assert mock_buffer.enqueue.call_args.kwargs["token"] == self.team.api_token
+
+    @override_settings(CSP_REPORT_BUFFERED_FORWARD=True)
+    @patch("posthog.api.report.csp_report_buffer")
+    def test_buffered_mode_missing_token_returns_400_without_enqueue(self, mock_buffer) -> None:
+        resp = self.client.post(
+            "/report/",
+            data=json.dumps(CSP_PAYLOAD),
+            content_type="application/csp-report",
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert mock_buffer.enqueue.call_count == 0
+
+    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.csp_report_buffer")
+    def test_default_mode_stays_synchronous(self, mock_buffer, mock_capture) -> None:
+        mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
+        resp = self.client.post(
+            f"/report/?token={self.team.api_token}",
+            data=json.dumps(CSP_PAYLOAD),
+            content_type="application/csp-report",
+        )
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert mock_capture.call_count == 1
+        assert mock_buffer.enqueue.call_count == 0
+
+
+class TestCspReportBufferLogic(SimpleTestCase):
+    def _buffer(self, maxsize: int = 10) -> CspReportBuffer:
+        return CspReportBuffer(maxsize=maxsize, flush_interval=0.01, flush_max_events=100)
+
+    # _ensure_sender is patched out so no sender thread runs — collect/flush are driven synchronously.
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    @patch("posthog.api.report_buffer.capture_batch_internal")
+    def test_flush_groups_events_by_token(self, mock_capture, _mock_sender) -> None:
+        mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
+        buf = self._buffer()
+        buf.enqueue([{"event": "a"}, {"event": "b"}], token="token-1")
+        buf.enqueue([{"event": "c"}], token="token-2")
+
+        buf._flush(buf._collect())
+
+        assert mock_capture.call_count == 2
+        calls = {call.kwargs["token"]: call.kwargs["events"] for call in mock_capture.call_args_list}
+        assert [e["event"] for e in calls["token-1"]] == ["a", "b"]
+        assert [e["event"] for e in calls["token-2"]] == ["c"]
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_enqueue_on_full_buffer_drops_oldest_without_blocking(self, _mock_sender) -> None:
+        buf = self._buffer(maxsize=2)
+        buf.enqueue([{"event": "a"}, {"event": "b"}, {"event": "c"}], token="token-1")
+
+        remaining = [buf._queue.get_nowait()[1]["event"] for _ in range(2)]
+        assert remaining == ["b", "c"]
+        with self.assertRaises(queue.Empty):
+            buf._queue.get_nowait()
+
+    @patch("posthog.api.report_buffer.capture_exception")
+    @patch("posthog.api.report_buffer.capture_batch_internal", side_effect=Exception("capture down"))
+    def test_flush_failure_does_not_raise(self, mock_capture, mock_capture_exception) -> None:
+        buf = self._buffer()
+        buf._flush([("token-1", {"event": "a"})])
+        assert mock_capture.call_count == 1
+        assert mock_capture_exception.call_count == 1

--- a/posthog/api/test/test_report_buffer.py
+++ b/posthog/api/test/test_report_buffer.py
@@ -72,9 +72,20 @@ class TestCspReportBufferedView(BaseTest):
 
 
 class TestCspReportBufferLogic(SimpleTestCase):
-    def _buffer(self, maxsize: int = 10, max_token_share: float = 1.0) -> CspReportBuffer:
+    def _buffer(
+        self,
+        maxsize: int = 10,
+        max_token_share: float = 1.0,
+        max_bytes: int = 1_000_000,
+        max_event_bytes: int = 100_000,
+    ) -> CspReportBuffer:
         return CspReportBuffer(
-            maxsize=maxsize, flush_interval=0.01, flush_max_events=100, max_token_share=max_token_share
+            maxsize=maxsize,
+            flush_interval=0.01,
+            flush_max_events=100,
+            max_token_share=max_token_share,
+            max_bytes=max_bytes,
+            max_event_bytes=max_event_bytes,
         )
 
     # _ensure_sender is patched out so no sender thread runs — collect/flush are driven synchronously.
@@ -99,7 +110,7 @@ class TestCspReportBufferLogic(SimpleTestCase):
         buf.enqueue([{"event": "a"}, {"event": "b"}], token="token-1")
         buf.enqueue([{"event": "c"}], token="token-2")
 
-        remaining = [(t, e["event"]) for t, e in (buf._queue.get_nowait() for _ in range(2))]
+        remaining = [(t, e["event"]) for t, e, _ in (buf._queue.get_nowait() for _ in range(2))]
         assert remaining == [("token-1", "b"), ("token-2", "c")]
         with self.assertRaises(queue.Empty):
             buf._queue.get_nowait()
@@ -111,8 +122,8 @@ class TestCspReportBufferLogic(SimpleTestCase):
         buf.enqueue([{"event": "quiet-1"}, {"event": "quiet-2"}], token="token-quiet")
 
         contents = [buf._queue.get_nowait() for _ in range(4)]
-        assert [e["event"] for t, e in contents if t == "token-noisy"] == ["noisy-0", "noisy-1"]
-        assert [e["event"] for t, e in contents if t == "token-quiet"] == ["quiet-1", "quiet-2"]
+        assert [e["event"] for t, e, _ in contents if t == "token-noisy"] == ["noisy-0", "noisy-1"]
+        assert [e["event"] for t, e, _ in contents if t == "token-quiet"] == ["quiet-1", "quiet-2"]
 
     @patch.object(CspReportBuffer, "_ensure_sender")
     def test_collect_frees_token_share_for_new_events(self, _mock_sender) -> None:
@@ -121,12 +132,31 @@ class TestCspReportBufferLogic(SimpleTestCase):
         assert len(buf._collect()) == 2
 
         buf.enqueue([{"event": "d"}], token="token-1")
-        assert [e["event"] for _, e in buf._collect()] == ["d"]
+        assert [e["event"] for _, e, _s in buf._collect()] == ["d"]
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_oversized_event_is_dropped(self, _mock_sender) -> None:
+        buf = self._buffer(max_event_bytes=100)
+        buf.enqueue([{"event": "big", "raw": "x" * 500}, {"event": "small"}], token="token-1")
+
+        contents = [buf._queue.get_nowait() for _ in range(buf._queue.qsize())]
+        assert [e["event"] for _, e, _s in contents] == ["small"]
+
+    @patch.object(CspReportBuffer, "_ensure_sender")
+    def test_byte_budget_evicts_oldest(self, _mock_sender) -> None:
+        buf = self._buffer(max_bytes=250, max_event_bytes=200)
+        # Each event serializes to ~120 bytes, so the third pushes total over 250.
+        events = [{"event": str(i), "raw": "x" * 100} for i in range(3)]
+        buf.enqueue(events, token="token-1")
+
+        contents = [buf._queue.get_nowait() for _ in range(buf._queue.qsize())]
+        assert [e["event"] for _, e, _s in contents] == ["1", "2"]
+        assert buf._total_bytes <= 250
 
     @patch("posthog.api.report_buffer.capture_exception")
     @patch("posthog.api.report_buffer.capture_batch_internal", side_effect=Exception("capture down"))
     def test_flush_failure_does_not_raise(self, mock_capture, mock_capture_exception) -> None:
         buf = self._buffer()
-        buf._flush([("token-1", {"event": "a"})])
+        buf._flush([("token-1", {"event": "a"}, 20)])
         assert mock_capture.call_count == 1
         assert mock_capture_exception.call_count == 1

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -83,6 +83,12 @@ CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS = get_from_env(
     "CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS", type_cast=float, default=0.5
 )
 CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS = get_from_env("CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS", type_cast=int, default=1000)
+# Wall-clock ceiling per flush: token groups are submitted serially, so many
+# distinct tokens against a slow capture-rs would otherwise stall the sender for
+# the sum of every group's transport budget. Events still unsent at the deadline
+# are dropped (reason="flush_deadline"). A healthy flush finishes well under a
+# second; the ceiling only bites while capture-rs degrades.
+CSP_REPORT_BUFFER_FLUSH_MAX_SECONDS = get_from_env("CSP_REPORT_BUFFER_FLUSH_MAX_SECONDS", type_cast=float, default=5.0)
 # Fairness: the largest share of the buffer any single token may hold, so one
 # token's report storm cannot evict every other token's events on overflow.
 CSP_REPORT_BUFFER_MAX_TOKEN_SHARE = get_from_env("CSP_REPORT_BUFFER_MAX_TOKEN_SHARE", type_cast=float, default=0.5)

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -83,6 +83,11 @@ CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS = get_from_env(
     "CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS", type_cast=float, default=0.5
 )
 CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS = get_from_env("CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS", type_cast=int, default=1000)
+# Memory bounds: the count cap alone doesn't bound memory because events carry the
+# raw report body. Per-event cap rejects pathological payloads (legit CSP reports
+# are a few KB); the total cap evicts oldest when crossed.
+CSP_REPORT_BUFFER_MAX_EVENT_BYTES = get_from_env("CSP_REPORT_BUFFER_MAX_EVENT_BYTES", type_cast=int, default=64 * 1024)
+CSP_REPORT_BUFFER_MAX_BYTES = get_from_env("CSP_REPORT_BUFFER_MAX_BYTES", type_cast=int, default=64 * 1024 * 1024)
 NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS = get_set(os.getenv("NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS", ""))
 
 ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS = get_set(os.getenv("ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS", ""))

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -83,6 +83,9 @@ CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS = get_from_env(
     "CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS", type_cast=float, default=0.5
 )
 CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS = get_from_env("CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS", type_cast=int, default=1000)
+# Fairness: the largest share of the buffer any single token may hold, so one
+# token's report storm cannot evict every other token's events on overflow.
+CSP_REPORT_BUFFER_MAX_TOKEN_SHARE = get_from_env("CSP_REPORT_BUFFER_MAX_TOKEN_SHARE", type_cast=float, default=0.5)
 # Memory bounds: the count cap alone doesn't bound memory because events carry the
 # raw report body. Per-event cap rejects pathological payloads (legit CSP reports
 # are a few KB); the total cap evicts oldest when crossed.

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -71,6 +71,18 @@ CAPTURE_V1_INTERNAL_RETRY_AFTER_CAP_SECONDS = get_from_env(
 )
 # Chunk fan-out reuses CAPTURE_INTERNAL_MAX_WORKERS (above) for its thread pool.
 CAPTURE_INTERNAL_BATCH_CHUNK_SIZE = get_from_env("CAPTURE_INTERNAL_BATCH_CHUNK_SIZE", type_cast=int, default=200)
+
+# Buffered CSP capture-forward: when enabled, /report/ enqueues accepted reports to a
+# bounded in-process buffer and returns 204 immediately; a background thread batches
+# them to capture-rs. Keeps request-worker hold time independent of capture-rs latency,
+# which is required for servers with bounded worker pools (WSGI). Off = legacy
+# synchronous forward.
+CSP_REPORT_BUFFERED_FORWARD = get_from_env("CSP_REPORT_BUFFERED_FORWARD", False, type_cast=str_to_bool)
+CSP_REPORT_BUFFER_MAX_EVENTS = get_from_env("CSP_REPORT_BUFFER_MAX_EVENTS", type_cast=int, default=10000)
+CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS = get_from_env(
+    "CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS", type_cast=float, default=0.5
+)
+CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS = get_from_env("CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS", type_cast=int, default=1000)
 NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS = get_set(os.getenv("NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS", ""))
 
 ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS = get_set(os.getenv("ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS", ""))


### PR DESCRIPTION
## Problem

The /report/ endpoint forwards every accepted CSP report to capture-rs synchronously, inside the request. That couples request-worker hold time to capture-rs latency, including its full retry budget (transport retries plus up to 4 resubmit rounds with Retry-After sleeps). On a server with a bounded worker pool, a capture-rs slowdown pins every worker while CPU sits idle, and the service starves. This is the app-side prerequisite for running the report role on a bounded-worker (WSGI) server, see PostHog/charts#12606 for origin context.

## Changes

- New `CspReportBuffer` (`posthog/api/report_buffer.py`): bounded in-process queue plus one daemon sender thread that batches events per token to `capture_batch_internal`. Overflow evicts oldest (counted in `csp_report_buffer_dropped`), flush failures are logged, counted and sent to error tracking, never raised. Best-effort final drain at exit.
- `get_csp_event` gains a buffered branch behind `CSP_REPORT_BUFFERED_FORWARD` (default off): validate, enqueue, return 204 immediately. Missing token still 400s before enqueue. Default-off means the synchronous path is byte-for-byte unchanged.
- New settings in `posthog/settings/ingestion.py`: `CSP_REPORT_BUFFERED_FORWARD`, `CSP_REPORT_BUFFER_MAX_EVENTS` (10000), `CSP_REPORT_BUFFER_FLUSH_INTERVAL_SECONDS` (0.5), `CSP_REPORT_BUFFER_FLUSH_MAX_EVENTS` (1000).
- Prometheus metrics: enqueued/dropped/submitted/failed counters and a queue depth gauge.

Behavior trade-off, deliberate: in buffered mode capture failures no longer surface in the response status, and buffered events are lost if the process dies before the drain. CSP reporting is best-effort and browsers never read the response body, so no caller can observe the difference.

## How did you test this code?

Automated tests only (`posthog/api/test/test_report_buffer.py`, all passing locally plus the existing `test_report.py` suite). Each group catches a regression no existing test covers:

- buffered mode returns 204 without calling capture and enqueues with the right token (flag silently not honored / still blocking in-request)
- missing token 400s without enqueueing (silently buffering batches that capture would reject)
- flush groups events by token (cross-token mixing would misattribute events between teams)
- full buffer drops oldest and never blocks the caller (the entire point of the change)
- flush failure is swallowed and counted (a capture outage killing the sender loop would silently stop all forwarding)
- default mode still calls capture synchronously (flag leaking into existing behavior)

No manual testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing user-facing, env flags are internal deployment config.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @webjunkie. The work follows an observability analysis of a brief WSGI experiment on the report role: profiling showed the synchronous capture-forward is the only blocking I/O on this path, and the sizing math (concurrency = rate x downstream latency) makes a bounded worker pool unsafe without decoupling. Consulted the repo /writing-tests skill for the test gate. Considered and rejected: Celery (broker round-trip per request just moves the blocking I/O, plus infra coupling for a best-effort endpoint) and merely tightening timeouts (bounds the damage but still couples worker slots to downstream latency). Chose drop-oldest over drop-newest on overflow so the freshest reports survive a backlog.
