### PR TITLE
chore(mcp-analytics): assign product ownership to team-mcp-analytics

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -290,9 +290,11 @@ posthog/hogql_queries/property_values_query_runner.py @PostHog/team-product-anal
 ee/clickhouse/views/groups.py @PostHog/team-product-analytics
 ee/clickhouse/queries/related_actors_query.py @PostHog/team-product-analytics
 posthog/temporal/product_analytics/ @PostHog/team-product-analytics
-posthog/temporal/mcp_analytics/ @PostHog/team-mcp-analytics
 frontend/src/scenes/themes/ @PostHog/team-product-analytics
 posthog/taxonomy/ @PostHog/team-product-analytics
+
+# MCP Analytics - owned by @PostHog/team-mcp-analytics
+posthog/temporal/mcp_analytics/ @PostHog/team-mcp-analytics
 
 # Experiments - owned by @PostHog/team-experiments
 frontend/src/scenes/experiments/ @PostHog/team-experiments

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -290,7 +290,7 @@ posthog/hogql_queries/property_values_query_runner.py @PostHog/team-product-anal
 ee/clickhouse/views/groups.py @PostHog/team-product-analytics
 ee/clickhouse/queries/related_actors_query.py @PostHog/team-product-analytics
 posthog/temporal/product_analytics/ @PostHog/team-product-analytics
-posthog/temporal/mcp_analytics/ @PostHog/team-product-analytics
+posthog/temporal/mcp_analytics/ @PostHog/team-mcp-analytics
 frontend/src/scenes/themes/ @PostHog/team-product-analytics
 posthog/taxonomy/ @PostHog/team-product-analytics
 

--- a/products/mcp_analytics/product.yaml
+++ b/products/mcp_analytics/product.yaml
@@ -1,3 +1,3 @@
 name: MCP analytics
 owners:
-    - team-product-analytics
+    - team-mcp-analytics


### PR DESCRIPTION
## Problem

MCP analytics signal reports and PRs weren't being routed to or tagging the owning team. `products/mcp_analytics/**` resolved to `team-product-analytics` (a large shared team), so mcp-analytics work had nothing reliably tying it to the dedicated team.

**Why:** so mcp-analytics signals/reports and code reviews notify and tag `@PostHog/team-mcp-analytics`. Follow-up to the scene-gating work in #67705 (now merged); this is split out onto master since that branch already landed.

## Changes

- `products/mcp_analytics/product.yaml` — owner `team-product-analytics` → `team-mcp-analytics`. This is the source the soft-codeowners auto-assigner reads for `products/<name>/**`.
- `.github/CODEOWNERS-soft` — the one out-of-product mcp_analytics path (`posthog/temporal/mcp_analytics/`) moved to the same team for consistency.

## How did you test this code?

Not runtime-testable. Note: the `Validate product.yaml owners` CI check calls the GitHub API to confirm the owner is a real PostHog/posthog collaborator team — this will fail if `@PostHog/team-mcp-analytics` hasn't been created yet. If it goes red, create the team rather than reverting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1782984116312979?thread_ts=1782984116.312979&cid=C0B3E1Y576X)*