### PR TITLE
fix(tasks): make resume snapshot timeouts retryable, raise deadline

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -26,6 +26,7 @@ import modal
 import requests
 from modal.exception import (
     ConnectionError as ModalConnectionError,
+    ServiceError as ModalServiceError,
     TimeoutError as ModalTimeoutError,
 )
 
@@ -105,10 +106,13 @@ AGENT_SERVER_HEALTH_MAX_ATTEMPTS = 240
 TRANSIENT_SNAPSHOT_ERRORS: tuple[type[BaseException], ...] = (
     ModalTimeoutError,
     ModalConnectionError,
+    ModalServiceError,
     TimeoutError,
     ConnectionError,
     asyncio.CancelledError,
 )
+
+DIRECTORY_SNAPSHOT_TIMEOUT_SECONDS = 240
 
 SESSION_INIT_PROBE_HOSTS = (
     "gateway.us.posthog.com",
@@ -1086,7 +1090,7 @@ class ModalSandbox(SandboxBase):
         try:
             quoted_path = shlex.quote(path)
             self._sandbox.exec("bash", "-c", f"mkdir -p {quoted_path} && test -d {quoted_path}", timeout=30).wait()
-            image = snapshot_directory(path, ttl=None)
+            image = snapshot_directory(path, timeout=DIRECTORY_SNAPSHOT_TIMEOUT_SECONDS, ttl=None)
             snapshot_id = image.object_id
 
             logger.info(f"Created directory snapshot for sandbox {self.id}, path: {path}, snapshot ID: {snapshot_id}")

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from modal.exception import (
     ConnectionError as ModalConnectionError,
+    ServiceError as ModalServiceError,
     TimeoutError as ModalTimeoutError,
 )
 from requests.exceptions import ConnectionError, Timeout
@@ -25,6 +26,7 @@ from products.tasks.backend.logic.services.modal_sandbox import (
     _GHCR_RESOLVE_MAX_ATTEMPTS,
     AGENT_SERVER_PORT,
     DEFAULT_MODAL_REGION,
+    DIRECTORY_SNAPSHOT_TIMEOUT_SECONDS,
     SANDBOX_IMAGE,
     ModalSandbox,
     _get_modal_region,
@@ -989,6 +991,7 @@ class TestModalSandboxCreateSnapshot:
         [
             ModalTimeoutError("Deadline exceeded"),
             ModalConnectionError("connection reset"),
+            ModalServiceError("Timeout expired"),
             builtins.TimeoutError("timed out"),
             builtins.ConnectionError("connection error"),
             asyncio.CancelledError(),
@@ -1017,3 +1020,12 @@ class TestModalSandboxCreateSnapshot:
             mock_sandbox.create_snapshot()
 
         capture_exception.assert_called_once()
+
+    def test_create_directory_snapshot_overrides_modal_default_timeout(self, mock_sandbox: Any):
+        mock_sandbox._sandbox.snapshot_directory.return_value = MagicMock(object_id="im-dir-123")
+
+        assert mock_sandbox.create_directory_snapshot("/tmp/workspace") == "im-dir-123"
+
+        mock_sandbox._sandbox.snapshot_directory.assert_called_once_with(
+            "/tmp/workspace", timeout=DIRECTORY_SNAPSHOT_TIMEOUT_SECONDS, ttl=None
+        )

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1141,7 +1141,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 use_directory_snapshot=self.context.use_modal_directory_resume_snapshots,
             ),
             start_to_close_timeout=timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=1),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
         if result.external_id:
             workflow.logger.info(f"Resume snapshot created: {result.external_id} for sandbox {sandbox_id}")

--- a/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_resume_snapshot.py
@@ -12,6 +12,7 @@ from products.tasks.backend.constants import (
     SNAPSHOT_KIND_FILESYSTEM,
     SnapshotKind,
 )
+from products.tasks.backend.exceptions import SandboxNotRunningError, SnapshotTimeoutError
 from products.tasks.backend.logic.services.sandbox import get_sandbox_class
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.metrics import increment_snapshot_create, record_snapshot_create_latency_ms
@@ -65,6 +66,7 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
 
     if not sandbox.is_running():
         outcome = "sandbox_not_running"
+        logger.warning("create_resume_snapshot_sandbox_not_running", sandbox_id=input.sandbox_id, run_id=input.run_id)
         increment_snapshot_create(snapshot_kind, outcome)
         record_snapshot_create_latency_ms(snapshot_kind, outcome, int((time.perf_counter() - started_at) * 1000))
         return CreateResumeSnapshotOutput(external_id=None, snapshot_kind=snapshot_kind, error="Sandbox not running")
@@ -75,6 +77,23 @@ def create_resume_snapshot(input: CreateResumeSnapshotInput) -> CreateResumeSnap
             external_id = sandbox.create_directory_snapshot(snapshot_mount_path)
         else:
             external_id = sandbox.create_snapshot()
+    except SnapshotTimeoutError as e:
+        outcome = "transient_error"
+        logger.warning("create_resume_snapshot_transient_error", sandbox_id=input.sandbox_id, error=str(e))
+        increment_snapshot_create(snapshot_kind, outcome)
+        record_snapshot_create_latency_ms(snapshot_kind, outcome, int((time.perf_counter() - started_at) * 1000))
+        raise
+    except SandboxNotRunningError as e:
+        outcome = "sandbox_not_running"
+        logger.warning(
+            "create_resume_snapshot_sandbox_not_running",
+            sandbox_id=input.sandbox_id,
+            run_id=input.run_id,
+            error=str(e),
+        )
+        increment_snapshot_create(snapshot_kind, outcome)
+        record_snapshot_create_latency_ms(snapshot_kind, outcome, int((time.perf_counter() - started_at) * 1000))
+        return CreateResumeSnapshotOutput(external_id=None, snapshot_kind=snapshot_kind, error=str(e))
     except Exception as e:
         outcome = "failed"
         logger.warning("create_resume_snapshot_snapshot_failed", sandbox_id=input.sandbox_id, error=str(e))

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_create_resume_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_create_resume_snapshot.py
@@ -3,6 +3,7 @@ import pytest
 from asgiref.sync import async_to_sync
 
 from products.tasks.backend.constants import DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH, SNAPSHOT_KIND_DIRECTORY
+from products.tasks.backend.exceptions import SnapshotTimeoutError
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.process_task.activities.create_resume_snapshot import (
     CreateResumeSnapshotInput,
@@ -43,3 +44,31 @@ def test_create_directory_resume_snapshot_uses_tmp_mount_path(activity_environme
     assert output.external_id == "im-dir"
     assert output.snapshot_kind == SNAPSHOT_KIND_DIRECTORY
     assert output.snapshot_mount_path == DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH
+
+
+@pytest.mark.django_db
+def test_transient_snapshot_error_propagates_so_temporal_retries(activity_environment, mocker) -> None:
+    sandbox = mocker.Mock()
+    sandbox.is_running.return_value = True
+    sandbox.create_directory_snapshot.side_effect = SnapshotTimeoutError(
+        "Transient error creating directory snapshot",
+        {"sandbox_id": "sandbox-1"},
+        cause=TimeoutError("Timeout expired"),
+        capture=False,
+    )
+    SandboxClass = mocker.Mock()
+    SandboxClass.get_by_id.return_value = sandbox
+
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.create_resume_snapshot.get_sandbox_class",
+        return_value=SandboxClass,
+    )
+    update_state = mocker.patch.object(TaskRun, "update_state_atomic")
+
+    with pytest.raises(SnapshotTimeoutError):
+        async_to_sync(activity_environment.run)(
+            create_resume_snapshot,
+            CreateResumeSnapshotInput(sandbox_id="sandbox-1", run_id="run-1", use_directory_snapshot=True),
+        )
+
+    update_state.assert_not_called()

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1104,7 +1104,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     use_directory_snapshot=self.context.use_modal_directory_resume_snapshots,
                 ),
                 start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=1),
+                retry_policy=RetryPolicy(maximum_attempts=3),
             )
             if result.external_id:
                 workflow.logger.info(f"Resume snapshot created: {result.external_id} for sandbox {sandbox_id}")


### PR DESCRIPTION
## Problem

currently we call `snapshot_directory(path, ttl=None)` without a `timeout`, so Modal's default 55s deadline applies. Snapshotting a full `/tmp/workspace` checkout regularly takes longer

## Changes

- pass an explicit timeout
- add `modal.exception.ServiceError` to `TRANSIENT_SNAPSHOT_ERRORS`
