### PR TITLE
feat(alerts): validate and schedule real_time alert interval

### DIFF
--- a/posthog/api/test/test_alert_real_time_interval.py
+++ b/posthog/api/test/test_alert_real_time_interval.py
@@ -131,6 +131,42 @@ class TestAlertRealTimeInterval(APIBaseTest):
         response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
         assert response.status_code == status.HTTP_201_CREATED, response.content
 
+    def test_patch_to_real_time_rejected_when_limit_reached(self) -> None:
+        self._enable_real_time_alerts(limit=1)
+        real_time = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert real_time.status_code == status.HTTP_201_CREATED, real_time.content
+
+        daily = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            self._creation_request(name="daily", calculation_interval=AlertCalculationInterval.DAILY),
+        )
+        assert daily.status_code == status.HTTP_201_CREATED, daily.content
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{daily.json()['id']}",
+            {"calculation_interval": AlertCalculationInterval.REAL_TIME},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "limit of 1 real-time alerts" in str(response.json())
+
+    def test_enable_real_time_rejected_when_limit_reached(self) -> None:
+        self._enable_real_time_alerts(limit=1)
+        first = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+
+        disabled = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            self._creation_request(name="disabled", enabled=False),
+        )
+        assert disabled.status_code == status.HTTP_201_CREATED, disabled.content
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{disabled.json()['id']}",
+            {"enabled": True},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "limit of 1 real-time alerts" in str(response.json())
+
 
 class TestAlertRealTimeScheduling:
     def test_calculation_interval_to_order_ranks_real_time_first(self) -> None:

--- a/posthog/api/test/test_alert_real_time_interval.py
+++ b/posthog/api/test/test_alert_real_time_interval.py
@@ -70,6 +70,19 @@ class TestAlertRealTimeInterval(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED, response.content
         assert response.json()["calculation_interval"] == AlertCalculationInterval.REAL_TIME
 
+    def test_patch_real_time_succeeds_with_entitlement(self) -> None:
+        self._enable_real_time_alerts()
+        create_response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        alert_id = create_response.json()["id"]
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{alert_id}",
+            {"name": "updated real time alert"},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["name"] == "updated real time alert"
+        assert response.json()["calculation_interval"] == AlertCalculationInterval.REAL_TIME
+
     def test_patch_existing_real_time_rejected_after_entitlement_removed(self) -> None:
         self._enable_real_time_alerts()
         create_response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())

