### PR TITLE
fix(cdp): rebuild mapping inputs on rerun so mapping destinations re-fire

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -620,6 +620,49 @@ describe('Hog Executor', () => {
                 `"https://example.com/posthog-webhook"`
             )
         })
+
+        it('rebuilds mapping inputs when an invocation arrives without inputs (rerun path)', async () => {
+            // The rerun path strips `inputs` from the persisted globals and lets
+            // the executor rebuild them. For mapping destinations the mapping's
+            // own inputs (e.g. Google Ads `gclid`) must be re-merged — otherwise
+            // they resolve to nothing and the function early-exits on rerun.
+            const hog = `return inputs.gclid`
+            const mappingFn = createHogFunction({
+                hog,
+                bytecode: await compileHog(hog),
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+                inputs_schema: [],
+                mappings: [
+                    {
+                        ...HOG_FILTERS_EXAMPLES.no_filters,
+                        inputs: {
+                            gclid: {
+                                order: 0,
+                                value: '{person.properties.gclid ?? person.properties.$initial_gclid}',
+                                bytecode: await compileHog(
+                                    'return person.properties.gclid ?? person.properties.$initial_gclid'
+                                ),
+                            },
+                        },
+                    },
+                ],
+            })
+
+            const invocation = createExampleInvocation(mappingFn, {
+                person: {
+                    id: 'uuid',
+                    name: 'test',
+                    url: 'http://localhost:8000/persons/1',
+                    properties: { email: 'test@posthog.com', $initial_gclid: 'INITIAL_TOKEN_ABC' },
+                },
+            })
+            // Simulate the rerun blob: inputs are stripped before persistence.
+            expect(invocation.state.globals.inputs).toBeUndefined()
+
+            const res = await executor.execute(invocation)
+            expect(res.error).toBeUndefined()
+            expect(res.execResult).toBe('INITIAL_TOKEN_ABC')
+        })
     })
 
     describe('slow functions', () => {

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -217,6 +217,51 @@ export class HogExecutorService {
         return this.hogInputsService.buildInputsWithGlobals(hogFunction, globals, additionalInputs)
     }
 
+    /**
+     * For mapping destinations the per-mapping inputs (e.g. the Google Ads
+     * `gclid`) are resolved only for mappings whose filters match the event —
+     * see `buildHogFunctionInvocations`, which merges `mapping.inputs` when it
+     * first builds the invocation. The rerun path re-enqueues invocations with
+     * `inputs` stripped and keeps no record of which mapping produced them, so
+     * a plain rebuild against the top-level config drops those inputs entirely
+     * and any function guarding on them (e.g. `if (empty(inputs.gclid))`)
+     * early-exits. Re-match the mappings here against the (current) config to
+     * rebuild the additional inputs before the executor resolves them.
+     *
+     * When several mappings match one event the original produced a separate
+     * invocation per mapping; the stored row can't be tied back to a single
+     * one, so we merge all matching mappings' inputs — exact for the common
+     * single-mapping case and strictly better than dropping them.
+     */
+    private async resolveMappingInputs(
+        hogFunction: HogFunctionType,
+        globals: HogFunctionInvocationGlobals
+    ): Promise<HogFunctionType['inputs'] | undefined> {
+        const mappings = hogFunction.mappings
+        if (!mappings || mappings.length === 0) {
+            return undefined
+        }
+
+        const filterGlobals = convertToHogFunctionFilterGlobal(globals)
+        let merged: HogFunctionType['inputs'] | undefined
+
+        for (const mapping of mappings) {
+            if (!mapping.inputs) {
+                continue
+            }
+            const { match } = await filterFunctionInstrumented({
+                fn: hogFunction,
+                filters: mapping.filters,
+                filterGlobals,
+            })
+            if (match) {
+                merged = { ...(merged ?? {}), ...mapping.inputs }
+            }
+        }
+
+        return merged
+    }
+
     async buildHogFunctionInvocations(
         hogFunctions: HogFunctionType[],
         triggerGlobals: HogFunctionInvocationGlobals
@@ -516,9 +561,17 @@ export class HogExecutorService {
                 if (invocation.state.globals.inputs) {
                     globals = invocation.state.globals
                 } else {
-                    globals = await this.hogInputsService.buildInputsWithGlobals(
+                    // Mapping destinations need their per-mapping inputs
+                    // re-merged here — they aren't part of the top-level config
+                    // and were stripped from the rerun blob.
+                    const additionalInputs = await this.resolveMappingInputs(
                         invocation.hogFunction,
                         invocation.state.globals
+                    )
+                    globals = await this.hogInputsService.buildInputsWithGlobals(
+                        invocation.hogFunction,
+                        invocation.state.globals,
+                        additionalInputs
                     )
                 }
             } catch (e) {


### PR DESCRIPTION
## Problem

Rerunning failed Google Ads conversion invocations (via the "Rerun failed invocations" flow) silently did nothing.
Every rerun hit the template's early-exit and never re-fired:

```hog
if (empty(inputs.gclid)) {
    print('Empty `gclid`. Skipping...')
    return
}
```

The person clearly had the data (`person.properties.gclid` and `person.properties.$initial_gclid` were both set),
so at first this looked like a person-resolution or property-naming bug.
It is neither. `$initial_gclid` was a red herring.

The real cause is that Google Ads is a **mapping** destination.
Its `gclid` input, with the default `{person.properties.gclid ?? person.properties.$initial_gclid}`,
lives on the mapping (`hogFunction.mappings[].inputs`), not on the top-level hog function config.

On the original send, `buildHogFunctionInvocations` builds a per-mapping invocation and merges `mapping.inputs` in,
so `inputs.gclid` resolves correctly.
On rerun, the paginator strips `inputs` from the persisted globals and the executor rebuilds them,
but the rebuild called `buildInputsWithGlobals(invocation.hogFunction, globals)` with no mapping inputs.
`buildInputs` only reads `hogFunction.inputs` / `hogFunction.encrypted_inputs`, never `mappings[].inputs`,
so `inputs.gclid` came back `undefined`, `empty(inputs.gclid)` was true, and the invocation skipped.

This is why it looked property-specific but was not.
For the confirmed row the bare `gclid` (first branch of the coalesce) was set and is known to resolve,
yet it still skipped, because `gclid` was never built at all. Both coalesce branches fail identically.

## Changes

- New `resolveMappingInputs()` on `HogExecutorService`.
  During the rerun input rebuild it re-evaluates each mapping's filters against the stored event
  (reusing the same filter machinery as the original send) and merges the matching mappings' inputs back in.
- Wired it into the executor's rebuild branch so a rerun of a mapping destination reconstructs `inputs.gclid`.

The re-match needs no new persisted context, which matters.
It reconstructs the mapping inputs from the stored event alone,
so it fixes reruns of already-persisted failed rows (the ones from the incident), not just future ones.
When several mappings match one event the matching set is merged,
exact for the common single-mapping case and strictly better than dropping the inputs.

## How did you test this code?

Added `rebuilds mapping inputs when an invocation arrives without inputs (rerun path)` to `hog-executor.service.test.ts`.
It builds a mapping destination whose `gclid` input coalesces to `person.properties.$initial_gclid`,
strips `inputs` to mimic the rerun blob, executes, and asserts `inputs.gclid` resolves.

I (Claude) first wrote this test and confirmed it **failed** without the fix (`Received: undefined`),
reproducing the exact production early-exit, then confirmed it passes with the fix.
I ran it via `pnpm exec jest src/cdp/services/hog-executor.service.test.ts`.

There is one unrelated, pre-existing failure in the same file (`handles security errors`, an `executeFetch` hostname check)
that fails locally with and without this change due to local `http://localhost` resolution. It is not touched by this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Debugged and implemented with Claude (PostHog Code).
The starting hypothesis in the handoff chased `$initial_gclid` vs `gclid`, person resolution, and the hog VM.
I traced the original-send path against the rerun path and found the divergence.
Mapping inputs are merged at send time but the rerun rebuild only reads top-level inputs.
I rejected the originally proposed "persist and re-resolve via `person_id`" fix,
because for the confirmed row the person JOIN already returned the right person with `gclid` set,
so it would not have changed the outcome. The re-match approach fixes it without schema or persistence changes.

Greptile flagged the test as asserting behavior the executor "cannot deliver."
That review looked at the branch mid-state where the test commit landed before the fix commit,
so at that commit the test genuinely failed in isolation.
I squashed the test and fix into one atomic commit so the PR is green per-commit and the intent reads clearly.
I also dropped an unrelated `uv.lock` diff that had been swept into an earlier commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
