### PR TITLE
fix(mongodb): stop reporting connectivity timeouts as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -231,8 +231,10 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         except ServerSelectionTimeoutError as e:
             # pymongo dumps a verbose topology description into str(e); surface a concise,
             # actionable message instead. A DNS failure means the host doesn't resolve at all,
-            # which is distinct from an allowlist/reachability problem.
-            capture_exception(e)
+            # which is distinct from an allowlist/reachability problem. Server selection only times
+            # out on an upstream connectivity problem the user must fix (cluster paused, IP not
+            # allowlisted, host unresolved, TLS handshake rejected) — never our bug — and we already
+            # return an actionable message for it, so don't report it as error-tracking noise.
             message = str(e)
             if any(marker in message for marker in _DNS_RESOLUTION_FAILURE_MARKERS):
                 return False, _MONGO_HOST_UNRESOLVED_MESSAGE

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-from pymongo.errors import InvalidURI, OperationFailure
+from pymongo.errors import InvalidURI, OperationFailure, ServerSelectionTimeoutError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
@@ -65,8 +65,6 @@ class TestMongoValidateCredentialsServerSelection:
     @pytest.mark.parametrize("marker", _DNS_RESOLUTION_FAILURE_MARKERS)
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
     def test_dns_resolution_failure_returns_unresolved_message(self, mock_get_collections, marker):
-        from pymongo.errors import ServerSelectionTimeoutError
-
         # The verbose topology-description message pymongo raises when the host doesn't resolve.
         mock_get_collections.side_effect = ServerSelectionTimeoutError(
             f"cluster0.qwi73.mongodb.net:27017: [Errno -5] {marker} "
@@ -82,8 +80,6 @@ class TestMongoValidateCredentialsServerSelection:
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
     def test_unreachable_cluster_returns_allowlist_message(self, mock_get_collections):
-        from pymongo.errors import ServerSelectionTimeoutError
-
         mock_get_collections.side_effect = ServerSelectionTimeoutError(
             "No servers found yet, Topology Description: ..."
         )
@@ -150,53 +146,41 @@ class TestMongoValidateCredentialsOperationFailure:
 
 
 class TestMongoValidateCredentialsErrorTrackingNoise:
-    # Unescaped credentials are a user mistake we already surface an actionable message for, so
-    # they must not be reported to error tracking; genuinely unexpected errors still must be.
+    # Errors we already surface an actionable message for are user/upstream problems, not our bug,
+    # so they must not be reported to error tracking; genuinely unexpected errors still must be.
+    # The SSL-handshake host/port here are redacted — matching a real customer value would leak it.
+    @pytest.mark.parametrize(
+        "exc, expected_message, should_capture",
+        [
+            (
+                InvalidURI("Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"),
+                _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
+                False,
+            ),
+            (
+                ServerSelectionTimeoutError(
+                    "SSL handshake failed: <redacted-host>:27017: [SSL: TLSV1_ALERT_INTERNAL_ERROR] "
+                    "tlsv1 alert internal error, Topology Description: <TopologyDescription ...>"
+                ),
+                _MONGO_UNREACHABLE_MESSAGE,
+                False,
+            ),
+            (Exception("some-internal-driver-detail"), _MONGO_CONNECT_FAILED_MESSAGE, True),
+        ],
+    )
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_unescaped_credentials_not_reported(self, mock_get_collections, mock_capture):
-        mock_get_collections.side_effect = InvalidURI(
-            "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"
-        )
+    def test_capture_only_for_unexpected_errors(
+        self, mock_get_collections, mock_capture, exc, expected_message, should_capture
+    ):
+        mock_get_collections.side_effect = exc
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
 
         ok, err = MongoDBSource().validate_credentials(config, team_id=1)
 
         assert ok is False
-        assert err == _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
-        mock_capture.assert_not_called()
-
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_server_selection_timeout_not_reported(self, mock_get_collections, mock_capture):
-        from pymongo.errors import ServerSelectionTimeoutError
-
-        # An Atlas TLS handshake rejection: the cluster is unreachable for the whole selection
-        # window (paused, IP not allowlisted, TLS rejected). Host/port are redacted — matching a
-        # real customer value here would leak it. This is an upstream problem, not our bug.
-        mock_get_collections.side_effect = ServerSelectionTimeoutError(
-            "SSL handshake failed: <redacted-host>:27017: [SSL: TLSV1_ALERT_INTERNAL_ERROR] "
-            "tlsv1 alert internal error, Topology Description: <TopologyDescription ...>"
-        )
-        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
-
-        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert err == _MONGO_UNREACHABLE_MESSAGE
-        mock_capture.assert_not_called()
-
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_unexpected_error_is_reported(self, mock_get_collections, mock_capture):
-        mock_get_collections.side_effect = Exception("some-internal-driver-detail")
-        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
-
-        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert err == _MONGO_CONNECT_FAILED_MESSAGE
-        mock_capture.assert_called_once()
+        assert err == expected_message
+        assert mock_capture.called is should_capture
 
     # A recognized OperationFailure on listCollections is a user-side credential/permission problem
     # — a missing read role ("not authorized") or bad credentials — that we already surface an

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -168,6 +168,26 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_server_selection_timeout_not_reported(self, mock_get_collections, mock_capture):
+        from pymongo.errors import ServerSelectionTimeoutError
+
+        # An Atlas TLS handshake rejection: the cluster is unreachable for the whole selection
+        # window (paused, IP not allowlisted, TLS rejected). Host/port are redacted — matching a
+        # real customer value here would leak it. This is an upstream problem, not our bug.
+        mock_get_collections.side_effect = ServerSelectionTimeoutError(
+            "SSL handshake failed: <redacted-host>:27017: [SSL: TLSV1_ALERT_INTERNAL_ERROR] "
+            "tlsv1 alert internal error, Topology Description: <TopologyDescription ...>"
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_UNREACHABLE_MESSAGE
+        mock_capture.assert_not_called()
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
     def test_unexpected_error_is_reported(self, mock_get_collections, mock_capture):
         mock_get_collections.side_effect = Exception("some-internal-driver-detail")
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})


