### PR TITLE
feat(visual-review): add per-story diff threshold overrides

### DIFF
--- a/products/visual_review/backend/diffing.py
+++ b/products/visual_review/backend/diffing.py
@@ -16,24 +16,17 @@ from pixelhog import thumbnail as pixelhog_thumbnail
 from .diff import THUMB_HEIGHT, THUMB_WIDTH, CompareResult, compare_images
 from .diff_metadata import DiffMetadata
 from .facade.enums import ChangeKind, ClassificationReason, SnapshotResult, ToleratedReason
-from .models import RunSnapshot, ToleratedHash
+from .models import RunSnapshot, StoryThresholdOverride, ToleratedHash
+from .thresholds import PIXEL_DIFF_THRESHOLD_PERCENT, SSIM_DISSIMILARITY_THRESHOLD, effective_thresholds
 
 logger = structlog.get_logger(__name__)
 
-# Two-tier classification thresholds:
-#
-# 1. Pixel diff ratio — fast path for obvious changes. Snapshots above
-#    this are immediately classified as CHANGED.
-# 2. SSIM perceptual threshold — safety net for tall-page dilution. A real UI
-#    change at the bottom of a long screenshot affects few pixels but produces
-#    a measurable structural shift that SSIM catches.
-#
-# Only when both are below threshold is the snapshot reclassified as UNCHANGED.
-PIXEL_DIFF_THRESHOLD_PERCENT = 2.5
-SSIM_DISSIMILARITY_THRESHOLD = 0.01  # 1% structural difference
 
-
-def classify_compare_result(result: CompareResult) -> ChangeKind | None:
+def classify_compare_result(
+    result: CompareResult,
+    pixel_threshold: float = PIXEL_DIFF_THRESHOLD_PERCENT,
+    ssim_threshold: float = SSIM_DISSIMILARITY_THRESHOLD,
+) -> ChangeKind | None:
     """Classify a compare result into a ChangeKind, or None for unchanged.
 
     Pure function — no DB, no side effects — so tests can drive every
@@ -41,13 +34,17 @@ def classify_compare_result(result: CompareResult) -> ChangeKind | None:
     drives `_diff_snapshot` below; keeping it here means the production
     branch and the tests can't drift.
 
+    Thresholds default to the global constants but are overridable per story
+    (see `StoryThresholdOverride`) so a story with known rendering movement can
+    relax the tier that keeps tripping.
+
     Size mismatch is *not* a kind — pixelhog pads to the largest dims and
     we still get a real pixel/SSIM answer over that padded image. The fact
     that sizes differed is recorded separately on `DiffMetadata`.
     """
-    if result.diff_percentage >= PIXEL_DIFF_THRESHOLD_PERCENT:
+    if result.diff_percentage >= pixel_threshold:
         return ChangeKind.PIXEL
-    if (1.0 - result.ssim_score) >= SSIM_DISSIMILARITY_THRESHOLD:
+    if (1.0 - result.ssim_score) >= ssim_threshold:
         return ChangeKind.STRUCTURAL
     return None
 
@@ -124,7 +121,7 @@ def _store_diff(
     )
 
 
