### PR TITLE
fix(bigquery): treat resourcesExceeded query failures as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -533,6 +533,12 @@ def _get_primary_keys_for_table(table: bigquery.Table, client: bigquery.Client) 
     return primary_keys
 
 
+# Stable wording BigQuery puts in a `resourcesExceeded` query failure's message. Shared between
+# `_is_bigquery_resource_exceeded` and `BigQuerySource.get_non_retryable_errors` so the two sites
+# stay in lockstep if BigQuery ever adjusts the phrasing.
+BIGQUERY_RESOURCES_EXCEEDED_ERROR = "Resources exceeded during query execution"
+
+
 def _is_bigquery_resource_exceeded(error: BadRequest) -> bool:
     """True for BigQuery's `resourcesExceeded` query failures.
 
@@ -543,7 +549,7 @@ def _is_bigquery_resource_exceeded(error: BadRequest) -> bool:
     crash.
     """
     reasons = {err.get("reason") for err in (getattr(error, "errors", None) or [])}
-    return "resourcesExceeded" in reasons or "Resources exceeded during query execution" in str(error)
+    return "resourcesExceeded" in reasons or BIGQUERY_RESOURCES_EXCEEDED_ERROR in str(error)
 
 
 def _has_duplicate_primary_keys(table: bigquery.Table, client: bigquery.Client, primary_keys: list[str] | None) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -194,6 +194,17 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # the Read API and spams error tracking until a later sync finds the table caught up.
             # Matched on the stable freshness phrasing rather than the volatile table id.
             "un-applied upsert data that is not fresh enough": "BigQuery couldn't read this table through the Storage Read API because it uses change data capture and has pending upserts that haven't been applied within the table's max_staleness window. This usually clears once BigQuery applies the pending changes, so a later sync should recover. If it persists, lower the table's max_staleness or run a query against the table in BigQuery to apply the changes.",
+            # BigQuery aborts a query job with "Resources exceeded during query execution" (reason
+            # `resourcesExceeded`) when the query can't run within a worker's memory — heavy sorts or
+            # analytic OVER() clauses over a large table or view. We copy incremental / view /
+            # row-filtered reads into a temp table before reading them (`_run_destination_query_with_job_retry`
+            # in `bigquery.py`), and that copy carries the offending shape, so it fails here. It's a
+            # deterministic property of the customer's data volume and query shape — retrying the same
+            # query always fails identically (Google's own default job-retry doesn't retry this reason),
+            # so it just spams error tracking. The user must reduce the data synced or simplify the
+            # source view. Matched on BigQuery's stable wording, not the volatile peak-usage percentage
+            # or job id.
+            "Resources exceeded during query execution": "BigQuery couldn't run a query for this source because it exceeded the memory allowed for a single query. This is usually caused by heavy sorts or analytic (window) functions over a large table or view. Retrying won't help — please reduce how much data you're syncing (for example add row filters or an incremental field), or simplify the source view, then re-enable the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -14,6 +14,7 @@ from posthog.schema import (
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
+    BIGQUERY_RESOURCES_EXCEEDED_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryImplementation,
     build_destination_table_prefix,
@@ -204,7 +205,7 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # so it just spams error tracking. The user must reduce the data synced or simplify the
             # source view. Matched on BigQuery's stable wording, not the volatile peak-usage percentage
             # or job id.
-            "Resources exceeded during query execution": "BigQuery couldn't run a query for this source because it exceeded the memory allowed for a single query. This is usually caused by heavy sorts or analytic (window) functions over a large table or view. Retrying won't help — please reduce how much data you're syncing (for example add row filters or an incremental field), or simplify the source view, then re-enable the source.",
+            BIGQUERY_RESOURCES_EXCEEDED_ERROR: "BigQuery couldn't run a query for this source because it exceeded the memory allowed for a single query. This is usually caused by heavy sorts or analytic (window) functions over a large table or view. Retrying won't help — please reduce how much data you're syncing (for example add row filters or an incremental field), or simplify the source view, then re-enable the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1281,3 +1281,23 @@ def test_bigquery_cdc_staleness_key_does_not_match_unrelated_errors(other_error)
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
     assert "un-applied upsert data that is not fresh enough" not in other_error
     assert not any(key in other_error for key in non_retryable_errors)
