### PR TITLE
test(agent_platform): harden oracle trustworthiness (floors + CI-invocation)

### DIFF
--- a/products/agent_platform/backend/tests/test_ci_guard_coverage.py
+++ b/products/agent_platform/backend/tests/test_ci_guard_coverage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CI_AGENTS = _REPO_ROOT / ".github" / "workflows" / "ci-agents.yml"
+_GENERATED_DIR = Path(__file__).resolve().parent.parent / "logic"
+
+
+def _agents_filter_patterns() -> list[str]:
+    workflow = yaml.safe_load(_CI_AGENTS.read_text(encoding="utf-8"))
+    for job in (workflow.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            with_block: dict[str, Any] = step.get("with") or {}
+            raw = with_block.get("filters")
+            if not isinstance(raw, str):
+                continue
+            parsed = yaml.safe_load(raw) or {}
+            agents = parsed.get("agents")
+            if isinstance(agents, list):
+                return [p for p in agents if isinstance(p, str)]
+    raise AssertionError("could not find the `agents` path filter in ci-agents.yml")
+
+
+def test_ci_agents_filter_covers_every_generated_artifact() -> None:
+    patterns = _agents_filter_patterns()
+    generated = sorted(p.name for p in _GENERATED_DIR.glob("*.generated.json"))
+    assert generated, "no *.generated.json artifacts found — did the path change?"
+
+    for name in generated:
+        rel = f"products/agent_platform/backend/logic/{name}"
+        # A `**` glob in the filter also covers this file; fnmatch treats `**`
+        # loosely, which is fine — we only need at least one pattern to match.
+        covered = any(fnmatch.fnmatch(rel, pattern.replace("**", "*")) for pattern in patterns)
+        assert covered, (
+            f"{rel} is not covered by the ci-agents path filter, so an edit to it "
+            f"would not re-run the freshness guard. Add its directory to the `agents` "
+            f"filter in .github/workflows/ci-agents.yml."
+        )

--- a/products/agent_platform/services/agent-shared/src/persistence/approval-scope-totality.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/approval-scope-totality.test.ts
@@ -5,6 +5,9 @@ import { effectiveApprovalType } from './approval-store'
 
 describe('approval-authority totality', () => {
     it('every concrete ApprovalType round-trips (no silent downgrade)', () => {
+        // Floor: an empty domain would pass vacuously — fail loud if the
+        // vocabulary projection ever collapses.
+        expect(ApprovalTypeSchema.options.length).toBeGreaterThanOrEqual(2)
         for (const type of ApprovalTypeSchema.options) {
             const resolved = effectiveApprovalType({ type, allow_edit: false })
             expect(resolved, `authority "${type}" must resolve to itself, not the default gate`).toBe(type)

--- a/products/agent_platform/services/agent-shared/src/spec/spec-codegen.test.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec-codegen.test.ts
@@ -10,6 +10,12 @@ import { GENERATED_ARTIFACTS } from './spec-codegen'
  * goes red. Set UPDATE_GENERATED=1 to (re)write the files instead of asserting.
  */
 describe('spec generated artifacts', () => {
+    // Floor: `it.each([])` registers zero tests and passes green — a vacuous guard.
+    // Assert the registry is populated so an emptied `GENERATED_ARTIFACTS` fails loud.
+    it('the artifact registry is non-empty (guard is non-vacuous)', () => {
+        expect(GENERATED_ARTIFACTS.length).toBeGreaterThanOrEqual(3)
+    })
+
     if (process.env.UPDATE_GENERATED) {
         for (const artifact of GENERATED_ARTIFACTS) {
             // Atomic write: an interrupted regen must not leave a half-file that


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
