### PR TITLE
feat(data-warehouse): bulk temporal ops for schema re-enable command

### DIFF
--- a/posthog/management/commands/reenable_schemas_by_error.py
+++ b/posthog/management/commands/reenable_schemas_by_error.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 
 import structlog
 
-from products.warehouse_sources.backend.facade.models import ExternalDataSchema, update_should_sync
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, bulk_update_should_sync
 
 logger = structlog.get_logger(__name__)
 
@@ -40,6 +40,17 @@ class Command(BaseCommand):
             type=str,
             default=None,
             help="Only include schemas updated before this ISO8601 datetime (e.g. 2026-04-17T00:00:00Z)",
+        )
+        parser.add_argument(
+            "--trigger",
+            action="store_true",
+            help="Trigger an immediate sync for each re-enabled schema instead of waiting for its next scheduled run",
+        )
+        parser.add_argument(
+            "--concurrency",
+            type=int,
+            default=10,
+            help="Number of concurrent Temporal schedule operations",
         )
 
     def handle(self, *args, **options):
@@ -92,21 +103,30 @@ class Command(BaseCommand):
             )
             return
 
-        succeeded = 0
-        failed = 0
+        failures = bulk_update_should_sync(
+            schema_list,
+            should_sync=True,
+            trigger=options["trigger"],
+            concurrency=options["concurrency"],
+        )
 
         for schema in schema_list:
-            try:
-                update_should_sync(schema_id=str(schema.id), team_id=schema.team_id, should_sync=True)
-                succeeded += 1
+            error = failures.get(str(schema.id))
+            if error is not None:
+                logger.error(
+                    "Failed to re-enable schema",
+                    schema_id=str(schema.id),
+                    team_id=schema.team_id,
+                    error=str(error),
+                )
+            else:
                 logger.info(
                     "Re-enabled schema",
                     schema_id=str(schema.id),
                     team_id=schema.team_id,
                     source_type=schema.source.source_type,
                 )
-            except Exception:
-                failed += 1
-                logger.exception("Failed to re-enable schema", schema_id=str(schema.id), team_id=schema.team_id)
 
-        self.stdout.write(self.style.SUCCESS(f"\nDone. Re-enabled: {succeeded}, Failed: {failed}"))
+        self.stdout.write(
+            self.style.SUCCESS(f"\nDone. Re-enabled: {len(schema_list) - len(failures)}, Failed: {len(failures)}")
+        )

--- a/posthog/management/commands/test/test_reenable_schemas_by_error.py
+++ b/posthog/management/commands/test/test_reenable_schemas_by_error.py
@@ -43,7 +43,11 @@ def _create_schema(source, name="test_table", should_sync=True, latest_error=Non
     )
 
 
-@patch("posthog.management.commands.reenable_schemas_by_error.update_should_sync")
+def _updated_schema_ids(mock_update):
+    return [str(schema.id) for schema in mock_update.call_args.args[0]]
+
+
+@patch("posthog.management.commands.reenable_schemas_by_error.bulk_update_should_sync", return_value={})
 class TestReenableSchemasByError:
     def test_reenables_matching_schemas(self, mock_update, team):
         source = _create_source(team)
@@ -55,7 +59,8 @@ class TestReenableSchemasByError:
 
         call_command("reenable_schemas_by_error", "connection is insecure", live_run=True)
 
-        mock_update.assert_called_once_with(schema_id=str(schema.id), team_id=team.id, should_sync=True)
+        assert _updated_schema_ids(mock_update) == [str(schema.id)]
+        assert mock_update.call_args.kwargs == {"should_sync": True, "trigger": False, "concurrency": 10}
 
     def test_case_insensitive_match(self, mock_update, team):
         source = _create_source(team)
@@ -127,7 +132,7 @@ class TestReenableSchemasByError:
 
         call_command("reenable_schemas_by_error", "connection is insecure", source_type="Postgres", live_run=True)
 
-        mock_update.assert_called_once_with(schema_id=str(pg_schema.id), team_id=team.id, should_sync=True)
+        assert _updated_schema_ids(mock_update) == [str(pg_schema.id)]
 
     def test_reenables_across_teams(self, mock_update, team, team_2):
         source_1 = _create_source(team)
@@ -137,7 +142,7 @@ class TestReenableSchemasByError:
 
         call_command("reenable_schemas_by_error", "connection is insecure", live_run=True)
 
