### PR TITLE
fix(agent_platform): single fail-closed chokepoint for gated tool dispatch

### DIFF
--- a/products/agent_platform/services/agent-runner/src/loop/driver.test.ts
+++ b/products/agent_platform/services/agent-runner/src/loop/driver.test.ts
@@ -19,6 +19,7 @@ import {
     AgentRevision,
     type ApprovalRequest,
     type ApprovalStore,
+    ApprovalTypeSchema,
     AgentSession,
     AgentSpecSchema,
     buildTestBundleStore,
@@ -41,6 +42,7 @@ const KAFKA_HOSTS = process.env.KAFKA_HOSTS ?? 'localhost:9092'
 import { buildApprovalDecidedMarker } from '@posthog/agent-shared'
 
 import { runSession } from './driver'
+import { assertToolsGated, gateTool } from './gate-tool'
 import type { OpenedMcp, RemoteMcpTool } from './mcp-clients'
 
 const FAUX_MODEL_ID = 'faux/test'
@@ -185,6 +187,42 @@ async function run(
         posthogApiBaseUrl: 'http://localhost:8010',
         ...over,
     })
+}
+
+// Minimal `OpenedMcp` stub that tracks `callTool` invocations, so a test can
+// assert the gated path never reached the remote.
+function makeFakeMcp(
+    prefix: string,
+    ref: McpRef,
+    tools: Record<string, { description: string; result: unknown }>
+): OpenedMcp & { calls: Array<{ name: string; args: Record<string, unknown> }> } {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = []
+    return {
+        prefix,
+        ref,
+        listTools: async (): Promise<RemoteMcpTool[]> =>
+            Object.entries(tools).map(([name, t]) => ({
+                name,
+                description: t.description,
+                inputSchema: { type: 'object' },
+            })),
+        callTool: async (name, args) => {
+            calls.push({ name, args })
+            const result = tools[name]?.result ?? null
+            return {
+                content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+                structuredContent: result as Record<string, unknown>,
+            }
+        },
+        close: async () => undefined,
+        calls,
+    } as OpenedMcp & { calls: typeof calls }
+}
+
+const principalAlice: SessionPrincipal = {
+    kind: 'posthog',
+    user_id: 'alice',
+    team_id: 1,
 }
 
 describe('driver runSession', () => {
@@ -366,38 +404,6 @@ describe('driver runSession', () => {
      * relies on (which always queues — there is no fast-path).
      */
     describe('MCP tool approval gating', () => {
-        // Minimal `OpenedMcp` stub — same shape as `build-agent-tools.test.ts`'s
-        // helper but trimmed to what these cases need. Tracks `callTool`
-        // invocations so we can assert the gated path didn't reach the
-        // remote.
-        function makeFakeMcp(
-            prefix: string,
-            ref: McpRef,
-            tools: Record<string, { description: string; result: unknown }>
-        ): OpenedMcp & { calls: Array<{ name: string; args: Record<string, unknown> }> } {
-            const calls: Array<{ name: string; args: Record<string, unknown> }> = []
-            return {
-                prefix,
-                ref,
-                listTools: async (): Promise<RemoteMcpTool[]> =>
-                    Object.entries(tools).map(([name, t]) => ({
-                        name,
-                        description: t.description,
-                        inputSchema: { type: 'object' },
-                    })),
-                callTool: async (name, args) => {
-                    calls.push({ name, args })
-                    const result = tools[name]?.result ?? null
-                    return {
-                        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-                        structuredContent: result as Record<string, unknown>,
-                    }
-                },
-                close: async () => undefined,
-                calls,
-            } as OpenedMcp & { calls: typeof calls }
-        }
-
         // Route through `AgentSpecSchema.parse` so the approval-policy
         // defaults (`type`, `allow_edit`, `ttl_ms`) get materialised — the
         // runner reads the strict shape, not the zod input form.
@@ -421,12 +427,6 @@ describe('driver runSession', () => {
                 },
             ],
         }).mcps[0]
-
-        const principalAlice: SessionPrincipal = {
-            kind: 'posthog',
-            user_id: 'alice',
-            team_id: 1,
-        }
 
         it('queues an approval row when the model calls a gated MCP tool', async () => {
             // Concierge-shape: the model invokes promote-create; the
@@ -805,6 +805,84 @@ describe('driver runSession', () => {
             expect(out.state).toBe('completed')
             // explore_tools ran (no approval queued) — read-only catalog browsing.
             expect(await approvals.listBySession(TEST_SESSION_ID)).toHaveLength(0)
+        })
+    })
+
+    /**
+     * Pin the two fail-closed properties of the gate chokepoint (gate-tool.ts):
+     * under any approval authority a gated call queues and never runs the real
+     * executor; an unbranded tool throws at `assertToolsGated` before dispatch.
+     */
+    describe('gate chokepoint (fail-closed dispatch)', () => {
+        it('enumerates at least two approval authorities — an empty enum would pass every case below vacuously', () => {
+            expect(ApprovalTypeSchema.options.length).toBeGreaterThanOrEqual(2)
+        })
+
+        it.each(ApprovalTypeSchema.options)(
+            'queues instead of executing a tool gated under approval type=%s (real executor never runs)',
+            async (authority) => {
+                const ref: McpRef = AgentSpecSchema.parse({
+                    model: FAUX_MODEL_ID,
+                    mcps: [
+                        {
+                            kind: 'agent',
+                            default_tool_approval: 'deny',
+                            id: 'gate',
+                            url: 'https://example.com/gate',
+                            secrets: [],
+                            tools: [
+                                {
+                                    name: 'risky',
+                                    level: 'approve',
+                                    approval_policy: { type: authority, ttl_ms: 900_000 },
+                                },
+                            ],
+                        },
+                    ],
+                }).mcps[0]
+                const mcp = makeFakeMcp('gate', ref, { risky: { description: 'd', result: { done: true } } })
+                const approvals = new PgApprovalStore(pool)
+                const session = makeSession({ principal: principalAlice })
+                const out = await run(makeRev({ mcps: [ref as never] }), session, {
+                    script: [toolUse([call('gate__risky', { x: 1 })]), stop('queued')],
+                    approvals,
+                    mcpClients: [mcp],
+                })
+                expect(out.state).toBe('completed')
+                // The real executor never ran, regardless of who decides.
+                expect(mcp.calls).toEqual([])
+                const rows = await approvals.listBySession(TEST_SESSION_ID)
+                expect(rows).toHaveLength(1)
+                expect(rows[0].state).toBe('queued')
+                expect(rows[0].approver_scope).toMatchObject({ type: authority })
+            }
+        )
+
+        it('throws before dispatch when a tool reaches the chokepoint unbranded (a lane bypassed gateTool)', () => {
+            const bypassedExecute = vi.fn(async () => ({ content: [], details: {} }))
+            const branded = gateTool(
+                {
+                    name: 'ok-tool',
+                    label: 'ok-tool',
+                    description: '',
+                    parameters: { type: 'object' } as never,
+                    execute: async () => ({ content: [], details: {} }),
+                },
+                () => ({ gate: false }),
+                async () => ({ content: [], details: {} }) as never
+            )
+            // Simulates a future lane that builds an `AgentTool` without ever
+            // calling `gateTool`.
+            const bypassed = {
+                name: 'bypassed-tool',
+                label: 'bypassed-tool',
+                description: '',
+                parameters: { type: 'object' } as never,
+                execute: bypassedExecute,
+            }
+            expect(() => assertToolsGated([branded, bypassed as never])).toThrow(/bypassed-tool/)
+            // The unbranded tool's execute is never invoked.
+            expect(bypassedExecute).not.toHaveBeenCalled()
         })
     })
 

--- a/products/agent_platform/services/agent-runner/src/loop/driver.ts
+++ b/products/agent_platform/services/agent-runner/src/loop/driver.ts
@@ -33,14 +33,7 @@
  * `pending_inputs` — handled in `getSteeringMessages`.
  */
 
-import type {
-    AgentContext,
-    AgentEvent,
-    AgentEventSink,
-    AgentMessage,
-    AgentToolResult,
-    StreamFn,
-} from '@earendil-works/pi-agent-core'
+import type { AgentContext, AgentEvent, AgentEventSink, AgentMessage, StreamFn } from '@earendil-works/pi-agent-core'
 import { runAgentLoop } from '@earendil-works/pi-agent-core'
 import type { AssistantMessage, Message } from '@earendil-works/pi-ai'
 import { streamSimple } from '@earendil-works/pi-ai'
@@ -96,6 +89,7 @@ import { nativeToolApprovalClass } from '@posthog/agent-tools'
 import { approvalMarkerRequestId, ApprovalPolicy, dispatchApprovedResult, queueApprovalResult } from './approval'
 import { AgentToolDeps, buildAgentTools, MetaControl, RealToolExecute, ToolResultDetails } from './build-agent-tools'
 import { fallbackStreamFn, ResolvedModel } from './fallback-stream'
+import { assertToolsGated, gateTool, QueueGated } from './gate-tool'
 import { resolveMaxOutputTokens } from './max-output-tokens'
 import type { McpOpenFailure, OpenedMcp } from './mcp-clients'
 import {
@@ -543,10 +537,10 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
         let lastOutput: unknown = null
         const toolStarts = new Map<string, { args: Record<string, unknown>; t0: number }>()
 
-        // Keep each tool's real execute, then swap gated tools for the queue path.
-        // The real execute is what an approved call runs on resume (the human has
-        // already cleared the gate). `approvals` is mandatory (runSession throws
-        // otherwise), so gating is unconditional — there is no ungated fast path.
+        // Keep each tool's real execute (what an approved call runs on resume,
+        // once the human has cleared the gate), then rebuild every tool through
+        // `gateTool`. `approvals` is mandatory (runSession throws otherwise), so
+        // gating is unconditional — there is no ungated fast path.
         const realExecute = new Map<string, RealToolExecute>()
         for (const tool of tools) {
             // Tools are named with their original id.
@@ -554,16 +548,11 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
         }
         {
             const approvals = deps.approvals
-            // Shared by the static wrap and the dynamic proxy wrap. Every gated
-            // call queues for a human decision — being the asker is not consent
-            // to the specific call (the model could have been steered by content
-            // it read). `toolName` is what the approval row records.
-            const queueGated = async (
-                toolName: string,
-                toolCallId: string,
-                args: Record<string, unknown>,
-                policy: ApprovalPolicy
-            ): Promise<AgentToolResult<ToolResultDetails>> => {
+            // Shared by every lane's resolver below. Every gated call queues for
+            // a human decision — being the asker is not consent to the specific
+            // call (the model could have been steered by content it read).
+            // `toolName` is what the approval row records.
+            const queueGated: QueueGated = async (toolName, toolCallId, args, policy) => {
                 const queued = await queueApprovalResult({
                     approvals,
                     buildApprovalUrl: deps.buildApprovalUrl,
@@ -599,33 +588,32 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
             // so the synthetic read-only helpers below can be recognised as ours.
             const proxiedPrefixes = proxiedPrefixesFromCallTools(mcpProxyCallTools.keys())
 
-            for (const tool of tools) {
+            for (let i = 0; i < tools.length; i++) {
+                const tool = tools[i]
                 const id = tool.name
                 // Proxy `call_tool` gates dynamically: the underlying tool is
                 // only known at call time (the `tool_name` arg), so re-key the
                 // gate on `<prefix>__<tool_name>` per call.
                 const proxyEntry = mcpProxyCallTools.get(id)
                 if (proxyEntry) {
-                    const realProxyExecute = tool.execute as RealToolExecute
-                    tool.execute = async (toolCallId, args) => {
-                        const a = (args ?? {}) as Record<string, unknown>
-                        const raw = typeof a.tool_name === 'string' ? a.tool_name : ''
-                        // Resolve the same way `call_tool` will at dispatch time
-                        // (mcp-proxy.ts `resolveProxyRemoteName`): prefer the raw
-                        // name when it exists in the exposed catalog, only strip
-                        // `<prefix>__` when the stripped name does. Unconditionally
-                        // stripping was a bypass: a remote tool whose RAW name was
-                        // `<prefix>__delete` would gate as `delete` (no entry,
-                        // policy=allow) while dispatch ran the raw `<prefix>__delete`.
-                        // Sharing the resolver keeps the two paths in lockstep.
-                        const remoteName = proxyEntry.resolveRemoteName(raw)
-                        const exposedName = `${proxyEntry.client.prefix}${PREFIX_SEPARATOR}${remoteName}`
-                        const gate = lookupMcpToolApproval(exposedName, rev.spec)
-                        if (gate?.requires_approval) {
-                            return queueGated(exposedName, toolCallId, a, gate.approval_policy)
-                        }
-                        return realProxyExecute(toolCallId, a)
-                    }
+                    tools[i] = gateTool(
+                        tool,
+                        (_toolCallId, args) => {
+                            const raw = typeof args.tool_name === 'string' ? args.tool_name : ''
+                            // Resolve the same way `call_tool` will at dispatch time
+                            // (mcp-proxy.ts `resolveProxyRemoteName`): prefer the raw
+                            // name when it exists in the exposed catalog, only strip
+                            // `<prefix>__` when the stripped name does. Gate and dispatch
+                            // must key on the same name or one tool gates while another runs.
+                            const remoteName = proxyEntry.resolveRemoteName(raw)
+                            const exposedName = `${proxyEntry.client.prefix}${PREFIX_SEPARATOR}${remoteName}`
+                            const gate = lookupMcpToolApproval(exposedName, rev.spec)
+                            return gate?.requires_approval
+                                ? { gate: true, toolName: exposedName, policy: gate.approval_policy }
+                                : { gate: false }
+                        },
+                        queueGated
+                    )
                     continue
                 }
                 // Synthetic proxy read-only helpers (`explore_tools` /
@@ -635,6 +623,7 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
                 // `lookupMcpToolApproval` (which can't tell a synthetic helper from
                 // a real same-named tool); the proxy-aware check lives here.
                 if (isProxyReadOnlyHelper(id, proxiedPrefixes)) {
+                    tools[i] = gateTool(tool, () => ({ gate: false }), queueGated)
                     continue
                 }
 
@@ -670,12 +659,17 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
                     : mcpGate?.requires_approval
                       ? mcpGate.approval_policy
                       : null
-                if (policy) {
-                    tool.execute = async (toolCallId, args) =>
-                        queueGated(id, toolCallId, (args ?? {}) as Record<string, unknown>, policy)
-                }
+                tools[i] = gateTool(
+                    tool,
+                    () => (policy ? { gate: true, toolName: id, policy } : { gate: false }),
+                    queueGated
+                )
             }
         }
+
+        // Fail-closed: every tool must be `gateTool`-branded before dispatch
+        // (see gate-tool.ts).
+        assertToolsGated(tools)
 
         const sink: AgentEventSink = async (event: AgentEvent): Promise<void> => {
             switch (event.type) {

--- a/products/agent_platform/services/agent-runner/src/loop/gate-tool.ts
+++ b/products/agent_platform/services/agent-runner/src/loop/gate-tool.ts
@@ -1,0 +1,73 @@
+import type { AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core'
+import type { TSchema } from '@earendil-works/pi-ai'
+
+import type { ApprovalPolicy } from './approval'
+import type { RealToolExecute, ToolResultDetails } from './build-agent-tools'
+
+/** Per-call gate outcome: dispatch for real, or queue for a human decision
+ *  under `toolName` (which may differ from the tool's own name — the MCP
+ *  proxy's `call_tool` re-keys onto the underlying remote tool). */
+export type GateDecision = { gate: false } | { gate: true; toolName: string; policy: ApprovalPolicy }
+
+/** Decide the gate outcome for one call. Most tools ignore the args (a fixed
+ *  policy resolved once at session start); the MCP proxy's `call_tool`
+ *  inspects `args.tool_name` to re-key the gate per call. */
+export type ResolveGate = (toolCallId: string, args: Record<string, unknown>) => GateDecision | Promise<GateDecision>
+
+/** Queues a gated call for a human decision instead of running it. */
+export type QueueGated = (
+    toolName: string,
+    toolCallId: string,
+    args: Record<string, unknown>,
+    policy: ApprovalPolicy
+) => Promise<AgentToolResult<ToolResultDetails>>
+
+/** Set by `gateTool`, checked by `assertToolsGated`. Module-private so
+ *  nothing outside this file can forge the brand on a hand-rolled tool. */
+const GATED = Symbol('gateTool.branded')
+
+type Gated<T> = T & { [GATED]?: true }
+
+/**
+ * Wrap a tool's `execute` so every call is routed through `resolve` first:
+ * gated calls queue via `queue` (never touching the real executor); ungated
+ * calls run the tool's original `execute` unchanged. Returns a new tool
+ * object carrying the brand `assertToolsGated` checks for.
+ *
+ * This is the ONLY place that is allowed to decide "does this call reach the
+ * real executor" — every tool lane (native/custom/client/MCP inline/MCP
+ * proxy) must construct its dispatched tool through this function.
+ */
+export function gateTool(
+    tool: AgentTool<TSchema, ToolResultDetails>,
+    resolve: ResolveGate,
+    queue: QueueGated
+): AgentTool<TSchema, ToolResultDetails> {
+    const realExecute = tool.execute as RealToolExecute
+    const gated: Gated<AgentTool<TSchema, ToolResultDetails>> = {
+        ...tool,
+        execute: async (toolCallId, args) => {
+            const a = (args ?? {}) as Record<string, unknown>
+            const decision = await resolve(toolCallId, a)
+            return decision.gate ? queue(decision.toolName, toolCallId, a, decision.policy) : realExecute(toolCallId, a)
+        },
+    }
+    gated[GATED] = true
+    return gated
+}
+
+/**
+ * Fail-closed chokepoint: throws (naming the tool) unless every tool carries
+ * the brand `gateTool` stamps. Call at the single point the driver hands the
+ * tool surface to the model loop — an unbranded tool means some lane built an
+ * `AgentTool[]` without routing through `gateTool`.
+ */
+export function assertToolsGated(tools: ReadonlyArray<AgentTool<TSchema, ToolResultDetails>>): void {
+    for (const tool of tools) {
+        if (!(tool as Gated<AgentTool<TSchema, ToolResultDetails>>)[GATED]) {
+            throw new Error(
+                `approval gate bypassed for tool "${tool.name}" — every tool must be wrapped via gateTool() before dispatch`
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
