### PR TITLE
fix(mongodb): stop reporting missing-read-privilege errors as noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -215,7 +215,9 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # signature hashes, BSON ids — so str(e) must never be surfaced. Map the stable error
             # markers to a clean message; an authorization failure ("not authorized") means the
             # credentials are valid but lack read access, which is distinct from a bad password.
-            capture_exception(e)
+            # Both are user-side credential/permission problems we already surface an actionable
+            # message for and classify as non-retryable — never a PostHog bug — so don't report
+            # them to error tracking as non-actionable noise.
             if "not authorized" in str(e):
                 return False, _MONGO_NOT_AUTHORIZED_MESSAGE
             return False, _MONGO_AUTHENTICATION_FAILED_MESSAGE

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -218,9 +218,16 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # Both are user-side credential/permission problems we already surface an actionable
             # message for and classify as non-retryable — never a PostHog bug — so don't report
             # them to error tracking as non-actionable noise.
-            if "not authorized" in str(e):
+            message = str(e)
+            if "not authorized" in message:
                 return False, _MONGO_NOT_AUTHORIZED_MESSAGE
-            return False, _MONGO_AUTHENTICATION_FAILED_MESSAGE
+            if any(marker in message for marker in ("AuthenticationFailed", "Authentication failed", "bad auth")):
+                return False, _MONGO_AUTHENTICATION_FAILED_MESSAGE
+            # Any other OperationFailure on listCollections is unexpected (server bug, unsupported
+            # option, ...) — capture it so the signal isn't lost, and surface a generic message
+            # rather than mislabelling it as an authentication problem.
+            capture_exception(e)
+            return False, _MONGO_CONNECT_FAILED_MESSAGE
         except ServerSelectionTimeoutError as e:
             # pymongo dumps a verbose topology description into str(e); surface a concise,
             # actionable message instead. A DNS failure means the host doesn't resolve at all,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -177,3 +177,37 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
         assert ok is False
         assert err == _MONGO_CONNECT_FAILED_MESSAGE
         mock_capture.assert_called_once()
