### PR TITLE
fix(file-system): allow deleting ref-less desktop canvas rows

### DIFF
--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -517,6 +517,16 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             }
         )
 
+    def _allow_delete_without_ref(self, entry: FileSystem) -> bool:
+        """Whether a registered-type row with no ref may be deleted as a bare row.
+
+        On the web surface every registered row references a real object, so a
+        ref-less row is a data-integrity error we refuse to delete. Surfaces where
+        registered types can legitimately be ref-less (desktop canvases store their
+        source in `meta`, not a backing Dashboard) override this to allow it.
+        """
+        return False
+
     def _ensure_can_delete(self, entry: FileSystem) -> None:
         stack: list[FileSystem] = [entry]
         seen: set[str] = set()
@@ -557,7 +567,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if not is_file_system_type_registered(current.type):
                 continue
 
-            if remaining == 0 and not current.ref:
+            if remaining == 0 and not current.ref and not self._allow_delete_without_ref(current):
                 raise serializers.ValidationError(
                     {"detail": f"Cannot delete type '{current.type}' without a reference."}
                 )
@@ -595,6 +605,9 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return deleted_objects
 
         if not entry.ref:
+            if self._allow_delete_without_ref(entry):
+                entry.delete()
+                return deleted_objects
             raise serializers.ValidationError({"detail": f"Cannot delete type '{entry.type}' without a reference."})
 
         entry_path = entry.path
@@ -1026,6 +1039,12 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
     """
 
     file_system_surface = "desktop"
+
+    def _allow_delete_without_ref(self, entry: FileSystem) -> bool:
+        # Desktop canvases are `dashboard`-typed rows whose source lives in `meta`,
+        # not a backing Dashboard, so they legitimately have no ref. Delete the bare
+        # row (nothing to cascade to) rather than refusing.
+        return True
 
     def perform_create(self, serializer: serializers.BaseSerializer) -> None:
         super().perform_create(serializer)

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1043,8 +1043,10 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
     def _allow_delete_without_ref(self, entry: FileSystem) -> bool:
         # Desktop canvases are `dashboard`-typed rows whose source lives in `meta`,
         # not a backing Dashboard, so they legitimately have no ref. Delete the bare
-        # row (nothing to cascade to) rather than refusing.
-        return True
+        # row (nothing to cascade to) rather than refusing. Scope this to `dashboard`
+        # only — any other registered type with no ref is still a data-integrity
+        # error we refuse to delete, even on the desktop surface.
+        return entry.type == "dashboard"
 
     def perform_create(self, serializer: serializers.BaseSerializer) -> None:
         super().perform_create(serializer)

--- a/posthog/api/file_system/test/test_canvas_publish.py
+++ b/posthog/api/file_system/test/test_canvas_publish.py
@@ -117,3 +117,20 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
         self.assertFalse(FileSystem.objects.filter(id=folder.id).exists())
         self.assertFalse(FileSystem.objects.filter(id=item_id).exists())
+
+    def test_delete_ref_less_non_dashboard_registered_row_still_refused_on_desktop(self):
+        # The desktop ref-less exemption is scoped to `dashboard` canvases. Any other
+        # registered type with no ref is still a data-integrity error we refuse to delete.
+        file_obj = FileSystem.objects.create(
+            team=self.team,
+            path="MyChannel/OrphanInsight",
+            type="insight",
+            surface="desktop",
+            created_by=self.user,
+        )
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/desktop_file_system/{file_obj.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.json()["detail"], "Cannot delete type 'insight' without a reference.")
+        self.assertTrue(FileSystem.objects.filter(id=file_obj.id).exists())

--- a/posthog/api/file_system/test/test_canvas_publish.py
+++ b/posthog/api/file_system/test/test_canvas_publish.py
@@ -95,3 +95,25 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
         bad = self.client.patch(self._canvas_url(item_id), {"prompt": "only a prompt"})
         self.assertEqual(bad.status_code, status.HTTP_400_BAD_REQUEST, bad.json())
         self.assertIn("code", bad.json())
+
+    def test_delete_canvas_removes_ref_less_dashboard_row(self):
+        # Desktop canvases are `dashboard`-typed rows with no ref; deleting one must not
+        # trip the "without a reference" guard meant for real object-backed rows.
+        item_id = self._create_dashboard()
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/desktop_file_system/{item_id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertFalse(FileSystem.objects.filter(id=item_id).exists())
+
+    def test_delete_channel_folder_cascades_to_ref_less_canvas(self):
+        # Deleting a channel folder cascades into its ref-less canvas children, which must
+        # bare-delete rather than raise in `_ensure_can_delete`.
+        item_id = self._create_dashboard(path="MyChannel/MyCanvas")
+        folder = FileSystem.objects.get(team=self.team, path="MyChannel", type="folder")
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/desktop_file_system/{folder.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertFalse(FileSystem.objects.filter(id=folder.id).exists())
+        self.assertFalse(FileSystem.objects.filter(id=item_id).exists())

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -180,6 +180,26 @@ class TestFileSystemAPI(APIBaseTest):
         self.assertFalse(FileSystem.objects.filter(pk=file1_obj.pk).exists())
         self.assertFalse(FileSystem.objects.filter(pk=file2_obj.pk).exists())
 
+    def test_delete_ref_less_registered_row_refused_on_web_surface(self):
+        """
+        On the default (web) surface every registered-type row points at a real object via `ref`.
+        A ref-less registered row is a data-integrity error, so deletion is refused, not silently applied.
+        """
+        file_obj = FileSystem.objects.create(
+            team=self.team,
+            path="DeleteMe/RefLessDashboard",
+            type="dashboard",
+            created_by=self.user,
+        )
+
+        delete_response = self.client.delete(f"/api/projects/{self.team.id}/file_system/{file_obj.pk}/")
+
+        self.assertEqual(delete_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            delete_response.json()["detail"], "Cannot delete type 'dashboard' without a reference."
+        )
+        self.assertTrue(FileSystem.objects.filter(pk=file_obj.pk).exists())
+
     def test_unfiled_endpoint_no_content(self):
         """
         If there are no relevant items to create (e.g. no FeatureFlags, Experiments, etc.),

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -195,9 +195,7 @@ class TestFileSystemAPI(APIBaseTest):
         delete_response = self.client.delete(f"/api/projects/{self.team.id}/file_system/{file_obj.pk}/")
 
         self.assertEqual(delete_response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            delete_response.json()["detail"], "Cannot delete type 'dashboard' without a reference."
-        )
+        self.assertEqual(delete_response.json()["detail"], "Cannot delete type 'dashboard' without a reference.")
         self.assertTrue(FileSystem.objects.filter(pk=file_obj.pk).exists())
 
     def test_unfiled_endpoint_no_content(self):


