### PR TITLE
chore(marketing-analytics): add fine-grained timing spans to query build

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -174,8 +174,10 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         """Get marketing source adapters using the new adapter architecture"""
         try:
             factory: MarketingSourceFactory = self._factory(date_range=date_range)
-            adapters = factory.create_adapters()
-            valid_adapters = factory.get_valid_adapters(adapters)
+            with self.timings.measure("ma_adapters_create"):
+                adapters = factory.create_adapters()
+            with self.timings.measure("ma_adapters_validate"):
+                valid_adapters = factory.get_valid_adapters(adapters)
 
             # Apply integration filter if present (getattr: some query kinds lack the field)
             integration_filter = getattr(self.query, "integrationFilter", None)
@@ -216,7 +218,8 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             database=self._shared_hogql_database,
         )
         mat_factory = MarketingSourceFactory(context=mat_context)
-        mat_adapters = mat_factory.get_valid_adapters(mat_factory.create_adapters())
+        with self.timings.measure("ma_precompute_adapters"):
+            mat_adapters = mat_factory.get_valid_adapters(mat_factory.create_adapters())
         # NonIntegratedConversionsTableQuery has no integrationFilter field — getattr keeps the
         # precompute path working for it instead of raising AttributeError and falling back to S3.
         integration_filter = getattr(self.query, "integrationFilter", None)
@@ -241,7 +244,8 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         job_ids: list = []
         s3_fallback_adapters: list[MarketingSourceAdapter] = []
         for adapter in mat_adapters:
-            insert_query = adapter.build_materialization_query(adapter.get_source_id())
+            with self.timings.measure("ma_precompute_build_mat_query"):
+                insert_query = adapter.build_materialization_query(adapter.get_source_id())
             if insert_query is None:
                 logger.info(
                     "marketing_costs_precompute",
@@ -252,14 +256,15 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
                 )
                 s3_fallback_adapters.append(adapter)
                 continue
-            result = ensure_precomputed(
-                team=self.team,
-                insert_query=insert_query,
-                time_range_start=date_range.date_from(),
-                time_range_end=date_range.date_to(),
-                ttl_seconds=ttl_seconds,
-                table=LazyComputationTable.MARKETING_COSTS_PREAGGREGATED,
-            )
+            with self.timings.measure("ma_precompute_ensure"):
+                result = ensure_precomputed(
+                    team=self.team,
+                    insert_query=insert_query,
+                    time_range_start=date_range.date_from(),
+                    time_range_end=date_range.date_to(),
+                    ttl_seconds=ttl_seconds,
+                    table=LazyComputationTable.MARKETING_COSTS_PREAGGREGATED,
+                )
             if not result.ready:
                 logger.info(
                     "marketing_costs_precompute",


### PR DESCRIPTION
## Problem

After cost precompute lands, ClickHouse execution for the marketing analytics ads query drops to ~60ms, but total query time stays multi-second. The remaining cost is entirely Python-side query build, not ClickHouse. Master already isolates the top-level phases (`ma_build_database`, `ma_get_adapters`, `ma_build_costs_precompute`), but two of them are still opaque boxes — together they account for the bulk of the build time and we can't tell _where_ inside them the time goes.

## Changes

Adds fine-grained timing sub-spans inside the two opaque phases, so the query `timings` breakdown attributes their cost precisely:

- `ma_get_adapters` → `ma_adapters_create` (factory `create_adapters`) + `ma_adapters_validate` (`get_valid_adapters`)
- `ma_build_costs_precompute` → `ma_precompute_adapters` (build + validate adapters at the materialization grain), `ma_precompute_build_mat_query` (build the INSERT AST per source), and `ma_precompute_ensure` (`ensure_precomputed` readiness/dispatch per source)

The loop spans accumulate across sources (`HogQLTimings` sums per key). No behavior change — pure observability.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Automated only:

- Ran the existing `test_marketing_analytics_table_query_runner.py` suite (59 passed), confirming the `with self.timings.measure(...)` wrappers don't alter control flow — including the exception-handling path around `create_adapters()`.
- Verified with a throwaway test that the new sub-spans appear and nest correctly under their parents in `runner.timings.to_dict()` after `to_query()` (`.../ma_get_adapters/ma_adapters_create`, etc.). Removed before commit.

The precompute-loop spans (`ma_precompute_build_mat_query`, `ma_precompute_ensure`) only fire when the precompute path has materializable sources, which local dev lacks — those get validated on an environment with real warehouse data. This overhead is proportional to warehouse table / source count and does not reproduce locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at the user's direction while investigating post-precompute latency. The top-level phase spans were already in master; this PR only adds the missing sub-spans to break down the two remaining opaque phases before deciding where to optimize (leading candidate: lazy-defer of Postgres FK lazy-join construction in `warehouse_foreign_keys`, tracked separately). No skills were required. Scoped deliberately to a single file — the originating working tree had unrelated changes that were excluded by branching fresh from master.
