### PR TITLE
fix(customer-analytics): use searchable selects in custom property source modal

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { LemonBanner, LemonButton, LemonModal, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonModal, LemonSearchableSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
@@ -74,7 +74,7 @@ export function CustomPropertySourceModal(): JSX.Element {
                 >
                     <LemonField name="savedQuery" label="View">
                         {({ value, onChange }) => (
-                            <LemonSelect
+                            <LemonSearchableSelect
                                 value={value}
                                 onChange={(newValue) => {
                                     onChange(newValue)
@@ -96,7 +96,7 @@ export function CustomPropertySourceModal(): JSX.Element {
                         help="The column whose value is written to this property."
                     >
                         {({ value, onChange }) => (
-                            <LemonSelect
+                            <LemonSearchableSelect
                                 value={value}
                                 onChange={onChange}
                                 options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}
@@ -115,7 +115,7 @@ export function CustomPropertySourceModal(): JSX.Element {
                         help="The column matched against each account's external ID."
                     >
                         {({ value, onChange }) => (
-                            <LemonSelect
+                            <LemonSearchableSelect
                                 value={value}
                                 onChange={onChange}
                                 options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}


### PR DESCRIPTION
## Problem

The three selects in the custom property sync modal aren't searchable, which gets painful with many views or columns.

Part of https://github.com/PostHog/posthog/issues/60300
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Swap `LemonSelect` for `LemonSearchableSelect` in the view, value column, and key column selects of `CustomPropertySourceModal`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Drop-in prop-compatible swap; no automated tests run. I wasn't able to verify in the browser.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code). Considered the quill `Combobox` used by the update-account-property workflow action, but it requires a trigger/popover restructure per field; `LemonSearchableSelect` (as used in the data warehouse join modal) is a drop-in replacement.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