-        assert mock_update.call_count == 2
+        assert len(_updated_schema_ids(mock_update)) == 2
 
     def test_no_matches_prints_warning(self, mock_update, team, capsys):
         call_command("reenable_schemas_by_error", "nonexistent error string", live_run=True)
@@ -146,16 +151,25 @@ class TestReenableSchemasByError:
         captured = capsys.readouterr()
         assert "No disabled schemas found" in captured.out
 
-    def test_continues_on_individual_failure(self, mock_update, team):
+    def test_trigger_flag_forwarded(self, mock_update, team):
         source = _create_source(team)
-        _create_schema(source, name="t1", should_sync=False, latest_error="connection is insecure")
+        _create_schema(source, should_sync=False, latest_error="connection is insecure")
+
+        call_command("reenable_schemas_by_error", "connection is insecure", live_run=True, trigger=True)
+
+        assert mock_update.call_args.kwargs["trigger"] is True
+
+    def test_failures_reported_in_summary(self, mock_update, team, capsys):
+        source = _create_source(team)
+        failing = _create_schema(source, name="t1", should_sync=False, latest_error="connection is insecure")
         _create_schema(source, name="t2", should_sync=False, latest_error="connection is insecure")
 
-        mock_update.side_effect = [Exception("temporal down"), None]
+        mock_update.return_value = {str(failing.id): Exception("temporal down")}
 
         call_command("reenable_schemas_by_error", "connection is insecure", live_run=True)
 
