### PR TITLE
feat(alerts): add real_time calculation interval schema, feature, and model helpers

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -68,6 +68,7 @@ class License(models.Model):
         AvailableFeature.RECORDINGS_FILE_EXPORT,
         AvailableFeature.RECORDINGS_PERFORMANCE,
         AvailableFeature.HIGH_FREQUENCY_ALERTS,
+        AvailableFeature.REAL_TIME_ALERTS,
     ]
 
     ENTERPRISE_PLAN = "enterprise"

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1041,9 +1041,9 @@ snapshots:
     components-hogfetti--hogfetti--light:
         hash: v1.k794b7964.80f9c47f95582b6d6da53cf7a080dbf7835d01a8dbe160773035ebdabb69000d.uI29XeShHiPghfdriLFGvqeZ2NAdr8FOC3_Y0kUubFM
     components-hogqleditor--hog-ql-editor--dark:
-        hash: v1.k794b7964.af3f4ba00327c226f149cdbe34310632259b2c21c7a6befdc64d3f0c137751d3.GtvvdAE7HsFRpUqze7X-Ox9rVKV18vsYkJFmZX4f_kc
+        hash: v1.k794b7964.055040d75e2b4e6a07673f1f9836f8f5fcdd18fd7ee4028b223e361ea2697cb7.RtM8ViC49MU53lnoErIQg7XCm48gBFIGAm2ksWh72Yc
     components-hogqleditor--hog-ql-editor--light:
-        hash: v1.k794b7964.9b7511d40f2441bada1894ee6f3eda6bffa56d557d9a8ae27db1620e2a79bf94.p0bzJ5RqruNF_p5160_0Fx_ClXHPh9iBUMKWJ01KA2s
+        hash: v1.k794b7964.048ca6844cb0dbb300a24d4a76f97229124595a80b9594173b95f0aae2f74619.flfXLgF1XbS0aEiFTjbadk4uHzplWg8OJbkY93tLLSY
     components-hogqleditor--no-value--dark:
         hash: v1.k794b7964.f3934fefc6a8074b273204f1f99cd644366fc7c14bdc4dee7c5d8e50e8e2145f.EJxnJvDxlnisT20mGnTF4Ms4oNLuiBjw_NAZ-iDD7H8
     components-hogqleditor--no-value--light:
@@ -1383,7 +1383,7 @@ snapshots:
     components-playerinspector--with-logs-filter--dark:
         hash: v1.k794b7964.4a27837802248b94d5c146c18b6962bfc713ce40ec3da10a23d4fc89639cf794.PRcX4NksDqdhgKXU-BTlmrZ4mkRVcQIAlLsj5nbUq9I
     components-playerinspector--with-logs-filter--light:
-        hash: v1.k794b7964.92f552147017e8b361ea4c2eff62c087ce37fedfc44d40945ba40dbf12e01f08.KBu7dt9Qb1dmTqIGmFIKmCjktRGu8gAFQa0YzD86djA
+        hash: v1.k794b7964.722c6c05402dd3b37b4ab640f76b8c10aa0d593898b9c0b4847ed07ac0565f98.6K-Za5e6Y6Ypjq-8zVtjxdv7EB3qWVOhh0gUkg6hpy0
     components-playerinspector--with-logs-filter-upsell--dark:
         hash: v1.k794b7964.5e4afe863e34df7278c0dd092946adfd396ee778f0cd0a41e5e3f5e1771a9601.SBOdVp0jJnn1w2H4fMR-3Vf2ac00QSBFQjsl93AbcYA
     components-playerinspector--with-logs-filter-upsell--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1041,9 +1041,9 @@ snapshots:
     components-hogfetti--hogfetti--light:
         hash: v1.k794b7964.80f9c47f95582b6d6da53cf7a080dbf7835d01a8dbe160773035ebdabb69000d.uI29XeShHiPghfdriLFGvqeZ2NAdr8FOC3_Y0kUubFM
     components-hogqleditor--hog-ql-editor--dark:
