### PR TITLE
chore(navigation): declutter the more menu icons and section spacing

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -501,13 +501,13 @@ snapshots:
     components-hedgehogmode--static-hedgehog--light:
         hash: v1.k794b7964.43d71f5c3ad02bd9e1fa87433d34df79e0de653c4b55004188bed5de78a2c3f5.i2ATBYyqY7uq7UxwlL2Rdte6AuMyySa8Jnbeb1VouoQ
     components-help-menu--open--dark:
-        hash: v1.k794b7964.56fed330a41688685d6976693bf923ff70bc0b7e8229311c87d7e43d3aa22514.PD3PLiVadKw2tCCs6RY5mNzHuRU8pza8TFoiVajmL-Q
+        hash: v1.k794b7964.ee1644981db75ef4ebd937c32055a35fc97cc4e9fd7c393fea728473f40e5e74.74zH3AjzNeMoSQoEf0LxYiPpLWs4XHIvX03xEsVR96k
     components-help-menu--open--light:
-        hash: v1.k794b7964.f477988e96a6cc7fd41bd60429da9653bdf1d26fccfccdd8a1bbaefb4f8a754b.fiAFuUxsW5xNCfnbm037HB-uGCUsajO9AcHMgZhiZ60
+        hash: v1.k794b7964.1d848415946c7241b7d4b7141bfb26cae94e1d5c522016672f2d9afe1463532a.ZZmCGr3y47OFVbGyzvj9D8316Y5q3kZh3WRC_yim_Vk
     components-help-menu--open-with-health-issues--dark:
-        hash: v1.k794b7964.04caecb24549cd53686a3b1d0f65eb983b16652c7d3029ac32b38b08b0ab5df0.DvgOCzvUAZIF-eno2LluJW3TEqUcSltrVwBRNUgRSNs
+        hash: v1.k794b7964.e97c0233d83389b713058f0cfe98b6aa3c851e70234cad7ef96b0cb39a309b57.gceFrulg3pWMMaIOPxd1g92Db4b_Zpcyc0QmdBEHkgM
     components-help-menu--open-with-health-issues--light:
-        hash: v1.k794b7964.9aa9db0a06b253bbab5d211804b2a53eba4b123c99f42c3d96402f49d35ce538.69XlTkZdG3-zjs9Ikv0lSwxqpIZkF9YzMqtceSD0-AI
+        hash: v1.k794b7964.99103b402eb01abd3b43e48fe1339448b4f4d3183f91925a476ca92d37124998.kGgix-wMF0AfwIp9JiS8BlHJbz5Epu84QypwvRaFCIc
     components-hogcharts-barchart--custom-corner-radius--dark:
         hash: v1.k794b7964.ced56b04fb5a6f225291cfda3afa86a761a918389cbef178ff90b0fdce9ff410.1jGojIWZ8Zyj8PgzJOSsBG2_WnQaWs1TVc_QNwTVto0
     components-hogcharts-barchart--custom-corner-radius--light:

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -195,7 +195,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             data-attr="more-menu-health-button"
                                         >
                                             <LemonBadge
-                                                size="small"
+                                                size="xsmall"
                                                 content={triggerBadgeContent}
                                                 status={triggerBadgeStatus}
                                             />
@@ -222,7 +222,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                         >
                                             <LemonBadge
                                                 content={postHogStatusBadgeContent}
-                                                size="small"
+                                                size="xsmall"
                                                 status={postHogStatusBadgeStatus}
                                             />
                                             Status

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -19,13 +19,10 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
-import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SidePanelTab } from '~/types'
 
-import { ThemeMenu } from '../Menus/ThemeMenu'
 import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
-import { shortcutLogic } from '../Shortcuts/shortcutLogic'
 import { RenderKeybind } from '../Shortcuts/ShortcutMenu'
 import { keyBinds } from '../Shortcuts/shortcuts'
 import { openCHQueriesDebugModal } from '../Shortcuts/utils/DebugCHQueries'
