### PR TITLE
test(agent_platform): trigger-module conformance suite (edge semantics)

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/triggers/conformance.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/conformance.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Trigger-module conformance suite.
+ *
+ * Every `TRIGGER_MODULES` entry re-implements the same edges (signature
+ * verification, content-type robustness, untrusted-vs-broken sender, redelivery
+ * dedup); this encodes that contract once against the real HTTP surface so a new
+ * trigger must satisfy it explicitly. `CONFORMANCE_FIXTURES` is the source of
+ * truth for which edge classes apply to which trigger.
+ *
+ * Auth enforcement (declared kind == enforced kind) is covered by
+ * agent-tests/src/cases/auth-contract.test.ts; this suite owns edge semantics —
+ * what happens once a request clears (or deliberately fails) that gate.
+ */
+
+import { createHmac, randomUUID } from 'crypto'
+import { Express } from 'express'
+import { Pool } from 'pg'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+    AgentApplication,
+    AgentRevision,
+    AgentSession,
+    AgentSpecSchema,
+    PgApprovalStore,
+    PgCredentialBroker,
+    PgRevisionStore,
+    PgSessionQueue,
+    RedisSessionEventBus,
+    SecretResolver,
+} from '@posthog/agent-shared'
+import { reset } from '@posthog/agent-shared/testing'
+
+import { buildApp, TRIGGER_MODULES } from '../routing/server'
+import { encodeElevationActionValue } from './slack'
+import type { TriggerType } from './types'
+
+const TEST_DB_URL =
+    process.env.AGENT_TEST_DB_URL ?? 'postgres://posthog:posthog@localhost:5432/agent_runtime_queue_test'
+// nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379'
+const HARNESS_ENCRYPTION_SALT_KEYS = '01234567890123456789012345678901'
+const SLACK_SECRET = 'conformance-slack-secret'
+
+const PUBLIC_AUTH = { modes: [{ type: 'public' as const, acknowledge_public_exposure: true as const }] }
+
+/** An HTTP request the harness fires verbatim — headers/body come from the fixture and are never mutated, so a fixture-set signature or Content-Type survives untouched. */
+interface RawRequest {
+    path: string
+    headers: Record<string, string>
+    rawBody: string
+}
+
+interface DeployedTrigger {
+    application: AgentApplication
+    revision: AgentRevision
+}
+
+/**
+ * One trigger's conformance contract. Optional fields are edge classes the
+ * trigger opts into by declaring them, letting the assertions below iterate
+ * generically instead of hardcoding trigger names.
+ */
+interface ConformanceFixture {
+    type: TriggerType
+    /** Deploy a fresh agent wired only for this trigger's happy path (public
+     *  auth, permissive allowlist where applicable). */
+    deployHappy(): Promise<DeployedTrigger>
+    /** A valid, fully-authenticated request for a fresh event tagged by
+     *  `nonce` — reused across edge classes to build a "this should work"
+     *  baseline before perturbing one axis at a time. */
+    validRequest(dep: DeployedTrigger, nonce: string): RawRequest
+    /** Pull the enqueued/resumed session id out of a successful response body. */
+    sessionIdFromResponse(body: unknown): string | undefined
+    /** Normalize a session's seed message to a string for comparison. */
+    contentOf(session: AgentSession): string
+    /** The SAME logical event as `validRequest`, but mislabeled with a
+     *  mismatched Content-Type (JSON sent as `application/x-www-form-urlencoded`).
+     *  Omitted only for a route whose natural transport already IS urlencoded
+     *  (the slack-interactivity case). */
+    mislabeledRequest?(dep: DeployedTrigger, nonce: string): RawRequest
+    /** The EXACT seed a correct parse of `mislabeledRequest` produces. Exact,
+     *  not substring: Express's urlencoded mis-parse yields a garbage object
+     *  that, re-stringified into a seed, still CONTAINS the nonce — only exact
+     *  equality catches the garbled-but-still-2xx shape. */
+    expectedContentAfterMislabel?(nonce: string): string
+    /** Signature verification. Declared only by triggers whose auth is a
+     *  computed signature over the raw body (today: slack). */
+    signing?: {
+        /** Build a request signed with `secret` — pass the real secret for a
+         *  "missing secret resolver" probe, or a wrong one for an "invalid
+         *  signature" probe. */
+        request(dep: DeployedTrigger, nonce: string, secret: string): RawRequest
+    }
+    /** A secondary trust gate evaluated AFTER auth succeeds (today: slack's
+     *  `trusted_workspaces`). Declared only by triggers that have one. */
+    allowlist?: {
+        /** Deploy an agent whose allowlist will reject the probe identity
+         *  `rejectedRequest` uses. */
+        deployRejecting(): Promise<DeployedTrigger>
+        /** A request that authenticates/signs fine but misses the allowlist. */
+        rejectedRequest(dep: DeployedTrigger, nonce: string): RawRequest
+    }
+    /** Redelivery dedup. Declared only by triggers with a dedup identity
+     *  (a provider delivery-id header, or — for slack — the event's own
+     *  (channel, ts) coordinates). */
+    dedup?: {
+        /** Build a request carrying the same dedup identity for a given
+         *  `nonce`; calling this twice with the same nonce must collapse to
+         *  one session. */
+        request(dep: DeployedTrigger, nonce: string): RawRequest
+    }
+}
+
+function jsonRequest(path: string, body: unknown, extraHeaders: Record<string, string> = {}): RawRequest {
+    return { path, headers: { 'content-type': 'application/json', ...extraHeaders }, rawBody: JSON.stringify(body) }
+}
+
+/** Same bytes as `jsonRequest`, but the Content-Type header lies — raw body is still valid JSON. */
+function mislabeledAsUrlencoded(path: string, body: unknown, extraHeaders: Record<string, string> = {}): RawRequest {
+    return {
+        path,
+        headers: { 'content-type': 'application/x-www-form-urlencoded', ...extraHeaders },
+        rawBody: JSON.stringify(body),
+    }
+}
+
+function signSlackBody(rawBody: string, secret: string): { ts: string; sig: string } {
+    const ts = String(Math.floor(Date.now() / 1000))
+    const mac = createHmac('sha256', secret).update(`v0:${ts}:${rawBody}`).digest('hex')
+    return { ts, sig: `v0=${mac}` }
+}
+
+function slackSignedRequest(path: string, bodyObj: unknown, contentType: string, secret: string): RawRequest {
+    const raw = JSON.stringify(bodyObj)
+    const { ts, sig } = signSlackBody(raw, secret)
+    return {
+        path,
+        headers: { 'content-type': contentType, 'x-slack-request-timestamp': ts, 'x-slack-signature': sig },
+        rawBody: raw,
+    }
+}
+
+/** Seed message content is `ConversationMessage['content']`, which can be a
+ *  plain string or a structured block list — normalize to a string so the
+ *  content-type test can `.toContain(nonce)` regardless of shape. */
+function seedContent(session: AgentSession): string {
+    const content = session.conversation[0]?.content ?? ''
+    return typeof content === 'string' ? content : JSON.stringify(content)
+}
+
+function slackEventBody(nonce: string, workspace: string): Record<string, unknown> {
+    return {
+        type: 'event_callback',
+        team_id: workspace,
+        event: { type: 'message', channel: `C-${nonce}`, user: 'U1', text: `hello-${nonce}`, ts: `${nonce}.000` },
+    }
+}
+
+/** The exact seed slack.ts builds for a plain `message` event from
+ *  `slackEventBody` (never hits the mention/DM/resume branches). Mirrors the
+ *  `slackContext` template in `slack.ts`. */
+function expectedSlackSeed(nonce: string, workspace: string): string {
+    return [
+        '[slack]',
+        `channel: C-${nonce}`,
+        `ts: ${nonce}.000`,
+        `thread_ts: ${nonce}.000`,
+        `workspace: ${workspace}`,
+        'user: U1',
+        'mention: false',
+        'dm: false',
+        '',
+        `hello-${nonce}`,
+    ].join('\n')
+}
+
+let pool: Pool
+let bus: RedisSessionEventBus
+let revisions: PgRevisionStore
+let queue: PgSessionQueue
+let approvals: PgApprovalStore
+let credentialBroker: PgCredentialBroker
+let happyApp: Express
+
+function buildTestApp(overrides: { slackSigningSecretResolver?: SecretResolver } = {}): Express {
+    return buildApp({
+        revisions,
+        queue,
+        approvals,
+        bus,
+        credentialBroker,
+        routingMode: 'path',
+        pathPrefix: '/agents',
+        slackSigningSecretResolver: overrides.slackSigningSecretResolver ?? {
+            async resolve(): Promise<string | null> {
+                return SLACK_SECRET
+            },
+        },
+    })
+}
+
+async function deployAgent(triggers: unknown[]): Promise<DeployedTrigger> {
+    const slug = `conformance-${randomUUID().slice(0, 12)}`
+    const application = await revisions.createApplication({ team_id: 1, slug, name: slug, description: '' })
+    const revision = await revisions.createRevision({
+        application_id: application.id,
+        parent_revision_id: null,
+        created_by_id: null,
+        bundle_uri: 's3://x/',
+        spec: AgentSpecSchema.parse({ model: 'test/x', triggers }),
+    })
+    await revisions.setRevisionState(revision.id, 'live')
+    await revisions.setLiveRevision(application.id, revision.id)
+    return { application, revision }
+}
+
+async function fire(app: Express, req: RawRequest): Promise<request.Response> {
+    let r = request(app).post(req.path)
+    for (const [name, value] of Object.entries(req.headers)) {
+        r = r.set(name, value)
+    }
+    return r.send(req.rawBody)
+}
+
+const CONFORMANCE_FIXTURES: Partial<Record<TriggerType, ConformanceFixture>> = {
+    chat: {
+        type: 'chat',
+        async deployHappy() {
+            return deployAgent([{ type: 'chat', config: {}, auth: PUBLIC_AUTH }])
+        },
+        validRequest(dep, nonce) {
+            return jsonRequest(`/agents/${dep.application.slug}/run`, {
+                message: `hello-${nonce}`,
+                external_key: `chat-ext-${nonce}`,
+            })
+        },
+        mislabeledRequest(dep, nonce) {
+            return mislabeledAsUrlencoded(`/agents/${dep.application.slug}/run`, { message: `hello-${nonce}` })
+        },
+        // ChatRunBodySchema requires `message` as a top-level key, which urlencoded mis-parsing can't produce, so this arm 400s first (unreachable today; declared for parity).
+        expectedContentAfterMislabel: (nonce) => `hello-${nonce}`,
+        sessionIdFromResponse: (body) => (body as { session_id?: string }).session_id,
+        contentOf: seedContent,
+        // No signing (bearer auth, not a body signature), no allowlist (auth
+        // IS the gate), no dedup (client picks external_key; there's no
+        // provider delivery id to redeliver).
+    },
+    webhook: {
+        type: 'webhook',
+        async deployHappy() {
+            return deployAgent([{ type: 'webhook', config: { path: '/webhook' }, auth: PUBLIC_AUTH }])
+        },
+        validRequest(dep, nonce) {
+            return jsonRequest(`/agents/${dep.application.slug}/webhook`, { event: `payload-${nonce}` })
+        },
+        mislabeledRequest(dep, nonce) {
+            return mislabeledAsUrlencoded(`/agents/${dep.application.slug}/webhook`, { event: `payload-${nonce}` })
+        },
+        // webhook.ts delivers the body verbatim as the first user message (JSON-stringified), so a correct parse of `{ event: ... }` produces exactly this string.
+        expectedContentAfterMislabel: (nonce) => JSON.stringify({ event: `payload-${nonce}` }),
+        sessionIdFromResponse: (body) => (body as { session_id?: string }).session_id,
+        contentOf: seedContent,
+        // No allowlist knob — auth is the only gate webhook has.
+        dedup: {
+            request(dep, nonce) {
+                // `X-GitHub-Delivery` is one of the provider delivery-id
+                // headers webhook.ts keys dedup on.
+                return jsonRequest(
+                    `/agents/${dep.application.slug}/webhook`,
+                    { event: `dedup-${nonce}` },
+                    { 'x-github-delivery': `gh-${nonce}` }
+                )
+            },
+        },
+    },
+    mcp: {
+        type: 'mcp',
+        async deployHappy() {
+            return deployAgent([{ type: 'mcp', config: {}, auth: PUBLIC_AUTH }])
+        },
+        validRequest(dep, nonce) {
+            return jsonRequest(`/agents/${dep.application.slug}/mcp`, {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'ask', arguments: { message: `hello-${nonce}` } },
+            })
+        },
+        mislabeledRequest(dep, nonce) {
+            return mislabeledAsUrlencoded(`/agents/${dep.application.slug}/mcp`, {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'ask', arguments: { message: `hello-${nonce}` } },
+            })
+        },
+        // McpRequestBodySchema requires `jsonrpc`/`method` as top-level keys, which urlencoded mis-parsing can't produce, so this arm 400s first (unreachable; declared for parity).
+        expectedContentAfterMislabel: (nonce) => `hello-${nonce}`,
+        sessionIdFromResponse(body) {
+            const rpc = body as { result?: { content?: Array<{ text?: string }> } }
+            const text = rpc.result?.content?.[0]?.text
+            if (!text) {
+                return undefined
+            }
+            try {
+                return (JSON.parse(text) as { session_id?: string }).session_id
+            } catch {
+                return undefined
+            }
+        },
+        contentOf: seedContent,
+        // No signing, no allowlist, no dedup — MCP has no provider
+        // delivery-id concept; session continuation is client-driven.
+    },
+    slack: {
+        type: 'slack',
+        async deployHappy() {
+            return deployAgent([{ type: 'slack', config: { trusted_workspaces: '*' } }])
+        },
+        validRequest(dep, nonce) {
+            return slackSignedRequest(
+                `/agents/${dep.application.slug}/slack/events`,
+                slackEventBody(nonce, 'T-TRUSTED'),
+                'application/json',
+                SLACK_SECRET
+            )
+        },
+        mislabeledRequest(dep, nonce) {
+            return slackSignedRequest(
+                `/agents/${dep.application.slug}/slack/events`,
+                slackEventBody(nonce, 'T-TRUSTED'),
+                'application/x-www-form-urlencoded',
+                SLACK_SECRET
+            )
+        },
+        expectedContentAfterMislabel: (nonce) => expectedSlackSeed(nonce, 'T-TRUSTED'),
+        sessionIdFromResponse: (body) => (body as { session_id?: string }).session_id,
+        contentOf: seedContent,
+        signing: {
+            request(dep, nonce, secret) {
+                return slackSignedRequest(
+                    `/agents/${dep.application.slug}/slack/events`,
+                    slackEventBody(nonce, 'T-TRUSTED'),
+                    'application/json',
+                    secret
+                )
+            },
+        },
+        allowlist: {
+            async deployRejecting() {
+                return deployAgent([{ type: 'slack', config: { trusted_workspaces: ['T-ALLOWED-ONLY'] } }])
+            },
+            rejectedRequest(dep, nonce) {
+                return slackSignedRequest(
+                    `/agents/${dep.application.slug}/slack/events`,
+                    slackEventBody(nonce, 'T-NOT-ALLOWED'),
+                    'application/json',
+                    SLACK_SECRET
+                )
+            },
+        },
+        dedup: {
+            request(dep, nonce) {
+                // Same nonce twice → same (channel, ts) → the same `slack:msg:<channel>:<ts>` idempotency key slack.ts computes; the dedup identity is the event envelope, not a wire header.
+                return slackSignedRequest(
+                    `/agents/${dep.application.slug}/slack/events`,
+                    slackEventBody(nonce, 'T-TRUSTED'),
+                    'application/json',
+                    SLACK_SECRET
+                )
+            },
+        },
+    },
+}
+
+describe('trigger-module conformance suite', () => {
+    beforeAll(async () => {
+        pool = new Pool({ connectionString: TEST_DB_URL })
+        bus = new RedisSessionEventBus({
+            url: REDIS_URL,
+            channelPrefix: `conformance_${Math.random().toString(36).slice(2, 10)}`,
+        })
+        await bus.connect()
+        revisions = new PgRevisionStore(pool)
+        queue = new PgSessionQueue(pool)
+        approvals = new PgApprovalStore(pool)
+        credentialBroker = new PgCredentialBroker(pool, { encryptionSaltKeys: HARNESS_ENCRYPTION_SALT_KEYS })
+    })
+
+    beforeEach(async () => {
+        await reset({ databaseUrl: TEST_DB_URL })
+        happyApp = buildTestApp()
+    })
+
+    afterAll(async () => {
+        await bus.disconnect()
+        await pool.end()
+    })
+
+    describe('fixture totality (the ratchet)', () => {
+        it(`every TRIGGER_MODULES entry has a CONFORMANCE_FIXTURES entry (floor: ${TRIGGER_MODULES.length} modules)`, () => {
+            // Floor first: a totality loop over an empty `TRIGGER_MODULES` passes vacuously, so pin a count floor — a registry collapsing to nothing fails here instead of silently disabling every case.
+            expect(TRIGGER_MODULES.length).toBeGreaterThanOrEqual(4)
+            const missing = TRIGGER_MODULES.map((m) => m.type).filter((t) => !CONFORMANCE_FIXTURES[t])
+            // A newly registered trigger with no fixture shows up here by name.
+            expect(missing).toEqual([])
+        })
+    })
+
+    describe('signing fail-closed', () => {
+        const fixtures = Object.values(CONFORMANCE_FIXTURES).filter(
+            (f): f is ConformanceFixture & { signing: NonNullable<ConformanceFixture['signing']> } =>
+                Boolean(f?.signing)
+        )
+
+        it.each(fixtures)('$type: unresolvable signing secret → 5xx, never a 2xx', async (fx) => {
+            const dep = await fx.deployHappy()
+            const unconfiguredApp = buildTestApp({
+                slackSigningSecretResolver: {
+                    async resolve(): Promise<string | null> {
+                        return null
+                    },
+                },
+            })
+            const req = fx.signing.request(dep, randomUUID().slice(0, 8), SLACK_SECRET)
+            const res = await fire(unconfiguredApp, req)
+            expect(res.status).toBeGreaterThanOrEqual(500)
+            expect(res.status).toBeLessThan(600)
+        })
+
+        it.each(fixtures)('$type: invalid signature → 401', async (fx) => {
+            const dep = await fx.deployHappy()
+            const req = fx.signing.request(dep, randomUUID().slice(0, 8), 'definitely-the-wrong-secret')
+            const res = await fire(happyApp, req)
+            expect(res.status).toBe(401)
+            expect((res.body as { error?: string }).error).toBe('invalid_signature')
+        })
+    })
+
+    describe('content-type robustness (urlencoded-mislabeled body must never silently drop)', () => {
+        const fixtures = Object.values(CONFORMANCE_FIXTURES).filter(
+            (
+                f
+            ): f is ConformanceFixture & {
+                mislabeledRequest: NonNullable<ConformanceFixture['mislabeledRequest']>
+                expectedContentAfterMislabel: NonNullable<ConformanceFixture['expectedContentAfterMislabel']>
+            } => Boolean(f?.mislabeledRequest)
+        )
+
+        it.each(fixtures)(
+            '$type: a JSON body mislabeled as application/x-www-form-urlencoded is rejected explicitly or processed correctly — never acked while dropped',
+            async (fx) => {
+                const dep = await fx.deployHappy()
+                const nonce = randomUUID().slice(0, 8)
+                const before = await queue.listByApplication(dep.application.id, { limit: 50 })
+                const req = fx.mislabeledRequest(dep, nonce)
+                const res = await fire(happyApp, req)
+                const accepted = res.status >= 200 && res.status < 300
+                if (accepted) {
+                    // "process correctly" arm: assert the body was actually parsed, not just acked. Exact equality (not substring) — see `expectedContentAfterMislabel`.
+                    const sessionId = fx.sessionIdFromResponse(res.body)
+                    expect(sessionId).toBeTruthy()
+                    const session = await queue.get(sessionId!)
+                    expect(session).not.toBeNull()
+                    expect(fx.contentOf(session!)).toBe(fx.expectedContentAfterMislabel(nonce))
+                } else {
+                    // "reject explicitly" arm: a clear 4xx naming the problem —
+                    // never a 5xx (that's the trigger's own fault, not the
+                    // caller's) and never a bare ack.
+                    expect(res.status).toBeGreaterThanOrEqual(400)
+                    expect(res.status).toBeLessThan(500)
+                    expect((res.body as { error?: string })?.error).toBeTruthy()
+                }
+                const after = await queue.listByApplication(dep.application.id, { limit: 50 })
+                expect(after.length).toBe(before.length + (accepted ? 1 : 0))
+            }
+        )
+
+        // Slack's interactivity route legitimately receives `payload=<json>` as
+        // urlencoded, so this is its dedicated "process correctly" arm: prove the
+        // Express body-parser actually extracts `payload` (a regression would 400
+        // on `missing_payload` instead of reaching the session lookup below).
+        it('slack: /slack/interactivity legitimately consumes application/x-www-form-urlencoded payload=', async () => {
+            const dep = await deployAgent([{ type: 'slack', config: { trusted_workspaces: '*' } }])
+            const actionValue = encodeElevationActionValue({
+                sessionId: randomUUID(),
+                requestId: randomUUID(),
+                decision: 'grant',
+            })
+            const payload = JSON.stringify({
+                type: 'block_actions',
+                team: { id: 'T-TRUSTED' },
+                user: { id: 'U1', team_id: 'T-TRUSTED' },
+                actions: [{ action_id: 'a', value: actionValue }],
+            })
+            const raw = `payload=${encodeURIComponent(payload)}`
+            const { ts, sig } = signSlackBody(raw, SLACK_SECRET)
+            const res = await request(happyApp)
+                .post(`/agents/${dep.application.slug}/slack/interactivity`)
+                .set('content-type', 'application/x-www-form-urlencoded')
+                .set('x-slack-request-timestamp', ts)
+                .set('x-slack-signature', sig)
+                .send(raw)
+            expect(res.status).toBe(404)
+            expect((res.body as { error?: string }).error).toBe('session_not_found')
+        })
+    })
+
+    describe('drop semantics: an authenticated event that fails an allowlist must ack 2xx with a drop indication', () => {
+        const fixtures = Object.values(CONFORMANCE_FIXTURES).filter(
+            (f): f is ConformanceFixture & { allowlist: NonNullable<ConformanceFixture['allowlist']> } =>
+                Boolean(f?.allowlist)
+        )
+
+        it.each(fixtures)('$type: allowlist miss → 2xx ack with drop indication, never a 4xx', async (fx) => {
+            const dep = await fx.allowlist.deployRejecting()
+            const nonce = randomUUID().slice(0, 8)
+            const before = await queue.listByApplication(dep.application.id, { limit: 50 })
+            const req = fx.allowlist.rejectedRequest(dep, nonce)
+            const res = await fire(happyApp, req)
+            // A signed, authenticated delivery that misses an allowlist is a
+            // routing decision, not a delivery failure — providers retry
+            // non-2xx responses, so a 4xx here would cause redelivery storms.
+            expect(res.status).toBeGreaterThanOrEqual(200)
+            expect(res.status).toBeLessThan(300)
+            expect((res.body as { dropped?: string }).dropped).toBeTruthy()
+            const after = await queue.listByApplication(dep.application.id, { limit: 50 })
+            expect(after.length).toBe(before.length)
+        })
+    })
+
+    describe('dedup: a redelivered event collapses to one enqueue', () => {
+        const fixtures = Object.values(CONFORMANCE_FIXTURES).filter(
+            (f): f is ConformanceFixture & { dedup: NonNullable<ConformanceFixture['dedup']> } => Boolean(f?.dedup)
+        )
+
+        it.each(fixtures)('$type: the same event delivered twice → a single session', async (fx) => {
+            const dep = await fx.deployHappy()
+            const nonce = randomUUID().slice(0, 8)
+            const first = await fire(happyApp, fx.dedup.request(dep, nonce))
+            const firstSessionId = fx.sessionIdFromResponse(first.body)
+            expect(firstSessionId).toBeTruthy()
+
+            const second = await fire(happyApp, fx.dedup.request(dep, nonce))
+            const secondSessionId = fx.sessionIdFromResponse(second.body)
+            expect(secondSessionId).toBe(firstSessionId)
+
+            const sessions = await queue.listByApplication(dep.application.id, { limit: 50 })
+            expect(sessions).toHaveLength(1)
+            const session = await queue.get(firstSessionId!)
+            expect(session!.conversation).toHaveLength(1)
+            expect(session!.pending_inputs).toHaveLength(0)
+        })
+    })
+})

