### PR TITLE
feat(toolbar): add otel spans to the element stats endpoint

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -77,10 +77,13 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         Currently only $autocapture and $rageclick and $dead_click are supported
         """
 
-        with ELEMENT_STATS_TIME_HISTOGRAM.time():
+        with (
+            ELEMENT_STATS_TIME_HISTOGRAM.time(),
+            tracer.start_as_current_span("elements_api_stats") as span,
+        ):
             timer = ServerTimingsGathered()
 
-            with timer("prepare_for_query"):
+            with timer("prepare_for_query"), tracer.start_as_current_span("elements_api_stats.prepare_for_query"):
                 filter = Filter(request=request, team=self.team)
                 date_params = {}
                 query_date_range = QueryDateRange(filter=filter, team=self.team, should_round=True)
@@ -114,7 +117,13 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     hogql_context=filter.hogql_context,
                 )
 
-            with timer("execute_query"):
+            span.set_attribute("team_id", self.team.pk)
+            span.set_attribute("limit", limit)
+            span.set_attribute("offset", offset)
+            span.set_attribute("sampling_factor", sampling_factor)
+            span.set_attribute("include_event_types", ",".join(sorted(events_filter)))
+
+            with timer("execute_query"), tracer.start_as_current_span("elements_api_stats.execute_query"):
                 result = sync_execute(
                     GET_ELEMENTS.format(
                         date_from=date_from,
@@ -135,7 +144,10 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     },
                 )
 
-            with timer("prepare_for_serialization"):
+            with (
+                timer("prepare_for_serialization"),
+                tracer.start_as_current_span("elements_api_stats.prepare_for_serialization"),
+            ):
                 elements_data = [
                     {
                         "count": elements[1],
@@ -146,9 +158,10 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     for elements in result[:limit]
                 ]
 
-            with timer("serialize_elements"):
+            with timer("serialize_elements"), tracer.start_as_current_span("elements_api_stats.serialize_elements"):
                 serialized_elements = ElementStatsSerializer(elements_data, many=True).data
 
+            span.set_attribute("result_count", len(serialized_elements))
             ELEMENT_STATS_RESULT_COUNT_HISTOGRAM.labels(limit=limit).observe(len(serialized_elements))
 
             has_next = len(result) == limit + 1


### PR DESCRIPTION
## Problem

The toolbar clickmap now loads a 5,000-row page from `/api/element/stats/`, and the endpoint's latency is the next visible bottleneck. The `stats` action has `Server-Timing` phases and a prometheus duration histogram, but no OTel spans — a check of the web service's span operations over 24h shows zero element-stats operations, so there is no way to attribute production time between the ClickHouse query, chain parsing, and DRF serialization. (The neighboring `values` action was instrumented; `stats` never was.)

## Changes

- Wrap the action in an `elements_api_stats` root span carrying `team_id`, `limit`, `offset`, `sampling_factor`, `include_event_types`, and `result_count`.
- Mirror the four existing `Server-Timing` phases as child spans: `prepare_for_query`, `execute_query`, `prepare_for_serialization`, `serialize_elements`.

Instrumentation-only: no behavior, schema, or response changes.

## How did you test this code?

- `python -m py_compile` and ruff locally; the existing `posthog/api/test/test_element.py` suite runs in CI (docker unavailable in the working sandbox). No new tests: context-manager instrumentation with no observable API behavior to assert.
- Local benchmarking of the phases this instruments (5,000-row request: ~590ms chain parsing, ~265ms DRF serialization) motivates the split — a follow-up PR optimizes those phases and these spans are how the win (and any regression) will be visible in production.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code while investigating toolbar clickmap API latency. Production span inventory was checked via PostHog APM MCP tools; the Python phase costs were measured with a local benchmark replicating the endpoint's exact parse+serialize path.
- Skills invoked: /improving-drf-endpoints, posthog:exploring-apm-traces, /optimizing-clickhouse-and-hogql-queries.
- Decisions: span names mirror the existing Server-Timing keys under an `elements_api_stats.` prefix, matching the file's existing `elements_api_property_values` naming.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
