### PR TITLE
feat(billing): link from product card to bill-influencing config

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.stories.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.stories.tsx
@@ -7,6 +7,7 @@ import preflightJson from '~/mocks/fixtures/_preflight.json'
 import { BillingProductV2Type } from '~/types'
 
 import { BillingProduct } from './BillingProduct'
+import { CODE_PRODUCT_KEY } from './constants'
 
 const meta: Meta = {
     title: 'Scenes-Other/Billing Product',
@@ -289,6 +290,30 @@ export const BillingProductTemporarilyFree: Story = {
         }
 
         return <BillingProduct product={product as BillingProductV2Type} />
+    },
+}
+
+// Only products with a bill-influencing settings page get the "Manage" action. The billing fixture
+// has no Code product, so borrow a tiered one and relabel it.
+export const BillingProductWithManagementLink: Story = {
+    render: () => {
+        useStorybookMocks({
+            get: {
+                '/api/billing/': {
+                    ...billingJson,
+                },
+            },
+        })
+
+        const baseProduct = billingJson.products.find((product) => product.type === 'feature_flags')
+        const product = {
+            ...baseProduct,
+            type: CODE_PRODUCT_KEY,
+            name: 'PostHog Code',
+            description: 'Autonomous agents that investigate your product and open pull requests.',
+        }
+
+        return <BillingProduct product={product as unknown as BillingProductV2Type} />
     },
 }
 

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
-import { IconChevronDown, IconDocument, IconInfo } from '@posthog/icons'
+import { IconChevronDown, IconDocument, IconGear, IconInfo } from '@posthog/icons'
 import { IconChevronRight } from '@posthog/icons'
 import { LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
 
@@ -32,7 +32,7 @@ import { billingLogic } from './billingLogic'
 import { BillingProductAddon } from './BillingProductAddon'
 import { billingProductLogic } from './billingProductLogic'
 import { BillingProductPricingTable } from './BillingProductPricingTable'
-import { REALTIME_DESTINATIONS_BILLING_START_DATE } from './constants'
+import { PRODUCT_MANAGEMENT_LINKS, REALTIME_DESTINATIONS_BILLING_START_DATE } from './constants'
 import { paymentEntryLogic } from './paymentEntryLogic'
 import { PlatformAddonComparison } from './PlatformAddonComparison'
 import { ProductPricingModal } from './ProductPricingModal'
@@ -93,6 +93,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
         workflows_emails: 'Workflows',
     }
     const displayProductName = productDisplayNameOverrides[product.type] || product.name
+    const managementLink = PRODUCT_MANAGEMENT_LINKS[product.type]
     const isPlatformProduct = product.type === 'platform_and_support'
     const addonSectionLabel = isPlatformProduct ? 'Packages' : 'Add-ons'
 
@@ -158,6 +159,17 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
 
                         {/* Product actions */}
                         <div className="flex grow justify-end gap-x-2 items-center">
