### PR TITLE
refactor(agent_platform): serialize approvals through the shared serializer

### DIFF
--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -1649,14 +1649,13 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise JanitorUpstreamError(e) from e
         # Only `agent`-type approvals are decided through the console. A
         # `principal`-type request is the session owner's to clear at the ingress
-        # decision API; collapse it to not-found here. (Legacy rows queued before
-        # the principal/agent split carry `approvers[]` instead of `type` — map
-        # `team_admins` → agent so an in-flight old row stays decidable.)
+        # decision API; collapse it to not-found here. The janitor serializes
+        # approvals through the shared serializer, which resolves
+        # `approver_scope.type` — including legacy `approvers[]` rows — via the one
+        # owner of that mapping, so Django trusts the resolved type here rather than
+        # re-deriving it (which used to be a third copy of the rule).
         scope = existing.get("approver_scope", {})
-        approval_type = scope.get("type")
-        if approval_type is None:
-            approval_type = "agent" if "team_admins" in (scope.get("approvers") or []) else "principal"
-        if approval_type != "agent":
+        if scope.get("type") != "agent":
             raise NotFound("Approval not found")
         # A human acting interactively only: SessionAuthentication, or a bearer
         # from a first-party PostHog OAuth app (e.g. PostHog Code, where a human

--- a/products/agent_platform/services/agent-janitor/src/server.ts
+++ b/products/agent_platform/services/agent-janitor/src/server.ts
@@ -57,6 +57,7 @@ import {
     GatewayCatalog,
     ApprovalStore,
     applyApprovalDecision,
+    serializeApprovalRequest,
     BundleEntry,
     BundleStore,
     buildSlackManifest,
@@ -686,28 +687,6 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
         return true
     }
 
-    const summariseApproval = (r: ApprovalRequest): Record<string, unknown> => ({
-        id: r.id,
-        session_id: r.session_id,
-        application_id: r.application_id,
-        team_id: r.team_id,
-        revision_id: r.revision_id,
-        turn: r.turn,
-        tool_call_id: r.tool_call_id,
-        tool_name: r.tool_name,
-        proposed_args: r.proposed_args,
-        decided_args: r.decided_args,
-        assistant_message: r.assistant_message,
-        approver_scope: r.approver_scope,
-        state: r.state,
-        decision_by: r.decision_by,
-        decision_at: r.decision_at,
-        decision_reason: r.decision_reason,
-        dispatch_outcome: r.dispatch_outcome,
-        created_at: r.created_at,
-        expires_at: r.expires_at,
-    })
-
     app.get(
         '/approvals',
         asyncHandler(async (req, res) => {
@@ -720,7 +699,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
                 limit: q.limit,
                 offset: q.offset,
             })
-            res.json({ results: rows.map(summariseApproval) })
+            res.json({ results: rows.map(serializeApprovalRequest) })
         })
     )
 
@@ -742,7 +721,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
                 limit: q.limit,
                 offset: q.offset,
             })
-            res.json({ results: rows.map(summariseApproval) })
+            res.json({ results: rows.map(serializeApprovalRequest) })
         })
     )
 
@@ -757,7 +736,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
                 res.status(404).json({ error: 'not_found' })
                 return
             }
-            res.json(summariseApproval(row))
+            res.json(serializeApprovalRequest(row))
         })
     )
 

--- a/products/agent_platform/services/agent-shared/src/persistence/approval-store.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/approval-store.test.ts
@@ -4,7 +4,14 @@ import { Pool } from 'pg'
 import { reset } from '@posthog/agent-shared/testing'
 
 import { AssistantMessageRecord } from '../spec/spec'
-import { ApprovalStore, effectiveApprovalType, hashCanonicalArgs, UpsertApprovalRequestInput } from './approval-store'
+import {
+    ApprovalRequest,
+    ApprovalStore,
+    effectiveApprovalType,
+    hashCanonicalArgs,
+    serializeApprovalRequest,
+    UpsertApprovalRequestInput,
+} from './approval-store'
 import { PgApprovalStore } from './pg-approval-store'
 
 describe('effectiveApprovalType', () => {
@@ -16,6 +23,39 @@ describe('effectiveApprovalType', () => {
         ['empty / unknown → principal', {}, 'principal'],
     ])('%s', (_label, scope, expected) => {
         expect(effectiveApprovalType(scope as never)).toBe(expected)
+    })
+})
+
+describe('serializeApprovalRequest wire shape', () => {
+    const rowWithScope = (approver_scope: unknown): ApprovalRequest => ({
+        id: 'a',
+        session_id: 's',
+        application_id: 'app',
+        team_id: 1,
+        revision_id: 'r',
+        turn: 0,
+        tool_call_id: 'tc',
+        tool_name: 'tool',
+        proposed_args: {},
+        args_hash: Buffer.alloc(0),
+        assistant_message: { role: 'assistant', content: [], timestamp: 0 } as AssistantMessageRecord,
+        approver_scope: approver_scope as ApprovalRequest['approver_scope'],
+        state: 'queued',
+        decision_by: null,
+        decision_at: null,
+        decision_reason: null,
+        decided_args: null,
+        dispatch_outcome: null,
+        created_at: 't',
+        expires_at: 't',
+    })
+
+    // The serializer must resolve the type, not pass the scope raw: a raw legacy
+    // scope reaches the console with an undefined type and the decide gate 404s a
+    // decidable owner approval.
+    it('resolves a legacy approvers[] scope to a concrete type and drops the raw approvers', () => {
+        const out = serializeApprovalRequest(rowWithScope({ approvers: ['team_admins'], allow_edit: false }))
+        expect(out.approver_scope).toEqual({ type: 'agent', allow_edit: false })
     })
 })
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
