### PR TITLE
feat(error-tracking): surface signal report analysis on the issue page

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5141,6 +5141,8 @@ const api = {
             ordering?: string
             /** Comma-separated source products. */
             source_product?: string
+            /** Comma-separated source record IDs (e.g. error tracking issue UUIDs); requires source_product. */
+            source_id?: string
             /** Comma-separated P0–P4. */
             priority?: string
             /** Comma-separated actionability values (immediately_actionable|requires_human_input|not_actionable). */

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -295,6 +295,7 @@ export const FEATURE_FLAGS = {
     EDITOR_DRAFTS: 'editor-drafts', // owner: @EDsCODE #team-data-tools
     ENDPOINTS: 'embedded-analytics', // owner: @sakce #team-clickhouse
     ENGINEERING_ANALYTICS: 'engineering-analytics', // owner: #team-devex
+    ERROR_TRACKING_ISSUE_ANALYSIS: 'error-tracking-issue-analysis', // owner: @catalin #team-error-tracking
     ERROR_TRACKING_ISSUE_CORRELATION: 'error-tracking-issue-correlation', // owner: @david #team-error-tracking
     ERROR_TRACKING_ISSUE_SPLITTING: 'error-tracking-issue-splitting', // owner: @david #team-error-tracking
     ERROR_TRACKING_RATE_LIMITING: 'error-tracking-rate-limiting', // owner: @ablaszkiewicz #team-error-tracking

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -13,7 +13,8 @@ import { inboxSceneLogic } from '../../inboxSceneLogic'
 import { inboxTaskKickoffLogic } from '../../inboxTaskKickoffLogic'
 import { inboxBulkActionsLogic } from '../../logics/inboxBulkActionsLogic'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from '../../logics/reportListLogic'
-import { ACTIONABLE_ACTIONABILITY_VALUES, SignalReport, SignalReportStatus } from '../../types'
+import { SignalReport, SignalReportStatus } from '../../types'
+import { canCreateImplementationPr } from '../../utils/reportPresentation'
 import { useReportArchive } from '../cards/useReportArchive'
 import { openFeedbackReportDialog } from '../shell/FeedbackReportDialog'
 
@@ -29,26 +30,6 @@ export interface ReportDetailAction {
     onClick: (event: MouseEvent) => void
     loading?: boolean
     tooltip?: string
-}
-
-/**
- * Should the Create PR action be offered? Mirrors desktop `canCreateImplementationPr` /
- * the server-side autostart rules: only when ready & actionable, or blocked on user input.
- */
-function canCreateImplementationPr(report: SignalReport): boolean {
-    if (report.implementation_pr_url) {
-        return false
-    }
-    if (report.already_addressed === true) {
-        return false
-    }
-    if (report.status === 'pending_input') {
-        return true
-    }
-    if (report.status === 'ready') {
-        return report.actionability != null && ACTIONABLE_ACTIONABILITY_VALUES.includes(report.actionability)
-    }
-    return false
 }
 
 /**

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -25,7 +25,7 @@ export const INBOX_EVENTS = {
 type InboxEvent = (typeof INBOX_EVENTS)[keyof typeof INBOX_EVENTS]
 
 /** Action surface an `Inbox report action` fired from. */
-export type InboxReportActionSurface = 'detail_pane' | 'list_row' | 'bulk_bar'
+export type InboxReportActionSurface = 'detail_pane' | 'list_row' | 'bulk_bar' | 'issue_scene'
 
 /** How a report detail was opened. */
 export type InboxReportOpenMethod = 'click' | 'deeplink' | 'unknown'

--- a/frontend/src/scenes/inbox/utils/reportPresentation.ts
+++ b/frontend/src/scenes/inbox/utils/reportPresentation.ts
@@ -2,6 +2,8 @@
 // Shared across the Inbox cards/detail so the conventional-commit + headline parsing
 // lives in exactly one place.
 
+import { ACTIONABLE_ACTIONABILITY_VALUES, SignalReport } from '../types'
+
 const MAX_HEADLINE_LENGTH = 140
 const SENTENCE_END = /([.!?])[*_`]*(?=\s|$)/
 const EDGE_EMPHASIS = /^[*_`\s]+|[*_`\s]+$/g
@@ -64,6 +66,26 @@ export function displayConventionalCommitTitle(title: string | null | undefined,
     }
     const trimmed = title?.trim()
     return trimmed ? trimmed : fallback
+}
+
+/**
+ * Should the Create PR action be offered? Mirrors desktop `canCreateImplementationPr` /
+ * the server-side autostart rules: only when ready & actionable, or blocked on user input.
+ */
+export function canCreateImplementationPr(report: SignalReport): boolean {
+    if (report.implementation_pr_url) {
+        return false
+    }
+    if (report.already_addressed === true) {
+        return false
+    }
+    if (report.status === 'pending_input') {
+        return true
+    }
+    if (report.status === 'ready') {
+        return report.actionability != null && ACTIONABLE_ACTIONABILITY_VALUES.includes(report.actionability)
+    }
+    return false
 }
 
 /**

--- a/products/error_tracking/frontend/components/IssueAnalysis/IssueAnalysis.tsx
+++ b/products/error_tracking/frontend/components/IssueAnalysis/IssueAnalysis.tsx
@@ -1,0 +1,151 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconPullRequest, IconSparkles } from '@posthog/icons'
+import { LemonButton, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { SignalReportActionabilityBadge } from 'scenes/inbox/components/badges/SignalReportActionabilityBadge'
+import { SignalReportPriorityBadge } from 'scenes/inbox/components/badges/SignalReportPriorityBadge'
+import { captureInboxReportAction } from 'scenes/inbox/inboxAnalytics'
+import { inboxTaskKickoffLogic } from 'scenes/inbox/inboxTaskKickoffLogic'
+import { deriveHeadline, displayConventionalCommitTitle, safeHttpUrl } from 'scenes/inbox/utils/reportPresentation'
+import { urls } from 'scenes/urls'
+
+import { errorTrackingIssueSceneLogic } from '../../scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic'
+import { IssueFinding, issueAnalysisLogic } from './issueAnalysisLogic'
+
+const MAX_CODE_PATHS = 6
+const MAX_COMMITS = 3
+
+/**
+ * The signals pipeline researches every new error tracking issue and writes its conclusions to a
+ * signal report (summary, suspect code paths and commits, priority, actionability). This card
+ * surfaces that report on the issue itself, with the fix CTA the inbox offers.
+ */
+export function IssueAnalysis(): JSX.Element | null {
+    const { issueId } = useValues(errorTrackingIssueSceneLogic)
+    const logic = issueAnalysisLogic({ issueId })
+    const { report, showCard, researchPending, cta, issueFindings } = useValues(logic)
+    const { isCreatingPr } = useValues(inboxTaskKickoffLogic)
+    const { createPrFromReport } = useActions(inboxTaskKickoffLogic)
+    const [summaryExpanded, setSummaryExpanded] = useState(false)
+
+    if (!report || !showCard) {
+        return null
+    }
+
+    const title = displayConventionalCommitTitle(report.title, 'Issue analysis')
+    const headline = deriveHeadline(report.summary)
+    const summary = report.summary?.trim()
+    const prUrl = safeHttpUrl(report.implementation_pr_url)
+
+    return (
+        <div className="flex flex-col gap-1.5 border-b px-3 py-2 shrink-0" data-attr="error-tracking-issue-analysis">
+            <div className="flex items-center gap-1.5">
+                <IconSparkles className="text-accent shrink-0" />
+                <span className="text-xs font-semibold uppercase tracking-wide text-secondary">AI analysis</span>
+                <SignalReportPriorityBadge priority={report.priority} />
+                <SignalReportActionabilityBadge actionability={report.actionability} />
+                {researchPending && (
+                    <span className="flex items-center gap-1 text-xs text-tertiary">
+                        <Spinner className="text-sm" />
+                        Analyzing…
+                    </span>
+                )}
+            </div>
+
+            {report.title && <div className="text-sm font-semibold break-words">{title}</div>}
+
+            {summary &&
+                (summaryExpanded ? (
+                    <LemonMarkdown className="text-xs" lowKeyHeadings>
+                        {summary}
+                    </LemonMarkdown>
+                ) : (
+                    headline && <p className="m-0 text-xs text-secondary break-words">{headline}</p>
+                ))}
+            {summary && summary !== headline && (
+                <button
+                    type="button"
+                    className="self-start text-xs text-accent cursor-pointer bg-transparent border-0 p-0"
+                    onClick={() => setSummaryExpanded(!summaryExpanded)}
+                >
+                    {summaryExpanded ? 'Show less' : 'Show more'}
+                </button>
+            )}
+
+            <IssueFindingChips findings={issueFindings} />
+
+            <div className="flex items-center gap-2">
+                {cta === 'create_pr' && (
+                    <LemonButton
+                        type="primary"
+                        size="xsmall"
+                        icon={<IconPullRequest />}
+                        loading={isCreatingPr}
+                        tooltip="Have Self-driving open a pull request for this report"
+                        data-attr="error-tracking-issue-analysis-create-pr"
+                        onClick={() => {
+                            captureInboxReportAction({ report, actionType: 'create_pr', surface: 'issue_scene' })
+                            createPrFromReport(report)
+                        }}
+                    >
+                        Create fix PR
+                    </LemonButton>
+                )}
+                {cta === 'view_pr' && prUrl && (
+                    <LemonButton
+                        type="primary"
+                        size="xsmall"
+                        icon={<IconPullRequest />}
+                        to={prUrl}
+                        targetBlank
+                        data-attr="error-tracking-issue-analysis-view-pr"
+                    >
+                        View fix PR
+                    </LemonButton>
+                )}
+                <LemonButton
+                    type="secondary"
+                    size="xsmall"
+                    to={urls.inboxReport('reports', report.id)}
+                    data-attr="error-tracking-issue-analysis-view-report"
+                >
+                    View full analysis
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+/** Suspect code paths and commits from this issue's `signal_finding` artefacts, capped for card display. */
+function IssueFindingChips({ findings }: { findings: IssueFinding[] }): JSX.Element | null {
+    const codePaths = Array.from(new Set(findings.flatMap((f) => f.codePaths)))
+    const commits = findings.flatMap((f) => f.commits)
+    if (!codePaths.length && !commits.length) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-1">
+            {codePaths.slice(0, MAX_CODE_PATHS).map((path) => (
+                <LemonTag key={path} size="small" className="font-mono max-w-full">
+                    <span className="truncate" title={path}>
+                        {path}
+                    </span>
+                </LemonTag>
+            ))}
+            {codePaths.length > MAX_CODE_PATHS && (
+                <span className="text-xs text-tertiary">+{codePaths.length - MAX_CODE_PATHS} more</span>
+            )}
+            {commits.slice(0, MAX_COMMITS).map(({ sha, reason }) => (
+                <Tooltip key={sha} title={reason || 'Suspect commit'}>
+                    <LemonTag size="small" type="highlight" className="font-mono">
+                        {sha.slice(0, 7)}
+                    </LemonTag>
+                </Tooltip>
+            ))}
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/components/IssueAnalysis/issueAnalysisLogic.test.ts
+++ b/products/error_tracking/frontend/components/IssueAnalysis/issueAnalysisLogic.test.ts
@@ -1,0 +1,130 @@
+import type { SignalNode } from 'scenes/debug/signals/types'
+import { SignalReport, SignalReportArtefact, SignalReportStatus } from 'scenes/inbox/types'
+
+import { deriveIssueAnalysisCta, extractIssueFindings, IssueAnalysisCta, pickPrimaryReport } from './issueAnalysisLogic'
+
+const ISSUE_ID = 'issue-1'
+
+function report(overrides: Partial<SignalReport> = {}): SignalReport {
+    return {
+        id: 'report-1',
+        title: 'fix(err): handle null user',
+        summary: 'A null user crashes the profile page.',
+        status: SignalReportStatus.READY,
+        total_weight: 1,
+        signal_count: 1,
+        relevant_user_count: null,
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-01T00:00:00Z',
+        artefact_count: 1,
+        is_suggested_reviewer: false,
+        actionability: 'immediately_actionable',
+        ...overrides,
+    }
+}
+
+function signal(overrides: Partial<SignalNode> = {}): SignalNode {
+    return {
+        signal_id: 'sig-1',
+        content: '',
+        source_product: 'error_tracking',
+        source_type: 'issue_created',
+        source_id: ISSUE_ID,
+        weight: 1,
+        timestamp: '2026-07-01T00:00:00Z',
+        extra: {},
+        ...overrides,
+    }
+}
+
+function findingArtefact(signalId: string, content: Record<string, any> = {}): SignalReportArtefact {
+    return {
+        id: `artefact-${signalId}-${Math.random()}`,
+        type: 'signal_finding',
+        content: { signal_id: signalId, relevant_code_paths: ['src/profile.ts'], ...content },
+        created_at: '2026-07-01T00:00:00Z',
+    }
+}
+
+describe('issueAnalysisLogic helpers', () => {
+    describe('deriveIssueAnalysisCta', () => {
+        it.each<[string, Partial<SignalReport>, IssueAnalysisCta]>([
+            // An existing PR must win over Create PR, or the card offers a duplicate kickoff.
+            ['ready + actionable + PR', { implementation_pr_url: 'https://github.com/x/y/pull/1' }, 'view_pr'],
+            ['ready + actionable, no PR', {}, 'create_pr'],
+            ['pending input', { status: SignalReportStatus.PENDING_INPUT, actionability: null }, 'create_pr'],
+            ['ready + not actionable', { actionability: 'not_actionable' }, null],
+            ['ready + already addressed', { already_addressed: true }, null],
+            ['research queued', { status: SignalReportStatus.CANDIDATE, actionability: null }, 'in_progress'],
+            ['research running', { status: SignalReportStatus.IN_PROGRESS, actionability: null }, 'in_progress'],
+            // A researched report reset to potential keeps its analysis — no misleading spinner.
+            ['reset to potential, researched', { status: SignalReportStatus.POTENTIAL, actionability: null }, null],
+            [
+                'fresh potential, unresearched',
+                { status: SignalReportStatus.POTENTIAL, title: null, summary: null, actionability: null },
+                'in_progress',
+            ],
+        ])('%s', (_label, overrides, expected) => {
+            expect(deriveIssueAnalysisCta(report(overrides))).toBe(expected)
+        })
+    })
+
+    describe('pickPrimaryReport', () => {
+        it('picks the report with the freshest activity', () => {
+            const stale = report({ id: 'stale', updated_at: '2026-06-01T00:00:00Z' })
+            const fresh = report({ id: 'fresh', updated_at: '2026-07-02T00:00:00Z' })
+            expect(pickPrimaryReport([stale, fresh])?.id).toBe('fresh')
+            expect(pickPrimaryReport([])).toBeNull()
+            expect(pickPrimaryReport(null)).toBeNull()
+        })
+    })
+
+    describe('extractIssueFindings', () => {
+        it("keeps only this issue's signals and the newest finding per signal", () => {
+            const signals = [
+                signal({ signal_id: 'sig-1' }),
+                // Same report, different issue — its finding must not leak into this issue's card.
+                signal({ signal_id: 'sig-other', source_id: 'issue-2' }),
+                // Non-error-tracking signal whose source_id collides with the issue id.
+                signal({ signal_id: 'sig-replay', source_product: 'session_replay' }),
+            ]
+            const artefacts = [
+                findingArtefact('sig-1', { relevant_code_paths: ['src/new.ts'] }), // newest wins
+                findingArtefact('sig-1', { relevant_code_paths: ['src/old.ts'] }),
+                findingArtefact('sig-other'),
+                findingArtefact('sig-replay'),
+            ]
+
+            const findings = extractIssueFindings(ISSUE_ID, signals, artefacts)
+
+            expect(findings).toHaveLength(1)
+            expect(findings[0].signalId).toBe('sig-1')
+            expect(findings[0].codePaths).toEqual(['src/new.ts'])
+        })
+
+        it('drops findings with no code paths or commits and tolerates malformed content', () => {
+            const artefacts = [
+                findingArtefact('sig-1', { relevant_code_paths: [], relevant_commit_hashes: null }),
+                { id: 'a', type: 'signal_finding', content: {}, created_at: '2026-07-01T00:00:00Z' },
+                {
+                    id: 'b',
+                    type: 'signal_finding',
+                    content: { signal_id: 'sig-1', relevant_code_paths: 'not-an-array', relevant_commit_hashes: ['x'] },
+                    created_at: '2026-07-01T00:00:00Z',
+                },
+            ]
+            expect(extractIssueFindings(ISSUE_ID, [signal()], artefacts)).toEqual([])
+        })
+
+        it('maps commit hashes with their reasons', () => {
+            const artefacts = [
+                findingArtefact('sig-1', {
+                    relevant_code_paths: [],
+                    relevant_commit_hashes: { abc1234: 'introduced the null path' },
+                }),
+            ]
+            const findings = extractIssueFindings(ISSUE_ID, [signal()], artefacts)
+            expect(findings[0].commits).toEqual([{ sha: 'abc1234', reason: 'introduced the null path' }])
+        })
+    })
+})

--- a/products/error_tracking/frontend/components/IssueAnalysis/issueAnalysisLogic.ts
+++ b/products/error_tracking/frontend/components/IssueAnalysis/issueAnalysisLogic.ts
@@ -1,0 +1,177 @@
+import { afterMount, kea, key, listeners, path, props, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import type { SignalNode } from 'scenes/debug/signals/types'
+import { SignalReport, SignalReportArtefact, SignalReportStatus } from 'scenes/inbox/types'
+import { canCreateImplementationPr } from 'scenes/inbox/utils/reportPresentation'
+
+import type { issueAnalysisLogicType } from './issueAnalysisLogicType'
+
+export interface IssueAnalysisLogicProps {
+    issueId: string
+}
+
+/** A `signal_finding` artefact narrowed to one of this issue's signals: where the research agent looked. */
+export interface IssueFinding {
+    signalId: string
+    codePaths: string[]
+    commits: { sha: string; reason: string }[]
+    verified: boolean
+}
+
+export type IssueAnalysisCta = 'create_pr' | 'view_pr' | 'in_progress' | null
+
+// Statuses meaning a research run is queued or currently executing for the report.
+const RESEARCH_PENDING_STATUSES: SignalReportStatus[] = [SignalReportStatus.CANDIDATE, SignalReportStatus.IN_PROGRESS]
+
+/**
+ * An issue's created/reopened/spiking signals can land in several reports over time — surface the
+ * one with the freshest activity.
+ */
+export function pickPrimaryReport(reports: SignalReport[] | null): SignalReport | null {
+    if (!reports?.length) {
+        return null
+    }
+    return [...reports].sort((a, b) => b.updated_at.localeCompare(a.updated_at))[0]
+}
+
+export function isResearchPending(report: SignalReport | null): boolean {
+    if (!report) {
+        return false
+    }
+    // `potential` without a title is a fresh group whose first research run hasn't started yet;
+    // `potential` with one is a researched report reset by the actionability judge — show it as-is.
+    return (
+        RESEARCH_PENDING_STATUSES.includes(report.status) ||
+        (report.status === SignalReportStatus.POTENTIAL && !report.title)
+    )
+}
+
+export function deriveIssueAnalysisCta(report: SignalReport | null): IssueAnalysisCta {
+    if (!report) {
+        return null
+    }
+    if (report.implementation_pr_url) {
+        return 'view_pr'
+    }
+    if (canCreateImplementationPr(report)) {
+        return 'create_pr'
+    }
+    if (isResearchPending(report)) {
+        return 'in_progress'
+    }
+    return null
+}
+
+/**
+ * Narrow a report's `signal_finding` artefacts to the given issue's signals. Artefacts are
+ * newest-first and finding identity is per signal, so the first row seen per signal wins.
+ */
+export function extractIssueFindings(
+    issueId: string,
+    signals: SignalNode[],
+    artefacts: SignalReportArtefact[]
+): IssueFinding[] {
+    const issueSignalIds = new Set(
+        signals.filter((s) => s.source_product === 'error_tracking' && s.source_id === issueId).map((s) => s.signal_id)
+    )
+    const findings: IssueFinding[] = []
+    const seen = new Set<string>()
+    for (const artefact of artefacts) {
+        if (artefact.type !== 'signal_finding') {
+            continue
+        }
+        const signalId = artefact.content?.signal_id
+        if (typeof signalId !== 'string' || !issueSignalIds.has(signalId) || seen.has(signalId)) {
+            continue
+        }
+        seen.add(signalId)
+        const codePaths = Array.isArray(artefact.content.relevant_code_paths)
+            ? artefact.content.relevant_code_paths.filter((p): p is string => typeof p === 'string')
+            : []
+        const rawCommits = artefact.content.relevant_commit_hashes
+        const commits =
+            rawCommits && typeof rawCommits === 'object' && !Array.isArray(rawCommits)
+                ? Object.entries(rawCommits as Record<string, unknown>).map(([sha, reason]) => ({
+                      sha,
+                      reason: typeof reason === 'string' ? reason : '',
+                  }))
+                : []
+        if (codePaths.length || commits.length) {
+            findings.push({ signalId, codePaths, commits, verified: !!artefact.content.verified })
+        }
+    }
+    return findings
+}
+
+export const issueAnalysisLogic = kea<issueAnalysisLogicType>([
+    props({} as IssueAnalysisLogicProps),
+    key((props) => props.issueId),
+    path((key) => ['products', 'error_tracking', 'issueAnalysisLogic', key]),
+
+    loaders(({ props, values }) => ({
+        reports: [
+            null as SignalReport[] | null,
+            {
+                loadReports: async () => {
+                    const response = await api.signalReports.list({
+                        source_product: 'error_tracking',
+                        source_id: props.issueId,
+                        limit: 20,
+                    })
+                    return response.results
+                },
+            },
+        ],
+        issueFindings: [
+            [] as IssueFinding[],
+            {
+                loadIssueFindings: async () => {
+                    const report = values.report
+                    if (!report) {
+                        return []
+                    }
+                    const [{ signals }, artefacts] = await Promise.all([
+                        api.signalReports.getReportSignals(report.id),
+                        api.signalReports.artefacts(report.id, { limit: 1000 }),
+                    ])
+                    return extractIssueFindings(props.issueId, signals, artefacts.results)
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        report: [(s) => [s.reports], (reports): SignalReport | null => pickPrimaryReport(reports)],
+        researchPending: [(s) => [s.report], (report): boolean => isResearchPending(report)],
+        cta: [(s) => [s.report], (report): IssueAnalysisCta => deriveIssueAnalysisCta(report)],
+        showCard: [
+            (s) => [s.report, s.researchPending],
+            (report, researchPending): boolean => !!report && (!!report.title || !!report.summary || researchPending),
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        loadReportsSuccess: () => {
+            const report = values.report
+            if (!report) {
+                return
+            }
+            actions.loadIssueFindings()
+            posthog.capture('error_tracking_issue_analysis_shown', {
+                issue_id: props.issueId,
+                report_id: report.id,
+                report_status: report.status,
+                priority: report.priority ?? null,
+                actionability: report.actionability ?? null,
+                has_implementation_pr: !!report.implementation_pr_url,
+            })
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadReports()
+    }),
+])

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -40,6 +40,7 @@ import { EventsTable } from '../../components/EventsTable/EventsTable'
 import { ExceptionCard } from '../../components/ExceptionCard'
 import { StackTraceActions } from '../../components/ExceptionCard/Tabs/StackTraceTab/StackTraceActions'
 import { StatusIndicator } from '../../components/Indicators'
+import { IssueAnalysis } from '../../components/IssueAnalysis/IssueAnalysis'
 import { ErrorFilters } from '../../components/IssueFilters'
 import { issueFiltersLogic } from '../../components/IssueFilters/issueFiltersLogic'
 import { Metadata } from '../../components/IssueMetadata'
@@ -302,6 +303,7 @@ const LeftHandColumn = ({ isMobile }: { isMobile: boolean }): JSX.Element => {
     const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
     const hasTasks = useFeatureFlag('TASKS')
     const hasSimilarIssues = useFeatureFlag('ERROR_TRACKING_RELATED_ISSUES')
+    const hasIssueAnalysis = useFeatureFlag('ERROR_TRACKING_ISSUE_ANALYSIS')
 
     return (
         <div
@@ -317,6 +319,7 @@ const LeftHandColumn = ({ isMobile }: { isMobile: boolean }): JSX.Element => {
             }
             className={clsx('flex flex-col h-full relative bg-surface-primary', isMobile && 'flex-1 max-w-full')}
         >
+            {hasIssueAnalysis && <IssueAnalysis />}
             <TabsPrimitive
                 value={category}
                 onValueChange={(value) => setCategory(value as ErrorTrackingIssueSceneCategory)}

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -604,6 +604,57 @@ def fetch_report_ids_for_source_products(team: Team, source_products: list[str])
 
 
 # ---------------------------------------------------------------------------
+# fetch_report_ids_for_source_records — synchronous, for the viewset list filter
+# ---------------------------------------------------------------------------
+
+
+def fetch_report_ids_for_source_records(team: Team, source_products: list[str], source_ids: list[str]) -> set[str]:
+    """Return report IDs with at least one non-deleted signal matching the given source products AND source ids.
+
+    Reverse lookup from a source record (e.g. an error tracking issue) to every report its signals
+    grouped into — one record can feed several reports over time (created / reopened / spiking
+    signals may match different reports). Unlike `fetch_report_ids_for_source_ids`, which resolves
+    the single latest report per scout finding, this keeps every report the record contributed to.
+
+    Uses argMax deduplication for stable results regardless of ReplacingMergeTree merge state.
+    """
+    if not source_products or not source_ids:
+        return set()
+
+    # Push the source_id filter into the document_embeddings scan so we only dedup the handful of
+    # signals for these records, not the team's entire signal history. `source_id` is stable across
+    # a document's versions, so `extra_where` is safe here (see `_deduped_signals_subquery`).
+    source_id_scan_filter = "JSONExtractString(metadata, 'source_id') IN ({source_ids})"
+    ch_query = f"""
+        SELECT DISTINCT report_id
+        FROM (
+            SELECT
+                JSONExtractString(metadata, 'report_id') as report_id,
+                JSONExtractBool(metadata, 'deleted') as is_deleted,
+                JSONExtractString(metadata, 'source_product') as source_product
+            FROM ({_deduped_signals_subquery(extra_where=source_id_scan_filter)})
+        )
+        WHERE NOT is_deleted
+          AND report_id != ''
+          AND source_product IN ({{source_products}})
+    """
+
+    tag_queries(product=Product.SIGNALS, feature=Feature.QUERY)
+    result = execute_hogql_query(
+        query_type="SignalsFilterBySourceRecord",
+        query=ch_query,
+        team=team,
+        placeholders={
+            "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+            "source_products": ast.Tuple(exprs=[ast.Constant(value=sp) for sp in source_products]),
+            "source_ids": ast.Tuple(exprs=[ast.Constant(value=sid) for sid in source_ids]),
+        },
+    )
+
+    return {row[0] for row in (result.results or []) if row[0]}
+
+
+# ---------------------------------------------------------------------------
 # fetch_source_products_for_reports — synchronous, for the serializer list view
 # ---------------------------------------------------------------------------
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -23,7 +23,7 @@ from posthog.models.team.team import Team
 from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
 from products.signals.backend.task_run_artefacts import append_task_run_artefact, record_implementation_task
-from products.signals.backend.temporal.signal_queries import ReportSignalMeta
+from products.signals.backend.temporal.signal_queries import ReportSignalMeta, fetch_report_ids_for_source_records
 
 if TYPE_CHECKING:
     from products.tasks.backend.models import Task, TaskRun
@@ -852,6 +852,38 @@ class TestSignalReportListAPI(APIBaseTest):
         body = response.json()
         assert body["attr"] == "actionability"
         assert body["code"] == "invalid_input"
+
+    # --- source_id ---
+
+    def test_list_filters_by_source_record(self):
+        matched = self._create_report(title="Matched")
+        self._create_report(title="Unmatched")
+
+        with patch(
+            "products.signals.backend.views.fetch_report_ids_for_source_records",
+            return_value={str(matched.id)},
+        ) as mock_fetch:
+            response = self.client.get(self._list_url(source_product="error_tracking", source_id="issue-1,issue-2"))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [r["id"] for r in response.json()["results"]] == [str(matched.id)]
+        mock_fetch.assert_called_once_with(self.team, ["error_tracking"], ["issue-1", "issue-2"])
+
+    def test_list_source_id_without_source_product_returns_400(self):
+        response = self.client.get(self._list_url(source_id="issue-1"))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "source_id"
+
+    def test_fetch_report_ids_for_source_records_query_compiles(self):
+        # The lookup pushes the source_id filter into the shared dedup subquery, which exposes
+        # `metadata` as an argMax alias — a naive pushed-down WHERE binds to the aggregate alias
+        # and HogQL rejects the whole query. Mocked view tests never exercise the query, so run
+        # the real one against an empty ClickHouse: it must compile and return an empty set.
+        result = fetch_report_ids_for_source_records(
+            self.team, ["error_tracking"], ["00000000-0000-0000-0000-000000000000"]
+        )
+        assert result == set()
 
     # --- source_products ---
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -108,6 +108,7 @@ from products.signals.backend.temporal.grouping_v2 import TeamSignalGroupingV2Wo
 from products.signals.backend.temporal.reingestion import SignalReportReingestionWorkflow
 from products.signals.backend.temporal.signal_queries import (
     fetch_report_ids_for_source_products,
+    fetch_report_ids_for_source_records,
     fetch_signals_for_report_sync,
     fetch_source_products_for_reports,
 )
@@ -680,14 +681,20 @@ class SignalReportViewSet(
 
     def _apply_signal_report_source_product_filter(self, queryset):
         source_product_filter = self.request.query_params.get("source_product")
-        if not source_product_filter:
-            return queryset
+        source_id_filter = self.request.query_params.get("source_id")
+        source_products = [s.strip() for s in (source_product_filter or "").split(",") if s.strip()]
+        source_ids = [s.strip() for s in (source_id_filter or "").split(",") if s.strip()]
 
-        source_products = [s.strip() for s in source_product_filter.split(",") if s.strip()]
+        # A bare source_id is ambiguous across products and would force an unbounded metadata scan.
+        if source_ids and not source_products:
+            raise serializers.ValidationError({"source_id": "source_id requires source_product to be set."})
         if not source_products:
             return queryset
 
-        report_ids_with_source = fetch_report_ids_for_source_products(self.team, source_products)
+        if source_ids:
+            report_ids_with_source = fetch_report_ids_for_source_records(self.team, source_products, source_ids)
+        else:
+            report_ids_with_source = fetch_report_ids_for_source_products(self.team, source_products)
         return queryset.filter(id__in=report_ids_with_source)
 
     def _latest_suggested_reviewers_qs(self):
@@ -1116,6 +1123,17 @@ class SignalReportViewSet(
                 description=(
                     "Comma-separated list of source products to include. Reports are kept if at least one of "
                     "their contributing signals comes from one of these products (e.g. error_tracking, session_replay)."
+                ),
+            ),
+            OpenApiParameter(
+                name="source_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Comma-separated list of source record IDs (e.g. error tracking issue UUIDs). Reports are "
+                    "kept if at least one of their contributing signals comes from one of these records. "
+                    "Requires source_product to be set."
                 ),
             ),
             OpenApiParameter(

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1852,6 +1852,10 @@ export type SignalsReportsListParams = {
      */
     search?: string
     /**
+     * Comma-separated list of source record IDs (e.g. error tracking issue UUIDs). Reports are kept if at least one of their contributing signals comes from one of these records. Requires source_product to be set.
+     */
+    source_id?: string
+    /**
      * Comma-separated list of source products to include. Reports are kept if at least one of their contributing signals comes from one of these products (e.g. error_tracking, session_replay).
      */
     source_product?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -65951,6 +65951,10 @@ export namespace Schemas {
      */
     search?: string;
     /**
+     * Comma-separated list of source record IDs (e.g. error tracking issue UUIDs). Reports are kept if at least one of their contributing signals comes from one of these records. Requires source_product to be set.
+     */
+    source_id?: string;
+    /**
      * Comma-separated list of source products to include. Reports are kept if at least one of their contributing signals comes from one of these products (e.g. error_tracking, session_replay).
      */
     source_product?: string;

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -38,6 +38,12 @@ export const SignalsReportsListQueryParams = /* @__PURE__ */ zod.object({
             'Comma-separated list of priorities to include. Valid values: P0, P1, P2, P3, P4. Reports without a priority assignment are excluded when this filter is set.'
         ),
     search: zod.string().optional().describe('Case-insensitive substring match against report title and summary.'),
+    source_id: zod
+        .string()
+        .optional()
+        .describe(
+            'Comma-separated list of source record IDs (e.g. error tracking issue UUIDs). Reports are kept if at least one of their contributing signals comes from one of these records. Requires source_product to be set.'
+        ),
     source_product: zod
         .string()
         .optional()

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -221,6 +221,7 @@ const inboxReportsList = (): ToolBase<
                 ordering: params.ordering,
                 priority: params.priority,
                 search: params.search,
+                source_id: params.source_id,
                 source_product: params.source_product,
                 status: params.status,
                 suggested_reviewers: params.suggested_reviewers,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
@@ -25,6 +25,10 @@
             "description": "Case-insensitive substring match against report title and summary.",
             "type": "string"
         },
+        "source_id": {
+            "description": "Comma-separated list of source record IDs (e.g. error tracking issue UUIDs). Reports are kept if at least one of their contributing signals comes from one of these records. Requires source_product to be set.",
+            "type": "string"
+        },
         "source_product": {
             "description": "Comma-separated list of source products to include. Reports are kept if at least one of their contributing signals comes from one of these products (e.g. error_tracking, session_replay).",
             "type": "string"


### PR DESCRIPTION
## Problem

Every new error tracking issue already gets researched by the signals pipeline: cymbal emits an `issue_created` signal at ingestion, grouping folds it into a signal report, and the agentic research run produces a summary, suspect code paths and commits, priority, actionability, and sometimes an auto-created fix PR. None of that surfaces where the person debugging the issue actually is – the issue page. The only UI for it today is the Inbox.

## Changes

Backend

- `GET /api/projects/:id/signals/reports/` gains a `source_id` filter (comma-separated, requires `source_product`), so the frontend can resolve "which reports did this issue's signals land in". Backed by a new ClickHouse lookup `fetch_report_ids_for_source_records` that pushes the `source_id` predicate into the shared dedup subquery, mirroring the existing scout reverse lookup.
- A bare `source_id` without `source_product` is a 400 – it would be ambiguous across products and force an unbounded metadata scan.

Frontend (behind the new `error-tracking-issue-analysis` flag)

- New "AI analysis" card at the top of the issue scene's left column. It shows the freshest report the issue's signals grouped into: title, priority and actionability badges, expandable summary, and the suspect code paths/commits from this issue's `signal_finding` artefacts.
- CTA state machine: `View fix PR` when an implementation PR exists, `Create fix PR` (reusing the inbox's `inboxTaskKickoffLogic.createPrFromReport`) when the report is ready and actionable, an "Analyzing…" spinner while research runs, and always a `View full analysis` link into the Inbox.
- The card renders nothing when the issue has no report (source disabled, org without AI processing approval, or nothing grouped yet).
- Moved `canCreateImplementationPr` from `ReportDetailActions` into `scenes/inbox/utils/reportPresentation.ts` so the issue card and the inbox detail pane share one gate, and added `issue_scene` to the inbox analytics surface union.

Design notes

- The issue→report link is resolved read-time from ClickHouse signal metadata. No new Postgres table: the API contract (`source_product` + `source_id` filters) stays stable, so storage can later move to a persisted link table (for issue-list badges or >3-month lookback beyond the embeddings TTL) without touching the frontend.
- The reports API lives on the signals side because tach only allows `signals → error_tracking`, not the reverse; the issue page composes the two products' APIs in the frontend.

## How did you test this code?

- `hogli test products/signals/backend/test/test_signal_report_api.py::TestSignalReportListAPI -k "source_record or source_id_without"` – 3 passed. New cases: the list endpoint honors the ClickHouse lookup result and parses comma-separated params (no existing test covered the source filters), `source_id` without `source_product` 400s, and a no-mock compile test that runs the real HogQL against an empty ClickHouse – the pushed-down `extra_where` aliasing broke silently once before for the scout lookup, and mocked view tests can't catch it.
- `hogli test products/error_tracking/frontend/components/IssueAnalysis/issueAnalysisLogic.test.ts` – 13 passed. Pure-function cases: the CTA machine never offers `Create fix PR` when a PR already exists (double-kickoff), findings from other issues' signals in the same report don't leak into the card, newest finding per signal wins, freshest report is picked.
- `ruff`, `oxlint`/`oxfmt`, kea typegen, and `tsgo --noEmit` clean on every touched file. I (Claude) did not manually test the UI against a running stack – the flag is off by default, so the card is inert until enabled.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (investigation + implementation session). Skills invoked: /pr-closeout, /improving-drf-endpoints, /writing-tests, /writing-kea-logics, /adopting-generated-api-types.
- Options considered for the issue→report link: read-time ClickHouse lookup (chosen – no migration, works retroactively, contract-stable), a persisted `SignalReportSource` table written at signal-assignment time (deferred fast-follow, needed for issue-list badges and history beyond the embeddings TTL), and a `report_id` on `ErrorTrackingIssue` (rejected – wrong coupling direction under tach, and issue→report is 1:N).
- UI placement considered: left-column card above the tabs (chosen – above the fold without a tab click), a ScenePanel section (cramped, dual-write rule), or upgrading the existing Autofix tab (hidden behind a click). Folding the Autofix tab into this card is a possible follow-up once validated.
- Known v1 gaps, accepted deliberately: merged-away issue ids aren't chased (their signals keep the old id), and reports older than the embeddings TTL (~3 months) lose the link.