@@ -34,18 +31,10 @@ import { helpMenuLogic } from './helpMenuLogic'
 import { IconCheeseburger } from './IconCheeseburger'
 import { posthogStatusLogic } from './posthogStatusLogic'
 
-// Empty leading slot that keeps menu labels aligned where the item's icon has been removed.
-// Only the AI icon and the green/red status badges keep a visible glyph in this slot.
-function IconSlotPlaceholder(): JSX.Element {
-    return <span aria-hidden className="size-4 shrink-0" />
-}
-
 export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Element {
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { isHelpMenuOpen, triggerBadgeContent, triggerBadgeStatus } = useValues(helpMenuLogic)
     const { setHelpMenuOpen } = useActions(helpMenuLogic)
-    const { toggleZenMode } = useActions(navigation3000Logic)
-    const { setShortcutMenuOpen } = useActions(shortcutLogic)
     const { user } = useValues(userLogic)
     const { isCloudOrDev, preflight } = useValues(preflightLogic)
     const { reportAccountOwnerClicked } = useActions(eventUsageLogic)
@@ -129,8 +118,8 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             buttonProps={{ menuItem: true }}
                                             data-attr="more-menu-ask-ai-button"
                                         >
-                                            <IconSparkles className="text-ai" />
                                             Ask PostHog AI
+                                            <IconSparkles className="text-ai" />
                                         </Link>
                                     )}
                                 />
@@ -138,7 +127,6 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                     onClick={() => openSidePanel(SidePanelTab.Support)}
                                     render={
                                         <ButtonPrimitive menuItem data-attr="more-menu-support-button">
-                                            <IconSlotPlaceholder />
                                             Support
                                             <IconOpenSidebar className="size-3" />
                                         </ButtonPrimitive>
@@ -157,25 +145,35 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             tooltipPlacement="right"
                                             data-attr="more-menu-docs-button"
                                         >
-                                            <IconSlotPlaceholder />
                                             Docs
                                         </Link>
                                     )}
                                 />
 
                                 <Label intent="menu" className="px-2 mt-3">
-                                    Project
+                                    System
                                 </Label>
                                 <Menu.Item
                                     render={(props) => (
                                         <Link
                                             {...props}
-                                            to={urls.exports()}
+                                            targetBlankIcon
+                                            target="_blank"
                                             buttonProps={{ menuItem: true }}
-                                            data-attr="more-menu-exports-button"
+                                            to={statusPageUrl}
+                                            tooltip={postHogStatusTooltip}
+                                            tooltipPlacement="right"
+                                            tooltipCloseDelayMs={0}
+                                            data-attr="more-menu-status-button"
                                         >
-                                            <IconSlotPlaceholder />
-                                            Exports
+                                            Status Page
+                                            {postHogStatusBadgeStatus !== 'success' && (
+                                                <LemonBadge
+                                                    content={postHogStatusBadgeContent}
+                                                    size="xsmall"
+                                                    status={postHogStatusBadgeStatus}
+                                                />
+                                            )}
                                         </Link>
                                     )}
                                 />
@@ -194,41 +192,16 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             tooltipCloseDelayMs={0}
                                             data-attr="more-menu-health-button"
                                         >
+                                            Health
                                             <LemonBadge
-                                                size="xsmall"
+                                                size="small"
                                                 content={triggerBadgeContent}
                                                 status={triggerBadgeStatus}
                                             />
-                                            Health
                                         </Link>
                                     )}
                                 />
 
