### PR TITLE
fix(tasks): reliably start the Slack agent-design relay child workflow

### DIFF
--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1188,18 +1188,16 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             return
         relay_workflow_id = f"slack-agent-design-relay-{self.context.run_id}-{workflow.uuid4()}"
         self._current_slack_relay_workflow_id = relay_workflow_id
-        asyncio.ensure_future(
-            workflow.execute_child_workflow(
-                SlackAgentDesignRelayWorkflow.run,
-                SlackAgentDesignRelayInput(slack_thread_context=slack_ctx),
-                id=relay_workflow_id,
-                task_queue=workflow.info().task_queue,
-                # Cancel on parent close so the relay's finally block runs
-                # stop_slack_agent_design_stream — otherwise the plan-block
-                # stream is orphaned until Slack's own GC.
-                parent_close_policy=ParentClosePolicy.REQUEST_CANCEL,
-                execution_timeout=timedelta(hours=1),
-            )
+        await workflow.start_child_workflow(
+            SlackAgentDesignRelayWorkflow.run,
+            SlackAgentDesignRelayInput(slack_thread_context=slack_ctx),
+            id=relay_workflow_id,
+            task_queue=workflow.info().task_queue,
+            # Cancel on parent close so the relay's finally block runs
+            # stop_slack_agent_design_stream — otherwise the plan-block
+            # stream is orphaned until Slack's own GC.
+            parent_close_policy=ParentClosePolicy.REQUEST_CANCEL,
+            execution_timeout=timedelta(hours=1),
         )
 
     @temporalio.workflow.signal


### PR DESCRIPTION
## Problem

- With `slack-app-agent-design` on, the normal Slack reply is suppressed and the response streams through a per-turn `slack-agent-design-relay` child workflow (opened in the `turn_started` signal handler).
- On the DEV region instance the child never started. `turn_started` arrived, but there was no `StartChildWorkflowExecutionInitiated`, no relay executions, and no error. Net effect: flag on, silence in Slack.
- Cause: the handler started the child via fire-and-forget `asyncio.ensure_future(workflow.execute_child_workflow(...))`. The unawaited start can be dropped before its `StartChildWorkflowExecution` command is issued, which is timing dependent.

## Changes

- Swap `ensure_future(execute_child_workflow(...))` for `await workflow.start_child_workflow(...)`.
- `start_child_workflow` awaits only the start handshake, not the child's run, so the relay is guaranteed running before the handler returns, without blocking on its lifetime.

## How did you test this code?

- AFAICT it ran fine locally even before this fix. Local timing happened to flush the unawaited start in time, so local is not a reliable signal for this bug.
- The failure only reproduced on the deployed DEV region instance (child never started, no error).
- `ruff` clean. No unit test covers Temporal child-workflow start.
- Verify on DEV: `slack-agent-design-relay` children now appear and the plan-block streams back into the thread.

Model: Opus 4.8 (1M context) via Claude Code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a
