### PR TITLE
chore(llma): add deterministic otel ai traffic generator and verifier

### DIFF
--- a/products/ai_observability/otel_traffic_generator/README.md
+++ b/products/ai_observability/otel_traffic_generator/README.md
@@ -1,0 +1,114 @@
+# OTel AI observability traffic generator
+
+A standalone tool that sends synthetic LLM-analytics traffic through the AI
+OpenTelemetry ingestion endpoint (`POST /i/v0/ai/otel`) and verifies it lands
+correctly via the PostHog Django API. Built to validate AI ingestion against a
+real environment (including prod) using only project-scoped credentials.
+
+It follows a **plan → run → verify → compare** flow so the exact same traffic
+can be replayed deterministically and results compared across runs — e.g. before
+and after a change to the ingestion pipeline (the `AI_SINK_MODE` primary →
+secondary cutover).
+
+## Why plan-first
+
+A `plan` is a pure, reviewable JSON artifact describing every trace, span, and
+attribute to send, plus the expectations to assert after ingestion. It carries
+no wall-clock time and no concrete span IDs — those are derived at `run` time
+from `(plan_id, run_id)`. Consequences:
+
+- `plan --seed N` is **byte-stable**: same inputs, same `plan_id`, same bytes.
+- A `run` with a fixed `--run-id` and `--base-time` sends **byte-identical**
+  requests every time (idempotent replay).
+- A `run` with a fresh `--run-id` is **independently scoped** — its events never
+  collide with a previous run's — so two runs can be verified and compared
+  cleanly.
+
+## Credentials
+
+| Phase           | Credential                             | Notes                                                                                                   |
+| --------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `run` (ingest)  | Public project token `phc_…`           | `--token` / `POSTHOG_OTEL_TOKEN`. Sent as `Authorization: Bearer`.                                      |
+| `verify` (read) | **Personal API key** with `query:read` | `--api-key` / `POSTHOG_PERSONAL_API_KEY`, plus `--project-id` / `POSTHOG_PROJECT_ID` (numeric team id). |
+
+Note: the `/query` and `/events` endpoints do **not** accept a project secret
+API key (`phs_`) today — there is no `query` scope available to project secret
+keys — so verification uses a personal API key. Ingestion is project-token only.
+
+## Running
+
+Needs `requests` and `opentelemetry-proto` (both already in the repo's flox
+venv, so from a checkout you can usually run with no install). Run as a module
+from the repo root:
+
+```bash
+# 1. Build a deterministic plan
+python -m products.ai_observability.otel_traffic_generator plan \
+    --seed 42 --out plan.json
+
+# 2. Send it (public project token). Writes run-<run_id>.json.
+POSTHOG_OTEL_TOKEN=phc_xxx \
+python -m products.ai_observability.otel_traffic_generator run \
+    --plan plan.json --cloud us
+
+# 3. Verify ingestion (personal API key with query:read + project id)
+POSTHOG_PERSONAL_API_KEY=phx_xxx POSTHOG_PROJECT_ID=12345 \
+python -m products.ai_observability.otel_traffic_generator verify \
+    --plan plan.json --run run-<run_id>.json --cloud us
+```
+
+`run --verify` chains send + verify in one step. `run --dry-run` builds and
+summarizes the OTLP requests without sending. `--cloud` picks host presets
+(`us`, `eu`, `local`); override with `--capture-host` / `--api-host`.
+
+## Comparing a pipeline change (primary vs secondary sink)
+
+```bash
+python -m ...otel_traffic_generator plan --seed 42 --out plan.json
+
+# Baseline: AI_SINK_MODE=primary
+python -m ...otel_traffic_generator run --plan plan.json --run-id baseline --verify \
+    --result-out result-baseline.json
+
+# ... flip AI_SINK_MODE to secondary, redeploy capture-ai ...
+
+# Candidate: same plan, fresh scope
+python -m ...otel_traffic_generator run --plan plan.json --run-id secondary --verify \
+    --result-out result-secondary.json
+
+# Diff the run-independent surface (event totals, tokens, cost, models, checks)
+python -m ...otel_traffic_generator compare \
+    --baseline result-baseline.json --candidate result-secondary.json
+```
+
+Because the plan is identical and costs are deterministic from model + tokens, a
+healthy cutover yields `MATCH`. Any diff is attributable to the pipeline change.
+
+## Coverage
+
+The default plan exercises a broad, realistic slice of the ingestion + AI
+observability surface:
+
+- **Event types:** `$ai_generation`, `$ai_embedding`, `$ai_span`, and root spans
+  promoted to `$ai_trace`.
+- **SDK namespaces:** generic `gen_ai.*` (OpenAI-style), Vercel AI (`ai.*`),
+  Traceloop/OpenLLMetry (`llm.request.type`), Pydantic AI (`pydantic_ai.*`).
+- **Attribute mapping:** model, provider, input/output tokens, prompt/completion
+  messages, cache-read/creation tokens, `server.address`, SDK name/version.
+- **Derived properties:** cost from model + tokens, latency from span timestamps,
+  `$ai_ingestion_source=otel`, trace/span/parent id linkage.
+- **Scenarios:** single chat, multi-turn, RAG (embedding + generation), tool
+  calls, error status (`$ai_is_error`), Anthropic cache tokens, multi-provider
+  and multi-user distinct ids.
+
+Scale volume with `--multiplier N` (repeats each scenario as N distinct users).
+Narrow with `--scenarios openai_chat,rag_embedding`.
+
+## Files
+
+- `plan.py` — plan model + scenario catalog + deterministic build/hash.
+- `send.py` — resolve a plan into OTLP protobuf and POST it; run receipt.
+- `verify.py` — query the API (HogQL + `TracesQuery`/`TraceQuery`), build a
+  normalized result, and diff two results.
+- `cli.py` — argparse entry point.
+- `test_generator.py` — determinism + OTLP-shape tests (no network).

