### PR TITLE
fix(customer-analytics): bypass warehouse view access control in userless sync

### DIFF
--- a/products/customer_analytics/backend/logic/custom_property_sync.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync.py
@@ -129,7 +129,9 @@ def _read_view(team: Team, view_name: str, columns: list[str]) -> list:
         select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
     )
     with tags_context(product=Product.CUSTOMER_ANALYTICS, feature=Feature.ACCOUNTS, team_id=team.pk):
-        return execute_hogql_query(query, team=team).results or []
+        # Runs as a userless system sync, so bypass user-scoped warehouse-view access control
+        # (it fails closed without a user); tenant isolation still holds via team.
+        return execute_hogql_query(query, team=team, bypass_warehouse_access_control=True).results or []
 
 
 def record_sync_outcome(

--- a/products/customer_analytics/backend/logic/custom_property_sync_test.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync_test.py
@@ -1,6 +1,6 @@
 import pytest
-from posthog.test.base import BaseTest
-from unittest.mock import patch
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+from unittest.mock import Mock, patch
 
 from django.apps import apps
 
@@ -8,6 +8,7 @@ from parameterized import parameterized
 
 from products.customer_analytics.backend.logic.custom_property_sync import (
     MAX_CONSECUTIVE_SYNC_FAILURES,
+    _read_view,
     record_sync_outcome,
     run_custom_property_sync,
     sync_custom_property_values,
@@ -135,6 +136,23 @@ class CustomPropertySyncTest(TeamScopedTestMixin, BaseTest):
         assert source.consecutive_failures == 1
         assert source.last_sync_error == "boom"
         mock_capture.assert_called_once()
+
+
+@patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
+class ReadViewAccessControlTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTest):
+    def test_userless_sync_reads_view_despite_warehouse_access_control(self):
+        # The Celery sync runs with no user, so HogQL warehouse-view access control (flag on)
+        # fails closed and denies the view unless the sync bypasses it.
+        view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="account_health_scores",
+            query={"kind": "HogQLQuery", "query": "SELECT 'acme' AS org_id, 100 AS health_score"},
+            columns={"org_id": "String", "health_score": "Int64"},
+        )
+
+        rows = _read_view(self.team, view.name, ["health_score", "org_id"])
+
+        assert rows == [(100, "acme")]
 
 
 class RecordSyncOutcomeTest(TeamScopedTestMixin, BaseTest):


### PR DESCRIPTION
## Problem

Custom property sync from a data warehouse view fails with `You don't have access to table` for teams with warehouse access control enabled.

Part of https://github.com/PostHog/posthog/issues/60300
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Pass `bypass_warehouse_access_control=True` when the sync reads the view
- The sync runs as a userless Celery task, so HogQL's user-scoped warehouse-view access control fails closed and denies every view
- Tenant isolation still holds via `team`
- Add a test that runs real HogQL (no mock) with the flag on and no user — reproduces the exact denial before the fix, reads the view after

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests (`custom_property_sync_test.py`, 18 pass). The new `ReadViewAccessControlTest` catches the regression no existing test did: the sync tests all mock `execute_hogql_query`, so none exercised the real access-control path where this bug lives.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude). Arthur reported the `You don't have access to table` error from a custom-property view sync and asked me to trace the cause. Root cause: `_read_view` in `custom_property_sync.py` called `execute_hogql_query` with only `team` — no user, no bypass. In HogQL's `_is_warehouse_view_denied`, a `None` `user_access_control` fails closed and denies the view (only when the `hogql-warehouse-access-control` flag is on for the team). Fix is to bypass user-scoped access control for this system sync; tenant scoping is preserved by `team`.

Considered passing a real/synthetic user instead — rejected because this is a scheduled task with no requesting principal, so bypass is the correct model.

Wrote the test first (red) to reproduce the exact production error, then applied the one-line fix (green). Skill invoked: `/writing-tests`.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
