### PR TITLE
fix(replay): explain relevance sort and keep recency for intent-driven views

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -43,7 +43,7 @@ const SortingKeyToLabel = {
 }
 
 const RELEVANCE_SORT_EXPLANATION =
-    'Relevance predicts which sessions are worth watching, using signals like rage clicks, dead clicks, console errors, and failed network requests. The highest-scoring recordings appear first.'
+    'Relevance predicts which sessions are worth watching, using signals like rage clicks, dead clicks, console errors, failed network requests, and in-session activity. The highest-scoring recordings appear first.'
 
 function getLabel(filters: RecordingUniversalFilters): string {
     const order_field = filters.order || 'start_time'

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -2,8 +2,8 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconChevronRight, IconEllipsis, IconEye, IconPlus, IconSort, IconTrash } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner } from '@posthog/lemon-ui'
+import { IconChevronRight, IconEllipsis, IconEye, IconInfo, IconPlus, IconSort, IconTrash } from '@posthog/icons'
+import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
@@ -41,6 +41,9 @@ const SortingKeyToLabel = {
     recording_ttl: 'Expiration',
     surfacing_score: 'Relevance',
 }
+
+const RELEVANCE_SORT_EXPLANATION =
+    'Relevance predicts which sessions are worth watching, using signals like rage clicks, dead clicks, console errors, and failed network requests. The highest-scoring recordings appear first.'
 
 function getLabel(filters: RecordingUniversalFilters): string {
     const order_field = filters.order || 'start_time'
@@ -100,8 +103,7 @@ function SortedBy({
                     ? [
                           {
                               label: SortingKeyToLabel['surfacing_score'],
-                              tooltip:
-                                  'Ranks recordings by a relevance score so the sessions most likely to be worth watching appear first.',
+                              tooltip: RELEVANCE_SORT_EXPLANATION,
                               onClick: () => changeSort({ order: 'surfacing_score', order_direction: 'DESC' }),
                               active: filters.order === 'surfacing_score',
                           },
@@ -180,7 +182,18 @@ function SortedBy({
                 },
             ]}
             icon={<IconSort className="text-lg" />}
-            label={getLabel(filters)}
+            label={
+                filters.order === 'surfacing_score' ? (
+                    <span className="inline-flex items-center gap-1">
+                        {SortingKeyToLabel['surfacing_score']}
+                        <Tooltip title={RELEVANCE_SORT_EXPLANATION}>
+                            <IconInfo className="text-sm" />
+                        </Tooltip>
+                    </span>
+                ) : (
+                    getLabel(filters)
+                )
+            }
         />
     )
 }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1367,39 +1367,50 @@ describe('sessionRecordingsPlaylistLogic', () => {
             expect(getDefaultFilters(personUUID, pinnedFilters).order).toBe(expectedOrder)
         })
 
-        it.each<[string, Partial<RecordingUniversalFilters>, string]>([
-            ['defaults to recency when the URL omits order', {}, DEFAULT_RECORDING_FILTERS_ORDER_BY],
-            ['respects an explicit order in the URL', { order: 'console_error_count' }, 'console_error_count'],
-        ])('deep link with pre-applied filters %s for the test arm', async (_name, extraFilters, expectedOrder) => {
-            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' })
-            logic = sessionRecordingsPlaylistLogic({
-                logicKey: 'relevance-deep-link-test',
-                updateSearchParams: true,
-            })
-            logic.mount()
-
-            // "View recordings" style navigation carrying pre-applied filters
-            router.actions.push('/replay', {
-                filters: {
-                    filter_group: {
-                        type: FilterLogicalOperator.And,
-                        values: [
-                            {
-                                type: FilterLogicalOperator.And,
-                                values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                            },
-                        ],
-                    },
-                    ...extraFilters,
-                },
-            })
-
-            await expectLogic(logic)
-                .toDispatchActions(['setFilters'])
-                .toMatchValues({
-                    filters: expect.objectContaining({ order: expectedOrder }),
+        it.each<[string, Partial<RecordingUniversalFilters>, Record<string, unknown>, string]>([
+            ['defaults to recency when the URL omits order', {}, {}, DEFAULT_RECORDING_FILTERS_ORDER_BY],
+            [
+                'respects an explicit order in the URL filters',
+                { order: 'console_error_count' },
+                {},
+                'console_error_count',
+            ],
+            // order arriving as its own URL search param beside filters takes a separate code path
+            ['respects a standalone order URL param', {}, { order: 'console_error_count' }, 'console_error_count'],
+        ])(
+            'deep link with pre-applied filters %s for the test arm',
+            async (_name, extraFilters, extraSearchParams, expectedOrder) => {
+                mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' })
+                logic = sessionRecordingsPlaylistLogic({
+                    logicKey: 'relevance-deep-link-test',
+                    updateSearchParams: true,
                 })
-        })
+                logic.mount()
+
+                // "View recordings" style navigation carrying pre-applied filters
+                router.actions.push('/replay', {
+                    filters: {
+                        filter_group: {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    type: FilterLogicalOperator.And,
+                                    values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                                },
+                            ],
+                        },
+                        ...extraFilters,
+                    },
+                    ...extraSearchParams,
+                })
+
+                await expectLogic(logic)
+                    .toDispatchActions(['setFilters'])
+                    .toMatchValues({
+                        filters: expect.objectContaining({ order: expectedOrder }),
+                    })
+            }
+        )
     })
 
     describe('pinnedFilters', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -14,6 +14,7 @@ import {
     PropertyFilterType,
     PropertyOperator,
     RecordingUniversalFilters,
+    UniversalFiltersGroup,
 } from '~/types'
 
 import { deletedRecordingsLogic } from '../deletedRecordingsLogic'
@@ -1305,28 +1306,99 @@ describe('sessionRecordingsPlaylistLogic', () => {
             jest.spyOn(posthog, 'getFeatureFlag').mockImplementation((key) => flags[key as string] as any)
         }
 
-        const cases: [string, Record<string, string | boolean>, string][] = [
+        const intentPinnedFilters: UniversalFiltersGroup = {
+            type: FilterLogicalOperator.And,
+            values: [
+                {
+                    type: 'events',
+                    name: 'All events',
+                    properties: [{ key: "$group_0 = 'abc'", type: 'hogql' }],
+                } as ActionFilter,
+            ],
+        }
+
+        const cases: [
+            string,
+            Record<string, string | boolean>,
+            string,
+            { personUUID?: string; pinnedFilters?: UniversalFiltersGroup },
+        ][] = [
             [
                 'test arm defaults to relevance',
                 { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' },
                 'surfacing_score',
+                {},
             ],
             [
                 'control arm keeps recency',
                 { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'control' },
                 DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                {},
             ],
-            ['not enrolled keeps recency', {}, DEFAULT_RECORDING_FILTERS_ORDER_BY],
+            ['not enrolled keeps recency', {}, DEFAULT_RECORDING_FILTERS_ORDER_BY, {}],
             [
                 'surfacing-score rollout flag forces relevance',
                 { [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true },
                 'surfacing_score',
+                {},
+            ],
+            [
+                'test arm on a person page keeps recency',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                { personUUID: 'some-person-uuid' },
+            ],
+            [
+                'test arm with pinned filters keeps recency',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                { pinnedFilters: intentPinnedFilters },
+            ],
+            [
+                'surfacing-score rollout on a person page keeps recency',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                { personUUID: 'some-person-uuid' },
             ],
         ]
 
-        it.each(cases)('%s', (_name, flags, expectedOrder) => {
+        it.each(cases)('%s', (_name, flags, expectedOrder, { personUUID, pinnedFilters }) => {
             mockFlags(flags)
-            expect(getDefaultFilters().order).toBe(expectedOrder)
+            expect(getDefaultFilters(personUUID, pinnedFilters).order).toBe(expectedOrder)
+        })
+
+        it.each<[string, Partial<RecordingUniversalFilters>, string]>([
+            ['defaults to recency when the URL omits order', {}, DEFAULT_RECORDING_FILTERS_ORDER_BY],
+            ['respects an explicit order in the URL', { order: 'console_error_count' }, 'console_error_count'],
+        ])('deep link with pre-applied filters %s for the test arm', async (_name, extraFilters, expectedOrder) => {
+            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' })
+            logic = sessionRecordingsPlaylistLogic({
+                logicKey: 'relevance-deep-link-test',
+                updateSearchParams: true,
+            })
+            logic.mount()
+
+            // "View recordings" style navigation carrying pre-applied filters
+            router.actions.push('/replay', {
+                filters: {
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                            },
+                        ],
+                    },
+                    ...extraFilters,
+                },
+            })
+
+            await expectLogic(logic)
+                .toDispatchActions(['setFilters'])
+                .toMatchValues({
+                    filters: expect.objectContaining({ order: expectedOrder }),
+                })
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -170,12 +170,14 @@ export const DEFAULT_RECORDING_FILTERS: RecordingUniversalFilters = {
 
 export const getDefaultFilters = (
     personUUID?: PersonUUID,
-    pinnedFilters?: UniversalFiltersGroup
+    pinnedFilters?: UniversalFiltersGroup,
+    urlFilters?: Partial<RecordingUniversalFilters>
 ): RecordingUniversalFilters => {
     const filterTestAccounts = getDefaultFilterTestAccounts()
-    // Person/group pages (personUUID/pinnedFilters) come with a specific session in mind,
+    // Person/group pages (personUUID/pinnedFilters) and deep links with pre-applied filters
+    // (urlFilters, e.g. "View recordings" CTAs) come with a specific session in mind,
     // where recency is the better default than relevance
-    const hasSpecificIntent = !!personUUID || !!pinnedFilters
+    const hasSpecificIntent = !!personUUID || !!pinnedFilters || !!urlFilters
     const defaults: RecordingUniversalFilters = {
         ...DEFAULT_RECORDING_FILTERS,
         filter_test_accounts: filterTestAccounts,
@@ -1554,10 +1556,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     // omits don't inherit stale values
                     ...(params.filters && !equal(params.filters, values.filters)
                         ? {
-                              ...getDefaultFilters(props.personUUID, props.pinnedFilters),
-                              // deep links with pre-applied filters (e.g. "View recordings" CTAs) come with a
-                              // specific session in mind, where recency is the better default than relevance
-                              order: DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                              ...getDefaultFilters(props.personUUID, props.pinnedFilters, params.filters),
                               ...params.filters,
                           }
                         : {}),

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -173,14 +173,18 @@ export const getDefaultFilters = (
     pinnedFilters?: UniversalFiltersGroup
 ): RecordingUniversalFilters => {
     const filterTestAccounts = getDefaultFilterTestAccounts()
+    // Person/group pages (personUUID/pinnedFilters) come with a specific session in mind,
+    // where recency is the better default than relevance
+    const hasSpecificIntent = !!personUUID || !!pinnedFilters
     const defaults: RecordingUniversalFilters = {
         ...DEFAULT_RECORDING_FILTERS,
         filter_test_accounts: filterTestAccounts,
         date_from: personUUID ? '-30d' : '-3d',
         // Default to sorting by relevance for the surfacing-score rollout or the relevance-sort experiment's test arm
         order:
-            posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
-            posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test'
+            !hasSpecificIntent &&
+            (posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
+                posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test')
                 ? 'surfacing_score'
                 : DEFAULT_RECORDING_FILTERS.order,
     }
@@ -1545,11 +1549,17 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             }
 
             if (isReplayURLSearchParams(params)) {
-                const updatedFilters = {
+                const updatedFilters: Partial<RecordingUniversalFilters> = {
                     // layer URL filters onto defaults, not the persisted state, so fields the URL
                     // omits don't inherit stale values
                     ...(params.filters && !equal(params.filters, values.filters)
-                        ? { ...getDefaultFilters(props.personUUID, props.pinnedFilters), ...params.filters }
+                        ? {
+                              ...getDefaultFilters(props.personUUID, props.pinnedFilters),
+                              // deep links with pre-applied filters (e.g. "View recordings" CTAs) come with a
+                              // specific session in mind, where recency is the better default than relevance
+                              order: DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                              ...params.filters,
+                          }
                         : {}),
                     ...(params.order && !equal(params.order, values.filters.order) ? { order: params.order } : {}),
                     ...(params.order_direction && !equal(params.order_direction, values.filters.order_direction)


### PR DESCRIPTION
## Problem

The relevance-sort experiment (#66702) defaults the recordings list to relevance for the test arm.
Early results show two friction points driving users to switch the sort away:

1. **Snap-judgment abandonment.** Users see an unfamiliar ordering, have no explanation of what the relevance score means anywhere in the UI (the only tooltip is buried inside the sort menu), and revert to Latest within seconds.
2. **Intent mismatch.** Users arriving from a person or group profile, or via a "View recordings" CTA with pre-applied filters, already have a specific session in mind. Relevance ordering is actively unhelpful there, and it also polluted the experiment metric with switches that say nothing about the organic browsing experience.

## Changes

- When the list is sorted by relevance, the "Sort by: Relevance" control now shows an info icon with a tooltip explaining what the score is based on (rage clicks, dead clicks, console errors, failed network requests, activity). The sort menu item reuses the same copy.
- `getDefaultFilters` no longer applies the relevance default when the playlist is scoped to a person (`personUUID`) or embedded with pinned filters (group pages). Those views keep Latest.
- Deep links that arrive with pre-applied `filters` in the URL (the "View recordings" CTA path) now default to Latest as well. An explicit `order` in the URL still wins, so saved filters and shared links that specify a sort are unaffected.

Control arm and non-enrolled users see no behavior change: their default order was already Latest in all of these paths.

## How did you test this code?

- Extended the existing parameterized `relevance sort experiment` jest table with three cases (test arm + person page, test arm + pinned filters, rollout flag + person page). These catch the regression where the intent gate is removed and profile pages silently default back to relevance.
- Added a parameterized deep-link case (URL filters without order → Latest, URL filters with explicit order → respected). This catches the regression where the urlToAction merge base reverts to the experiment default for CTA arrivals.
- Ran the full playlist jest suite (96 tests passing) and the frontend typecheck (no errors in changed files; pre-existing unrelated errors on master).
- I was not able to manually verify the tooltip rendering in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). Skills invoked: /writing-tests.
- Considered also defaulting the event/person property quick-filter URL shortcuts to Latest, but left them untouched: they have no in-app producers and changing them would alter persisted-sort behavior for control users too.
- The deep-link recency default flows through a third `urlFilters` param on `getDefaultFilters`, so the intent-to-recency rule lives in one place (URL filters spread after the defaults, so an explicit order still wins).