-def _diff_snapshot(snapshot: RunSnapshot) -> None:
+def _diff_snapshot(snapshot: RunSnapshot, overrides: dict[str, StoryThresholdOverride]) -> None:
     """Compare snapshot against baseline; classify and store diff metrics.
 
     Classification (in priority order):
@@ -132,6 +129,9 @@ def _diff_snapshot(snapshot: RunSnapshot) -> None:
     2. SSIM dissimilarity above threshold -> CHANGED, kind=structural
        (tall-page dilution safety net)
     3. Both below -> UNCHANGED (noise), auto-populate tolerance cache.
+
+    Thresholds are the global defaults unless this snapshot's story has a
+    `StoryThresholdOverride`, in which case the overridden tier(s) apply.
 
     Size mismatch is recorded as `diff_metadata.size_mismatch` and surfaced
     separately in the UI — a snapshot can have a different viewport AND a
@@ -163,14 +163,21 @@ def _diff_snapshot(snapshot: RunSnapshot) -> None:
 
     _store_thumbnail(snapshot, result)
 
-    kind = classify_compare_result(result)
+    pixel_threshold, ssim_threshold, _, _ = effective_thresholds(snapshot.identifier, overrides)
+    kind = classify_compare_result(result, pixel_threshold, ssim_threshold)
     if kind is not None:
         _store_diff(snapshot, result, kind)
         return
 
-    # Both tiers below threshold — genuine noise, reclassify and cache for future runs
+    # Below the effective thresholds — reclassify as UNCHANGED. If the global
+    # defaults would have flagged this, a per-story override is what let it
+    # pass, so record STORY_OVERRIDE (and skip the hash-tolerance write — the
+    # override already covers every future run regardless of hash).
+    flagged_by_default = classify_compare_result(result) is not None
+    reason = ClassificationReason.STORY_OVERRIDE if flagged_by_default else ClassificationReason.BELOW_THRESHOLD
+
     snapshot.result = SnapshotResult.UNCHANGED
-    snapshot.classification_reason = ClassificationReason.BELOW_THRESHOLD
+    snapshot.classification_reason = reason
     snapshot.diff_percentage = result.diff_percentage
     snapshot.diff_pixel_count = result.diff_pixel_count
     snapshot.ssim_score = result.ssim_score
@@ -183,7 +190,11 @@ def _diff_snapshot(snapshot: RunSnapshot) -> None:
         identifier=snapshot.identifier,
         diff_percentage=result.diff_percentage,
         ssim_score=result.ssim_score,
+        classification_reason=reason.value,
     )
+
+    if flagged_by_default:
+        return
 
     # Auto-populate tolerance cache so future runs skip diffing for this hash.
     # Explicit team_id in the lookup (not just defaults) so the IDOR audit
@@ -249,6 +260,13 @@ def process_diffs(run_id: UUID) -> None:
     from . import logic
 
     snapshots = logic.get_run_snapshots(run_id)
+    if not snapshots:
+        return
+
+    run = snapshots[0].run
+    overrides = {
+        o.story_stem: o for o in StoryThresholdOverride.objects.filter(repo_id=run.repo_id, run_type=run.run_type)
+    }
 
     for snapshot in snapshots:
         if snapshot.result == SnapshotResult.NEW and snapshot.current_artifact:
@@ -261,7 +279,7 @@ def process_diffs(run_id: UUID) -> None:
             continue
 
         try:
-            _diff_snapshot(snapshot)
+            _diff_snapshot(snapshot, overrides)
         except Exception as e:
             logger.warning(
                 "visual_review.snapshot_diff_failed",

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -23,6 +23,8 @@ from posthog.helpers.trigram_search import search_match_type_from_instance
 
 from .. import logic
 from ..diff_metadata import DiffMetadata
+from ..models import StoryThresholdOverride
+from ..thresholds import effective_thresholds
 from . import contracts
 from .enums import RunPurpose
 
@@ -126,10 +128,16 @@ def _parse_diff_metadata(
 
 
 def _to_snapshot(
-    snapshot, repo_id: UUID, user_basic_infos: dict[int, contracts.UserBasicInfo] | None = None
+    snapshot,
+    repo_id: UUID,
+    user_basic_infos: dict[int, contracts.UserBasicInfo] | None = None,
+    overrides: dict[str, StoryThresholdOverride] | None = None,
 ) -> contracts.Snapshot:
     reviewed_by = (user_basic_infos or {}).get(snapshot.reviewed_by_id) if snapshot.reviewed_by_id else None
     cluster_summary, size_mismatch = _parse_diff_metadata(snapshot.diff_metadata)
+    pixel_threshold, ssim_threshold, pixel_overridden, ssim_overridden = effective_thresholds(
+        snapshot.identifier, overrides or {}
+    )
     return contracts.Snapshot(
         id=snapshot.id,
         run_id=snapshot.run_id,
@@ -152,6 +160,10 @@ def _to_snapshot(
         change_kind=snapshot.change_kind or "",
         cluster_summary=cluster_summary,
         size_mismatch=size_mismatch,
+        pixel_threshold_percent=pixel_threshold,
+        structural_threshold_percent=ssim_threshold * 100,
+        pixel_threshold_overridden=pixel_overridden,
+        structural_threshold_overridden=ssim_overridden,
     )
 
 
@@ -433,12 +445,13 @@ def get_run_snapshots(
         if team_id is not None
         else set()
     )
+    overrides = logic.get_story_overrides_map(repo_id, run_type)
     user_ids = {s.reviewed_by_id for s in snapshots if s.reviewed_by_id}
     user_basic_infos = _fetch_user_basic_infos(user_ids)
     dtos: list[contracts.Snapshot] = []
     quarantined_count = 0
     for s in snapshots:
-        dto = _to_snapshot(s, repo_id, user_basic_infos)
+        dto = _to_snapshot(s, repo_id, user_basic_infos, overrides)
         if dto.identifier in quarantined_identifiers:
             quarantined_count += 1
             if not include_quarantined:
@@ -475,7 +488,8 @@ def get_snapshot_history(repo_id: UUID, identifier: str, run_type: str) -> list[
 
 def mark_snapshot_as_tolerated(run_id: UUID, snapshot_id: UUID, user_id: int, team_id: int) -> contracts.Snapshot:
     snapshot = logic.mark_snapshot_as_tolerated(run_id, snapshot_id, user_id, team_id)
-    return _to_snapshot(snapshot, snapshot.run.repo_id)
+    overrides = logic.get_story_overrides_map(snapshot.run.repo_id, snapshot.run.run_type)
+    return _to_snapshot(snapshot, snapshot.run.repo_id, overrides=overrides)
 
 
 def get_tolerated_hashes(repo_id: UUID, identifier: str) -> list[contracts.ToleratedHashEntry]:
@@ -665,3 +679,50 @@ def unquarantine_identifier(repo_id: UUID, identifier: str, run_type: str, team_
 
 def expire_quarantine_entry(entry_id: UUID, team_id: int) -> None:
     logic.expire_quarantine_entry(entry_id=entry_id, team_id=team_id)
+
+
+# --- Story threshold overrides ---
+
+
+def _to_story_override_entry(
+    o, user_basic_infos: dict[int, contracts.UserBasicInfo] | None = None
+) -> contracts.StoryThresholdOverrideEntry:
+    created_by = (user_basic_infos or {}).get(o.created_by_id) if o.created_by_id else None
+    return contracts.StoryThresholdOverrideEntry(
+        id=o.id,
+        story_stem=o.story_stem,
+        run_type=o.run_type,
+        pixel_threshold_percent=o.pixel_threshold_percent,
+        ssim_dissimilarity_threshold=o.ssim_dissimilarity_threshold,
+        created_at=o.created_at,
+        updated_at=o.updated_at,
+        created_by=created_by,
+    )
+
+
+def list_story_overrides(
+    repo_id: UUID, team_id: int, run_type: str | None = None
+) -> list[contracts.StoryThresholdOverrideEntry]:
+    entries = logic.list_story_overrides(repo_id, team_id, run_type=run_type)
+    user_ids = {e.created_by_id for e in entries if e.created_by_id}
+    user_basic_infos = _fetch_user_basic_infos(user_ids)
+    return [_to_story_override_entry(e, user_basic_infos) for e in entries]
+
+
+def set_story_threshold_override(
+    repo_id: UUID, run_type: str, input: contracts.SetStoryThresholdInput, user_id: int, team_id: int
+) -> contracts.StoryThresholdOverrideEntry:
+    entry = logic.set_story_threshold_override(
+        repo_id=repo_id,
+        run_type=run_type,
+        identifier=input.identifier,
+        pixel_threshold_percent=input.pixel_threshold_percent,
+        ssim_dissimilarity_threshold=input.ssim_dissimilarity_threshold,
+        user_id=user_id,
+        team_id=team_id,
+    )
+    return _to_story_override_entry(entry, _fetch_user_basic_infos({user_id}))
+
+
+def delete_story_override(repo_id: UUID, run_type: str, identifier: str, team_id: int) -> None:
+    logic.delete_story_override(repo_id=repo_id, run_type=run_type, identifier=identifier, team_id=team_id)

--- a/products/visual_review/backend/facade/contracts.py
+++ b/products/visual_review/backend/facade/contracts.py
@@ -222,6 +222,15 @@ class Snapshot:
     change_kind: str = ""
     cluster_summary: ClusterSummary | None = None
     size_mismatch: bool = False
+    # Effective classification thresholds that apply to this snapshot's story,
+    # so the UI can render both diff numbers against their thresholds and flag
+    # whether a per-story override is in effect. `structural_threshold_percent`
+    # is the SSIM dissimilarity threshold expressed as a percentage to line up
+    # with the structural diff % the UI derives from `ssim_score`.
+    pixel_threshold_percent: float = 0.0
+    structural_threshold_percent: float = 0.0
+    pixel_threshold_overridden: bool = False
+    structural_threshold_overridden: bool = False
 
 
 @dataclass(frozen=True)
@@ -358,6 +367,39 @@ class QuarantineInput:
     # "what was wrong" later. Omitted when quarantining from the snapshot
     # history page where no run is in context.
     source_run_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class StoryThresholdOverrideEntry:
+    """A per-story override of the diff classifier thresholds.
+
+    Keyed by `story_stem` (identifier with theme/viewport/browser stripped), so
+    it covers every variant of a story. Either threshold may be null, meaning
+    "use the global default". `ssim_dissimilarity_threshold` is the raw 0.0-1.0
+    fraction the classifier compares against.
+    """
+
+    id: UUID
+    story_stem: str
+    run_type: str
+    pixel_threshold_percent: float | None
+    ssim_dissimilarity_threshold: float | None
+    created_at: datetime
+    updated_at: datetime
+    created_by: UserBasicInfo | None = None
+
+
+@dataclass(frozen=True)
+class SetStoryThresholdInput:
+    """Input for setting/clearing a per-story threshold override. run_type comes from URL path.
+
+    A null threshold clears that tier back to the global default; the story
+    stem is derived server-side from `identifier`.
+    """
+
+    identifier: str
+    pixel_threshold_percent: float | None = None
+    ssim_dissimilarity_threshold: float | None = None
 
 
 @dataclass(frozen=True)

--- a/products/visual_review/backend/facade/enums.py
+++ b/products/visual_review/backend/facade/enums.py
@@ -67,6 +67,7 @@ class ClassificationReason(StrEnum):
     EXACT = "exact"  # Hash matches baseline
     TOLERATED_HASH = "tolerated_hash"  # Matched a known tolerated alternate
     BELOW_THRESHOLD = "below_threshold"  # Diffed this run, below pixel/SSIM threshold
+    STORY_OVERRIDE = "story_override"  # Below a per-story overridden threshold that a global default would have flagged
 
 
 class ChangeKind(StrEnum):

--- a/products/visual_review/backend/identifiers.py
+++ b/products/visual_review/backend/identifiers.py
@@ -1,0 +1,33 @@
+"""Pure helpers for decomposing snapshot identifiers.
+
+A Storybook identifier is assembled in
+``common/storybook/.storybook/test-runner.ts`` as::
+
+    {story-id}[--{widthName}]--{theme}[--{browser}]
+
+- ``theme`` is always present (``light`` / ``dark``)
+- ``widthName`` is optional (multi-viewport stories)
+- ``browser`` is appended only when the browser is not chromium
+
+``story_stem`` strips those trailing facet tokens so a per-story threshold
+override keys on the story itself and covers every theme/viewport/browser
+variant at once. It is deterministic — the stem computed when an override is
+created matches the stem computed at classification time — so it stays
+self-consistent even for identifiers that don't follow the Storybook grammar.
+"""
+
+_THEMES = frozenset({"light", "dark"})
+_WIDTH_NAMES = frozenset({"narrow", "medium", "wide", "superwide"})
+_BROWSERS = frozenset({"chromium", "webkit", "firefox"})
+
+
+def story_stem(identifier: str) -> str:
+    """Strip trailing browser, theme, and viewport-width tokens from an identifier."""
+    tokens = identifier.split("--")
+    if len(tokens) > 1 and tokens[-1] in _BROWSERS:
+        tokens = tokens[:-1]
+    if len(tokens) > 1 and tokens[-1] in _THEMES:
+        tokens = tokens[:-1]
+    if len(tokens) > 1 and tokens[-1] in _WIDTH_NAMES:
+        tokens = tokens[:-1]
+    return "--".join(tokens)

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -45,7 +45,8 @@ from .facade.enums import (
     SnapshotResult,
     ToleratedReason,
 )
-from .models import Artifact, QuarantinedIdentifier, Repo, Run, RunSnapshot, ToleratedHash
+from .identifiers import story_stem
+from .models import Artifact, QuarantinedIdentifier, Repo, Run, RunSnapshot, StoryThresholdOverride, ToleratedHash
 from .signing import sign_snapshot_hash, verify_signed_hash
 from .storage import ArtifactStorage
 
@@ -2966,6 +2967,72 @@ def expire_quarantine_entry(entry_id: UUID, team_id: int) -> None:
         run_type=entry.run_type,
         team_id=team_id,
     ).filter(active).update(expires_at=now)
+
+
+# --- Story threshold overrides ---
+
+
+def get_story_overrides_map(repo_id: UUID, run_type: str) -> dict[str, StoryThresholdOverride]:
+    """All threshold overrides for a repo+run_type, keyed by story stem.
+
+    Loaded once per run so the diff pipeline and the snapshot mapper can resolve
+    a snapshot's effective thresholds without a per-snapshot query.
+    """
+    return {
+        o.story_stem: o
+        for o in StoryThresholdOverride.objects.using(WRITER_DB).filter(repo_id=repo_id, run_type=run_type)
+    }
+
+
+def list_story_overrides(repo_id: UUID, team_id: int, run_type: str | None = None) -> list[StoryThresholdOverride]:
+    get_repo(repo_id, team_id)  # raises RepoNotFoundError if repo not owned by team
+    qs = StoryThresholdOverride.objects.using(WRITER_DB).filter(repo_id=repo_id, team_id=team_id)
+    if run_type:
+        qs = qs.filter(run_type=run_type)
+    return list(qs.order_by("run_type", "story_stem"))
+
+
+def set_story_threshold_override(
+    repo_id: UUID,
+    run_type: str,
+    identifier: str,
+    pixel_threshold_percent: float | None,
+    ssim_dissimilarity_threshold: float | None,
+    user_id: int,
+    team_id: int,
+) -> StoryThresholdOverride:
+    """Upsert a per-story threshold override. The stem is derived from `identifier`."""
+    get_repo(repo_id, team_id)  # raises RepoNotFoundError if repo not owned by team
+    stem = story_stem(identifier)
+    # Explicit team_id in the lookup (not just relying on the scoped manager) so
+    # the IDOR audit rule sees the scope and get_or_create writes it on create.
+    override, created = StoryThresholdOverride.objects.using(WRITER_DB).get_or_create(
+        repo_id=repo_id,
+        run_type=run_type,
+        story_stem=stem,
+        team_id=team_id,
+        defaults={
+            "pixel_threshold_percent": pixel_threshold_percent,
+            "ssim_dissimilarity_threshold": ssim_dissimilarity_threshold,
+            "created_by_id": user_id,
+        },
+    )
+    if not created:
+        override.pixel_threshold_percent = pixel_threshold_percent
+        override.ssim_dissimilarity_threshold = ssim_dissimilarity_threshold
+        override.save(
+            using=WRITER_DB,
+            update_fields=["pixel_threshold_percent", "ssim_dissimilarity_threshold", "updated_at"],
+        )
+    return override
+
+
+def delete_story_override(repo_id: UUID, run_type: str, identifier: str, team_id: int) -> None:
+    get_repo(repo_id, team_id)  # raises RepoNotFoundError if repo not owned by team
+    stem = story_stem(identifier)
+    StoryThresholdOverride.objects.using(WRITER_DB).filter(
+        repo_id=repo_id, run_type=run_type, story_stem=stem, team_id=team_id
+    ).delete()
 
 
 def update_snapshot_diff(

--- a/products/visual_review/backend/migrations/0015_story_threshold_override.py
+++ b/products/visual_review/backend/migrations/0015_story_threshold_override.py
@@ -46,4 +46,21 @@ class Migration(migrations.Migration):
                 fields=["repo", "run_type", "story_stem"], name="unique_story_threshold_override"
             ),
         ),
+        # Choices-only change (adds the story_override reason). No SQL — Django
+        # doesn't enforce choices in Postgres — just keeps migration state in sync.
+        migrations.AlterField(
+            model_name="runsnapshot",
+            name="classification_reason",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("exact", "exact"),
+                    ("tolerated_hash", "tolerated_hash"),
+                    ("below_threshold", "below_threshold"),
+                    ("story_override", "story_override"),
+                ],
+                default="",
+                max_length=20,
+            ),
+        ),
     ]

--- a/products/visual_review/backend/migrations/0015_story_threshold_override.py
+++ b/products/visual_review/backend/migrations/0015_story_threshold_override.py
@@ -1,0 +1,49 @@
+import uuid
+
+import django.db.models.manager
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("visual_review", "0014_run_search_trgm"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="StoryThresholdOverride",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("team_id", models.BigIntegerField(db_index=True)),
+                ("run_type", models.CharField(max_length=64)),
+                ("story_stem", models.CharField(max_length=512)),
+                ("pixel_threshold_percent", models.FloatField(blank=True, null=True)),
+                ("ssim_dissimilarity_threshold", models.FloatField(blank=True, null=True)),
+                ("created_by_id", models.BigIntegerField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "repo",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="story_threshold_overrides",
+                        to="visual_review.repo",
+                    ),
+                ),
+            ],
+            managers=[
+                ("all_teams", django.db.models.manager.Manager()),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="storythresholdoverride",
+            index=models.Index(fields=["repo", "run_type", "story_stem"], name="story_override_lookup"),
+        ),
+        migrations.AddConstraint(
+            model_name="storythresholdoverride",
+            constraint=models.UniqueConstraint(
+                fields=["repo", "run_type", "story_stem"], name="unique_story_threshold_override"
+            ),
+        ),
+    ]

--- a/products/visual_review/backend/migrations/max_migration.txt
+++ b/products/visual_review/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0014_run_search_trgm
+0015_story_threshold_override

--- a/products/visual_review/backend/models.py
+++ b/products/visual_review/backend/models.py
@@ -348,6 +348,54 @@ class ToleratedHash(ProductTeamModel):
         return f"{self.identifier} {self.alternate_hash[:12]}... ({self.reason})"
 
 
+class StoryThresholdOverride(ProductTeamModel):
+    """
+    Per-story overrides for the two-tier diff classifier thresholds.
+
+    Keyed by the story stem (identifier with theme/viewport/browser tokens
+    stripped — see ``identifiers.story_stem``) so one override covers every
+    variant of a story. Either threshold may be null, meaning "use the global
+    default"; the other can still be overridden independently.
+
+    A story that renders with slight non-deterministic movement trips the SSIM
+    (structural) tier every run and mints a fresh alternate hash each time, so
+    hash-based ``ToleratedHash`` never sticks. Relaxing the story's structural
+    threshold here fixes it permanently, regardless of hash.
+    """
+
+    # nosemgrep: prefer-uuid7-django-pk -- TODO: migrate to uuid7 (UUIDModel)
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    repo = models.ForeignKey(Repo, on_delete=models.CASCADE, related_name="story_threshold_overrides")
+
+    run_type = models.CharField(max_length=64)
+    story_stem = models.CharField(max_length=512)
+
+    # Null = fall back to the global default (PIXEL_DIFF_THRESHOLD_PERCENT /
+    # SSIM_DISSIMILARITY_THRESHOLD in diffing.py). Percent for the pixel tier,
+    # 0.0-1.0 dissimilarity fraction for the SSIM tier — same units the
+    # classifier compares against.
+    pixel_threshold_percent = models.FloatField(null=True, blank=True)
+    ssim_dissimilarity_threshold = models.FloatField(null=True, blank=True)
+
+    created_by_id = models.BigIntegerField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["repo", "run_type", "story_stem"],
+                name="unique_story_threshold_override",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["repo", "run_type", "story_stem"], name="story_override_lookup"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.story_stem} (pixel={self.pixel_threshold_percent}, ssim={self.ssim_dissimilarity_threshold})"
+
+
 class QuarantinedIdentifier(ProductTeamModel):
     """
     Tracks quarantine events for snapshot identifiers.

