### PR TITLE
chore(insights): adopt useChartConfig as the chart config seam

### DIFF
--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { type DependencyList, useMemo } from 'react'
 
 import type { ChartTheme } from '@posthog/quill-charts'
 
@@ -14,4 +14,14 @@ export function useChartTheme(overrides?: Partial<ChartTheme>): ChartTheme {
     const { isDarkModeOn } = useValues(themeLogic)
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return useMemo(() => buildTheme(overrides), [isDarkModeOn, overrides])
+}
+
+/** Drop-in replacement for the `useMemo` that builds a chart's config object. This is the central
+ *  seam for applying app-level rendering defaults to every quill chart config — currently a plain
+ *  memo; config defaults (with the chart's own keys winning) hook in here. */
+export function useChartConfig<T extends object>(factory: () => T, deps: DependencyList): T
+export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined
+export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useMemo(factory, deps)
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react'
 
 import { type ChartTheme, type Series } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { LineGraphProps } from './LineGraph'
@@ -23,7 +23,7 @@ export interface SqlChartModel<TConfig> {
     config: TConfig
 }
 
-export function useSqlChartModel<TConfig>(
+export function useSqlChartModel<TConfig extends object>(
     { xData, yData, visualizationType, chartSettings, dashboardId, goalLines }: LineGraphProps,
     buildConfig: (args: BuildBarConfigArgs) => TConfig
 ): SqlChartModel<TConfig> | null {
@@ -44,7 +44,7 @@ export function useSqlChartModel<TConfig>(
 
     const theme = useChartTheme()
 
-    const config = useMemo(
+    const config = useChartConfig(
         () =>
             xData
                 ? buildConfig({

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -5,7 +5,7 @@ import { BoxPlot } from '@posthog/quill-charts'
 import type { BoxPlotClickData, BoxPlotConfig, BoxPlotSeries, BoxPlotTooltipContext } from '@posthog/quill-charts'
 
 import 'scenes/insights/InsightTooltip/InsightTooltip.scss'
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getSeriesColor } from 'lib/colors'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -92,7 +92,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
 
     const formatValue = useCallback((value: number) => formatAggregationAxisValue(trendsFilter, value), [trendsFilter])
 
-    const config = useMemo<BoxPlotConfig>(
+    const config = useChartConfig<BoxPlotConfig>(
         () => ({
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             yTickFormatter: formatValue,

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import {
     ChoiceTooltip,
     ChoiceTooltipContextData,
@@ -58,7 +58,7 @@ export function MultipleChoiceBarChart({
     // rendered through the category-axis formatter instead.
     const labels = useMemo(() => chartData.map((_, i) => String(i)), [chartData])
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => ({
             axisOrientation: 'horizontal',
             barLayout: 'grouped',

--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { NpsBucketMeta, RatingTooltip } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
@@ -48,7 +48,7 @@ export function RatingBarChart({
         [chartLabels, data, barColors]
     )
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => ({
             hideYAxis: true,
             bars: { bandPadding: 0.2, valuePadding: VALUE_LABEL_PADDING },

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -5,7 +5,7 @@ import { useMemo, type ErrorInfo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { hexToRGBA } from 'lib/utils/colors'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -55,7 +55,7 @@ export function FunnelHistogramChart(): JSX.Element | null {
         [histogramGraphData, histogramGraphDataPrevious, currentColor]
     )
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => (isComparing ? { ...CHART_CONFIG, barLayout: 'grouped' } : CHART_CONFIG),
         [isComparing]
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -10,7 +10,7 @@ import type {
     TooltipContext,
 } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -137,7 +137,7 @@ export function FunnelLineChart({
         [showLegend, series.length, legendPosition, canEditInsight, inSharedMode]
     )
 
-    const chartConfig: TimeSeriesLineChartConfig = useMemo(
+    const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildFunnelLineTimeSeriesConfig({
                 indexedSteps: steps,

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { BarChart, DEFAULT_MARGINS } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -83,7 +83,7 @@ export function FunnelStepsBarChart({
     const isBreakdownCompare = steps[0]?.nested_breakdown?.some(
         (variant) => variant.compare_label != null && hasBreakdown(variant.breakdown_value)
     )
-    const config = useMemo(
+    const config = useChartConfig(
         () => withFunnelStepsBarInteraction(chartConfig, { isBreakdownCompare, quillTooltipEnabled }),
         [isBreakdownCompare, quillTooltipEnabled]
     )

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -170,7 +170,7 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
 
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
-    const barConfig = useMemo(
+    const barConfig = useChartConfig(
         () => buildRetentionBarChartConfig({ isPercentage, goalLines, series, tooltip: TOOLTIP_CONFIG }),
         [isPercentage, goalLines, series, TOOLTIP_CONFIG]
     )

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -173,7 +173,7 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
 
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
-    const lineConfig = useMemo(
+    const lineConfig = useChartConfig(
         () =>
             buildRetentionLineChartConfig({ isPercentage, goalLines, showTrendLines, series, tooltip: TOOLTIP_CONFIG }),
         [isPercentage, goalLines, showTrendLines, series, TOOLTIP_CONFIG]

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -113,7 +113,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         [indexedResults, getTrendsColor, getTrendsHidden, getLabel, quillLegendEnabled]
     )
 
-    const chartConfig: TimeSeriesBarChartConfig = useMemo(
+    const chartConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildStickinessBarTimeSeriesConfig({
                 yAxisScaleType,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -115,7 +115,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         [indexedResults, display, getTrendsColor, getTrendsHidden, getLabel, showMultipleYAxes, quillLegendEnabled]
     )
 
-    const chartConfig: TimeSeriesLineChartConfig = useMemo(
+    const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildStickinessLineTimeSeriesConfig({
                 yAxisScaleType,

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@posthog/quill-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { percentage } from 'lib/utils/numbers'
@@ -216,7 +216,7 @@ export function TrendsBarChart({
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const timeSeriesConfig: TimeSeriesBarChartConfig = useMemo(
+    const timeSeriesConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildTrendsBarTimeSeriesConfig({
                 trendsFilter,
@@ -261,7 +261,7 @@ export function TrendsBarChart({
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const aggregatedConfig: BarChartConfig = useMemo(() => {
+    const aggregatedConfig: BarChartConfig = useChartConfig(() => {
         // Band keys are synthetic per-series; render the human label via the categorical-axis
         // formatter and skip repeats so band-shared breakdown rows don't double-paint.
         let xTickFormatter: BarChartConfig['xTickFormatter']

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getBarColorFromStatus } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -105,7 +105,11 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         [formatValue, showValuesOnSeries, showPercentagesOnSeries]
     )
 
-    const { series, labels, config } = useMemo(
+    const {
+        series,
+        labels,
+        config: baseConfig,
+    } = useMemo(
         () =>
             buildLifecycleChartModel<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 getColor: (status) => getBarColorFromStatus((status ?? 'new') as LifecycleToggle),
@@ -139,6 +143,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             quillTooltipEnabled,
         ]
     )
+    const config = useChartConfig(() => baseConfig, [baseConfig])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ciRanges } from 'lib/statistics'
@@ -240,7 +240,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         ]
     )
 
-    const config = useMemo(
+    const config = useChartConfig(
         () =>
             buildTrendsLineTimeSeriesConfig<IndexedTrendResult>({
                 results: indexedResults ?? [],

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 import { BarChart } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -170,6 +170,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
         replayScannerLogic({ id: scannerId })
     )
     const theme = useChartTheme()
+    const config = useChartConfig(() => ({ showGrid: false }), [])
     if (!scorerSummary || !scorerHistogram) {
         return (
             <OverviewPanel title="Score distribution">
@@ -190,7 +191,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
                 <BarChart
                     labels={scorerHistogram.labels}
                     series={[{ key: 'count', label: 'Sessions', color: theme.colors[0], data: scorerHistogram.counts }]}
-                    config={{ showGrid: false }}
+                    config={config}
                     theme={theme}
                 />
             </div>

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -11,7 +11,7 @@ import type {
     YAxisConfig,
 } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -111,14 +111,27 @@ export function RevenueAnalyticsChart({
 
     // No xAxis config: the backend ships pre-formatted period labels, so the time-axis date
     // formatter is intentionally left inert (it would otherwise re-format the labels itself).
-    if (kind === 'bar') {
-        const config: TimeSeriesBarChartConfig = {
+    const barConfig = useChartConfig<TimeSeriesBarChartConfig>(
+        () => ({
             yAxis,
             goalLines,
             barLayout: 'stacked',
             divergingStack,
             tooltip: TOOLTIP_CONFIG,
-        }
+        }),
+        [yAxis, goalLines, divergingStack]
+    )
+    const lineConfig = useChartConfig<TimeSeriesLineChartConfig>(
+        () => ({
+            yAxis,
+            goalLines,
+            showCrosshair: true,
+            tooltip: TOOLTIP_CONFIG,
+        }),
+        [yAxis, goalLines]
+    )
+
+    if (kind === 'bar') {
         return (
             <ChartLegend
                 show={showLegend}
@@ -130,7 +143,7 @@ export function RevenueAnalyticsChart({
                     series={series}
                     labels={labels}
                     theme={theme}
-                    config={config}
+                    config={barConfig}
                     tooltip={renderTooltip}
                     className="BarGraph"
                     dataAttr={dataAttr}
@@ -139,12 +152,6 @@ export function RevenueAnalyticsChart({
         )
     }
 
-    const config: TimeSeriesLineChartConfig = {
-        yAxis,
-        goalLines,
-        showCrosshair: true,
-        tooltip: TOOLTIP_CONFIG,
-    }
     return (
         <ChartLegend
             show={showLegend}
@@ -156,7 +163,7 @@ export function RevenueAnalyticsChart({
                 series={series}
                 labels={labels}
                 theme={theme}
-                config={config}
+                config={lineConfig}
                 tooltip={renderTooltip}
                 className="LineGraph"
                 dataAttr={dataAttr}


### PR DESCRIPTION
## Problem

Every quill chart component builds its config object with a bare `useMemo`. There's no single place to apply app-level rendering defaults across chart surfaces — an upcoming flag-gated style refresh (#67779) would otherwise have to edit ~17 components to thread its defaults, and any future default would again.

## Changes

Stacked on #67761 (the `useChartTheme` counterpart for themes) — this is the config half of the same idea.

- New `useChartConfig(factory, deps)` in `lib/charts/hooks.ts` — a drop-in replacement for the config-building `useMemo`, same signature, currently a plain memo. It exists purely as the seam where app-level config defaults hook in.
- Adopted at every chart config call site: trends (line/bar/lifecycle), stickiness, retention, funnels (line/histogram/steps), surveys, box plot, SQL charts, revenue analytics, replay scanners. The diff at each site is essentially `useMemo` → `useChartConfig` (a couple of sites hoisted an inline config above a conditional return so the hook call is unconditional).

No behavior change: the hook is a passthrough memo.

## How did you test this code?

- `oxlint` clean on all touched files (3 pre-existing warnings unrelated to this change)
- Full-frontend `tsgo --noEmit`: no errors in touched files
- No new tests: pure mechanical seam adoption with no logic

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal refactor.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The author split this out of the style-refresh PR so the mechanical seam adoption can merge ahead of the styling work, which will keep iterating. The hook deliberately mirrors `useMemo`'s `(factory, deps)` signature — an earlier shape that wrapped an already-memoized object forced nested hooks at call sites and was rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)