### PR DESCRIPTION
## Problem

In the PostHog Code desktop app, deleting a channel (or an individual canvas) fails with a 400 toast:

```
Cannot delete type 'dashboard' without a reference.
```

Desktop canvases are stored as `desktop_file_system` rows with type `dashboard` and their React source in `meta`. They have no `ref` because they are not backed by a real `Dashboard` model object (the `publish_canvas` action operates on exactly these ref-less rows). But `dashboard` is a registered file-system type, and the shared delete logic in `FileSystemViewSet` assumes every registered-type row points at a real object via `ref`. So it refuses to delete a ref-less registered row. Deleting a channel folder cascades into its canvas children and trips the same guard.

## Changes

Added an overridable `_allow_delete_without_ref` hook to `FileSystemViewSet`, defaulting to `False` so the web surface is unchanged. `DesktopFileSystemViewSet` overrides it to `True`.

When deletion of a ref-less registered row is allowed, we delete the bare `FileSystem` row (there's nothing to cascade to) instead of raising. This is wired into both paths:

- `_delete_file_system_entry` (the leaf case, hit when deleting a single canvas)
- `_ensure_can_delete` (the cascade guard, hit when deleting a channel folder with canvas children)

Backend only, scoped to the desktop surface. The web surface still refuses ref-less registered rows as before, since a ref-less registered row there is a genuine data-integrity error.

## How did you test this code?

Added automated tests. I (Claude) could not run them in this environment (no Postgres/ClickHouse, empty venv), so these still need to pass in CI:

- `test_canvas_publish.py::test_delete_canvas_removes_ref_less_dashboard_row` — deleting a single ref-less canvas returns 204 and removes the row (exercises `_delete_file_system_entry`).
- `test_canvas_publish.py::test_delete_channel_folder_cascades_to_ref_less_canvas` — deleting the parent channel folder returns 204 and removes both the folder and its canvas (exercises the `_ensure_can_delete` cascade guard).
- `test_file_system.py::test_delete_ref_less_registered_row_refused_on_web_surface` — confirms the web surface still refuses a ref-less registered row with the "without a reference" 400 and leaves the row intact (guards against the fix leaking into the web surface).

Run locally with:

```
pytest posthog/api/file_system/test/test_canvas_publish.py posthog/api/file_system/test/test_file_system.py
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) implemented this from a detailed bug report and fix spec provided by the author. Invoked `/improving-drf-endpoints` before touching the viewset and `/writing-tests` before adding the tests, per repo convention.

The core decision was to make the ref-less-delete behavior a per-surface hook rather than a blanket change: a ref-less registered row is legitimate on the desktop surface (canvas source lives in `meta`) but a data-integrity error on the web surface, so the default stays `False` and only the desktop viewset opts in. Each test targets a distinct guard so a regression of any single code path (leaf delete, cascade delete, or the web-surface refusal) is caught independently.