--- a/posthog/api/test/test_alert_real_time_interval.py
+++ b/posthog/api/test/test_alert_real_time_interval.py
@@ -1,0 +1,129 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock
+
+from rest_framework import status
+
+from posthog.schema import AlertCalculationInterval, AlertConditionType, InsightThresholdType
+
+from posthog.constants import AvailableFeature
+from posthog.tasks.alerts.utils import (
+    alert_calculation_interval_to_relativedelta,
+    calculation_interval_to_order,
+    next_check_time,
+)
+
+from products.alerts.backend.models.alert import AlertConfiguration
+
+
+class TestAlertRealTimeInterval(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.default_insight_data: dict[str, Any] = {
+            "query": {
+                "kind": "TrendsQuery",
+                "series": [
+                    {
+                        "kind": "EventsNode",
+                        "event": "$pageview",
+                    }
+                ],
+                "trendsFilter": {"display": "BoldNumber"},
+            },
+        }
+        self.insight = self.client.post(f"/api/projects/{self.team.id}/insights", data=self.default_insight_data).json()
+
+    def _creation_request(self, **overrides: Any) -> dict[str, Any]:
+        payload = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "name": "real time alert",
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {"lower": 0}}},
+            "calculation_interval": AlertCalculationInterval.REAL_TIME,
+        }
+        payload.update(overrides)
+        return payload
+
+    def _enable_real_time_alerts(self, limit: int | None = None) -> None:
+        feature: dict[str, Any] = {"key": AvailableFeature.REAL_TIME_ALERTS, "name": "Real-time alerts"}
+        if limit is not None:
+            feature["limit"] = limit
+        self.organization.available_product_features = [
+            *(self.organization.available_product_features or []),
+            feature,
+        ]
+        self.organization.save()
+
+    def test_create_real_time_rejected_without_billing_entitlement(self) -> None:
+        response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Scale or Enterprise" in str(response.json())
+
+    def test_create_real_time_succeeds_with_entitlement(self) -> None:
+        self._enable_real_time_alerts()
+        response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        assert response.json()["calculation_interval"] == AlertCalculationInterval.REAL_TIME
+
+    def test_patch_existing_real_time_rejected_after_entitlement_removed(self) -> None:
+        self._enable_real_time_alerts()
+        create_response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        alert_id = create_response.json()["id"]
+
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{alert_id}",
+            {"name": "still real time"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Scale or Enterprise" in str(response.json())
+
+    def test_create_real_time_rejected_when_limit_reached(self) -> None:
+        self._enable_real_time_alerts(limit=1)
+        first = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+
+        second = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request(name="second"))
+        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert "limit of 1 real-time alerts" in str(second.json())
+
+    def test_real_time_limit_ignores_other_intervals(self) -> None:
+        self._enable_real_time_alerts(limit=1)
+        daily = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            self._creation_request(name="daily", calculation_interval=AlertCalculationInterval.DAILY),
+        )
+        assert daily.status_code == status.HTTP_201_CREATED, daily.content
+
+        response = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+
+
+class TestAlertRealTimeScheduling:
+    def test_calculation_interval_to_order_ranks_real_time_first(self) -> None:
+        assert calculation_interval_to_order(AlertCalculationInterval.REAL_TIME) < calculation_interval_to_order(
+            AlertCalculationInterval.EVERY_15_MINUTES
+        )
+
+    def test_alert_calculation_interval_to_relativedelta_real_time(self) -> None:
+        delta = alert_calculation_interval_to_relativedelta(AlertCalculationInterval.REAL_TIME)
+        assert delta.minutes == 2
+
+    def test_next_check_time_advances_by_2_minutes(self) -> None:
+        alert = MagicMock(spec=AlertConfiguration)
+        alert.calculation_interval = AlertCalculationInterval.REAL_TIME
+        alert.next_check_at = datetime(2026, 4, 6, 14, 0, 0, tzinfo=UTC)
+        alert.team = MagicMock()
+        alert.team.timezone = "UTC"
+        alert.schedule_restriction = None
+        alert.skip_weekend = False
+
+        with freeze_time("2026-04-06T14:00:00Z"):
+            assert next_check_time(alert) == datetime(2026, 4, 6, 14, 2, 0, tzinfo=UTC)

--- a/posthog/api/test/test_alert_real_time_interval.py
+++ b/posthog/api/test/test_alert_real_time_interval.py
@@ -94,6 +94,19 @@ class TestAlertRealTimeInterval(APIBaseTest):
         assert second.status_code == status.HTTP_400_BAD_REQUEST
         assert "limit of 1 real-time alerts" in str(second.json())
 