+
+    # An OperationFailure on listCollections is a user-side credential/permission problem — a
+    # missing read role ("not authorized") or a bad password — that we already surface an
+    # actionable message for and classify as non-retryable, so it must not be captured as noise.
+    @pytest.mark.parametrize(
+        "exc, expected_message",
+        [
+            (
+                OperationFailure(
+                    "not authorized on demo_db to execute command { listCollections: 1 }",
+                    13,
+                    {"ok": 0.0, "errmsg": "not authorized on demo_db", "code": 13, "codeName": "Unauthorized"},
+                ),
+                _MONGO_NOT_AUTHORIZED_MESSAGE,
+            ),
+            (
+                OperationFailure(
+                    "Authentication failed.", 18, {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18}
+                ),
+                _MONGO_AUTHENTICATION_FAILED_MESSAGE,
+            ),
+        ],
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_operation_failure_not_reported(self, mock_get_collections, mock_capture, exc, expected_message):
+        mock_get_collections.side_effect = exc
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == expected_message
+        mock_capture.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -178,11 +178,12 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
         assert err == _MONGO_CONNECT_FAILED_MESSAGE
         mock_capture.assert_called_once()
 
-    # An OperationFailure on listCollections is a user-side credential/permission problem — a
-    # missing read role ("not authorized") or a bad password — that we already surface an
-    # actionable message for and classify as non-retryable, so it must not be captured as noise.
+    # A recognized OperationFailure on listCollections is a user-side credential/permission problem
+    # — a missing read role ("not authorized") or bad credentials — that we already surface an
+    # actionable message for and classify as non-retryable, so it must not be captured as noise. An
+    # unrecognized OperationFailure is unexpected and must still be captured so the signal isn't lost.
     @pytest.mark.parametrize(
-        "exc, expected_message",
+        "exc, expected_message, should_capture",
         [
             (
                 OperationFailure(
@@ -191,18 +192,40 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
                     {"ok": 0.0, "errmsg": "not authorized on demo_db", "code": 13, "codeName": "Unauthorized"},
                 ),
                 _MONGO_NOT_AUTHORIZED_MESSAGE,
+                False,
             ),
             (
                 OperationFailure(
                     "Authentication failed.", 18, {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18}
                 ),
                 _MONGO_AUTHENTICATION_FAILED_MESSAGE,
+                False,
+            ),
+            (
+                OperationFailure(
+                    "bad auth : authentication failed",
+                    8000,
+                    {"ok": 0.0, "errmsg": "bad auth : authentication failed", "code": 8000, "codeName": "AtlasError"},
+                ),
+                _MONGO_AUTHENTICATION_FAILED_MESSAGE,
+                False,
+            ),
+            (
+                OperationFailure(
+                    "listCollections: unrecognized field 'authorizedCollections'",
+                    40415,
+                    {"ok": 0.0, "errmsg": "unrecognized field", "code": 40415, "codeName": "Location40415"},
+                ),
+                _MONGO_CONNECT_FAILED_MESSAGE,
+                True,
             ),
         ],
     )
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_operation_failure_not_reported(self, mock_get_collections, mock_capture, exc, expected_message):
+    def test_operation_failure_capture_behavior(
+        self, mock_get_collections, mock_capture, exc, expected_message, should_capture
+    ):
         mock_get_collections.side_effect = exc
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
 
@@ -210,4 +233,4 @@ class TestMongoValidateCredentialsErrorTrackingNoise:
 
         assert ok is False
         assert err == expected_message
-        mock_capture.assert_not_called()
+        assert mock_capture.called is should_capture


### PR DESCRIPTION
## Problem

Error tracking is getting a recurring `OperationFailure` from the MongoDB import source: `not authorized on <db> to execute command { listCollections: 1, ... }` (codeName `Unauthorized`, code 13). The customer's MongoDB user authenticates fine but lacks a read role on the database, so listing collections is denied.

This is a pure user-side permission problem. We already handle it correctly everywhere it matters:

- `"not authorized"` is in `get_non_retryable_errors`, so the import path and schema discovery already stop retrying and skip quietly.
- `validate_credentials` already maps it to a clean, actionable message (`_MONGO_NOT_AUTHORIZED_MESSAGE`) telling the user to grant a read role.

The only thing still wrong: `validate_credentials`'s `except OperationFailure` handler calls `capture_exception(e)` unconditionally, so every validation of an under-privileged connection reports this handled, non-retryable user error to error tracking as if it were a bug. That is the noise the issue is made of.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f22f8-2665-7512-aaf4-25554d3f77db

## Changes

Drop the `capture_exception(e)` from the `OperationFailure` handler in `validate_credentials`. Both branches it feeds - `"not authorized"` (missing read role) and the fallback `Authentication failed` (bad password) - are user-side credential/permission problems we already surface an actionable message for and already classify as non-retryable. Neither is a PostHog bug, so neither belongs in error tracking.

This mirrors the existing convention in this exact area:

- `_get_rows_to_sync` in `mongo.py` deliberately does not capture expected auth/connectivity `PyMongoError`s.
- `sync_new_schemas_activity` skips quietly on non-retryable source errors.
- The `refresh_schemas` view suppresses capture for "expected source errors" via `_classify_refresh_schemas_error`, which keys off `get_non_retryable_errors()`.
- Sibling PR #67763 applies the same fix to the `ServerSelectionTimeoutError` handler (connectivity timeouts). This one covers `OperationFailure` (auth/permission). Distinct exception types, distinct root causes, complementary fixes.

Genuinely unexpected failures still get captured: the generic `except Exception` fallback is untouched.

## How did you test this code?

Extended `TestMongoValidateCredentialsErrorTrackingNoise` in `test_database_name.py` with a parametrized case asserting the two recognized `OperationFailure` errors (`not authorized`, `Authentication failed`) return their clean message and do **not** call `capture_exception`. This catches a re-introduction of the capture - no existing test asserted capture behavior for the `OperationFailure` branch. The generic-`Exception`-is-still-captured case remains covered.

Ran the full file locally: `python -m pytest products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py` - 20 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged by Claude (Claude Code) from an error-tracking webhook. Pulled the issue via the PostHog error-tracking MCP tools, traced the stack (`_list_importable_collection_names` at `mongo.py:443`, raised through `get_collection_names` from `validate_credentials`) and confirmed the retry classification was already correct, so the remaining defect was the unconditional `capture_exception`.

Skills invoked: `/writing-tests` (to gate the added regression test).

Decisions along the way:
- Considered treating this as a `NonRetryableErrors` gap, but `"not authorized"` is already there - adding it would have been a no-op. The real, non-no-op fix is the error-tracking capture.
- Scoped the change to the `OperationFailure` handler only; left the generic `except Exception` capture intact so real bugs still surface.
- Checked for duplicates: #67763 fixes the sibling `ServerSelectionTimeoutError` capture and #66548 adds invalid-database-name handling - neither touches the `OperationFailure` capture, so this is not a duplicate.
