### PR TITLE
fix(bigquery): give write-permission guidance for temp-table access denials

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -58,6 +58,18 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # be repaired by retrying — the user must re-upload an intact JSON key file. Matched on the
             # stable "Unable to load PEM file" wording rather than the volatile InvalidData detail.
             "Unable to load PEM file": "We couldn't read the private key in your Google Cloud JSON key file — it appears truncated or corrupted. Please download a fresh service account key from Google Cloud and re-upload the JSON file.",
+            # Writing query results into the `__posthog_import_...` temp tables PostHog creates
+            # (`WRITE_TRUNCATE` in `_run_destination_query_with_job_retry`, on incremental / view /
+            # row-filtered reads) needs write access on the dataset those tables live in. When the
+            # service account only has read access, BigQuery rejects the copy with "Permission
+            # bigquery.tables.update denied on table <temp id>". This is a distinct problem from the
+            # read-side denials the "Access Denied:" key below covers — and that key would match this
+            # message first and misdirect the customer to grant *read* access (Data Viewer), which
+            # can't fix a *write* failure. Keep this key above "Access Denied:" so the write-specific
+            # guidance wins. Deterministic IAM config problem — retrying can't grant the permission.
+            # Matched on the stable permission name (also covers `bigquery.tables.updateData`), not
+            # the volatile temp-table id.
+            "bigquery.tables.update": "BigQuery denied write access to a temporary table PostHog creates in your dataset. PostHog copies query results into temporary tables before reading them, so read access alone isn't enough. Please grant your service account write access (for example the BigQuery Data Editor role) on the dataset where these temporary tables are created — your main dataset, or the temporary dataset if you configured one — then reconnect the source.",
             # BigQuery prefixes every IAM/permission failure with "Access Denied:" — e.g.
             # "Access Denied: Table <id>: Permission bigquery.tables.getData denied on table <id>
             # (or it may not exist).". The matched string above only covers the REST client's

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -843,7 +843,8 @@ def test_temp_table_write_denial_surfaces_write_permission_guidance():
         )
     )
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
-    friendly = next(msg for key, msg in non_retryable_errors.items() if key in observed_error)
+    first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
+    assert first_key == "bigquery.tables.update"
     assert friendly is not None
     assert "write access" in friendly
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -831,6 +831,23 @@ def test_non_retryable_errors_match_permission_denied(observed_error):
     assert any(key in observed_error for key in non_retryable_errors)
 
 
+def test_temp_table_write_denial_surfaces_write_permission_guidance():
+    # A tables.update denial on a PostHog temp table also contains "Access Denied:", so both keys
+    # match. external_data_job surfaces the first matching key's message, so the write-specific key
+    # must sit above "Access Denied:" — otherwise the customer is told to grant read access to fix a
+    # write failure.
+    observed_error = str(
+        Forbidden(
+            "Access Denied: Table prj:ds.__posthog_import_abc_123: Permission bigquery.tables.update "
+            "denied on table prj:ds.__posthog_import_abc_123 (or it may not exist)."
+        )
+    )
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    friendly = next(msg for key, msg in non_retryable_errors.items() if key in observed_error)
+    assert friendly is not None
+    assert "write access" in friendly
+
+
 @pytest.mark.parametrize(
     "observed_error",
     [


### PR DESCRIPTION
## Problem

BigQuery error tracking surfaced a recurring `Forbidden` from the data warehouse import path:

```
Access Denied: Table <project>:<dataset>.__posthog_import_<redacted>: Permission
bigquery.tables.update denied on table <project>:<dataset>.__posthog_import_<redacted>
(or it may not exist).; reason: accessDenied
```

Issue: https://us.posthog.com/project/2/error_tracking/019f22ad-1f4c-7533-96b4-fd3defb68694

The raise site is in this source's code: `_run_destination_query_with_job_retry` in `bigquery.py`. For incremental syncs, and for views / external tables / row-filtered reads, PostHog copies query results into a temporary `__posthog_import_...` table with `WRITE_TRUNCATE` and then reads that table via the Storage Read API. That copy needs write access on the dataset the temp tables live in. When the service account only has read access, BigQuery rejects it with `Permission bigquery.tables.update denied`.

This message already contains `Access Denied:`, so it already matches an existing non-retryable key and the sync correctly stops retrying. The bug is the guidance: the `Access Denied:` message tells the customer to grant read access (`bigquery.tables.getData`, the BigQuery Data Viewer role). That never resolves a write-permission failure, so the customer grants Data Viewer, re-enables, and hits the same denial.

## Changes

Add a specific `bigquery.tables.update` non-retryable key with accurate guidance, inserted ahead of the generic `Access Denied:` key. The classifier surfaces the first matching key's message, so ordering matters — the write-specific message now wins over the read-oriented one. It points the customer at write access (for example the BigQuery Data Editor role) on the dataset where the temp tables are created, which is either their main dataset or the configured temporary dataset.

Retry behavior is unchanged (already non-retryable via `Access Denied:`); this only corrects the message the customer sees. The key also covers `bigquery.tables.updateData`, the sibling write permission for the same copy, since it contains the same substring.

## How did you test this code?

Automated only, no manual BigQuery run.

- Added `test_temp_table_write_denial_surfaces_write_permission_guidance`. It builds the exact `bigquery.tables.update`-on-temp-table denial and asserts that the first matching non-retryable key's message is the write-permission one (`"write access"`). This catches the ordering regression specifically: if the new key is removed or moved below `Access Denied:`, the generic read-oriented message wins again and the test fails. No existing test exercised which friendly message is surfaced for a temp-table write denial.
- Ran the bigquery source non-retryable / permission-denied tests: `36 passed`.
- `ruff check` and `ruff format --check` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live BigQuery error-tracking issue with Claude Code. Confirmed the failure originates in `bigquery/bigquery.py` (`_run_destination_query_with_job_retry`, the `WRITE_TRUNCATE` copy into the `__posthog_import_` temp table), then traced the classifier in `external_data_job.py` (plain substring match, first matching key's message wins).

Key decision: this is not a retry-behavior bug — `Access Denied:` already makes it non-retryable. It's a guidance bug. The generic message points at read access, but a `bigquery.tables.update` denial is a write-permission problem on the temp-table dataset. Followed the source's established pattern of adding a specific key with tailored guidance ahead of the generic catch-all (as already done for `bigquery.readsessions.create` and federated `permission denied for table`). Checked open warehouse PRs including the maintainer's own; the nearest (#67387) handles `invalid_grant` during temp-table cleanup, a different root cause.

Skills invoked: `/writing-tests` (to gate the regression test).
