### PR TITLE
refactor(agent_platform): single-source trigger secrets across TS and Python

### DIFF
--- a/products/agent_platform/backend/logic/spec_schema.py
+++ b/products/agent_platform/backend/logic/spec_schema.py
@@ -15,46 +15,31 @@ Django concern (the promote gate reads `encrypted_env`) and has no schema.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 # ── Per-trigger-type required secrets ──────────────────────────────────────
 #
-# Mirrors `services/agent-shared/src/spec/trigger-secrets.ts` for the
-# Django-side validation path. Keep the two in lockstep — the slack trigger
-# handler in agent-ingress reads `SLACK_SIGNING_SECRET_KEY` and the freeze /
-# promote gate here rejects revisions whose agent's `encrypted_env` is missing
-# the same key.
+# NOT authored here. `TRIGGER_REQUIRED_SECRETS` is owned by the TS registry
+# (`services/agent-shared/src/spec/trigger-secrets.ts`), which is total by
+# construction (`Record<TriggerType, …>`). That registry emits the checked-in
+# JSON we load below; there is no Python copy to keep in lockstep. This is the
+# same move Django already made for the agent-spec schema — a hand-maintained
+# Python mirror was a recurring drift hazard. Regenerate the JSON after editing
+# the TS registry (a freshness test guards it):
+#
+#   UPDATE_GENERATED=1 npx vitest run src/spec/trigger-secrets-codegen.test.ts
+#
+# The slack trigger handler in agent-ingress reads these same keys via the TS
+# constants; the freeze / promote gate here rejects revisions whose agent's
+# `encrypted_env` is missing a `required` key.
 
 SLACK_SIGNING_SECRET_KEY = "SLACK_SIGNING_SECRET"
 SLACK_BOT_TOKEN_KEY = "SLACK_BOT_TOKEN"
 
-TRIGGER_REQUIRED_SECRETS: dict[str, list[dict[str, Any]]] = {
-    "chat": [],
-    "webhook": [],
-    "cron": [],
-    "mcp": [],
-    "slack": [
-        {
-            "key": SLACK_SIGNING_SECRET_KEY,
-            "label": "Slack signing secret",
-            "description": (
-                "Your Slack app's signing secret. Find it under Settings → Basic Information → "
-                "Signing Secret. Required to verify inbound Slack event signatures."
-            ),
-            "required": True,
-        },
-        {
-            "key": SLACK_BOT_TOKEN_KEY,
-            "label": "Slack bot user OAuth token",
-            "description": (
-                "Your Slack app's bot token (starts with `xoxb-`). Find it under Settings → "
-                "Install App → Bot User OAuth Token after installing the app to your workspace. "
-                "Used by native slack tools to call the Slack API."
-            ),
-            "required": True,
-        },
-    ],
-}
+_GENERATED_REGISTRY = Path(__file__).parent / "trigger_required_secrets.generated.json"
+TRIGGER_REQUIRED_SECRETS: dict[str, list[dict[str, Any]]] = json.loads(_GENERATED_REGISTRY.read_text())
 
 
 def _auth_mode_secret_requirement(mode: dict[str, Any]) -> dict[str, Any] | None:

--- a/products/agent_platform/backend/logic/trigger_required_secrets.generated.json
+++ b/products/agent_platform/backend/logic/trigger_required_secrets.generated.json
@@ -1,0 +1,20 @@
+{
+    "chat": [],
+    "webhook": [],
+    "cron": [],
+    "mcp": [],
+    "slack": [
+        {
+            "key": "SLACK_SIGNING_SECRET",
+            "label": "Slack signing secret",
+            "description": "Your Slack app's signing secret. Find it under Settings → Basic Information → Signing Secret. Required to verify inbound Slack event signatures.",
+            "required": true
+        },
+        {
+            "key": "SLACK_BOT_TOKEN",
+            "label": "Slack bot user OAuth token",
+            "description": "Your Slack app's bot token (starts with `xoxb-`). Find it under Settings → Install App → Bot User OAuth Token after installing the app to your workspace. Used by native slack tools to call the Slack API.",
+            "required": true
+        }
+    ]
+}

--- a/products/agent_platform/services/agent-shared/src/spec/trigger-secrets-codegen.test.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/trigger-secrets-codegen.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+import { GENERATED_JSON_PATH, serializeTriggerSecrets } from './trigger-secrets-codegen'
+
+/**
+ * Generated-artifact freshness (Coherence — collapse the TS/Python copies to one).
+ *
+ * `TRIGGER_REQUIRED_SECRETS` is authored once in TS; Django imports the JSON this
+ * emits. The only way that bridge rots is if the registry changes and the JSON
+ * isn't regenerated — so this asserts the checked-in file is byte-for-byte what
+ * the current TS source produces. Edit the registry without regenerating and it
+ * goes red, naming the fix. This is a same-tree comparison (TS object vs the JSON
+ * it produced), not a cross-language source scrape.
+ *
+ * Set UPDATE_GENERATED=1 to (re)write the file instead of asserting.
+ */
+describe('trigger-secrets generated artifact', () => {
+    if (process.env.UPDATE_GENERATED) {
+        writeFileSync(GENERATED_JSON_PATH, serializeTriggerSecrets())
+    }
+
+    it('checked-in JSON matches the TS registry (regenerate with UPDATE_GENERATED=1)', () => {
+        const onDisk = readFileSync(GENERATED_JSON_PATH, 'utf-8')
+        expect(onDisk).toBe(serializeTriggerSecrets())
+    })
+})

--- a/products/agent_platform/services/agent-shared/src/spec/trigger-secrets-codegen.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/trigger-secrets-codegen.ts
@@ -1,0 +1,37 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { TRIGGER_REQUIRED_SECRETS } from './trigger-secrets'
+
+/**
+ * Cross-language bridge for the per-trigger required-secrets registry.
+ *
+ * `TRIGGER_REQUIRED_SECRETS` (trigger-secrets.ts) is the single authored home —
+ * typed `Record<TriggerType, …>`, so it's total by construction on the TS side.
+ * The Django promote gate needs the same contract, but a hand-maintained Python
+ * copy is exactly the drift hazard Django already retired for the spec schema
+ * (see `backend/logic/spec_schema.py`). So instead of a second copy kept in sync
+ * by convention, TS *emits* the registry as a checked-in JSON that Python
+ * *imports*. There is then no parity to assert — one source, one derived artifact.
+ *
+ * The freshness of the emitted file is guarded by `trigger-secrets-codegen.test.ts`
+ * (same-tree: TS object vs the JSON it produced — not a cross-language source
+ * scrape). Regenerate after editing the registry:
+ *
+ *   UPDATE_GENERATED=1 npx vitest run src/spec/trigger-secrets-codegen.test.ts
+ */
+
+/** Absolute path of the generated file — lives next to its Python consumer in the
+ *  Django tree, mirroring how generated frontend types live under `frontend/generated/`. */
+export const GENERATED_JSON_PATH = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../../backend/logic/trigger_required_secrets.generated.json'
+)
+
+/** Canonical JSON projection of the TS registry: stable (authored) key order,
+ *  4-space indent + trailing newline to match oxfmt (the repo JSON formatter), so
+ *  the committed artifact survives lint-staged untouched and a byte-for-byte
+ *  freshness comparison stays meaningful. */
+export function serializeTriggerSecrets(): string {
+    return `${JSON.stringify(TRIGGER_REQUIRED_SECRETS, null, 4)}\n`
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