--- a/products/visual_review/backend/presentation/serializers.py
+++ b/products/visual_review/backend/presentation/serializers.py
@@ -31,9 +31,11 @@ from ..facade.contracts import (
     Repo,
     Run,
     RunSummary,
+    SetStoryThresholdInput,
     Snapshot,
     SnapshotHistoryEntry,
     SnapshotManifestItem,
+    StoryThresholdOverrideEntry,
     ToleratedHashEntry,
     UpdateRepoRequestInput,
     UploadTarget,
@@ -84,6 +86,30 @@ class SnapshotSerializer(DataclassSerializer):
     diff_artifact = ArtifactSerializer(allow_null=True, required=False)
     reviewed_by = UserBasicInfoSerializer(allow_null=True, required=False)
     cluster_summary = ClusterSummarySerializer(allow_null=True, required=False)
+    pixel_threshold_percent = serializers.FloatField(
+        read_only=True,
+        help_text=(
+            "Effective pixel-diff threshold (percent) for this snapshot's story. A snapshot is a pixel-tier "
+            "change when its diff percentage reaches this value. Equals the global default unless a per-story "
+            "override is set (see `pixel_threshold_overridden`)."
+        ),
+    )
+    structural_threshold_percent = serializers.FloatField(
+        read_only=True,
+        help_text=(
+            "Effective structural (SSIM) threshold expressed as a percentage. A snapshot is a structural-tier "
+            "change when its structural difference — `(1 - ssim_score) * 100` — reaches this value. Equals the "
+            "global default unless a per-story override is set (see `structural_threshold_overridden`)."
+        ),
+    )
+    pixel_threshold_overridden = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether the pixel threshold above comes from a per-story override rather than the global default.",
+    )
+    structural_threshold_overridden = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether the structural threshold above comes from a per-story override rather than the global default.",
+    )
 
     class Meta:
         dataclass = Snapshot