-        assert mock_update.call_count == 2
+        captured = capsys.readouterr()
+        assert "Re-enabled: 1, Failed: 1" in captured.out
 
     @pytest.mark.parametrize(
         "disabled_after,disabled_before,expected_name",
@@ -185,4 +199,4 @@ class TestReenableSchemasByError:
 
         call_command("reenable_schemas_by_error", "connection is insecure", **kwargs)
 
-        mock_update.assert_called_once_with(schema_id=str(expected_schema.id), team_id=team.id, should_sync=True)
+        assert _updated_schema_ids(mock_update) == [str(expected_schema.id)]

--- a/products/warehouse_sources/backend/facade/models.py
+++ b/products/warehouse_sources/backend/facade/models.py
@@ -25,6 +25,7 @@ from products.warehouse_sources.backend.models.custom_oauth2_integration import 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob, get_latest_run_if_exists
 from products.warehouse_sources.backend.models.external_data_schema import (
     ExternalDataSchema,
+    bulk_update_should_sync,
     get_all_schemas_for_source_id,
     sync_frequency_interval_to_sync_frequency,
     sync_frequency_to_sync_frequency_interval,
@@ -67,6 +68,7 @@ __all__ = [
     "WarehouseColumnStatistics",
     "acreate_datawarehousetable",
     "asave_datawarehousetable",
+    "bulk_update_should_sync",
     "get_custom_oauth2_integration",
     "get_all_schemas_for_source_id",
     "get_direct_external_data_source_for_connection",

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -1,6 +1,7 @@
 import sys
 import uuid
-from collections.abc import Callable, Iterable
+import asyncio
+from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, timedelta
 from typing import Any, Literal, Optional
 
@@ -8,6 +9,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.utils import timezone
 
+from asgiref.sync import async_to_sync
 from dateutil import parser
 from django_deprecate_fields import deprecate_field
 
@@ -715,6 +717,80 @@ def update_should_sync(schema_id: str, team_id: int, should_sync: bool) -> Exter
             sync_external_data_job_workflow(schema, create=True)
 
     return schema
+
+
+def bulk_update_should_sync(
+    schemas: Sequence[ExternalDataSchema],
+    should_sync: bool,
+    *,
+    trigger: bool = False,
+    concurrency: int = 10,
+) -> dict[str, BaseException]:
+    """Batch counterpart of update_should_sync sharing one Temporal connection.
+
+    update_should_sync opens two fresh mTLS connections per schema, which caps
+    mass re-enables at a few schemas per second. Returns schema id -> exception
+    for the schemas that failed; the rest succeeded.
+    """
+    # Same reason as update_should_sync: keep temporalio off the django.setup() path
+    from temporalio.client import Client  # noqa: PLC0415
+
+    from posthog.temporal.common.client import async_connect  # noqa: PLC0415
+    from posthog.temporal.common.schedule import (  # noqa: PLC0415
+        a_pause_schedule,
+        a_schedule_exists,
+        a_trigger_schedule,
+        a_unpause_schedule,
+    )
+
+    from products.data_warehouse.backend.facade.api import sync_external_data_job_workflow  # noqa: PLC0415
+
+    failures: dict[str, BaseException] = {}
+    saved: list[ExternalDataSchema] = []
+    for schema in schemas:
+        try:
+            schema.should_sync = should_sync
+            schema.save()
+            saved.append(schema)
+        except Exception as e:
+            failures[str(schema.id)] = e
+
+    to_schedule = [schema for schema in saved if schema.source.supports_scheduled_sync]
+
+    async def _apply(client: Client, semaphore: asyncio.Semaphore, schema: ExternalDataSchema) -> bool:
+        async with semaphore:
+            schedule_id = str(schema.id)
+            if not await a_schedule_exists(client, schedule_id=schedule_id):
+                return False
+            if should_sync:
+                await a_unpause_schedule(client, schedule_id=schedule_id)
+                if trigger:
+                    await a_trigger_schedule(client, schedule_id=schedule_id)
+            else:
+                await a_pause_schedule(client, schedule_id=schedule_id)
+            return True
+
+    async def _apply_all() -> list[bool | BaseException]:
+        client = await async_connect()
+        semaphore = asyncio.Semaphore(concurrency)
+        return await asyncio.gather(
+            *(_apply(client, semaphore, schema) for schema in to_schedule), return_exceptions=True
+        )
+
+    results: list[bool | BaseException] = async_to_sync(_apply_all)() if to_schedule else []
+
+    for schema, result in zip(to_schedule, results, strict=True):
+        if isinstance(result, BaseException):
+            failures[str(schema.id)] = result
+        elif result is False and should_sync:
+            # Schedule missing despite should_sync flipping on — recreate it. Rare enough
+            # that the per-schema connection sync_external_data_job_workflow opens is fine.
+            try:
+                sync_external_data_job_workflow(schema, create=True)
+            except Exception as e:
+                failures[str(schema.id)] = e
+
+    return failures
 
 
 def update_sync_type_config_keys(

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -1,11 +1,15 @@
 import uuid
+from contextlib import contextmanager
 from datetime import date, datetime
+from types import SimpleNamespace
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.db.models import Model
+
+from parameterized import parameterized
 
 from posthog.models.signals import model_activity_signal
 
@@ -14,6 +18,7 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import (
     ExternalDataSchema,
     apply_incremental_lookback,
+    bulk_update_should_sync,
     process_incremental_value,
     update_sync_type_config_keys,
 )
@@ -572,3 +577,93 @@ class TestStagedIncrementalCursor:
         with patch.object(schema, "save"):
             schema.update_sync_type_config_for_reset_pipeline()
         assert "incremental_staged" not in schema.sync_type_config
+
+
+class TestBulkUpdateShouldSync(BaseTest):
+    def _create_schema(self, name: str) -> ExternalDataSchema:
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+        )
+        return ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source=source,
+            name=name,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+
+    @contextmanager
+    def _temporal_mocks(self, exists: bool = True, unpause_side_effect=None):
+        with (
+            patch("posthog.temporal.common.client.async_connect", new=AsyncMock(return_value=MagicMock())),
+            patch(
+                "posthog.temporal.common.schedule.a_schedule_exists", new=AsyncMock(return_value=exists)
+            ) as exists_mock,
+            patch(
+                "posthog.temporal.common.schedule.a_unpause_schedule", new=AsyncMock(side_effect=unpause_side_effect)
+            ) as unpause_mock,
+            patch("posthog.temporal.common.schedule.a_pause_schedule", new=AsyncMock()) as pause_mock,
+            patch("posthog.temporal.common.schedule.a_trigger_schedule", new=AsyncMock()) as trigger_mock,
+            patch("products.data_warehouse.backend.facade.api.sync_external_data_job_workflow") as create_mock,
+        ):
+            yield SimpleNamespace(
+                exists=exists_mock,
+                unpause=unpause_mock,
+                pause=pause_mock,
+                trigger=trigger_mock,
+                create=create_mock,
+            )
+
+    @parameterized.expand(
+        [
+            (True, False, 1, 0, 0),
+            (True, True, 1, 0, 1),
+            (False, False, 0, 1, 0),
+        ]
+    )
+    def test_dispatches_schedule_operation(
+        self, should_sync: bool, trigger: bool, unpause_calls: int, pause_calls: int, trigger_calls: int
+    ) -> None:
+        schema = self._create_schema("t1")
+
+        with self._temporal_mocks() as mocks:
+            failures = bulk_update_should_sync([schema], should_sync=should_sync, trigger=trigger)
+
+        assert failures == {}
+        assert mocks.unpause.call_count == unpause_calls
+        assert mocks.pause.call_count == pause_calls
+        assert mocks.trigger.call_count == trigger_calls
+        schema.refresh_from_db()
+        assert schema.should_sync is should_sync
+
+    def test_one_failure_does_not_block_other_schemas(self) -> None:
+        ok = self._create_schema("ok")
+        bad = self._create_schema("bad")
+
+        def unpause(client, schedule_id: str, note=None) -> None:
+            if schedule_id == str(bad.id):
+                raise RuntimeError("temporal down")
+
+        with self._temporal_mocks(unpause_side_effect=unpause) as mocks:
+            failures = bulk_update_should_sync([ok, bad], should_sync=True)
+
+        assert list(failures) == [str(bad.id)]
+        assert {call.kwargs["schedule_id"] for call in mocks.unpause.call_args_list} == {str(ok.id), str(bad.id)}
+        ok.refresh_from_db()
+        bad.refresh_from_db()
+        assert ok.should_sync is True
+        assert bad.should_sync is True
+
+    def test_missing_schedule_is_recreated(self) -> None:
+        schema = self._create_schema("t1")
+
+        with self._temporal_mocks(exists=False) as mocks:
+            failures = bulk_update_should_sync([schema], should_sync=True)
+
+        assert failures == {}
+        mocks.unpause.assert_not_called()
+        mocks.create.assert_called_once_with(schema, create=True)


### PR DESCRIPTION
## Problem

`reenable_schemas_by_error` re-enables schemas that were auto-disabled by a non-retryable error, but it processes ~3 schemas per second. Each schema goes through `update_should_sync`, which opens two fresh mTLS Temporal connections (one for the schedule-exists check, one for the unpause) and runs everything sequentially. On a mass re-enable spanning hundreds of schemas that adds up to minutes of waiting.

The command also had no way to kick off a sync right away. Unpausing a Temporal schedule doesn't backfill missed runs, so a re-enabled schema waits for its next regular slot (up to 6 hours on the default frequency).

## Changes

- New `bulk_update_should_sync` in `products/warehouse_sources/backend/models/external_data_schema.py` (exported through the facade). It saves the DB rows first (per-row `.save()` so activity logging is preserved), then runs the Temporal schedule operations concurrently over a single shared client connection, bounded by a semaphore. A schedule that's missing gets recreated, and per-schema failures are collected into a returned dict instead of aborting the batch.
- `reenable_schemas_by_error` now calls the bulk function and gains two flags:
  - `--trigger` triggers each schedule right after unpausing, so re-enabled schemas sync immediately instead of waiting for the next scheduled run.
  - `--concurrency` controls Temporal op parallelism (default 10).
- `update_should_sync` is untouched, so its single-schema callers (API, workflow) behave exactly as before.

## How did you test this code?

Automated tests only, all run locally:

- `posthog/management/commands/test/test_reenable_schemas_by_error.py` (adapted): the filtering/dry-run tests now assert against the bulk call. New cases catch regressions that didn't exist before this change: `--trigger` not being forwarded to the bulk call, and the summary miscounting when the bulk call reports per-schema failures.
- `products/warehouse_sources/backend/tests/test_models.py::TestBulkUpdateShouldSync` (new): one schema's Temporal failure must not block the rest of the batch (guards `return_exceptions` and the result-to-schema mapping), pause/unpause/trigger dispatch per `should_sync`/`trigger` combination, and the recreate-missing-schedule fallback.
- Full `test_models.py` + `test_facade.py` suites pass (91 tests), and `tach check --dependencies --interfaces` is clean for the facade export.

I have not run the command against a real Temporal cluster as part of this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Fable 5) under my direction, after we traced a slow mass re-enable to the per-schema connection setup in `update_should_sync`. Skills invoked: /writing-tests. Considered optimizing `update_should_sync` in place (e.g. caching the Temporal client), but a separate bulk function keeps the single-schema semantics untouched for its other callers and makes the concurrency opt-in. The `--trigger` flag was added in the same pass since unpause alone leaves schemas waiting for their next scheduled slot.
