### PR TITLE
feat(alerts): support real_time interval in Max upsert_alert tool

### DIFF
--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -76,6 +76,7 @@ UPSERT_ALERT_TOOL_DESCRIPTION = dedent("""
     - For percentage-based thresholds, set threshold_type to "percentage" and use decimal values (e.g., 0.5 for 50%)
 
     # Calculation intervals
+    - **real_time**: Check every 2 minutes (Scale+ required)
     - **every_15_minutes**: Check every 15 minutes (Boost+ required)
     - **hourly**: Check every hour
     - **daily**: Check once per day (default for create)
@@ -115,7 +116,7 @@ class CreateAlertAction(BaseModel):
     )
     calculation_interval: AlertCalculationInterval = Field(
         default=AlertCalculationInterval.DAILY,
-        description="How often to check: every_15_minutes (Boost+), hourly, daily, weekly, or monthly",
+        description="How often to check: real_time (every 2 minutes, Scale+), every_15_minutes (Boost+), hourly, daily, weekly, or monthly",
     )
     upper_threshold: float | None = Field(
         default=None,
@@ -150,7 +151,7 @@ class UpdateAlertAction(BaseModel):
     condition_type: AlertConditionType | None = Field(default=None, description="New condition type")
     calculation_interval: AlertCalculationInterval | None = Field(
         default=None,
-        description="New calculation interval (every_15_minutes requires Boost+)",
+        description="New calculation interval (real_time requires Scale+, every_15_minutes requires Boost+)",
     )
     upper_threshold: float | None = Field(default=None, description="New upper threshold bound")
     lower_threshold: float | None = Field(default=None, description="New lower threshold bound")

--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -76,7 +76,7 @@ UPSERT_ALERT_TOOL_DESCRIPTION = dedent("""
     - For percentage-based thresholds, set threshold_type to "percentage" and use decimal values (e.g., 0.5 for 50%)
 
     # Calculation intervals
-    - **real_time**: Check every 2 minutes (Scale+ required)
+    - **real_time**: Check in real time (Scale+ required)
     - **every_15_minutes**: Check every 15 minutes (Boost+ required)
     - **hourly**: Check every hour
     - **daily**: Check once per day (default for create)
@@ -116,7 +116,7 @@ class CreateAlertAction(BaseModel):
     )
     calculation_interval: AlertCalculationInterval = Field(
         default=AlertCalculationInterval.DAILY,
-        description="How often to check: real_time (every 2 minutes, Scale+), every_15_minutes (Boost+), hourly, daily, weekly, or monthly",
+        description="How often to check: real_time (Scale+), every_15_minutes (Boost+), hourly, daily, weekly, or monthly",
     )
     upper_threshold: float | None = Field(
         default=None,


### PR DESCRIPTION
## Problem

Max `upsert_alert` tool support for `real_time`. Part 6 of 6, stacked on #67936.

## Changes

- Validates `REAL_TIME_ALERTS` entitlement and per-team limit in `max_tools.py` on create and update
- Limit counted when an alert newly becomes real-time; no-op updates keep their existing slot
- Tool descriptions updated (no `tools.yaml` change needed — description flows from serializer)

## How did you test this code?

`test_max_tools.py` passes (37 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*