### PR TITLE
feat(billing): run usage reports v2 workflow every 3 hours

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -577,12 +577,12 @@ async def cleanup_legacy_session_summarization_schedules(client: Client):
 
 
 async def create_run_usage_reports_schedule(client: Client):
-    """Daily Temporal-based usage report run at 04:45 UTC.
+    """Temporal-based usage report run every 3 hours at minute 45 (8 times a day).
 
-    Runs an hour after the existing Celery beat for `send_all_org_usage_reports`
-    (03:45 UTC) so ClickHouse has breathing room while both flows run side by
-    side. The workflow writes per-org usage data to S3 and sends a single SQS
-    pointer to the billing service.
+    The 04:45 UTC slot runs an hour after the existing Celery beat for
+    `send_all_org_usage_reports` (03:45 UTC) so ClickHouse has breathing room
+    while both flows run side by side. The workflow writes per-org usage data
+    to S3 and sends a single SQS pointer to the billing service.
     """
     run_usage_reports_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
@@ -597,8 +597,8 @@ async def create_run_usage_reports_schedule(client: Client):
         spec=ScheduleSpec(
             calendars=[
                 ScheduleCalendarSpec(
-                    comment="Daily at 04:45 UTC",
-                    hour=[ScheduleRange(start=4, end=4)],
+                    comment="Every 3 hours at minute 45 (01:45, 04:45, ..., 22:45 UTC)",
+                    hour=[ScheduleRange(start=1, end=22, step=3)],
                     minute=[ScheduleRange(start=45, end=45)],
                 )
             ]


### PR DESCRIPTION
## Problem

The UsageReportsV2 Temporal workflow (`run-usage-reports-schedule`) runs once a day at 04:45 UTC.
We want fresher usage data flowing to billing, so the workflow should run more often.

## Changes

Changed the Temporal schedule spec from a single daily run to every 3 hours at minute 45, so it now fires 8 times a day at 01:45, 04:45, 07:45, 10:45, 13:45, 16:45, 19:45 and 22:45 UTC.

A few notes on why this is safe:

- The 04:45 slot is preserved, keeping the original intent of running an hour after the `send_all_org_usage_reports` Celery beat (03:45 UTC) to give ClickHouse breathing room.
- Each run derives its S3 keys from the unique Temporal run id and always reports on the previous day's period, so intra-day runs don't collide.
- The existing `ScheduleOverlapPolicy.SKIP` policy prevents overlapping runs if one takes longer than 3 hours.
- No manual Temporal changes needed. `bin/migrate` runs `schedule_temporal_workflows` on every deploy, which takes the `a_update_schedule` path and replaces the spec wholesale.

One thing for reviewers to confirm: billing will now receive 8 SQS pointers per day for the same reporting period, so it needs to handle repeated same-day reports idempotently.

## How did you test this code?

Existing tests in `posthog/temporal/tests/usage_report/test_schedule.py` cover the schedule-builder's create/update branches and input serializability. They don't pin the calendar times, so no test changes were needed. `ruff check` and `ruff format` pass on the changed file. I did not add a new test for the spec itself since it would only be a change detector.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcelino asked to increase the UsageReportsV2 workflow frequency from daily to 8 times a day. I (Claude, via PostHog Code) located the schedule in `posthog/temporal/schedule.py`, checked that the workflow's run-id-scoped S3 keys and SKIP overlap policy make intra-day runs safe, and verified the deploy-time reconciliation path (`bin/migrate` → `schedule_temporal_workflows` → `a_update_schedule`) applies the new spec automatically. The only decision of note was anchoring the 3-hourly cadence to keep the existing 04:45 UTC slot rather than starting at 00:45, preserving the deliberate offset from the Celery beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
