### PR TITLE
feat(usage-reports): speed up v2 workflow aggregation and upload

### DIFF
--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -423,8 +423,11 @@ def object_storage_client() -> ObjectStorageClient:
     global _client
 
     if not settings.OBJECT_STORAGE_ENABLED:
-        _client = UnavailableStorage()
-    elif isinstance(_client, UnavailableStorage):
+        # Don't touch the cached client here: `_client` must only ever be
+        # written under `_client_lock`, and a stateless no-op instance is
+        # what this branch always handed out anyway.
+        return UnavailableStorage()
+    if isinstance(_client, UnavailableStorage):
         with _client_lock:
             if isinstance(_client, UnavailableStorage):  # re-check now that we hold the lock
                 _client = _build_object_storage_client()

--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -404,6 +404,11 @@ class ObjectStorage(ObjectStorageClient):
 
 
 _client: ObjectStorageClient = UnavailableStorage()
+# Guards first-time construction: boto3 client *use* is thread-safe, but
+# creating clients from the shared default session concurrently is not, and
+# concurrent first-callers exist (e.g. thread pools whose first task touches
+# S3). Same pattern as `_accelerated_client_lock` below.
+_client_lock = threading.Lock()
 
 
 def is_usable_endpoint(endpoint: str | None) -> bool:
@@ -420,49 +425,55 @@ def object_storage_client() -> ObjectStorageClient:
     if not settings.OBJECT_STORAGE_ENABLED:
         _client = UnavailableStorage()
     elif isinstance(_client, UnavailableStorage):
-        s3_config = Config(
-            signature_version="s3v4",
-            connect_timeout=1,
-            retries={"max_attempts": 1},
-        )
-        aws_client = client(
-            "s3",
-            endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
-            aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-            config=s3_config,
-            region_name=settings.OBJECT_STORAGE_REGION,
-        )
-        presigned_client = None
-        public_endpoint = settings.OBJECT_STORAGE_PUBLIC_ENDPOINT
-        if public_endpoint != settings.OBJECT_STORAGE_ENDPOINT:
-            # A misconfigured public endpoint (e.g. an unsubstituted `${POSTHOG_DOMAIN}`
-            # deployment template literal) must never take down the read path: every reader
-            # routes through this factory, and boto3 raises `ValueError` when handed an
-            # invalid endpoint. Validate up front and degrade to the internal client so
-            # presigned URLs lose their public host but reads keep working.
-            if is_usable_endpoint(public_endpoint):
-                try:
-                    presigned_client = client(
-                        "s3",
-                        endpoint_url=public_endpoint,
-                        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-                        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-                        config=s3_config,
-                        region_name=settings.OBJECT_STORAGE_REGION,
-                    )
-                except Exception as e:
-                    logger.exception("object_storage.invalid_public_endpoint", endpoint=public_endpoint, error=e)
-                    capture_exception(e)
-            else:
-                # The Django system check only fails `manage.py`-style startup; gunicorn/ASGI
-                # workers skip it, so capture here too to surface the bad config in Sentry.
-                error = ValueError(f"Invalid OBJECT_STORAGE_PUBLIC_ENDPOINT: {public_endpoint!r}")
-                logger.error("object_storage.invalid_public_endpoint", endpoint=public_endpoint, error=error)
-                capture_exception(error)
-        _client = ObjectStorage(aws_client, presigned_client)
+        with _client_lock:
+            if isinstance(_client, UnavailableStorage):  # re-check now that we hold the lock
+                _client = _build_object_storage_client()
 
     return _client
