### PR TITLE
fix(temporal): stop double-instrumenting worker trace spans

### DIFF
--- a/posthog/temporal/common/client.py
+++ b/posthog/temporal/common/client.py
@@ -23,6 +23,7 @@ async def connect(
     server_root_ca_cert: str | None = None,
     settings: Any | None = django_settings,
     use_pydantic_converter: bool = False,
+    add_otel_tracing_interceptor: bool = True,
 ) -> Client:
     tls: TLSConfig | bool = False
     if client_cert and client_key:
@@ -42,12 +43,22 @@ async def connect(
             payload_codec=EncryptionCodec.from_settings(settings=settings),
         )
 
+    # The classic TracingInterceptor injects trace context into workflow start headers (so a
+    # caller's span becomes the parent of the workflow) AND creates spans for activity/workflow
+    # execution on any worker built from this client. Worker processes disable it via
+    # `add_otel_tracing_interceptor=False` because they trace execution through the worker's
+    # OpenTelemetryPlugin instead; leaving both on double-instruments every activity and workflow.
+    # Non-worker callers (Django, Celery, the CLI, schedules) keep it for start-context propagation.
+    interceptors: list[temporalio.client.Interceptor] = []
+    if add_otel_tracing_interceptor:
+        interceptors.append(temporalio.contrib.opentelemetry.TracingInterceptor())
+
     client = await Client.connect(
         f"{host}:{port}",
         namespace=namespace,
         tls=tls,
         runtime=runtime,
-        interceptors=[temporalio.contrib.opentelemetry.TracingInterceptor()],
+        interceptors=interceptors,
         data_converter=data_converter,
     )
     return client

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -345,6 +345,10 @@ async def create_worker(
         client_key=client_key,
         runtime=runtime,
         use_pydantic_converter=use_pydantic_converter,
+        # This worker traces activity/workflow execution through the OpenTelemetryPlugin below.
+        # Keeping the client-level TracingInterceptor as well would emit a second, duplicate span
+        # for every activity and workflow, so drop it here.
+        add_otel_tracing_interceptor=False,
     )
     supported_interceptors = [
         interceptor() for interceptor in ALL_INTERCEPTOR_CLASSES if is_task_queue_supported(task_queue, interceptor)


### PR DESCRIPTION
## Problem

When the OpenTelemetry plugin is enabled on a Temporal worker, every activity and workflow emits **two** identical spans. In Jaeger you see two `RunWorkflow:<type>` and two `RunActivity:<type>` per execution (one carrying interceptor-set attributes like `team_id`, one bare).

The cause is two worker-side tracing interceptors running at once:

- The classic `TracingInterceptor` set on the client in `posthog/temporal/common/client.py` (added in #34628). It implements both `intercept_client` (start-context propagation) **and** the worker-side `intercept_activity` / `workflow_interceptor_class`. Workers inherit their client's interceptors, so it instruments execution too.
- The worker's `OpenTelemetryPlugin(add_temporal_spans=True)` in `posthog/temporal/common/worker.py` (added in #52875, gated on the OTel flag). Its `OpenTelemetryInterceptor` also spans every activity and workflow.

The plugin landed 9 months after the client interceptor and nobody removed the old one, so on any OTel-enabled worker they stack. This doubles span volume for the Max AI and tasks queues (which force-enable OTel) and for anything running with `TEMPORAL_OTEL_PLUGIN_ENABLED`.

## Changes

Add an `add_otel_tracing_interceptor: bool = True` flag to `connect()`. Worker processes pass `False` and trace execution through the plugin only; every other caller keeps the default and still gets the classic interceptor for start-context propagation.

Why this split is safe: the classic interceptor's remaining job is injecting trace context when a **caller** starts a workflow (Django request, Celery task, CLI, schedule) so the caller's span parents the workflow. Worker processes don't need it for that. Both the classic interceptor and the plugin propagate context through the same Temporal header (`_tracer-data`) using the same `default_text_map_propagator`, so a context injected by a Django client is still read by the plugin on the worker. Cross-process linking (the Django-request-to-activity trace the worker comment at `worker.py` calls out for Max AI / tasks) is preserved.

`connect()` is the only client entry point and `create_worker` is the only production worker path, so the blast radius is contained to these two files.

## How did you test this code?

Verified locally end to end. I ran a worker from this branch with the OTel plugin enabled, triggered S3 batch exports via schedule backfills, and inspected the traces in Jaeger. Full detail is in the agent context below.

- **After (this branch):** four independent `s3-export` traces, every operation appears exactly once. Single root `RunWorkflow:s3-export`, each `StartActivity` correctly parenting its `RunActivity`. No orphan roots, no duplicates.
- **Before (master's client wiring + plugin):** the same executions produced two of each span, which is the behavior this PR removes.

I did not add automated tests. Asserting span counts end to end needs a real worker plus an in-memory span exporter, which is heavy and brittle for what is a wiring change; the existing tracing setup ships without such tests. I could not reproduce the full Max AI Django-to-workflow flow locally, but I confirmed the header/propagator interop that makes that linking work.

### Screenshots in Jaeger UI

#### Before (with duplicate spans)

<img width="898" height="481" alt="before_with_duplicates" src="https://github.com/user-attachments/assets/ea497c50-ef2d-4df0-9095-7962dc758c77" />

#### After

<img width="823" height="277" alt="after" src="https://github.com/user-attachments/assets/ae831b31-3bc3-490a-a57b-1da619f23157" />

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Ross) directed this; Claude (PostHog Code) did the investigation, implementation, and local verification. Requesting review from @frankh and @tomasfarias since they wired up the two tracing mechanisms involved (#34628 and #52875) and this is fleet-wide.

How the fix was chosen:
- Rejected "just delete the client `TracingInterceptor`" — that would strip start-context propagation from Django / Celery / CLI / schedules and break caller-to-workflow linking.
- Rejected moving the plugin onto the client (so workers inherit it and the worker-level plugin is removed). It's the more idiomatic temporalio setup, but it puts the plugin on every process unconditionally and leans on replay-safety behavior when OTel isn't initialized. Bigger, riskier change than the observed bug warrants.
- Chose the targeted flag: keep the classic interceptor everywhere it does real work, disable it only on the worker client where it duplicates the plugin. Smallest change, preserves the current gating and replay-safety exactly.

Verified against temporalio 1.24: `Worker` auto-prepends client plugins and only warns on duplicates (`temporalio/worker/_worker.py`), and the classic interceptor's default header key (`_tracer-data`) and propagator match the new plugin's, which is what preserves cross-process linking.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
