### PR TITLE
fix(tasks): use sync Redis client for task-run stream publish

### DIFF
--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -12,6 +12,15 @@ from redis import asyncio as aioredis
 
 _client_map: Dict[str, Any] = {}
 _test_async_client_map: Dict[str, Any] = {}  # For test mode, where we don't need per-loop isolation
+_test_fake_server_map: Dict[str, Any] = {}  # Shared FakeServer per url so sync + async fake clients see one store
+
+
+def _get_test_fake_server(redis_url: str):
+    import fakeredis
+
+    if redis_url not in _test_fake_server_map:
+        _test_fake_server_map[redis_url] = fakeredis.FakeServer()
+    return _test_fake_server_map[redis_url]
 
 
 def get_client(redis_url: Optional[str] = None) -> redis.Redis:
@@ -26,7 +35,7 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
             # This import is only used in tests, we don't want to import it in production
             import fakeredis
 
-            client: Any = fakeredis.FakeRedis()
+            client: Any = fakeredis.FakeRedis(server=_get_test_fake_server(redis_url))
         elif redis_url:
             client = redis.from_url(redis_url, db=0)
         else:
@@ -109,7 +118,7 @@ def get_async_client(redis_url: Optional[str] = None):
         if redis_url not in _test_async_client_map:
             import fakeredis
 
-            _test_async_client_map[redis_url] = fakeredis.FakeAsyncRedis()
+            _test_async_client_map[redis_url] = fakeredis.FakeAsyncRedis(server=_get_test_fake_server(redis_url))
         return _test_async_client_map[redis_url]
     else:
         # Production code: use per-loop caching for real Redis connections

--- a/products/tasks/backend/logic/stream/redis_stream.py
+++ b/products/tasks/backend/logic/stream/redis_stream.py
@@ -7,11 +7,10 @@ from django.conf import settings
 
 import structlog
 import redis.exceptions as redis_exceptions
-from asgiref.sync import async_to_sync
 
 from products.tasks.backend.logic.services.connection_token import SANDBOX_EVENT_INGEST_TOKEN_TTL
 from products.tasks.backend.logic.services.sandbox_config import SANDBOX_TTL_SECONDS
-from products.tasks.backend.redis import get_tasks_stream_redis_async
+from products.tasks.backend.redis import get_tasks_stream_redis_async, get_tasks_stream_redis_sync
 
 logger = structlog.get_logger(__name__)
 