@@ -288,6 +314,56 @@ class QuarantineInputSerializer(DataclassSerializer):
 
 class UnquarantineQuerySerializer(serializers.Serializer):
     identifier = serializers.CharField(max_length=512, help_text="Snapshot identifier to unquarantine")
+
+
+class StoryThresholdOverrideEntrySerializer(DataclassSerializer):
+    created_by = UserBasicInfoSerializer(allow_null=True, required=False)
+    pixel_threshold_percent = serializers.FloatField(
+        allow_null=True,
+        required=False,
+        help_text="Overridden pixel-diff threshold (percent) for this story, or null to use the global default.",
+    )
+    ssim_dissimilarity_threshold = serializers.FloatField(
+        allow_null=True,
+        required=False,
+        help_text=(
+            "Overridden structural (SSIM) threshold as a 0.0-1.0 dissimilarity fraction for this story, or null "
+            "to use the global default. A snapshot is structurally changed when `1 - ssim_score` reaches this."
+        ),
+    )
+
+    class Meta:
+        dataclass = StoryThresholdOverrideEntry
+
+
+class SetStoryThresholdInputSerializer(DataclassSerializer):
+    identifier = serializers.CharField(
+        max_length=512,
+        help_text=(
+            "A snapshot identifier from the story. The server strips its theme/viewport/browser tokens to a "
+            "story stem, so the override applies to every variant of the story."
+        ),
+    )
+    pixel_threshold_percent = serializers.FloatField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        max_value=100,
+        help_text="Pixel-diff threshold (percent) to allow for this story. Null clears it back to the global default.",
+    )
+    ssim_dissimilarity_threshold = serializers.FloatField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        max_value=1,
+        help_text=(
+            "Structural (SSIM) threshold as a 0.0-1.0 dissimilarity fraction to allow for this story. "
+            "Null clears it back to the global default."
+        ),
+    )
+
+    class Meta:
+        dataclass = SetStoryThresholdInput
 
 
 class CreateRepoInputSerializer(DataclassSerializer):

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -37,6 +37,7 @@ from ..facade.contracts import (
     CreateRunInput,
     FinalizeRunRequestInput,
     QuarantineInput,
+    SetStoryThresholdInput,
     UpdateRepoInput,
     UpdateRepoRequestInput,
 )
@@ -57,8 +58,10 @@ from .serializers import (
     RepoSerializer,
     ReviewStateCountsSerializer,
     RunSerializer,
+    SetStoryThresholdInputSerializer,
     SnapshotHistoryEntrySerializer,
     SnapshotSerializer,
+    StoryThresholdOverrideEntrySerializer,
     ToleratedHashEntrySerializer,
     UpdateRepoInputSerializer,
 )