+
+
+def test_bigquery_resources_exceeded_is_non_retryable():
+    """A `resourcesExceeded` query failure exceeds a worker's memory deterministically (heavy sorts /
+    analytic OVER() clauses over a large table or view), so retrying the identical temp-table copy in
+    `_run_destination_query_with_job_retry` always fails — it must be recognised as non-retryable
+    rather than retried on every attempt."""
+    error_msg = str(
+        BadRequest(
+            "GET https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/queries/<redacted>"
+            "?maxResults=0&location=us-central1&prettyPrint=false: Resources exceeded during query "
+            "execution: The query could not be executed in the allotted memory. Peak usage: 122% of limit."
+        )
+    )
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in error_msg]
+
+    assert matching, "resourcesExceeded query failure should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)


### PR DESCRIPTION
## Problem

A BigQuery data-warehouse source is failing its sync with a `BadRequest` that keeps retrying and spamming error tracking:

```
Resources exceeded during query execution: The query could not be executed in the allotted memory. Peak usage: 122% of limit.
Top memory consumer(s):
  sort operations used for analytic OVER() clauses: 99%
  other/unattributed: 1%
```

It's raised from `_run_destination_query_with_job_retry` in `bigquery.py` (via `get_rows`). For incremental / view / row-filtered reads we copy the source into a temp table first, and that copy carries the customer's query shape. When the source is a large table or a view with heavy sorts or analytic `OVER()` clauses, BigQuery can't run it within a worker's memory and aborts with reason `resourcesExceeded`.

This is a deterministic property of the customer's data volume and query shape — the identical query fails identically on every retry. Google's own default job-retry predicate doesn't retry this reason, and the codebase already treats it as "a data-volume limit we can't fix" in the best-effort duplicate-key probe (`_is_bigquery_resource_exceeded` / `_has_duplicate_primary_keys`). But the main data-copy path still lets it crash and be retried by Temporal, so it retries forever and floods error tracking with non-actionable noise.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f23a5-10f0-7a83-b32a-4ab98fa875b2

## Changes

Add `"Resources exceeded during query execution"` to `BigQuerySource.get_non_retryable_errors`, mapped to an actionable message telling the user to reduce the data synced or simplify the source view. Matched on BigQuery's stable wording, not the volatile peak-usage percentage or job id.

This is a user/upstream limit, not a bug we can fix in code: the memory ceiling is per-worker and can't be raised by config, and the dominant consumer here (99%) is the customer's own analytic `OVER()` sorts, so there's nothing sensible to do but stop retrying and surface guidance.

## How did you test this code?

Added `test_bigquery_resources_exceeded_is_non_retryable`, which builds a representative `resourcesExceeded` `BadRequest` (project/job id redacted) and asserts it's recognised as non-retryable with a non-null message. It catches the regression where removing this key sends memory-exhaustion syncs back to retrying forever. No existing test covered the non-retryable-errors mapping for this condition (the existing resource-exceeded test only covers the best-effort duplicate-key skip). Verified the existing `test_non_retryable_errors_does_not_match_transient` guards still pass, so the new key doesn't catch transient rate-limit or connection errors.

Ran the affected suite locally (`pytest -k 'non_retryable or resources_exceeded or transient'`): 47 passed. Ran ruff check + format: clean. I (Claude) did not do manual end-to-end testing against a live BigQuery source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Invoked the `/writing-tests` skill before adding the regression test.

Decision: I confirmed the stack genuinely originates in the bigquery source (`get_rows` → `_run_destination_query_with_job_retry`), then classified it as a user/upstream limit rather than a fixable bug — the failing query's memory blowup is 99% the customer's analytic `OVER()` sorts, which no code change on our side can shrink, and retrying the same query+data is deterministically hopeless. I matched on the canonical `"Resources exceeded during query execution"` substring (the same wording the existing `_is_bigquery_resource_exceeded` helper keys on) rather than the memory-specific tail, since every `resourcesExceeded` variant is a deterministic query-shape problem requiring user action. Checked open PRs (including the maintainer's) for a duplicate; the nearest matches touch job-not-found retries in the same files, not this condition.