@@ -516,14 +515,18 @@ def publish_task_run_stream_event(run_id: str, event: dict, use_dedicated: bool 
 
     This is intended for sync Django model/view code that needs to mirror
     user-visible task-run events into the live SSE stream.
+
+    Bouncing back to the loop via ``async_to_sync`` would block that executor
+    thread. A sync client does the I/O inline on the calling thread with no
+    event-loop round-trip.
     """
-
-    async def _publish() -> str:
-        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), use_dedicated)
-        return await redis_stream.write_event(event)
-
+    stream_key = get_task_run_stream_key(run_id)
+    client = get_tasks_stream_redis_sync(use_dedicated)
+    raw = json.dumps(event)
     try:
-        return async_to_sync(_publish)()
+        stream_id = client.xadd(stream_key, {DATA_KEY: raw}, maxlen=TASK_RUN_STREAM_MAX_LENGTH, approximate=True)
+        client.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+        return _normalize_stream_id(stream_id)
     except Exception:
         logger.exception("task_run_stream_publish_failed", run_id=run_id)
         return None
@@ -531,12 +534,37 @@ def publish_task_run_stream_event(run_id: str, event: dict, use_dedicated: bool 
 
 def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -> None:
     """Synchronously publish a completion sentinel for a task-run stream."""
-
-    async def _publish() -> None:
-        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), use_dedicated)
-        await redis_stream.mark_complete()
+    stream_key = get_task_run_stream_key(run_id)
+    completed_key = get_task_run_stream_completed_key(stream_key)
+    client = get_tasks_stream_redis_sync(use_dedicated)
+    raw = json.dumps({"type": "STREAM_STATUS", "status": "complete"})
 
     try:
-        async_to_sync(_publish)()
+        if settings.TEST:
+            # fakeredis doesn't support WATCH/MULTI; the sequencing race the
+            # transaction guards against can't happen under the test harness.
+            if client.exists(completed_key):
+                return
+            client.xadd(stream_key, {DATA_KEY: raw}, maxlen=TASK_RUN_STREAM_MAX_LENGTH, approximate=True)
+            client.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+            client.set(completed_key, "1", ex=TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
+            return
+
+        with client.pipeline(transaction=True) as pipe:
+            while True:
+                try:
+                    pipe.watch(completed_key)
+                    if pipe.exists(completed_key):
+                        pipe.reset()
+                        return
+                    pipe.multi()
+                    pipe.xadd(stream_key, {DATA_KEY: raw}, maxlen=TASK_RUN_STREAM_MAX_LENGTH, approximate=True)
+                    pipe.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+                    pipe.set(completed_key, "1", ex=TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
+                    pipe.execute()
+                    return
+                except redis_exceptions.WatchError:
+                    logger.debug("task_run_stream_complete_watch_retry", run_id=run_id)
+                    continue
     except Exception:
         logger.exception("task_run_stream_complete_publish_failed", run_id=run_id)

--- a/products/tasks/backend/tests/test_redis_stream_routing.py
+++ b/products/tasks/backend/tests/test_redis_stream_routing.py
@@ -1,10 +1,15 @@
+import asyncio
+import concurrent.futures
+
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
 
+from asgiref.sync import sync_to_async
 from parameterized import parameterized
 
 from products.tasks.backend import redis as tasks_redis
+from products.tasks.backend.logic.stream import redis_stream
 
 
 class TestStreamRouting(SimpleTestCase):
@@ -51,3 +56,53 @@ class TestEvaluateDedicatedStreamFlag(SimpleTestCase):
     def test_fails_safe_to_shared_on_flag_error(self):
         with patch.object(tasks_redis.posthoganalytics, "feature_enabled", side_effect=RuntimeError("boom")):
             self.assertFalse(tasks_redis.evaluate_dedicated_stream_flag(organization_id="org", distinct_id="u"))
+
+
+class _ThreadHungryAsyncClient:
+    """Async Redis stand-in whose ops need a default-executor thread to finish.
+
+    Mirrors real asyncio Redis: connecting resolves the host via
+    loop.run_in_executor(None, getaddrinfo), so each op consumes a thread from the
+    same bounded pool the activity bodies run on.
+    """
+
+    async def _needs_thread(self, value):
+        return await asyncio.get_running_loop().run_in_executor(None, lambda: value)
+
+    async def xadd(self, *args, **kwargs):
+        return await self._needs_thread("1-0")
+
+    async def expire(self, *args, **kwargs):
+        return await self._needs_thread(True)
+
+
+class TestSyncPublishDoesNotStarveExecutor(SimpleTestCase):
+    def test_publish_event_does_not_deadlock_bounded_executor(self):
+        # Asyncified activities run their body on the event loop's bounded default
+        # ThreadPoolExecutor (sync_to_async(thread_sensitive=False)). A regression to
+        # async_to_sync over the async client would bounce back to the loop and need a
+        # *second* executor thread, so once concurrent bodies fill the pool nothing
+        # completes. The async client is patched to be thread-hungry precisely to catch
+        # that: the fix uses the sync client and never touches it (asserted below), so
+        # this run completes; a revert would use it and deadlock this gather().
+        workers = 4
+        n = workers + 4
+
+        async def main():
+            asyncio.get_running_loop().set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=workers))
+
+            async def body(i):
+                return await sync_to_async(redis_stream.publish_task_run_stream_event, thread_sensitive=False)(
+                    "run-under-test", {"type": "probe", "i": i}, False
+                )
+
+            return await asyncio.wait_for(asyncio.gather(*(body(i) for i in range(n))), timeout=15)
+
+        with patch.object(
+            redis_stream, "get_tasks_stream_redis_async", return_value=_ThreadHungryAsyncClient()
+        ) as async_client:
+            results = asyncio.run(main())
+
+        async_client.assert_not_called()  # sync publish path must not build the async client
+        self.assertEqual(len(results), n)
+        self.assertTrue(all(r is not None for r in results))


### PR DESCRIPTION
## Problem

Cloud task (`process-task`) workflows in dev were failing because their first activity, `get_task_processing_context`, hit its 2-minute `StartToClose` timeout on all 3 attempts and then failed the whole workflow. `update_task_run_status` showed the same thing against its 1-minute limit. Both are trivial activities (a DB read plus a status write), so a multi-minute hang made no sense.

The root cause is a thread-pool starvation deadlock in the Temporal worker, not slow I/O.

Every asyncified activity body runs on the event loop's default `ThreadPoolExecutor` via `sync_to_async(thread_sensitive=False)`. That pool is sized `min(32, os.cpu_count() + 4)`, and the tasks-agent pods report `cpu_count == 2`, so it's only **6 threads**. Inside those bodies, `emit_agent_log` and `publish_stream_state_event` both call `publish_task_run_stream_event`, which used `async_to_sync` over the async Redis client. `async_to_sync` from inside a `sync_to_async` thread bounces the coroutine back to the loop and blocks the executor thread until it finishes. But the async Redis op itself needs another executor thread (asyncio resolves the host via `run_in_executor(None, getaddrinfo)`). Once 6 activity bodies are concurrently parked in `async_to_sync`, all 6 threads are occupied waiting for a coroutine that can never get a thread. The pool wedges, every asyncified activity across every workflow stalls, and Temporal can't interrupt a running sync thread so they hang until the server-side timeout fires.

A burst of ≥6 concurrent activities is enough to trip it. In dev (single replica) that happens constantly, e.g. a rollout re-dispatching in-flight activities. Prod runs many replicas so per-pod concurrency usually stays under 6, but it's the same latent bug and the same config, so a bunched-up pod can wedge there too.

## Changes

`publish_task_run_stream_event` and `publish_task_run_stream_complete` now talk to Redis through the blocking sync client (`get_tasks_stream_redis_sync`) and do their `xadd`/`expire`/`set` inline on the calling thread. No `async_to_sync`, no event-loop round-trip, so the activity body never needs a second executor thread. The completion sentinel keeps its optimistic `WATCH`/`MULTI` transaction against real Redis, with the same fakeredis-friendly simple path under tests that the async version had.

This is the root-cause fix. Raising the executor size or capping `max_concurrent_activities` would only move the threshold.

Also touches `posthog/redis.py`: in tests the sync (`get_client`) and async (`get_async_client`) fake Redis clients were separate `FakeRedis`/`FakeAsyncRedis` instances with no shared store, so a sync write was invisible to an async reader. Production has one Redis where both see the same data. Now both fake clients share a `FakeServer` per URL, which the SSE stream tests need (they seed via the sync publish and read back over the async reader) and which also flushes cleanly via the existing per-test `flushdb`.

## How did you test this code?

- Added `TestSyncPublishDoesNotStarveExecutor` in `test_redis_stream_routing.py`. It drives more concurrent activity bodies than the executor has threads through the real `publish_task_run_stream_event`, with the async client stubbed to need an executor thread (mirroring asyncio DNS). Reverting to the `async_to_sync` path makes it deadlock and time out; the sync path passes. I confirmed the differential: with the old body restored the test fails with `TimeoutError` at 15s, and with the fix it passes in ~0.1s.
- Ran the tasks stream test module (13 passing) and the `TaskRun` model tests that cover the emit/publish paths (28 passing). The 5 `test_heartbeat_workflow_*` failures in that class are pre-existing on master (they need a real Temporal connection the local env can't mock), unrelated to this change.

- The SSE stream tests in `test_api.py` (`TestTaskRunStream*`) initially failed in CI because seeded events landed in the sync fake store while the reader used the async one. Fixed by the shared `FakeServer` above; all `TestTaskRunStreamAPI`, `TestTaskRunStreamKeepaliveAPI`, and `TestTaskRunStreamConnectionCapAPI` cases pass locally now.
- Drove a full local cloud-task run against the PostHog Code app over CDP (the `posthog-code-cloud-e2e` skill): fresh task, a real resume (terminal run + snapshot), and a cold reload. All three exercised the changed publish paths (`emit_agent_log`, `emit_progress`, `publish_stream_state_event`) end-to-end with the conversation rendering once and in order, and no publish errors in the worker logs.

I (Claude) could not reproduce the DNS-based starvation with fakeredis directly, which is why the regression test stubs the async client to require a thread. That stub is the faithful stand-in for what real asyncio Redis does.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 4.8, via Claude Code) investigated a dev `process-task` timeout that Alessandro flagged, traced it to the executor-starvation deadlock, wrote the fix and the regression test, and ran the local e2e. Skills invoked: `writing-tests` (to gate the regression test) and `posthog-code-cloud-e2e` (for the local end-to-end run).

Investigation path: ruled out the obvious suspects first by probing from inside a dev worker pod. S3 via smokescreen, the app DB via pgbouncer (even at 40x concurrency), and Redis were all fast in isolation, and every activity stalled right after its first log line with zero exceptions. That pointed at the execution model rather than any dependency. `os.cpu_count() == 2` on the pod gave the 6-thread pool, and a small in-pod repro of the `async_to_sync`-inside-`sync_to_async` pattern deadlocked at concurrency ≥ 6, which nailed it.

Chose the sync-client fix over widening the executor because the nesting is deadlock-prone at any pool size once concurrency catches up. Scoped the change to the two sync publish entry points and confirmed they're the only `async_to_sync` calls on an asyncified-activity path (the other two in the tasks backend are a web-context workflow trigger and a DRF SSE view, neither on the worker).
