### PR TITLE
fix(llma): preserve prompt edits on publish version conflict

### DIFF
--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -1,8 +1,10 @@
 import { expectLogic } from 'kea-test-utils'
 
+import api from '~/lib/api'
+import { ApiError } from '~/lib/api-error'
 import { EventsQuery, NodeKind, TracesQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { PropertyFilterType, PropertyOperator } from '~/types'
+import { LLMPromptResolveResponse, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { PromptAnalyticsScope, PromptMode, llmPromptLogic } from './llmPromptLogic'
 
@@ -247,6 +249,42 @@ describe('llmPromptLogic', () => {
         logic.actions.setPrompt(mockPrompt)
 
         expect(logic.values.breadcrumbs[1].name).toBe('my-test-prompt v2')
+
+        logic.unmount()
+    })
+
+    it('preserves form edits and advances the base version on a publish conflict', async () => {
+        const { versions, has_more, ...promptFields } = mockPrompt
+        const conflictingLatest = {
+            ...promptFields,
+            id: 'prompt-version-3',
+            prompt: 'Someone else edited this prompt.',
+            version: 3,
+            latest_version: 3,
+            version_count: 3,
+        }
+
+        jest.spyOn(api.llmPrompts, 'resolveByName')
+            .mockResolvedValueOnce({ prompt: promptFields, versions, has_more } as unknown as LLMPromptResolveResponse)
+            .mockResolvedValue({ prompt: conflictingLatest, versions, has_more } as unknown as LLMPromptResolveResponse)
+        jest.spyOn(api.llmPrompts, 'update').mockRejectedValue(
+            new ApiError('conflict', 409, undefined, { detail: 'The prompt changed since you opened it.' })
+        )
+
+        const logic = llmPromptLogic({ promptName: 'my-test-prompt' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPromptSuccess'])
+
+        logic.actions.setMode(PromptMode.Edit)
+        logic.actions.setPromptFormValues({ name: 'my-test-prompt', prompt: 'My in-progress edit.' })
+
+        logic.actions.submitPromptForm()
+        await expectLogic(logic).toDispatchActions(['submitPromptFormFailure'])
+
+        expect(logic.values.promptForm.prompt).toBe('My in-progress edit.')
+        expect(logic.values.publishConflict).toEqual({ latestVersion: 3 })
+        expect(logic.values.prompt).toMatchObject({ latest_version: 3 })
+        expect(logic.values.mode).toBe(PromptMode.Edit)
 
         logic.unmount()
     })

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -85,7 +85,11 @@ const PROMPT_VERSIONS_LIMIT = 50
 export const PROMPT_NAME_MAX_LENGTH = 255
 const DEFAULT_PROMPT_ANALYTICS_DATE_FROM = '-1d'
 const STALE_PROMPT_ERROR_MESSAGE =
-    'This prompt changed while you were editing it. Review the latest version and try again.'
+    'This prompt changed while you were editing it. Your edits are preserved — review the latest version and publish again.'
+
+export interface PublishConflict {
+    latestVersion: number | null
+}
 
 async function fetchResolvedPrompt(
     promptName: string,
@@ -164,6 +168,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         toggleMarkdownRendering: true,
         setCompareVersion: (compareVersion: number | null) => ({ compareVersion }),
         toggleOutlineExpanded: true,
+        setPublishConflict: (publishConflict: PublishConflict | null) => ({ publishConflict }),
     }),
 
     reducers(({ props }) => ({
@@ -225,6 +230,14 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             false,
             {
                 toggleOutlineExpanded: (state) => !state,
+            },
+        ],
+        publishConflict: [
+            null as PublishConflict | null,
+            {
+                setPublishConflict: (_, { publishConflict }) => publishConflict,
+                setMode: () => null,
+                loadPromptSuccess: () => null,
             },
         ],
     })),
@@ -335,11 +348,17 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                     }
 
                     if (error instanceof ApiError && error.status === 409) {
+                        // Refresh the underlying prompt so base_version advances, but keep the
+                        // user's in-progress edits in the form — never overwrite their work.
+                        let latestVersion: number | null = null
                         try {
-                            await refreshLatestPromptState(props.promptName, actions)
+                            const latestPrompt = await fetchResolvedPrompt(props.promptName)
+                            actions.setPrompt(latestPrompt)
+                            latestVersion = latestPrompt.latest_version ?? latestPrompt.version
                         } catch {}
 
-                        lemonToast.error(error.detail || STALE_PROMPT_ERROR_MESSAGE)
+                        actions.setPublishConflict({ latestVersion })
+                        lemonToast.error(STALE_PROMPT_ERROR_MESSAGE)
                         throw error
                     }
 

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -478,11 +478,20 @@ export function PromptEditForm({
     isHistoricalVersion: boolean
     selectedVersion: number | null
 }): JSX.Element {
-    const { promptVariables, isNewPrompt, isRenderingMarkdown, promptForm } = useValues(llmPromptLogic)
+    const { promptVariables, isNewPrompt, isRenderingMarkdown, promptForm, publishConflict } = useValues(llmPromptLogic)
     const { toggleMarkdownRendering } = useActions(llmPromptLogic)
 
     return (
         <div className="mt-4 max-w-3xl space-y-4">
+            {publishConflict ? (
+                <LemonBanner type="warning" data-attr="llma-prompt-publish-conflict-banner">
+                    {publishConflict.latestVersion
+                        ? `v${publishConflict.latestVersion} was published while you were editing.`
+                        : 'This prompt changed while you were editing.'}{' '}
+                    Your edits below are preserved — review them before publishing again.
+                </LemonBanner>
+            ) : null}
+
             {isHistoricalVersion && selectedVersion ? (
                 <LemonBanner type="info">
                     You are publishing a new latest version from historical version v{selectedVersion}. The original


### PR DESCRIPTION
## Problem

When publishing a prompt version hits a 409 conflict (someone else published meanwhile), the editor replaced the user's in-progress edits with the refetched latest content, silently destroying their work.

## Changes

On 409, keep the form values. Only the underlying prompt state is refreshed so the base version advances, and a warning banner in the editor explains what happened.

## How did you test this code?

Added a kea logic test that submits into a mocked 409 and asserts the form keeps the user's edit while the base version advances to the refetched latest. No existing test covered the publish conflict path. Full `llmPromptLogic.test.ts` suite passes (10 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during a UX review of the prompt editing flow, where this data-loss path was found by reading the conflict handler. Skills invoked: /writing-tests.