+    def test_real_time_limit_ignores_disabled_alerts(self) -> None:
+        self._enable_real_time_alerts(limit=1)
+        first = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request())
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+
+        self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{first.json()['id']}",
+            {"enabled": False},
+        )
+
+        second = self.client.post(f"/api/projects/{self.team.id}/alerts", self._creation_request(name="second"))
+        assert second.status_code == status.HTTP_201_CREATED, second.content
+
     def test_real_time_limit_ignores_other_intervals(self) -> None:
         self._enable_real_time_alerts(limit=1)
         daily = self.client.post(

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -48,16 +48,18 @@ def is_non_time_series_trend(query: TrendsQuery) -> bool:
 
 def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> int:
     match interval:
-        case AlertCalculationInterval.EVERY_15_MINUTES:
+        case AlertCalculationInterval.REAL_TIME:
             return 0
-        case AlertCalculationInterval.HOURLY:
+        case AlertCalculationInterval.EVERY_15_MINUTES:
             return 1
-        case AlertCalculationInterval.DAILY:
+        case AlertCalculationInterval.HOURLY:
             return 2
+        case AlertCalculationInterval.DAILY:
+            return 3
         case AlertCalculationInterval.WEEKLY:
-            return 3
+            return 4
         case AlertCalculationInterval.MONTHLY:
-            return 3
+            return 4
         case None:
             raise ValueError("Invalid alert calculation interval: None")
         case _ as unreachable:
@@ -66,6 +68,8 @@ def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> 
 
 def alert_calculation_interval_to_relativedelta(alert_calculation_interval: AlertCalculationInterval) -> relativedelta:
     match alert_calculation_interval:
+        case AlertCalculationInterval.REAL_TIME:
+            return relativedelta(minutes=2)
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return relativedelta(minutes=15)
         case AlertCalculationInterval.HOURLY:
@@ -97,6 +101,8 @@ def _next_check_time_core(alert: AlertConfiguration) -> datetime:
     team_timezone = pytz.timezone(alert.team.timezone)
 
     match alert.calculation_interval:
+        case AlertCalculationInterval.REAL_TIME:
+            return (alert.next_check_at or now) + relativedelta(minutes=2)
         case AlertCalculationInterval.EVERY_15_MINUTES:
             return (alert.next_check_at or now) + relativedelta(minutes=15)
         case AlertCalculationInterval.HOURLY:

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -63,10 +63,11 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
         # time-sensitive checks get workers first when the due batch is large.
         # Keep ordering in sync with calculation_interval_to_order in posthog/tasks/alerts/utils.py.
         calculation_interval_order = Case(
-            When(calculation_interval=AlertCalculationInterval.EVERY_15_MINUTES.value, then=Value(0)),
-            When(calculation_interval=AlertCalculationInterval.HOURLY.value, then=Value(1)),
-            When(calculation_interval=AlertCalculationInterval.DAILY.value, then=Value(2)),
-            default=Value(3),
+            When(calculation_interval=AlertCalculationInterval.REAL_TIME.value, then=Value(0)),
+            When(calculation_interval=AlertCalculationInterval.EVERY_15_MINUTES.value, then=Value(1)),
+            When(calculation_interval=AlertCalculationInterval.HOURLY.value, then=Value(2)),
+            When(calculation_interval=AlertCalculationInterval.DAILY.value, then=Value(3)),
+            default=Value(4),
             output_field=IntegerField(),
         )
 

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -61,6 +61,18 @@ def _validate_every_15_minutes_interval(
         raise ValidationError({"calculation_interval": [error]})
 
 
+def _validate_real_time_interval(
+    *,
+    calculation_interval: str | AlertCalculationInterval | None,
+    organization,
+) -> None:
+    if error := AlertConfiguration.real_time_interval_validation_error(
+        calculation_interval=calculation_interval,
+        organization=organization,
+    ):
+        raise ValidationError({"calculation_interval": [error]})
+
+
 def _require_insight_viewer_access(context: dict[str, Any], insight: Insight) -> None:
     # Team scoping alone doesn't gate per-object insight access controls, so require viewer access
     # explicitly — alert write/simulate access must not expose a restricted insight's results.
@@ -258,7 +270,7 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
     calculation_interval = serializers.ChoiceField(
         choices=AlertConfiguration.CALCULATION_INTERVAL_CHOICES,
         required=False,
-        help_text="How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.",
+        help_text="How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.",
     )
     snoozed_until = RelativeDateTimeField(
         allow_null=True,
@@ -642,6 +654,10 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
             calculation_interval=calculation_interval,
             organization=organization,
         )
+        _validate_real_time_interval(
+            calculation_interval=calculation_interval,
+            organization=organization,
+        )
 
         # Investigation agent is only supported for detector-based alerts.
         investigation_enabled = attrs.get(
@@ -678,12 +694,17 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
                 }
             )
 
-        # only validate alert count when creating a new alert
+        # only validate alert counts when creating a new alert
         if self.context["request"].method != "POST":
             return attrs
 
         if msg := AlertConfiguration.check_alert_limit(self.context["team_id"], self.context["get_organization"]()):
             raise ValidationError({"alert": [msg]})
+
+        if calculation_interval == AlertCalculationInterval.REAL_TIME and (
+            msg := AlertConfiguration.check_real_time_alert_limit(self.context["team_id"], organization)
+        ):
+            raise ValidationError({"calculation_interval": [msg]})
 
         return attrs
 

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -694,26 +694,47 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
                 }
             )
 
-        # only validate alert counts when creating a new alert
-        if self.context["request"].method != "POST":
-            return attrs
+        # Total alert count only checked on create.
+        if self.context["request"].method == "POST":
+            if msg := AlertConfiguration.check_alert_limit(self.context["team_id"], self.context["get_organization"]()):
+                raise ValidationError({"alert": [msg]})
 
