### PR TITLE
refactor(agent_platform): single-source the assistant stop-reason vocabulary

### DIFF
--- a/products/agent_platform/backend/logic/assistant_stop_reasons.generated.json
+++ b/products/agent_platform/backend/logic/assistant_stop_reasons.generated.json
@@ -1,0 +1,1 @@
+["stop", "length", "toolUse", "error", "aborted"]

--- a/products/agent_platform/backend/logic/generated.py
+++ b/products/agent_platform/backend/logic/generated.py
@@ -22,3 +22,6 @@ TRIGGER_REQUIRED_SECRETS: dict[str, list[dict[str, Any]]] = _load("trigger_requi
 # States the runner writes to `agent_tool_approval_request.state` (source: approval-store.ts).
 # Consumed by the DRF serializer choices and the model's DB CheckConstraint.
 APPROVAL_REQUEST_STATES: list[str] = _load("approval_request_states.generated.json")
+
+# Assistant turn stop reasons (source: spec.ts). Consumed by the assistant-message serializer's `stopReason` choices.
+ASSISTANT_STOP_REASONS: list[str] = _load("assistant_stop_reasons.generated.json")

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -72,7 +72,7 @@ from posthog.permissions import get_authenticator_scopes
 from posthog.security.outbound_proxy import internal_requests
 
 from ..db import WRITER_DB
-from ..logic.generated import APPROVAL_REQUEST_STATES
+from ..logic.generated import APPROVAL_REQUEST_STATES, ASSISTANT_STOP_REASONS
 from ..logic.internal_jwt import AgentInternalAudience, encode_agent_internal_jwt
 from ..logic.janitor_client import JanitorClient, JanitorClientError, default_client
 from ..logic.kernel_skills import all_kernel_skill_ids, kernel_skills_for
@@ -446,7 +446,8 @@ _AGENT_ASSISTANT_MESSAGE = inline_serializer(
         "model": drf_serializers.CharField(required=False),
         "usage": drf_serializers.DictField(child=drf_serializers.JSONField(), required=False),
         "stopReason": drf_serializers.ChoiceField(
-            choices=["stop", "length", "toolUse", "error", "aborted"],
+            # Imported from the generated artifact (source: spec.ts) so it can't drift from what the runner writes.
+            choices=ASSISTANT_STOP_REASONS,
             required=False,
         ),
         "errorMessage": drf_serializers.CharField(required=False),

--- a/products/agent_platform/services/agent-shared/src/spec/spec-codegen.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec-codegen.ts
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { APPROVAL_REQUEST_STATES } from '../persistence/approval-store'
+import { ASSISTANT_STOP_REASONS } from './spec'
 import { TRIGGER_REQUIRED_SECRETS } from './trigger-secrets'
 
 /**
@@ -37,5 +38,9 @@ export const GENERATED_ARTIFACTS: GeneratedArtifact[] = [
     {
         path: backendLogic('approval_request_states.generated.json'),
         content: () => asJson(APPROVAL_REQUEST_STATES),
+    },
+    {
+        path: backendLogic('assistant_stop_reasons.generated.json'),
+        content: () => asJson(ASSISTANT_STOP_REASONS),
     },
 ]

--- a/products/agent_platform/services/agent-shared/src/spec/spec.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec.ts
@@ -1478,10 +1478,18 @@ export interface AssistantMessageRecord {
         totalTokens?: number
         cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; total?: number }
     }
-    stopReason?: 'stop' | 'length' | 'toolUse' | 'error' | 'aborted'
+    stopReason?: AssistantStopReason
     errorMessage?: string
     timestamp: number
 }
+
+/**
+ * Why the model stopped a turn (mirrors pi-ai). Source of truth for the
+ * vocabulary — Django's serializer `choices` derives from the emitted JSON (see
+ * `spec-codegen.ts`), not a hand-copy.
+ */
+export const ASSISTANT_STOP_REASONS = ['stop', 'length', 'toolUse', 'error', 'aborted'] as const
+export type AssistantStopReason = (typeof ASSISTANT_STOP_REASONS)[number]
 
 export interface ToolResultMessage {
     role: 'toolResult'


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
