### PR TITLE
chore(insights): dedupe quill chart theme wiring into useChartTheme hook

### DIFF
--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -1,0 +1,17 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import type { ChartTheme } from '@posthog/quill-charts'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
+import { buildTheme } from './utils/theme'
+
+/** Theme for app quill charts. `buildTheme()` reads CSS variables from the DOM, so the memo keys on
+ *  `isDarkModeOn` to re-read them when the app theme flips. Pass a stable (memoized or module-level)
+ *  `overrides` object — a fresh object every render defeats the memo. */
+export function useChartTheme(overrides?: Partial<ChartTheme>): ChartTheme {
+    const { isDarkModeOn } = useValues(themeLogic)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useMemo(() => buildTheme(overrides), [isDarkModeOn, overrides])
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
@@ -1,14 +1,11 @@
 import clsx from 'clsx'
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { LemonColorGlyph } from '@posthog/lemon-ui'
 import { PieChart, TooltipSurface, TooltipSwatch } from '@posthog/quill-charts'
 import type { PieChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { useChartTheme } from 'lib/charts/hooks'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
@@ -30,10 +27,7 @@ export const SqlPieGraph = ({
     presetChartHeight,
     className,
 }: LineGraphProps): JSX.Element => {
-    const { isDarkModeOn } = useValues(themeLogic)
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const slices = useMemo(() => buildPieSlices(xData, yData), [xData, yData])
     const formattingSettings = yData[0]?.settings

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -3,10 +3,8 @@ import { useEffect, useMemo } from 'react'
 
 import { type ChartTheme, type Series } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { LineGraphProps } from './LineGraph'
 import {
@@ -30,7 +28,6 @@ export function useSqlChartModel<TConfig>(
     buildConfig: (args: BuildBarConfigArgs) => TConfig
 ): SqlChartModel<TConfig> | null {
     const { timezone } = useValues(teamLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
 
     useEffect(() => {
         if (exceedsMaxSeries(yData, dashboardId)) {
@@ -45,8 +42,7 @@ export function useSqlChartModel<TConfig>(
         [ySeriesData, visualizationType]
     )
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const config = useMemo(
         () =>

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -5,7 +5,7 @@ import { BoxPlot } from '@posthog/quill-charts'
 import type { BoxPlotClickData, BoxPlotConfig, BoxPlotSeries, BoxPlotTooltipContext } from '@posthog/quill-charts'
 
 import 'scenes/insights/InsightTooltip/InsightTooltip.scss'
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { getSeriesColor } from 'lib/colors'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -18,7 +18,6 @@ import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { BoxPlotDatum, InsightActorsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { ChartParams } from '~/types'
 
@@ -64,12 +63,10 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
     const { boxplotData, seriesGroups, dateLabels, yAxisScaleType, querySource, interval, insightData, trendsFilter } =
         useValues(boxPlotChartLogic(insightProps))
     const { timezone, weekStartDay } = useValues(teamLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
 
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const series = useMemo<BoxPlotSeries[]>(
         () =>

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
@@ -1,17 +1,15 @@
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import {
     ChoiceTooltip,
     ChoiceTooltipContextData,
 } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ChoiceQuestionResponseData } from '~/types'
 
 const CATEGORY_LABEL_WIDTH = 280
@@ -38,8 +36,7 @@ export function MultipleChoiceBarChart({
     tooltipContextByIndex,
     onBarClick,
 }: Props): JSX.Element {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     // Bars encode the share of respondents who picked each choice against a fixed 0–100% domain;
     // counts surface in the labels and tooltip. Per-bar overrides carry the colors — the series

--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
@@ -1,14 +1,12 @@
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { NpsBucketMeta, RatingTooltip } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ChoiceQuestionResponseData } from '~/types'
 
 // Room above each bar tip for the value label's height, so it floats rather than overlapping the bar.
@@ -35,8 +33,7 @@ export function RatingBarChart({
     npsBucketByIndex,
     onBarClick,
 }: Props): JSX.Element {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const series = useMemo<Series[]>(
         () => [

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -1,15 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
 
-import { type ChartTheme } from '@posthog/quill-charts'
-
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { teamLogic } from 'scenes/teamLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { McpDateFilter } from './components/McpDateFilter'
 import { ActivityChart } from './dashboard/ActivityChart'
@@ -42,12 +37,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         propertyFilters,
     } = useValues(mcpDashboardOverviewLogic)
     const { setDateFilter, setFilterTestAccounts, setPropertyFilters } = useActions(mcpDashboardOverviewLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn is the dep that forces a recompute when
-    // the theme flips (it isn't passed as an argument).
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     return (
         <div className="flex flex-col gap-4">

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -26,7 +26,7 @@ import {
     TableRow,
 } from '@posthog/quill-primitives'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
@@ -34,7 +34,6 @@ import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { FeaturePreviewSceneGate } from '~/layout/scenes/components/FeaturePreviewSceneGate'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -495,11 +494,9 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
         topUserRows,
         topUserRowsLoading,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn forces a recompute on theme flip.
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const callsSeries = useMemo<Series[]>(
         () => seriesFor(dailyChartData, theme, ['calls', 'errors']),
         [dailyChartData, theme]

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
@@ -1,18 +1,14 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
 
 import { IconX } from '@posthog/icons'
-import { type ChartTheme } from '@posthog/quill-charts'
 import { Button } from '@posthog/quill-primitives'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { TagsCombobox } from 'lib/components/Scenes/TagsCombobox'
 import { LinkPrimitive } from 'lib/lemon-ui/Link/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { McpDateFilter } from './components/McpDateFilter'
 import { mcpAnalyticsToolQualityLogic } from './mcpAnalyticsToolQualityLogic'
@@ -98,12 +94,9 @@ function ChartsScopeHeader(): JSX.Element {
 
 export function MCPAnalyticsToolQuality(): JSX.Element {
     const { dailyChartData, dailyStatsLoading } = useValues(mcpAnalyticsToolQualityLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn is the dep that forces a recompute when
-    // the theme flips (it isn't passed as an argument).
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     return (
         <div className="flex flex-col gap-4" data-quill>

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -2,9 +2,9 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { type ErrorInfo, useMemo } from 'react'
 
-import { type ChartTheme, type TooltipContext } from '@posthog/quill-charts'
+import { type TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -43,7 +43,7 @@ export function FunnelBarHorizontalChart({
     inCardView,
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const fillerColor = useMemo(() => getFillerColor(), [isDarkModeOn])
 
     const { insightProps } = useValues(insightLogic)

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -5,14 +5,12 @@ import { useMemo, type ErrorInfo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { hexToRGBA } from 'lib/utils/colors'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { buildFunnelHistogramData } from './funnelHistogramTransforms'
 
@@ -35,8 +33,7 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 }
 
 export function FunnelHistogramChart(): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { histogramGraphData, histogramGraphDataPrevious } = useValues(funnelDataLogic(insightProps))
     const { theme: dataColorTheme } = useValues(insightVizDataLogic(insightProps))

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -10,7 +10,7 @@ import type {
     TooltipContext,
 } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -22,7 +22,6 @@ import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import type { Noun } from '~/models/groupsModel'
 import { groupsModel } from '~/models/groupsModel'
@@ -65,8 +64,7 @@ export function FunnelLineChart({
     inSharedMode,
     showPersonsModal: showPersonsModalProp = true,
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { BarChart, DEFAULT_MARGINS } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -15,7 +15,6 @@ import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { hasBreakdown } from 'scenes/funnels/funnelUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { ChartParams } from '~/types'
 
@@ -49,12 +48,9 @@ export function FunnelStepsBarChart({
     showPersonsModal: showPersonsModalProp = true,
     inCardView,
 }: ChartParams): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-    // buildTheme() reads CSS vars; we re-memo on isDarkModeOn so the theme refreshes
-    // when the user toggles dark mode even though the function takes no arguments.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { visibleStepsWithConversionMetrics, getFunnelsColor, breakdownFilter, querySource, insightData } = useValues(
         funnelDataLogic(insightProps)

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -14,7 +14,6 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
 import { retentionModalLogic } from 'scenes/retention/retentionModalLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
@@ -56,11 +55,10 @@ function resolveGroupTypeLabel(
 
 export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const {
         hasValidBreakdown,

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -14,7 +14,6 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
 import { retentionModalLogic } from 'scenes/retention/retentionModalLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
@@ -56,11 +55,10 @@ function resolveGroupTypeLabel(
 
 export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const {
         hasValidBreakdown,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -49,7 +49,7 @@ interface StickinessBarChartProps {
 const handleChartError = makeChartErrorHandler('stickiness-bar-chart')
 
 export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -49,7 +49,7 @@ interface StickinessLineChartProps {
 const handleChartError = makeChartErrorHandler('stickiness-line-chart')
 
 export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@posthog/quill-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { percentage } from 'lib/utils/numbers'
@@ -89,7 +89,7 @@ export function TrendsBarChart({
     inSharedMode = false,
     embedded = false,
 }: TrendsBarChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TIME_SERIES_TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
@@ -252,7 +252,7 @@ export function TrendsBarChart({
             showValuesOnSeries,
             valueLabelFormatter,
             legendConfig,
-            quillTooltipEnabled,
+            TIME_SERIES_TOOLTIP_CONFIG,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { getBarColorFromStatus } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -52,7 +52,7 @@ const handleChartError = makeChartErrorHandler('trends-lifecycle-chart')
 const renderLifecycleSeriesLabel = (datum: SeriesDatum): React.ReactNode => datum.label
 
 export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLifecycleChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { insightProps, insight, canEditInsight } = useValues(insightLogic)

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ciRanges } from 'lib/statistics'
@@ -18,7 +18,6 @@ import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -46,11 +45,10 @@ interface TrendsLineChartProps {
 const handleChartError = makeChartErrorHandler('trends-line-chart')
 
 export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps, insight } = useValues(insightLogic)
 
     const legendConfig = useInsightsLegendConfig({ insightProps, inSharedMode })

--- a/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { PieChart } from '@posthog/quill-charts'
 import type { PieChartConfig, RadialSlicePayload, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
@@ -22,7 +22,6 @@ import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -50,9 +49,7 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieChartProps): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-    const { isDarkModeOn } = useValues(themeLogic)
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const { insightProps } = useValues(insightLogic)
     const { baseCurrency } = useValues(teamLogic)

--- a/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { SlopeChart, createXAxisTickCallback } from '@posthog/quill-charts'
 import type { Series, SlopeChartConfig, SlopeSeriesMeta } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -13,7 +13,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
@@ -26,8 +25,7 @@ interface TrendsSlopeChartProps {
 const handleChartError = makeChartErrorHandler('trends-slope-chart')
 
 export function TrendsSlopeChart({ context }: TrendsSlopeChartProps): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
 
     const { indexedResults, currentPeriodResult, getTrendsColor, getTrendsHidden, trendsFilter, interval, showLegend } =

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -1,10 +1,9 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
 
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 import { BarChart } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -170,7 +169,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
     const { scorerSummary, scorerHistogram, hasActiveObservationFilters, observationStatsApiLoading } = useValues(
         replayScannerLogic({ id: scannerId })
     )
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     if (!scorerSummary || !scorerHistogram) {
         return (
             <OverviewPanel title="Score distribution">

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -11,7 +11,7 @@ import type {
     YAxisConfig,
 } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -73,7 +73,7 @@ export function RevenueAnalyticsChart({
     const { dateFilter } = useValues(revenueAnalyticsLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     // isDarkModeOn is a dep (not an arg): getColor can resolve theme-dependent CSS colors into
     // concrete values, so the series must rebuild on a light/dark toggle.


### PR DESCRIPTION
## Problem

Every quill chart consumer copy-pastes the same theme wiring: `useValues(themeLogic)` plus `useMemo(() => buildTheme(), [isDarkModeOn])`. Five of them (`TrendsBarChart`, `TrendsLifecycleChart`, `StickinessLineChart`, `StickinessBarChart`, `ScannerOverview`) got the deps wrong (`[]`), so those charts don't re-read CSS variables when the user toggles dark mode.

Having ~23 hand-rolled copies also makes any future theme-level change (for example a flag-gated restyle, which I'm working on separately) a 23-file diff instead of a 1-file one.

## Changes

- New `useChartTheme(overrides?)` hook in `frontend/src/lib/charts/hooks.ts` that owns the dark-mode-aware `buildTheme()` memo
- Migrated all 23 consumer components (trends, stickiness, retention, funnels, surveys, box plot, SQL charts, MCP analytics, revenue analytics, replay scanners) to the hook
- Removed the now-unneeded `themeLogic` imports and `isDarkModeOn` destructures where the theme memo was their only use (`FunnelBarHorizontalChart` and `RevenueAnalyticsChart` keep theirs for other purposes)
- Stories keep calling `buildTheme()` directly (no hooks outside components)

No visual changes. The only behavior change is the intentional fix: the five charts with `[]` deps now refresh their theme on dark-mode toggle like the rest.

## How did you test this code?

- `oxlint` + `oxfmt` on the touched files, plus lint-staged on commit
- `tsgo --noEmit` full-frontend typecheck: no errors in any touched file (pre-existing unrelated errors on master remain)
- No new tests: pure mechanical refactor with no new logic to regress

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal refactor.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The human spotted that a planned flag-gated chart restyle was dragging a mechanical refactor along with it and asked to split this out as a standalone first PR. Claude wrote the hook, ran a scripted migration over the call sites, and hand-verified each diff. One note for reviewers: an `oxlint --fix-dangerously` pass tried to mangle two unrelated files' dependency arrays during formatting; those were reverted and only the intended files are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)