### PR TITLE
perf(error-tracking): avoid deep-cloning event properties in issue linking

### DIFF
--- a/rust/cymbal/src/modes/processing/stages/linking/issue.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/issue.rs
@@ -29,7 +29,7 @@ pub struct IssueLinker;
 
 impl IssueLinker {
     pub async fn fetch_or_create_issue(
-        input: ExceptionProperties,
+        input: &ExceptionProperties,
         ctx: Arc<AppContext>,
     ) -> Result<Issue, UnhandledError> {
         // Extract name and description for the issue
@@ -67,13 +67,15 @@ impl ValueOperator for IssueLinker {
         ISSUE_LINKER_OPERATOR
     }
 
-    async fn execute_value(
-        &self,
-        mut input: Self::Item,
-        ctx: LinkingStage,
-    ) -> OperatorResult<Self> {
+    async fn execute_value(&self, input: Self::Item, ctx: LinkingStage) -> OperatorResult<Self> {
         let fingerprint = input.fingerprint.clone().unwrap();
         let key = (input.team_id, fingerprint);
+
+        // Wrap the (large) event in an `Arc` so the cache-loader closures capture a cheap
+        // refcount bump instead of a full deep clone. The loaders only ever borrow the
+        // event, and they don't run at all on the warm-cache path, so on the hot path this
+        // is one `Arc` allocation and no `ExceptionProperties` copies.
+        let input = Arc::new(input);
 
         // Two-layer cache: per-batch dedup wraps the cross-request `issue_id` cache.
         // - Per-batch cache (this `try_get_with`): events with the same fingerprint in
@@ -84,16 +86,21 @@ impl ValueOperator for IssueLinker {
         //   skips the expensive fingerprint JOIN on warm fingerprints.
         // Status is always read fresh from PG inside the loader, so `IssueSuppression`
         // and `maybe_reopen` never see stale state.
-        let cloned_input = input.clone();
+        let input_for_load = input.clone();
         let ctx_for_load = ctx.clone();
         let issue: Issue = ctx
             .batch_issue_cache
             .try_get_with(key, async move {
-                resolve_via_id_cache(cloned_input, &ctx_for_load).await
+                resolve_via_id_cache(input_for_load, &ctx_for_load).await
             })
             .await
             .map_err(|e: Arc<UnhandledError>| UnhandledError::Other(e.to_string()))?;
 
+        // The only `Arc` clones were captured by this call's loader closures, which have
+        // all completed (or been dropped when moka deduped them), so we uniquely own the
+        // event again and can reclaim it to write back the resolved issue.
+        let mut input =
+            Arc::into_inner(input).expect("input Arc uniquely held after cache resolution");
         input.issue_id = Some(issue.id);
         input.issue = Some(issue);
 
@@ -108,7 +115,7 @@ impl ValueOperator for IssueLinker {
 // - On cache hit we re-read by id (cheap PK lookup) and call `maybe_reopen` so
 //   suppression and reopen always see current PG state.
 async fn resolve_via_id_cache(
-    input: ExceptionProperties,
+    input: Arc<ExceptionProperties>,
     ctx: &LinkingStage,
 ) -> Result<Issue, UnhandledError> {
     let fingerprint = input.fingerprint.clone().unwrap();
@@ -125,7 +132,7 @@ async fn resolve_via_id_cache(
     let issue_id: Uuid = ctx
         .issue_cache
         .try_get_with(key.clone(), async move {
-            let issue = IssueLinker::fetch_or_create_issue(cloned_input, app_ctx).await?;
+            let issue = IssueLinker::fetch_or_create_issue(&cloned_input, app_ctx).await?;
             let id = issue.id;
             *slot.lock().expect("just_resolved mutex poisoned") = Some(issue);
             Ok::<Uuid, UnhandledError>(id)
@@ -156,7 +163,7 @@ async fn resolve_via_id_cache(
         None => {
             // Cached id no longer exists in PG. Invalidate and run the slow path.
             ctx.issue_cache.invalidate(&key).await;
-            IssueLinker::fetch_or_create_issue(input, ctx.app_context.clone()).await
+            IssueLinker::fetch_or_create_issue(&input, ctx.app_context.clone()).await
         }
     }
 }
@@ -216,7 +223,7 @@ async fn resolve_issue(
     name: String,
     description: String,
     event_timestamp: DateTime<Utc>,
-    event_properties: ExceptionProperties,
+    event_properties: &ExceptionProperties,
 ) -> Result<Issue, UnhandledError> {
     let team_id = event_properties.team_id;
     let fingerprint = event_properties
@@ -232,7 +239,7 @@ async fn resolve_issue(
         if issue.maybe_reopen(&mut *conn).await? {
             let first_seen_for_state = fingerprint_first_seen.unwrap_or(issue.created_at);
             let assignment =
-                process_assignment(&mut conn, &context.team_manager, &issue, &event_properties)
+                process_assignment(&mut conn, &context.team_manager, &issue, event_properties)
                     .await?;
             send_fingerprint_issue_state(
                 context,
@@ -301,7 +308,7 @@ async fn resolve_issue(
         if issue.maybe_reopen(&mut *conn).await? {
             let first_seen_for_state = fingerprint_first_seen.unwrap_or(issue.created_at);
             let assignment =
-                process_assignment(&mut conn, &context.team_manager, &issue, &event_properties)
+                process_assignment(&mut conn, &context.team_manager, &issue, event_properties)
                     .await?;
             send_fingerprint_issue_state(
                 context,
@@ -327,9 +334,9 @@ async fn resolve_issue(
     } else {
         metrics::counter!(ISSUE_CREATED).increment(1);
         let assignment =
-            process_assignment(&mut txn, &context.team_manager, &issue, &event_properties).await?;
+            process_assignment(&mut txn, &context.team_manager, &issue, event_properties).await?;
 
-        let output_props = event_properties.clone().to_output(issue.id)?;
+        let output_props = event_properties.to_output(issue.id)?;
         send_fingerprint_issue_state(
             context,
             &issue,


### PR DESCRIPTION
## Problem

CPU profiling of cymbal showed a few percent of service CPU going to deep clones of `ExceptionProperties` in the issue-linking path. It is the largest object in the pipeline (full exception list with resolved frames and context lines, plus the event's whole properties map), and we cloned it twice per event: once for the per-batch cache loader closure in `IssueLinker::execute_value`, and a second time for the cross-batch cache loader in `resolve_via_id_cache`. Both clones happened unconditionally, even on the warm path where both caches hit and the loaders never run.

## Changes

- `execute_value` wraps the event in an `Arc` once, and the two moka cache-loader closures capture `Arc` clones (refcount bumps) instead of deep copies.
- After both `try_get_with` calls resolve, `Arc::into_inner` reclaims sole ownership of the event to write back the resolved issue. This is guaranteed to succeed, since the only clones are held by this call's own loader futures, which moka has dropped by then (unpolled on a hit, completed on a miss).
- `fetch_or_create_issue` and `resolve_issue` take `&ExceptionProperties` instead of owned values, and the issue-creation path drops a leftover `event_properties.clone().to_output()` (`to_output` takes `&self`).

No behavior changes. Created/reopened side effects fire in the same places, moka's per-key dedup semantics are unchanged, the `just_resolved` slot optimization still applies, and error wrapping is untouched. `process_assignment` keeps its signature.

## How did you test this code?

No new tests. The existing DB-backed integration tests already pin the observable behavior here (`creates_issue_with_fingerprint`, `same_fingerprint_returns_same_issue`, `suppressed_issue_returns_suppressed_response` in `tests/event.rs`, plus `tests/assignment_rules.rs`), and this change is a pure ownership restructuring with no new observable states to catch.

Ran locally in the `rust/` workspace:

- `cargo fmt -p cymbal -- --check`
- `cargo check -p cymbal`
- `cargo clippy -p cymbal --all-targets -- -D warnings`
- `cargo test -p cymbal`: 142 passed. The 30 failures are all infra-only in the local sandbox (sqlx tests needing Postgres, plus tests binding local sockets) and unrelated to this path; CI runs them for real. `cargo test -p cymbal --no-run` confirms every test target compiles.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal perf change, no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code, directed by me. The autoreview closeout skill ran a Codex review of the diff, which came back with no actionable findings.

Decisions along the way:

- I (well, Claude) first considered extracting a minimal "seed" struct for the loader closures instead of `Arc`-wrapping, but the miss/reopen paths genuinely consume the whole event (assignment rules, `to_output` for notifications), so the seed would have grown back into a full copy. The `Arc` keeps the warm path free of `ExceptionProperties` copies at the cost of one allocation.
- Chose `Arc::into_inner(..).expect(..)` over a clone fallback when reclaiming ownership. The uniqueness invariant is structural (clones never escape this call's loader futures), and the file already uses `expect` for invariants like the `just_resolved` mutex.
- Left `process_assignment` taking `&ExceptionProperties` as-is, since `tests/assignment_rules.rs` depends on that signature.
