### PR TITLE
fix(data-warehouse): align new-source prefix validation with the backend rule

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1833,8 +1833,20 @@ export const getErrorsForFields = (
         if (!values?.prefix?.trim()) {
             errors['prefix'] = 'Please enter a name for this direct query source.'
         }
-    } else if (!/^[a-zA-Z0-9_-]*$/.test(values?.prefix ?? '')) {
-        errors['prefix'] = "Please enter a valid prefix (only letters, numbers, and '_' or '-')."
+    } else {
+        // Mirror the backend `validate_source_prefix` rules so an invalid prefix is caught here
+        // rather than only after the source-create request round-trips.
+        const prefix = values?.prefix ?? ''
+        const cleaned = prefix.trim().replace(/^_+|_+$/g, '')
+        if (prefix && !cleaned) {
+            errors['prefix'] =
+                prefix.trim().length === 0
+                    ? 'Prefix cannot be empty whitespace'
+                    : 'Prefix cannot consist of only underscores'
+        } else if (cleaned && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(cleaned)) {
+            errors['prefix'] =
+                'Prefix must contain only letters, numbers, and underscores, and start with a letter or underscore'
+        }
     }
 
     // Payload errors

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1834,15 +1834,12 @@ export const getErrorsForFields = (
             errors['prefix'] = 'Please enter a name for this direct query source.'
         }
     } else {
-        // Mirror the backend `validate_source_prefix` rules so an invalid prefix is caught here
-        // rather than only after the source-create request round-trips.
+        // Mirror the backend `validate_source_prefix` rules (which strip only underscores, not
+        // whitespace) so an invalid prefix is caught here rather than after the create request.
         const prefix = values?.prefix ?? ''
-        const cleaned = prefix.trim().replace(/^_+|_+$/g, '')
+        const cleaned = prefix.replace(/^_+|_+$/g, '')
         if (prefix && !cleaned) {
-            errors['prefix'] =
-                prefix.trim().length === 0
-                    ? 'Prefix cannot be empty whitespace'
-                    : 'Prefix cannot consist of only underscores'
+            errors['prefix'] = 'Prefix cannot consist of only underscores'
         } else if (cleaned && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(cleaned)) {
             errors['prefix'] =
                 'Prefix must contain only letters, numbers, and underscores, and start with a letter or underscore'

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -268,6 +268,7 @@ describe('sourceWizardLogic', () => {
             ['my-prefix', true], // hyphen — rejected by the backend, previously allowed here
             ['2things', true], // leading digit
             ['___', true], // only underscores
+            [' my ', true], // backend strips only underscores, not whitespace
             ['my_prefix', false],
             ['_leading', false],
             ['', false], // empty prefix is allowed

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -261,9 +261,23 @@ describe('sourceWizardLogic', () => {
             expect(res).toEqual({ payload: {} })
         })
 
-        it('returns errors for an invalid prefix', () => {
-            const res = getErrorsForFields([], { prefix: '@@@', payload: {} })
-            expect(res.prefix).toBeTruthy()
+        // Warehouse-mode prefixes must satisfy the backend `validate_source_prefix` rules so an
+        // invalid prefix is caught in the wizard rather than only after the create request fails.
+        it.each([
+            ['@@@', true],
+            ['my-prefix', true], // hyphen — rejected by the backend, previously allowed here
+            ['2things', true], // leading digit
+            ['___', true], // only underscores
+            ['my_prefix', false],
+            ['_leading', false],
+            ['', false], // empty prefix is allowed
+        ])('validates warehouse-mode prefix %p', (prefix, expectError) => {
+            const res = getErrorsForFields([], { prefix, payload: {} })
+            if (expectError) {
+                expect(res.prefix).toBeTruthy()
+            } else {
+                expect(res.prefix).toBeUndefined()
+            }
         })
 
         it('requires name for direct mode', () => {


### PR DESCRIPTION
## Problem

In the data warehouse new-source wizard, the client-side prefix validator and the backend disagree on what a valid prefix is.

- The wizard's `getErrorsForFields` accepted `^[a-zA-Z0-9_-]*$` — hyphens allowed, leading digits allowed.
- The backend `validate_source_prefix` requires `^[A-Za-z_][A-Za-z0-9_]*$` after stripping underscores — no hyphens, must start with a letter or underscore.

Because the wizard's validator is what gates the Next button, a prefix like `my-prefix` slipped through the wizard and only failed once the source-create request round-tripped to the backend. Users saw the "only letters, numbers, and underscores" format error late, after clicking through, instead of inline as they typed. Replay of onboarding sessions showed people hitting this prefix-format rejection and having to go back and correct it.

## Changes

Mirror the backend `validate_source_prefix` rules in the wizard's `getErrorsForFields` for warehouse-mode sources, matching the same constraint the inline field validator in `SourceForm.tsx` already shows. Invalid prefixes are now caught up front with the same message the backend would return, so the Next button is blocked before the request is made.

The backend strips only underscores, not whitespace, so the client mirrors that exactly (no `.trim()`) — a whitespace-padded prefix like `" my "` is rejected both places. Empty prefixes stay allowed, and direct-query name validation is unchanged.

## How did you test this code?

Parameterized the existing `getErrorsForFields` prefix test to cover the cases that matter: hyphen, leading digit, only-underscores, and whitespace-padded (all rejected), plus valid prefixes and empty (allowed). The hyphen and whitespace cases are the regressions this locks in — they used to pass this validator and fail at the backend. Ran the suite locally:

```
jest products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts -t prefix
# 9 passed
```

I (Claude) did not manually click through the wizard UI. TypeScript check across the frontend surfaces only pre-existing missing-generated-type errors in unrelated products (codegen wasn't run in this environment); `sourceWizardLogic.tsx` itself is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) while reviewing data-warehouse onboarding session summaries for low-risk friction fixes. Invoked the `/writing-tests` skill before adding the parameterized test to confirm it catches concrete regressions (hyphen and whitespace-padded prefixes accepted client-side but rejected server-side) that no existing test covered.

I chose to mirror the backend rule on the client rather than loosen the backend, since the backend regex reflects a real HogQL/ClickHouse identifier constraint. The three checks — backend `validate_source_prefix`, the inline `SourceForm.tsx` field validator, and this wizard gate — now agree.