### PR TITLE
chore(posthog_ai): replace Monaco editor with @pierre/diffs for code rendering

### DIFF
--- a/products/posthog_ai/frontend/components/tool/DiffFileContent.tsx
+++ b/products/posthog_ai/frontend/components/tool/DiffFileContent.tsx
@@ -1,0 +1,71 @@
+import { type FileDiffMetadata, type FileDiffOptions, parseDiffFromFile } from '@pierre/diffs'
+import { FileDiff } from '@pierre/diffs/react'
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+import { useInView } from 'react-intersection-observer'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
+import { EditorSkeleton } from './EditorSkeleton'
+
+// Shiki bundled themes that read closest to GitHub's diff view; Pierre swaps between them based on
+// `themeType`, which we drive off PostHog's own light/dark state.
+const DIFF_THEME = { light: 'github-light', dark: 'github-dark' } as const
+
+/**
+ * Read-only, GitHub-style rendering of an edit — parses the before/after file contents into a
+ * `@pierre/diffs` diff and renders it unified, in a card that reads cleanly embedded in a chat card
+ * (no editor chrome, our own file header rendered by the caller). Lazy-mounted: only parses/renders
+ * once the card scrolls near the viewport.
+ */
+export function DiffFileContent({
+    oldText,
+    newText,
+    path,
+}: {
+    oldText: string
+    newText: string
+    path?: string
+}): JSX.Element {
+    const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
+    const { isDarkModeOn } = useValues(themeLogic)
+
+    const name = path ?? 'file'
+    const [parseFailed, fileDiff] = useMemo<[boolean, FileDiffMetadata | null]>(() => {
+        if (!inView) {
+            return [false, null]
+        }
+        try {
+            return [false, parseDiffFromFile({ name, contents: oldText }, { name, contents: newText })]
+        } catch {
+            return [true, null]
+        }
+    }, [inView, name, oldText, newText])
+
+    const options = useMemo<FileDiffOptions<undefined>>(
+        () => ({
+            theme: DIFF_THEME,
+            themeType: isDarkModeOn ? 'dark' : 'light',
+            diffStyle: 'unified',
+            disableFileHeader: true,
+            overflow: 'scroll',
+        }),
+        [isDarkModeOn]
+    )
+
+    return (
+        <div ref={ref} className="w-full min-w-0">
+            {!inView ? (
+                <EditorSkeleton />
+            ) : parseFailed || !fileDiff ? (
+                <pre className="m-0 whitespace-pre-wrap rounded border border-border-secondary p-2 text-xs">
+                    {newText}
+                </pre>
+            ) : (
+                <div className="rounded border border-border-secondary overflow-hidden">
+                    <FileDiff fileDiff={fileDiff} options={options} disableWorkerPool />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/posthog_ai/frontend/components/tool/EditDiffRenderer.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/EditDiffRenderer.test.tsx
@@ -5,32 +5,17 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ToolCallMessage } from '../../types/toolTypes'
 import { EditDiffRenderer } from './EditDiffRenderer'
 
-// Monaco can't render in jsdom — stand it in for a marker that echoes the diff props we care about.
-jest.mock('lib/components/MonacoDiffEditor', () => ({
+// @pierre/diffs is ESM-only and can't be resolved by Jest/jsdom — stand the diff renderer in for a
+// marker that echoes the props we care about so jsdom never has to import the real thing.
+jest.mock('./DiffFileContent', () => ({
     __esModule: true,
-    default: ({
-        original,
-        modified,
-        language,
-        theme,
-    }: {
-        original?: string
-        modified?: string
-        language?: string
-        theme?: string
-    }) => (
-        <div
-            data-attr="monaco-diff"
-            data-original={original}
-            data-modified={modified}
-            data-language={language}
-            data-theme={theme}
-        />
+    DiffFileContent: ({ oldText, newText, path }: { oldText?: string; newText?: string; path?: string }) => (
+        <div data-attr="diff-file" data-old-text={oldText} data-new-text={newText} data-path={path} />
     ),
 }))
 
 // A newly created file renders the single-pane read view, not a diff — stand it in for a marker that
-// echoes the content + path so jsdom never instantiates real Monaco (and never pulls monaco-editor).
+// echoes the content + path so jsdom never instantiates the real (also @pierre/diffs-backed) component.
 jest.mock('./ReadFileContent', () => ({
     __esModule: true,
     ReadFileContent: ({ text, path }: { text: string; path?: string }) => (
@@ -41,14 +26,6 @@ jest.mock('./ReadFileContent', () => ({
 // Force the lazy-mount gate open so the editor instantiates.
 jest.mock('react-intersection-observer', () => ({
     useInView: () => ({ ref: () => {}, inView: true }),
-}))
-
-// Drive the app theme without mounting themeLogic (and its scene/user deps). The arrow reads
-// `mockDarkMode` lazily at render time, so flipping it per test works.
-let mockDarkMode = false
-jest.mock('kea', () => ({
-    ...jest.requireActual('kea'),
-    useValues: () => ({ isDarkModeOn: mockDarkMode }),
 }))
 
 function makeMessage(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
@@ -74,7 +51,6 @@ function renderExpanded(message: ToolCallMessage): void {
 describe('EditDiffRenderer', () => {
     afterEach(() => {
         cleanup()
-        mockDarkMode = false
     })
 
     it('renders an inline diff with +/- stats for an Edit with a diff block', () => {
@@ -85,12 +61,11 @@ describe('EditDiffRenderer', () => {
             })
         )
 
-        const editor = screen.getByTestId('monaco-diff')
-        expect(editor).toBeInTheDocument()
-        expect(editor).toHaveAttribute('data-original', 'a\nb')
-        expect(editor).toHaveAttribute('data-modified', 'a\nb\nc')
-        expect(editor).toHaveAttribute('data-language', 'typescript')
-        expect(editor).toHaveAttribute('data-theme', 'vs')
+        const diffContent = screen.getByTestId('diff-file')
+        expect(diffContent).toBeInTheDocument()
+        expect(diffContent).toHaveAttribute('data-old-text', 'a\nb')
+        expect(diffContent).toHaveAttribute('data-new-text', 'a\nb\nc')
+        expect(diffContent).toHaveAttribute('data-path', 'foo.ts')
         expect(screen.getByText('foo.ts')).toBeInTheDocument()
         expect(screen.getByText('+1')).toBeInTheDocument()
         expect(screen.getByText('-0')).toBeInTheDocument()
@@ -118,7 +93,7 @@ describe('EditDiffRenderer', () => {
             })
         )
 
-        expect(screen.getAllByTestId('monaco-diff')).toHaveLength(2)
+        expect(screen.getAllByTestId('diff-file')).toHaveLength(2)
     })
 
     it('renders a single-pane read view (not a diff) with all-added stats for a new file (Write)', () => {
@@ -130,7 +105,7 @@ describe('EditDiffRenderer', () => {
         expect(screen.getByText('Created a file')).toBeInTheDocument()
 
         fireEvent.click(screen.getByRole('button'))
-        expect(screen.queryByTestId('monaco-diff')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('diff-file')).not.toBeInTheDocument()
         const readView = screen.getByTestId('read-file')
         expect(readView).toHaveAttribute('data-text', 'print(1)\nprint(2)')
         expect(readView).toHaveAttribute('data-path', 'new.py')
@@ -138,7 +113,7 @@ describe('EditDiffRenderer', () => {
         expect(screen.getByText('+2')).toBeInTheDocument()
     })
 
-    it('resolves filename and language from rawInput.file_path when the diff block has no path', () => {
+    it('resolves the path from rawInput.file_path when the diff block has no path', () => {
         renderExpanded(
             makeMessage({
                 content: [{ type: 'diff', oldText: 'a', newText: 'b' }],
@@ -147,7 +122,7 @@ describe('EditDiffRenderer', () => {
         )
 
         expect(screen.getByText('main.go')).toBeInTheDocument()
-        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-language', 'go')
+        expect(screen.getByTestId('diff-file')).toHaveAttribute('data-path', 'main.go')
     })
 
     it('falls back to the generic tool card (no editor) when there is no diff block', () => {
@@ -160,15 +135,8 @@ describe('EditDiffRenderer', () => {
         })
         render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
 
-        expect(screen.queryByTestId('monaco-diff')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('diff-file')).not.toBeInTheDocument()
         // The generic card still renders the rich tool title as its header.
         expect(screen.getByText('Edit `foo.ts`')).toBeInTheDocument()
-    })
-
-    it('uses the dark Monaco theme when the app is in dark mode', () => {
-        mockDarkMode = true
-        renderExpanded(makeMessage({ content: [{ type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' }] }))
-
-        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-theme', 'vs-dark')
     })
 })

--- a/products/posthog_ai/frontend/components/tool/EditDiffRenderer.tsx
+++ b/products/posthog_ai/frontend/components/tool/EditDiffRenderer.tsx
@@ -1,74 +1,12 @@
-import { useValues } from 'kea'
-import type { editor } from 'monaco-editor'
-import { useInView } from 'react-intersection-observer'
-
 import { IconPencil } from '@posthog/icons'
 
-import MonacoDiffEditor from 'lib/components/MonacoDiffEditor'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-
-import { EditorSkeleton } from './EditorSkeleton'
+import { DiffFileContent } from './DiffFileContent'
 import { FilePath } from './FilePath'
 import { GenericMcpToolRenderer } from './GenericMcpToolRenderer'
 import { ReadFileContent } from './ReadFileContent'
 import { ToolActivity } from './ToolActivity'
-import { findAllDiffContent, getDiffStats, languageFromPath, type ToolCallDiffContent } from './toolDiffContent'
+import { findAllDiffContent, getDiffStats } from './toolDiffContent'
 import type { ToolRendererProps } from './toolRegistry'
-
-// A stripped-down, unified diff that reads cleanly embedded in a chat card — mirrors the look of the
-// sandbox agent's own diff UI (unified style, soft-wrapped, compact font, no editor chrome). Module-level
-// so the object identity is stable across renders: MonacoDiffEditor calls `updateOptions` whenever this
-// prop changes, and a fresh literal each render would thrash it during streaming.
-const DIFF_EDITOR_OPTIONS: editor.IDiffEditorConstructionOptions = {
-    readOnly: true,
-    renderSideBySide: false,
-    hideUnchangedRegions: { enabled: true },
-    diffAlgorithm: 'advanced',
-    wordWrap: 'on',
-    diffWordWrap: 'inherit',
-    fontSize: 12,
-    lineNumbers: 'on',
-    minimap: { enabled: false },
-    renderOverviewRuler: false,
-    overviewRulerLanes: 0,
-    overviewRulerBorder: false,
-    hideCursorInOverviewRuler: true,
-    scrollBeyondLastLine: false,
-    folding: false,
-    glyphMargin: false,
-    renderLineHighlight: 'none',
-    renderGutterMenu: false,
-    guides: { indentation: false },
-    padding: { top: 4, bottom: 4 },
-    // Don't trap the thread's scroll when the cursor is over the diff.
-    scrollbar: { alwaysConsumeMouseWheel: false, vertical: 'auto', horizontal: 'auto' },
-}
-
-function DiffEditor({ diff, path }: { diff: ToolCallDiffContent; path?: string }): JSX.Element {
-    // Lazy-mount: only instantiate the Monaco diff editor once the card scrolls near the viewport.
-    const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
-    // Match the surrounding app theme — without this Monaco falls back to its default `vs` (white) theme.
-    const { isDarkModeOn } = useValues(themeLogic)
-
-    return (
-        <div ref={ref} className="w-full min-w-0">
-            {inView ? (
-                <MonacoDiffEditor
-                    original={diff.oldText ?? ''}
-                    value={diff.newText ?? ''}
-                    modified={diff.newText ?? ''}
-                    language={languageFromPath(path)}
-                    theme={isDarkModeOn ? 'vs-dark' : 'vs'}
-                    options={DIFF_EDITOR_OPTIONS}
-                    loading={<EditorSkeleton />}
-                />
-            ) : (
-                <div className="h-24 rounded border border-border-secondary" />
-            )}
-        </div>
-    )
-}
 
 /** +added / -removed mono stat chip for a diff. */
 function DiffStats({ added, removed }: { added: number; removed: number }): JSX.Element {
@@ -111,7 +49,7 @@ export function EditDiffRenderer(props: ToolRendererProps): JSX.Element {
                         {diff.oldText == null ? (
                             <ReadFileContent text={diff.newText ?? ''} path={path} />
                         ) : (
-                            <DiffEditor diff={diff} path={path} />
+                            <DiffFileContent oldText={diff.oldText} newText={diff.newText ?? ''} path={path} />
                         )}
                     </div>
                 )

--- a/products/posthog_ai/frontend/components/tool/EditorSkeleton.tsx
+++ b/products/posthog_ai/frontend/components/tool/EditorSkeleton.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
 interface EditorSkeletonProps {
-    /** Match the editor's computed height so the card keeps its shape when Monaco mounts. */
+    /** Match the content's expected height so the card keeps its shape when the real view mounts. */
     height?: number | string
     /** Number of code-line rows to render. */
     lines?: number
@@ -14,8 +14,8 @@ const DEFAULT_LINES = 5
 const LINE_WIDTHS = ['w-3/4', 'w-1/2', 'w-5/6', 'w-2/3', 'w-11/12', 'w-1/3']
 
 /**
- * Editor-shaped loading skeleton for the Monaco-backed tool cards (read view + diff view). A
- * `LemonSkeleton`-only leaf — no Monaco, no lazy renderers — so it's safe both as a `Suspense`
+ * Editor-shaped loading skeleton for the code-rendering tool cards (read view + diff view). A
+ * `LemonSkeleton`-only leaf — no diff renderer, no lazy chunks — so it's safe both as a `Suspense`
  * fallback and inside the always-loaded built-in chunk. Renders a line-number gutter column next to
  * varied-width code-line bars to read as "content loading" rather than an empty/spinning box.
  */

--- a/products/posthog_ai/frontend/components/tool/ReadFileContent.tsx
+++ b/products/posthog_ai/frontend/components/tool/ReadFileContent.tsx
@@ -1,104 +1,41 @@
+import type { FileOptions } from '@pierre/diffs'
+import { File } from '@pierre/diffs/react'
 import { useValues } from 'kea'
-import type { editor } from 'monaco-editor'
-import { useEffect, useRef } from 'react'
+import { useMemo } from 'react'
 import { useInView } from 'react-intersection-observer'
-
-import 'lib/monaco/monacoEnvironment'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { EditorSkeleton } from './EditorSkeleton'
-import { languageFromPath } from './toolDiffContent'
 
-const LINE_HEIGHT = 18
-const MIN_LINES = 5
-const MAX_LINES = 30
-
-// Module-level so the object identity is stable across renders — monaco calls `updateOptions` whenever
-// this prop changes.
-const READ_EDITOR_OPTIONS: editor.IStandaloneEditorConstructionOptions = {
-    readOnly: true,
-    wordWrap: 'on',
-    fontSize: 12,
-    lineNumbers: 'on',
-    minimap: { enabled: false },
-    overviewRulerLanes: 0,
-    overviewRulerBorder: false,
-    hideCursorInOverviewRuler: true,
-    scrollBeyondLastLine: false,
-    folding: false,
-    glyphMargin: false,
-    renderLineHighlight: 'none',
-    guides: { indentation: false },
-    padding: { top: 4, bottom: 4 },
-    automaticLayout: true,
-    // Don't trap the thread's scroll when the cursor is over the editor.
-    scrollbar: { alwaysConsumeMouseWheel: false, vertical: 'auto', horizontal: 'auto' },
-}
+// Shiki bundled themes that read closest to GitHub's diff view; Pierre swaps between them based on
+// `themeType`, which we drive off PostHog's own light/dark state.
+const FILE_THEME = { light: 'github-light', dark: 'github-dark' } as const
 
 export function ReadFileContent({ text, path }: { text: string; path?: string }): JSX.Element {
-    // Lazy-mount: only instantiate the Monaco editor once the card scrolls near the viewport.
+    // Lazy-mount: only parse/render once the card scrolls near the viewport.
     const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
-    // Match the surrounding app theme — without this Monaco falls back to its default `vs` (white) theme.
     const { isDarkModeOn } = useValues(themeLogic)
-    const lineCount = Math.max(MIN_LINES, Math.min(MAX_LINES, text.split('\n').length))
-    const height = lineCount * LINE_HEIGHT + 8
 
-    const containerRef = useRef<HTMLDivElement>(null)
-    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
-
-    useEffect(() => {
-        if (!inView || !containerRef.current) {
-            return
-        }
-
-        const container = containerRef.current
-        let disposed = false
-
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        import('monaco-editor').then((monaco) => {
-            if (disposed || !container) {
-                return
-            }
-            const instance = monaco.editor.create(container, {
-                value: text,
-                language: languageFromPath(path),
-                theme: isDarkModeOn ? 'vs-dark' : 'vs',
-                ...READ_EDITOR_OPTIONS,
-            })
-            editorRef.current = instance
-        })
-
-        return () => {
-            disposed = true
-            editorRef.current?.dispose()
-            editorRef.current = null
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [inView])
-
-    useEffect(() => {
-        const model = editorRef.current?.getModel()
-        if (model) {
-            model.setValue(text)
-        }
-    }, [text])
-
-    useEffect(() => {
-        editorRef.current?.updateOptions({ theme: isDarkModeOn ? 'vs-dark' : 'vs' })
-    }, [isDarkModeOn])
+    const options = useMemo<FileOptions<undefined>>(
+        () => ({
+            theme: FILE_THEME,
+            themeType: isDarkModeOn ? 'dark' : 'light',
+            disableFileHeader: true,
+            overflow: 'scroll',
+        }),
+        [isDarkModeOn]
+    )
 
     return (
         <div ref={ref} className="w-full min-w-0">
             {inView ? (
-                <div
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ height }}
-                    ref={containerRef}
-                    className="w-full"
-                />
+                // Cap the height so a very large Read doesn't blow up the thread — scroll inside the card instead.
+                <div className="max-h-[548px] overflow-y-auto rounded border border-border-secondary">
+                    <File file={{ name: path ?? 'file', contents: text }} options={options} disableWorkerPool />
+                </div>
             ) : (
-                <EditorSkeleton height={height} />
+                <EditorSkeleton />
             )}
         </div>
     )

--- a/products/posthog_ai/frontend/components/tool/builtinToolRenderers.tsx
+++ b/products/posthog_ai/frontend/components/tool/builtinToolRenderers.tsx
@@ -28,7 +28,7 @@ import {
 import { ToolBody, ToolBodySection, ToolOutput } from './ToolOutput'
 import type { ToolRendererProps } from './toolRegistry'
 
-// Monaco-backed read-only file view, lazy so monaco stays out of the always-loaded built-in chunk.
+// Pierre-diffs-backed read-only file view, lazy so it (and its ESM-only dep) stay out of the always-loaded built-in chunk.
 const ReadFileContent = lazy(() => import('./ReadFileContent').then((m) => ({ default: m.ReadFileContent })))
 
 function asString(value: unknown): string {


### PR DESCRIPTION
## Problem

The tool card renderers for file reads and diffs currently use Monaco editor, which adds significant bundle weight and complexity. We can achieve the same visual result with a lighter, more maintainable solution using the `@pierre/diffs` library, which provides GitHub-style syntax highlighting and diff rendering via Shiki.

## Changes

- **ReadFileContent**: Replaced Monaco editor with `@pierre/diffs` `File` component. Removed manual editor lifecycle management (create, dispose, update) and replaced with a simple memoized options object. Removed hardcoded height calculation logic.

- **DiffFileContent** (new): Created a dedicated component for rendering diffs using `@pierre/diffs` `FileDiff` component. Parses before/after content into a unified diff and renders with GitHub-style themes. Falls back to a plain `<pre>` block if parsing fails.

- **EditDiffRenderer**: Removed the inline `DiffEditor` component and Monaco diff editor options. Now delegates to `DiffFileContent` for diffs and `ReadFileContent` for new files.

- **EditorSkeleton**: Updated comments to reflect the new rendering backend (no longer Monaco-specific).

- **Tests**: Updated mocks to stand in `DiffFileContent` instead of `MonacoDiffEditor`. Removed the dark mode theme test since theme switching is now handled transparently by `@pierre/diffs`.

Both components use lazy mounting (via `useInView`) to defer parsing/rendering until the card scrolls near the viewport, and both respect the app's light/dark theme via `themeLogic`.

## How did you test this code?

- Updated unit tests in `EditDiffRenderer.test.tsx` to mock `DiffFileContent` and verify it receives the correct props (`oldText`, `newText`, `path`).
- Removed the dark mode theme test since `@pierre/diffs` handles theme switching internally based on the `themeType` prop.
- All existing tests pass with the new mocks in place.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This refactor replaces a heavy Monaco-based rendering pipeline with a lighter `@pierre/diffs`-based approach. The change maintains the same lazy-mounting and theme-switching behavior while reducing bundle size and simplifying component logic. No new dependencies were added (both `@pierre/diffs` and Shiki are already in the project). The new `DiffFileContent` component mirrors the structure and patterns of `ReadFileContent`, ensuring consistency across the codebase.

https://claude.ai/code/session_011oAt2RAKDpaDjREvH7Jj22