-                                <Label intent="menu" className="px-2 mt-3">
-                                    PostHog
-                                </Label>
-                                <Menu.Item
-                                    render={(props) => (
-                                        <Link
-                                            {...props}
-                                            targetBlankIcon
-                                            target="_blank"
-                                            buttonProps={{ menuItem: true }}
-                                            to={statusPageUrl}
-                                            tooltip={postHogStatusTooltip}
-                                            tooltipPlacement="right"
-                                            tooltipCloseDelayMs={0}
-                                            data-attr="more-menu-status-button"
-                                        >
-                                            <LemonBadge
-                                                content={postHogStatusBadgeContent}
-                                                size="xsmall"
-                                                status={postHogStatusBadgeStatus}
-                                            />
-                                            Status
-                                        </Link>
-                                    )}
-                                />
                                 <Menu.Item
                                     render={(props) => (
                                         <Link
@@ -241,8 +214,20 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             to="https://posthog.com/changelog"
                                             data-attr="more-menu-changelog-button"
                                         >
-                                            <IconSlotPlaceholder />
                                             Changelog
+                                        </Link>
+                                    )}
+                                />
+
+                                <Menu.Item
+                                    render={(props) => (
+                                        <Link
+                                            {...props}
+                                            to={urls.exports()}
+                                            buttonProps={{ menuItem: true }}
+                                            data-attr="more-menu-exports-button"
+                                        >
+                                            Exports
                                         </Link>
                                     )}
                                 />
@@ -256,7 +241,6 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                                 buttonProps={{ menuItem: true }}
                                                 data-attr="help-menu-upgrade-to-cloud-button"
                                             >
-                                                <IconSlotPlaceholder />
                                                 Try PostHog Cloud
                                             </Link>
                                         )}
@@ -268,7 +252,6 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                         <Menu.SubmenuTrigger
                                             render={
                                                 <ButtonPrimitive menuItem data-attr="help-menu-admin-button">
-                                                    <IconSlotPlaceholder />
                                                     Admin (Lucky you!)
                                                     <MenuOpenIndicator intent="sub" />
                                                 </ButtonPrimitive>
@@ -346,42 +329,6 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                         </Menu.Portal>
                                     </Menu.SubmenuRoot>
                                 )}
-
-                                <Label intent="menu" className="px-2 mt-3">
-                                    Display
-                                </Label>
-                                <Menu.Item
-                                    onClick={() => setShortcutMenuOpen(true)}
-                                    render={
-                                        <ButtonPrimitive
-                                            tooltip="Open shortcut menu"
-                                            tooltipPlacement="right"
-                                            menuItem
-                                            data-attr="more-menu-shortcuts-button"
-                                        >
-                                            <IconSlotPlaceholder />
-                                            Shortcuts
-                                            <div className="flex gap-1 ml-auto items-center">
-                                                <KeyboardShortcut command option k />
-                                                <span className="text-xs opacity-75">or</span>
-                                                <KeyboardShortcut command shift k />
-                                            </div>
-                                        </ButtonPrimitive>
-                                    }
-                                />
-                                <Menu.Item
-                                    onClick={() => toggleZenMode('help_menu')}
-                                    render={
-                                        <ButtonPrimitive menuItem data-attr="more-menu-zen-mode-button">
-                                            <IconSlotPlaceholder />
-                                            Zen mode
-                                            <div className="flex gap-1 ml-auto items-center">
-                                                <KeyboardShortcut command option z />
-                                            </div>
-                                        </ButtonPrimitive>
-                                    }
-                                />
-                                <ThemeMenu />
 
                                 {billing?.account_owner?.email && billing?.account_owner?.name && (
                                     <>

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -1,26 +1,12 @@
 import { Menu } from '@base-ui/react/menu'
 import { useActions, useValues } from 'kea'
 
-import {
-    IconBook,
-    IconCloud,
-    IconConfetti,
-    IconCopy,
-    IconDatabase,
-    IconDownload,
-    IconExpand45,
-    IconHeart,
-    IconLive,
-    IconOpenSidebar,
-    IconServer,
-    IconShieldLock,
-    IconSparkles,
-    IconStethoscope,
-} from '@posthog/icons'
+import { IconCopy, IconDatabase, IconOpenSidebar, IconServer, IconShieldLock, IconSparkles } from '@posthog/icons'
 import { ProfilePicture } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconMenu, IconWithBadge } from 'lib/lemon-ui/icons'
+import { LemonBadge } from 'lib/lemon-ui/LemonBadge/LemonBadge'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
@@ -37,8 +23,6 @@ import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SidePanelTab } from '~/types'
 
