### PR TITLE
chore(experiments): remove experiments-llm-prompts feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -309,7 +309,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_END_MODAL_CONCLUSION_FIRST: 'experiments-end-modal-conclusion-first', // owner: @ruby.c #team-experiments
     EXPERIMENTS_EXCLUDED_VARIANTS: 'experiments-excluded-variants', // owner: @rodrigoi #team-experiments
-    EXPERIMENTS_LLM_PROMPTS: 'experiments-llm-prompts', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_METRICS_RECALCULATION: 'experiments-metrics-recalculation', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments

--- a/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
@@ -7,9 +7,7 @@ import { LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { NotFound } from 'lib/components/NotFound'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -57,15 +55,9 @@ export function LLMPromptScene(): JSX.Element {
         canLoadMoreVersions,
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const promptExperimentsEnabled = !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_LLM_PROMPTS]
     const currentSearchParams = searchParams ?? {}
     const activeViewTab =
-        searchParams?.tab === 'usage'
-            ? 'usage'
-            : searchParams?.tab === 'experiments' && promptExperimentsEnabled
-              ? 'experiments'
-              : 'overview'
+        searchParams?.tab === 'usage' ? 'usage' : searchParams?.tab === 'experiments' ? 'experiments' : 'overview'
 
     const { submitPromptForm, deletePrompt, setMode, setPromptFormValues, loadMoreVersions } =
         useActions(llmPromptLogic)
@@ -196,15 +188,11 @@ export function LLMPromptScene(): JSX.Element {
                                     label: 'Usage',
                                     content: <PromptUsage prompt={prompt} />,
                                 },
-                                ...(promptExperimentsEnabled
-                                    ? [
-                                          {
-                                              key: 'experiments',
-                                              label: 'Experiments',
-                                              content: <PromptExperiments prompt={prompt} />,
-                                          },
-                                      ]
-                                    : []),
+                                {
+                                    key: 'experiments',
+                                    label: 'Experiments',
+                                    content: <PromptExperiments prompt={prompt} />,
+                                },
                             ]}
                         />
                     ) : (

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -33,7 +33,6 @@ from posthog.models.filters.filter import Filter
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.ph_client import feature_enabled_or_false
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.experiments.models import ExperimentTimeseriesRecalculationWorkflowInputs
@@ -144,23 +143,6 @@ def list_is_legacy_annotation() -> Case:
         When(inline_legacy | saved_legacy, then=Value(True)),
         default=Value(False),
         output_field=BooleanField(),
-    )
-
-
-PROMPT_EXPERIMENTS_FEATURE_FLAG = "experiments-llm-prompts"
-
-
-def _is_prompt_experiments_feature_enabled(user: User, team: Team) -> bool:
-    distinct_id = user.distinct_id or str(user.uuid)
-    organization_id = str(team.organization_id)
-    project_id = str(team.id)
-    return feature_enabled_or_false(
-        PROMPT_EXPERIMENTS_FEATURE_FLAG,
-        distinct_id,
-        groups={"organization": organization_id, "project": project_id},
-        group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
-        only_evaluate_locally=False,
-        send_feature_flag_events=False,
     )
 
 
@@ -676,9 +658,6 @@ class EnterpriseExperimentsViewSet(
         metric per selected template, each scoped to the prompt's $ai_prompt_name.
         Resulting experiment is in draft state.
         """
-        if not _is_prompt_experiments_feature_enabled(cast(User, request.user), self.team):
-            return Response({"detail": "Not found."}, status=404)
-
         serializer = CreateFromPromptInputSerializer(data=request.data, context={"team": self.team})
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
@@ -755,9 +734,6 @@ class EnterpriseExperimentsViewSet(
     )
     def prompt_templates(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """List the LLM metric templates that can be passed to `create_from_prompt`."""
-        if not _is_prompt_experiments_feature_enabled(cast(User, request.user), self.team):
-            return Response({"detail": "Not found."}, status=404)
-
         return Response(list_templates())
 
     @extend_schema(

--- a/products/experiments/backend/test/test_create_from_prompt.py
+++ b/products/experiments/backend/test/test_create_from_prompt.py
@@ -1,8 +1,6 @@
 import json
 from typing import Any
 
-from unittest.mock import patch
-
 from parameterized import parameterized
 from rest_framework import status
 
@@ -28,13 +26,6 @@ def _expected_splits(n: int) -> list[int]:
 class TestExperimentsCreateFromPrompt(APILicensedTest):
     def setUp(self) -> None:
         super().setUp()
-        self.feature_flag_patcher = patch(
-            "products.experiments.backend.presentation.views.feature_enabled_or_false",
-            return_value=True,
-        )
-        self.mock_feature_enabled = self.feature_flag_patcher.start()
-        self.addCleanup(self.feature_flag_patcher.stop)
-
         self.prompt_name = "my-prompt"
         for version in (1, 2, 3, 4, 5):
             LLMPrompt.objects.create(
@@ -68,17 +59,6 @@ class TestExperimentsCreateFromPrompt(APILicensedTest):
         for entry in body:
             self.assertIn("label", entry)
             self.assertIn("description", entry)
-
-    def test_create_from_prompt_404_when_feature_flag_disabled(self) -> None:
-        self.mock_feature_enabled.return_value = False
-        response = self._post()
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertFalse(Experiment.objects.filter(team_id=self.team.id).exists())
-
-    def test_prompt_templates_404_when_feature_flag_disabled(self) -> None:
-        self.mock_feature_enabled.return_value = False
-        response = self.client.get(f"/api/projects/{self.team.id}/experiments/prompt_templates/")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @parameterized.expand(
         [(name, n) for name in TEMPLATE_NAMES for n in (2, 3, 5)],


### PR DESCRIPTION
## Problem

The `experiments-llm-prompts` flag is now at 100% rollout, so the gating around the LLM-prompt experiments feature is dead weight.

## Changes

Removed the flag and all its gates: the backend 404 checks on `create_from_prompt` and `prompt_templates`, the frontend tab gate in `LLMPromptScene`, and the `EXPERIMENTS_LLM_PROMPTS` constant. Dropped the now-obsolete flag-disabled tests.

## How did you test this code?

Ran `products/experiments/backend/test/test_create_from_prompt.py` (24 passing) and linted the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) removed the flag references, its constant, and the two backend gates, then dropped the two flag-disabled unit tests and the unused mock/import. Invoked no repo skills — the change is a straight flag cleanup.