+
+
+def _build_object_storage_client() -> ObjectStorage:
+    s3_config = Config(
+        signature_version="s3v4",
+        connect_timeout=1,
+        retries={"max_attempts": 1},
+    )
+    aws_client = client(
+        "s3",
+        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        config=s3_config,
+        region_name=settings.OBJECT_STORAGE_REGION,
+    )
+    presigned_client = None
+    public_endpoint = settings.OBJECT_STORAGE_PUBLIC_ENDPOINT
+    if public_endpoint != settings.OBJECT_STORAGE_ENDPOINT:
+        # A misconfigured public endpoint (e.g. an unsubstituted `${POSTHOG_DOMAIN}`
+        # deployment template literal) must never take down the read path: every reader
+        # routes through this factory, and boto3 raises `ValueError` when handed an
+        # invalid endpoint. Validate up front and degrade to the internal client so
+        # presigned URLs lose their public host but reads keep working.
+        if is_usable_endpoint(public_endpoint):
+            try:
+                presigned_client = client(
+                    "s3",
+                    endpoint_url=public_endpoint,
+                    aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+                    aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+                    config=s3_config,
+                    region_name=settings.OBJECT_STORAGE_REGION,
+                )
+            except Exception as e:
+                logger.exception("object_storage.invalid_public_endpoint", endpoint=public_endpoint, error=e)
+                capture_exception(e)
+        else:
+            # The Django system check only fails `manage.py`-style startup; gunicorn/ASGI
+            # workers skip it, so capture here too to surface the bad config in Sentry.
+            error = ValueError(f"Invalid OBJECT_STORAGE_PUBLIC_ENDPOINT: {public_endpoint!r}")
+            logger.error("object_storage.invalid_public_endpoint", endpoint=public_endpoint, error=error)
+            capture_exception(error)
+    return ObjectStorage(aws_client, presigned_client)
 
 
 def write(file_name: str, content: Union[str, bytes], extras: dict | None = None, bucket: str | None = None) -> None:

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 import pytest
 from unittest.mock import patch
 
