### PR TITLE
fix(data-warehouse): stop v3 claim window contention in the loader

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -38,6 +38,12 @@ RECONCILE_LOOKBACK_SECONDS = 24 * 60 * 60  # wide enough to catch jobs orphaned 
 
 SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
 
+# Per-poll fetch cap multiplier: fetch at most (free slots x this) batches so a poll
+# never leases far more groups than it can dispatch. Runs average ~2 batches per
+# group (batch 0 + final), so x3 gives headroom for multi-batch runs without
+# re-creating the over-claim problem.
+BATCHES_PER_GROUP_FETCH_FACTOR = 3
+
 
 class OwnershipLostError(Exception):
     """Raised when the group lease for a (team_id, schema_id) is no longer held by this consumer."""
@@ -300,7 +306,7 @@ class BatchConsumer:
                     conn = await self._ensure_poll_conn()
                     batches = await self._adapter.fetch_and_lock(
                         conn,
-                        limit=self._config.poll_limit,
+                        limit=self._fetch_limit(available),
                         retry_backoff_base_seconds=self._config.retry_backoff_base_seconds,
                         owner_token=self._owner_token,
                         lease_ttl_seconds=self._lease_ttl_seconds,
@@ -317,26 +323,57 @@ class BatchConsumer:
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
                     continue
 
-                groups = _group_by_key(batches)
-
-                logger.debug(
-                    self._event("poll_returned"),
-                    batch_count=len(batches),
-                    group_count=len(groups),
-                )
-
-                for key, group_batches in groups.items():
-                    if key in self._in_flight:
-                        continue
-                    if len(self._in_flight) >= self._config.max_concurrency:
-                        break
-                    task = asyncio.create_task(self._process_group_tracked(key, group_batches))
-                    self._in_flight[key] = task
-                    self._metrics.active_groups.inc()
+                await self._dispatch_groups(conn, batches)
 
                 await self._wait_or_shutdown(self._config.poll_interval_seconds)
         finally:
             await self._close()
+
+    def _fetch_limit(self, available: int) -> int:
+        """Cap the poll fetch so we never lease far more groups than we have free slots to run.
+
+        ``fetch_and_lock`` claims a lease for every group it returns, and a
+        leased-but-undispatched group is dark to the whole fleet until its TTL
+        expires.
+        """
+        return min(self._config.poll_limit, available * BATCHES_PER_GROUP_FETCH_FACTOR)
+
+    async def _dispatch_groups(self, conn: psycopg.AsyncConnection[Any], batches: list[PendingBatch]) -> None:
+        """Start a group task per fetched group, up to ``max_concurrency``; release the rest.
+
+        Groups the poll leased but we cannot dispatch are unlocked immediately —
+        holding their leases would leave them unclaimable fleet-wide until the
+        lease TTL expires. Groups already in flight keep their (just renewed) leases.
+        """
+        groups = _group_by_key(batches)
+
+        logger.debug(
+            self._event("poll_returned"),
+            batch_count=len(batches),
+            group_count=len(groups),
+        )
+
+        undispatched: list[PendingBatch] = []
+        for key, group_batches in groups.items():
+            if key in self._in_flight:
+                continue
+            if len(self._in_flight) >= self._config.max_concurrency:
+                undispatched.extend(group_batches)
+                continue
+            task = asyncio.create_task(self._process_group_tracked(key, group_batches))
+            self._in_flight[key] = task
+            self._metrics.active_groups.inc()
+
+        if undispatched:
+            logger.info(
+                self._event("released_undispatched_groups"),
+                batch_count=len(undispatched),
+            )
+            try:
+                await self._adapter.unlock(conn, batches=undispatched, owner_token=self._owner_token)
+            except Exception as e:
+                logger.exception(self._event("release_undispatched_failed"))
+                capture_exception(e)
 
     def _reap_finished_tasks(self) -> None:
         """Remove completed group tasks from the in-flight registry."""

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -279,6 +279,15 @@ class BatchQueue:
         Per-team fairness: candidates are interleaved round-robin across teams so one
         team's deep backlog cannot monopolize the ``LIMIT`` window; within a team,
         oldest-first order (and so per-run ``batch_index`` ordering) is preserved.
+
+        Disjoint windows across pods: groups live-leased by *another* owner are
+        excluded from candidates entirely, not merely dropped at the claim step.
+        Otherwise every pod computes the same top-``LIMIT`` window and groups
+        already owned elsewhere occupy window slots that losing pods can never
+        claim — with enough of them at the head of the queue the whole window is
+        dead weight and fleet concurrency collapses to roughly one window's worth.
+        Own-leased groups stay in the window so a pod can keep draining a group it
+        already holds.
         """
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(
@@ -331,6 +340,14 @@ class BatchQueue:
                                 AND b_busy.schema_id = b.schema_id
                                 AND b_busy.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                                 AND s_busy.job_state = 'executing'
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM {LEASE_TABLE} l_live
+                            WHERE l_live.team_id = b.team_id
+                                AND l_live.schema_id = b.schema_id
+                                AND l_live.expires_at > now()
+                                AND l_live.owner_token != %(owner)s
                         )
                     ORDER BY
                         row_number() OVER (

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1057,3 +1057,40 @@ class TestShutdown:
 
         assert drained.is_set()
         assert len(consumer._in_flight) == 0
+
+
+class TestDispatchGroups:
+    def test_fetch_limit_caps_to_free_slots_and_poll_limit(self):
+        consumer = _make_consumer(max_concurrency=16, poll_limit=50)
+        # 1 free slot must not lease a whole 50-batch window (orphaned-lease regression).
+        assert consumer._fetch_limit(1) == 3
+        assert consumer._fetch_limit(4) == 12
+        assert consumer._fetch_limit(16) == 48
+        wide = _make_consumer(max_concurrency=64, poll_limit=50)
+        assert wide._fetch_limit(64) == 50
+
+    @pytest.mark.asyncio
+    async def test_undispatched_groups_release_their_leases_in_the_same_cycle(self):
+        consumer = _make_consumer(max_concurrency=2)
+        consumer._in_flight[(1, "schema-0")] = AsyncMock()
+
+        dispatched = _make_batch(id="00000000-0000-0000-0000-00000000000a", schema_id="schema-1", run_uuid="run-1")
+        dropped_1 = _make_batch(id="00000000-0000-0000-0000-00000000000b", schema_id="schema-2", run_uuid="run-2")
+        dropped_2 = _make_batch(
+            id="00000000-0000-0000-0000-00000000000c", schema_id="schema-2", run_uuid="run-2", batch_index=1
+        )
+
+        with patch.object(consumer._adapter, "unlock", new=AsyncMock()) as mock_unlock:
+            await consumer._dispatch_groups(_make_healthy_conn(), [dispatched, dropped_1, dropped_2])
+
+            # One free slot: schema-1 dispatched; schema-2's lease must be released now,
+            # not left dark until the 300s TTL expires (the fleet-throughput regression).
+            assert (1, "schema-1") in consumer._in_flight
+            assert (1, "schema-2") not in consumer._in_flight
+            released = mock_unlock.call_args.kwargs["batches"]
+            assert {b.id for b in released} == {dropped_1.id, dropped_2.id}
+
+        task = consumer._in_flight.pop((1, "schema-1"))
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -709,3 +709,31 @@ class TestGetRunActivitySummary:
         assert summary.has_batches is False
         assert summary.has_non_terminal is False
         assert summary.is_stale is True
+
+
+@pytest.mark.django_db(transaction=True)
+class TestClaimWindowSkipsForeignLeasedGroups:
+    @pytest.mark.asyncio
+    async def test_foreign_leased_group_does_not_occupy_the_window(self, conn, conn_b):
+        # Two claimable groups; A is older so it sits at the head of the window.
+        await _insert_batch(conn, team_id=1, schema_id="schema-A", job_id="job-A", run_uuid="run-A")
+        await _insert_batch(conn, team_id=2, schema_id="schema-B", job_id="job-B", run_uuid="run-B")
+
+        got_b = await _claim(conn_b, owner=OWNER_B, limit=1)
+        assert [b.schema_id for b in got_b] == ["schema-A"]
+
+        # OWNER_A polls with a window of 1. If foreign-leased groups occupied window
+        # slots (the pre-fix behavior), group A would fill the window, its lease claim
+        # would fail, and OWNER_A would get nothing while group B sat claimable —
+        # window starvation. The fix hands the slot to group B instead.
+        got_a = await _claim(conn, owner=OWNER_A, limit=1)
+        assert [b.schema_id for b in got_a] == ["schema-B"]
+
+        # A holder's own live lease keeps its group claimable (group continuation).
+        got_b_again = await _claim(conn_b, owner=OWNER_B, limit=2)
+        assert "schema-A" in {b.schema_id for b in got_b_again}
+
+        # Expired foreign leases stop shielding the group.
+        await conn.execute(f"UPDATE {LEASE_TABLE} SET expires_at = now() - interval '1 second'")
+        got_a_after_expiry = await _claim(conn, owner=OWNER_A, limit=2)
+        assert "schema-A" in {b.schema_id for b in got_a_after_expiry}


### PR DESCRIPTION
## Problem

The v3 delta loader's fleet concurrency sits far below its nominal capacity (pods x `max_concurrency` group slots), producing multi-hour sync latency behind the daily enqueue peak. Jobs look "stuck Running" for hours while their batches are simply waiting in line to be claimed.

Production metrics point at two compounding defects in the claim path, not at processing capacity:

1. **Shared candidate window.** Every pod computes the same deterministic top-`poll_limit` candidate window in `get_unprocessed_and_lock`, and groups live-leased by another pod still occupy window slots (candidates never filtered on leases - only the claim step dropped them). Losing pods fetch ~0 batches while claimable work sits just past the window edge, so fleet concurrency collapses to roughly one window's worth regardless of pod count.
2. **Lease-then-drop orphaning.** A poll claims a lease for every group in its window, but the dispatch loop stops at `max_concurrency` and silently drops the rest - keeping their 300s leases with no renewal and no unlock. Those groups are dark to the whole fleet until the TTL expires, then get refetched: batches fetched ran 2-3x batches processed.

The two feed each other: orphaned leases clog the shared window head, which starves every other pod's poll.

## Changes

- `jobs_db.py get_unprocessed_and_lock`: the candidates CTE now excludes groups with a live lease held by *another* owner, making each pod's window disjoint, genuinely claimable work. A pod's own leases stay visible so it can keep draining groups it already holds. The lease upsert remains the single atomic arbiter of group ownership - this is a visibility fix, not a locking change.
- `batch_consumer.py`: the poll fetch is capped to free slots (`min(poll_limit, available x BATCHES_PER_GROUP_FETCH_FACTOR)`), and any group a poll leased but could not dispatch has its lease released in the same cycle (owner-scoped delete, so it can never touch another pod's lease). Groups already in flight are never released.
- Dispatch logic extracted into `_dispatch_groups()` and the cap into `_fetch_limit()` so both behaviors are unit-testable without driving the run loop.

Ordering and exclusivity invariants are unchanged: the head-of-line gate, busy-group gate, failed-run exclusion, per-batch `_verify_ownership`, and the lease upsert are all untouched. The window ordering (`per-team row_number, created_at, batch_index`) guarantees a truncated fetch can never include batch N+1 without its unprocessed earlier siblings.

Explicitly not done (wrong levers): raising `poll_limit` (worsens orphaning), adding replicas (adds losers to the same window race).

## How did you test this code?

Automated tests I (the agent) ran locally - full `test_jobs_db.py` + `test_consumer.py` suites green (81 passed) plus three new tests:

- `TestClaimWindowSkipsForeignLeasedGroups` (real SQL, queue DB): with group A foreign-leased and a window of 1, a second pod now claims group B instead of nothing - the exact window-starvation regression. Also asserts own-lease continuation and that an expired foreign lease stops shielding the group.
- `TestDispatchGroups::test_undispatched_groups_release_their_leases_in_the_same_cycle`: one free slot, two fetched groups - the dispatched group keeps its lease, the dropped group's batches are released immediately (catches a revert to the old `break`-and-hold behavior).
- `TestDispatchGroups::test_fetch_limit_caps_to_free_slots_and_poll_limit`: guards the fetch cap against reverting to a full-window fetch.

No manual/staging testing. Post-deploy verification plan (prod metrics): `sum(warehouse_pg_consumer_active_groups)` at the evening peak should rise several-fold; `poll_batches_fetched` average should approach the cap instead of low single digits; the fetched-vs-processed ratio should drop to ~1.0; queue delay (first status row minus batch `created_at`) should fall from hours to minutes at peak.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Estefania) directed this with Claude (PostHog Code). It came out of a production investigation of V3 pipeline runs using the repo's `investigating-warehouse-sources-load` skill (Grafana Loki/VictoriaMetrics + the federated queue tables). The investigation went through one important self-correction: an initial "stranded executing backlog" theory turned out to be an artifact of the federated copy of `v_latest_source_batch_status` accumulating historical states; recomputing from the base status table showed the queue itself healthy and pointed the latency at the claim path. The claim-window mechanics were then verified against live metrics (fleet active groups vs nominal slots, poll rate, per-poll fetch size, fetched-vs-processed ratio, prod config from `batch_consumer_started` logs) before any code was written.

Decisions: excluding foreign-leased groups from candidates was chosen over per-pod ordering jitter (keeps strict oldest-first fairness); the fetch cap plus same-cycle release was chosen over only capping (belt and suspenders - the cap alone still orphans when groups are smaller than expected). The `/writing-tests` skill gated the three added tests. A follow-up remains if poll latency stays multi-second after this lands: bounding the failed-run exclusion subquery in the claim query.

Agent-authored code; requires human review - please don't self-merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
