### PR TITLE
perf(error-tracking): stop copying debug images per exception

### DIFF
--- a/rust/cymbal/src/modes/processing/stages/resolution/frame.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/frame.rs
@@ -110,9 +110,10 @@ impl ValueOperator for FrameResolver {
         mut evt: ExceptionProperties,
         ctx: ResolutionStage,
     ) -> OperatorResult<Self> {
-        // `debug_images` is not read again on this event (the output props drop
-        // it), so move it into the shared Arc instead of cloning the Vec.
-        let debug_images = Arc::new(std::mem::take(&mut evt.debug_images));
+        // Clone rather than take: `$debug_images` is serialized back onto the
+        // event after resolution (rules eval and the /process response), so the
+        // field must survive this stage.
+        let debug_images = Arc::new(evt.debug_images.clone());
         evt.exception_list = FrameResolver::resolve_exception_list_frames(
             evt.team_id,
             evt.exception_list,

--- a/rust/cymbal/src/modes/processing/stages/resolution/frame.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/frame.rs
@@ -29,7 +29,7 @@ impl FrameResolver {
                 move |exc, ctx| {
                     let debug_images = debug_images.clone();
                     async move {
-                        FrameResolver::resolve_exception_frames(team_id, exc, &debug_images, ctx)
+                        FrameResolver::resolve_exception_frames(team_id, exc, debug_images, ctx)
                             .await
                     }
                 },
@@ -42,12 +42,11 @@ impl FrameResolver {
     pub async fn resolve_exception_frames(
         team_id: i32,
         mut exc: Exception,
-        debug_images: &[DebugImage],
+        debug_images: Arc<Vec<DebugImage>>,
         ctx: ResolutionStage,
     ) -> Result<Exception, UnhandledError> {
         exc.stack = match exc.stack {
             Some(Stacktrace::Raw { frames }) => {
-                let debug_images = Arc::new(debug_images.to_vec());
                 let frame_batches: Batch<Vec<Frame>> = Batch::from(frames)
                     .apply_func(
                         move |frame, ctx| {
@@ -111,7 +110,9 @@ impl ValueOperator for FrameResolver {
         mut evt: ExceptionProperties,
         ctx: ResolutionStage,
     ) -> OperatorResult<Self> {
-        let debug_images = Arc::new(evt.debug_images.clone());
+        // `debug_images` is not read again on this event (the output props drop
+        // it), so move it into the shared Arc instead of cloning the Vec.
+        let debug_images = Arc::new(std::mem::take(&mut evt.debug_images));
         evt.exception_list = FrameResolver::resolve_exception_list_frames(
             evt.team_id,
             evt.exception_list,

--- a/rust/cymbal/src/modes/resolution/service/resolve.rs
+++ b/rust/cymbal/src/modes/resolution/service/resolve.rs
@@ -293,7 +293,7 @@ async fn resolve_one_exception(
         exception
     };
 
-    FrameResolver::resolve_exception_frames(team_id, exception, &debug_images, stage)
+    FrameResolver::resolve_exception_frames(team_id, exception, Arc::new(debug_images), stage)
         .await
         .map_err(|err| capture_unhandled(team_id, err))
 }


### PR DESCRIPTION
## Problem

CPU profiling of cymbal frame resolution showed we re-copy the event's debug image list for every exception. `execute_value` already wraps the list in an `Arc<Vec<DebugImage>>` once per event, but `resolve_exception_frames` took a slice and immediately re-materialized an owned copy (`Arc::new(debug_images.to_vec())`) just to satisfy the `'static` closures passed to `Batch::apply_func`. Native and mobile events can carry hundreds of debug images, so that is a needless allocation and copy per exception in every event.

## Changes

Mechanical plumbing, no behavior difference:

- `resolve_exception_frames` now takes the `Arc<Vec<DebugImage>>` by value and clones the refcount into the per-frame closures instead of copying the Vec.
- `resolve_exception_list_frames` passes its per-exception Arc clone by value.
- `execute_value` keeps cloning the event's `debug_images` into the Arc once per event. An earlier revision of this PR used `std::mem::take` there, but that was reverted: the field is serialized back onto the event after resolution (rules evaluation and the processed event returned by the service), and `$debug_images` uses `skip_serializing_if`, so emptying it would have dropped the property from locally resolved events. A code comment records why the clone stays.
- The resolution-mode gRPC service (`resolve_one_exception`) wraps its owned Vec in `Arc::new(...)` at its single call site, which is a move, not a copy.

`resolve_frame` still takes `&[DebugImage]` since it only borrows.

## How did you test this code?

No behavior change intended, so no new tests. I (well, Claude) ran locally:

- `cargo fmt --check` - clean
- `cargo check -p cymbal` - clean
- `cargo clippy -p cymbal --all-targets -- -D warnings` - clean
- `cargo test -p cymbal` - 142 passed. The 30 failures are all environmental (sqlx tests needing a local Postgres, plus httpmock test servers blocked from binding sockets in the sandbox) and are identical on an unmodified checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change, nothing to document.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code, directed by a human starting from a production CPU profile of frame resolution.
- Claude searched the crate for all callers of `resolve_exception_frames` / `resolve_exception_list_frames`. There are exactly two (the processing-mode operator and the resolution-mode gRPC service) and both were updated.
- An initial `std::mem::take` micro-optimization in `execute_value` was based on checking `OutputErrProps` only, which misses that the whole `ExceptionProperties` struct is re-serialized onto the output event. The Codex PR review caught this and the take was reverted to a clone in a follow-up commit, keeping the per-exception copy removal that is the point of this PR.
- The `autoreview` skill (Codex engine) was run on the original diff and came back clean; the GitHub Codex review subsequently found the serialization gap described above, which is fixed on this branch.