-        hash: v1.k794b7964.055040d75e2b4e6a07673f1f9836f8f5fcdd18fd7ee4028b223e361ea2697cb7.RtM8ViC49MU53lnoErIQg7XCm48gBFIGAm2ksWh72Yc
+        hash: v1.k794b7964.af3f4ba00327c226f149cdbe34310632259b2c21c7a6befdc64d3f0c137751d3.GtvvdAE7HsFRpUqze7X-Ox9rVKV18vsYkJFmZX4f_kc
     components-hogqleditor--hog-ql-editor--light:
-        hash: v1.k794b7964.048ca6844cb0dbb300a24d4a76f97229124595a80b9594173b95f0aae2f74619.flfXLgF1XbS0aEiFTjbadk4uHzplWg8OJbkY93tLLSY
+        hash: v1.k794b7964.9b7511d40f2441bada1894ee6f3eda6bffa56d557d9a8ae27db1620e2a79bf94.p0bzJ5RqruNF_p5160_0Fx_ClXHPh9iBUMKWJ01KA2s
     components-hogqleditor--no-value--dark:
         hash: v1.k794b7964.f3934fefc6a8074b273204f1f99cd644366fc7c14bdc4dee7c5d8e50e8e2145f.EJxnJvDxlnisT20mGnTF4Ms4oNLuiBjw_NAZ-iDD7H8
     components-hogqleditor--no-value--light:
@@ -1383,7 +1383,7 @@ snapshots:
     components-playerinspector--with-logs-filter--dark:
         hash: v1.k794b7964.4a27837802248b94d5c146c18b6962bfc713ce40ec3da10a23d4fc89639cf794.PRcX4NksDqdhgKXU-BTlmrZ4mkRVcQIAlLsj5nbUq9I
     components-playerinspector--with-logs-filter--light:
-        hash: v1.k794b7964.722c6c05402dd3b37b4ab640f76b8c10aa0d593898b9c0b4847ed07ac0565f98.6K-Za5e6Y6Ypjq-8zVtjxdv7EB3qWVOhh0gUkg6hpy0
+        hash: v1.k794b7964.97c396a5d41b78e6f653cdcb59a7e59dce49c44d08a9c3903dd69324eb20fdd6.UcFWQBXiTFaua5umBEqB8d8UUCI6aLN4cXg2abaVyJ0
     components-playerinspector--with-logs-filter-upsell--dark:
         hash: v1.k794b7964.5e4afe863e34df7278c0dd092946adfd396ee778f0cd0a41e5e3f5e1771a9601.SBOdVp0jJnn1w2H4fMR-3Vf2ac00QSBFQjsl93AbcYA
     components-playerinspector--with-logs-filter-upsell--light:

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -612,7 +612,7 @@
             "type": "string"
         },
         "AlertCalculationInterval": {
-            "enum": ["every_15_minutes", "hourly", "daily", "weekly", "monthly"],
+            "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },
         "AlertCondition": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5087,6 +5087,7 @@ export enum AlertState {
 }
 
 export enum AlertCalculationInterval {
+    REAL_TIME = 'real_time',
     EVERY_15_MINUTES = 'every_15_minutes',
     HOURLY = 'hourly',
     DAILY = 'daily',

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -40,6 +40,7 @@ class AvailableFeature(StrEnum):
     DATA_PIPELINES = "data_pipelines"
     ALERTS = "alerts"
     HIGH_FREQUENCY_ALERTS = "high_frequency_alerts"
+    REAL_TIME_ALERTS = "real_time_alerts"
     DATA_COLOR_THEMES = "data_color_themes"
     API_QUERIES_CONCURRENCY = "api_queries_concurrency"
     ORGANIZATION_INVITE_SETTINGS = "organization_invite_settings"

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -65,6 +65,7 @@ class AggregationAxisFormat(StrEnum):
 
 
 class AlertCalculationInterval(StrEnum):
+    REAL_TIME = "real_time"
     EVERY_15_MINUTES = "every_15_minutes"
     HOURLY = "hourly"
     DAILY = "daily"

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -202,10 +202,6 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             AlertCalculationInterval.REAL_TIME,
         )
 
-    @property
-    def is_real_time_interval(self) -> bool:
-        return self.calculation_interval == AlertCalculationInterval.REAL_TIME
-
     def get_subscribed_users_emails(self) -> list[str]:
         return list(
             self.subscribed_users.filter(organization_membership__organization=self.team.organization).values_list(
@@ -343,10 +339,6 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         return None
 
     @classmethod
-    def supports_real_time_intervals(cls, organization: Organization) -> bool:
-        return organization.is_feature_available(AvailableFeature.REAL_TIME_ALERTS)
-
-    @classmethod
     def real_time_interval_validation_error(
         cls,
         *,
@@ -355,7 +347,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
     ) -> str | None:
         if calculation_interval != AlertCalculationInterval.REAL_TIME:
             return None
-        if not cls.supports_real_time_intervals(organization):
+        if not organization.is_feature_available(AvailableFeature.REAL_TIME_ALERTS):
             return "Real-time alert intervals require a Scale or Enterprise plan."
         return None
 

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -377,7 +377,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             return None
 
         existing_count = cls.objects.filter(
-            team_id=team_id, calculation_interval=AlertCalculationInterval.REAL_TIME
+            team_id=team_id, calculation_interval=AlertCalculationInterval.REAL_TIME, enabled=True
         ).count()
         if existing_count >= allowed:
             return f"Your team has reached the limit of {allowed} real-time alerts on your plan."

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -195,8 +195,6 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
     @property
     def is_high_frequency_interval(self) -> bool:
-        # Real-time counts as high frequency so its checks always run fresh ClickHouse
-        # queries (CALCULATE_BLOCKING_ALWAYS) instead of reading a possibly stale cache.
         return self.calculation_interval in (
             AlertCalculationInterval.EVERY_15_MINUTES,
             AlertCalculationInterval.REAL_TIME,

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -195,7 +195,16 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
     @property
     def is_high_frequency_interval(self) -> bool:
-        return self.calculation_interval == AlertCalculationInterval.EVERY_15_MINUTES
+        # Real-time counts as high frequency so its checks always run fresh ClickHouse
+        # queries (CALCULATE_BLOCKING_ALWAYS) instead of reading a possibly stale cache.
+        return self.calculation_interval in (
+            AlertCalculationInterval.EVERY_15_MINUTES,
+            AlertCalculationInterval.REAL_TIME,
+        )
+
+    @property
+    def is_real_time_interval(self) -> bool:
+        return self.calculation_interval == AlertCalculationInterval.REAL_TIME
 
     def get_subscribed_users_emails(self) -> list[str]:
         return list(
@@ -331,6 +340,47 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             return None
         if not cls.supports_high_frequency_intervals(organization):
             return "15-minute alert intervals require a Boost, Scale, or Enterprise platform add-on."
+        return None
+
+    @classmethod
+    def supports_real_time_intervals(cls, organization: Organization) -> bool:
+        return organization.is_feature_available(AvailableFeature.REAL_TIME_ALERTS)
+
+    @classmethod
+    def real_time_interval_validation_error(
+        cls,
+        *,
+        calculation_interval: str | AlertCalculationInterval | None,
+        organization: Organization,
+    ) -> str | None:
+        if calculation_interval != AlertCalculationInterval.REAL_TIME:
+            return None
+        if not cls.supports_real_time_intervals(organization):
+            return "Real-time alert intervals require a Scale or Enterprise plan."
+        return None
+
+    @classmethod
+    def check_real_time_alert_limit(cls, team_id: int, organization: Organization) -> str | None:
+        """Return an error message if the team has reached its real-time alert limit, else None.
+
+        Unlike check_alert_limit (which counts every alert against the ALERTS feature), this
+        counts only real-time alerts against the REAL_TIME_ALERTS feature's limit. Orgs without
+        the feature are already blocked by real_time_interval_validation_error.
+        """
+        feature = organization.get_available_feature(AvailableFeature.REAL_TIME_ALERTS)
+        if not feature:
+            return None
+
+        allowed = feature.get("limit")
+        # If allowed is None then the org is allowed unlimited real-time alerts
+        if allowed is None:
+            return None
+
+        existing_count = cls.objects.filter(
+            team_id=team_id, calculation_interval=AlertCalculationInterval.REAL_TIME
+        ).count()
+        if existing_count >= allowed:
+            return f"Your team has reached the limit of {allowed} real-time alerts on your plan."
         return None
 
 

--- a/products/alerts/frontend/components/editAlertModal/editAlertModalUtils.tsx
+++ b/products/alerts/frontend/components/editAlertModal/editAlertModalUtils.tsx
@@ -4,6 +4,13 @@ import { AlertCalculationInterval } from '~/queries/schema/schema-general'
 
 export function getSimulationRangeOptions(interval: AlertCalculationInterval): { label: string; value: string }[] {
     switch (interval) {
+        case AlertCalculationInterval.REAL_TIME:
+            return [
+                { label: 'Last 2h', value: '-2h' },
+                { label: 'Last 6h', value: '-6h' },
+                { label: 'Last 12h', value: '-12h' },
+                { label: 'Last 24h', value: '-24h' },
+            ]
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return [
                 { label: 'Last 12h', value: '-12h' },
@@ -44,6 +51,8 @@ export function getSimulationRangeOptions(interval: AlertCalculationInterval): {
 
 export function alertCalculationIntervalToLabel(interval: AlertCalculationInterval): string {
     switch (interval) {
+        case AlertCalculationInterval.REAL_TIME:
+            return 'Real time'
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return '15 minutes'
         case AlertCalculationInterval.HOURLY:

--- a/products/alerts/frontend/components/editAlertModal/editAlertModalUtils.tsx
+++ b/products/alerts/frontend/components/editAlertModal/editAlertModalUtils.tsx
@@ -6,10 +6,9 @@ export function getSimulationRangeOptions(interval: AlertCalculationInterval): {
     switch (interval) {
         case AlertCalculationInterval.REAL_TIME:
             return [
-                { label: 'Last 2h', value: '-2h' },
-                { label: 'Last 6h', value: '-6h' },
-                { label: 'Last 12h', value: '-12h' },
-                { label: 'Last 24h', value: '-24h' },
+                { label: 'Last 10 minutes', value: '-10m' },
+                { label: 'Last 1 hour', value: '-1h' },
+                { label: 'Last 3 hours', value: '-3h' },
             ]
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return [

--- a/products/alerts/frontend/logic/alertIntervalHelpers.ts
+++ b/products/alerts/frontend/logic/alertIntervalHelpers.ts
@@ -7,6 +7,8 @@ import { AvailableFeature } from '~/types'
 
 export function getDefaultSimulationRange(interval: AlertCalculationInterval): string {
     switch (interval) {
+        case AlertCalculationInterval.REAL_TIME:
+            return '-2h'
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return '-12h'
         case AlertCalculationInterval.HOURLY:

--- a/products/alerts/frontend/logic/alertIntervalHelpers.ts
+++ b/products/alerts/frontend/logic/alertIntervalHelpers.ts
@@ -8,7 +8,7 @@ import { AvailableFeature } from '~/types'
 export function getDefaultSimulationRange(interval: AlertCalculationInterval): string {
     switch (interval) {
         case AlertCalculationInterval.REAL_TIME:
-            return '-2h'
+            return '-1h'
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return '-12h'
         case AlertCalculationInterval.HOURLY:


### PR DESCRIPTION
## Problem

Adds the `real_time` calculation interval — schema, constants, and model helpers. Part 1 of 6. DB migration is in #67946, billing feature in PostHog/billing#2003.

## Changes

- `real_time` added to `AlertCalculationInterval` enum, regenerated Python schema
- New `AvailableFeature.REAL_TIME_ALERTS` added to Scale/Enterprise features
- Model helpers: entitlement validation, per-team limit check (counts only enabled real-time alerts)
- `is_high_frequency_interval` extended to include `real_time` (forces fresh ClickHouse queries)

## How did you test this code?

Tests land in #67934.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a until rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*