### PR TITLE
fix(deps): declare uWebSockets.js directly to pass blockExoticSubdeps

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -135,6 +135,7 @@
         "tail": "^2.2.6",
         "tldts": "^6.1.57",
         "typescript": "catalog:",
+        "uWebSockets.js": "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3",
         "ultimate-express": "2.0.9",
         "undici": "^7.24.0",
         "undici-types": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
             "react-dom": "18.3.1",
             "sha.js": ">=2.4.12",
             "typescript": "6.0.3",
-            "uWebSockets.js": "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3",
+            "ultimate-express>uWebSockets.js": "-",
             "fast-xml-parser@^4": ">=4.5.4",
             "fast-xml-parser@^5": ">=5.3.5",
             "jest-playwright-preset>playwright-core": "1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ overrides:
   react-dom: 18.3.1
   sha.js: '>=2.4.12'
   typescript: 6.0.3
-  uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3
+  ultimate-express>uWebSockets.js: '-'
   fast-xml-parser@^4: '>=4.5.4'
   fast-xml-parser@^5: '>=5.3.5'
   jest-playwright-preset>playwright-core: 1.60.0
@@ -1613,6 +1613,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      uWebSockets.js:
+        specifier: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3
       ultimate-express:
         specifier: 2.0.9
         version: 2.0.9
@@ -22034,8 +22037,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.440.0:
-    resolution: {integrity: sha512-IAAk7vf2Hp4VkhIuVtYPVz6B0ez41e0+nfm6rYXleEhMT4P6UHTuH64iNYIdt2b3mxWzzfttyhVU4HWDa6xIYQ==}
+  unlayer-types@1.441.0:
+    resolution: {integrity: sha512-kv517UseH1plEpm11xANkIS4jx7rwpvT/7KPHepEnVn3JQitZ0te+XkznG37+1bfXcFJcyKlpI0wznlU4aPJTw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -42997,7 +43000,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.440.0
+      unlayer-types: 1.441.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -45220,7 +45223,6 @@ snapshots:
       statuses: 2.0.2
       tseep: 1.3.1
       type-is: 2.0.1
-      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/cfc9a40d8132a34881813cec3d5f8e3a185b3ce3
       vary: 1.1.2
 
   unbox-primitive@1.0.2:
@@ -45338,7 +45340,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.440.0: {}
+  unlayer-types@1.441.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Problem

`pnpm install` is broken since we set `blockExoticSubdeps: true` due to [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js), which is not in the npm registry. That's an `ultimate-express` dependency.

## Changes

Added a override to strip the exotic subdep of `ultimate-express` dependency graph, and added `uWebSockets.js` as a direct dependency, pinned to the same codeload tarball. 

## How did you test this code?

- `pnpm install` completes cleanly with `blockExoticSubdeps: true` enabled (previously failed on `uWebSockets.js`).
- Smoke-tested the runtime resolution: `require('ultimate-express')`, created an app, started a server, and verified an HTTP roundtrip returns `ok` — confirming the native `uWebSockets.js` binding still loads from its new location in the graph.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
