### PR TITLE
fix(query-performance): cap export scan parallelism at 24 threads

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -99,6 +99,7 @@ ONE_GB = 1024 * 1024 * 1024
 
 
 class QueryLogArchiveExportConfig(dagster.Config):
+    max_threads: int = 24
     s3_prefix: str = "query_log_archive"
     s3_bucket: str = settings.QUERY_LOG_ARCHIVE_EXPORT_S3_BUCKET
 
@@ -133,7 +134,7 @@ SELECT
     normalizeQuery(lc_query__query) AS hogql_shape
 FROM {SOURCE_TABLE}
 WHERE event_date = toDate('{day}') AND is_initial_query
-SETTINGS s3_truncate_on_insert = 1
+SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads}
 """
 
     def run(client: Client) -> str:

--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -99,7 +99,7 @@ ONE_GB = 1024 * 1024 * 1024
 
 
 class QueryLogArchiveExportConfig(dagster.Config):
-    max_threads: int = 24
+    max_threads: int = dagster.Field(int, default_value=24, description="ClickHouse max_threads for the export scan. Must be ≥ 1 (0 means auto/all-cores in ClickHouse and will re-enable the OOM risk).")  # type: ignore[assignment]
     s3_prefix: str = "query_log_archive"
     s3_bucket: str = settings.QUERY_LOG_ARCHIVE_EXPORT_S3_BUCKET
 

--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -1,4 +1,5 @@
 import dagster
+import pydantic
 from clickhouse_driver import Client
 
 from posthog import settings
@@ -99,7 +100,11 @@ ONE_GB = 1024 * 1024 * 1024
 
 
 class QueryLogArchiveExportConfig(dagster.Config):
-    max_threads: int = dagster.Field(int, default_value=24, description="ClickHouse max_threads for the export scan. Must be ≥ 1 (0 means auto/all-cores in ClickHouse and will re-enable the OOM risk).")  # type: ignore[assignment]
+    max_threads: int = pydantic.Field(
+        default=24,
+        ge=1,
+        description="ClickHouse max_threads for the export scan. Must be ≥ 1 (0 means auto/all-cores in ClickHouse and will re-enable the OOM risk).",
+    )
     s3_prefix: str = "query_log_archive"
     s3_bucket: str = settings.QUERY_LOG_ARCHIVE_EXPORT_S3_BUCKET
 


### PR DESCRIPTION
## Problem

The last three daily `query_log_archive` exports (days 06-29, 06-30, 07-01) all failed with:

```
Code: 241. DB::Exception: Query memory limit exceeded: would use 20.01 GiB ...
```

This is the query hitting its own 20 GiB `max_memory_usage` cap — a different failure than the earlier transient node-total OOMs, and deterministic, so retries can't fix it.

Two compounding causes, from the OPS `query_log`:

- Daily volume grew: 06-30 had read 1.01 TiB before dying, vs 0.5–0.8 TiB total for successful May days (similar row counts — rows got wider).
- The export runs with the default `max_threads = 60` (node cores). At 06:00 UTC the node is idle, so the scan reads at ~1 GiB/s while the downstream normalizeQuery + Parquet encode + S3 upload drains far slower. Buffered blocks pile up until the cap kills the query within 7–16 minutes.

## Changes

- Set `max_threads = 24` on the export query, exposed as run config so a failed partition can be relaunched with a different value from the UI without a code change.

Scan memory scales with parallel streams, so this drops peak memory well under the 20 GiB cap even at the grown volume. Runtime impact should be small: the pipeline is bottlenecked downstream (successful runs took 45–60 min while the scan alone takes ~15 at full parallelism). This is safer than raising the memory cap: the shared OPS node has ~41.5 GiB total and also runs merges/ingest, and we've already seen node-total OOMs there.

## How did you test this code?

I'm an agent (Claude Code). `ruff` + `ty check` clean; the job loads and the config default resolves to 24. The real proof is the next scheduled run (or relaunching the three failed partitions) completing under the cap.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from the OPS `system.query_log`: all three failures show `max_threads=60`, peak memory pinned at exactly 20 GiB, and death 7–16 min in with 0.5–1 TiB already read — a scan outrunning the sink, not a heavier query shape. Chose throttling parallelism over raising the memory cap to preserve node headroom.
