### PR TITLE
feat(tasks): make hogdesk-originated tasks team-visible

### DIFF
--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -333,6 +333,38 @@ class TestTaskCreatorScoping(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["id"], str(task.id))
 
+    def test_retrieve_hogdesk_task_owned_by_another_user_is_visible(self):
+        # HogDesk Code threads are pinned to a support ticket via a shared ticket
+        # tag; any agent opening the ticket must be able to load the same task.
+        other_user = self.create_organization_user("hogdesk-owner")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=other_user,
+            title="HogDesk Task",
+            description="Started from a support ticket",
+            origin_product=Task.OriginProduct.HOGDESK,
+        )
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(task.id))
+
+    def test_list_runs_hogdesk_task_owned_by_another_user_succeeds(self):
+        other_user = self.create_organization_user("hogdesk-owner")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=other_user,
+            title="HogDesk Task",
+            description="Started from a support ticket",
+            origin_product=Task.OriginProduct.HOGDESK,
+        )
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {r["id"] for r in response.json()["results"]}
+        self.assertEqual(ids, {str(run.id)})
+
     def test_retrieve_other_user_non_signal_internal_task_returns_404(self):
         # Non-signal internal tasks created by another user remain private.
         other_user = self.create_organization_user("victim")

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -16,10 +16,14 @@ from products.tasks.backend.models import Task
 # - ONBOARDING: the "Set up PostHog" wizard task. Its `created_by` is the real person who
 #   went through onboarding (not a system pick), but we surface it team-wide so anyone on
 #   the team can see and pick up the setup, not just whoever happened to start it.
+# - HOGDESK: support-desk Code threads. The task is pinned to the support ticket via a
+#   shared ticket tag, so any agent opening the ticket resumes the same thread — it must
+#   be viewable by the whole team, not just the agent who started it.
 TEAM_VISIBLE_ORIGIN_PRODUCTS = [
     Task.OriginProduct.SIGNAL_REPORT,
     Task.OriginProduct.SIGNALS_SCOUT,
     Task.OriginProduct.ONBOARDING,
+    Task.OriginProduct.HOGDESK,
 ]
 
 


### PR DESCRIPTION
## Problem

HogDesk (our internal support desk client) starts coding-agent investigations from support tickets via the Tasks API. The task id is pinned to the ticket with a shared `code-task_<id>` tag, so any agent opening the ticket tries to load the same thread. But tasks are person-scoped by default, so everyone except the agent who started the thread gets a 404 on the task, its runs, the live stream, and the logs.

The visibility module already has an extension point for exactly this: `TEAM_VISIBLE_ORIGIN_PRODUCTS`, used by signal reports, signals scout, and onboarding tasks.

## Changes

- Add `Task.OriginProduct.HOGDESK` to `TEAM_VISIBLE_ORIGIN_PRODUCTS` in `products/tasks/backend/visibility.py`, so hogdesk-originated tasks (and their runs, streams, and logs, via `task_run_visibility_q`) are visible to the whole team.
- `created_by` is still set to the creating user, so OAuth token minting for the sandbox is unaffected. This only widens read visibility.
- The HogDesk client is being updated separately to send `origin_product: "hogdesk"` (it previously sent `support_queue`, which stays person-scoped).

## How did you test this code?

Added two tests mirroring the existing per-origin visibility tests, one per visibility function:

- `test_retrieve_hogdesk_task_owned_by_another_user_is_visible` – catches removal of hogdesk from the team-visible list on the task path (`task_visibility_q`)
- `test_list_runs_hogdesk_task_owned_by_another_user_succeeds` – same for the run path (`task_run_visibility_q`)

I (or, actually Claude) could not run the Django test suite locally (no Python environment on the authoring machine), so these tests are verified by CI only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this change under my direction. We considered two alternatives and rejected both: creating tasks with `created_by = null` (legacy-unowned tasks are team-visible but cannot run, since OAuth minting requires a creator) and reusing an existing team-visible origin like `signal_report` (misrepresents the origin and triggers signal-specific handling such as forcing the team GitHub integration). Adding the already-existing `hogdesk` origin to the team-visible list was the designed-for path.