### PR DESCRIPTION
## Problem

MongoDB source setup surfaced a `ServerSelectionTimeoutError` in error tracking: a TLS handshake rejection against an Atlas cluster, where all replica set members were unreachable for the whole selection window ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f22cc-72bf-7372-ba1a-3eae6a34ef6e)).

The failure originates in `validate_credentials` (the synchronous `database_schema` connection-test endpoint), which caught the `ServerSelectionTimeoutError`, returned a clean actionable message to the user, and *also* called `capture_exception` on it. A `ServerSelectionTimeoutError` only ever means an upstream connectivity problem the user has to fix on their side (cluster paused, IP not allowlisted, host unresolved, TLS handshake rejected). It is never our bug, and we already tell the user what to do, so reporting it to error tracking is non-actionable noise.

## Changes

Dropped the `capture_exception` call from the `except ServerSelectionTimeoutError` branch in `validate_credentials`. The returned messages (`_MONGO_HOST_UNRESOLVED_MESSAGE` / `_MONGO_UNREACHABLE_MESSAGE`) are unchanged, so the user-facing behavior is identical.

This mirrors the existing convention in this source: the RFC-3986 unescaped-credentials case and `_get_rows_to_sync` both already skip capture for expected operational errors.

The retry side needed no change. These errors are already non-retryable via the `"SSL handshake failed"` and `"Topology Description:"` entries in `get_non_retryable_errors`, so the import pipeline already stops retrying them.

## How did you test this code?

Added `test_server_selection_timeout_not_reported` to the existing `TestMongoValidateCredentialsErrorTrackingNoise` class. It feeds a redacted SSL-handshake `ServerSelectionTimeoutError` through `validate_credentials` and asserts the unreachable message is returned and `capture_exception` is not called. No existing test caught this: the `TestMongoValidateCredentialsServerSelection` tests only assert the returned message, so a revert would still pass them but fail this one.

Ran the file locally, all 19 tests pass. Ran ruff check and format on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged autonomously by Claude (Claude Code) from an error-tracking webhook. Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the frame under `products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py`, and read the source plus the shared `mongo.py` helper.

Decision: this is a user/upstream connectivity error, not a bug in our request logic. I considered extending `NonRetryableErrors` but rejected it — the message already matches two existing entries there, so it would be a no-op. The real defect was the over-eager `capture_exception` in the validation path, which is what put this in error tracking. I scoped the fix to that one branch and left the `OperationFailure` and generic handlers alone. Checked open PRs (including the maintainer's own) for a duplicate; #66548 touches the same file but handles a different error (`InvalidName`).

Skills invoked: `/writing-tests`.