-import { SidePanelSupportIcon } from 'products/conversations/frontend/components/SidePanel/SidePanelSupportIcon'
-
 import { ThemeMenu } from '../Menus/ThemeMenu'
 import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 import { shortcutLogic } from '../Shortcuts/shortcutLogic'
@@ -49,6 +33,12 @@ import { healthSummaryLogic } from './healthSummaryLogic'
 import { helpMenuLogic } from './helpMenuLogic'
 import { IconCheeseburger } from './IconCheeseburger'
 import { posthogStatusLogic } from './posthogStatusLogic'
+
+// Empty leading slot that keeps menu labels aligned where the item's icon has been removed.
+// Only the AI icon and the green/red status badges keep a visible glyph in this slot.
+function IconSlotPlaceholder(): JSX.Element {
+    return <span aria-hidden className="size-4 shrink-0" />
+}
 
 export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Element {
     const { openSidePanel } = useActions(sidePanelStateLogic)
@@ -148,7 +138,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                     onClick={() => openSidePanel(SidePanelTab.Support)}
                                     render={
                                         <ButtonPrimitive menuItem data-attr="more-menu-support-button">
-                                            <SidePanelSupportIcon />
+                                            <IconSlotPlaceholder />
                                             Support
                                             <IconOpenSidebar className="size-3" />
                                         </ButtonPrimitive>
@@ -167,13 +157,13 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             tooltipPlacement="right"
                                             data-attr="more-menu-docs-button"
                                         >
-                                            <IconBook />
+                                            <IconSlotPlaceholder />
                                             Docs
                                         </Link>
                                     )}
                                 />
 
-                                <Label intent="menu" className="px-2 mt-2">
+                                <Label intent="menu" className="px-2 mt-3">
                                     Project
                                 </Label>
                                 <Menu.Item
@@ -184,7 +174,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             buttonProps={{ menuItem: true }}
                                             data-attr="more-menu-exports-button"
                                         >
-                                            <IconDownload />
+                                            <IconSlotPlaceholder />
                                             Exports
                                         </Link>
                                     )}
@@ -204,19 +194,17 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             tooltipCloseDelayMs={0}
                                             data-attr="more-menu-health-button"
                                         >
-                                            <IconWithBadge
-                                                size="xsmall"
+                                            <LemonBadge
+                                                size="small"
                                                 content={triggerBadgeContent}
                                                 status={triggerBadgeStatus}
-                                            >
-                                                <IconStethoscope />
-                                            </IconWithBadge>
+                                            />
                                             Health
                                         </Link>
                                     )}
                                 />
 
-                                <Label intent="menu" className="px-2 mt-2">
+                                <Label intent="menu" className="px-2 mt-3">
                                     PostHog
                                 </Label>
                                 <Menu.Item
@@ -232,14 +220,11 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             tooltipCloseDelayMs={0}
                                             data-attr="more-menu-status-button"
                                         >
-                                            <IconWithBadge
+                                            <LemonBadge
                                                 content={postHogStatusBadgeContent}
-                                                size="xsmall"
+                                                size="small"
                                                 status={postHogStatusBadgeStatus}
-                                                className="flex"
-                                            >
-                                                <IconCloud />
-                                            </IconWithBadge>
+                                            />
                                             Status
                                         </Link>
                                     )}
@@ -256,7 +241,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             to="https://posthog.com/changelog"
                                             data-attr="more-menu-changelog-button"
                                         >
-                                            <IconLive />
+                                            <IconSlotPlaceholder />
                                             Changelog
                                         </Link>
                                     )}
