### PR TITLE
chore(data-warehouse): drop stale incident_io scaffolded-list entry

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -454,7 +454,6 @@ doesn't conflict with concurrent PRs.
 - ikas
 - illumina_basespace
 - imagga
-- incident_io
 - inflowinventory
 - infor_nexus
 - insightful


### PR DESCRIPTION
## Problem

While finishing the `incident_io` data warehouse source, I found it listed in two places in `SOURCES.md`: the Implemented sources table (where it belongs) and the Scaffolded sources list (where it does not). The Scaffolded list is defined as sources still on an `unreleasedSource=True` placeholder with no sync logic, which `incident_io` is not.

## Changes

Remove the stale `incident_io` bullet from the Scaffolded sources list. It stays in the Implemented table with its comm method (HTTP), library (requests), and tracked-transport state (✅). No code behavior changes.

## How did you test this code?

Documentation-only change (one line of `SOURCES.md`). No automated tests apply. I (Claude) could not run the Python suite in this environment - it has no provisioned interpreter, pytest, or Django deps - but this change touches no Python.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) picked this up under a task to "implement the `incident_io` source end to end." On inspection the source is already fully implemented and merged on `master`: the `source.py` / `settings.py` / `incident_io.py` / `canonical_descriptions.py` split, the `ResumableSource` transport with Bearer auth, `after`-cursor pagination, `updated_at[gte]` incremental on incidents only, tracked-transport HTTP, 429/5xx retries, `get_non_retryable_errors`, all the enum/schema/config wiring, the icon, and two comprehensive parameterized test modules. So the only real gap was this duplicate bookkeeping line, which is all this PR fixes.

Two things I deliberately did not do. First, I left the source visible with `releaseStatus=ALPHA` rather than re-adding `unreleasedSource=True` - the committed test asserts `unreleasedSource is None`, and re-hiding a shipped connector would be a regression. Second, the user-facing doc still needs to land in the `posthog.com` repo at `contents/docs/cdp/sources/incident-io.md` (matching the source's `docsUrl`); there is no `posthog.com` checkout here, so I drafted it for a follow-up rather than committing it to the wrong repo. I ran `/implementing-warehouse-sources` and `/documenting-warehouse-sources` while assessing this.
