### PR TITLE
chore(devbox): diagnose dns failures via the tailscale exit node

### DIFF
--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -17,7 +17,16 @@ If `hogli devbox:doctor` reports the control plane unreachable, the fix is a PR 
 
 When doctor shows `[ok] Tailscale connected` but fails reachability with a **DNS** cause (`DNS lookup for coder.dev.posthog.dev failed`), that's usually not the grant: the client's split-DNS routes don't cover `dev.posthog.dev`, so the name never reaches the internal resolver.
 The fix is selecting a Tailscale **exit node** — it routes DNS through infra that resolves `*.dev.posthog.dev`.
-Check and fix via the Tailscale menu bar app (Exit Node) or CLI (`tailscale exit-node list`; on macOS the CLI is `/Applications/Tailscale.app/Contents/MacOS/Tailscale` when `tailscale` isn't on `PATH`).
+Check available exit nodes and select one via the Tailscale menu bar app (Exit Node) or CLI:
+
+```bash
+tailscale exit-node list                            # list available exit nodes
+tailscale set --exit-node=<name>                    # enable one (use the Name from the list)
+# on macOS when `tailscale` isn't on PATH:
+/Applications/Tailscale.app/Contents/MacOS/Tailscale exit-node list
+/Applications/Tailscale.app/Contents/MacOS/Tailscale set --exit-node=<name>
+```
+
 Do not suggest `/etc/hosts` or `/etc/resolver` workarounds — they hardcode internal ELB IPs that rotate, and the exit node is the supported path.
 To confirm it's resolution rather than the grant: `dig coder.dev.posthog.dev @10.90.0.2` answering while the system resolver fails proves the name exists and only the resolution path is missing.
 

--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -13,6 +13,14 @@ The devbox control plane lives inside a private VPC reachable only over Tailscal
 
 If `hogli devbox:doctor` reports the control plane unreachable, the fix is a PR adding the user to `group:engineering` in `tailnet-policy.hujson` (then ask Team DevEx if still blocked). Diagnose this before touching anything else.
 
+### Control plane unreachable with a DNS cause? Check the exit node first
+
+When doctor shows `[ok] Tailscale connected` but fails reachability with a **DNS** cause (`DNS lookup for coder.dev.posthog.dev failed`), that's usually not the grant: the client's split-DNS routes don't cover `dev.posthog.dev`, so the name never reaches the internal resolver.
+The fix is selecting a Tailscale **exit node** — it routes DNS through infra that resolves `*.dev.posthog.dev`.
+Check and fix via the Tailscale menu bar app (Exit Node) or CLI (`tailscale exit-node list`; on macOS the CLI is `/Applications/Tailscale.app/Contents/MacOS/Tailscale` when `tailscale` isn't on `PATH`).
+Do not suggest `/etc/hosts` or `/etc/resolver` workarounds — they hardcode internal ELB IPs that rotate, and the exit node is the supported path.
+To confirm it's resolution rather than the grant: `dig coder.dev.posthog.dev @10.90.0.2` answering while the system resolver fails proves the name exists and only the resolution path is missing.
+
 ## Workflow
 
 ### 1. Check state — `hogli devbox:doctor`


### PR DESCRIPTION
## Problem

`hogli devbox:doctor` reporting "Coder control plane unreachable" sends the `setting-up-devbox` skill straight to the tailnet-grant diagnosis. But when the failure cause is DNS (`DNS lookup for coder.dev.posthog.dev failed`) while Tailscale is connected, the grant usually isn't the problem — the client's split-DNS routes don't cover `dev.posthog.dev`, so the name never reaches the internal resolver. An agent following the skill today ends up suggesting `/etc/hosts` / `/etc/resolver` workarounds, which hardcode internal ELB IPs that rotate.

Hit in practice this week: doctor green on tailnet, DNS failure on the control plane name; selecting a Tailscale exit node fixed resolution immediately, no host config change needed.

## Changes

Add a short diagnosis subsection to the tailnet-prerequisite section: distinguish the DNS-cause failure from the grant failure, check/suggest the Tailscale exit node as the supported fix (menu bar app or CLI, with the macOS app-bundle CLI path), explicitly steer away from `/etc/hosts` / `/etc/resolver` workarounds, and give the `dig @10.90.0.2` probe that proves it's a resolution-path problem rather than a missing grant.

## How did you test this code?

- `hogli lint:skills` passes (101 skills).
- The added guidance is the verbatim diagnosis path that resolved the real occurrence: internal resolver answered for the name, system resolver didn't, exit node selection fixed it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code after the agent hit this exact failure mode while setting up a devbox and initially proposed an `/etc/resolver` workaround; the user pointed out the exit node is the right fix and asked for the skill to encode it.
- Skills invoked: /writing-skills, /setting-up-devbox.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