-from posthog.tasks.usage_report import InstanceMetadata, OrgReport, UsageReportCounters
+from posthog.tasks.usage_report import InstanceMetadata, OrgReport, UsageReportCounters, serialize_full_org_report
 from posthog.temporal.usage_report.aggregator import (
     batched,
     build_manifest,
@@ -156,33 +156,78 @@ def test_load_all_data_multi_output_missing_source_key_yields_empty() -> None:
 
 
 class _FakeOrgReport:
-    """Minimal stand-in: only `organization_id` is touched directly by
-    `iter_chunk_lines`. The rest goes through `serialize_full_org_report`,
-    which we mock per test.
+    """Minimal stand-in for tests that only touch `organization_id`
+    (filtering / sorting).
     """
 
     def __init__(self, organization_id: str) -> None:
         self.organization_id = organization_id
 
 
-def test_iter_chunk_lines_emits_id_and_report() -> None:
-    org_a = _FakeOrgReport("org-a")
-    org_b = _FakeOrgReport("org-b")
+def _instance_metadata() -> InstanceMetadata:
+    # Structured fields are deliberately non-None (self-hosted shape) so the
+    # serializer's normalization of nested lists/dicts is exercised, not just
+    # the cloud all-None shape.
+    return InstanceMetadata(
+        deployment_infrastructure="test",
+        realm="hosted-clickhouse",
+        period={
+            "start_inclusive": "2026-05-04T00:00:00+00:00",
+            "end_inclusive": "2026-05-04T23:59:59.999999+00:00",
+        },
+        site_url="https://us.posthog.com",
+        product="open source",
+        helm={"chart": "posthog", "version": "1.0"},
+        clickhouse_version="24.8",
+        users_who_logged_in=[{"id": 1, "distinct_id": "d1"}, {"id": 2, "distinct_id": "d2", "email": "a@b.c"}],
+        users_who_logged_in_count=2,
+        users_who_signed_up=[{"id": 3, "distinct_id": "d3"}],
+        users_who_signed_up_count=1,
+        table_sizes={"posthog_event": 100, "posthog_sessionrecordingevent": 0},
+        plugins_installed={"a-plugin": 2},
+        plugins_enabled={"a-plugin": 1},
+        instance_tag="none",
+    )
 
-    def fake_serialize(report, _meta) -> dict:
-        if report.organization_id == "org-a":
-            return {"event_count_in_period": 10, "has_non_zero_usage": True}
-        return {"event_count_in_period": 0, "has_non_zero_usage": False}
 
-    with patch("posthog.temporal.usage_report.aggregator.serialize_full_org_report", side_effect=fake_serialize):
-        result = list(
-            iter_chunk_lines(cast(list[OrgReport], [org_a, org_b]), instance_metadata=cast(InstanceMetadata, None))
+def _zero_counters(**overrides: Any) -> UsageReportCounters:
+    fields: dict[str, Any] = {f.name: 0 for f in dataclasses.fields(UsageReportCounters)}
+    fields.update(overrides)
+    return UsageReportCounters(**fields)
+
+
+def _as_billing_sees_it(report_dict: dict[str, Any]) -> dict[str, Any]:
+    """Normalize through JSON exactly like the send path does, so the
+    comparison is about what billing decodes rather than in-memory types.
+    """
+    return json.loads(json.dumps(report_dict, default=str))
+
+
+def test_iter_chunk_lines_matches_legacy_serializer() -> None:
+    """The fast per-org serializer must decode to exactly what the legacy
+    `serialize_full_org_report` emits — drift here is drift in what billing
+    receives. Exercises the nested `teams` breakdown, instance-metadata
+    fields, and the `has_non_zero_usage` flag on both a usage and a
+    zero-usage org.
+    """
+    metadata = _instance_metadata()
+    org_a = _empty_org_report("org-a", event_count_in_period=10)
+    org_a.teams = {
+        "1": _zero_counters(event_count_in_period=4),
+        "2": _zero_counters(event_count_in_period=6, dwh_total_storage_in_s3_in_mib=1.5),
+    }
+    org_a.team_count = 2
+    org_b = _empty_org_report("org-b")
+
+    lines = list(iter_chunk_lines([org_a, org_b], metadata))
+
+    assert [line["organization_id"] for line in lines] == ["org-a", "org-b"]
+    for line, org in zip(lines, [org_a, org_b]):
+        assert _as_billing_sees_it(line["usage_report"]) == _as_billing_sees_it(
+            serialize_full_org_report(org, metadata)
         )
-
-    assert result == [
-        {"organization_id": "org-a", "usage_report": {"event_count_in_period": 10, "has_non_zero_usage": True}},
-        {"organization_id": "org-b", "usage_report": {"event_count_in_period": 0, "has_non_zero_usage": False}},
-    ]
+    assert lines[0]["usage_report"]["has_non_zero_usage"] is True
+    assert lines[1]["usage_report"]["has_non_zero_usage"] is False
 
 
 # ---- build_manifest ------------------------------------------------------

--- a/posthog/temporal/tests/usage_report/test_storage.py
+++ b/posthog/temporal/tests/usage_report/test_storage.py
@@ -93,6 +93,22 @@ def test_write_json_roundtrip_via_minio(minio_workflow_ctx: WorkflowContext) -> 
     assert decoded == {"data": [[1, 100], [2, 50]], "meta": {"version": 1}}
 
 
+def test_write_json_compressed_roundtrip_via_minio(minio_workflow_ctx: WorkflowContext) -> None:
+    """`compress=True` payloads must come back through `read_json`'s gzip
+    sniffing — a regression here crashes the aggregation activity's readback
+    of every per-query intermediate.
+    """
+    key = queries_key(minio_workflow_ctx, "teams_with_event_count_in_period")
+    payload = {"data": [(1, 100), (2, 50)], "meta": {"version": 1}}
+
+    write_json(key, payload, compress=True)
+
+    body = object_storage.read_bytes(key, bucket=storage.bucket())
+    assert body is not None
+    assert body[:2] == b"\x1f\x8b", "compressed intermediates should be gzip on the wire"
+    assert storage.read_json(key) == {"data": [[1, 100], [2, 50]], "meta": {"version": 1}}
+
+
 def test_write_jsonl_chunk_gzip_roundtrip_via_minio(minio_workflow_ctx: WorkflowContext) -> None:
     """End-to-end: gzipped JSONL written via the helper is downloadable
     and decompresses to the original lines.
@@ -147,12 +163,12 @@ def test_write_jsonl_chunk_gzip_handles_empty_input_via_minio(minio_workflow_ctx
 # trigger it against real S3 short of taking the bucket offline.
 
 
-def test_write_jsonl_chunk_gzip_does_one_put_object_call() -> None:
-    """Each chunk should land via a single `object_storage.write` call.
-    Multiple writes per chunk would defeat the whole point of batching the
+def test_write_jsonl_chunk_gzip_does_one_upload_call() -> None:
+    """Each chunk should land via a single `object_storage.write_stream` call.
+    Multiple uploads per chunk would defeat the whole point of batching the
     upload — verify that path here so it stays single-shot.
     """
-    with patch("posthog.temporal.usage_report.storage.object_storage.write") as mock_write:
+    with patch("posthog.temporal.usage_report.storage.object_storage.write_stream") as mock_write:
         write_jsonl_chunk_gzip(
             "some/key.jsonl.gz",
             [

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -54,7 +54,11 @@ from posthog.utils import get_instance_region
 
 logger = structlog.get_logger(__name__)
 
-CHUNK_SIZE_ORGS = 50_000
+# Small enough that a run produces several chunks, so the concurrent
+# encode+gzip+PUT fan-out below has work to overlap (zlib releases the GIL
+# while compressing); large enough that each object is still MBs and the
+# manifest stays short.
+CHUNK_SIZE_ORGS = 10_000
 SQS_POINTER_VERSION = 2
 
 # Separate SQS queue for v2 messages so the existing per-org `usage_reports`
@@ -92,7 +96,9 @@ async def run_query_to_s3(inputs: RunQueryToS3Inputs) -> RunQueryToS3Result:
         duration_ms = int((time.monotonic() - started) * 1000)
 
         key = queries_key(inputs.ctx, inputs.query_name)
-        await sync_to_async(write_json)(key, result)
+        # Compressed: big row-shaped results shrink ~8-10x, which speeds up
+        # both this PUT and the readback in the aggregation activity.
+        await sync_to_async(write_json)(key, result, compress=True)
 
         return RunQueryToS3Result(
             query_name=inputs.query_name,
@@ -106,8 +112,9 @@ async def aggregate_and_chunk_org_reports(inputs: AggregateInputs) -> AggregateR
     """Read per-query S3 files, build org reports, and write JSONL chunks.
 
     The aggregation logic is delegated to `aggregator` so this activity reads
-    as a sequence of named steps. Output is byte-compatible with the existing
-    Celery flow so we can validate parity before billing cuts over.
+    as a sequence of named steps. Each decoded per-org payload is identical to
+    what the existing Celery flow emits (pinned by `test_parity.py`) so we can
+    validate parity before billing cuts over.
     """
     async with Heartbeater():
         all_data = await sync_to_async(load_all_data)(inputs.query_results)

--- a/posthog/temporal/usage_report/aggregator.py
+++ b/posthog/temporal/usage_report/aggregator.py
@@ -10,9 +10,11 @@ the per-org `count()` N+1 in the legacy helper never fires for Temporal.
 Activities import from here.
 """
 
+import json
 import itertools
 import dataclasses
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any
 
@@ -21,6 +23,7 @@ from django.db.models import Count
 
 from posthog.models import OrganizationMembership, Team
 from posthog.tasks.usage_report import (
+    FullUsageReport,
     InstanceMetadata,
     OrgReport,
     UsageReportCounters,
@@ -28,11 +31,27 @@ from posthog.tasks.usage_report import (
     _get_teams_for_usage_reports,
     convert_team_usage_rows_to_dict,
     has_non_zero_usage,
-    serialize_full_org_report,
 )
 from posthog.temporal.usage_report.queries import QUERY_INDEX
 from posthog.temporal.usage_report.storage import bucket, read_json
 from posthog.temporal.usage_report.types import Manifest, RunQueryToS3Result, WorkflowContext
+
+
+def _load_one_query(result: RunQueryToS3Result) -> list[tuple[str, dict[int, int]]]:
+    """Fetch one per-query file and convert it to its `all_data` entries.
+
+    Conversion happens here, inside the download worker, so the raw row
+    payload (the memory-heavy shape — one small list per team) is released
+    as soon as it's been folded into the compact per-team dict.
+    """
+    spec = QUERY_INDEX[result.query_name]
+    raw = read_json(result.s3_key)
+    if spec.output == "multi":
+        return [
+            (dest_key, convert_team_usage_rows_to_dict(raw.get(source_key, [])))
+            for source_key, dest_key in spec.multi_keys_mapping.items()
+        ]
+    return [(spec.name, convert_team_usage_rows_to_dict(raw))]
 
 
 def load_all_data(query_results: list[RunQueryToS3Result]) -> dict[str, dict[int, int]]:
@@ -42,18 +61,55 @@ def load_all_data(query_results: list[RunQueryToS3Result]) -> dict[str, dict[int
     specs are fanned out into the destination keys defined in their
     `multi_keys_mapping` so downstream code sees the same flat shape the
     Celery path produces today.
+
+    ~50 S3 GETs dominate wall-clock here when fetched back-to-back, so they
+    run concurrently; decoding still serializes on the GIL but overlaps with
+    the other threads' network waits.
     """
-    all_data: dict[str, dict[int, int]] = {}
-    for result in query_results:
-        spec = QUERY_INDEX[result.query_name]
-        raw = read_json(result.s3_key)
-        if spec.output == "multi":
-            for source_key, dest_key in spec.multi_keys_mapping.items():
-                rows = raw.get(source_key, [])
-                all_data[dest_key] = convert_team_usage_rows_to_dict(rows)
-        else:
-            all_data[spec.name] = convert_team_usage_rows_to_dict(raw)
-    return all_data
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        return {
+            dest_key: converted
+            for entries in pool.map(_load_one_query, query_results)
+            for dest_key, converted in entries
+        }
+
+
+def make_org_line_serializer(instance_metadata: InstanceMetadata) -> Callable[[OrgReport], dict[str, Any]]:
+    """Build a fast equivalent of `posthog.tasks.usage_report.serialize_full_org_report`.
+
+    The legacy helper pays for three recursive `dataclasses.asdict` passes per
+    organization (org report → kwargs, instance metadata → kwargs, then the
+    assembled `FullUsageReport` all over again), each deep-copying every leaf —
+    including the per-team counter dataclasses and the run-constant instance
+    metadata. At tens of thousands of orgs that is the dominant CPU cost of the
+    chunk-upload step. Here the instance metadata is converted once per run and
+    each org line is assembled with flat dict copies; output keys follow
+    `FullUsageReport` field order so the emitted JSON matches the legacy shape
+    key-for-key. Parity with the legacy serializer is pinned by
+    `test_iter_chunk_lines_matches_legacy_serializer` and `test_parity.py`.
+    """
+    # The json round-trip applies the same `default=str` coercion the legacy
+    # path defers to send time, and normalizes tuples/non-str keys, so every
+    # line is plain JSON-native data by the time the chunk writer encodes it.
+    instance_dict: dict[str, Any] = json.loads(json.dumps(dataclasses.asdict(instance_metadata), default=str))
+    field_names = [field.name for field in dataclasses.fields(FullUsageReport)]
+
+    def serialize(org_report: OrgReport) -> dict[str, Any]:
+        org_vars = vars(org_report)
+        report: dict[str, Any] = {}
+        for name in field_names:
+            if name == "teams":
+                report[name] = {team_id: dict(vars(team)) for team_id, team in org_report.teams.items()}
+            elif name in org_vars:
+                report[name] = org_vars[name]
+            else:
+                report[name] = instance_dict[name]
+        # Same trick as `filter_orgs_with_usage`: every field the check reads
+        # lives on `UsageReportCounters`, so the `OrgReport` works directly.
+        report["has_non_zero_usage"] = has_non_zero_usage(org_report)
+        return report
+
+    return serialize
 
 
 def iter_chunk_lines(
@@ -65,11 +121,11 @@ def iter_chunk_lines(
     Filtering by `has_non_zero_usage` happens upstream in the activity, so
     everything yielded here is expected to have usage.
     """
+    serialize = make_org_line_serializer(instance_metadata)
     for org_report in org_reports:
-        report_dict = serialize_full_org_report(org_report, instance_metadata)
         yield {
             "organization_id": org_report.organization_id,
-            "usage_report": report_dict,
+            "usage_report": serialize(org_report),
         }
 
 

--- a/posthog/temporal/usage_report/storage.py
+++ b/posthog/temporal/usage_report/storage.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from django.conf import settings
 
+import orjson
 import structlog
 
 from posthog.storage import object_storage
@@ -56,32 +57,45 @@ def manifest_key(ctx: WorkflowContext) -> str:
     return f"{run_prefix(ctx)}/manifest.json"
 
 
-def write_json(key: str, obj: Any) -> None:
+def write_json(key: str, obj: Any, *, compress: bool = False) -> None:
     """Write a JSON-encoded object to S3 with `application/json` content type.
 
     Uses `default=str` to coerce datetimes / Decimal / etc. into strings; the
     aggregation activity reads these back and feeds them through existing
     helpers that already tolerate string ints.
+
+    `compress=True` gzips the body before the PUT. Row-shaped query results
+    compress ~8-10x even at level 1 (which costs almost no CPU), cutting both
+    the upload here and the download in `load_all_data`. Keep the manifest
+    uncompressed — it's part of the billing-facing contract; only the
+    per-query intermediates (read back exclusively by `read_json`) opt in.
     """
-    object_storage.write(
-        key,
-        json.dumps(obj, default=str),
-        extras={"ContentType": "application/json"},
-        bucket=bucket(),
-    )
+    body: str | bytes = json.dumps(obj, default=str)
+    extras = {"ContentType": "application/json"}
+    if compress:
+        body = gzip.compress(body.encode("utf-8"), compresslevel=1)
+        extras["ContentEncoding"] = "gzip"
+    object_storage.write(key, body, extras=extras, bucket=bucket())
 
 
 def read_json(key: str) -> Any:
-    """Read a JSON object from S3. Raises if the key is missing."""
+    """Read a JSON object from S3. Raises if the key is missing.
+
+    Sniffs the gzip magic bytes instead of trusting metadata so it can read
+    both compressed and uncompressed payloads — a run can span a deploy where
+    the query activities wrote one format and aggregation reads with the other.
+    """
     raw = object_storage.read_bytes(key, bucket=bucket())
     if raw is None:
         raise FileNotFoundError(f"S3 key not found: {key}")
+    if raw[:2] == b"\x1f\x8b":
+        raw = gzip.decompress(raw)
     return json.loads(raw)
 
 
 def write_jsonl_chunk_gzip(key: str, lines: Iterable[dict[str, Any]]) -> int:
-    """Stream-encode `lines` as JSONL straight into gzip, then PUT the
-    compressed body to S3 in a single `put_object` call.
+    """Stream-encode `lines` as JSONL straight into gzip, then upload the
+    compressed body to S3 in a single `upload_fileobj` call.
 
     Per-line: one encoded `bytes` is fed to `gzip.GzipFile.write` and
     immediately compressed into the underlying `BytesIO`. We never hold
@@ -89,18 +103,39 @@ def write_jsonl_chunk_gzip(key: str, lines: Iterable[dict[str, Any]]) -> int:
     `compressed_size` plus gzip's 32 KB window and one in-flight encoded
     line. That matters when several chunks are written concurrently, since
     a naive `b"\\n".join(...)` would double-allocate ~25–50 MB per chunk.
+
+    Encoding and compression choices are the hot loop of the whole upload:
+
+    * orjson over stdlib json — several times faster per line.
+      `OPT_PASSTHROUGH_DATETIME` + `default=str` keeps datetime coercion
+      identical to the legacy `json.dumps(..., default=str)` (`str(dt)`,
+      space-separated), and `OPT_NON_STR_KEYS` matches stdlib's int-key
+      coercion. Parsed-payload parity with the Celery path is pinned by
+      `test_parity.py`.
+    * `compresslevel=6` over GzipFile's default 9 — roughly half the
+      compression CPU for ~1% larger chunks; zlib also releases the GIL
+      here, so concurrent chunk writers genuinely overlap.
+    * `write_stream` (multipart `upload_fileobj`) over `put_object` —
+      uploads large chunks in concurrent parts and avoids `getvalue()`
+      copying the whole compressed body.
     """
     line_count = 0
     buffer = io.BytesIO()
-    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz:
+    with gzip.GzipFile(fileobj=buffer, mode="wb", compresslevel=6) as gz:
         for line in lines:
-            gz.write(json.dumps(line, separators=(",", ":"), default=str).encode("utf-8"))
-            gz.write(b"\n")
+            gz.write(
+                orjson.dumps(
+                    line,
+                    default=str,
+                    option=orjson.OPT_APPEND_NEWLINE | orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_NON_STR_KEYS,
+                )
+            )
             line_count += 1
 
-    object_storage.write(
+    buffer.seek(0)
+    object_storage.write_stream(
         key,
-        buffer.getvalue(),
+        buffer,
         extras={"ContentType": "application/x-ndjson", "ContentEncoding": "gzip"},
         bucket=bucket(),
     )

--- a/posthog/temporal/usage_report/storage.py
+++ b/posthog/temporal/usage_report/storage.py
@@ -70,10 +70,11 @@ def write_json(key: str, obj: Any, *, compress: bool = False) -> None:
     uncompressed — it's part of the billing-facing contract; only the
     per-query intermediates (read back exclusively by `read_json`) opt in.
     """
-    body: str | bytes = json.dumps(obj, default=str)
+    serialized = json.dumps(obj, default=str)
     extras = {"ContentType": "application/json"}
+    body: str | bytes = serialized
     if compress:
-        body = gzip.compress(body.encode("utf-8"), compresslevel=1)
+        body = gzip.compress(serialized.encode("utf-8"), compresslevel=1)
         extras["ContentEncoding"] = "gzip"
     object_storage.write(key, body, extras=extras, bucket=bucket())
 


### PR DESCRIPTION
## Problem

The usage reports v2 Temporal workflow spends most of its wall clock in the `aggregate-and-chunk-org-reports` activity, on the way to S3 rather than in S3 itself. Per organization it ran three recursive `dataclasses.asdict` passes (each deep-copying every per-team counter and the run-constant instance metadata), encoded lines with stdlib json into gzip at level 9 (the slowest setting, silently the `GzipFile` default), and uploaded each chunk as one single-stream `put_object` after copying the whole compressed body. `CHUNK_SIZE_ORGS` was 50k, so the concurrent chunk fan-out usually had a single chunk to work with and everything ran on one thread. The ~50 per-query intermediates were also uncompressed and read back sequentially.

## Changes

- **Fast per-org serializer** (`aggregator.make_org_line_serializer`): converts instance metadata once per run and assembles each org line with flat dict copies, in exact `FullUsageReport` field order. Replaces the triple-`asdict` `serialize_full_org_report` in the chunk path only – the legacy Celery path is untouched. ~7x faster on serialization in a local micro-benchmark, more for orgs with many teams.
- **orjson + gzip level 6 for chunks**: ~2x faster encode+compress for ~1% larger chunks. `OPT_PASSTHROUGH_DATETIME` with `default=str` keeps datetime coercion byte-identical to stdlib `json.dumps(default=str)`.
- **`CHUNK_SIZE_ORGS` 50k → 10k** so runs produce several chunks and the existing concurrent encode+gzip+PUT fan-out actually overlaps work (zlib releases the GIL while compressing). The manifest and SQS pointer already carry chunk keys/count dynamically, so the billing contract is unchanged.
- **Multipart streaming upload**: chunks go out via `write_stream` (`upload_fileobj`) instead of `put_object`, which uploads parts concurrently and avoids `getvalue()` copying the compressed body.
- **Compressed intermediates + parallel readback**: per-query results are gzipped at level 1 (~8-10x fewer bytes each way), and `load_all_data` downloads them with a thread pool, converting inside the workers so raw row payloads are released immediately. `read_json` sniffs the gzip magic bytes, so a run spanning a deploy reads both formats. The manifest stays uncompressed (billing-facing).
- **Thread-safe lazy client init in `object_storage_client()`**: the parallel readback can be the first S3 access in a worker process, and concurrent boto3 client creation from the shared default session is not thread safe. Construction now happens under a lock with a re-check, mirroring the existing `_accelerated_client_lock` pattern in the same file.

The decoded per-org payload billing receives is unchanged. That's pinned by the existing end-to-end `test_parity.py` (Celery SQS payloads vs Temporal chunks) plus a new unit test comparing the fast serializer against the legacy one on identical inputs.

## How did you test this code?

Automated tests, all run locally:

- `test_iter_chunk_lines_matches_legacy_serializer` (new): pins the fast serializer against legacy `serialize_full_org_report` on a multi-team org and a zero-usage org, with self-hosted-shaped instance metadata so the nested list/dict normalization path is exercised. Catches serializer drift no existing unit test did.
- `test_write_json_compressed_roundtrip_via_minio` (new): gzipped intermediates must come back through `read_json`'s sniffing – a regression there crashes the aggregation readback.
- Updated `test_write_jsonl_chunk_gzip_does_one_upload_call` for the `write_stream` switch.
- Full runnable subset green locally: 35 usage-report tests + 10 object-storage factory tests. Also verified orjson output parses identically to stdlib `json.dumps(default=str)` for datetimes, Decimals, int keys, and non-ASCII strings.

Not run locally (need the MinIO/Postgres dev stack, which the sandbox lacks – confirmed the same tests fail identically on unmodified master there): `test_parity.py`, `test_aggregate_activity.py`, `test_query_activity.py`, and the MinIO roundtrip tests. These run in CI. No manual testing was done.

Local micro-benchmark (2k orgs): serialization 0.320s → 0.046s; encode+gzip 0.200s → 0.095s at +1.3% size; intermediates compress 3.6x at level 1 on synthetic rows.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or config change – internal Temporal workflow performance only. No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) directed by the assignee. Skills invoked: `/writing-tests` before adding/updating tests, plus `rs-self-review` and `rs-adversarial-review` for two adversarial review rounds after the initial implementation.

Decisions worth knowing: intermediates keep stdlib json (orjson stringifies tuples, and ClickHouse rows are tuples) while chunk lines use orjson (the serializer normalizes them to JSON-native types first). `read_json` sniffs magic bytes instead of trusting `ContentEncoding` so mixed-format runs across a deploy keep working. The review rounds produced the `object_storage_client()` lock (the parallel readback removed the accidental serialization that made the unlocked factory safe), a comment cleanup, and stronger test fixtures; a candidate finding about `write_stream` breaking the activity tests died on verification since those tests run against real MinIO.