--- a/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
@@ -40,7 +40,11 @@ export { verifySlackSignature }
 
 async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
     const { req, res, deps, resolved } = ctx
-    // Signature already verified by the slack_signing guard.
+    // Signature guard hashes raw bytes, so a mislabeled Content-Type passes it; under urlencoded Express mis-parses the JSON and drops the event behind a bare 200. Reject explicitly.
+    if (req.is('application/json') === false) {
+        res.status(400).json({ error: 'invalid_content_type', expected: 'application/json' })
+        return
+    }
     const slackSpecTrigger = resolved.revision.spec.triggers.find((t) => t.type === 'slack')
     const body = req.body as {
         type?: string
@@ -89,14 +93,15 @@ async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
     // message events lack event.team; fall back to the envelope team_id.
     const workspaceId = event.team ?? body.team_id ?? 'unknown'
     if (trusted !== '*' && (!Array.isArray(trusted) || !trusted.includes(workspaceId))) {
-        // The rejected workspace id is otherwise only in the 403 body — surface
-        // it (plus the configured allowlist) so "why is Slack getting a 403?"
+        // The rejected workspace id is otherwise only in the log line — surface
+        // it (plus the configured allowlist) so "why did Slack get dropped?"
         // is answerable from the logs alone.
         log.warn(
             { slug: resolved.application.slug, workspace: workspaceId, trusted_workspaces: trusted ?? null },
             'slack_event_rejected_workspace_not_trusted'
         )
-        res.status(403).json({ error: 'workspace_not_trusted', workspace: workspaceId })
+        // Ack-and-drop, not 4xx: an untrusted-workspace delivery is a routing decision, not a failure. Providers retry non-2xx, so ack like the other drop paths (dm_not_enabled, mention_only).
+        res.json({ ok: true, dropped: 'workspace_not_trusted', workspace: workspaceId })
         return
     }
 

--- a/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
@@ -18,6 +18,11 @@ import { WebhookBodySchema } from './webhook.schemas'
 
 async function webhookHandler(ctx: AuthedRouteCtx<z.infer<typeof WebhookBodySchema>>): Promise<void> {
     const { req, res, deps, resolved } = ctx
+    // A mislabeled urlencoded Content-Type still passes `WebhookBodySchema` (Express parses the raw JSON into a garbage form object), which would silently become the seed message. Reject explicitly.
+    if (req.is('application/json') === false) {
+        res.status(400).json({ error: 'invalid_content_type', expected: 'application/json' })
+        return
+    }
     const body = ctx.parsed
     const externalKeyHeader = req.headers['x-external-key']
     const externalKey = typeof externalKeyHeader === 'string' ? externalKeyHeader : null

--- a/products/agent_platform/services/agent-tests/src/cases/slack-identity.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/slack-identity.test.ts
@@ -72,15 +72,18 @@ describe('slack identity: real e2e', () => {
         }
     })
 
-    it('untrusted workspace on a trusted-list agent → 403', async () => {
+    it('untrusted workspace on a trusted-list agent → 200 ack + drop (never a 4xx delivery failure)', async () => {
         await c.deployAgent({
             slug: 'gated',
             spec: { triggers: [{ type: 'slack', config: { trusted_workspaces: ['T-OK-ONLY'] } }] },
             encrypted_env: SLACK_ENV,
         })
         const res = await c.slackPost('gated', 'events', slackEvent({ team: 'T-EVIL', user: 'U-EVIL' }), SLACK_SECRET)
-        expect(res.status).toBe(403)
-        expect(res.body.error).toBe('workspace_not_trusted')
+        // A signed, authenticated delivery that just isn't from a trusted
+        // workspace is a routing decision, not a delivery failure — Slack (and
+        // any provider) retries non-2xx responses, so this must ack.
+        expect(res.status).toBe(200)
+        expect(res.body.dropped).toBe('workspace_not_trusted')
     })
 
     it('"*" accepts any workspace; distinct (workspace, user) → distinct AgentUsers', async () => {

--- a/products/agent_platform/services/agent-tests/src/cases/slack-trigger.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/slack-trigger.test.ts
@@ -250,14 +250,19 @@ describe('slack trigger: real e2e', () => {
         )
         expect(ok.status).toBe(200)
         expect(ok.body.session_id).toBeTruthy()
-        // An untrusted envelope is still rejected.
-        const rejected = await c.slackPost(
+        // An untrusted envelope is dropped, not enqueued — but acked 200 with a
+        // drop indication, never a 4xx: a signed delivery that fails the workspace
+        // allowlist is a routing decision, and providers retry non-2xx (Slack
+        // redelivery storms). The drop is what matters; the status is 2xx.
+        const dropped = await c.slackPost(
             'ws-fallback',
             'events',
             slackEvent({ eventType: 'message', ts: '2.0', team_id: 'T-OTHER', text: 'hello' }),
             SLACK_SECRET
         )
-        expect(rejected.status).toBe(403)
+        expect(dropped.status).toBe(200)
+        expect(dropped.body.dropped).toBe('workspace_not_trusted')
+        expect(dropped.body.session_id).toBeFalsy()
     })
 
     it('thread_ts falls back to ts when the mention is a top-level channel message', async () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