+                            {managementLink && (
+                                <LemonButton
+                                    type="secondary"
+                                    icon={<IconGear />}
+                                    size="small"
+                                    to={managementLink.to}
+                                    tooltip={managementLink.tooltip}
+                                >
+                                    {managementLink.label}
+                                </LemonButton>
+                            )}
                             {product.docs_url && (
                                 <LemonButton
                                     icon={<IconDocument />}

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -45,7 +45,7 @@ import { UnsubscribeSurveyModal } from './UnsubscribeSurveyModal'
  * settings that actually influence their spend (e.g. pausing self-driving agents) without
  * hunting through the app. Keyed by billing product `type`.
  */
-const PRODUCT_MANAGEMENT_LINKS: Record<string, { to: string; label: string; tooltip: string }> = {
+const PRODUCT_MANAGEMENT_LINKS: Partial<Record<string, { to: string; label: string; tooltip: string }>> = {
     [CODE_PRODUCT_KEY]: {
         to: urls.inbox('config'),
         label: 'Manage agents',

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -16,6 +16,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyCurrency } from 'lib/utils/numbers'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { getProductIcon } from 'scenes/onboarding/shared/utils'
+import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { BillingProductV2AddonType, BillingProductV2Type, BillingTierType } from '~/types'
@@ -32,11 +33,25 @@ import { billingLogic } from './billingLogic'
 import { BillingProductAddon } from './BillingProductAddon'
 import { billingProductLogic } from './billingProductLogic'
 import { BillingProductPricingTable } from './BillingProductPricingTable'
-import { PRODUCT_MANAGEMENT_LINKS, REALTIME_DESTINATIONS_BILLING_START_DATE } from './constants'
+import { CODE_PRODUCT_KEY, REALTIME_DESTINATIONS_BILLING_START_DATE } from './constants'
 import { paymentEntryLogic } from './paymentEntryLogic'
 import { PlatformAddonComparison } from './PlatformAddonComparison'
 import { ProductPricingModal } from './ProductPricingModal'
 import { UnsubscribeSurveyModal } from './UnsubscribeSurveyModal'
+
+/**
+ * In-app management surfaces for products whose bill is driven by configurable behavior.
+ * Surfaced as a "Manage" deep link on the billing product card so users can reach the
+ * settings that actually influence their spend (e.g. pausing self-driving agents) without
+ * hunting through the app. Keyed by billing product `type`.
+ */
+const PRODUCT_MANAGEMENT_LINKS: Record<string, { to: string; label: string; tooltip: string }> = {
+    [CODE_PRODUCT_KEY]: {
+        to: urls.inbox('config'),
+        label: 'Manage agents',
+        tooltip: 'Configure scouts and how autonomously agents open PRs – the settings that drive this spend.',
+    },
+}
 
 export const getTierDescription = (
     tiers: BillingTierType[],

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -1,3 +1,5 @@
+import { urls } from 'scenes/urls'
+
 // sync with ee/hogai/tools/read_billing_tool/tool.py
 // Values are sent to the `billing` repo as `usage_types`; keep in sync with accepted types in `billing/types/usage.py`.
 export const USAGE_TYPES = [
@@ -35,6 +37,20 @@ export const CODE_PLAN_ALPHA_PRO = 'posthog-code-pro-0-20260422'
 
 export const CODE_PRO_PLAN_PREFIX = 'posthog-code-pro-'
 export const CODE_FREE_PLAN_PREFIX = 'posthog-code-free'
+
+/**
+ * In-app management surfaces for products whose bill is driven by configurable behavior.
+ * Surfaced as a "Manage" deep link on the billing product card so users can reach the
+ * settings that actually influence their spend (e.g. pausing self-driving agents) without
+ * hunting through the app. Keyed by billing product `type`.
+ */
+export const PRODUCT_MANAGEMENT_LINKS: Record<string, { to: string; label: string; tooltip: string }> = {
+    [CODE_PRODUCT_KEY]: {
+        to: urls.inbox('config'),
+        label: 'Manage agents',
+        tooltip: 'Configure scouts and how autonomously agents open PRs – the settings that drive this spend.',
+    },
+}
 
 // Date after which billing for data pipelines ends and add-on upgrades/downgrades are disabled,
 // in sync with billing_end_date of data_pipelines in billing plans config

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -1,5 +1,3 @@
-import { urls } from 'scenes/urls'
-
 // sync with ee/hogai/tools/read_billing_tool/tool.py
 // Values are sent to the `billing` repo as `usage_types`; keep in sync with accepted types in `billing/types/usage.py`.
 export const USAGE_TYPES = [
@@ -37,20 +35,6 @@ export const CODE_PLAN_ALPHA_PRO = 'posthog-code-pro-0-20260422'
 
 export const CODE_PRO_PLAN_PREFIX = 'posthog-code-pro-'
 export const CODE_FREE_PLAN_PREFIX = 'posthog-code-free'
-
-/**
- * In-app management surfaces for products whose bill is driven by configurable behavior.
- * Surfaced as a "Manage" deep link on the billing product card so users can reach the
- * settings that actually influence their spend (e.g. pausing self-driving agents) without
- * hunting through the app. Keyed by billing product `type`.
- */
-export const PRODUCT_MANAGEMENT_LINKS: Record<string, { to: string; label: string; tooltip: string }> = {
-    [CODE_PRODUCT_KEY]: {
-        to: urls.inbox('config'),
-        label: 'Manage agents',
-        tooltip: 'Configure scouts and how autonomously agents open PRs – the settings that drive this spend.',
-    },
-}
 
 // Date after which billing for data pipelines ends and add-on upgrades/downgrades are disabled,
 // in sync with billing_end_date of data_pipelines in billing plans config


### PR DESCRIPTION
## Problem

When a product's bill is driven by configurable behavior – like the self-driving code agents opening PRs – there's no path from the billing page to the settings that actually control that spend. People land on billing wanting to dial things back and can't find where to do it. (Raised in [this Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782993381919569?thread_ts=1782993381.919569&cid=C09SK2PAGKF), and a companion to #67409 which clarifies the PR pricing in onboarding.)

## Changes

Adds a "Manage" deep link to the billing product card actions that routes straight to the in-app settings driving that product's usage. The first product to use it is the self-driving code product, whose card now links to the inbox Configuration tab (scouts + agent autonomy) with a tooltip explaining that's what drives the spend.

Backed by a small reusable `PRODUCT_MANAGEMENT_LINKS` map keyed by billing product `type`, so other products can opt into the same affordance later. Renders only when a product has a management link, so every other card is unchanged.

### Screenshot

The new secondary action in the card's action row, from the new `BillingProductWithManagementLink` story:

![manage agents action](https://raw.githubusercontent.com/PostHog/pr-assets/67230af60a47992c451f5f7d14de22f812fe955f/2026/07/f89f7932-88f7-461b-916d-e5197d62630a.png)

Every other billing card is unchanged, which the existing `Scenes-Other/Billing Product` stories already pin.

## How did you test this code?

- Added a `BillingProductWithManagementLink` story, which is where this PR's visual-regression coverage comes from. It catches the regression this change could cause: the action row rendering wrong, or the button leaking onto products that have no management link (the other stories in the file are the control for that).
- The billing fixture has no Code product, so the story borrows a tiered product and relabels it to `posthog_code`. That's a fixture detail, not a claim about real billing data.
- Rendered it against a local Storybook, which is where the screenshot comes from.
- `oxlint` + `oxfmt` clean on the touched files.

I did not run the full app manually, so the deep link's destination is verified by reading `urls.inbox('config')` rather than by clicking it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The ask was to take the self-driving pricing-clarity work (#67409, inbox onboarding) and add a "sleek" companion in billing. I traced the self-driving PR spend to the `posthog_code` billing product (gateway product key) and its control surface to the inbox `/inbox/config` tab, then added a reusable product→management-link map rather than a one-off so the pattern generalizes. Chose a secondary `IconGear` button in the existing product-actions row over a new banner to keep the card uncluttered.

The story and screenshot landed in a later pass, with `/writing-tests` invoked to gate the story. That pass also ran the lint/format the original description said it couldn't.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782993381919569?thread_ts=1782993381.919569&cid=C09SK2PAGKF)*