@@ -271,7 +256,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                                 buttonProps={{ menuItem: true }}
                                                 data-attr="help-menu-upgrade-to-cloud-button"
                                             >
-                                                <IconConfetti />
+                                                <IconSlotPlaceholder />
                                                 Try PostHog Cloud
                                             </Link>
                                         )}
@@ -283,7 +268,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                         <Menu.SubmenuTrigger
                                             render={
                                                 <ButtonPrimitive menuItem data-attr="help-menu-admin-button">
-                                                    <IconHeart />
+                                                    <IconSlotPlaceholder />
                                                     Admin (Lucky you!)
                                                     <MenuOpenIndicator intent="sub" />
                                                 </ButtonPrimitive>
@@ -362,7 +347,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                     </Menu.SubmenuRoot>
                                 )}
 
-                                <Label intent="menu" className="px-2 mt-2">
+                                <Label intent="menu" className="px-2 mt-3">
                                     Display
                                 </Label>
                                 <Menu.Item
@@ -374,7 +359,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                             menuItem
                                             data-attr="more-menu-shortcuts-button"
                                         >
-                                            <span className="size-4 flex items-center justify-center">⌘</span>
+                                            <IconSlotPlaceholder />
                                             Shortcuts
                                             <div className="flex gap-1 ml-auto items-center">
                                                 <KeyboardShortcut command option k />
@@ -388,7 +373,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                     onClick={() => toggleZenMode('help_menu')}
                                     render={
                                         <ButtonPrimitive menuItem data-attr="more-menu-zen-mode-button">
-                                            <IconExpand45 />
+                                            <IconSlotPlaceholder />
                                             Zen mode
                                             <div className="flex gap-1 ml-auto items-center">
                                                 <KeyboardShortcut command option z />


### PR DESCRIPTION
## Problem

The "More" menu in the nav footer had grown noisy. Every item carried its own colored icon, so the sections blended together and the whole thing was hard to parse at a glance.

## Changes

- Drop the leading icon on every menu item except "Ask PostHog AI", which keeps its sparkles.
- Keep a blank, icon-width slot on the now icon-less items so all the labels stay aligned in one column (rather than the text jumping left).
- Move the Health and Status green/red status badges into the icon slot. They used to be a small badge overlaid on a stethoscope/cloud icon; now the badge itself sits where the icon was. Colors are unchanged (green = healthy/operational, amber = warning, red = danger/outage).
- Slightly increase the gap above each section label so sections read as distinct groups, without adding horizontal rules.

The Admin trigger row in the main list loses its icon like everything else. The nested Admin submenu (staff-only) and the theme submenu keep their own icons, since those are separate popups rather than part of the main list.

## How did you test this code?

I (actually the PostHog Slack app / Claude, with Rafa driving) could not run the frontend in this environment, since dependencies aren't installed in the working checkout. So I did not run the build, typecheck, Storybook, or Jest. The change is limited to one component: it removes the now-unused icon imports, adds `LemonBadge`, and swaps icons for a blank placeholder span. Please sanity-check the More menu in the nav footer and grab screenshots before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - Rafa directed this from a [Slack thread](https://posthog.slack.com/archives/C08499A7REU/p1782946936673939?thread_ts=1782946936.673939&cid=C08499A7REU); I (Claude, via the PostHog Slack app) made the edits.

The design call came out of the thread: drop all item icons except the AI sparkles, keep the icon slot blank for the rest so labels stay aligned, and move the green/red "alert/success" badges into that slot where they exist. I kept the blank placeholder specifically to preserve alignment rather than letting labels shift left.

Greptile flagged the status badge as slightly larger than the icon column, so I dropped it from `small` to `xsmall` (14px) to match the previous overlay size and keep row heights uniform.

Heads up: I first opened this against the wrong repo (posthog.com PR #18135) before realizing the More menu lives here. That PR is now superseded and should be closed.
