### PR TITLE
feat(data-warehouse): log why the repartition controller skips a table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -154,7 +154,7 @@ async def maybe_flag_for_repartition(
             return
 
         if not await asyncio.to_thread(is_auto_repartition_enabled, schema):
-            await logger.ainfo(
+            await logger.adebug(
                 "repartition: over budget but skipped, controller disabled by feature flag",
                 schema_id=str(schema.id),
                 max_partition_bytes=max_bytes,
@@ -163,7 +163,7 @@ async def maybe_flag_for_repartition(
             return
 
         if schema.repartition_pending is not None:
-            await logger.ainfo(
+            await logger.adebug(
                 "repartition: over budget but already queued for the next run",
                 schema_id=str(schema.id),
                 max_partition_bytes=max_bytes,
@@ -174,7 +174,7 @@ async def maybe_flag_for_repartition(
 
         cooldown_remaining = _cooldown_seconds_remaining(schema)
         if cooldown_remaining > 0:
-            await logger.ainfo(
+            await logger.adebug(
                 "repartition: over budget but skipped, in post-repartition cooldown",
                 schema_id=str(schema.id),
                 max_partition_bytes=max_bytes,
@@ -192,7 +192,7 @@ async def maybe_flag_for_repartition(
             props = base_event_props(schema, source, str(job.id))
             props.update({"max_partition_bytes_before": max_bytes, "reason": reason})
             await asyncio.to_thread(capture_repartition_event, "warehouse_repartition_skipped", props)
-            await logger.awarning(
+            await logger.adebug(
                 "repartition: over budget but skipped, no finer partitioning target available",
                 schema_id=str(schema.id),
                 reason=reason,
@@ -220,7 +220,7 @@ async def maybe_flag_for_repartition(
             }
         )
         await asyncio.to_thread(capture_repartition_event, "warehouse_repartition_flagged", props)
-        await logger.ainfo(
+        await logger.adebug(
             "repartition: flagged for next run",
             schema_id=str(schema.id),
             max_partition_bytes=max_bytes,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -106,15 +106,16 @@ def capture_repartition_event(event: str, props: dict[str, Any]) -> None:
     posthoganalytics.capture(distinct_id=get_machine_id(), event=event, properties=props)
 
 
-def _cooldown_active(schema: ExternalDataSchema) -> bool:
+def _cooldown_seconds_remaining(schema: ExternalDataSchema) -> float:
+    """Seconds until the per-table repartition cooldown expires; 0 when no cooldown is active."""
     last = schema.last_repartition_at
     if not last:
-        return False
+        return 0.0
     try:
         last_dt = parser.parse(last)
     except (ValueError, TypeError):
-        return False
-    return (timezone.now() - last_dt).total_seconds() < REPARTITION_COOLDOWN_SECONDS
+        return 0.0
+    return max(0.0, REPARTITION_COOLDOWN_SECONDS - (timezone.now() - last_dt).total_seconds())
 
 
 async def maybe_flag_for_repartition(
@@ -133,6 +134,9 @@ async def maybe_flag_for_repartition(
     try:
         partition_bytes = await asyncio.to_thread(measure_partition_bytes, delta_table)
         if not partition_bytes:
+            await logger.adebug(
+                "repartition: skipped, no partition measurements in the delta log", schema_id=str(schema.id)
+            )
             return
 
         max_bytes = max(partition_bytes.values())
@@ -140,17 +144,44 @@ async def maybe_flag_for_repartition(
 
         budget = target_partition_bytes()
         if max_bytes <= budget:
+            await logger.adebug(
+                "repartition: not needed, largest partition within budget",
+                schema_id=str(schema.id),
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+                partition_count=len(partition_bytes),
+            )
             return
 
         if not await asyncio.to_thread(is_auto_repartition_enabled, schema):
-            await logger.adebug("repartition: over budget but controller disabled", schema_id=str(schema.id))
+            await logger.ainfo(
+                "repartition: over budget but skipped, controller disabled by feature flag",
+                schema_id=str(schema.id),
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+            )
             return
 
         if schema.repartition_pending is not None:
-            return  # Already queued for the next run.
+            await logger.ainfo(
+                "repartition: over budget but already queued for the next run",
+                schema_id=str(schema.id),
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+                repartition_pending=schema.repartition_pending,
+            )
+            return
 
-        if _cooldown_active(schema):
-            await logger.adebug("repartition: over budget but in cooldown", schema_id=str(schema.id))
+        cooldown_remaining = _cooldown_seconds_remaining(schema)
+        if cooldown_remaining > 0:
+            await logger.ainfo(
+                "repartition: over budget but skipped, in post-repartition cooldown",
+                schema_id=str(schema.id),
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+                last_repartition_at=schema.last_repartition_at,
+                cooldown_seconds_remaining=int(cooldown_remaining),
+            )
             return
 
         target, reason = select_repartition_target(schema, partition_bytes, budget)
@@ -161,6 +192,16 @@ async def maybe_flag_for_repartition(
             props = base_event_props(schema, source, str(job.id))
             props.update({"max_partition_bytes_before": max_bytes, "reason": reason})
             await asyncio.to_thread(capture_repartition_event, "warehouse_repartition_skipped", props)
+            await logger.awarning(
+                "repartition: over budget but skipped, no finer partitioning target available",
+                schema_id=str(schema.id),
+                reason=reason,
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+                partition_mode=schema.partition_mode,
+                partition_format=schema.partition_format,
+                partition_count=len(partition_bytes),
+            )
             capture_exception(Exception(f"Repartition needed but skipped for schema {schema.id}: {reason}"))
             return
 
@@ -183,7 +224,11 @@ async def maybe_flag_for_repartition(
             "repartition: flagged for next run",
             schema_id=str(schema.id),
             max_partition_bytes=max_bytes,
+            budget_bytes=budget,
             target_mode=target.partition_mode,
+            target_format=target.partition_format,
+            target_count=target.partition_count,
+            target_size=target.partition_size,
         )
     except Exception as e:
         # Detection is best-effort; never fail post-load over it.


### PR DESCRIPTION
## Problem

When a Delta table's largest partition outgrows the memory-safe budget, the auto-repartition controller can decline to queue a rewrite for several reasons (feature flag off, already queued, cooldown, no finer target available). Most of these early returns were silent or logged with no context, making it hard to diagnose why a given table did or didn't get repartitioned.

## Changes

Adds structured debug logging to every decision point in `maybe_flag_for_repartition`:

- **No partition measurements / within budget** — logs the measured max partition bytes, the budget, and the partition count.
- **Over budget but feature flag disabled** — now includes max bytes and budget.
- **Over budget but already queued** — previously silent, now logged including the pending target.
- **Over budget but in cooldown** — now includes `last_repartition_at` and the seconds remaining until the cooldown expires (via a new `_cooldown_seconds_remaining` helper replacing the boolean `_cooldown_active`).
- **Over budget but no finer target available** — adds a log with the skip reason, current partition mode/format/count, max bytes, and budget alongside the existing metric, event, and exception capture.
- **Flagged for next run** — the existing log now also includes the budget and the full target (format, count, size).

All logs are at debug level, which is still produced to the job logs by default (`TEMPORAL_LOG_LEVEL_PRODUCE=DEBUG`), so every decision is diagnosable per job without adding noise to worker output.

## How did you test this code?

Logging-only change with no behavioral difference; existing controller tests (`test_repartition_controller.py`, including `test_cooldown_blocks_flagging`) cover the decision paths and run in CI. Ran `ruff check` / `ruff format` and a compile check locally; the local environment cannot run DB-backed pytest (pre-existing ClickHouse conftest import failure), so no tests were run locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal worker logging only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Scope was deliberately limited to log lines and the cooldown helper's return type — no changes to gating behavior, metrics, or captured events. Log levels were initially mixed (info/warning for over-budget skips) and then normalized to debug across the board at the author's direction, relying on the produce path to keep them visible in job logs.