--- a/products/ai_observability/otel_traffic_generator/__init__.py
+++ b/products/ai_observability/otel_traffic_generator/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic OTel AI observability traffic generator (plan -> run -> verify -> compare)."""

--- a/products/ai_observability/otel_traffic_generator/__main__.py
+++ b/products/ai_observability/otel_traffic_generator/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/products/ai_observability/otel_traffic_generator/cli.py
+++ b/products/ai_observability/otel_traffic_generator/cli.py
@@ -29,6 +29,8 @@ from . import (
 CLOUD_HOSTS: dict[str, tuple[str, str]] = {
     "us": ("https://us.i.posthog.com", "https://us.posthog.com"),
     "eu": ("https://eu.i.posthog.com", "https://eu.posthog.com"),
+    # Internal dev cluster serves ingest and app from the same host.
+    "dev": ("https://app.dev.posthog.dev", "https://app.dev.posthog.dev"),
     "local": ("http://localhost:8010", "http://localhost:8010"),
 }
 

--- a/products/ai_observability/otel_traffic_generator/cli.py
+++ b/products/ai_observability/otel_traffic_generator/cli.py
@@ -1,0 +1,224 @@
+"""Command-line entry point: plan -> run -> verify -> compare.
+
+    python -m products.ai_observability.otel_traffic_generator plan   ...
+    python -m products.ai_observability.otel_traffic_generator run    ...
+    python -m products.ai_observability.otel_traffic_generator verify ...
+    python -m products.ai_observability.otel_traffic_generator compare ...
+
+Config is read from flags, falling back to env vars (POSTHOG_OTEL_TOKEN,
+POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_CLOUD).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import secrets
+import argparse
+from calendar import timegm
+from typing import Any
+
+from . import (
+    plan as planmod,
+    send as sendmod,
+    verify as verifymod,
+)
+
+# capture (ingest) host, app (API) host
+CLOUD_HOSTS: dict[str, tuple[str, str]] = {
+    "us": ("https://us.i.posthog.com", "https://us.posthog.com"),
+    "eu": ("https://eu.i.posthog.com", "https://eu.posthog.com"),
+    "local": ("http://localhost:8010", "http://localhost:8010"),
+}
+
+
+def _resolve_hosts(args: argparse.Namespace) -> tuple[str, str]:
+    cloud = args.cloud or os.environ.get("POSTHOG_CLOUD", "us")
+    if cloud not in CLOUD_HOSTS:
+        raise SystemExit(f"unknown --cloud {cloud!r}; choose from {sorted(CLOUD_HOSTS)}")
+    capture_default, api_default = CLOUD_HOSTS[cloud]
+    capture_host = getattr(args, "capture_host", None) or capture_default
+    api_host = getattr(args, "api_host", None) or api_default
+    return capture_host, api_host
+
+
+def _base_time_ns(raw: str) -> int:
+    if raw == "now":
+        return time.time_ns()
+    # Accept ISO8601 UTC like 2026-07-02T10:00:00Z.
+    parsed = time.strptime(raw.replace("Z", "GMT"), "%Y-%m-%dT%H:%M:%S%Z")
+    return timegm(parsed) * 1_000_000_000
+
+
+def _cmd_plan(args: argparse.Namespace) -> int:
+    scenarios = args.scenarios.split(",") if args.scenarios else planmod.DEFAULT_SCENARIOS
+    plan = planmod.build_plan(seed=args.seed, scenarios=scenarios, multiplier=args.multiplier)
+    text = planmod.dumps(plan)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(text + "\n")
+        n_spans = sum(len(t["spans"]) for t in plan["traces"])
+        print(f"Wrote plan {plan['plan_id']} to {args.out}")
+        print(f"  {len(plan['traces'])} traces, {n_spans} spans, expect_totals={plan['expect_totals']}")
+    else:
+        print(text)
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    plan = planmod.load(args.plan)
+    capture_host, api_host = _resolve_hosts(args)
+    token = args.token or os.environ.get("POSTHOG_OTEL_TOKEN")
+    if not token:
+        raise SystemExit("missing ingest token: pass --token or set POSTHOG_OTEL_TOKEN (public phc_ project key)")
+    run_id = args.run_id or secrets.token_hex(4)
+    base_time_ns = _base_time_ns(args.base_time)
+
+    if args.dry_run:
+        reqs = sendmod.build_requests(plan, run_id, base_time_ns)
+        n_bytes = sum(len(r.SerializeToString()) for r in reqs)
+        rec = sendmod.receipt(plan, run_id, base_time_ns, capture_host, len(reqs))
+        print(f"[dry-run] plan {plan['plan_id']} run {run_id}")
+        print(
+            f"[dry-run] would POST {len(reqs)} request(s), {rec['sent_spans']} spans, {n_bytes} bytes to {capture_host}{sendmod.OTEL_PATH}"
+        )
+        _write_receipt(args, rec)
+        return 0
+
+    print(f"Sending plan {plan['plan_id']} as run {run_id} -> {capture_host}{sendmod.OTEL_PATH}")
+    rec = sendmod.send(plan, run_id, base_time_ns, capture_host, token)
+    print(f"  sent {rec['sent_spans']} spans in {rec['sent_requests']} request(s)")
+    _write_receipt(args, rec)
+
+    if args.verify:
+        return _run_verify(args, plan, rec, api_host)
+    print(f"Verify later with: verify --plan {args.plan} --run {_receipt_path(args, rec)}")
+    return 0
+
+
+def _receipt_path(args: argparse.Namespace, rec: sendmod.RunReceipt) -> str:
+    return args.out or f"run-{rec['run_id']}.json"
+
+
+def _write_receipt(args: argparse.Namespace, rec: sendmod.RunReceipt) -> None:
+    path = _receipt_path(args, rec)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(sendmod.dumps_receipt(rec) + "\n")
+    print(f"  wrote run receipt to {path}")
+
+
+def _run_verify(args: argparse.Namespace, plan: planmod.Plan, rec: sendmod.RunReceipt, api_host: str) -> int:
+    api_key = args.api_key or os.environ.get("POSTHOG_PERSONAL_API_KEY")
+    project_id = args.project_id or os.environ.get("POSTHOG_PROJECT_ID")
+    if not api_key or not project_id:
+        raise SystemExit("verify needs --api-key (personal key, query:read) and --project-id")
+    result = verifymod.verify(
+        plan, rec, api_host, project_id, api_key, timeout_s=args.timeout, query_timeout=args.query_timeout
+    )
+    out = args.result_out or f"result-{rec['run_id']}.json"
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(verifymod.dumps_result(result) + "\n")
+    _print_result(result, out)
+    return 0 if result["ok"] else 1
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    plan = planmod.load(args.plan)
+    rec = sendmod.load_receipt(args.run)
+    _, api_host = _resolve_hosts(args)
+    return _run_verify(args, plan, rec, api_host)
+
+
+def _print_result(result: verifymod.VerifyResult, out_path: str) -> None:
+    status = "PASS" if result["ok"] else "FAIL"
+    print(f"\n=== verify {status} — run {result['run_id']} ===")
+    print(f"observed_totals: {result['observed_totals']}  expected: {result['expect_totals']}")
+    m = result["metrics"]
+    print(
+        f"metrics: cost=${m['sum_total_cost_usd']} tokens_in={m['sum_input_tokens']} "
+        f"tokens_out={m['sum_output_tokens']} costed+={m['costed_events_positive']} "
+        f"errors={m['errors_observed']} models={m['models']}"
+    )
+    for c in result["checks"]:
+        mark = "ok  " if c["ok"] else "FAIL"
+        print(f"  [{mark}] {c['name']}: {c['detail']}")
+    print(f"result written to {out_path}")
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    baseline = verifymod.load_result(args.baseline)
+    candidate = verifymod.load_result(args.candidate)
+    same, diffs = verifymod.compare(baseline, candidate)
+    print(f"baseline run {baseline['run_id']} vs candidate run {candidate['run_id']}")
+    if same:
+        print("MATCH — no differences on the run-independent surface (totals, metrics, checks)")
+        return 0
+    print(f"DIFFERENCES ({len(diffs)}):")
+    for d in diffs:
+        print(f"  {d['field']}: baseline={d['baseline']!r}  candidate={d['candidate']!r}")
+    return 1
+
+
+def _add_host_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--cloud", choices=sorted(CLOUD_HOSTS), help="host preset (default us, or POSTHOG_CLOUD)")
+    p.add_argument("--capture-host", help="override OTel ingest host")
+    p.add_argument("--api-host", help="override Django API host")
+
+
+def _add_verify_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--api-key", help="personal API key with query:read (or POSTHOG_PERSONAL_API_KEY)")
+    p.add_argument("--project-id", help="numeric project/team id (or POSTHOG_PROJECT_ID)")
+    p.add_argument("--timeout", type=float, default=180.0, help="seconds to poll for ingestion (default 180)")
+    p.add_argument("--query-timeout", type=float, default=60.0, help="per-query HTTP timeout (default 60)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="otel-ai-traffic-generator", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_plan = sub.add_parser("plan", help="build a deterministic plan")
+    p_plan.add_argument("--seed", type=int, default=0)
+    p_plan.add_argument("--multiplier", type=int, default=1, help="repeat each scenario N times (more volume)")
+    p_plan.add_argument("--scenarios", help=f"comma-separated subset of: {','.join(planmod.DEFAULT_SCENARIOS)}")
+    p_plan.add_argument("--out", help="write plan JSON here (default: stdout)")
+    p_plan.set_defaults(func=_cmd_plan)
+
+    p_run = sub.add_parser("run", help="send a plan's traffic to the OTel endpoint")
+    p_run.add_argument("--plan", required=True, help="plan JSON path")
+    p_run.add_argument("--token", help="public project token, phc_… (or POSTHOG_OTEL_TOKEN)")
+    p_run.add_argument("--run-id", help="scope id; pass a fixed value for byte-identical repeat runs")
+    p_run.add_argument("--base-time", default="now", help="'now' (default) or ISO8601 UTC anchor for span timestamps")
+    p_run.add_argument("--out", help="run receipt path (default run-<run_id>.json)")
+    p_run.add_argument("--dry-run", action="store_true", help="build & summarize requests without sending")
+    p_run.add_argument("--verify", action="store_true", help="verify immediately after sending")
+    p_run.add_argument("--result-out", help="verify result path when --verify (default result-<run_id>.json)")
+    _add_host_args(p_run)
+    _add_verify_args(p_run)
+    p_run.set_defaults(func=_cmd_run)
+
+    p_verify = sub.add_parser("verify", help="verify an already-sent run via the PostHog API")
+    p_verify.add_argument("--plan", required=True, help="plan JSON path")
+    p_verify.add_argument("--run", required=True, help="run receipt JSON path")
+    p_verify.add_argument("--result-out", help="verify result path (default result-<run_id>.json)")
+    _add_host_args(p_verify)
+    _add_verify_args(p_verify)
+    p_verify.set_defaults(func=_cmd_verify)
+
+    p_compare = sub.add_parser("compare", help="diff two verify results (baseline vs candidate)")
+    p_compare.add_argument("--baseline", required=True)
+    p_compare.add_argument("--candidate", required=True)
+    p_compare.set_defaults(func=_cmd_compare)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func: Any = args.func
+    return int(func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/products/ai_observability/otel_traffic_generator/plan.py
+++ b/products/ai_observability/otel_traffic_generator/plan.py
@@ -1,0 +1,714 @@
+"""Deterministic plan model and scenario catalog for the OTel AI traffic generator.
+
+A *plan* is a pure, reviewable description of the synthetic AI traffic to send:
+a list of traces, each a list of OTLP spans with their gen_ai/Vercel/Traceloop/
+Pydantic attributes, plus the expectations we assert after ingestion. Plans carry
+no wall-clock time and no concrete span IDs — those are resolved at run time from
+``(plan_id, run_id)`` — so ``plan(seed=X)`` is byte-stable and a single plan can be
+run many times and compared across runs.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from typing import Any, Literal, TypedDict
+
+# ----- attribute value encoding (maps onto OTLP AnyValue) -------------------
+
+AttrType = Literal["str", "int", "double", "bool", "json"]
+
+
+class AttrVal(TypedDict):
+    t: AttrType
+    v: Any
+
+
+def s(v: str) -> AttrVal:
+    return {"t": "str", "v": v}
+
+
+def i(v: int) -> AttrVal:
+    return {"t": "int", "v": v}
+
+
+def d(v: float) -> AttrVal:
+    return {"t": "double", "v": v}
+
+
+def b(v: bool) -> AttrVal:
+    return {"t": "bool", "v": v}
+
+
+def j(v: Any) -> AttrVal:
+    """A structured value serialized to a JSON string (how gen_ai.*.messages arrive)."""
+    return {"t": "json", "v": v}
+
+
+# ----- plan structures ------------------------------------------------------
+
+# Second granularity so the whole scenario catalog fits well under any single
+# request's span budget while keeping realistic sub-second latencies.
+SECOND_NS = 1_000_000_000
+
+
+class SpanSpec(TypedDict):
+    index: int
+    name: str
+    # What this span is expected to become after capture + ingestion.
+    expect_event: str
+    parent_index: int | None
+    start_offset_ns: int
+    end_offset_ns: int
+    attributes: dict[str, AttrVal]
+    # Optional error status -> $ai_is_error / $ai_error / $ai_http_status.
+    error: ErrorSpec | None
+
+
+class ErrorSpec(TypedDict):
+    message: str
+    exception_type: str
+    exception_message: str
+    http_status: int
+
+
+class GenerationExpect(TypedDict, total=False):
+    span_index: int
+    model: str
+    input_tokens: int
+    output_tokens: int
+    provider: str
+    cost_positive: bool
+    latency_positive: bool
+    input_present: bool
+    output_present: bool
+    cache_read_tokens: int
+    is_error: bool
+
+
+class TraceSpec(TypedDict):
+    index: int
+    scenario: str
+    distinct_id: str
+    spans: list[SpanSpec]
+    # Expected count of each ingested event type for this trace.
+    expect_events: dict[str, int]
+    # Per-generation/embedding property expectations, verified by span_index.
+    expect_props: list[GenerationExpect]
+
+
+class Plan(TypedDict):
+    version: int
+    plan_id: str
+    seed: int
+    scenarios: list[str]
+    multiplier: int
+    traces: list[TraceSpec]
+    expect_totals: dict[str, int]
+
+
+PLAN_VERSION = 1
+
+
+# ----- message helpers ------------------------------------------------------
+
+
+def _user(text: str) -> dict[str, Any]:
+    return {"role": "user", "parts": [{"type": "text", "content": text}]}
+
+
+def _system(text: str) -> dict[str, Any]:
+    return {"role": "system", "parts": [{"type": "text", "content": text}]}
+
+
+def _assistant(text: str, finish_reason: str = "stop") -> dict[str, Any]:
+    return {"role": "assistant", "parts": [{"type": "text", "content": text}], "finish_reason": finish_reason}
+
+
+def _assistant_tool_call(call_id: str, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "parts": [{"type": "tool_call", "id": call_id, "name": name, "arguments": arguments}],
+        "finish_reason": "tool_calls",
+    }
+
+
+# ----- span builders --------------------------------------------------------
+
+
+def _sdk_attrs(name: str = "opentelemetry", version: str = "1.29.0") -> dict[str, AttrVal]:
+    return {"telemetry.sdk.name": s(name), "telemetry.sdk.version": s(version)}
+
+
+def _root_span(scenario_title: str, model: str, provider: str, end_s: float) -> SpanSpec:
+    """A parentless AI span: capture -> $ai_span, ingestion promotes it to $ai_trace."""
+    return {
+        "index": 0,
+        "name": scenario_title,
+        "expect_event": "$ai_trace",
+        "parent_index": None,
+        "start_offset_ns": 0,
+        "end_offset_ns": int(end_s * SECOND_NS),
+        # gen_ai.* prefix (so capture accepts the span) but no operation.name (so it
+        # classifies as $ai_span, not $ai_generation). request.model/system fall
+        # back to $ai_model/$ai_provider on the trace.
+        "attributes": {"gen_ai.request.model": s(model), "gen_ai.system": s(provider)},
+        "error": None,
+    }
+
+
+def _generation_span(
+    index: int,
+    name: str,
+    model: str,
+    provider: str,
+    input_tokens: int,
+    output_tokens: int,
+    prompt: str,
+    completion: str,
+    start_s: float,
+    end_s: float,
+    *,
+    parent_index: int | None = 0,
+    response_model: str | None = None,
+    system_prompt: str | None = None,
+    extra: dict[str, AttrVal] | None = None,
+) -> SpanSpec:
+    messages: list[dict[str, Any]] = []
+    if system_prompt is not None:
+        messages.append(_system(system_prompt))
+    messages.append(_user(prompt))
+    attributes: dict[str, AttrVal] = {
+        "gen_ai.operation.name": s("chat"),
+        "gen_ai.request.model": s(model),
+        "gen_ai.response.model": s(response_model or model),
+        "gen_ai.provider.name": s(provider),
+        "gen_ai.usage.input_tokens": i(input_tokens),
+        "gen_ai.usage.output_tokens": i(output_tokens),
+        "gen_ai.input.messages": j(messages),
+        "gen_ai.output.messages": j([_assistant(completion)]),
+        "server.address": s(f"api.{provider}.com"),
+        **_sdk_attrs(),
+    }
+    if extra:
+        attributes.update(extra)
+    return {
+        "index": index,
+        "name": name,
+        "expect_event": "$ai_generation",
+        "parent_index": parent_index,
+        "start_offset_ns": int(start_s * SECOND_NS),
+        "end_offset_ns": int(end_s * SECOND_NS),
+        "attributes": attributes,
+        "error": None,
+    }
+
+
+def _embedding_span(
+    index: int,
+    name: str,
+    model: str,
+    provider: str,
+    input_tokens: int,
+    text: str,
+    start_s: float,
+    end_s: float,
+    *,
+    parent_index: int | None = 0,
+) -> SpanSpec:
+    return {
+        "index": index,
+        "name": name,
+        "expect_event": "$ai_embedding",
+        "parent_index": parent_index,
+        "start_offset_ns": int(start_s * SECOND_NS),
+        "end_offset_ns": int(end_s * SECOND_NS),
+        "attributes": {
+            "gen_ai.operation.name": s("embeddings"),
+            "gen_ai.request.model": s(model),
+            "gen_ai.response.model": s(model),
+            "gen_ai.provider.name": s(provider),
+            "gen_ai.usage.input_tokens": i(input_tokens),
+            "gen_ai.input.messages": j([_user(text)]),
+            **_sdk_attrs(),
+        },
+        "error": None,
+    }
+
+
+# ----- scenario catalog -----------------------------------------------------
+#
+# Each scenario returns the spans + expectations for one trace. distinct_id and
+# trace index are filled in by build_plan. Scenarios deliberately span the whole
+# classification + mapping surface: gen_ai / Vercel / Traceloop / Pydantic
+# namespaces, generation / embedding / span / trace event types, tool calls,
+# cache tokens, and error status.
+
+ScenarioFn = Any  # Callable[[int, str], TraceSpec], kept loose to avoid import churn.
+
+
+def _openai_chat(index: int, distinct_id: str) -> TraceSpec:
+    spans = [
+        _root_span("OpenAI chat", "gpt-4o", "openai", 3.4),
+        _generation_span(
+            1,
+            "chat gpt-4o",
+            "gpt-4o",
+            "openai",
+            142,
+            318,
+            "Explain retrieval-augmented generation in two sentences.",
+            "RAG augments a model's prompt with documents fetched from an external "
+            "store at query time. This grounds answers in up-to-date, source-backed "
+            "context the model wasn't trained on.",
+            0.2,
+            3.1,
+            response_model="gpt-4o-2024-08-06",
+            system_prompt="You are a concise technical assistant.",
+        ),
+    ]
+    return {
+        "index": index,
+        "scenario": "openai_chat",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [
+            {
+                "span_index": 1,
+                "model": "gpt-4o-2024-08-06",
+                "input_tokens": 142,
+                "output_tokens": 318,
+                "provider": "openai",
+                "cost_positive": True,
+                "latency_positive": True,
+                "input_present": True,
+                "output_present": True,
+            }
+        ],
+    }
+
+
+def _multi_turn(index: int, distinct_id: str) -> TraceSpec:
+    spans = [
+        _root_span("Support conversation", "gpt-4o-mini", "openai", 6.0),
+        _generation_span(
+            1,
+            "chat turn 1",
+            "gpt-4o-mini",
+            "openai",
+            88,
+            120,
+            "My order hasn't arrived, can you check status 10432?",
+            "Order 10432 shipped yesterday and is out for delivery today. Anything else?",
+            0.2,
+            2.0,
+        ),
+        _generation_span(
+            2,
+            "chat turn 2",
+            "gpt-4o-mini",
+            "openai",
+            210,
+            64,
+            "Thanks. Can you also email me the receipt?",
+            "Done — I've emailed the receipt to the address on file.",
+            2.4,
+            5.8,
+        ),
+    ]
+    return {
+        "index": index,
+        "scenario": "multi_turn",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 2},
+        "expect_props": [
+            {"span_index": 1, "model": "gpt-4o-mini", "cost_positive": True, "latency_positive": True},
+            {"span_index": 2, "model": "gpt-4o-mini", "cost_positive": True, "latency_positive": True},
+        ],
+    }
+
+
+def _rag_embedding(index: int, distinct_id: str) -> TraceSpec:
+    spans = [
+        _root_span("RAG pipeline", "gpt-4o", "openai", 4.5),
+        _embedding_span(
+            1,
+            "embeddings text-embedding-3-small",
+            "text-embedding-3-small",
+            "openai",
+            96,
+            "What is the refund window for enterprise plans?",
+            0.2,
+            0.6,
+        ),
+        _generation_span(
+            2,
+            "chat gpt-4o",
+            "gpt-4o",
+            "openai",
+            540,
+            180,
+            "Answer using the retrieved policy documents.",
+            "Enterprise plans have a 30-day refund window from the invoice date.",
+            0.8,
+            4.2,
+            response_model="gpt-4o-2024-08-06",
+        ),
+    ]
+    return {
+        "index": index,
+        "scenario": "rag_embedding",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_embedding": 1, "$ai_generation": 1},
+        "expect_props": [
+            {"span_index": 1, "model": "text-embedding-3-small", "cost_positive": True, "input_present": True},
+            {"span_index": 2, "model": "gpt-4o-2024-08-06", "cost_positive": True, "latency_positive": True},
+        ],
+    }
+
+
+def _tool_call(index: int, distinct_id: str) -> TraceSpec:
+    gen = _generation_span(
+        1,
+        "chat gpt-4o tools",
+        "gpt-4o",
+        "openai",
+        160,
+        48,
+        "What's the weather in Lisbon and should I bring an umbrella?",
+        "",
+        0.2,
+        2.0,
+        response_model="gpt-4o-2024-08-06",
+    )
+    # Override the output with a tool call so tool extraction has something to chew on.
+    gen["attributes"]["gen_ai.output.messages"] = j(
+        [_assistant_tool_call("call_wx1", "get_weather", {"city": "Lisbon"})]
+    )
+    tool_span: SpanSpec = {
+        "index": 2,
+        "name": "tool get_weather",
+        "expect_event": "$ai_span",
+        "parent_index": 1,
+        "start_offset_ns": int(2.0 * SECOND_NS),
+        "end_offset_ns": int(2.3 * SECOND_NS),
+        # gen_ai.* prefix with no operation.name -> $ai_span (child, not promoted).
+        "attributes": {"gen_ai.tool.name": s("get_weather"), "gen_ai.tool.type": s("function")},
+        "error": None,
+    }
+    spans = [_root_span("Agent with tools", "gpt-4o", "openai", 3.0), gen, tool_span]
+    return {
+        "index": index,
+        "scenario": "tool_call",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1, "$ai_span": 1},
+        "expect_props": [{"span_index": 1, "model": "gpt-4o-2024-08-06", "cost_positive": True}],
+    }
+
+
+def _error_generation(index: int, distinct_id: str) -> TraceSpec:
+    gen = _generation_span(
+        1,
+        "chat gpt-4o (error)",
+        "gpt-4o",
+        "openai",
+        75,
+        0,
+        "Summarize this 900-page document.",
+        "",
+        0.2,
+        1.1,
+    )
+    gen["expect_event"] = "$ai_generation"
+    gen["error"] = {
+        "message": "rate limited",
+        "exception_type": "RateLimitError",
+        "exception_message": "429 Too Many Requests",
+        "http_status": 429,
+    }
+    spans = [_root_span("Failed generation", "gpt-4o", "openai", 1.3), gen]
+    return {
+        "index": index,
+        "scenario": "error_generation",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [{"span_index": 1, "model": "gpt-4o", "is_error": True}],
+    }
+
+
+def _anthropic_cache(index: int, distinct_id: str) -> TraceSpec:
+    gen = _generation_span(
+        1,
+        "chat claude cache",
+        "claude-sonnet-4.5",
+        "anthropic",
+        1200,
+        220,
+        "Given the cached system prompt, draft a release note.",
+        "Here is the release note draft based on the provided changelog.",
+        0.2,
+        3.6,
+        system_prompt="You are a release-notes writer. [large cached context]",
+        extra={
+            "gen_ai.usage.cache_read.input_tokens": i(1000),
+            "gen_ai.usage.cache_creation.input_tokens": i(200),
+        },
+    )
+    spans = [_root_span("Anthropic cached prompt", "claude-sonnet-4.5", "anthropic", 3.8), gen]
+    return {
+        "index": index,
+        "scenario": "anthropic_cache",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [
+            {
+                "span_index": 1,
+                "model": "claude-sonnet-4.5",
+                "provider": "anthropic",
+                "cost_positive": True,
+                "cache_read_tokens": 1000,
+            }
+        ],
+    }
+
+
+def _vercel_ai(index: int, distinct_id: str) -> TraceSpec:
+    # Vercel AI SDK: ai.* namespace. The root ai.* span with no .doGenerate/.doStream
+    # classifies as $ai_span (-> $ai_trace); the .doGenerate child is the generation.
+    root: SpanSpec = {
+        "index": 0,
+        "name": "ai.generateText",
+        "expect_event": "$ai_trace",
+        "parent_index": None,
+        "start_offset_ns": 0,
+        "end_offset_ns": int(2.6 * SECOND_NS),
+        "attributes": {"ai.operationId": s("ai.generateText"), "gen_ai.request.model": s("gpt-4o")},
+        "error": None,
+    }
+    child: SpanSpec = {
+        "index": 1,
+        "name": "ai.generateText.doGenerate",
+        "expect_event": "$ai_generation",
+        "parent_index": 0,
+        "start_offset_ns": int(0.1 * SECOND_NS),
+        "end_offset_ns": int(2.5 * SECOND_NS),
+        "attributes": {
+            "ai.operationId": s("ai.generateText.doGenerate"),
+            "gen_ai.request.model": s("gpt-4o"),
+            "gen_ai.response.model": s("gpt-4o-2024-08-06"),
+            "gen_ai.usage.input_tokens": i(130),
+            "gen_ai.usage.output_tokens": i(90),
+            "gen_ai.input.messages": j([_user("Write a haiku about latency.")]),
+            "gen_ai.output.messages": j(
+                [_assistant("Packets in the dark / waiting on a distant ACK / dawn of the reply")]
+            ),
+            **_sdk_attrs("vercel-ai", "4.0.0"),
+        },
+        "error": None,
+    }
+    return {
+        "index": index,
+        "scenario": "vercel_ai",
+        "distinct_id": distinct_id,
+        "spans": [root, child],
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [
+            {"span_index": 1, "model": "gpt-4o-2024-08-06", "cost_positive": True, "latency_positive": True}
+        ],
+    }
+
+
+def _traceloop(index: int, distinct_id: str) -> TraceSpec:
+    # Traceloop / OpenLLMetry: llm.request.type drives classification (reclassified
+    # from $ai_span -> $ai_generation in ingestion).
+    root: SpanSpec = {
+        "index": 0,
+        "name": "workflow.rag",
+        "expect_event": "$ai_trace",
+        "parent_index": None,
+        "start_offset_ns": 0,
+        "end_offset_ns": int(3.0 * SECOND_NS),
+        "attributes": {"traceloop.workflow.name": s("rag"), "traceloop.span.kind": s("workflow")},
+        "error": None,
+    }
+    child: SpanSpec = {
+        "index": 1,
+        "name": "openai.chat",
+        "expect_event": "$ai_generation",
+        "parent_index": 0,
+        "start_offset_ns": int(0.1 * SECOND_NS),
+        "end_offset_ns": int(2.8 * SECOND_NS),
+        "attributes": {
+            "llm.request.type": s("chat"),
+            "gen_ai.request.model": s("gpt-4o-mini"),
+            "gen_ai.response.model": s("gpt-4o-mini"),
+            "gen_ai.system": s("openai"),
+            "gen_ai.usage.prompt_tokens": i(210),
+            "gen_ai.usage.completion_tokens": i(75),
+            "gen_ai.input.messages": j([_user("Classify this ticket: 'app crashes on export'.")]),
+            "gen_ai.output.messages": j([_assistant("Category: bug. Severity: high.")]),
+            **_sdk_attrs("traceloop", "0.30.0"),
+        },
+        "error": None,
+    }
+    return {
+        "index": index,
+        "scenario": "traceloop",
+        "distinct_id": distinct_id,
+        "spans": [root, child],
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [{"span_index": 1, "model": "gpt-4o-mini", "cost_positive": True, "latency_positive": True}],
+    }
+
+
+def _pydantic_ai(index: int, distinct_id: str) -> TraceSpec:
+    # Pydantic AI: pydantic_ai.* -> $ai_span for every span (root promoted to trace).
+    root: SpanSpec = {
+        "index": 0,
+        "name": "agent run",
+        "expect_event": "$ai_trace",
+        "parent_index": None,
+        "start_offset_ns": 0,
+        "end_offset_ns": int(2.2 * SECOND_NS),
+        "attributes": {"pydantic_ai.agent_name": s("weather_agent")},
+        "error": None,
+    }
+    child: SpanSpec = {
+        "index": 1,
+        "name": "model request",
+        "expect_event": "$ai_span",
+        "parent_index": 0,
+        "start_offset_ns": int(0.1 * SECOND_NS),
+        "end_offset_ns": int(2.0 * SECOND_NS),
+        "attributes": {"pydantic_ai.step": s("model_request"), "gen_ai.request.model": s("gpt-4o")},
+        "error": None,
+    }
+    return {
+        "index": index,
+        "scenario": "pydantic_ai",
+        "distinct_id": distinct_id,
+        "spans": [root, child],
+        "expect_events": {"$ai_trace": 1, "$ai_span": 1},
+        "expect_props": [],
+    }
+
+
+def _gemini_chat(index: int, distinct_id: str) -> TraceSpec:
+    spans = [
+        _root_span("Gemini chat", "gemini-2.5-pro", "google", 2.8),
+        _generation_span(
+            1,
+            "chat gemini-2.5-pro",
+            "gemini-2.5-pro",
+            "google",
+            98,
+            210,
+            "Give me three names for a hedgehog-themed coffee shop.",
+            "Prickly Brew, The Spiny Bean, Hedgehog & Portafilter.",
+            0.2,
+            2.5,
+        ),
+    ]
+    return {
+        "index": index,
+        "scenario": "gemini_chat",
+        "distinct_id": distinct_id,
+        "spans": spans,
+        "expect_events": {"$ai_trace": 1, "$ai_generation": 1},
+        "expect_props": [
+            {
+                "span_index": 1,
+                "model": "gemini-2.5-pro",
+                "provider": "google",
+                "cost_positive": True,
+                "latency_positive": True,
+            }
+        ],
+    }
+
+
+SCENARIOS: dict[str, ScenarioFn] = {
+    "openai_chat": _openai_chat,
+    "multi_turn": _multi_turn,
+    "rag_embedding": _rag_embedding,
+    "tool_call": _tool_call,
+    "error_generation": _error_generation,
+    "anthropic_cache": _anthropic_cache,
+    "vercel_ai": _vercel_ai,
+    "traceloop": _traceloop,
+    "pydantic_ai": _pydantic_ai,
+    "gemini_chat": _gemini_chat,
+}
+
+DEFAULT_SCENARIOS: list[str] = list(SCENARIOS.keys())
+
+
+# ----- plan construction ----------------------------------------------------
+
+
+def build_plan(seed: int, scenarios: list[str], multiplier: int) -> Plan:
+    """Build a deterministic plan. Same (seed, scenarios, multiplier) -> identical bytes."""
+    if multiplier < 1:
+        raise ValueError("multiplier must be >= 1")
+    unknown = [name for name in scenarios if name not in SCENARIOS]
+    if unknown:
+        raise ValueError(f"unknown scenarios: {unknown}. known: {sorted(SCENARIOS)}")
+
+    traces: list[TraceSpec] = []
+    trace_index = 0
+    for copy in range(multiplier):
+        for name in scenarios:
+            # distinct_id namespaced by seed + copy so multiplier copies are
+            # distinct users but fully deterministic.
+            distinct_id = f"otelgen-s{seed}-u{copy}-{name}"
+            traces.append(SCENARIOS[name](trace_index, distinct_id))
+            trace_index += 1
+
+    expect_totals: dict[str, int] = {}
+    for trace in traces:
+        for event, count in trace["expect_events"].items():
+            expect_totals[event] = expect_totals.get(event, 0) + count
+
+    plan: Plan = {
+        "version": PLAN_VERSION,
+        "plan_id": "",
+        "seed": seed,
+        "scenarios": scenarios,
+        "multiplier": multiplier,
+        "traces": traces,
+        "expect_totals": expect_totals,
+    }
+    plan["plan_id"] = _plan_id(plan)
+    return plan
+
+
+def _canonical(plan: Plan) -> str:
+    """Stable serialization used for both plan_id hashing and on-disk storage."""
+    without_id = {k: v for k, v in plan.items() if k != "plan_id"}
+    return json.dumps(without_id, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _plan_id(plan: Plan) -> str:
+    return hashlib.sha256(_canonical(plan).encode("utf-8")).hexdigest()[:16]
+
+
+def dumps(plan: Plan) -> str:
+    return json.dumps(plan, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def load(path: str) -> Plan:
+    with open(path, encoding="utf-8") as f:
+        plan = json.load(f)
+    expected = _plan_id(plan)
+    if plan.get("plan_id") != expected:
+        raise ValueError(
+            f"plan_id mismatch in {path}: file has {plan.get('plan_id')!r}, "
+            f"content hashes to {expected!r}. The plan was edited by hand — regenerate it."
+        )
+    return plan

--- a/products/ai_observability/otel_traffic_generator/requirements.txt
+++ b/products/ai_observability/otel_traffic_generator/requirements.txt
@@ -1,0 +1,5 @@
+# Standalone deps for running the generator outside the repo venv.
+# Both are already present in the repo's flox venv, so from a checkout you can
+# usually run it with no install.
+requests>=2.31
+opentelemetry-proto>=1.20

--- a/products/ai_observability/otel_traffic_generator/send.py
+++ b/products/ai_observability/otel_traffic_generator/send.py
@@ -1,0 +1,209 @@
+"""Resolve a plan into OTLP protobuf and POST it to ``/i/v0/ai/otel``.
+
+Concrete trace/span IDs and event timestamps are *not* in the plan — they are
+derived here from ``(plan_id, run_id)`` and the run's base time. So a given
+``(plan, run_id, base_time)`` produces byte-identical requests every time
+(idempotent), while a fresh ``run_id`` yields an independently-scoped run whose
+events never collide with a previous run's — which is exactly what lets a
+baseline run and a post-cutover run be compared.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from typing import Any, TypedDict
+
+import requests
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+from opentelemetry.proto.common.v1 import common_pb2
+from opentelemetry.proto.resource.v1 import resource_pb2
+from opentelemetry.proto.trace.v1 import trace_pb2
+
+from .plan import AttrVal, Plan, SpanSpec, TraceSpec
+
+OTEL_PATH = "/i/v0/ai/otel"
+# Server rejects >100 AI spans per request; stay well under so mixed batches fit.
+MAX_SPANS_PER_REQUEST = 90
+RUN_RECEIPT_VERSION = 1
+
+
+class RunReceipt(TypedDict):
+    version: int
+    plan_id: str
+    run_id: str
+    base_time_ns: int
+    capture_host: str
+    # hex trace ids actually sent, in plan trace order — the scope key for verify.
+    trace_ids: list[str]
+    distinct_ids: list[str]
+    sent_spans: int
+    sent_requests: int
+    # Echo of the plan's expectations so verify/compare need only the receipt.
+    expect_totals: dict[str, int]
+
+
+def _digest(*parts: str, size: int) -> bytes:
+    return hashlib.blake2b("\x00".join(parts).encode("utf-8"), digest_size=size).digest()
+
+
+def trace_id_bytes(plan_id: str, run_id: str, trace_index: int) -> bytes:
+    return _digest(plan_id, run_id, "trace", str(trace_index), size=16)
+
+
+def span_id_bytes(plan_id: str, run_id: str, trace_index: int, span_index: int) -> bytes:
+    return _digest(plan_id, run_id, "span", str(trace_index), str(span_index), size=8)
+
+
+def _any_value(av: AttrVal) -> common_pb2.AnyValue:
+    t, v = av["t"], av["v"]
+    out = common_pb2.AnyValue()
+    if t == "str":
+        out.string_value = v
+    elif t == "int":
+        out.int_value = int(v)
+    elif t == "double":
+        out.double_value = float(v)
+    elif t == "bool":
+        out.bool_value = bool(v)
+    elif t == "json":
+        out.string_value = json.dumps(v, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    else:
+        raise ValueError(f"unknown attr type {t!r}")
+    return out
+
+
+def _kv(key: str, av: AttrVal) -> common_pb2.KeyValue:
+    return common_pb2.KeyValue(key=key, value=_any_value(av))
+
+
+def _build_span(
+    span: SpanSpec,
+    plan: Plan,
+    trace: TraceSpec,
+    run_id: str,
+    base_time_ns: int,
+) -> trace_pb2.Span:
+    plan_id = plan["plan_id"]
+    pb = trace_pb2.Span()
+    pb.trace_id = trace_id_bytes(plan_id, run_id, trace["index"])
+    pb.span_id = span_id_bytes(plan_id, run_id, trace["index"], span["index"])
+    if span["parent_index"] is not None:
+        pb.parent_span_id = span_id_bytes(plan_id, run_id, trace["index"], span["parent_index"])
+    pb.name = span["name"]
+    pb.start_time_unix_nano = base_time_ns + span["start_offset_ns"]
+    pb.end_time_unix_nano = base_time_ns + span["end_offset_ns"]
+
+    for key, av in span["attributes"].items():
+        pb.attributes.append(_kv(key, av))
+    # Run marker so events are also findable in the UI without knowing trace ids.
+    pb.attributes.append(_kv("$otelgen_run_id", {"t": "str", "v": run_id}))
+    pb.attributes.append(_kv("$otelgen_scenario", {"t": "str", "v": trace["scenario"]}))
+
+    error = span["error"]
+    if error is not None:
+        pb.status.code = trace_pb2.Status.StatusCode.STATUS_CODE_ERROR
+        pb.status.message = error["message"]
+        event = pb.events.add()
+        event.name = "exception"
+        event.time_unix_nano = pb.end_time_unix_nano
+        event.attributes.append(_kv("exception.type", {"t": "str", "v": error["exception_type"]}))
+        event.attributes.append(_kv("exception.message", {"t": "str", "v": error["exception_message"]}))
+        event.attributes.append(_kv("http.response.status_code", {"t": "int", "v": error["http_status"]}))
+    return pb
+
+
+def _resource_spans(
+    trace: TraceSpec,
+    plan: Plan,
+    run_id: str,
+    base_time_ns: int,
+) -> trace_pb2.ResourceSpans:
+    rs = trace_pb2.ResourceSpans()
+    rs.resource.CopyFrom(
+        resource_pb2.Resource(
+            attributes=[
+                _kv("service.name", {"t": "str", "v": "otel-ai-traffic-generator"}),
+                _kv("posthog.distinct_id", {"t": "str", "v": f"{run_id}:{trace['distinct_id']}"}),
+            ]
+        )
+    )
+    scope = rs.scope_spans.add()
+    for span in trace["spans"]:
+        scope.spans.append(_build_span(span, plan, trace, run_id, base_time_ns))
+    return rs
+
+
+def build_requests(plan: Plan, run_id: str, base_time_ns: int) -> list[trace_service_pb2.ExportTraceServiceRequest]:
+    """Chunk the plan's traces into OTLP requests, each under the span cap.
+
+    A whole trace is kept in one request so parent/child links never split.
+    """
+    requests_out: list[trace_service_pb2.ExportTraceServiceRequest] = []
+    current = trace_service_pb2.ExportTraceServiceRequest()
+    current_spans = 0
+    for trace in plan["traces"]:
+        n = len(trace["spans"])
+        if current_spans and current_spans + n > MAX_SPANS_PER_REQUEST:
+            requests_out.append(current)
+            current = trace_service_pb2.ExportTraceServiceRequest()
+            current_spans = 0
+        current.resource_spans.append(_resource_spans(trace, plan, run_id, base_time_ns))
+        current_spans += n
+    if current_spans:
+        requests_out.append(current)
+    return requests_out
+
+
+def receipt(plan: Plan, run_id: str, base_time_ns: int, capture_host: str, sent_requests: int) -> RunReceipt:
+    plan_id = plan["plan_id"]
+    trace_ids = [trace_id_bytes(plan_id, run_id, t["index"]).hex() for t in plan["traces"]]
+    distinct_ids = [f"{run_id}:{t['distinct_id']}" for t in plan["traces"]]
+    sent_spans = sum(len(t["spans"]) for t in plan["traces"])
+    return {
+        "version": RUN_RECEIPT_VERSION,
+        "plan_id": plan_id,
+        "run_id": run_id,
+        "base_time_ns": base_time_ns,
+        "capture_host": capture_host,
+        "trace_ids": trace_ids,
+        "distinct_ids": distinct_ids,
+        "sent_spans": sent_spans,
+        "sent_requests": sent_requests,
+        "expect_totals": plan["expect_totals"],
+    }
+
+
+def send(
+    plan: Plan,
+    run_id: str,
+    base_time_ns: int,
+    capture_host: str,
+    token: str,
+    *,
+    timeout: float = 30.0,
+    session: requests.Session | None = None,
+) -> RunReceipt:
+    """Build and POST every request for this run, then return the receipt."""
+    reqs = build_requests(plan, run_id, base_time_ns)
+    url = capture_host.rstrip("/") + OTEL_PATH
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/x-protobuf"}
+    sess = session or requests.Session()
+    for idx, req in enumerate(reqs):
+        body = req.SerializeToString()
+        resp = sess.post(url, data=body, headers=headers, timeout=timeout)
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"OTel ingest request {idx + 1}/{len(reqs)} failed: HTTP {resp.status_code} {resp.text[:500]}"
+            )
+    return receipt(plan, run_id, base_time_ns, capture_host, len(reqs))
+
+
+def dumps_receipt(r: RunReceipt) -> str:
+    return json.dumps(r, indent=2, sort_keys=True)
+
+
+def load_receipt(path: str) -> RunReceipt:
+    with open(path, encoding="utf-8") as f:
+        data: Any = json.load(f)
+    return data

--- a/products/ai_observability/otel_traffic_generator/test_generator.py
+++ b/products/ai_observability/otel_traffic_generator/test_generator.py
@@ -1,0 +1,129 @@
+"""Tests for the generator's core contract: determinism and correct OTLP shape.
+
+No network. These guard the promises the tool is built on — that a plan is
+byte-stable for a seed, that a run is reproducible for a fixed (run_id,
+base_time) yet independently scoped otherwise, and that the emitted OTLP spans
+carry the attributes ingestion needs to classify and map them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+from products.ai_observability.otel_traffic_generator import (
+    plan as planmod,
+    send as sendmod,
+    verify as verifymod,
+)
+
+BASE_NS = 1_704_067_200_000_000_000  # fixed 2024-01-01 anchor
+
+
+def test_plan_is_deterministic_for_a_seed():
+    a = planmod.build_plan(seed=7, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=2)
+    b = planmod.build_plan(seed=7, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=2)
+    assert a["plan_id"] == b["plan_id"]
+    assert planmod.dumps(a) == planmod.dumps(b)
+
+
+def test_plan_id_changes_with_content():
+    a = planmod.build_plan(seed=1, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=1)
+    b = planmod.build_plan(seed=2, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=1)
+    c = planmod.build_plan(seed=1, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=2)
+    assert len({a["plan_id"], b["plan_id"], c["plan_id"]}) == 3
+
+
+def test_load_rejects_hand_edited_plan(tmp_path):
+    plan = planmod.build_plan(seed=1, scenarios=["openai_chat"], multiplier=1)
+    path = tmp_path / "plan.json"
+    tampered = json.loads(planmod.dumps(plan))
+    tampered["traces"][0]["spans"][0]["name"] = "edited"
+    path.write_text(json.dumps(tampered))
+    with pytest.raises(ValueError, match="plan_id mismatch"):
+        planmod.load(str(path))
+
+
+def test_expect_totals_sum_matches_traces():
+    plan = planmod.build_plan(seed=0, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=1)
+    recomputed: dict[str, int] = {}
+    for trace in plan["traces"]:
+        for event, count in trace["expect_events"].items():
+            recomputed[event] = recomputed.get(event, 0) + count
+    assert recomputed == plan["expect_totals"]
+
+
+def test_same_run_id_and_base_time_is_byte_identical():
+    plan = planmod.build_plan(seed=3, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=1)
+    r1 = sendmod.build_requests(plan, run_id="fixed", base_time_ns=BASE_NS)
+    r2 = sendmod.build_requests(plan, run_id="fixed", base_time_ns=BASE_NS)
+    assert [r.SerializeToString() for r in r1] == [r.SerializeToString() for r in r2]
+
+
+def test_different_run_id_yields_disjoint_trace_ids():
+    plan = planmod.build_plan(seed=3, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=1)
+    a = set(sendmod.receipt(plan, "runA", BASE_NS, "http://x", 1)["trace_ids"])
+    b = set(sendmod.receipt(plan, "runB", BASE_NS, "http://x", 1)["trace_ids"])
+    assert a.isdisjoint(b)
+    assert len(a) == len(plan["traces"])
+
+
+def test_requests_stay_under_span_cap():
+    plan = planmod.build_plan(seed=0, scenarios=planmod.DEFAULT_SCENARIOS, multiplier=8)
+    for req in sendmod.build_requests(plan, run_id="r", base_time_ns=BASE_NS):
+        spans = sum(len(ss.spans) for rs in req.resource_spans for ss in rs.scope_spans)
+        assert spans <= sendmod.MAX_SPANS_PER_REQUEST
+
+
+def test_otlp_spans_carry_classification_attributes():
+    plan = planmod.build_plan(seed=0, scenarios=["openai_chat"], multiplier=1)
+    req = sendmod.build_requests(plan, run_id="r", base_time_ns=BASE_NS)[0]
+    # Round-trip through protobuf to prove it's wire-valid.
+    reparsed = trace_service_pb2.ExportTraceServiceRequest()
+    reparsed.ParseFromString(req.SerializeToString())
+    spans = [sp for rs in reparsed.resource_spans for ss in rs.scope_spans for sp in ss.spans]
+    gen = next(sp for sp in spans if sp.name == "chat gpt-4o")
+    keys = {kv.key for kv in gen.attributes}
+    assert "gen_ai.operation.name" in keys
+    assert "gen_ai.usage.input_tokens" in keys
+    assert "$otelgen_run_id" in keys
+    # Parent/child links resolve within the trace.
+    assert gen.parent_span_id != b""
+    assert len(gen.trace_id) == 16 and len(gen.span_id) == 8
+
+
+def test_error_span_sets_status_and_exception_event():
+    plan = planmod.build_plan(seed=0, scenarios=["error_generation"], multiplier=1)
+    req = sendmod.build_requests(plan, run_id="r", base_time_ns=BASE_NS)[0]
+    spans = [sp for rs in req.resource_spans for ss in rs.scope_spans for sp in ss.spans]
+    errored = [sp for sp in spans if sp.status.code == 2]  # STATUS_CODE_ERROR
+    assert len(errored) == 1
+    assert any(ev.name == "exception" for ev in errored[0].events)
+
+
+def test_compare_detects_metric_drift():
+    base: verifymod.VerifyResult = {
+        "version": 1,
+        "plan_id": "p",
+        "run_id": "a",
+        "ok": True,
+        "observed_totals": {"$ai_generation": 10},
+        "expect_totals": {"$ai_generation": 10},
+        "metrics": {"sum_total_cost_usd": 0.5, "models": ["gpt-4o"]},
+        "checks": [{"name": "count:$ai_generation", "ok": True, "detail": ""}],
+    }
+    candidate = json.loads(json.dumps(base))
+    candidate["run_id"] = "b"
+    same, diffs = verifymod.compare(base, candidate)
+    assert same and not diffs
+
+    candidate["observed_totals"]["$ai_generation"] = 7
+    candidate["metrics"]["sum_total_cost_usd"] = 0.35
+    same, diffs = verifymod.compare(base, candidate)
+    assert not same
+    fields = {d["field"] for d in diffs}
+    assert "observed_totals.$ai_generation" in fields
+    assert "metrics.sum_total_cost_usd" in fields

--- a/products/ai_observability/otel_traffic_generator/verify.py
+++ b/products/ai_observability/otel_traffic_generator/verify.py
@@ -159,15 +159,19 @@ def _fetch_ai_event_props(
     base_time_ns: int,
     query_timeout: float,
     log: Any,
-) -> dict[str, dict[str, Any]]:
+) -> tuple[dict[str, dict[str, Any]], set[int]]:
     """Map span_id (hex) -> event properties from ai_events, via TraceQuery.
 
     $ai_input / $ai_output_choices only exist on the ai_events table, which is
     not directly queryable in HogQL — the product's TraceQuery runner reads it.
     We query only the traces that actually have an input/output expectation.
+
+    Returns the props map plus the set of trace indices whose TraceQuery errored,
+    so a query failure is reported as "unverifiable" rather than "empty".
     """
     date_from = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(base_time_ns // 1_000_000_000 - 1800))
     out: dict[str, dict[str, Any]] = {}
+    failed: set[int] = set()
     for trace in plan["traces"]:
         if not _needs_ai_event_props(trace):
             continue
@@ -177,6 +181,7 @@ def _fetch_ai_event_props(
             data = _query(api_host, project_id, api_key, query, query_timeout)
         except _ApiError as exc:
             log(f"  TraceQuery({trace['scenario']}) error: {exc}")
+            failed.add(trace["index"])
             continue
         for result in data.get("results", []):
             for event in result.get("events", []):
@@ -184,11 +189,15 @@ def _fetch_ai_event_props(
                 span_id = props.get("$ai_span_id")
                 if span_id is not None:
                     out[str(span_id)] = props
-    return out
+    return out, failed
 
 
 def _check_props(
-    plan: Plan, run_id: str, rows: list[dict[str, Any]], ai_props: dict[str, dict[str, Any]]
+    plan: Plan,
+    run_id: str,
+    rows: list[dict[str, Any]],
+    ai_props: dict[str, dict[str, Any]],
+    ai_fetch_failed: set[int],
 ) -> list[Check]:
     by_span = {str(r["span_id"]): r for r in rows}
     checks: list[Check] = []
@@ -215,10 +224,17 @@ def _check_props(
                 failures.append("$ai_total_cost_usd not > 0")
             if exp.get("latency_positive") and float(row["latency"] or 0) <= 0:
                 failures.append("$ai_latency not > 0")
-            if exp.get("input_present") and not aep.get("$ai_input"):
-                failures.append("$ai_input empty (ai_events)")
-            if exp.get("output_present") and not aep.get("$ai_output_choices"):
-                failures.append("$ai_output_choices empty (ai_events)")
+            fetch_failed = trace["index"] in ai_fetch_failed
+            if exp.get("input_present"):
+                if fetch_failed:
+                    failures.append("$ai_input unverifiable (TraceQuery failed)")
+                elif not aep.get("$ai_input"):
+                    failures.append("$ai_input empty (ai_events)")
+            if exp.get("output_present"):
+                if fetch_failed:
+                    failures.append("$ai_output_choices unverifiable (TraceQuery failed)")
+                elif not aep.get("$ai_output_choices"):
+                    failures.append("$ai_output_choices empty (ai_events)")
             if "cache_read_tokens" in exp and int(row["cache_read_tokens"] or 0) != exp["cache_read_tokens"]:
                 failures.append(f"$ai_cache_read_input_tokens={row['cache_read_tokens']} != {exp['cache_read_tokens']}")
             if exp.get("is_error") and str(row["is_error"]).lower() != "true":
@@ -360,8 +376,10 @@ def verify(
         got = observed_totals.get(event, 0)
         checks.append({"name": f"count:{event}", "ok": got >= count, "detail": f"observed {got}, expected {count}"})
 
-    ai_props = _fetch_ai_event_props(api_host, project_id, api_key, plan, run_id, base_time_ns, query_timeout, log)
-    checks.extend(_check_props(plan, run_id, rows, ai_props))
+    ai_props, ai_fetch_failed = _fetch_ai_event_props(
+        api_host, project_id, api_key, plan, run_id, base_time_ns, query_timeout, log
+    )
+    checks.extend(_check_props(plan, run_id, rows, ai_props, ai_fetch_failed))
 
     metrics = _metrics_from_rows(rows)
     non_otel = {k: v for k, v in metrics["ingestion_sources"].items() if k != "otel"}

--- a/products/ai_observability/otel_traffic_generator/verify.py
+++ b/products/ai_observability/otel_traffic_generator/verify.py
@@ -1,0 +1,442 @@
+"""Verify ingested traffic through the PostHog Django API and compare runs.
+
+Verification reads back the events a run produced (scoped by the run's trace ids)
+and checks them against the plan's expectations, using both raw HogQL and the AI
+observability product's own ``TracesQuery`` / ``TraceQuery`` runners. It emits a
+*normalized* result whose ``metrics`` block is run-independent (no run id / trace
+ids), so a baseline run and a post-cutover run can be diffed directly with
+``compare``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, TypedDict
+
+import requests
+
+from .plan import Plan, TraceSpec
+from .send import RunReceipt, span_id_bytes, trace_id_bytes
+
+RESULT_VERSION = 1
+
+
+class Check(TypedDict):
+    name: str
+    ok: bool
+    detail: str
+
+
+class VerifyResult(TypedDict):
+    version: int
+    plan_id: str
+    run_id: str
+    ok: bool
+    observed_totals: dict[str, int]
+    expect_totals: dict[str, int]
+    metrics: dict[str, Any]
+    checks: list[Check]
+
+
+class _ApiError(RuntimeError):
+    pass
+
+
+def _query(api_host: str, project_id: str, api_key: str, query: dict[str, Any], timeout: float) -> dict[str, Any]:
+    url = f"{api_host.rstrip('/')}/api/projects/{project_id}/query/"
+    resp = requests.post(
+        url,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        # force_blocking bypasses the query result cache — without it, the first
+        # (empty) poll result is cached and every later poll of the same query
+        # keeps returning it even after the events have landed.
+        json={"query": query, "refresh": "force_blocking"},
+        timeout=timeout,
+    )
+    if resp.status_code != 200:
+        raise _ApiError(f"query failed: HTTP {resp.status_code} {resp.text[:500]}")
+    data: dict[str, Any] = resp.json()
+    return data
+
+
+def _quote_list(values: list[str]) -> str:
+    # trace ids are hex, but quote-escape defensively anyway.
+    return ", ".join("'" + v.replace("'", "\\'") + "'" for v in values)
+
+
+def _floor_datetime_sql(base_time_ns: int) -> str:
+    # 10 min before the run's base time — comfortably covers ingestion skew while
+    # keeping the scan bounded.
+    floor_s = base_time_ns // 1_000_000_000 - 600
+    return f"toDateTime({floor_s})"
+
+
+def _count_query(trace_ids: list[str], base_time_ns: int) -> str:
+    return (
+        "SELECT event, count() AS cnt FROM events "
+        f"WHERE properties.$ai_trace_id IN ({_quote_list(trace_ids)}) "
+        f"AND timestamp > {_floor_datetime_sql(base_time_ns)} "
+        "GROUP BY event"
+    )
+
+
+def _detail_query(trace_ids: list[str], base_time_ns: int) -> str:
+    return (
+        "SELECT "
+        "properties.$ai_trace_id AS trace_id, "
+        "properties.$ai_span_id AS span_id, "
+        "event, "
+        "properties.$otelgen_scenario AS scenario, "
+        "toString(properties.$ai_model) AS model, "
+        "toString(properties.$ai_provider) AS provider, "
+        "toString(properties.$ai_ingestion_source) AS ingestion_source, "
+        "toString(properties.$ai_is_error) AS is_error, "
+        "toFloat(properties.$ai_input_tokens) AS input_tokens, "
+        "toFloat(properties.$ai_output_tokens) AS output_tokens, "
+        "toFloat(properties.$ai_total_cost_usd) AS total_cost, "
+        "toFloat(properties.$ai_latency) AS latency, "
+        "toFloat(properties.$ai_cache_read_input_tokens) AS cache_read_tokens "
+        # $ai_input / $ai_output_choices are stripped from the `events` table by
+        # the split-ai-events step and live only on ai_events — verify them via
+        # TraceQuery instead (see _fetch_ai_event_props).
+        "FROM events "
+        f"WHERE properties.$ai_trace_id IN ({_quote_list(trace_ids)}) "
+        f"AND timestamp > {_floor_datetime_sql(base_time_ns)} "
+        "ORDER BY trace_id, timestamp LIMIT 5000"
+    )
+
+
+def _totals_from_rows(rows: list[list[Any]]) -> dict[str, int]:
+    return {str(event): int(cnt) for event, cnt in rows}
+
+
+def _meets(observed: dict[str, int], expected: dict[str, int]) -> bool:
+    return all(observed.get(event, 0) >= count for event, count in expected.items())
+
+
+def _poll_totals(
+    api_host: str,
+    project_id: str,
+    api_key: str,
+    trace_ids: list[str],
+    base_time_ns: int,
+    expect_totals: dict[str, int],
+    timeout_s: float,
+    query_timeout: float,
+    log: Any,
+) -> dict[str, int]:
+    """Poll the count query until expectations are met or the timeout elapses."""
+    deadline = time.monotonic() + timeout_s
+    delay = 3.0
+    observed: dict[str, int] = {}
+    count_sql = _count_query(trace_ids, base_time_ns)
+    while True:
+        try:
+            data = _query(api_host, project_id, api_key, {"kind": "HogQLQuery", "query": count_sql}, query_timeout)
+            observed = _totals_from_rows(data.get("results", []))
+        except _ApiError as exc:
+            log(f"  query error (will retry): {exc}")
+        if _meets(observed, expect_totals):
+            return observed
+        if time.monotonic() >= deadline:
+            return observed
+        log(f"  waiting for ingestion… observed={observed} expected={expect_totals}")
+        time.sleep(delay)
+        delay = min(delay * 1.5, 20.0)
+
+
+def _needs_ai_event_props(trace: TraceSpec) -> bool:
+    return any(exp.get("input_present") or exp.get("output_present") for exp in trace["expect_props"])
+
+
+def _fetch_ai_event_props(
+    api_host: str,
+    project_id: str,
+    api_key: str,
+    plan: Plan,
+    run_id: str,
+    base_time_ns: int,
+    query_timeout: float,
+    log: Any,
+) -> dict[str, dict[str, Any]]:
+    """Map span_id (hex) -> event properties from ai_events, via TraceQuery.
+
+    $ai_input / $ai_output_choices only exist on the ai_events table, which is
+    not directly queryable in HogQL — the product's TraceQuery runner reads it.
+    We query only the traces that actually have an input/output expectation.
+    """
+    date_from = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(base_time_ns // 1_000_000_000 - 1800))
+    out: dict[str, dict[str, Any]] = {}
+    for trace in plan["traces"]:
+        if not _needs_ai_event_props(trace):
+            continue
+        trace_hex = trace_id_bytes(plan["plan_id"], run_id, trace["index"]).hex()
+        query = {"kind": "TraceQuery", "traceId": trace_hex, "dateRange": {"date_from": date_from}}
+        try:
+            data = _query(api_host, project_id, api_key, query, query_timeout)
+        except _ApiError as exc:
+            log(f"  TraceQuery({trace['scenario']}) error: {exc}")
+            continue
+        for result in data.get("results", []):
+            for event in result.get("events", []):
+                props = event.get("properties", {})
+                span_id = props.get("$ai_span_id")
+                if span_id is not None:
+                    out[str(span_id)] = props
+    return out
+
+
+def _check_props(
+    plan: Plan, run_id: str, rows: list[dict[str, Any]], ai_props: dict[str, dict[str, Any]]
+) -> list[Check]:
+    by_span = {str(r["span_id"]): r for r in rows}
+    checks: list[Check] = []
+    for trace in plan["traces"]:
+        for exp in trace["expect_props"]:
+            span_index = exp["span_index"]
+            hex_id = span_id_bytes(plan["plan_id"], run_id, trace["index"], span_index).hex()
+            label = f"{trace['scenario']}[{trace['index']}].span{span_index}"
+            row = by_span.get(hex_id)
+            if row is None:
+                checks.append({"name": f"props:{label}", "ok": False, "detail": "event not found for span"})
+                continue
+            aep = ai_props.get(hex_id, {})
+            failures: list[str] = []
+            if "model" in exp and str(row["model"]) != exp["model"]:
+                failures.append(f"$ai_model={row['model']!r} != {exp['model']!r}")
+            if "provider" in exp and str(row["provider"]) != exp["provider"]:
+                failures.append(f"$ai_provider={row['provider']!r} != {exp['provider']!r}")
+            if "input_tokens" in exp and int(row["input_tokens"] or 0) != exp["input_tokens"]:
+                failures.append(f"$ai_input_tokens={row['input_tokens']} != {exp['input_tokens']}")
+            if "output_tokens" in exp and int(row["output_tokens"] or 0) != exp["output_tokens"]:
+                failures.append(f"$ai_output_tokens={row['output_tokens']} != {exp['output_tokens']}")
+            if exp.get("cost_positive") and float(row["total_cost"] or 0) <= 0:
+                failures.append("$ai_total_cost_usd not > 0")
+            if exp.get("latency_positive") and float(row["latency"] or 0) <= 0:
+                failures.append("$ai_latency not > 0")
+            if exp.get("input_present") and not aep.get("$ai_input"):
+                failures.append("$ai_input empty (ai_events)")
+            if exp.get("output_present") and not aep.get("$ai_output_choices"):
+                failures.append("$ai_output_choices empty (ai_events)")
+            if "cache_read_tokens" in exp and int(row["cache_read_tokens"] or 0) != exp["cache_read_tokens"]:
+                failures.append(f"$ai_cache_read_input_tokens={row['cache_read_tokens']} != {exp['cache_read_tokens']}")
+            if exp.get("is_error") and str(row["is_error"]).lower() != "true":
+                failures.append(f"$ai_is_error={row['is_error']!r} != true")
+            checks.append({"name": f"props:{label}", "ok": not failures, "detail": "; ".join(failures) or "ok"})
+    return checks
+
+
+def _metrics_from_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    costed = {"$ai_generation", "$ai_embedding"}
+    sources: dict[str, int] = {}
+    models: set[str] = set()
+    providers: set[str] = set()
+    sum_in = sum_out = 0
+    sum_cost = 0.0
+    costed_positive = 0
+    latency_present = 0
+    errors = 0
+    cache_read_total = 0
+    for r in rows:
+        src = str(r["ingestion_source"])
+        sources[src] = sources.get(src, 0) + 1
+        if r["model"]:
+            models.add(str(r["model"]))
+        if r["provider"]:
+            providers.add(str(r["provider"]))
+        sum_in += int(r["input_tokens"] or 0)
+        sum_out += int(r["output_tokens"] or 0)
+        sum_cost += float(r["total_cost"] or 0)
+        cache_read_total += int(r["cache_read_tokens"] or 0)
+        if str(r["event"]) in costed and float(r["total_cost"] or 0) > 0:
+            costed_positive += 1
+        if float(r["latency"] or 0) > 0:
+            latency_present += 1
+        if str(r["is_error"]).lower() == "true":
+            errors += 1
+    return {
+        "sum_input_tokens": sum_in,
+        "sum_output_tokens": sum_out,
+        "sum_total_cost_usd": round(sum_cost, 6),
+        "costed_events_positive": costed_positive,
+        "latency_present": latency_present,
+        "errors_observed": errors,
+        "cache_read_tokens_total": cache_read_total,
+        "models": sorted(models),
+        "providers": sorted(providers),
+        "ingestion_sources": sources,
+    }
+
+
+def _traces_api_check(
+    api_host: str,
+    project_id: str,
+    api_key: str,
+    trace_ids: list[str],
+    base_time_ns: int,
+    query_timeout: float,
+    log: Any,
+) -> tuple[Check, Check]:
+    """Exercise the product's TracesQuery (list) and TraceQuery (single) runners."""
+    date_from_s = base_time_ns // 1_000_000_000 - 1800
+    date_from = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(date_from_s))
+    traces_query = {
+        "kind": "TracesQuery",
+        "dateRange": {"date_from": date_from},
+        "limit": 500,
+        "properties": [{"key": "$ai_trace_id", "type": "event", "operator": "exact", "value": trace_ids}],
+    }
+    want = set(trace_ids)
+    try:
+        data = _query(api_host, project_id, api_key, traces_query, query_timeout)
+        results = data.get("results", [])
+        matched = [t for t in results if str(t.get("id")) in want]
+        list_check: Check = {
+            "name": "traces_api:list",
+            "ok": len(matched) > 0,
+            "detail": f"TracesQuery surfaced {len(matched)}/{len(want)} of our traces",
+        }
+    except _ApiError as exc:
+        log(f"  TracesQuery error: {exc}")
+        return (
+            {"name": "traces_api:list", "ok": False, "detail": f"TracesQuery failed: {exc}"},
+            {"name": "traces_api:single", "ok": False, "detail": "skipped (list failed)"},
+        )
+
+    # Single-trace read of the first trace id.
+    trace_query = {"kind": "TraceQuery", "traceId": trace_ids[0], "dateRange": {"date_from": date_from}}
+    try:
+        data = _query(api_host, project_id, api_key, trace_query, query_timeout)
+        results = data.get("results", [])
+        found = [t for t in results if str(t.get("id")) == trace_ids[0]]
+        n_events = len(found[0].get("events", [])) if found else 0
+        single_check: Check = {
+            "name": "traces_api:single",
+            "ok": bool(found) and n_events > 0,
+            "detail": f"TraceQuery returned trace with {n_events} events" if found else "trace not found",
+        }
+    except _ApiError as exc:
+        single_check = {"name": "traces_api:single", "ok": False, "detail": f"TraceQuery failed: {exc}"}
+    return list_check, single_check
+
+
+def verify(
+    plan: Plan,
+    receipt: RunReceipt,
+    api_host: str,
+    project_id: str,
+    api_key: str,
+    *,
+    timeout_s: float = 180.0,
+    query_timeout: float = 60.0,
+    log: Any = print,
+) -> VerifyResult:
+    if plan["plan_id"] != receipt["plan_id"]:
+        raise ValueError(f"plan/receipt mismatch: plan {plan['plan_id']} vs receipt {receipt['plan_id']}")
+
+    trace_ids = receipt["trace_ids"]
+    run_id = receipt["run_id"]
+    base_time_ns = receipt["base_time_ns"]
+    expect_totals = receipt["expect_totals"]
+
+    log(f"Polling for {expect_totals} across {len(trace_ids)} traces (timeout {timeout_s:.0f}s)…")
+    observed_totals = _poll_totals(
+        api_host, project_id, api_key, trace_ids, base_time_ns, expect_totals, timeout_s, query_timeout, log
+    )
+
+    data = _query(
+        api_host,
+        project_id,
+        api_key,
+        {"kind": "HogQLQuery", "query": _detail_query(trace_ids, base_time_ns)},
+        query_timeout,
+    )
+    columns = [str(c) for c in data.get("columns", [])]
+    rows = [dict(zip(columns, r)) for r in data.get("results", [])]
+
+    checks: list[Check] = []
+    for event, count in expect_totals.items():
+        got = observed_totals.get(event, 0)
+        checks.append({"name": f"count:{event}", "ok": got >= count, "detail": f"observed {got}, expected {count}"})
+
+    ai_props = _fetch_ai_event_props(api_host, project_id, api_key, plan, run_id, base_time_ns, query_timeout, log)
+    checks.extend(_check_props(plan, run_id, rows, ai_props))
+
+    metrics = _metrics_from_rows(rows)
+    non_otel = {k: v for k, v in metrics["ingestion_sources"].items() if k != "otel"}
+    checks.append(
+        {
+            "name": "ingestion_source:otel",
+            "ok": not non_otel,
+            "detail": f"non-otel sources: {non_otel}" if non_otel else "all otel",
+        }
+    )
+
+    list_check, single_check = _traces_api_check(
+        api_host, project_id, api_key, trace_ids, base_time_ns, query_timeout, log
+    )
+    checks.extend([list_check, single_check])
+
+    ok = all(c["ok"] for c in checks)
+    return {
+        "version": RESULT_VERSION,
+        "plan_id": plan["plan_id"],
+        "run_id": run_id,
+        "ok": ok,
+        "observed_totals": observed_totals,
+        "expect_totals": expect_totals,
+        "metrics": metrics,
+        "checks": checks,
+    }
+
+
+def dumps_result(result: VerifyResult) -> str:
+    return json.dumps(result, indent=2, sort_keys=True)
+
+
+def load_result(path: str) -> VerifyResult:
+    with open(path, encoding="utf-8") as f:
+        data: Any = json.load(f)
+    return data
+
+
+# ----- comparison -----------------------------------------------------------
+
+
+class Diff(TypedDict):
+    field: str
+    baseline: Any
+    candidate: Any
+
+
+def compare(baseline: VerifyResult, candidate: VerifyResult) -> tuple[bool, list[Diff]]:
+    """Diff two runs on their run-independent surfaces. Identical plan + healthy
+    pipeline on both sides => no diffs. Any diff is attributable to the change
+    between the two runs (e.g. the AI sink cutover)."""
+    diffs: list[Diff] = []
+
+    if baseline["plan_id"] != candidate["plan_id"]:
+        diffs.append({"field": "plan_id", "baseline": baseline["plan_id"], "candidate": candidate["plan_id"]})
+
+    def cmp(field: str, a: Any, b: Any) -> None:
+        if a != b:
+            diffs.append({"field": field, "baseline": a, "candidate": b})
+
+    for event in sorted(set(baseline["expect_totals"]) | set(candidate["expect_totals"])):
+        cmp(
+            f"observed_totals.{event}",
+            baseline["observed_totals"].get(event, 0),
+            candidate["observed_totals"].get(event, 0),
+        )
+
+    bm, cm = baseline["metrics"], candidate["metrics"]
+    for key in sorted(set(bm) | set(cm)):
+        cmp(f"metrics.{key}", bm.get(key), cm.get(key))
+
+    b_checks = {c["name"]: c["ok"] for c in baseline["checks"]}
+    c_checks = {c["name"]: c["ok"] for c in candidate["checks"]}
+    for name in sorted(set(b_checks) | set(c_checks)):
+        cmp(f"check.{name}", b_checks.get(name), c_checks.get(name))
+
+    return (not diffs, diffs)

--- a/products/ruff.toml
+++ b/products/ruff.toml
@@ -14,6 +14,8 @@ extend-select = ["ANN001", "ANN201", "ANN202", "ANN204"]
 "**/dags/**" = ["ANN"]
 "**/scripts/**" = ["ANN"]
 "**/stats/**" = ["ANN"]
+# Standalone CLI tool: stdout is its user interface, so print() is intentional.
+"ai_observability/otel_traffic_generator/**" = ["T201"]
 
 # Temporarily exempted — too many violations to fix in one pass.
 # Run: ruff check products/<name>/backend --select ANN --statistics


### PR DESCRIPTION
## Problem

The AI OpenTelemetry ingestion endpoint (`/i/v0/ai/otel`) is hard to exercise against a real environment, and the AI secondary-sink routing work (`AI_SINK_MODE` primary → secondary, #67021) needs a way to prove ingestion behaves identically before and after the cutover. There was no repeatable way to push synthetic LLM-analytics traffic through the endpoint and confirm it lands correctly.

## Changes

A standalone, product-owned tool at `products/ai_observability/otel_traffic_generator/` with a `plan → run → verify → compare` flow. It talks to prod (or any env) with only project-scoped credentials.

- **plan** — a deterministic, content-hashed JSON artifact describing the traffic (traces, spans, `gen_ai`/Vercel/Traceloop/Pydantic attributes) and the expectations to assert. It carries no wall-clock time and no concrete span ids, so `plan --seed N` is byte-stable.
- **run** — resolves a plan into OTLP protobuf with run-scoped ids and timestamps and POSTs to `/i/v0/ai/otel` with a public `phc_` token. A fixed `--run-id`/`--base-time` gives byte-identical replays; a fresh `--run-id` is independently scoped so runs never collide.
- **verify** — reads the events back through the Django query API (HogQL plus the product's own `TracesQuery`/`TraceQuery` runners) with a personal API key, and checks counts, model, tokens, cost, latency, error status, message content, and ingestion source against the plan. Emits a run-independent result.
- **compare** — diffs two results so a baseline run and a post-cutover run can be checked for drift. Same plan plus healthy pipeline yields `MATCH`; any diff is attributable to the change between the runs.

Coverage spans generation/embedding/span/trace events, four SDK namespaces, cost and latency derivation, cache tokens, tool calls, error status, and multi-user distinct ids. Also adds a `T201` ruff exemption for the tool dir, since stdout is its user interface.

Reads use a personal API key with `query:read`, not a project secret key: the `/query` and `/events` endpoints don't accept `phs_` keys today (there's no `query` scope for them). Ingestion stays project-token only.

## How did you test this code?

- Ran the full flow against prod US end to end. All 17 checks pass: 10 generations, 10 traces, 2 spans, 1 embedding, with correct models, tokens, cost, latency, error status, and message content, and `TracesQuery` surfacing 10/10 of the run's traces.
- The live run found and fixed two verifier bugs that static analysis would have missed: the `/query` endpoint caches by query text, so polling needs `refresh: force_blocking` (matching `common/ingestion/acceptance_tests/api_client.py`); and `$ai_input`/`$ai_output_choices` are stripped from the `events` table by the split-ai-events step, so message content is verified via `TraceQuery` against `ai_events`. A third finding (two model names that aren't in the cost table returned zero cost) was correct pipeline behavior, so the scenarios switched to costed model names.
- Added `test_generator.py`: determinism (plan byte-stability, idempotent replays, disjoint run scoping), OTLP wire shape, error status, and compare drift detection. Network-free, 10 tests. I ran `ruff check`/`format`, `ty check` (via lint-staged), and `pytest` locally; I did not run the repo's full CI suite locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus). It investigated the OTel ingest path (`rust/capture/src/otel`), the `gen_ai.* → $ai_*` mapping and cost computation (`nodejs/.../ingestion/pipelines/ai`), and the read/query surface before proposing the design. Key decisions: a plan/run/verify/compare shape so the same traffic replays deterministically and two runs compare cleanly across the sink cutover; run-scoped ids derived from `(plan_id, run_id)` to keep runs independent; and a personal API key for reads after finding project secret keys can't authenticate `/query`. No repo skills were required. The two verifier bugs above were surfaced by running against prod, not from reading code.