@@ -96,11 +99,19 @@ class RepoViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """
 
     scope_object = "visual_review"
-    scope_object_write_actions = ["create", "partial_update", "quarantine", "unquarantine"]
+    scope_object_write_actions = [
+        "create",
+        "partial_update",
+        "quarantine",
+        "unquarantine",
+        "set_story_override",
+        "delete_story_override",
+    ]
     scope_object_read_actions = [
         "list",
         "retrieve",
         "list_quarantined",
+        "list_story_overrides",
         "thumbnail",
         "baselines",
     ]
@@ -256,6 +267,72 @@ class RepoViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         """Expire all active quarantine entries for an identifier."""
         try:
             api.unquarantine_identifier(
+                repo_id=UUID(pk),
+                identifier=request.validated_data.identifier,
+                run_type=run_type,
+                team_id=self.team_id,
+            )
+        except api.RepoNotFoundError:
+            return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("id", OpenApiTypes.STR, OpenApiParameter.PATH),
+            OpenApiParameter("run_type", str, required=False, description="Filter by run type"),
+        ],
+        responses={200: StoryThresholdOverrideEntrySerializer(many=True)},
+        description=(
+            "List per-story diff threshold overrides for a repo. Each override relaxes the pixel and/or "
+            "structural (SSIM) threshold for one story so known rendering movement stops being flagged."
+        ),
+    )
+    @action(detail=True, methods=["get"], url_path="story-overrides")
+    def list_story_overrides(self, request: Request, pk: str, **kwargs) -> Response:
+        """List per-story threshold overrides, optionally filtered by run type."""
+        run_type = request.query_params.get("run_type")
+        try:
+            entries = api.list_story_overrides(UUID(pk), team_id=self.team_id, run_type=run_type)
+        except api.RepoNotFoundError:
+            return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
+        page = self.paginate_queryset(entries)
+        if page is not None:
+            serializer = StoryThresholdOverrideEntrySerializer(instance=page, many=True)
+            return self.get_paginated_response(serializer.data)
+        return Response(StoryThresholdOverrideEntrySerializer(instance=entries, many=True).data)
+
+    @validated_request(
+        request_serializer=SetStoryThresholdInputSerializer,
+        responses={200: OpenApiResponse(response=StoryThresholdOverrideEntrySerializer)},
+    )
+    @action(detail=True, methods=["post"], url_path=r"story-overrides/(?P<run_type>[^/]+)")
+    def set_story_override(
+        self, request: TypedRequest[SetStoryThresholdInput], pk: str, run_type: str, **kwargs
+    ) -> Response:
+        """Set (upsert) the per-story threshold override for a story in a run type."""
+        try:
+            entry = api.set_story_threshold_override(
+                repo_id=UUID(pk),
+                run_type=run_type,
+                input=request.validated_data,
+                user_id=cast(int, request.user.id),
+                team_id=self.team_id,
+            )
+        except api.RepoNotFoundError:
+            return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
+        return Response(StoryThresholdOverrideEntrySerializer(instance=entry).data)
+
+    @validated_request(
+        request_serializer=SetStoryThresholdInputSerializer,
+        responses={204: None},
+    )
+    @action(detail=True, methods=["post"], url_path=r"story-overrides/(?P<run_type>[^/]+)/delete")
+    def delete_story_override(
+        self, request: TypedRequest[SetStoryThresholdInput], pk: str, run_type: str, **kwargs
+    ) -> Response:
+        """Clear the per-story threshold override for a story (thresholds revert to global defaults)."""
+        try:
+            api.delete_story_override(
                 repo_id=UUID(pk),
                 identifier=request.validated_data.identifier,
                 run_type=run_type,

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -623,6 +623,58 @@ class TestRepoRunsSearch(VisualReviewTeamScopedTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class TestStoryThresholdOverrideViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
+    databases = PRODUCT_DATABASES
+
+    def setUp(self):
+        super().setUp()
+        self.repo = api.create_repo(team_id=self.team.id, repo_external_id=90909, repo_full_name="org/overrides")
+
+    def _url(self, suffix: str = "") -> str:
+        return f"/api/projects/{self.team.id}/visual_review/repos/{self.repo.id}/story-overrides/{suffix}"
+
+    def test_set_keys_on_story_stem_and_lists(self):
+        response = self.client.post(
+            self._url(f"{RunType.STORYBOOK}/"),
+            {"identifier": "scenes-app-dashboards--edit--wide--dark--webkit", "ssim_dissimilarity_threshold": 0.02},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        entry = response.json()
+        # Facet tokens (viewport/theme/browser) are stripped to the story stem.
+        self.assertEqual(entry["story_stem"], "scenes-app-dashboards--edit")
+        self.assertEqual(entry["ssim_dissimilarity_threshold"], 0.02)
+        self.assertIsNone(entry["pixel_threshold_percent"])
+
+        listed = self.client.get(self._url()).json()["results"]
+        self.assertEqual([e["story_stem"] for e in listed], ["scenes-app-dashboards--edit"])
+
+    def test_set_is_upsert_not_duplicate(self):
+        for ssim in (0.02, 0.05):
+            self.client.post(
+                self._url(f"{RunType.STORYBOOK}/"),
+                {"identifier": "scenes-app-dashboards--edit--light", "ssim_dissimilarity_threshold": ssim},
+                format="json",
+            )
+        results = self.client.get(self._url()).json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["ssim_dissimilarity_threshold"], 0.05)
+
+    def test_delete_clears_override(self):
+        self.client.post(
+            self._url(f"{RunType.STORYBOOK}/"),
+            {"identifier": "scenes-app-dashboards--edit--light", "pixel_threshold_percent": 5},
+            format="json",
+        )
+        response = self.client.post(
+            self._url(f"{RunType.STORYBOOK}/delete/"),
+            {"identifier": "scenes-app-dashboards--edit--dark"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(self.client.get(self._url()).json()["results"], [])
+
+
 class TestRunFinalizePersonalAPIKeyScopes(VisualReviewTeamScopedTestMixin, APIBaseTest):
     databases = PRODUCT_DATABASES
     CONFIG_AUTO_LOGIN = False

--- a/products/visual_review/backend/tests/test_story_thresholds.py
+++ b/products/visual_review/backend/tests/test_story_thresholds.py
@@ -1,0 +1,157 @@
+"""Pure-function tests for per-story threshold overrides.
+
+The classification math and stem derivation carry the whole feature: if the stem
+strips the wrong tokens, an override never matches the story it was set for; if
+`effective_thresholds` / `classify_compare_result` ignore the override, the story
+keeps flagging. These are pure so they stay at the bottom of the test pyramid.
+"""
+
+from parameterized import parameterized
+
+from products.visual_review.backend.diff import CompareResult
+from products.visual_review.backend.diffing import classify_compare_result
+from products.visual_review.backend.facade.enums import ChangeKind
+from products.visual_review.backend.identifiers import story_stem
+from products.visual_review.backend.models import StoryThresholdOverride
+from products.visual_review.backend.thresholds import (
+    PIXEL_DIFF_THRESHOLD_PERCENT,
+    SSIM_DISSIMILARITY_THRESHOLD,
+    effective_thresholds,
+)
+
+
+def _result(diff_percentage: float, ssim_score: float) -> CompareResult:
+    return CompareResult(
+        diff_image=None,
+        diff_hash="",
+        diff_percentage=diff_percentage,
+        diff_pixel_count=0,
+        ssim_score=ssim_score,
+        width=100,
+        height=100,
+        thumbnail=None,
+        thumbnail_hash="",
+        size_mismatch=False,
+        cluster_summary=None,
+    )
+
+
+class TestStoryStem:
+    @parameterized.expand(
+        [
+            ("theme only", "scenes-app-dashboards--edit--light", "scenes-app-dashboards--edit"),
+            ("theme dark", "scenes-app-dashboards--edit--dark", "scenes-app-dashboards--edit"),
+            ("width + theme", "scenes-app-dashboards--edit--wide--light", "scenes-app-dashboards--edit"),
+            ("theme + browser", "scenes-app-dashboards--edit--light--webkit", "scenes-app-dashboards--edit"),
+            (
+                "width + theme + browser",
+                "scenes-app-dashboards--edit--superwide--dark--webkit",
+                "scenes-app-dashboards--edit",
+            ),
+            ("no facet tokens", "components-lemon-button", "components-lemon-button"),
+            ("story word matches a token stays", "components-narrow-card--light", "components-narrow-card"),
+        ]
+    )
+    def test_strips_to_story_stem(self, _name: str, identifier: str, expected: str) -> None:
+        assert story_stem(identifier) == expected
+
+    def test_all_variants_of_a_story_share_a_stem(self) -> None:
+        stems = {
+            story_stem(i)
+            for i in [
+                "scenes-app-dashboards--edit--light",
+                "scenes-app-dashboards--edit--dark",
+                "scenes-app-dashboards--edit--wide--light",
+                "scenes-app-dashboards--edit--light--webkit",
+            ]
+        }
+        assert stems == {"scenes-app-dashboards--edit"}
+
+
+class TestEffectiveThresholds:
+    def test_no_override_uses_global_defaults(self) -> None:
+        pixel, ssim, pixel_overridden, ssim_overridden = effective_thresholds("story--light", {})
+        assert (pixel, ssim) == (PIXEL_DIFF_THRESHOLD_PERCENT, SSIM_DISSIMILARITY_THRESHOLD)
+        assert not pixel_overridden
+        assert not ssim_overridden
+
+    @parameterized.expand(
+        [
+            ("pixel only", 5.0, None, 5.0, SSIM_DISSIMILARITY_THRESHOLD, True, False),
+            ("ssim only", None, 0.05, PIXEL_DIFF_THRESHOLD_PERCENT, 0.05, False, True),
+            ("both", 5.0, 0.05, 5.0, 0.05, True, True),
+        ]
+    )
+    def test_override_tiers_are_independent(
+        self,
+        _name: str,
+        pixel_col: float | None,
+        ssim_col: float | None,
+        want_pixel: float,
+        want_ssim: float,
+        want_pixel_overridden: bool,
+        want_ssim_overridden: bool,
+    ) -> None:
+        override = StoryThresholdOverride(
+            story_stem="scenes-app-dashboards--edit",
+            pixel_threshold_percent=pixel_col,
+            ssim_dissimilarity_threshold=ssim_col,
+        )
+        overrides = {override.story_stem: override}
+
+        # An identifier from the story (with facet tokens) must resolve via its stem.
+        pixel, ssim, pixel_overridden, ssim_overridden = effective_thresholds(
+            "scenes-app-dashboards--edit--wide--dark--webkit", overrides
+        )
+        assert pixel == want_pixel
+        assert ssim == want_ssim
+        assert pixel_overridden is want_pixel_overridden
+        assert ssim_overridden is want_ssim_overridden
+
+
+class TestClassificationRespectsOverrides:
+    def test_structural_movement_below_override_stops_flagging(self) -> None:
+        # 0.28% pixels (under the 2.5% pixel tier) but 1.5% structural — trips the
+        # default 1% SSIM tier. This is the flaky-movement case the feature fixes.
+        result = _result(diff_percentage=0.28, ssim_score=0.985)
+
+        assert classify_compare_result(result) == ChangeKind.STRUCTURAL
+
+        override = StoryThresholdOverride(
+            story_stem="scenes-app-dashboards--edit",
+            pixel_threshold_percent=None,
+            ssim_dissimilarity_threshold=0.02,  # allow up to 2% structural
+        )
+        overrides = {override.story_stem: override}
+        pixel, ssim, _, _ = effective_thresholds("scenes-app-dashboards--edit--light", overrides)
+        assert classify_compare_result(result, pixel, ssim) is None
+
+    def test_override_does_not_mask_a_genuine_pixel_change(self) -> None:
+        # Relaxing structural must not let a real pixel-tier change through.
+        result = _result(diff_percentage=8.0, ssim_score=0.90)
+        override = StoryThresholdOverride(
+            story_stem="scenes-app-dashboards--edit",
+            pixel_threshold_percent=None,
+            ssim_dissimilarity_threshold=0.5,
+        )
+        overrides = {override.story_stem: override}
+        pixel, ssim, _, _ = effective_thresholds("scenes-app-dashboards--edit--light", overrides)
+        assert classify_compare_result(result, pixel, ssim) == ChangeKind.PIXEL
+
+    @parameterized.expand(
+        [
+            ("under custom pixel threshold", 4.0, 1.0, 5.0, 0.01, None),
+            ("at custom pixel threshold", 5.0, 1.0, 5.0, 0.01, ChangeKind.PIXEL),
+        ]
+    )
+    def test_custom_pixel_threshold(
+        self,
+        _name: str,
+        diff_percentage: float,
+        ssim_score: float,
+        pixel_threshold: float,
+        ssim_threshold: float,
+        expected: ChangeKind | None,
+    ) -> None:
+        result = _result(diff_percentage=diff_percentage, ssim_score=ssim_score)
+        assert classify_compare_result(result, pixel_threshold, ssim_threshold) == expected

--- a/products/visual_review/backend/thresholds.py
+++ b/products/visual_review/backend/thresholds.py
@@ -1,0 +1,49 @@
+"""Diff classification thresholds and per-story override resolution.
+
+Two-tier classification:
+
+1. **Pixel diff ratio** — fast path for obvious changes. Snapshots above this are
+   immediately classified as CHANGED.
+2. **SSIM perceptual threshold** — safety net for tall-page dilution. A real UI
+   change at the bottom of a long screenshot affects few pixels but produces a
+   measurable structural shift that SSIM catches.
+
+Only when both are below threshold is the snapshot reclassified as UNCHANGED.
+
+Both thresholds are global defaults, overridable per story via
+`StoryThresholdOverride` so a story with known rendering movement can relax the
+tier that keeps tripping.
+
+Kept free of heavy imports (no pixelhog / diff engine) so the request path — the
+snapshot mapper that surfaces effective thresholds to the UI — can import it
+without pulling in the comparison machinery.
+"""
+
+from .identifiers import story_stem
+from .models import StoryThresholdOverride
+
+PIXEL_DIFF_THRESHOLD_PERCENT = 2.5
+SSIM_DISSIMILARITY_THRESHOLD = 0.01  # 1% structural difference
+
+
+def effective_thresholds(
+    identifier: str, overrides: dict[str, StoryThresholdOverride]
+) -> tuple[float, float, bool, bool]:
+    """Resolve the thresholds that apply to a snapshot, honoring per-story overrides.
+
+    Returns `(pixel_threshold, ssim_threshold, pixel_overridden, ssim_overridden)`.
+    A null column on the override means "fall back to the global default" — each
+    tier is independent, so a story can override one without touching the other.
+    """
+    override = overrides.get(story_stem(identifier))
+    pixel_threshold = PIXEL_DIFF_THRESHOLD_PERCENT
+    ssim_threshold = SSIM_DISSIMILARITY_THRESHOLD
+    pixel_overridden = False
+    ssim_overridden = False
+    if override is not None and override.pixel_threshold_percent is not None:
+        pixel_threshold = override.pixel_threshold_percent
+        pixel_overridden = True
+    if override is not None and override.ssim_dissimilarity_threshold is not None:
+        ssim_threshold = override.ssim_dissimilarity_threshold
+        ssim_overridden = True
+    return pixel_threshold, ssim_threshold, pixel_overridden, ssim_overridden

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -15,6 +15,7 @@ import { QuarantineAction } from './QuarantineAction'
 import { SnapshotChangeBadge, hasSnapshotChangeBadge } from './SnapshotChangeBadge'
 import { SnapshotClusterPanel } from './SnapshotClusterPanel'
 import { SnapshotStatusIndicator } from './SnapshotStatusIndicator'
+import { StoryThresholdControl } from './StoryThresholdControl'
 
 function DiffMinimap({ url, onClick }: { url: string; onClick?: () => void }): JSX.Element {
     const [loaded, setLoaded] = useState(false)
@@ -50,6 +51,9 @@ interface SnapshotDiffViewerProps {
     quarantineEntry?: QuarantinedIdentifierEntryApi | null
     onQuarantine?: (reason: string, identifiers: string[], expiresAt: string | null, sourceRunId: string | null) => void
     onUnquarantine?: () => void
+    onSetStoryThresholds?: (pixelThresholdPercent: number | null, structuralThresholdPercent: number | null) => void
+    onClearStoryThresholds?: () => void
+    isSavingStoryThreshold?: boolean
     commitSha?: string
     prNumber?: number | null
     repoId?: string | null
@@ -72,6 +76,9 @@ export function SnapshotDiffViewer({
     quarantineEntry,
     onQuarantine,
     onUnquarantine,
+    onSetStoryThresholds,
+    onClearStoryThresholds,
+    isSavingStoryThreshold,
     commitSha,
     prNumber,
     repoId,
@@ -265,6 +272,16 @@ export function SnapshotDiffViewer({
                             totalPixels={diffPixelTotal}
                             highlightedIndex={highlightedClusterIndex}
                             onHighlight={setHighlightedClusterIndex}
+                        />
+                    )}
+
+                    {/* === Story thresholds === */}
+                    {onSetStoryThresholds && onClearStoryThresholds && (
+                        <StoryThresholdControl
+                            snapshot={snapshot}
+                            isSaving={isSavingStoryThreshold}
+                            onSetThresholds={onSetStoryThresholds}
+                            onClearThresholds={onClearStoryThresholds}
                         />
                     )}
 

--- a/products/visual_review/frontend/components/StoryThresholdControl.tsx
+++ b/products/visual_review/frontend/components/StoryThresholdControl.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react'
+
+import { LemonButton, LemonInput, LemonTag } from '@posthog/lemon-ui'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import type { SnapshotApi } from '../generated/api.schemas'
+
+// Colour bands relative to the effective threshold: comfortably under is green,
+// approaching is yellow, at-or-over (the tier that would flag this as changed)
+// is red. Purely a visual cue — the classifier still decides with the threshold.
+function bandClass(value: number, threshold: number): string {
+    if (threshold <= 0) {
+        return 'bg-danger-highlight text-danger'
+    }
+    if (value >= threshold) {
+        return 'bg-danger-highlight text-danger'
+    }
+    if (value >= threshold * 0.5) {
+        return 'bg-warning-highlight text-warning-dark'
+    }
+    return 'bg-success-highlight text-success'
+}
+
+function formatPct(value: number): string {
+    if (value > 0 && value < 0.1) {
+        return '<0.1%'
+    }
+    return value < 1 ? `${value.toFixed(2)}%` : `${value.toFixed(1)}%`
+}
+
+// Structural difference the SSIM tier compares against, as a percentage.
+function structuralDiffPercent(snapshot: SnapshotApi): number | null {
+    if (snapshot.ssim_score == null) {
+        return null
+    }
+    const clamped = Math.max(0, Math.min(1, snapshot.ssim_score))
+    return (1 - clamped) * 100
+}
+
+function ThresholdRow({
+    label,
+    tooltip,
+    measured,
+    threshold,
+    overridden,
+}: {
+    label: string
+    tooltip: string
+    measured: number | null
+    threshold: number
+    overridden: boolean
+}): JSX.Element {
+    return (
+        <div className="flex items-center justify-between text-xs gap-2">
+            <Tooltip title={tooltip}>
+                <span className="text-muted cursor-help">{label}</span>
+            </Tooltip>
+            <div className="flex items-center gap-1">
+                {measured != null ? (
+                    <span
+                        className={`font-mono tabular-nums rounded px-1 py-0 leading-none ${bandClass(
+                            measured,
+                            threshold
+                        )}`}
+                    >
+                        {formatPct(measured)}
+                    </span>
+                ) : (
+                    <span className="text-muted">—</span>
+                )}
+                <span className="text-muted">/ {formatPct(threshold)}</span>
+                {overridden && (
+                    <LemonTag type="highlight" size="small">
+                        Edited
+                    </LemonTag>
+                )}
+            </div>
+        </div>
+    )
+}
+
+interface StoryThresholdControlProps {
+    snapshot: SnapshotApi
+    isSaving?: boolean
+    onSetThresholds: (pixelThresholdPercent: number | null, structuralThresholdPercent: number | null) => void
+    onClearThresholds: () => void
+}
+
+/**
+ * Sidebar control showing both diff tiers (pixel and structural) against their
+ * effective thresholds, and letting a reviewer relax either threshold for the
+ * whole story. Unlike tolerating a hash, an override holds across every future
+ * run regardless of hash — the fix for stories with known rendering movement.
+ */
+export function StoryThresholdControl({
+    snapshot,
+    isSaving,
+    onSetThresholds,
+    onClearThresholds,
+}: StoryThresholdControlProps): JSX.Element {
+    const pixelThreshold = snapshot.pixel_threshold_percent ?? 0
+    const structuralThreshold = snapshot.structural_threshold_percent ?? 0
+    const pixelOverridden = !!snapshot.pixel_threshold_overridden
+    const structuralOverridden = !!snapshot.structural_threshold_overridden
+    const anyOverridden = pixelOverridden || structuralOverridden
+
+    const [editing, setEditing] = useState(false)
+    const [pixelInput, setPixelInput] = useState<number | undefined>(pixelThreshold)
+    const [structuralInput, setStructuralInput] = useState<number | undefined>(structuralThreshold)
+
+    const startEditing = (): void => {
+        setPixelInput(pixelThreshold)
+        setStructuralInput(structuralThreshold)
+        setEditing(true)
+    }
+
+    return (
+        <div>
+            <h4 className="text-xs font-semibold text-muted mb-2">Thresholds</h4>
+            <div className="space-y-2">
+                <ThresholdRow
+                    label="Pixel"
+                    tooltip="Percentage of pixels that differ. The story is flagged as a pixel change when this reaches the threshold."
+                    measured={snapshot.diff_percentage ?? null}
+                    threshold={pixelThreshold}
+                    overridden={pixelOverridden}
+                />
+                <ThresholdRow
+                    label="Structural"
+                    tooltip="Perceptual (SSIM) difference. Catches movement that shifts few pixels but changes structure; the story is flagged when this reaches the threshold."
+                    measured={structuralDiffPercent(snapshot)}
+                    threshold={structuralThreshold}
+                    overridden={structuralOverridden}
+                />
+
+                {editing ? (
+                    <div className="space-y-2 pt-1">
+                        <div className="flex items-center justify-between gap-2">
+                            <span className="text-xs text-muted">Pixel %</span>
+                            <LemonInput
+                                type="number"
+                                size="small"
+                                className="w-24"
+                                value={pixelInput}
+                                onChange={setPixelInput}
+                                min={0}
+                                max={100}
+                                step={0.1}
+                            />
+                        </div>
+                        <div className="flex items-center justify-between gap-2">
+                            <span className="text-xs text-muted">Structural %</span>
+                            <LemonInput
+                                type="number"
+                                size="small"
+                                className="w-24"
+                                value={structuralInput}
+                                onChange={setStructuralInput}
+                                min={0}
+                                max={100}
+                                step={0.1}
+                            />
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <LemonButton
+                                type="primary"
+                                size="xsmall"
+                                loading={isSaving}
+                                data-attr="visual-review-story-thresholds-save"
+                                onClick={() => {
+                                    onSetThresholds(pixelInput ?? null, structuralInput ?? null)
+                                    setEditing(false)
+                                }}
+                            >
+                                Save
+                            </LemonButton>
+                            <LemonButton
+                                type="secondary"
+                                size="xsmall"
+                                disabledReason={isSaving ? 'Saving…' : undefined}
+                                onClick={() => setEditing(false)}
+                            >
+                                Cancel
+                            </LemonButton>
+                        </div>
+                        <p className="text-xs text-muted">
+                            Leave a field blank to use the global default for that tier.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-1 pt-1">
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            data-attr="visual-review-story-thresholds-edit"
+                            onClick={startEditing}
+                        >
+                            {anyOverridden ? 'Edit thresholds' : 'Set thresholds'}
+                        </LemonButton>
+                        {anyOverridden && (
+                            <LemonButton
+                                type="secondary"
+                                size="xsmall"
+                                loading={isSaving}
+                                data-attr="visual-review-story-thresholds-reset"
+                                onClick={onClearThresholds}
+                            >
+                                Reset
+                            </LemonButton>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -228,6 +228,7 @@ export function VisualReviewRunScene(): JSX.Element {
         isRunInProgress,
         isRunProcessing,
         isReportingOnly,
+        isSavingStoryThreshold,
         failedThumbnails,
         thumbnailBasePath,
         addImagesToComment,
@@ -239,6 +240,8 @@ export function VisualReviewRunScene(): JSX.Element {
         markAsTolerated,
         quarantineSnapshot,
         unquarantineSnapshot,
+        setStoryThresholds,
+        clearStoryThresholds,
         recomputeRun,
         markThumbnailFailed,
         toggleQuarantinedThumbnails,
@@ -607,6 +610,11 @@ export function VisualReviewRunScene(): JSX.Element {
                                 quarantineSnapshot(reason, identifiers, expiresAt, sourceRunId)
                             }
                             onUnquarantine={() => unquarantineSnapshot(selectedSnapshot)}
+                            onSetStoryThresholds={(pixelThresholdPercent, structuralThresholdPercent) =>
+                                setStoryThresholds(selectedSnapshot, pixelThresholdPercent, structuralThresholdPercent)
+                            }
+                            onClearStoryThresholds={() => clearStoryThresholds(selectedSnapshot)}
+                            isSavingStoryThreshold={isSavingStoryThreshold}
                             commitSha={run.commit_sha}
                             prNumber={run.pr_number}
                             repoId={run.repo_id}

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -13,6 +13,8 @@ import {
     visualReviewReposQuarantineExpireCreate,
     visualReviewReposQuarantineList,
     visualReviewReposRetrieve,
+    visualReviewReposStoryOverridesCreate,
+    visualReviewReposStoryOverridesDeleteCreate,
     visualReviewRunsApproveCreate,
     visualReviewRunsFinalizeCreate,
     visualReviewRunsRecomputeCreate,
@@ -65,6 +67,14 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
             sourceRunId,
         }),
         unquarantineSnapshot: (snapshot: SnapshotApi) => ({ snapshot }),
+        setStoryThresholds: (
+            snapshot: SnapshotApi,
+            pixelThresholdPercent: number | null,
+            structuralThresholdPercent: number | null
+        ) => ({ snapshot, pixelThresholdPercent, structuralThresholdPercent }),
+        setStoryThresholdsSuccess: true,
+        setStoryThresholdsFailure: true,
+        clearStoryThresholds: (snapshot: SnapshotApi) => ({ snapshot }),
         recomputeRun: true,
         recomputeRunSuccess: true,
         recomputeRunFailure: true,
@@ -100,6 +110,14 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
                 recomputeRun: () => true,
                 recomputeRunSuccess: () => false,
                 recomputeRunFailure: () => false,
+            },
+        ],
+        isSavingStoryThreshold: [
+            false,
+            {
+                setStoryThresholds: () => true,
+                setStoryThresholdsSuccess: () => false,
+                setStoryThresholdsFailure: () => false,
             },
         ],
         failedThumbnails: [
@@ -478,6 +496,53 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
                 actions.loadQuarantinedIdentifiers()
             } catch (e: any) {
                 lemonToast.error(e?.detail || e?.message || 'Failed to unquarantine')
+            }
+        },
+        setStoryThresholds: async ({ snapshot, pixelThresholdPercent, structuralThresholdPercent }) => {
+            const { run } = values
+            if (!run) {
+                actions.setStoryThresholdsFailure()
+                return
+            }
+            try {
+                await visualReviewReposStoryOverridesCreate(
+                    String(values.currentProjectId),
+                    run.repo_id,
+                    run.run_type,
+                    {
+                        identifier: snapshot.identifier,
+                        pixel_threshold_percent: pixelThresholdPercent,
+                        // The API stores the structural threshold as a 0-1 SSIM dissimilarity
+                        // fraction; the UI works in percent, so convert on the way out.
+                        ssim_dissimilarity_threshold:
+                            structuralThresholdPercent == null ? null : structuralThresholdPercent / 100,
+                    }
+                )
+                actions.setStoryThresholdsSuccess()
+                lemonToast.success('Story thresholds updated — re-run CI to re-evaluate this story')
+                // Reload so the effective thresholds and "edited" flags refresh immediately.
+                actions.loadSnapshots()
+            } catch (e: any) {
+                actions.setStoryThresholdsFailure()
+                lemonToast.error(e?.detail || e?.message || 'Failed to update story thresholds')
+            }
+        },
+        clearStoryThresholds: async ({ snapshot }) => {
+            const { run } = values
+            if (!run) {
+                return
+            }
+            try {
+                await visualReviewReposStoryOverridesDeleteCreate(
+                    String(values.currentProjectId),
+                    run.repo_id,
+                    run.run_type,
+                    { identifier: snapshot.identifier }
+                )
+                lemonToast.success('Story thresholds reset to defaults')
+                actions.loadSnapshots()
+            } catch (e: any) {
+                lemonToast.error(e?.detail || e?.message || 'Failed to reset story thresholds')
             }
         },
     })),

--- a/products/visual_review/mcp/tools.yaml
+++ b/products/visual_review/mcp/tools.yaml
@@ -70,6 +70,58 @@ tools:
     visual-review-repos-snapshots-list:
         operation: visual_review_repos_snapshots_list
         enabled: false
+    visual-review-repos-story-overrides-list:
+        operation: visual_review_repos_story_overrides_list
+        enabled: true
+        scopes:
+            - visual_review:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List story threshold overrides
+        description: >
+            List per-story diff threshold overrides for a repo. Each override relaxes the pixel and/or structural
+            (SSIM) threshold for one story (keyed by a story stem — the snapshot identifier with theme, viewport, and
+            browser tokens stripped) so known, harmless rendering movement stops being flagged as a change. Returns
+            each override's story stem, run type, the pixel threshold percent and/or SSIM dissimilarity threshold
+            (null means "use the global default" for that tier), and who set it. Optional `run_type` query param
+            filters to one run type.
+        feature_flag: visual-review
+    visual-review-repos-story-overrides-create:
+        operation: visual_review_repos_story_overrides_create
+        enabled: true
+        scopes:
+            - visual_review:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set story threshold override
+        description: >
+            Set (upsert) the per-story diff threshold override for a story. Pass any snapshot `identifier` from the
+            story — the server strips its theme/viewport/browser tokens to a story stem, so the override applies to
+            every variant of the story. Set `pixel_threshold_percent` (0-100) to allow more pixel difference and/or
+            `ssim_dissimilarity_threshold` (0-1) to allow more structural difference; pass null for a tier to leave it
+            on the global default. Use this for a story with known non-deterministic rendering movement that keeps
+            being flagged — unlike tolerating a hash, this holds across every future run regardless of hash.
+        feature_flag: visual-review
+    visual-review-repos-story-overrides-delete-create:
+        operation: visual_review_repos_story_overrides_delete_create
+        enabled: true
+        scopes:
+            - visual_review:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Clear story threshold override
+        description: >
+            Clear the per-story diff threshold override for a story, reverting both tiers to the global defaults. Pass
+            any snapshot `identifier` from the story and its `run_type`; the server resolves the story stem. No-op if
+            the story has no override.
+        feature_flag: visual-review
     visual-review-repos-thumbnails-retrieve:
         operation: visual_review_repos_thumbnails_retrieve
         enabled: false


### PR DESCRIPTION
## TL;DR

Adds support for per-story threshold overrides in visual review diffing, allowing teams to relax pixel or SSIM thresholds for stories with known rendering quirks. Extracts threshold logic into a reusable module and updates snapshot classification to respect overrides while tracking when they're applied.

## Problem

Visual review snapshots are classified as changed/unchanged using global pixel diff and SSIM thresholds. Some stories have consistent rendering movement (e.g., dynamic content, layout shifts) that cause false positives at the default thresholds. Teams need a way to override thresholds per story without changing global defaults.

## Changes

- **Threshold extraction**: Moved `PIXEL_DIFF_THRESHOLD_PERCENT` and `SSIM_DISSIMILARITY_THRESHOLD` constants to new `thresholds.py` module with `effective_thresholds()` function that applies per-story overrides
- **Classification updates**: Modified `classify_compare_result()` to accept overridable pixel and SSIM thresholds as parameters
- **Override tracking**: Updated `_diff_snapshot()` to:
  - Accept `StoryThresholdOverride` objects and query them by repo/run type
  - Use effective thresholds from overrides when classifying
  - Record `ClassificationReason.STORY_OVERRIDE` when an override allows a snapshot to pass that would fail on defaults
  - Skip hash-tolerance cache writes for override-allowed snapshots (override covers all future runs)
- **API exposure**: Updated `_to_snapshot()` in facade API to return:
  - `pixel_threshold_percent` and `structural_threshold_percent` (effective thresholds)
  - `pixel_threshold_overridden` and `structural_threshold_overridden` flags to surface which thresholds are overridden
- **Data model**: Added `StoryThresholdOverride` import to diffing module for type support

## How did you test this code?

The diff shows structural changes to support threshold overrides. Automated tests would verify:
- `effective_thresholds()` correctly applies overrides for matching story stems
- `classify_compare_result()` respects passed threshold parameters
- `STORY_OVERRIDE` reason is recorded only when defaults would flag but overrides allow
- Hash-tolerance cache is skipped for override-allowed snapshots
- API contracts include override flags and effective threshold values

Manual testing would confirm the UI correctly displays threshold overrides and their effects on snapshot classifications.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*