### PR TITLE
feat(tasks): surface Task.internal in Django admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -11,14 +11,14 @@ from .models import CodeInvite, CodeInviteRedemption, SandboxSnapshot, Task, Tas
 
 @admin.register(Task)
 class TaskAdmin(admin.ModelAdmin):
-    list_display = ("slug", "title", "origin_product", "team", "created_by", "created_at", "deleted")
-    list_filter = ("origin_product", "deleted", "created_at")
+    list_display = ("slug", "title", "origin_product", "internal", "team", "created_by", "created_at", "deleted")
+    list_filter = ("origin_product", "internal", "deleted", "created_at")
     search_fields = ("title", "description", "repository")
     readonly_fields = ("id", "slug", "task_number", "created_at", "updated_at", "deleted_at")
     autocomplete_fields = ("team", "created_by", "github_integration", "github_user_integration")
 
     fieldsets = (
-        (None, {"fields": ("id", "slug", "task_number", "title", "description", "origin_product")}),
+        (None, {"fields": ("id", "slug", "task_number", "title", "description", "origin_product", "internal")}),
         ("Team & User", {"fields": ("team", "created_by")}),
         ("Repository", {"fields": ("github_integration", "github_user_integration", "repository")}),
         ("Schema", {"fields": ("json_schema",)}),


### PR DESCRIPTION
## Problem

The `Task.internal` flag controls whether a task shows up in a user's task list (it's kept orthogonal to `origin_product`). But it isn't surfaced anywhere readable — it's not in the Django admin — which made it hard to debug the case [raised in Slack](https://posthog.slack.com/archives/C09G8Q32R6F/p1782980449305369?thread_ts=1782980449.305369&cid=C09G8Q32R6F) where some auto-started tasks appeared in a user's list because they had `internal=False`.

## Changes

Surface `Task.internal` in the Django admin so it's debuggable:
- Add `internal` to the Task list display and as a list filter.
- Show `internal` on the task detail page.

Note: `TaskSerializer` already includes `internal` in its fields, so no serializer change was needed.

## How did you test this code?

- Change is limited to `TaskAdmin` display/filter/fieldset config referencing the existing `Task.internal` `BooleanField`; no logic or migration. Not run locally by the agent — happy to add manual verification notes if wanted.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1782980449305369?thread_ts=1782980449.305369&cid=C09G8Q32R6F)*