-        if msg := AlertConfiguration.check_alert_limit(self.context["team_id"], self.context["get_organization"]()):
-            raise ValidationError({"alert": [msg]})
-
-        if calculation_interval == AlertCalculationInterval.REAL_TIME and (
-            msg := AlertConfiguration.check_real_time_alert_limit(self.context["team_id"], organization)
-        ):
-            posthoganalytics.capture(
-                str(self.context["request"].user.distinct_id),
-                "real time alert limit reached",
-                properties={
-                    "team_id": self.context["team_id"],
-                    "organization_id": str(organization.id),
-                },
-                groups={"organization": str(organization.id)},
-            )
-            raise ValidationError({"calculation_interval": [msg]})
+        # Real-time limit applies on create and on any update that would increase the active count:
+        # switching an alert to real_time, or enabling an already-real_time alert.
+        is_create = self.context["request"].method == "POST"
+        existing_interval = self.instance.calculation_interval if self.instance else None
+        existing_enabled = self.instance.enabled if self.instance else True
+        becoming_real_time = (
+            is_create
+            and calculation_interval == AlertCalculationInterval.REAL_TIME
+            and attrs.get("enabled", True) is True
+        )
+        switching_to_real_time = (
+            not is_create
+            and calculation_interval == AlertCalculationInterval.REAL_TIME
+            and existing_interval != AlertCalculationInterval.REAL_TIME
+        )
+        enabling_real_time = (
+            not is_create
+            and calculation_interval == AlertCalculationInterval.REAL_TIME
+            and attrs.get("enabled", existing_enabled) is True
+            and not existing_enabled
+        )
+        if becoming_real_time or switching_to_real_time or enabling_real_time:
+            exclude_id = str(self.instance.pk) if self.instance else None
+            if msg := AlertConfiguration.check_real_time_alert_limit(
+                self.context["team_id"], organization, exclude_id=exclude_id
+            ):
+                posthoganalytics.capture(
+                    distinct_id=str(self.context["request"].user.distinct_id),
+                    event="real time alert limit reached",
+                    properties={
+                        "team_id": self.context["team_id"],
+                        "organization_id": str(organization.id),
+                    },
+                    groups={"organization": str(organization.id)},
+                )
+                raise ValidationError({"calculation_interval": [msg]})
 
         return attrs
 

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -707,7 +707,7 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
             posthoganalytics.capture(
                 str(self.context["request"].user.distinct_id),
                 "real time alert limit reached",
-                {
+                properties={
                     "team_id": self.context["team_id"],
                     "organization_id": str(organization.id),
                 },

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -270,7 +270,7 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
     calculation_interval = serializers.ChoiceField(
         choices=AlertConfiguration.CALCULATION_INTERVAL_CHOICES,
         required=False,
-        help_text="How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.",
+        help_text="How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.",
     )
     snoozed_until = RelativeDateTimeField(
         allow_null=True,

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -704,8 +704,6 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
         if calculation_interval == AlertCalculationInterval.REAL_TIME and (
             msg := AlertConfiguration.check_real_time_alert_limit(self.context["team_id"], organization)
         ):
-            import posthoganalytics  # noqa: PLC0415
-
             posthoganalytics.capture(
                 str(self.context["request"].user.distinct_id),
                 "real time alert limit reached",

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -704,6 +704,17 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
         if calculation_interval == AlertCalculationInterval.REAL_TIME and (
             msg := AlertConfiguration.check_real_time_alert_limit(self.context["team_id"], organization)
         ):
+            import posthoganalytics  # noqa: PLC0415
+
+            posthoganalytics.capture(
+                str(self.context["request"].user.distinct_id),
+                "real time alert limit reached",
+                {
+                    "team_id": self.context["team_id"],
+                    "organization_id": str(organization.id),
+                },
+                groups={"organization": str(organization.id)},
+            )
             raise ValidationError({"calculation_interval": [msg]})
 
         return attrs

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -353,7 +353,9 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         return None
 
     @classmethod
-    def check_real_time_alert_limit(cls, team_id: int, organization: Organization) -> str | None:
+    def check_real_time_alert_limit(
+        cls, team_id: int, organization: Organization, *, exclude_id: str | None = None
+    ) -> str | None:
         """Return an error message if the team has reached its real-time alert limit, else None.
 
         Unlike check_alert_limit (which counts every alert against the ALERTS feature), this
@@ -369,9 +371,10 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         if allowed is None:
             return None
 
-        existing_count = cls.objects.filter(
-            team_id=team_id, calculation_interval=AlertCalculationInterval.REAL_TIME, enabled=True
-        ).count()
+        qs = cls.objects.filter(team_id=team_id, calculation_interval=AlertCalculationInterval.REAL_TIME, enabled=True)
+        if exclude_id:
+            qs = qs.exclude(pk=exclude_id)
+        existing_count = qs.count()
         if existing_count >= allowed:
             return f"Your team has reached the limit of {allowed} real-time alerts on your plan."
         return None

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -522,7 +522,7 @@ export interface AlertApi {
     /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
     config?: AlertConfigUnionApi | null
     detector_config?: DetectorConfigApi | null
-    /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+    /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
      *
      * * `real_time` - real_time
      * * `every_15_minutes` - every_15_minutes
@@ -604,7 +604,7 @@ export interface PatchedAlertApi {
     /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
     config?: AlertConfigUnionApi | null
     detector_config?: DetectorConfigApi | null
-    /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+    /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
      *
      * * `real_time` - real_time
      * * `every_15_minutes` - every_15_minutes

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -522,7 +522,7 @@ export interface AlertApi {
     /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
     config?: AlertConfigUnionApi | null
     detector_config?: DetectorConfigApi | null
-    /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+    /** How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
      *
      * * `real_time` - real_time
      * * `every_15_minutes` - every_15_minutes
@@ -604,7 +604,7 @@ export interface PatchedAlertApi {
     /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
     config?: AlertConfigUnionApi | null
     detector_config?: DetectorConfigApi | null
-    /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+    /** How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
      *
      * * `real_time` - real_time
      * * `every_15_minutes` - every_15_minutes

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8951,7 +8951,7 @@ export namespace Schemas {
       /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
       config?: AlertConfigUnion | null;
       detector_config?: DetectorConfig | null;
-      /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+      /** How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
        *
        * * `real_time` - real_time
        * * `every_15_minutes` - every_15_minutes
@@ -35998,7 +35998,7 @@ export namespace Schemas {
       /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
       config?: AlertConfigUnion | null;
       detector_config?: DetectorConfig | null;
-      /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+      /** How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
        *
        * * `real_time` - real_time
        * * `every_15_minutes` - every_15_minutes

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8951,7 +8951,7 @@ export namespace Schemas {
       /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
       config?: AlertConfigUnion | null;
       detector_config?: DetectorConfig | null;
-      /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+      /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
        *
        * * `real_time` - real_time
        * * `every_15_minutes` - every_15_minutes
@@ -35998,7 +35998,7 @@ export namespace Schemas {
       /** Per-insight-kind alert configuration, discriminated by `type`. TrendsAlertConfig: series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). HogQLAlertConfig (SQL insights): column (which result column to evaluate, defaults to the single numeric column), evaluation ('last_row' checks the latest value of an oldest->newest query, 'first_row' checks the first value of a newest->oldest query, 'any_row' fires if any row breaches), and label_column (names the evaluated row(s) in breach messages, in every evaluation mode). FunnelsAlertConfig (funnel insights): funnel_step (the step to monitor, null for the overall last step), metric ('conversion_from_start' or 'conversion_from_previous'), and check_ongoing_interval (historical-trend funnels: also evaluate the current in-progress period). Steps funnels support only absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease (compared against the prior period). */
       config?: AlertConfigUnion | null;
       detector_config?: DetectorConfig | null;
-      /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
+      /** How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
        *
        * * `real_time` - real_time
        * * `every_15_minutes` - every_15_minutes

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -1226,7 +1226,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()
@@ -2537,7 +2537,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -1226,7 +1226,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()
@@ -2537,7 +2537,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         )
         .optional()
         .describe(
-            'How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
+            'How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
     snoozed_until: zod
         .string()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: real time (Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "description": "How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "description": "How often the alert is checked: real time (every 2 minutes, Scale+), every 15 minutes (Boost+), hourly, daily, weekly, or monthly.\n\n* `real_time` - real_time\n* `every_15_minutes` - every_15_minutes\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["real_time", "every_15_minutes", "hourly", "daily", "weekly", "monthly"],
             "type": "string"
         },


### PR DESCRIPTION
## Problem

API validation and scheduling for `real_time`. Part 3 of 6, stacked on #67946.

## Changes

- Serializer rejects `real_time` without `REAL_TIME_ALERTS` entitlement; enforces per-team limit on create
- Schedules checks every 2 minutes, ranked ahead of all other intervals
- `calculation_interval_to_order`, `retrieve_due_alerts` Case ordering, and `_next_check_time_core` all updated in sync

## How did you test this code?

New `test_alert_real_time_interval.py` — 10 tests covering entitlement rejection, PATCH success, limit enforcement, disabled alerts not consuming a slot, and scheduling math.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*