### PR TITLE
fix(hogql): iterate pushdown demand collection to a fixpoint

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -209,9 +209,6 @@ def prepare_ast_for_printing(
     if context.modifiers.optimizeProjections:
         with context.timings.measure("projection_pushdown"):
             node = pushdown_projections(node, context)
-        # Pushdown mutates SelectQueryType.columns, staling cached CTE tables. Drop them so a
-        # wrongly pruned column fails loudly at compile time instead of emitting broken SQL.
-        context.cte_database_table_cache.clear()
 
     if dialect in SQL_TARGET_DIALECTS:
         with context.timings.measure("resolve_lazy_tables"):

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -795,19 +795,15 @@ class TestResolver(BaseTest):
             enable_select_queries=True,
             modifiers=HogQLQueryModifiers(optimizeProjections=True),
         )
-        _, prepared = prepare_and_print_ast(query, context, "clickhouse")
+        sql, _ = prepare_and_print_ast(query, context, "clickhouse")
 
-        # The single shared CTE must project every column referenced across the branches.
-        assert isinstance(prepared, ast.SelectSetQuery)
-        first_branch = prepared.initial_select_query
-        assert isinstance(first_branch, ast.SelectQuery) and first_branch.ctes is not None
-        base_cte = first_branch.ctes["base"].expr
-        assert isinstance(base_cte, ast.SelectQuery)
-        cte_cols: set[str] = set()
-        for col in base_cte.select:
-            assert isinstance(col, ast.Alias | ast.Field)
-            cte_cols.add(col.alias if isinstance(col, ast.Alias) else str(col.chain[-1]))
-        assert cte_cols == {"a", "b", "d"}, f"CTE dropped columns referenced by sibling UNION branches: got {cte_cols}"
+        # The single shared CTE must project every column referenced across the branches. Assert
+        # on the printed SQL: printing is where the stale CTE-table cache masked the over-prune.
+        cte_projection = sql[: sql.index(" FROM")]
+        for column in ("a", "b", "d"):
+            assert f" AS {column}" in cte_projection, (
+                f"CTE dropped column {column!r} referenced by a sibling UNION branch: {cte_projection}"
+            )
 
     def test_ctes_with_aliases_in_joins(self):
         self.assertEqual(

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -799,7 +799,7 @@ class TestResolver(BaseTest):
 
         # The single shared CTE must project every column referenced across the branches. Assert
         # on the printed SQL: printing is where the stale CTE-table cache masked the over-prune.
-        cte_projection = sql[: sql.index(" FROM")]
+        cte_projection = sql[sql.index("base AS (") : sql.index(" FROM")]
         for column in ("a", "b", "d"):
             assert f" AS {column}" in cte_projection, (
                 f"CTE dropped column {column!r} referenced by a sibling UNION branch: {cte_projection}"

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -51,8 +51,9 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         demand_count = -1
         while True:
             self.visit(node)
-            if not self.saw_asterisk:
-                # Nothing to prune, so demand completeness doesn't matter — skip further walks.
+            if not self.saw_asterisk or not self.demands:
+                # No asterisk columns, or nothing demanded anything (plain SELECT * with no outer
+                # consumer): pruning is a no-op either way, so skip further walks.
                 return node
             new_demand_count = sum(len(names) for names in self.demands.values())
             if new_demand_count == demand_count:

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -13,9 +13,15 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
 
     Algorithm Overview:
     ──────────────────
-    This optimizer makes two top-down passes through the query tree: the first only collects
-    demands, the second prunes with the complete demand set. A CTE can be consumed by nodes
-    visited after it — notably sibling UNION branches — so pruning must wait for the full walk.
+    This optimizer walks the query tree in collect-only passes until the demand sets stop
+    growing, then makes one final pass that prunes with the complete demands. A CTE can be
+    consumed by nodes visited after it — notably sibling UNION branches — and each pass
+    propagates demands only one CTE hop, so chained CTEs need the fixpoint loop (demand sets
+    only ever grow, over a finite set of columns, so it terminates).
+
+    Two invariants keep the repeated walks sound: collect passes never mutate the tree (the
+    id()-keyed maps rely on stable node identities), and demands persist across passes with
+    grow-only set-union, so re-collection is idempotent and can only retain more columns.
 
     Each pass runs these phases per query:
 
@@ -23,19 +29,31 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
     Phase 2 - Collect: Gather column demands from WHERE/GROUP BY/ORDER BY/etc
     Phase 3 - Propagate: For demanded columns, visit their source to propagate to child queries
     Phase 4 - Recurse: Visit child subqueries (repeat phases 1-4)
-    Phase 5 - Prune: Remove unreferenced asterisk columns from this query (second pass only)
+    Phase 5 - Prune: Remove unreferenced asterisk columns from this query (final pass only)
     """
 
     def __init__(self):
         super().__init__()
         self.demands: dict[int, set[str]] = defaultdict(set)
         self.subquery_map: dict[int, ast.SelectQuery | ast.SelectSetQuery] = {}
-        # True during the first pass; gates pruning to the second (see class docstring)
-        self.collecting: bool = False
+        # Defaults to collect-only so a bare visit() can never prune with incomplete demands;
+        # only optimize() flips this off, once the demand fixpoint is reached.
+        self.collecting: bool = True
+        self.saw_asterisk: bool = False
 
     def optimize(self, node: ast.SelectQuery | ast.SelectSetQuery) -> ast.SelectQuery | ast.SelectSetQuery:
+        self.demands.clear()
+        self.subquery_map.clear()
+        self.saw_asterisk = False
         self.collecting = True
-        self.visit(node)
+        while True:
+            demand_count = sum(len(names) for names in self.demands.values())
+            self.visit(node)
+            if not self.saw_asterisk:
+                # Nothing to prune, so demand completeness doesn't matter — skip further walks.
+                return node
+            if sum(len(names) for names in self.demands.values()) == demand_count:
+                break
         self.collecting = False
         return cast(ast.SelectQuery | ast.SelectSetQuery, self.visit(node))
 
@@ -80,7 +98,7 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         if node.select_from:
             self.visit(node.select_from)
 
-        # Phase 5: Prune unreferenced asterisk columns from this query and CTEs (second pass only)
+        # Phase 5: Prune unreferenced asterisk columns from this query and CTEs (final pass only)
         if not self.collecting:
             self._prune_columns(node)
             if node.ctes:
@@ -110,8 +128,9 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         """Check if an expression was expanded from asterisk"""
         if isinstance(expr, ast.Alias):
             expr = expr.expr  # whoops - we want to take the Field from the Alias
-        if isinstance(expr, ast.Field):
-            return expr.from_asterisk
+        if isinstance(expr, ast.Field) and expr.from_asterisk:
+            self.saw_asterisk = True
+            return True
         return False
 
     def _propagate_demands_to_children(self, node: ast.SelectQuery) -> None:
@@ -302,5 +321,10 @@ def pushdown_projections(node: _T_AST, context: HogQLContext) -> _T_AST:
     """Prune unused columns from asterisk expansions in subqueries"""
     if not isinstance(node, (ast.SelectQuery, ast.SelectSetQuery)):
         return node
-    optimizer = ProjectionPushdownOptimizer()
-    return cast(_T_AST, optimizer.optimize(node))
+    try:
+        optimizer = ProjectionPushdownOptimizer()
+        return cast(_T_AST, optimizer.optimize(node))
+    finally:
+        # Pruning mutates SelectQueryType.columns, staling cached CTE tables. Drop them so a
+        # wrongly pruned column fails loudly at compile time instead of emitting broken SQL.
+        context.cte_database_table_cache.clear()

--- a/posthog/hogql/transforms/projection_pushdown.py
+++ b/posthog/hogql/transforms/projection_pushdown.py
@@ -42,18 +42,22 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         self.saw_asterisk: bool = False
 
     def optimize(self, node: ast.SelectQuery | ast.SelectSetQuery) -> ast.SelectQuery | ast.SelectSetQuery:
+        # Reset so a reused instance can't prune with stale demands, recycled id() keys, or
+        # collecting still False from a previous run.
         self.demands.clear()
         self.subquery_map.clear()
         self.saw_asterisk = False
         self.collecting = True
+        demand_count = -1
         while True:
-            demand_count = sum(len(names) for names in self.demands.values())
             self.visit(node)
             if not self.saw_asterisk:
                 # Nothing to prune, so demand completeness doesn't matter — skip further walks.
                 return node
-            if sum(len(names) for names in self.demands.values()) == demand_count:
+            new_demand_count = sum(len(names) for names in self.demands.values())
+            if new_demand_count == demand_count:
                 break
+            demand_count = new_demand_count
         self.collecting = False
         return cast(ast.SelectQuery | ast.SelectSetQuery, self.visit(node))
 
@@ -125,7 +129,7 @@ class ProjectionPushdownOptimizer(TraversingVisitor):
         return node
 
     def _is_from_asterisk(self, expr: ast.Expr) -> bool:
-        """Check if an expression was expanded from asterisk"""
+        """Check if an expression was expanded from asterisk. Also records self.saw_asterisk."""
         if isinstance(expr, ast.Alias):
             expr = expr.expr  # whoops - we want to take the Field from the Alias
         if isinstance(expr, ast.Field) and expr.from_asterisk:

--- a/posthog/hogql/transforms/test/test_projection_pushdown.py
+++ b/posthog/hogql/transforms/test/test_projection_pushdown.py
@@ -1,6 +1,8 @@
 import pytest
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql import ast
@@ -595,39 +597,37 @@ class TestProjectionPushdown(BaseTest):
 
         assert optimized.to_hogql() == self.snapshot
 
-    def test_cte_shared_by_union_branches_keeps_all_demanded_columns(self):
+    @parameterized.expand(
+        [
+            (
+                "single_cte",
+                "WITH base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)) "
+                "SELECT a FROM base "
+                "UNION ALL SELECT b FROM base "
+                "UNION ALL SELECT d FROM base",
+                ("base",),
+            ),
+            (
+                "chained_ctes",
+                "WITH inner_base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)), "
+                "mid AS (SELECT * FROM inner_base) "
+                "SELECT a FROM mid "
+                "UNION ALL SELECT b FROM mid "
+                "UNION ALL SELECT d FROM mid",
+                ("inner_base", "mid"),
+            ),
+        ]
+    )
+    def test_ctes_shared_by_union_branches_keep_all_demanded_columns(self, _name, query_str, cte_names):
         # The WITH lives on the first UNION branch but every sibling branch consumes it, so
         # pruning before all branches register their demands drops columns the siblings need.
-        optimized = self._optimize(
-            "WITH base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)) "
-            "SELECT a FROM base "
-            "UNION ALL SELECT b FROM base "
-            "UNION ALL SELECT d FROM base"
-        )
+        # Chained CTEs need the fixpoint loop too: demands cross one CTE hop per collect pass.
+        optimized = self._optimize(query_str)
 
         first_branch = optimized.initial_select_query
         assert isinstance(first_branch, ast.SelectQuery)
         assert first_branch.ctes is not None
-        base_cte = first_branch.ctes["base"].expr
-        assert isinstance(base_cte, ast.SelectQuery)
-        base_cols = {self._col_name(col) for col in base_cte.select}
-        assert base_cols == {"a", "b", "d"}, f"CTE dropped columns demanded by sibling branches: got {base_cols}"
-
-    def test_chained_ctes_shared_by_union_branches_keep_all_demanded_columns(self):
-        # Demands cross one CTE hop per collect pass, so a CTE feeding another CTE that union
-        # branches consume needs the demand fixpoint loop — two fixed passes over-pruned it.
-        optimized = self._optimize(
-            "WITH inner_base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)), "
-            "mid AS (SELECT * FROM inner_base) "
-            "SELECT a FROM mid "
-            "UNION ALL SELECT b FROM mid "
-            "UNION ALL SELECT d FROM mid"
-        )
-
-        first_branch = optimized.initial_select_query
-        assert isinstance(first_branch, ast.SelectQuery)
-        assert first_branch.ctes is not None
-        for cte_name in ("inner_base", "mid"):
+        for cte_name in cte_names:
             cte_query = first_branch.ctes[cte_name].expr
             assert isinstance(cte_query, ast.SelectQuery)
             cols = {self._col_name(col) for col in cte_query.select}

--- a/posthog/hogql/transforms/test/test_projection_pushdown.py
+++ b/posthog/hogql/transforms/test/test_projection_pushdown.py
@@ -5,6 +5,7 @@ from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import Table
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
@@ -611,3 +612,36 @@ class TestProjectionPushdown(BaseTest):
         assert isinstance(base_cte, ast.SelectQuery)
         base_cols = {self._col_name(col) for col in base_cte.select}
         assert base_cols == {"a", "b", "d"}, f"CTE dropped columns demanded by sibling branches: got {base_cols}"
+
+    def test_chained_ctes_shared_by_union_branches_keep_all_demanded_columns(self):
+        # Demands cross one CTE hop per collect pass, so a CTE feeding another CTE that union
+        # branches consume needs the demand fixpoint loop — two fixed passes over-pruned it.
+        optimized = self._optimize(
+            "WITH inner_base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)), "
+            "mid AS (SELECT * FROM inner_base) "
+            "SELECT a FROM mid "
+            "UNION ALL SELECT b FROM mid "
+            "UNION ALL SELECT d FROM mid"
+        )
+
+        first_branch = optimized.initial_select_query
+        assert isinstance(first_branch, ast.SelectQuery)
+        assert first_branch.ctes is not None
+        for cte_name in ("inner_base", "mid"):
+            cte_query = first_branch.ctes[cte_name].expr
+            assert isinstance(cte_query, ast.SelectQuery)
+            cols = {self._col_name(col) for col in cte_query.select}
+            assert cols == {"a", "b", "d"}, f"CTE {cte_name} dropped demanded columns: got {cols}"
+
+    def test_pushdown_clears_cte_database_table_cache(self):
+        # The cache holds CTE tables built from pre-prune columns; pushdown must drop them so a
+        # wrongly pruned column fails loudly downstream instead of resolving against stale state.
+        modifiers = HogQLQueryModifiers(optimizeProjections=False)
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, modifiers=modifiers)
+        query = parse_select("SELECT event FROM (SELECT * FROM events) AS sub")
+        prepared = prepare_ast_for_printing(query, context, dialect="hogql")
+        assert prepared is not None
+
+        context.cte_database_table_cache[12345] = ("sentinel", Table(fields={}))
+        pushdown_projections(prepared, context)
+        assert context.cte_database_table_cache == {}


### PR DESCRIPTION
## Problem

#67719 was merged mid-review-loop at `f63f9839`, before the review-driven fixes landed on the branch. This PR carries the three commits that were pushed to that branch after the merge.

The substantive one: #67719's two-pass optimizer (collect demands, then prune) is one iteration of a fixed-point computation. Demands propagate one CTE hop per collect pass, so a **chained** `SELECT *` CTE consumed across sibling `UNION ALL` branches still gets over-pruned:

```sql
WITH inner_base AS (SELECT * FROM (SELECT 1 AS a, 2 AS b, 3 AS d)),
     mid AS (SELECT * FROM inner_base)
SELECT a FROM mid UNION ALL SELECT b FROM mid UNION ALL SELECT d FROM mid
```

On current master this fails loudly at compile time (`Field "b" not found on table Table`) thanks to #67719's cache-clear tripwire — an improvement over the silently-wrong SQL it produced before #67719, but still a valid query class erroring, with `optimizeProjections` on by default. Found by a multi-reviewer swarm pass on #67719 (4 of 6 reviewers converged) and reproduced end-to-end.

## Changes

- `ProjectionPushdownOptimizer.optimize()` loops collect passes until the demand sets stop growing (grow-only sets over finite columns, so it terminates — typically 1 extra pass), then prunes once with complete demands.
- Skip all further walks when the first pass sees no asterisk columns or records no demands, so plain `SELECT *` and asterisk-free queries pay a single walk.
- `collecting` defaults on, so a bare `visit()` can never prune with incomplete demands; `optimize()` resets instance state on entry.
- The CTE-table cache clear moved into `pushdown_projections` under `try/finally` (invalidation lives with the mutation, and survives exceptions), with a test pinning it.
- The two load-bearing invariants (collect passes never mutate the tree; demands are grow-only so re-collection is idempotent) documented in the class docstring.
- Tests: chained-CTE + single-CTE union shapes as one parameterized test; the resolver regression test now asserts on printed SQL (the layer where the stale cache masked the original bug).

## How did you test this code?

Automated tests only:

- `test_projection_pushdown.py::test_ctes_shared_by_union_branches_keep_all_demanded_columns` (parameterized: single + chained) – the chained case fails on current master.
- `test_projection_pushdown.py::test_pushdown_clears_cte_database_table_cache` – fails if the cache-clear tripwire is removed; nothing covered it before.
- `test_resolver.py::test_star_cte_shared_by_union_branches_projects_all_columns` – now asserts on printed SQL, anchored to the CTE body.
- Full `test_resolver.py` + `test_printer.py` + `transforms/test/`: 1497 passed, 405 snapshots unchanged (run on the pre-merge branch; re-run on this rebase in CI).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A – internal query compiler change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session running the pr-shepherd loop on #67719: a four-perspective review swarm (qa-team specialists, two style reviewers, security audit) found the fixed-point gap, I reproduced it, fixed it, and the fixes went through two further swarm rounds (all clean, with termination proofs for the fixpoint loop and the early-exit equivalence). #67719 merged while round 1 was completing, so these commits are cherry-picked from that branch onto master. Skills invoked: /writing-tests, pr-shepherd (store), qa-swarm (store), simplify.
- Deliberately rejected from review feedback, with reasoning on the #67719 threads: a bounded-iteration cap (the grow-only invariant makes the loop provably terminating), and gating the cache clear on whether pruning occurred (fail-loud simplicity preferred).
- Two pre-existing (master-reproducible) pushdown gaps found by the same swarm are tracked separately, not in this PR: LIMIT BY / ARRAY JOIN / window-expression columns are never demanded and get pruned, and mixed asterisk/explicit UNION branches prune to mismatched column counts.
