### PR TITLE
refactor(agent_platform): single-source trigger routes and retire hand-mirrors

### DIFF
--- a/products/agent_platform/backend/logic/generated.py
+++ b/products/agent_platform/backend/logic/generated.py
@@ -38,6 +38,10 @@ def _load(name: str) -> Any:
 # Per-trigger-type required secrets (source: trigger-secrets.ts).
 TRIGGER_REQUIRED_SECRETS: dict[str, list[dict[str, Any]]] = _load("trigger_required_secrets.generated.json")
 
+# Per-trigger ingress route catalogue `{route_name: path}`, `{}` for triggers with no
+# inbound HTTP route (cron). Source: trigger-routes.ts, also imported by agent-ingress so the two can't drift.
+TRIGGER_ROUTES: dict[str, dict[str, str]] = _load("trigger_routes.generated.json")
+
 # States the runner writes to `agent_tool_approval_request.state` (source: approval-store.ts).
 # Consumed by the DRF serializer choices and the model's DB CheckConstraint.
 APPROVAL_REQUEST_STATES: list[str] = _load("approval_request_states.generated.json")

--- a/products/agent_platform/backend/logic/trigger_routes.generated.json
+++ b/products/agent_platform/backend/logic/trigger_routes.generated.json
@@ -1,0 +1,22 @@
+{
+    "chat": {
+        "run": "/run",
+        "send": "/send",
+        "cancel": "/cancel",
+        "listen": "/listen",
+        "client_tool_result": "/client_tool_result"
+    },
+    "slack": {
+        "events": "/slack/events",
+        "interactivity": "/slack/interactivity"
+    },
+    "cron": {},
+    "webhook": {
+        "post": "/webhook"
+    },
+    "mcp": {
+        "rpc": "/mcp",
+        "stream": "/mcp/stream",
+        "connect_info": "/mcp/connect-info"
+    }
+}

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -72,7 +72,7 @@ from posthog.permissions import get_authenticator_scopes
 from posthog.security.outbound_proxy import internal_requests
 
 from ..db import WRITER_DB
-from ..logic.generated import APPROVAL_REQUEST_STATES, ASSISTANT_STOP_REASONS
+from ..logic.generated import APPROVAL_REQUEST_STATES, ASSISTANT_STOP_REASONS, TRIGGER_ROUTES
 from ..logic.internal_jwt import AgentInternalAudience, encode_agent_internal_jwt
 from ..logic.janitor_client import JanitorClient, JanitorClientError, default_client
 from ..logic.kernel_skills import all_kernel_skill_ids, kernel_skills_for
@@ -100,6 +100,10 @@ from .serializers import (
 )
 
 logger = logging.getLogger(__name__)
+
+# `TRIGGER_ROUTES` keys are the full trigger-kind enumeration (`Record<TriggerType, …>`,
+# cron included), so help_text can render the list without hand-copying it.
+_TRIGGER_KIND_ENUM = " | ".join(TRIGGER_ROUTES.keys())
 
 
 def _resolve_application(queryset: QuerySet, lookup_value: str | None) -> AgentApplication | None:
