### PR TITLE
chore(charts): dedupe dim-opacity constant, document slope collision strategy

### DIFF
--- a/packages/quill/packages/charts/src/charts/SlopeChart/SlopeValueLabels.tsx
+++ b/packages/quill/packages/charts/src/charts/SlopeChart/SlopeValueLabels.tsx
@@ -28,7 +28,11 @@ interface ValueCandidate {
 
 const LABEL_HEIGHT = 16
 
-/** Keep labels in one column top-to-bottom, dropping any that would crowd the one above it. */
+/** Keep labels in one column top-to-bottom, dropping any that would crowd the one above it.
+ *  Unlike `nonCollidingKeys` (series/slice labels), this drops by vertical position, not by a
+ *  significance score: value labels share a single fixed-x column where the only sensible reading
+ *  order is top-to-bottom, and — being the point's own value — carry no cross-label priority that
+ *  would justify keeping a lower label over the one above it. */
 function columnSweep(candidates: ValueCandidate[], minGap: number): ValueCandidate[] {
     const sorted = [...candidates].sort((a, b) => a.y - b.y)
     const kept: ValueCandidate[] = []

--- a/packages/quill/packages/charts/src/charts/utils/derived-series.ts
+++ b/packages/quill/packages/charts/src/charts/utils/derived-series.ts
@@ -1,10 +1,9 @@
 import type { Series } from '../../core/types'
-import { dimHex } from '../../utils/comparison-dimming'
+import { DIM_OPACITY, dimHex } from '../../utils/comparison-dimming'
 import { linearRegression, movingAverage, trendLine } from '../../utils/statistics'
 
 export type { TrendLineConfig } from './use-derived-series'
 
-const TREND_LINE_DIM_OPACITY = 0.5
 const CI_FILL_OPACITY = 0.2
 const MA_DASH_PATTERN = [10, 3]
 const TREND_LINE_DASH_PATTERN = [1, 3]
@@ -86,7 +85,7 @@ export function buildTrendLineSeries<Meta = unknown>(input: BuildTrendLineSeries
         key: `${sourceSeries.key}__trendline`,
         label: input.label ?? sourceSeries.label,
         data,
-        color: dimHex(baseColor, TREND_LINE_DIM_OPACITY),
+        color: dimHex(baseColor, DIM_OPACITY),
         yAxisId: sourceSeries.yAxisId,
         meta: sourceSeries.meta,
         stroke: { pattern: TREND_LINE_DASH_PATTERN },

--- a/packages/quill/packages/charts/src/utils/comparison-dimming.ts
+++ b/packages/quill/packages/charts/src/utils/comparison-dimming.ts
@@ -1,7 +1,9 @@
 import type { Series } from '../core/types'
 import { hexToRGBA } from './format'
 
-const COMPARISON_DIM_OPACITY = 0.5
+/** Alpha applied to subordinate series (comparison periods and trend-line overlays) so they read
+ *  as secondary to their primary. Shared with `buildTrendLineSeries` via {@link dimHex}. */
+export const DIM_OPACITY = 0.5
 
 /** Re-render comparison series at reduced opacity so they read as subordinate to their
  *  primary. Series whose colour is missing or already an `rgba(...)` string are left as-is
@@ -17,7 +19,7 @@ export function applyComparisonDimming<Meta = unknown>(
         if (!(s.key in comparisonOf)) {
             return s
         }
-        const dimmed = dimHex(s.color, COMPARISON_DIM_OPACITY)
+        const dimmed = dimHex(s.color, DIM_OPACITY)
         return dimmed === s.color ? s : { ...s, color: dimmed }
     })
 }


### PR DESCRIPTION
## Problem

The quill-charts improvement review flagged a handful of correctness-adjacent findings in the charts package. Working through them verify-first, all four turned out to be non-bugs (every real consumer already passes hex colors, the legend index math already matches the canvas coloring, the bar-scale degenerate case already matches `buildValueScale`, and the SlopeChart collision divergence is legitimate). What was left were two small code smells worth cleaning up: a `0.5` dim-opacity constant duplicated across two files, and an undocumented reason for why SlopeChart value labels use a different collision strategy than series/slice labels.

## Changes

- Consolidate the two separate `0.5` dim-opacity constants into one exported `DIM_OPACITY` in `utils/comparison-dimming.ts`, imported by `charts/utils/derived-series.ts` so comparison-series and trend-line dimming can't drift.
- Add a comment to SlopeChart's `columnSweep` explaining why value labels drop by vertical position rather than the magnitude priority `nonCollidingKeys` uses for series/slice labels.
- No behavior change.

## How did you test this code?

I'm an agent (Claude, via PostHog Code). I ran the charts package typecheck (`tsc -p tsconfig.build.json --noEmit`, clean) and the affected Jest suites (`comparison-dimming`, `derived-series`, `SlopeChart` — 42 tests, all passing). Existing tests already cover both the hex→rgba dimming path and the trend-line dimmed color, so they pin the no-behavior-change claim. No manual/browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam directed a session continuing the internal quill-charts improvement effort: work the "verify-first correctness batch" from the (untracked) `IMPROVEMENTS.md` backlog. I verified each of the four findings against current code rather than fixing on faith, and the notable outcome is that none were live user-visible bugs:

- **dimHex on `var()` colors:** not a bug. The `--data-color-*` tokens are hex literals, so the default palette, trends (`getColorFromToken`), and data-viz (`getSeriesColor`) all resolve to hex before dimming. I rejected the review's suggested `color-mix` rewrite: it churns a working, tested path for inputs no consumer passes, and `var()` can't render on canvas anyway. Kept only the constant dedup.
- **Legend palette/exclusion, bar-scale drift, SlopeChart collision:** verified correct/benign; documented the SlopeChart one, left the others as-is with rationale recorded in the backlog.

Skills invoked: `/writing-tests` (which led me to *not* add speculative tests for already-correct behavior). Applied `skip-agent-review` since this is a trivial chore.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*