@@ -275,43 +279,11 @@ def _mint_preview_jwt(
     return token, ttl_seconds
 
 
-# Per-trigger route catalogue. Mirrors the `path:` arrays in each
-# `services/agent-ingress/src/triggers/<type>.ts` `routes` export — keep
-# these tables in sync (a sibling test validates the chat one). Source of
-# truth is still the ingress; this is here so the preview-token caller
-# doesn't have to grep the ingress source to know which path to hit.
-_TRIGGER_ROUTES: dict[str, dict[str, str]] = {
-    "chat": {
-        "run": "/run",
-        "send": "/send",
-        "cancel": "/cancel",
-        "listen": "/listen",
-        "client_tool_result": "/client_tool_result",
-    },
-    "mcp": {
-        "rpc": "/mcp",
-        "stream": "/mcp/stream",
-        "connect_info": "/mcp/connect-info",
-    },
-    "slack": {
-        "events": "/slack/events",
-        "interactivity": "/slack/interactivity",
-    },
-    "webhook": {
-        "post": "/webhook",
-    },
-    # `cron` triggers have no externally-callable ingress endpoint —
-    # they fire from the janitor's scheduler. Omit from the catalogue
-    # so the preview response doesn't advertise a URL the caller can't
-    # actually hit.
-}
-
-
 def _build_preview_endpoints(ingress_slug: str, spec: dict[str, Any]) -> dict[str, dict[str, str]]:
-    """Return `{trigger_type: {route_name: absolute_url}}` for every
-    trigger the spec declares that has a public ingress route in
-    `_TRIGGER_ROUTES`. Empty when no public agent-ingress URL is configured
-    for the active routing mode (local dev without `bin/agent-tunnel`)."""
+    """Return `{trigger_type: {route_name: absolute_url}}` for every spec trigger with a
+    public ingress route in `TRIGGER_ROUTES`. `cron` maps to `{}` (no ingress endpoint) and
+    is skipped. Empty when no public agent-ingress URL is configured (local dev without
+    `bin/agent-tunnel`)."""
     triggers = spec.get("triggers") or []
     if not isinstance(triggers, list):
         return {}
@@ -322,7 +294,7 @@ def _build_preview_endpoints(ingress_slug: str, spec: dict[str, Any]) -> dict[st
         ttype = trigger.get("type")
         if not isinstance(ttype, str):
             continue
-        routes = _TRIGGER_ROUTES.get(ttype)
+        routes = TRIGGER_ROUTES.get(ttype)
         if not routes:
             continue
         # First trigger of a given type wins; spec-side validation
@@ -1111,7 +1083,7 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                                     required=False,
                                     help_text=(
                                         "Trigger-specific metadata stamped at session creation. Discriminated on "
-                                        "`kind`: chat | slack | cron | webhook | mcp. The Zod source of truth is "
+                                        f"`kind`: {_TRIGGER_KIND_ENUM}. The Zod source of truth is "
                                         "`agent-shared/src/runtime/trigger-metadata.ts`; the node side validates "
                                         "and strips unknown keys at the persistence boundary, so consumers can "
                                         "trust `kind` and per-kind fields. TODO: narrow this DictField to a "
@@ -1318,7 +1290,7 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                         required=False,
                         help_text=(
                             "Trigger-specific metadata stamped at session creation. Discriminated on "
-                            "`kind`: chat | slack | cron | webhook | mcp. The Zod source of truth is "
+                            f"`kind`: {_TRIGGER_KIND_ENUM}. The Zod source of truth is "
                             "`agent-shared/src/runtime/trigger-metadata.ts`; the node side validates and "
                             "strips unknown keys at the persistence boundary, so consumers can trust "
                             "`kind` and per-kind fields. TODO: narrow this DictField to a polymorphic "
@@ -3254,7 +3226,7 @@ class AgentFleetViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                                     required=False,
                                     help_text=(
                                         "Trigger-specific metadata stamped at session creation. Discriminated on "
-                                        "`kind`: chat | slack | cron | webhook | mcp. The Zod source of truth is "
+                                        f"`kind`: {_TRIGGER_KIND_ENUM}. The Zod source of truth is "
                                         "`agent-shared/src/runtime/trigger-metadata.ts`; the node side validates "
                                         "and strips unknown keys at the persistence boundary, so consumers can "
                                         "trust `kind` and per-kind fields. TODO: narrow this DictField to a "

--- a/products/agent_platform/backend/tests/test_spec_schema.py
+++ b/products/agent_platform/backend/tests/test_spec_schema.py
@@ -15,7 +15,7 @@ import pytest
 
 from rest_framework.exceptions import ValidationError
 
-from ..logic.generated import APPROVAL_REQUEST_STATES, ASSISTANT_STOP_REASONS, TRIGGER_REQUIRED_SECRETS
+from ..logic.generated import APPROVAL_REQUEST_STATES, ASSISTANT_STOP_REASONS, TRIGGER_REQUIRED_SECRETS, TRIGGER_ROUTES
 from ..logic.spec_schema import SLACK_BOT_TOKEN_KEY, SLACK_SIGNING_SECRET_KEY, missing_required_secrets
 from ..presentation.serializers import AgentRevisionSerializer, AgentSpecField
 
@@ -132,6 +132,14 @@ def test_generated_vocabularies_load_and_are_nonempty() -> None:
     assert APPROVAL_REQUEST_STATES and all(isinstance(s, str) and s for s in APPROVAL_REQUEST_STATES)
     assert ASSISTANT_STOP_REASONS and all(isinstance(s, str) and s for s in ASSISTANT_STOP_REASONS)
     assert TRIGGER_REQUIRED_SECRETS.get("slack")
+    assert TRIGGER_ROUTES
+    assert TRIGGER_ROUTES.get("chat") == {
+        "run": "/run",
+        "send": "/send",
+        "cancel": "/cancel",
+        "listen": "/listen",
+        "client_tool_result": "/client_tool_result",
+    }
 
 
 def test_missing_required_secrets_fails_closed_on_unregistered_trigger() -> None:

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
@@ -13,7 +13,7 @@
 
 import { z } from 'zod'
 
-import { buildClientToolResultMarker } from '@posthog/agent-shared'
+import { buildClientToolResultMarker, TRIGGER_ROUTES } from '@posthog/agent-shared'
 
 import { buildElevationResponse, principalDisplay, recordElevationRequest, requireAclAccess } from '../enqueue/acl'
 import { enqueueOrResume } from '../enqueue/enqueue'
@@ -318,35 +318,35 @@ export const chatTrigger: TriggerModule = {
     routes: [
         defineRoute({
             method: 'POST',
-            path: '/run',
+            path: TRIGGER_ROUTES.chat.run,
             auth: 'agent_spec',
             schema: ChatRunBodySchema,
             handler: runHandler,
         }),
         defineRoute({
             method: 'POST',
-            path: '/send',
+            path: TRIGGER_ROUTES.chat.send,
             auth: 'agent_spec',
             schema: ChatSendBodySchema,
             handler: sendHandler,
         }),
         defineRoute({
             method: 'POST',
-            path: '/cancel',
+            path: TRIGGER_ROUTES.chat.cancel,
             auth: 'agent_spec',
             schema: ChatCancelBodySchema,
             handler: cancelHandler,
         }),
         defineRoute({
             method: 'GET',
-            path: '/listen',
+            path: TRIGGER_ROUTES.chat.listen,
             auth: 'agent_spec',
             schema: ChatListenQuerySchema,
             handler: listenHandler,
         }),
         defineRoute({
             method: 'POST',
-            path: '/client_tool_result',
+            path: TRIGGER_ROUTES.chat.client_tool_result,
             auth: 'agent_spec',
             schema: ChatClientToolResultBodySchema,
             handler: clientToolResultHandler,

--- a/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
@@ -45,7 +45,13 @@ import { randomUUID } from 'crypto'
 import { Request } from 'express'
 import { z } from 'zod'
 
-import { AgentSession, lastAssistantTextPreview, SessionPrincipal, triggerAuthConfig } from '@posthog/agent-shared'
+import {
+    AgentSession,
+    lastAssistantTextPreview,
+    SessionPrincipal,
+    TRIGGER_ROUTES,
+    triggerAuthConfig,
+} from '@posthog/agent-shared'
 
 import { buildElevationResponse, principalDisplay, recordElevationRequest, requireAclAccess } from '../enqueue/acl'
 import { principalsMatch } from '../enqueue/auth'
@@ -594,21 +600,21 @@ export const mcpTrigger: TriggerModule = {
     routes: [
         {
             method: 'POST',
-            path: '/mcp',
+            path: TRIGGER_ROUTES.mcp.rpc,
             bodySchema: z.toJSONSchema(McpRequestBodySchema),
             auth: 'custom',
             handler: mcpHandler,
         },
         defineRoute({
             method: 'GET',
-            path: '/mcp/stream',
+            path: TRIGGER_ROUTES.mcp.stream,
             auth: 'agent_spec',
             schema: McpStreamQuerySchema,
             handler: mcpStreamHandler,
         }),
         {
             method: 'GET',
-            path: '/mcp/connect-info',
+            path: TRIGGER_ROUTES.mcp.connect_info,
             // Public — anyone who knows the URL can ask "how do I connect?".
             // Discovery cannot itself require auth without a chicken-and-egg.
             auth: 'public',

--- a/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
@@ -25,6 +25,7 @@ import {
     principalsMatch,
     SessionPrincipal,
     SLACK_BOT_TOKEN_KEY,
+    TRIGGER_ROUTES,
 } from '@posthog/agent-shared'
 
 import { applyElevationDecline, applyElevationGrant, authorizeGrant } from '../enqueue/acl'
@@ -731,14 +732,14 @@ export const slackTrigger: TriggerModule = {
     routes: [
         {
             method: 'POST',
-            path: '/slack/events',
+            path: TRIGGER_ROUTES.slack.events,
             bodySchema: z.toJSONSchema(SlackEventBodySchema),
             auth: 'slack_signing',
             handler: slackEventsHandler,
         },
         {
             method: 'POST',
-            path: '/slack/interactivity',
+            path: TRIGGER_ROUTES.slack.interactivity,
             // Slack posts urlencoded `payload=<json>` — published schema is the
             // decoded JSON so authoring tools see the actual interactivity
             // contract, not just an opaque form-data envelope.

--- a/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
@@ -11,6 +11,8 @@ import { Request } from 'express'
 import { createHash } from 'node:crypto'
 import type { z } from 'zod'
 
+import { TRIGGER_ROUTES } from '@posthog/agent-shared'
+
 import { principalDisplay } from '../enqueue/acl'
 import { enqueueOrResume } from '../enqueue/enqueue'
 import { defineRoute, type AuthedRouteCtx, type TriggerModule } from './types'
@@ -104,7 +106,7 @@ export const webhookTrigger: TriggerModule = {
     routes: [
         defineRoute({
             method: 'POST',
-            path: '/webhook',
+            path: TRIGGER_ROUTES.webhook.post,
             auth: 'agent_spec',
             schema: WebhookBodySchema,
             handler: webhookHandler,

--- a/products/agent_platform/services/agent-shared/src/index.ts
+++ b/products/agent_platform/services/agent-shared/src/index.ts
@@ -20,6 +20,7 @@ export * from './spec/tool-approval'
 export * from './spec/framework-preamble'
 export * from './spec/system-prompt'
 export * from './spec/trigger-secrets'
+export * from './spec/trigger-routes'
 
 export * from './storage/bundle'
 export * from './storage/s3-bundle-store'

--- a/products/agent_platform/services/agent-shared/src/spec/spec-codegen.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec-codegen.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import { APPROVAL_REQUEST_STATES } from '../persistence/approval-store'
 import { ASSISTANT_STOP_REASONS } from './spec'
+import { TRIGGER_ROUTES } from './trigger-routes'
 import { TRIGGER_REQUIRED_SECRETS } from './trigger-secrets'
 
 /**
@@ -34,6 +35,10 @@ export const GENERATED_ARTIFACTS: GeneratedArtifact[] = [
     {
         path: backendLogic('trigger_required_secrets.generated.json'),
         content: () => asJson(TRIGGER_REQUIRED_SECRETS),
+    },
+    {
+        path: backendLogic('trigger_routes.generated.json'),
+        content: () => asJson(TRIGGER_ROUTES),
     },
     {
         path: backendLogic('approval_request_states.generated.json'),

--- a/products/agent_platform/services/agent-shared/src/spec/trigger-routes.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/trigger-routes.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-trigger-type ingress route catalogue. Single source shared by agent-ingress
+ * (each trigger module imports its `path:` values from here) and Django's
+ * preview-endpoint builder (via the generated artifact), so the routes can't drift.
+ * `cron` maps to `{}` — janitor-fired, no inbound route. `Record<TriggerType, …>`
+ * is total: a new trigger type without an entry here fails to compile.
+ */
+
+import type { TriggerType } from './spec'
+
+export const TRIGGER_ROUTES: Record<TriggerType, Record<string, string>> = {
+    chat: {
+        run: '/run',
+        send: '/send',
+        cancel: '/cancel',
+        listen: '/listen',
+        client_tool_result: '/client_tool_result',
+    },
+    slack: {
+        events: '/slack/events',
+        interactivity: '/slack/interactivity',
+    },
+    cron: {},
+    webhook: {
+        post: '/webhook',
+    },
+    mcp: {
+        rpc: '/mcp',
+        stream: '/mcp/stream',
+        connect_info: '/mcp/connect-info',
+    },
+}

--- a/products/agent_platform/services/agent-tests/src/examples/seed.py
+++ b/products/agent_platform/services/agent-tests/src/examples/seed.py
@@ -99,12 +99,30 @@ METADATA: dict[str, dict[str, str]] = {
 # auth modes. Mirrors the declarative/intrinsic split in `spec.ts`.
 DECLARATIVE_TRIGGERS: set[str] = {"webhook", "chat", "mcp"}
 
-# Secret keys each trigger type requires before promote — mirrors
-# TRIGGER_REQUIRED_SECRETS in products/agent_platform/backend/spec_schema.py.
-# Used only by the optional SEED_DUMMY_SECRETS placeholder path below.
-TRIGGER_REQUIRED_SECRETS: dict[str, list[str]] = {
-    "slack": ["SLACK_SIGNING_SECRET", "SLACK_BOT_TOKEN"],
-}
+
+def _load_trigger_required_secrets() -> dict[str, list[str]]:
+    """Required secret keys per trigger type, read from the checked-in
+    generated artifact (`trigger_required_secrets.generated.json`, emitted
+    from `services/agent-shared/src/spec/trigger-secrets.ts`) rather than
+    hand-copied — the same registry `backend/logic/spec_schema.py`'s promote
+    gate reads via `backend/logic/generated.py`. Only `required: true`
+    entries block promote, matching that gate's filter. Used only by the
+    optional SEED_DUMMY_SECRETS placeholder path below."""
+    backend_logic_dir = next(
+        (p / "backend" / "logic" for p in EXAMPLES_ROOT.parents if (p / "backend" / "logic").is_dir()),
+        None,
+    )
+    if backend_logic_dir is None:
+        raise RuntimeError("couldn't locate products/agent_platform/backend/logic from seed.py's path")
+    artifact = backend_logic_dir / "trigger_required_secrets.generated.json"
+    raw: dict[str, list[dict[str, object]]] = json.loads(artifact.read_text(encoding="utf-8"))
+    return {
+        trigger_type: [str(r["key"]) for r in requirements if r.get("required")]
+        for trigger_type, requirements in raw.items()
+    }
+
+
+TRIGGER_REQUIRED_SECRETS: dict[str, list[str]] = _load_trigger_required_secrets()
 
 # Opt-in: set obviously-fake placeholder values for any secret an agent requires
 # (declared `spec.secrets[]` + per-trigger required keys) that isn't already


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
