### PR TITLE
chore(cohorts): decouple heartbeat

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,0 +1,4 @@
+# SESSION — deferred issues (PR #67940, decouple heartbeat)
+
+- **`run_pauser_loop` executes blocking librdkafka FFI on a tokio worker thread.** The 3-thread runtime is already saturated by sync RocksDB reads (gate report §3); a wedged `pause()`/`resume()` call parks one of three threads. It no longer gates the heartbeat (that runs on the consume loop), but under thread starvation the re-assertion could lag. Optional hardening: `spawn_blocking` inside the pauser loop, or a dedicated single-thread runtime for the pauser.
+- **`EventDispatcher::dispatch` (blocking) has zero production callers** — ~30 test call sites in `consumers/events.rs` + 1 in `tests/sweep_worker.rs`. Follow-up (per haacked, explicitly deferred out of #67940): migrate tests to `dispatch_events_nonblocking` and delete `dispatch` so there's a single dispatch path to maintain.

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -39,7 +39,7 @@ use crate::observability::metrics::{
     PARTITIONS_REVOKED_TOTAL, PARTITION_STATE_DELETED_TOTAL, PENDING_HELD_EVENTS,
     REBALANCE_CLEANUP_SKIPPED_TOTAL, REVOKE_DRAIN_DURATION_SECONDS,
 };
-use crate::partitions::backpressure::Backpressure;
+use crate::partitions::backpressure::{Backpressure, PauseDeltas};
 use crate::partitions::offset_tracker::OffsetTracker;
 use crate::partitions::pause::{ConsumerPauser, PartitionPauser};
 use crate::partitions::rebalance::{CohortConsumerContext, ConsumerCommandReceiver};
@@ -947,6 +947,11 @@ impl CohortStreamEventsConsumer {
             self.handle.clone(),
         ));
 
+        // Apply pause/resume off the consume loop: librdkafka `pause`/`resume` are synchronous, un-timed
+        // FFI calls, so a wedged client must never delay the liveness heartbeat.
+        let (pause_tx, pause_rx) = tokio::sync::mpsc::unbounded_channel::<PauseDeltas>();
+        let pauser_task = tokio::spawn(run_pauser_loop(self.pauser.clone(), pause_rx));
+
         // One-shot guards; each pre-marked done when its gate is off, keeping the non-durable path unchanged.
         let mut boot_sweep_done = !self.dispatcher.durable_restore_enabled();
         let mut eager_redrive_done = !self.dispatcher.durable_restore_enabled();
@@ -985,7 +990,7 @@ impl CohortStreamEventsConsumer {
                         restore_seek_done = self.run_restore_seek();
                         continue;
                     }
-                    self.dispatch_with_backpressure(outcome, &mut backpressure).await;
+                    self.dispatch_with_backpressure(outcome, &mut backpressure, &pause_tx).await;
                 }
             }
         }
@@ -993,6 +998,11 @@ impl CohortStreamEventsConsumer {
         // Await the commit task before the final synchronous commit so the two don't race.
         if let Err(err) = commit_task.await {
             warn!(error = %err, "offset-commit task did not exit cleanly");
+        }
+        // Drop the sender so the pauser task drains and exits.
+        drop(pause_tx);
+        if let Err(err) = pauser_task.await {
+            warn!(error = %err, "pauser task did not exit cleanly");
         }
 
         let tracker = self.dispatcher.shutdown().await;
@@ -1089,12 +1099,13 @@ impl CohortStreamEventsConsumer {
     }
 
     /// One steady-state cycle: prune revoked holdover, retry-flush held partitions, dispatch the polled
-    /// batch, reconcile pauses/resumes. Every step is non-blocking, so the heartbeat below fires each
-    /// iteration regardless of downstream drain.
+    /// batch, reconcile the paused set and hand its deltas to the pauser task. Every step is
+    /// non-blocking, so the heartbeat below fires each iteration regardless of downstream drain.
     async fn dispatch_with_backpressure(
         &self,
         outcome: ConsumeOutcome,
         backpressure: &mut Backpressure,
+        pause_tx: &tokio::sync::mpsc::UnboundedSender<PauseDeltas>,
     ) {
         histogram!(COHORT_STREAM_CONSUME_BATCH_SIZE).record(outcome.events.len() as f64);
         if !outcome.events.is_empty() {
@@ -1118,8 +1129,10 @@ impl CohortStreamEventsConsumer {
             .dispatch_events_nonblocking(outcome.events, &backpressure.held_partitions());
         backpressure.absorb(full);
         let deltas = backpressure.reconcile();
-        self.pauser.pause(&deltas.pause);
-        self.pauser.resume(&deltas.resume);
+        if (!deltas.pause.is_empty() || !deltas.resume.is_empty()) && pause_tx.send(deltas).is_err() {
+            // The receiver is gone only at shutdown, where an unapplied delta is moot.
+            debug!("pauser task has exited; skipping a pause/resume delta");
+        }
         gauge!(PARTITIONS_PAUSED).set(backpressure.paused_count() as f64);
         gauge!(PENDING_HELD_EVENTS).set(backpressure.held_event_count() as f64);
 
@@ -1291,6 +1304,19 @@ async fn run_commit_loop(
                 );
             }
         }
+    }
+}
+
+/// Applies pause/resume deltas off the consume loop, so a blocking librdkafka `pause`/`resume` can
+/// never delay the liveness heartbeat. Deltas are applied in the order received, preserving the
+/// paused-set transitions. Exits when the sender is dropped.
+async fn run_pauser_loop(
+    pauser: Arc<dyn PartitionPauser>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<PauseDeltas>,
+) {
+    while let Some(deltas) = rx.recv().await {
+        pauser.pause(&deltas.pause);
+        pauser.resume(&deltas.resume);
     }
 }
 

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -224,14 +224,10 @@ impl EventDispatcher {
         counter!(COHORT_STREAM_EVENTS_DISPATCHED).increment(stats.dispatched);
     }
 
-    /// Non-blocking events dispatch: the hot-path sibling of [`dispatch`](Self::dispatch) that never
-    /// awaits, so the consume loop's liveness heartbeat is never gated on a full worker channel.
-    ///
-    /// Owns-filters, ensures a worker, and `try_send`s each non-held partition's sub-batch, raising the
-    /// dispatch ceiling only for what actually lands. Events for a partition in `held` (already paused
-    /// behind an older holdover) skip the send and are returned to queue behind it — never leapfrog.
-    /// Returns the un-dispatched events per partition (held-deferred plus any that just filled a
-    /// channel); the caller appends them to that partition's holdover and pauses it.
+    /// Non-blocking events dispatch: `try_send`s each non-held partition's sub-batch and raises the
+    /// dispatch ceiling only for what lands. Events for a partition in `held` (already paused behind an
+    /// older holdover) skip the send and are returned to queue behind it. Returns the un-dispatched
+    /// events per partition for the caller to hold and pause.
     pub fn dispatch_events_nonblocking(
         &self,
         batch: Vec<ConsumedEvent>,
@@ -262,8 +258,8 @@ impl EventDispatcher {
                 event: Box::new(consumed.event),
                 cse_offset: consumed.offset,
             };
-            // librdkafka can still deliver a few already-fetched stragglers just after a pause; queue
-            // them behind the partition's holdover rather than racing them ahead of older offsets.
+            // A paused partition can still deliver a few already-fetched stragglers; queue them behind
+            // the holdover rather than racing them ahead of older offsets.
             if held.contains(&partition) {
                 full.entry(partition).or_default().push(message);
             } else {
@@ -276,15 +272,14 @@ impl EventDispatcher {
         full
     }
 
-    /// Retry-send held sub-batches (paused partitions) before polling, raising the ceiling for any that
-    /// flush. Returns the partitions still full (their retained holdover) so the caller keeps them
-    /// paused; a flushed or worker-gone partition is absent, so the caller resumes it (a dropped one
-    /// replays from the pinned commit).
+    /// Retry-send held sub-batches, raising the ceiling for any that flush. Returns the partitions
+    /// still full (retained holdover) to keep paused; a flushed or worker-gone one is absent, so the
+    /// caller resumes it.
     pub fn redispatch_held(
         &self,
         held: Vec<(i32, Vec<ShuffleMessage>)>,
     ) -> HashMap<i32, Vec<ShuffleMessage>> {
-        // Flatten to one grouped route; each partition's Vec is contiguous, so offset order is kept.
+        // Each partition's Vec stays contiguous, so the regrouped route keeps offset order.
         let mut messages: Vec<(i32, ShuffleMessage)> = Vec::new();
         for (partition, batch) in held {
             for message in batch {
@@ -296,9 +291,8 @@ impl EventDispatcher {
         still_full
     }
 
-    /// `try_send` owned, worker-ensured events and fold the per-partition outcomes: raise the ceiling
-    /// for what landed, collect the un-sent sub-batch of a full channel into `full`, and count a
-    /// missing/closed worker as a route error (the router already recorded the drop).
+    /// `try_send` events and fold the outcomes: raise the ceiling for what landed, collect a full
+    /// channel's un-sent sub-batch into `full`, and count a missing/closed worker as a route error.
     fn route_fresh(
         &self,
         messages: Vec<(i32, ShuffleMessage)>,
@@ -889,8 +883,7 @@ pub struct CohortStreamEventsConsumer {
     topic: String,
     dispatcher: Arc<EventDispatcher>,
     handle: Handle,
-    /// Pauses/resumes events partitions to express downstream backpressure as lag on the hot
-    /// partition, keeping the consume loop non-blocking.
+    /// Pauses/resumes events partitions to express downstream backpressure as lag.
     pauser: Arc<dyn PartitionPauser>,
     recv_batch_size: usize,
     recv_batch_timeout: Duration,
@@ -940,8 +933,7 @@ impl CohortStreamEventsConsumer {
     ///
     /// Offset commit runs on its own interval task so a CPU-saturated consume loop or worker backlog
     /// can't block offset advancement; it shares the shutdown signal and is awaited before the final
-    /// synchronous commit. Liveness is reported inline from the non-blocking backpressure cycle, so a
-    /// full worker channel becomes paused partitions and lag, never a stalled heartbeat.
+    /// synchronous commit. Liveness is reported inline from the non-blocking backpressure cycle.
     pub async fn process(self) {
         let _guard = self.handle.process_scope();
         info!(topic = %self.topic, "cohort_stream_events consume loop starting");
@@ -959,8 +951,7 @@ impl CohortStreamEventsConsumer {
         let mut eager_redrive_done = !self.dispatcher.durable_restore_enabled();
         let mut restore_seek_done = self.restore_manifest.is_none();
         let mut prev_assignment: Option<HashSet<i32>> = None;
-        // Per-partition holdover + pause state. Untouched until boot recovery completes below, so a
-        // partition is never paused during boot.
+        // Untouched until boot recovery completes below, so nothing pauses during boot.
         let mut backpressure = Backpressure::new();
 
         loop {
@@ -1096,10 +1087,9 @@ impl CohortStreamEventsConsumer {
         }
     }
 
-    /// One steady-state cycle: prune revoked holdover, retry-flush held partitions, dispatch the freshly
-    /// polled batch, then reconcile pauses/resumes. Every step is non-blocking (`try_send`, sync
-    /// pause/resume), so the heartbeat below fires each iteration regardless of downstream drain — the
-    /// crux of the fix: a saturated worker channel becomes a paused partition and lag, never a stall.
+    /// One steady-state cycle: prune revoked holdover, retry-flush held partitions, dispatch the polled
+    /// batch, reconcile pauses/resumes. Every step is non-blocking, so the heartbeat below fires each
+    /// iteration regardless of downstream drain.
     async fn dispatch_with_backpressure(
         &self,
         outcome: ConsumeOutcome,
@@ -1117,18 +1107,15 @@ impl CohortStreamEventsConsumer {
         }
 
         let owned = self.dispatcher.owned_set();
-        // 1. Drop holdover for revoked partitions (their range replays on the next owner).
         backpressure.prune_revoked(&owned);
-        // 2. Retry-flush existing holdovers before dispatching new events, so an older held offset can
-        //    never be leapfrogged by a newer one on the same partition.
+        // Retry-flush held partitions before dispatching new events, so a newer offset never leapfrogs
+        // an older held one on the same partition.
         let still_full = self.dispatcher.redispatch_held(backpressure.take_held());
         backpressure.set_pending(still_full);
-        // 3. Dispatch the freshly polled batch, queueing new events behind any still-held partition.
         let full = self
             .dispatcher
             .dispatch_events_nonblocking(outcome.events, &backpressure.held_partitions());
         backpressure.absorb(full);
-        // 4. Reconcile the paused set and apply the deltas to Kafka.
         let deltas = backpressure.reconcile();
         self.pauser.pause(&deltas.pause);
         self.pauser.resume(&deltas.resume);
@@ -1935,8 +1922,8 @@ mod tests {
         let _tracker = dispatcher.shutdown().await;
     }
 
-    /// A dispatcher whose router has `buffer` channel slots and drains through no real worker, so a
-    /// pre-filled channel deterministically exercises the non-blocking `try_send`-full path.
+    /// A dispatcher whose router uses `buffer` channel slots and no real worker, so a pre-filled
+    /// channel exercises the `try_send`-full path.
     fn dispatcher_with_buffer(
         store: &CohortStore,
         catalog: Arc<CatalogHandle>,
@@ -1965,8 +1952,8 @@ mod tests {
         let (_dir, store) = temp_store();
         let dispatcher = dispatcher_with_buffer(&store, behavioral_catalog(), 1);
         dispatcher.assign_partition(0);
-        // Hold the receiver so nothing drains; ensure_worker finds the channel registered and spawns no
-        // worker, leaving this rx the only consumer.
+        // Hold the receiver so nothing drains; ensure_worker reuses the registered channel and spawns
+        // no worker, leaving this rx the only consumer.
         let mut rx = dispatcher.router.add_partition(0).unwrap();
         let no_held = HashSet::new();
 
@@ -2018,8 +2005,8 @@ mod tests {
         dispatcher.assign_partition(0);
         let mut rx = dispatcher.router.add_partition(0).unwrap();
 
-        // Partition 0 is already held (paused behind an older holdover): its fresh events queue behind
-        // it rather than racing onto the channel, even though there is room — the ordering invariant.
+        // Partition 0 is already held: its fresh events queue behind the holdover rather than racing
+        // onto the channel, even with room.
         let held: HashSet<i32> = [0].into_iter().collect();
         let mut full =
             dispatcher.dispatch_events_nonblocking(vec![consumed(person(1), 0, 200)], &held);
@@ -2042,7 +2029,7 @@ mod tests {
 
         dispatcher.dispatch_events_nonblocking(vec![consumed(person(1), 0, 0)], &no_held);
         // The second dispatch onto the saturated channel returns the holdover synchronously instead of
-        // awaiting a drain — the property that keeps the consume loop's heartbeat firing under overload.
+        // awaiting a drain.
         let full =
             dispatcher.dispatch_events_nonblocking(vec![consumed(person(2), 0, 1)], &no_held);
         assert!(

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -36,7 +36,7 @@ use crate::observability::metrics::{
     DURABLE_RESTORE_PARTITIONS_KEPT_TOTAL, DURABLE_RESTORE_PARTITIONS_WIPED_STALE_TOTAL,
     DURABLE_RESTORE_PENDING_TRANSFERS_RECOVERED_PARTITIONS_TOTAL, MERGE_HELD_OFFSET_GAUGE,
     MERGE_PENDING_TRANSFERS_GAUGE, PARTITIONS_ASSIGNED_TOTAL, PARTITIONS_PAUSED,
-    PARTITIONS_REVOKED_TOTAL, PARTITION_STATE_DELETED_TOTAL, PENDING_SUBBATCHES,
+    PARTITIONS_REVOKED_TOTAL, PARTITION_STATE_DELETED_TOTAL, PENDING_HELD_EVENTS,
     REBALANCE_CLEANUP_SKIPPED_TOTAL, REVOKE_DRAIN_DURATION_SECONDS,
 };
 use crate::partitions::backpressure::Backpressure;
@@ -197,7 +197,8 @@ impl EventDispatcher {
         &self.store
     }
 
-    /// Route a consumed batch to per-partition workers, lazily spawning on first delivery.
+    /// Blocking events dispatch, retained for tests; the consume loop uses
+    /// [`dispatch_events_nonblocking`](Self::dispatch_events_nonblocking).
     ///
     /// The dispatch ceiling is raised before routing so a `RouteError` leaves the offset
     /// uncommittable and Kafka replays it. Events for unowned partitions are dropped before any
@@ -1120,7 +1121,7 @@ impl CohortStreamEventsConsumer {
         self.pauser.pause(&deltas.pause);
         self.pauser.resume(&deltas.resume);
         gauge!(PARTITIONS_PAUSED).set(backpressure.paused_count() as f64);
-        gauge!(PENDING_SUBBATCHES).set(backpressure.held_event_count() as f64);
+        gauge!(PENDING_HELD_EVENTS).set(backpressure.held_event_count() as f64);
 
         if outcome.transport_error {
             tokio::time::sleep(RECV_ERROR_BACKOFF).await;

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -39,7 +39,7 @@ use crate::observability::metrics::{
     PARTITIONS_REVOKED_TOTAL, PARTITION_STATE_DELETED_TOTAL, PENDING_HELD_EVENTS,
     REBALANCE_CLEANUP_SKIPPED_TOTAL, REVOKE_DRAIN_DURATION_SECONDS,
 };
-use crate::partitions::backpressure::{Backpressure, PauseDeltas};
+use crate::partitions::backpressure::Backpressure;
 use crate::partitions::offset_tracker::OffsetTracker;
 use crate::partitions::pause::{ConsumerPauser, PartitionPauser};
 use crate::partitions::rebalance::{CohortConsumerContext, ConsumerCommandReceiver};
@@ -269,7 +269,7 @@ impl EventDispatcher {
         }
         counter!(COHORT_STREAM_EVENTS_SKIPPED_NOT_OWNED).increment(not_owned);
 
-        self.route_fresh(fresh, &mut full);
+        self.route_and_fold(fresh, &mut full);
         full
     }
 
@@ -288,13 +288,14 @@ impl EventDispatcher {
             }
         }
         let mut still_full = HashMap::new();
-        self.route_fresh(messages, &mut still_full);
+        self.route_and_fold(messages, &mut still_full);
         still_full
     }
 
     /// `try_send` events and fold the outcomes: raise the ceiling for what landed, collect a full
     /// channel's un-sent sub-batch into `full`, and count a missing/closed worker as a route error.
-    fn route_fresh(
+    /// Folds for both the fresh dispatch and the [`redispatch_held`](Self::redispatch_held) retry.
+    fn route_and_fold(
         &self,
         messages: Vec<(i32, ShuffleMessage)>,
         full: &mut HashMap<i32, Vec<ShuffleMessage>>,
@@ -304,7 +305,20 @@ impl EventDispatcher {
         for (partition, outcome) in self.router.try_route_batch(messages) {
             match outcome {
                 SendOutcome::Sent { max_offset, count } => {
-                    self.tracker.mark_dispatched(partition, max_offset + 1);
+                    // The ceiling is raised *after* `try_send` hands the batch to the worker's channel,
+                    // so a worker on another thread could in principle mark this batch processed before
+                    // this mark lands and trip a spurious `CappedAheadOfDispatch`. Unreachable in
+                    // practice — processing an event is ~hundreds of store reads while this mark is
+                    // microseconds away on the same task — and harmless if it ever fired: the marks are
+                    // monotonic, so the next dispatch corrects the ceiling, and commits derive from
+                    // `processed` (never advanced past the true handoff), so the worst case is a
+                    // conservative re-commit that per-key replay dedup absorbs. Marking before the send
+                    // is not an option: `try_send` only reports `Sent` once the worker can already see
+                    // the batch, and pre-marking would raise the ceiling for `Full`/dropped sub-batches
+                    // too. `None` (a batch with no events) leaves the ceiling untouched.
+                    if let Some(max_offset) = max_offset {
+                        self.tracker.mark_dispatched(partition, max_offset + 1);
+                    }
                     dispatched += count as u64;
                 }
                 SendOutcome::Full(returned) => {
@@ -948,8 +962,9 @@ impl CohortStreamEventsConsumer {
         ));
 
         // Apply pause/resume off the consume loop: librdkafka `pause`/`resume` are synchronous, un-timed
-        // FFI calls, so a wedged client must never delay the liveness heartbeat.
-        let (pause_tx, pause_rx) = tokio::sync::mpsc::unbounded_channel::<PauseDeltas>();
+        // FFI calls, so a wedged client must never delay the liveness heartbeat. The loop hands the
+        // pauser task the paused *target* (the held-partition set); the task owns the re-assertion.
+        let (pause_tx, pause_rx) = tokio::sync::mpsc::unbounded_channel::<HashSet<i32>>();
         let pauser_task = tokio::spawn(run_pauser_loop(self.pauser.clone(), pause_rx));
 
         // One-shot guards; each pre-marked done when its gate is off, keeping the non-durable path unchanged.
@@ -959,6 +974,9 @@ impl CohortStreamEventsConsumer {
         let mut prev_assignment: Option<HashSet<i32>> = None;
         // Untouched until boot recovery completes below, so nothing pauses during boot.
         let mut backpressure = Backpressure::new();
+        // The paused target we last handed the pauser task, so we only send while backpressure is
+        // active (plus the one cycle it clears) and stay silent in the healthy steady state.
+        let mut prev_paused_target: HashSet<i32> = HashSet::new();
 
         loop {
             tokio::select! {
@@ -990,7 +1008,13 @@ impl CohortStreamEventsConsumer {
                         restore_seek_done = self.run_restore_seek();
                         continue;
                     }
-                    self.dispatch_with_backpressure(outcome, &mut backpressure, &pause_tx).await;
+                    self.dispatch_with_backpressure(
+                        outcome,
+                        &mut backpressure,
+                        &mut prev_paused_target,
+                        &pause_tx,
+                    )
+                    .await;
                 }
             }
         }
@@ -1105,7 +1129,8 @@ impl CohortStreamEventsConsumer {
         &self,
         outcome: ConsumeOutcome,
         backpressure: &mut Backpressure,
-        pause_tx: &tokio::sync::mpsc::UnboundedSender<PauseDeltas>,
+        prev_paused_target: &mut HashSet<i32>,
+        pause_tx: &tokio::sync::mpsc::UnboundedSender<HashSet<i32>>,
     ) {
         histogram!(COHORT_STREAM_CONSUME_BATCH_SIZE).record(outcome.events.len() as f64);
         if !outcome.events.is_empty() {
@@ -1123,17 +1148,26 @@ impl CohortStreamEventsConsumer {
         // Retry-flush held partitions before dispatching new events, so a newer offset never leapfrogs
         // an older held one on the same partition.
         let still_full = self.dispatcher.redispatch_held(backpressure.take_held());
-        backpressure.set_pending(still_full);
+        backpressure.absorb(still_full);
         let full = self
             .dispatcher
             .dispatch_events_nonblocking(outcome.events, &backpressure.held_partitions());
         backpressure.absorb(full);
-        let deltas = backpressure.reconcile();
-        if (!deltas.pause.is_empty() || !deltas.resume.is_empty()) && pause_tx.send(deltas).is_err() {
-            // The receiver is gone only at shutdown, where an unapplied delta is moot.
-            debug!("pauser task has exited; skipping a pause/resume delta");
+
+        // Hand the pauser task the paused target (the still-held partitions). It owns the idempotent
+        // pause/resume re-assertion, so a wedged librdkafka call can never delay the heartbeat below.
+        // Send while the target is non-empty — re-asserting each cycle so a swallowed pause error or a
+        // rebalance that reset the toppar self-heals — plus the one cycle it clears (to flush the
+        // resumes); stay silent in the healthy steady state.
+        let target = backpressure.held_partitions();
+        if !target.is_empty() || !prev_paused_target.is_empty() {
+            if pause_tx.send(target.clone()).is_err() {
+                // The receiver is gone only at shutdown, where an unapplied target is moot.
+                debug!("pauser task has exited; skipping a pause/resume update");
+            }
+            *prev_paused_target = target;
         }
-        gauge!(PARTITIONS_PAUSED).set(backpressure.paused_count() as f64);
+        gauge!(PARTITIONS_PAUSED).set(backpressure.held_partition_count() as f64);
         gauge!(PENDING_HELD_EVENTS).set(backpressure.held_event_count() as f64);
 
         if outcome.transport_error {
@@ -1307,16 +1341,23 @@ async fn run_commit_loop(
     }
 }
 
-/// Applies pause/resume deltas off the consume loop, so a blocking librdkafka `pause`/`resume` can
-/// never delay the liveness heartbeat. Deltas are applied in the order received, preserving the
-/// paused-set transitions. Exits when the sender is dropped.
+/// Applies the paused-partition target off the consume loop, so a blocking librdkafka `pause`/`resume`
+/// can never delay the liveness heartbeat. Owns the `applied` set and re-asserts the full target on
+/// every update: librdkafka `pause`/`resume` are idempotent, so re-pausing the whole target self-heals
+/// both a pause whose error [`ConsumerPauser`] swallowed last cycle and a partition librdkafka silently
+/// un-paused across a revoke→reassign rebalance. `applied` is a best-effort record used only to compute
+/// which partitions to resume (the ones that left the target). Exits when the sender is dropped.
 async fn run_pauser_loop(
     pauser: Arc<dyn PartitionPauser>,
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<PauseDeltas>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<HashSet<i32>>,
 ) {
-    while let Some(deltas) = rx.recv().await {
-        pauser.pause(&deltas.pause);
-        pauser.resume(&deltas.resume);
+    let mut applied: HashSet<i32> = HashSet::new();
+    while let Some(target) = rx.recv().await {
+        let to_pause: Vec<i32> = target.iter().copied().collect();
+        let to_resume: Vec<i32> = applied.difference(&target).copied().collect();
+        pauser.pause(&to_pause);
+        pauser.resume(&to_resume);
+        applied = target;
     }
 }
 
@@ -1349,6 +1390,75 @@ mod tests {
     const TEAM: i32 = 7;
     const BEHAVIORAL_HASH: [u8; 16] = *b"0123456789abcdef";
     const BASE_TS: &str = "2026-05-26 12:34:56.789000";
+
+    /// A broker-free [`PartitionPauser`] that records every pause/resume call, so the pauser task's
+    /// re-assertion wiring can be exercised without a Kafka client.
+    #[derive(Default)]
+    struct RecordingPauser {
+        paused: std::sync::Mutex<Vec<Vec<i32>>>,
+        resumed: std::sync::Mutex<Vec<Vec<i32>>>,
+    }
+
+    impl RecordingPauser {
+        /// The non-empty pause calls, in order (the pauser also issues empty no-ops each idle cycle).
+        fn nonempty_pauses(&self) -> Vec<Vec<i32>> {
+            Self::nonempty(&self.paused)
+        }
+
+        fn nonempty_resumes(&self) -> Vec<Vec<i32>> {
+            Self::nonempty(&self.resumed)
+        }
+
+        fn nonempty(calls: &std::sync::Mutex<Vec<Vec<i32>>>) -> Vec<Vec<i32>> {
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| !call.is_empty())
+                .cloned()
+                .collect()
+        }
+    }
+
+    impl PartitionPauser for RecordingPauser {
+        fn pause(&self, partitions: &[i32]) {
+            self.paused.lock().unwrap().push(partitions.to_vec());
+        }
+
+        fn resume(&self, partitions: &[i32]) {
+            self.resumed.lock().unwrap().push(partitions.to_vec());
+        }
+    }
+
+    #[tokio::test]
+    async fn pauser_loop_reasserts_the_full_target_each_cycle_and_resumes_on_drop() {
+        let pauser = Arc::new(RecordingPauser::default());
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<HashSet<i32>>();
+        let task = tokio::spawn(run_pauser_loop(pauser.clone(), rx));
+
+        // Two cycles with a stable held target: the full target is re-paused each cycle. That
+        // idempotent re-assertion is exactly what heals a swallowed pause error or a partition
+        // librdkafka silently un-paused across a rebalance.
+        tx.send(HashSet::from([5])).unwrap();
+        tx.send(HashSet::from([5])).unwrap();
+        // Partition 5 drains and 7 becomes held: 5 leaves the target (resumed), 7 is paused.
+        tx.send(HashSet::from([7])).unwrap();
+        // Target clears: 7 is resumed.
+        tx.send(HashSet::new()).unwrap();
+        drop(tx);
+        task.await.unwrap();
+
+        assert_eq!(
+            pauser.nonempty_pauses(),
+            vec![vec![5], vec![5], vec![7]],
+            "the full target is re-paused every cycle it is non-empty",
+        );
+        assert_eq!(
+            pauser.nonempty_resumes(),
+            vec![vec![5], vec![7]],
+            "a partition is resumed only once it leaves the target",
+        );
+    }
 
     #[test]
     fn deserializes_a_full_shuffler_envelope() {

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -305,17 +305,12 @@ impl EventDispatcher {
         for (partition, outcome) in self.router.try_route_batch(messages) {
             match outcome {
                 SendOutcome::Sent { max_offset, count } => {
-                    // The ceiling is raised *after* `try_send` hands the batch to the worker's channel,
-                    // so a worker on another thread could in principle mark this batch processed before
-                    // this mark lands and trip a spurious `CappedAheadOfDispatch`. Unreachable in
-                    // practice — processing an event is ~hundreds of store reads while this mark is
-                    // microseconds away on the same task — and harmless if it ever fired: the marks are
-                    // monotonic, so the next dispatch corrects the ceiling, and commits derive from
-                    // `processed` (never advanced past the true handoff), so the worst case is a
-                    // conservative re-commit that per-key replay dedup absorbs. Marking before the send
-                    // is not an option: `try_send` only reports `Sent` once the worker can already see
-                    // the batch, and pre-marking would raise the ceiling for `Full`/dropped sub-batches
-                    // too. `None` (a batch with no events) leaves the ceiling untouched.
+                    // Ceiling raised after `try_send`, so a worker could mark this batch processed first
+                    // and trip a spurious `CappedAheadOfDispatch`. Harmless (marks are monotonic and
+                    // commits derive from `processed`, so the next dispatch corrects it) and near
+                    // unreachable (per-event work is ~hundreds of reads; this mark is microseconds off).
+                    // Marking before the send would wrongly raise the ceiling for `Full`/dropped
+                    // sub-batches. `None` carries no offset, so it leaves the ceiling untouched.
                     if let Some(max_offset) = max_offset {
                         self.tracker.mark_dispatched(partition, max_offset + 1);
                     }
@@ -961,9 +956,9 @@ impl CohortStreamEventsConsumer {
             self.handle.clone(),
         ));
 
-        // Apply pause/resume off the consume loop: librdkafka `pause`/`resume` are synchronous, un-timed
-        // FFI calls, so a wedged client must never delay the liveness heartbeat. The loop hands the
-        // pauser task the paused *target* (the held-partition set); the task owns the re-assertion.
+        // Apply pause/resume off the consume loop: librdkafka's are synchronous, un-timed FFI, so a
+        // wedged client must never delay the heartbeat. The loop hands over the paused *target* (the
+        // held-partition set); the pauser task owns re-asserting it.
         let (pause_tx, pause_rx) = tokio::sync::mpsc::unbounded_channel::<HashSet<i32>>();
         let pauser_task = tokio::spawn(run_pauser_loop(self.pauser.clone(), pause_rx));
 
@@ -974,8 +969,8 @@ impl CohortStreamEventsConsumer {
         let mut prev_assignment: Option<HashSet<i32>> = None;
         // Untouched until boot recovery completes below, so nothing pauses during boot.
         let mut backpressure = Backpressure::new();
-        // The paused target we last handed the pauser task, so we only send while backpressure is
-        // active (plus the one cycle it clears) and stay silent in the healthy steady state.
+        // Last paused target sent to the pauser task: lets us send only while backpressure is active
+        // (plus the cycle it clears) and stay silent otherwise.
         let mut prev_paused_target: HashSet<i32> = HashSet::new();
 
         loop {
@@ -1154,11 +1149,10 @@ impl CohortStreamEventsConsumer {
             .dispatch_events_nonblocking(outcome.events, &backpressure.held_partitions());
         backpressure.absorb(full);
 
-        // Hand the pauser task the paused target (the still-held partitions). It owns the idempotent
-        // pause/resume re-assertion, so a wedged librdkafka call can never delay the heartbeat below.
-        // Send while the target is non-empty — re-asserting each cycle so a swallowed pause error or a
-        // rebalance that reset the toppar self-heals — plus the one cycle it clears (to flush the
-        // resumes); stay silent in the healthy steady state.
+        // Hand the pauser task the paused target (the still-held partitions); it re-asserts pause
+        // idempotently, so no librdkafka call can delay the heartbeat below. Send every cycle the
+        // target is non-empty (re-asserting heals a swallowed pause error or a rebalance-reset toppar),
+        // plus the one cycle it clears (to resume); stay silent otherwise.
         let target = backpressure.held_partitions();
         if !target.is_empty() || !prev_paused_target.is_empty() {
             if pause_tx.send(target.clone()).is_err() {
@@ -1341,12 +1335,10 @@ async fn run_commit_loop(
     }
 }
 
-/// Applies the paused-partition target off the consume loop, so a blocking librdkafka `pause`/`resume`
-/// can never delay the liveness heartbeat. Owns the `applied` set and re-asserts the full target on
-/// every update: librdkafka `pause`/`resume` are idempotent, so re-pausing the whole target self-heals
-/// both a pause whose error [`ConsumerPauser`] swallowed last cycle and a partition librdkafka silently
-/// un-paused across a revoke→reassign rebalance. `applied` is a best-effort record used only to compute
-/// which partitions to resume (the ones that left the target). Exits when the sender is dropped.
+/// Applies the paused-partition target off the consume loop, so blocking librdkafka `pause`/`resume`
+/// never delays the heartbeat. Re-asserts the full target every update — idempotent in librdkafka — so
+/// a swallowed pause error or a rebalance-reset toppar self-heals. `applied` tracks only which
+/// partitions to resume (those that left the target). Exits when the sender is dropped.
 async fn run_pauser_loop(
     pauser: Arc<dyn PartitionPauser>,
     mut rx: tokio::sync::mpsc::UnboundedReceiver<HashSet<i32>>,
@@ -1391,8 +1383,8 @@ mod tests {
     const BEHAVIORAL_HASH: [u8; 16] = *b"0123456789abcdef";
     const BASE_TS: &str = "2026-05-26 12:34:56.789000";
 
-    /// A broker-free [`PartitionPauser`] that records every pause/resume call, so the pauser task's
-    /// re-assertion wiring can be exercised without a Kafka client.
+    /// Broker-free [`PartitionPauser`] recording every pause/resume call, to exercise the pauser task
+    /// without a Kafka client.
     #[derive(Default)]
     struct RecordingPauser {
         paused: std::sync::Mutex<Vec<Vec<i32>>>,
@@ -1436,9 +1428,8 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<HashSet<i32>>();
         let task = tokio::spawn(run_pauser_loop(pauser.clone(), rx));
 
-        // Two cycles with a stable held target: the full target is re-paused each cycle. That
-        // idempotent re-assertion is exactly what heals a swallowed pause error or a partition
-        // librdkafka silently un-paused across a rebalance.
+        // Stable target over two cycles: re-paused each time. That idempotent re-assertion is what
+        // heals a swallowed pause error or a rebalance-reset toppar.
         tx.send(HashSet::from([5])).unwrap();
         tx.send(HashSet::from([5])).unwrap();
         // Partition 5 drains and 7 becomes held: 5 leaves the target (resumed), 7 is paused.

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -35,12 +35,15 @@ use crate::observability::metrics::{
     COHORT_STREAM_TRANSFERS_SKIPPED_NOT_OWNED, COHORT_STREAM_WORKERS_SPAWNED,
     DURABLE_RESTORE_PARTITIONS_KEPT_TOTAL, DURABLE_RESTORE_PARTITIONS_WIPED_STALE_TOTAL,
     DURABLE_RESTORE_PENDING_TRANSFERS_RECOVERED_PARTITIONS_TOTAL, MERGE_HELD_OFFSET_GAUGE,
-    MERGE_PENDING_TRANSFERS_GAUGE, PARTITIONS_ASSIGNED_TOTAL, PARTITIONS_REVOKED_TOTAL,
-    PARTITION_STATE_DELETED_TOTAL, REBALANCE_CLEANUP_SKIPPED_TOTAL, REVOKE_DRAIN_DURATION_SECONDS,
+    MERGE_PENDING_TRANSFERS_GAUGE, PARTITIONS_ASSIGNED_TOTAL, PARTITIONS_PAUSED,
+    PARTITIONS_REVOKED_TOTAL, PARTITION_STATE_DELETED_TOTAL, PENDING_SUBBATCHES,
+    REBALANCE_CLEANUP_SKIPPED_TOTAL, REVOKE_DRAIN_DURATION_SECONDS,
 };
+use crate::partitions::backpressure::Backpressure;
 use crate::partitions::offset_tracker::OffsetTracker;
+use crate::partitions::pause::{ConsumerPauser, PartitionPauser};
 use crate::partitions::rebalance::{CohortConsumerContext, ConsumerCommandReceiver};
-use crate::partitions::router::PartitionRouter;
+use crate::partitions::router::{PartitionRouter, SendOutcome};
 use crate::partitions::shuffle_message::ShuffleMessage;
 use crate::producer::MembershipSink;
 use crate::store::durability::OffsetManifest;
@@ -219,6 +222,113 @@ impl EventDispatcher {
         let stats = self.dispatch_to_workers(items, &self.tracker).await;
         counter!(COHORT_STREAM_EVENTS_SKIPPED_NOT_OWNED).increment(stats.not_owned_skipped);
         counter!(COHORT_STREAM_EVENTS_DISPATCHED).increment(stats.dispatched);
+    }
+
+    /// Non-blocking events dispatch: the hot-path sibling of [`dispatch`](Self::dispatch) that never
+    /// awaits, so the consume loop's liveness heartbeat is never gated on a full worker channel.
+    ///
+    /// Owns-filters, ensures a worker, and `try_send`s each non-held partition's sub-batch, raising the
+    /// dispatch ceiling only for what actually lands. Events for a partition in `held` (already paused
+    /// behind an older holdover) skip the send and are returned to queue behind it — never leapfrog.
+    /// Returns the un-dispatched events per partition (held-deferred plus any that just filled a
+    /// channel); the caller appends them to that partition's holdover and pauses it.
+    pub fn dispatch_events_nonblocking(
+        &self,
+        batch: Vec<ConsumedEvent>,
+        held: &HashSet<i32>,
+    ) -> HashMap<i32, Vec<ShuffleMessage>> {
+        if self.draining.load(Ordering::SeqCst) {
+            if !batch.is_empty() {
+                counter!(COHORT_STREAM_EVENTS_SKIPPED_NOT_OWNED).increment(batch.len() as u64);
+                debug!(
+                    dropped = batch.len(),
+                    "dispatch after shutdown began; dropping batch for replay"
+                );
+            }
+            return HashMap::new();
+        }
+
+        let mut full: HashMap<i32, Vec<ShuffleMessage>> = HashMap::new();
+        let mut fresh: Vec<(i32, ShuffleMessage)> = Vec::with_capacity(batch.len());
+        let mut not_owned = 0u64;
+        for consumed in batch {
+            let partition = consumed.partition;
+            if !self.owned.contains(&partition) {
+                not_owned += 1;
+                continue;
+            }
+            self.ensure_worker(partition);
+            let message = ShuffleMessage::Event {
+                event: Box::new(consumed.event),
+                cse_offset: consumed.offset,
+            };
+            // librdkafka can still deliver a few already-fetched stragglers just after a pause; queue
+            // them behind the partition's holdover rather than racing them ahead of older offsets.
+            if held.contains(&partition) {
+                full.entry(partition).or_default().push(message);
+            } else {
+                fresh.push((partition, message));
+            }
+        }
+        counter!(COHORT_STREAM_EVENTS_SKIPPED_NOT_OWNED).increment(not_owned);
+
+        self.route_fresh(fresh, &mut full);
+        full
+    }
+
+    /// Retry-send held sub-batches (paused partitions) before polling, raising the ceiling for any that
+    /// flush. Returns the partitions still full (their retained holdover) so the caller keeps them
+    /// paused; a flushed or worker-gone partition is absent, so the caller resumes it (a dropped one
+    /// replays from the pinned commit).
+    pub fn redispatch_held(
+        &self,
+        held: Vec<(i32, Vec<ShuffleMessage>)>,
+    ) -> HashMap<i32, Vec<ShuffleMessage>> {
+        // Flatten to one grouped route; each partition's Vec is contiguous, so offset order is kept.
+        let mut messages: Vec<(i32, ShuffleMessage)> = Vec::new();
+        for (partition, batch) in held {
+            for message in batch {
+                messages.push((partition, message));
+            }
+        }
+        let mut still_full = HashMap::new();
+        self.route_fresh(messages, &mut still_full);
+        still_full
+    }
+
+    /// `try_send` owned, worker-ensured events and fold the per-partition outcomes: raise the ceiling
+    /// for what landed, collect the un-sent sub-batch of a full channel into `full`, and count a
+    /// missing/closed worker as a route error (the router already recorded the drop).
+    fn route_fresh(
+        &self,
+        messages: Vec<(i32, ShuffleMessage)>,
+        full: &mut HashMap<i32, Vec<ShuffleMessage>>,
+    ) {
+        let mut dispatched = 0u64;
+        let mut route_errors = 0u64;
+        for (partition, outcome) in self.router.try_route_batch(messages) {
+            match outcome {
+                SendOutcome::Sent { max_offset, count } => {
+                    self.tracker.mark_dispatched(partition, max_offset + 1);
+                    dispatched += count as u64;
+                }
+                SendOutcome::Full(returned) => {
+                    full.entry(partition).or_default().extend(returned);
+                }
+                SendOutcome::NoWorker | SendOutcome::ChannelClosed => route_errors += 1,
+            }
+        }
+        if dispatched > 0 {
+            counter!(COHORT_STREAM_EVENTS_DISPATCHED).increment(dispatched);
+        }
+        if route_errors > 0 {
+            counter!(COHORT_STREAM_ROUTE_ERRORS).increment(route_errors);
+        }
+    }
+
+    /// Snapshot of the partitions currently owned, for the backpressure prune/reconcile pass.
+    pub fn owned_set(&self) -> HashSet<i32> {
+        self.owned.iter().map(|entry| *entry).collect()
     }
 
     /// Route a consumed `person_merge_events` batch to per-partition workers, ceiling on the merge
@@ -779,6 +889,9 @@ pub struct CohortStreamEventsConsumer {
     topic: String,
     dispatcher: Arc<EventDispatcher>,
     handle: Handle,
+    /// Pauses/resumes events partitions to express downstream backpressure as lag on the hot
+    /// partition, keeping the consume loop non-blocking.
+    pauser: Arc<dyn PartitionPauser>,
     recv_batch_size: usize,
     recv_batch_timeout: Duration,
     offset_commit_interval: Duration,
@@ -805,11 +918,15 @@ impl CohortStreamEventsConsumer {
         consumer_command_rx: ConsumerCommandReceiver,
         restore_manifest: Option<OffsetManifest>,
     ) -> Self {
+        let consumer = Arc::new(consumer);
+        let pauser: Arc<dyn PartitionPauser> =
+            Arc::new(ConsumerPauser::new(consumer.clone(), topic.clone()));
         Self {
-            consumer: Arc::new(consumer),
+            consumer,
             topic,
             dispatcher,
             handle,
+            pauser,
             recv_batch_size,
             recv_batch_timeout,
             offset_commit_interval,
@@ -823,7 +940,8 @@ impl CohortStreamEventsConsumer {
     ///
     /// Offset commit runs on its own interval task so a CPU-saturated consume loop or worker backlog
     /// can't block offset advancement; it shares the shutdown signal and is awaited before the final
-    /// synchronous commit. Liveness is reported inline from `handle_outcome`.
+    /// synchronous commit. Liveness is reported inline from the non-blocking backpressure cycle, so a
+    /// full worker channel becomes paused partitions and lag, never a stalled heartbeat.
     pub async fn process(self) {
         let _guard = self.handle.process_scope();
         info!(topic = %self.topic, "cohort_stream_events consume loop starting");
@@ -841,6 +959,9 @@ impl CohortStreamEventsConsumer {
         let mut eager_redrive_done = !self.dispatcher.durable_restore_enabled();
         let mut restore_seek_done = self.restore_manifest.is_none();
         let mut prev_assignment: Option<HashSet<i32>> = None;
+        // Per-partition holdover + pause state. Untouched until boot recovery completes below, so a
+        // partition is never paused during boot.
+        let mut backpressure = Backpressure::new();
 
         loop {
             tokio::select! {
@@ -872,7 +993,7 @@ impl CohortStreamEventsConsumer {
                         restore_seek_done = self.run_restore_seek();
                         continue;
                     }
-                    self.handle_outcome(outcome).await;
+                    self.dispatch_with_backpressure(outcome, &mut backpressure).await;
                 }
             }
         }
@@ -975,7 +1096,15 @@ impl CohortStreamEventsConsumer {
         }
     }
 
-    async fn handle_outcome(&self, outcome: ConsumeOutcome) {
+    /// One steady-state cycle: prune revoked holdover, retry-flush held partitions, dispatch the freshly
+    /// polled batch, then reconcile pauses/resumes. Every step is non-blocking (`try_send`, sync
+    /// pause/resume), so the heartbeat below fires each iteration regardless of downstream drain — the
+    /// crux of the fix: a saturated worker channel becomes a paused partition and lag, never a stall.
+    async fn dispatch_with_backpressure(
+        &self,
+        outcome: ConsumeOutcome,
+        backpressure: &mut Backpressure,
+    ) {
         histogram!(COHORT_STREAM_CONSUME_BATCH_SIZE).record(outcome.events.len() as f64);
         if !outcome.events.is_empty() {
             counter!(COHORT_STREAM_EVENTS_CONSUMED).increment(outcome.events.len() as u64);
@@ -987,7 +1116,24 @@ impl CohortStreamEventsConsumer {
             counter!(COHORT_STREAM_EMPTY_PAYLOAD).increment(outcome.empty_payloads);
         }
 
-        self.dispatcher.dispatch(outcome.events).await;
+        let owned = self.dispatcher.owned_set();
+        // 1. Drop holdover for revoked partitions (their range replays on the next owner).
+        backpressure.prune_revoked(&owned);
+        // 2. Retry-flush existing holdovers before dispatching new events, so an older held offset can
+        //    never be leapfrogged by a newer one on the same partition.
+        let still_full = self.dispatcher.redispatch_held(backpressure.take_held());
+        backpressure.set_pending(still_full);
+        // 3. Dispatch the freshly polled batch, queueing new events behind any still-held partition.
+        let full = self
+            .dispatcher
+            .dispatch_events_nonblocking(outcome.events, &backpressure.held_partitions());
+        backpressure.absorb(full);
+        // 4. Reconcile the paused set and apply the deltas to Kafka.
+        let deltas = backpressure.reconcile();
+        self.pauser.pause(&deltas.pause);
+        self.pauser.resume(&deltas.resume);
+        gauge!(PARTITIONS_PAUSED).set(backpressure.paused_count() as f64);
+        gauge!(PENDING_SUBBATCHES).set(backpressure.held_event_count() as f64);
 
         if outcome.transport_error {
             tokio::time::sleep(RECV_ERROR_BACKOFF).await;
@@ -1173,6 +1319,7 @@ mod tests {
         MergeStateTransfer, PendingTransfer, PersonMergeEvent, Tombstone, TransferLeaf,
         MERGE_EVENT_SCHEMA_VERSION,
     };
+    use crate::partitions::offset_tracker::MarkOutcome;
     use crate::partitions::partitioner::{partition_of, COHORT_PARTITION_COUNT};
     use crate::producer::{
         CaptureSink, CaptureStreamEventSink, CaptureTransferSink, MembershipStatus,
@@ -1786,6 +1933,122 @@ mod tests {
         assert_eq!(dispatcher.workers.len(), 0);
         assert!(dispatcher.tracker().committable_offsets().is_empty());
         let _tracker = dispatcher.shutdown().await;
+    }
+
+    /// A dispatcher whose router has `buffer` channel slots and drains through no real worker, so a
+    /// pre-filled channel deterministically exercises the non-blocking `try_send`-full path.
+    fn dispatcher_with_buffer(
+        store: &CohortStore,
+        catalog: Arc<CatalogHandle>,
+        buffer: usize,
+    ) -> EventDispatcher {
+        let sink: Arc<dyn MembershipSink> = Arc::new(CaptureSink::new());
+        EventDispatcher::new(
+            PartitionRouter::new(buffer),
+            Arc::new(OffsetTracker::new()),
+            store.clone(),
+            catalog,
+            sink,
+            MergeWorkerDeps::capture(),
+        )
+    }
+
+    fn held_offsets(messages: &[ShuffleMessage]) -> Vec<i64> {
+        messages
+            .iter()
+            .filter_map(ShuffleMessage::event_offset)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn nonblocking_dispatch_holds_a_full_channel_and_advances_the_offset_only_after_flush() {
+        let (_dir, store) = temp_store();
+        let dispatcher = dispatcher_with_buffer(&store, behavioral_catalog(), 1);
+        dispatcher.assign_partition(0);
+        // Hold the receiver so nothing drains; ensure_worker finds the channel registered and spawns no
+        // worker, leaving this rx the only consumer.
+        let mut rx = dispatcher.router.add_partition(0).unwrap();
+        let no_held = HashSet::new();
+
+        // Batch A fills the one slot and raises the ceiling to 105.
+        assert!(dispatcher
+            .dispatch_events_nonblocking(vec![consumed(person(1), 0, 104)], &no_held)
+            .is_empty());
+        // Batch B finds the channel full: held verbatim, ceiling unchanged.
+        let mut full =
+            dispatcher.dispatch_events_nonblocking(vec![consumed(person(2), 0, 105)], &no_held);
+        let held = full.remove(&0).expect("partition 0 was held");
+        assert_eq!(held_offsets(&held), vec![105]);
+        assert!(
+            dispatcher.workers.is_empty(),
+            "no worker drained the channel"
+        );
+
+        // The hole at 105 can't be committed past: a worker marking beyond the ceiling clamps to it.
+        assert_eq!(
+            dispatcher.tracker().mark_processed(0, 106),
+            MarkOutcome::CappedAheadOfDispatch,
+        );
+        assert_eq!(
+            dispatcher.tracker().committable_offsets().get(&0),
+            Some(&105),
+            "committable pinned at the sent ceiling while 105 is held",
+        );
+
+        // Drain A; the retry-flush now sends B and the ceiling advances past it.
+        let _a = rx.recv().await.unwrap();
+        assert!(
+            dispatcher.redispatch_held(vec![(0, held)]).is_empty(),
+            "the holdover flushed once the channel had room",
+        );
+        assert_eq!(
+            dispatcher.tracker().mark_processed(0, 106),
+            MarkOutcome::WithinDispatch,
+        );
+        assert_eq!(
+            dispatcher.tracker().committable_offsets().get(&0),
+            Some(&106)
+        );
+    }
+
+    #[tokio::test]
+    async fn nonblocking_dispatch_defers_events_for_a_held_partition_even_with_room() {
+        let (_dir, store) = temp_store();
+        let dispatcher = dispatcher_with_buffer(&store, behavioral_catalog(), 16);
+        dispatcher.assign_partition(0);
+        let mut rx = dispatcher.router.add_partition(0).unwrap();
+
+        // Partition 0 is already held (paused behind an older holdover): its fresh events queue behind
+        // it rather than racing onto the channel, even though there is room — the ordering invariant.
+        let held: HashSet<i32> = [0].into_iter().collect();
+        let mut full =
+            dispatcher.dispatch_events_nonblocking(vec![consumed(person(1), 0, 200)], &held);
+
+        assert_eq!(held_offsets(&full.remove(&0).unwrap()), vec![200]);
+        assert!(rx.try_recv().is_err(), "nothing was sent to the channel");
+        assert!(
+            !dispatcher.tracker().committable_offsets().contains_key(&0),
+            "a deferred event never raised the ceiling",
+        );
+    }
+
+    #[tokio::test]
+    async fn nonblocking_dispatch_returns_promptly_when_the_channel_is_saturated() {
+        let (_dir, store) = temp_store();
+        let dispatcher = dispatcher_with_buffer(&store, behavioral_catalog(), 1);
+        dispatcher.assign_partition(0);
+        let _rx = dispatcher.router.add_partition(0).unwrap();
+        let no_held = HashSet::new();
+
+        dispatcher.dispatch_events_nonblocking(vec![consumed(person(1), 0, 0)], &no_held);
+        // The second dispatch onto the saturated channel returns the holdover synchronously instead of
+        // awaiting a drain — the property that keeps the consume loop's heartbeat firing under overload.
+        let full =
+            dispatcher.dispatch_events_nonblocking(vec![consumed(person(2), 0, 1)], &no_held);
+        assert!(
+            full.contains_key(&0),
+            "the saturated partition's events are held, never blocked on",
+        );
     }
 
     #[tokio::test]

--- a/rust/cohort-stream-processor/src/consumers/merges.rs
+++ b/rust/cohort-stream-processor/src/consumers/merges.rs
@@ -265,11 +265,10 @@ impl<R: FollowerRoute> FollowerConsumer<R> {
             counter!(R::DESERIALIZE_ERRORS_TOTAL).increment(outcome.deserialize_errors);
         }
 
-        // The follower keeps the blocking dispatch on purpose: merges/transfers/cascades are
-        // low-volume, so a full worker channel here can await a drain without risking the heartbeat —
-        // unlike the events consumer, which routes non-blocking and pauses partitions to shed
-        // backpressure (see `EventDispatcher::dispatch_events_nonblocking`). If any of these topics
-        // ever approaches events-topic volume, port that non-blocking path here too.
+        // Follower keeps the blocking dispatch on purpose: merges/transfers/cascades are low-volume, so
+        // a full channel here can await a drain without risking the heartbeat — unlike the events
+        // consumer's non-blocking, partition-pausing path (`EventDispatcher::dispatch_events_nonblocking`).
+        // Port that path here if any of these topics ever approaches events-topic volume.
         R::dispatch(&self.dispatcher, outcome.messages).await;
 
         if outcome.transport_error {

--- a/rust/cohort-stream-processor/src/consumers/merges.rs
+++ b/rust/cohort-stream-processor/src/consumers/merges.rs
@@ -265,6 +265,11 @@ impl<R: FollowerRoute> FollowerConsumer<R> {
             counter!(R::DESERIALIZE_ERRORS_TOTAL).increment(outcome.deserialize_errors);
         }
 
+        // The follower keeps the blocking dispatch on purpose: merges/transfers/cascades are
+        // low-volume, so a full worker channel here can await a drain without risking the heartbeat —
+        // unlike the events consumer, which routes non-blocking and pauses partitions to shed
+        // backpressure (see `EventDispatcher::dispatch_events_nonblocking`). If any of these topics
+        // ever approaches events-topic volume, port that non-blocking path here too.
         R::dispatch(&self.dispatcher, outcome.messages).await;
 
         if outcome.transport_error {

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -202,6 +202,17 @@ pub const PARTITIONS_ACTIVE: &str = "partitions_active";
 pub const PARTITION_ROUTE_DROPPED_TOTAL: &str = "partition_route_dropped_total";
 /// Sub-batches queued in a partition worker's channel, labelled by `partition` (gauge).
 pub const PARTITION_CHANNEL_DEPTH: &str = "partition_channel_depth";
+/// Events held back because a partition worker's channel was full, labelled by `partition` (counter).
+/// Backpressure, not loss: the partition is paused and its events are redispatched once the channel
+/// drains. Rising counts are the signal that once crash-looped the pod; **alert paired with lag**.
+pub const PARTITION_CHANNEL_FULL_TOTAL: &str = "partition_channel_full_total";
+/// Partitions currently paused on the events consumer to shed downstream backpressure (gauge). A
+/// sustained non-zero level means overload is being expressed as lag rather than a crash — the
+/// replacement signal for the former "crash = overload".
+pub const PARTITIONS_PAUSED: &str = "partitions_paused";
+/// Events currently held across all paused partitions, awaiting redispatch (gauge). Bounded — a
+/// paused partition stops fetching — so a monotonically climbing value flags a stuck worker.
+pub const PENDING_SUBBATCHES: &str = "pending_subbatches";
 
 /// Non-empty rebalance callbacks, labelled by `event_type` (`assign`|`revoke`) (counter).
 pub const REBALANCES_TOTAL: &str = "rebalances_total";
@@ -553,6 +564,13 @@ mod tests {
         assert_eq!(TOKIO_BLOCKING_THREADS, "tokio_blocking_threads");
         assert_eq!(TOKIO_IDLE_BLOCKING_THREADS, "tokio_idle_blocking_threads");
         assert_eq!(TOKIO_BLOCKING_QUEUE_DEPTH, "tokio_blocking_queue_depth");
+    }
+
+    #[test]
+    fn partition_backpressure_metric_names_are_stable() {
+        assert_eq!(PARTITION_CHANNEL_FULL_TOTAL, "partition_channel_full_total");
+        assert_eq!(PARTITIONS_PAUSED, "partitions_paused");
+        assert_eq!(PENDING_SUBBATCHES, "pending_subbatches");
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -204,12 +204,14 @@ pub const PARTITION_ROUTE_DROPPED_TOTAL: &str = "partition_route_dropped_total";
 pub const PARTITION_CHANNEL_DEPTH: &str = "partition_channel_depth";
 /// Events held back because a partition worker's channel was full, labelled by `partition` (counter).
 /// Backpressure, not loss: the partition is paused and its events redispatch once the channel drains.
+/// Re-counted on every retry of a still-full holdover, so it is a pressure rate, not a distinct-event
+/// count.
 pub const PARTITION_CHANNEL_FULL_TOTAL: &str = "partition_channel_full_total";
 /// Partitions currently paused on the events consumer to shed downstream backpressure (gauge).
 pub const PARTITIONS_PAUSED: &str = "partitions_paused";
 /// Events currently held across all paused partitions, awaiting redispatch (gauge). Bounded — a
 /// paused partition stops fetching — so a climbing value flags a stuck worker.
-pub const PENDING_SUBBATCHES: &str = "pending_subbatches";
+pub const PENDING_HELD_EVENTS: &str = "pending_held_events";
 
 /// Non-empty rebalance callbacks, labelled by `event_type` (`assign`|`revoke`) (counter).
 pub const REBALANCES_TOTAL: &str = "rebalances_total";
@@ -567,7 +569,7 @@ mod tests {
     fn partition_backpressure_metric_names_are_stable() {
         assert_eq!(PARTITION_CHANNEL_FULL_TOTAL, "partition_channel_full_total");
         assert_eq!(PARTITIONS_PAUSED, "partitions_paused");
-        assert_eq!(PENDING_SUBBATCHES, "pending_subbatches");
+        assert_eq!(PENDING_HELD_EVENTS, "pending_held_events");
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -203,15 +203,12 @@ pub const PARTITION_ROUTE_DROPPED_TOTAL: &str = "partition_route_dropped_total";
 /// Sub-batches queued in a partition worker's channel, labelled by `partition` (gauge).
 pub const PARTITION_CHANNEL_DEPTH: &str = "partition_channel_depth";
 /// Events held back because a partition worker's channel was full, labelled by `partition` (counter).
-/// Backpressure, not loss: the partition is paused and its events are redispatched once the channel
-/// drains. Rising counts are the signal that once crash-looped the pod; **alert paired with lag**.
+/// Backpressure, not loss: the partition is paused and its events redispatch once the channel drains.
 pub const PARTITION_CHANNEL_FULL_TOTAL: &str = "partition_channel_full_total";
-/// Partitions currently paused on the events consumer to shed downstream backpressure (gauge). A
-/// sustained non-zero level means overload is being expressed as lag rather than a crash — the
-/// replacement signal for the former "crash = overload".
+/// Partitions currently paused on the events consumer to shed downstream backpressure (gauge).
 pub const PARTITIONS_PAUSED: &str = "partitions_paused";
 /// Events currently held across all paused partitions, awaiting redispatch (gauge). Bounded — a
-/// paused partition stops fetching — so a monotonically climbing value flags a stuck worker.
+/// paused partition stops fetching — so a climbing value flags a stuck worker.
 pub const PENDING_SUBBATCHES: &str = "pending_subbatches";
 
 /// Non-empty rebalance callbacks, labelled by `event_type` (`assign`|`revoke`) (counter).

--- a/rust/cohort-stream-processor/src/partitions/backpressure.rs
+++ b/rust/cohort-stream-processor/src/partitions/backpressure.rs
@@ -1,30 +1,22 @@
-//! The events consume loop's per-partition backpressure state, kept broker-free so its transitions are
-//! unit-testable in isolation.
+//! The events consume loop's per-partition backpressure state: the holdover of un-dispatched events
+//! per partition, kept broker-free so its transitions are unit-testable in isolation.
 //!
-//! Invariant: a partition holds a non-empty entry in [`pending`](Backpressure::pending) **iff** it is
-//! paused. [`reconcile`](Backpressure::reconcile) restores it each iteration by diffing the holdover
-//! keys against the previously-applied [`paused`](Backpressure::paused) set.
+//! A partition holds a non-empty entry in [`pending`](Backpressure::pending) **iff** its events could
+//! not be dispatched, so [`held_partitions`](Backpressure::held_partitions) (`pending.keys()`) is
+//! exactly the set to keep paused. Applying that target to the consumer — and re-asserting it so a
+//! swallowed pause error or a rebalance that reset librdkafka's pause flags self-heals — is owned by
+//! the pauser task (`run_pauser_loop`), not this struct.
 
 use std::collections::{HashMap, HashSet};
 
 use crate::partitions::shuffle_message::ShuffleMessage;
 
-/// Pause/resume actions the loop must apply to the consumer after a [`reconcile`](Backpressure::reconcile).
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct PauseDeltas {
-    pub pause: Vec<i32>,
-    pub resume: Vec<i32>,
-}
-
-/// Held events and paused partitions for the events consume loop. Never keeps an empty holdover, so
-/// `pending.keys()` is exactly the set of partitions that should be paused.
+/// Held events per held partition for the events consume loop. Never keeps an empty holdover, so
+/// `pending.keys()` is exactly the paused target.
 #[derive(Debug, Default)]
 pub struct Backpressure {
-    /// Un-dispatched events per paused partition, coalesced in offset order.
+    /// Un-dispatched events per held partition, coalesced in offset order.
     pending: HashMap<i32, Vec<ShuffleMessage>>,
-    /// Partitions currently paused on the consumer — what the last [`reconcile`](Self::reconcile)
-    /// applied. Diffed against the holdover key set to compute the next pause/resume deltas.
-    paused: HashSet<i32>,
 }
 
 impl Backpressure {
@@ -32,28 +24,21 @@ impl Backpressure {
         Self::default()
     }
 
-    /// Drop holdover and pause-tracking for partitions no longer owned. Their offsets replay on the
-    /// next owner; resuming a partition we no longer own would only error.
+    /// Drop the holdover for partitions no longer owned. Their offsets replay on the next owner, and
+    /// the pauser task resumes them once they leave the held target.
     pub fn prune_revoked(&mut self, owned: &HashSet<i32>) {
         self.pending
             .retain(|partition, _| owned.contains(partition));
-        self.paused.retain(|partition| owned.contains(partition));
     }
 
-    /// Take the whole holdover for a retry-flush, emptying `pending`; the caller reinstates whatever
-    /// stays full via [`set_pending`](Self::set_pending). Leaves `paused` untouched — the reconcile
-    /// resumes anything that flushed.
+    /// Take the whole holdover for a retry-flush, emptying `pending`; the caller re-[`absorb`](Self::absorb)s
+    /// whatever stays full.
     pub fn take_held(&mut self) -> Vec<(i32, Vec<ShuffleMessage>)> {
         std::mem::take(&mut self.pending).into_iter().collect()
     }
 
-    /// Reinstate the post-flush holdover (the partitions whose channel is still full).
-    pub fn set_pending(&mut self, pending: HashMap<i32, Vec<ShuffleMessage>>) {
-        self.pending = pending;
-    }
-
-    /// Partitions with an outstanding holdover — the set a fresh dispatch must queue new events behind
-    /// (never leapfrog) rather than sending them.
+    /// Partitions with an outstanding holdover — the paused target, and the set a fresh dispatch must
+    /// queue new events behind (never leapfrog) rather than sending them.
     pub fn held_partitions(&self) -> HashSet<i32> {
         self.pending.keys().copied().collect()
     }
@@ -72,22 +57,12 @@ impl Backpressure {
         }
     }
 
-    /// Diff the target paused set (partitions that still hold events) against the currently-paused set,
-    /// returning the pause/resume actions and adopting the target as the new paused set.
-    pub fn reconcile(&mut self) -> PauseDeltas {
-        let target: HashSet<i32> = self.pending.keys().copied().collect();
-        let pause = target.difference(&self.paused).copied().collect();
-        let resume = self.paused.difference(&target).copied().collect();
-        self.paused = target;
-        PauseDeltas { pause, resume }
+    /// Partitions currently held (== the paused target size). Feeds the `partitions_paused` gauge.
+    pub fn held_partition_count(&self) -> usize {
+        self.pending.len()
     }
 
-    /// Partitions currently paused (== holdover count). Feeds the `partitions_paused` gauge.
-    pub fn paused_count(&self) -> usize {
-        self.paused.len()
-    }
-
-    /// Total events held across all paused partitions. Feeds the `pending_held_events` gauge.
+    /// Total events held across all held partitions. Feeds the `pending_held_events` gauge.
     pub fn held_event_count(&self) -> usize {
         self.pending.values().map(Vec::len).sum()
     }
@@ -126,71 +101,50 @@ mod tests {
             .collect()
     }
 
-    fn set(partitions: [i32; 1]) -> HashSet<i32> {
-        partitions.into_iter().collect()
-    }
-
     #[test]
-    fn a_newly_full_partition_is_stashed_and_paused() {
+    fn a_newly_full_partition_becomes_the_held_target() {
         let mut bp = Backpressure::new();
         bp.absorb(HashMap::from([(5, vec![event(10)])]));
 
-        let deltas = bp.reconcile();
-        assert_eq!(deltas.pause, vec![5]);
-        assert!(deltas.resume.is_empty());
-        assert!(bp.held_partitions().contains(&5));
-        assert_eq!(bp.paused_count(), 1);
+        assert_eq!(bp.held_partitions(), HashSet::from([5]));
+        assert_eq!(bp.held_partition_count(), 1);
     }
 
     #[test]
-    fn a_fully_flushed_partition_is_resumed_and_cleared() {
+    fn a_flushed_partition_leaves_the_held_target() {
         let mut bp = Backpressure::new();
         bp.absorb(HashMap::from([(5, vec![event(10)])]));
-        assert_eq!(bp.reconcile().pause, vec![5]);
 
-        // Next iteration: the holdover flushed (nothing stays full).
+        // Next iteration: the holdover flushed (nothing re-absorbed), so the partition drops out of
+        // the held target and the pauser task resumes it.
         let _held = bp.take_held();
-        bp.set_pending(HashMap::new());
-        let deltas = bp.reconcile();
 
-        assert!(deltas.pause.is_empty());
-        assert_eq!(deltas.resume, vec![5]);
         assert!(bp.held_partitions().is_empty());
-        assert_eq!(bp.paused_count(), 0);
+        assert_eq!(bp.held_partition_count(), 0);
     }
 
     #[test]
-    fn a_still_full_partition_stays_paused_with_no_delta() {
+    fn a_still_full_partition_stays_in_the_held_target() {
         let mut bp = Backpressure::new();
         bp.absorb(HashMap::from([(5, vec![event(10)])]));
-        assert_eq!(bp.reconcile().pause, vec![5]);
 
-        // Retry-flush leaves it full: reinstated verbatim, no pause/resume churn.
+        // Retry-flush leaves it full: re-absorbed verbatim, still held.
         let held = bp.take_held();
-        bp.set_pending(held.into_iter().collect());
-        let deltas = bp.reconcile();
+        bp.absorb(held.into_iter().collect());
 
-        assert!(deltas.pause.is_empty() && deltas.resume.is_empty());
-        assert!(bp.held_partitions().contains(&5));
+        assert_eq!(bp.held_partitions(), HashSet::from([5]));
     }
 
     #[test]
-    fn a_revoked_paused_partition_is_pruned_and_never_resumed() {
+    fn a_revoked_partition_is_pruned_from_the_held_target() {
         let mut bp = Backpressure::new();
-        bp.absorb(HashMap::from([(5, vec![event(10)])]));
-        assert_eq!(bp.reconcile().pause, vec![5]);
+        bp.absorb(HashMap::from([(5, vec![event(10)]), (6, vec![event(20)])]));
 
-        // Partition 5 revoked: dropped, not resumed.
-        bp.prune_revoked(&set([9]));
-        let deltas = bp.reconcile();
+        // Only partition 6 is still owned: 5's holdover is dropped for replay on its next owner.
+        bp.prune_revoked(&HashSet::from([6]));
 
-        assert!(deltas.pause.is_empty());
-        assert!(
-            deltas.resume.is_empty(),
-            "a revoked partition is not resumed"
-        );
-        assert!(bp.held_partitions().is_empty());
-        assert_eq!(bp.paused_count(), 0);
+        assert_eq!(bp.held_partitions(), HashSet::from([6]));
+        assert_eq!(bp.held_partition_count(), 1);
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/partitions/backpressure.rs
+++ b/rust/cohort-stream-processor/src/partitions/backpressure.rs
@@ -1,11 +1,9 @@
-//! The events consume loop's per-partition backpressure state, kept broker-free so its transitions
-//! are unit-testable in isolation (the loop supplies the I/O: `try_send` via the router, pause/resume
-//! via the [`PartitionPauser`](super::pause::PartitionPauser)).
+//! The events consume loop's per-partition backpressure state, kept broker-free so its transitions are
+//! unit-testable in isolation.
 //!
-//! Invariant: a partition is present in [`pending`](Backpressure::pending) with a non-empty holdover
-//! **iff** it is paused. [`reconcile`](Backpressure::reconcile) restores that invariant each iteration
-//! by diffing the holdover key set against the previously-applied [`paused`](Backpressure::paused)
-//! set, so overload becomes lag on the hot partition alone rather than a stalled consume loop.
+//! Invariant: a partition holds a non-empty entry in [`pending`](Backpressure::pending) **iff** it is
+//! paused. [`reconcile`](Backpressure::reconcile) restores it each iteration by diffing the holdover
+//! keys against the previously-applied [`paused`](Backpressure::paused) set.
 
 use std::collections::{HashMap, HashSet};
 
@@ -34,9 +32,8 @@ impl Backpressure {
         Self::default()
     }
 
-    /// Drop holdover and pause-tracking for partitions no longer owned (revoked mid-tenure). Their
-    /// uncommitted offsets replay on the next owner, so we neither redispatch nor resume them — a
-    /// resume of an unassigned partition would only error.
+    /// Drop holdover and pause-tracking for partitions no longer owned. Their offsets replay on the
+    /// next owner; resuming a partition we no longer own would only error.
     pub fn prune_revoked(&mut self, owned: &HashSet<i32>) {
         self.pending
             .retain(|partition, _| owned.contains(partition));
@@ -61,8 +58,8 @@ impl Backpressure {
         self.pending.keys().copied().collect()
     }
 
-    /// Append un-dispatched events to their partition's holdover, in offset order (coalesced into the
-    /// single per-partition `Vec`, never nested). Empty batches are ignored so the pause invariant holds.
+    /// Append un-dispatched events to their partition's holdover in offset order. Empty batches are
+    /// skipped, so a present entry always means a non-empty holdover.
     pub fn absorb(&mut self, full: HashMap<i32, Vec<ShuffleMessage>>) {
         for (partition, mut messages) in full {
             if messages.is_empty() {
@@ -183,7 +180,7 @@ mod tests {
         bp.absorb(HashMap::from([(5, vec![event(10)])]));
         assert_eq!(bp.reconcile().pause, vec![5]);
 
-        // Partition 5 revoked: drop its holdover and pause-tracking, don't resume (new owner replays).
+        // Partition 5 revoked: dropped, not resumed.
         bp.prune_revoked(&set([9]));
         let deltas = bp.reconcile();
 

--- a/rust/cohort-stream-processor/src/partitions/backpressure.rs
+++ b/rust/cohort-stream-processor/src/partitions/backpressure.rs
@@ -1,11 +1,10 @@
-//! The events consume loop's per-partition backpressure state: the holdover of un-dispatched events
-//! per partition, kept broker-free so its transitions are unit-testable in isolation.
+//! The events consume loop's per-partition holdover of un-dispatched events, kept broker-free so its
+//! transitions are unit-testable in isolation.
 //!
 //! A partition holds a non-empty entry in [`pending`](Backpressure::pending) **iff** its events could
 //! not be dispatched, so [`held_partitions`](Backpressure::held_partitions) (`pending.keys()`) is
-//! exactly the set to keep paused. Applying that target to the consumer — and re-asserting it so a
-//! swallowed pause error or a rebalance that reset librdkafka's pause flags self-heals — is owned by
-//! the pauser task (`run_pauser_loop`), not this struct.
+//! exactly the paused target. Applying and re-asserting that target on the consumer is owned by the
+//! pauser task (`run_pauser_loop`), not this struct.
 
 use std::collections::{HashMap, HashSet};
 
@@ -37,8 +36,8 @@ impl Backpressure {
         std::mem::take(&mut self.pending).into_iter().collect()
     }
 
-    /// Partitions with an outstanding holdover — the paused target, and the set a fresh dispatch must
-    /// queue new events behind (never leapfrog) rather than sending them.
+    /// Partitions with an outstanding holdover: the paused target, and the set fresh events must queue
+    /// behind rather than leapfrog.
     pub fn held_partitions(&self) -> HashSet<i32> {
         self.pending.keys().copied().collect()
     }

--- a/rust/cohort-stream-processor/src/partitions/backpressure.rs
+++ b/rust/cohort-stream-processor/src/partitions/backpressure.rs
@@ -1,0 +1,219 @@
+//! The events consume loop's per-partition backpressure state, kept broker-free so its transitions
+//! are unit-testable in isolation (the loop supplies the I/O: `try_send` via the router, pause/resume
+//! via the [`PartitionPauser`](super::pause::PartitionPauser)).
+//!
+//! Invariant: a partition is present in [`pending`](Backpressure::pending) with a non-empty holdover
+//! **iff** it is paused. [`reconcile`](Backpressure::reconcile) restores that invariant each iteration
+//! by diffing the holdover key set against the previously-applied [`paused`](Backpressure::paused)
+//! set, so overload becomes lag on the hot partition alone rather than a stalled consume loop.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::partitions::shuffle_message::ShuffleMessage;
+
+/// Pause/resume actions the loop must apply to the consumer after a [`reconcile`](Backpressure::reconcile).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PauseDeltas {
+    pub pause: Vec<i32>,
+    pub resume: Vec<i32>,
+}
+
+/// Held events and paused partitions for the events consume loop. Never keeps an empty holdover, so
+/// `pending.keys()` is exactly the set of partitions that should be paused.
+#[derive(Debug, Default)]
+pub struct Backpressure {
+    /// Un-dispatched events per paused partition, coalesced in offset order.
+    pending: HashMap<i32, Vec<ShuffleMessage>>,
+    /// Partitions currently paused on the consumer — what the last [`reconcile`](Self::reconcile)
+    /// applied. Diffed against the holdover key set to compute the next pause/resume deltas.
+    paused: HashSet<i32>,
+}
+
+impl Backpressure {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Drop holdover and pause-tracking for partitions no longer owned (revoked mid-tenure). Their
+    /// uncommitted offsets replay on the next owner, so we neither redispatch nor resume them — a
+    /// resume of an unassigned partition would only error.
+    pub fn prune_revoked(&mut self, owned: &HashSet<i32>) {
+        self.pending
+            .retain(|partition, _| owned.contains(partition));
+        self.paused.retain(|partition| owned.contains(partition));
+    }
+
+    /// Take the whole holdover for a retry-flush, emptying `pending`; the caller reinstates whatever
+    /// stays full via [`set_pending`](Self::set_pending). Leaves `paused` untouched — the reconcile
+    /// resumes anything that flushed.
+    pub fn take_held(&mut self) -> Vec<(i32, Vec<ShuffleMessage>)> {
+        std::mem::take(&mut self.pending).into_iter().collect()
+    }
+
+    /// Reinstate the post-flush holdover (the partitions whose channel is still full).
+    pub fn set_pending(&mut self, pending: HashMap<i32, Vec<ShuffleMessage>>) {
+        self.pending = pending;
+    }
+
+    /// Partitions with an outstanding holdover — the set a fresh dispatch must queue new events behind
+    /// (never leapfrog) rather than sending them.
+    pub fn held_partitions(&self) -> HashSet<i32> {
+        self.pending.keys().copied().collect()
+    }
+
+    /// Append un-dispatched events to their partition's holdover, in offset order (coalesced into the
+    /// single per-partition `Vec`, never nested). Empty batches are ignored so the pause invariant holds.
+    pub fn absorb(&mut self, full: HashMap<i32, Vec<ShuffleMessage>>) {
+        for (partition, mut messages) in full {
+            if messages.is_empty() {
+                continue;
+            }
+            self.pending
+                .entry(partition)
+                .or_default()
+                .append(&mut messages);
+        }
+    }
+
+    /// Diff the target paused set (partitions that still hold events) against the currently-paused set,
+    /// returning the pause/resume actions and adopting the target as the new paused set.
+    pub fn reconcile(&mut self) -> PauseDeltas {
+        let target: HashSet<i32> = self.pending.keys().copied().collect();
+        let pause = target.difference(&self.paused).copied().collect();
+        let resume = self.paused.difference(&target).copied().collect();
+        self.paused = target;
+        PauseDeltas { pause, resume }
+    }
+
+    /// Partitions currently paused (== holdover count). Feeds the `partitions_paused` gauge.
+    pub fn paused_count(&self) -> usize {
+        self.paused.len()
+    }
+
+    /// Total events held across all paused partitions. Feeds the `pending_subbatches` gauge.
+    pub fn held_event_count(&self) -> usize {
+        self.pending.values().map(Vec::len).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumers::events::CohortStreamEvent;
+
+    fn event(cse_offset: i64) -> ShuffleMessage {
+        ShuffleMessage::Event {
+            event: Box::new(CohortStreamEvent {
+                team_id: 1,
+                person_id: "p".to_string(),
+                distinct_id: "d".to_string(),
+                uuid: "u".to_string(),
+                event: "$pageview".to_string(),
+                timestamp: "2026-05-26 12:34:56.789000".to_string(),
+                properties: None,
+                person_properties: None,
+                elements_chain: None,
+                source_offset: cse_offset,
+                source_partition: 0,
+                redirected_from: None,
+                redirect_hops: 0,
+            }),
+            cse_offset,
+        }
+    }
+
+    fn offsets(messages: &[ShuffleMessage]) -> Vec<i64> {
+        messages
+            .iter()
+            .filter_map(ShuffleMessage::event_offset)
+            .collect()
+    }
+
+    fn set(partitions: [i32; 1]) -> HashSet<i32> {
+        partitions.into_iter().collect()
+    }
+
+    #[test]
+    fn a_newly_full_partition_is_stashed_and_paused() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([(5, vec![event(10)])]));
+
+        let deltas = bp.reconcile();
+        assert_eq!(deltas.pause, vec![5]);
+        assert!(deltas.resume.is_empty());
+        assert!(bp.held_partitions().contains(&5));
+        assert_eq!(bp.paused_count(), 1);
+    }
+
+    #[test]
+    fn a_fully_flushed_partition_is_resumed_and_cleared() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([(5, vec![event(10)])]));
+        assert_eq!(bp.reconcile().pause, vec![5]);
+
+        // Next iteration: the holdover flushed (nothing stays full).
+        let _held = bp.take_held();
+        bp.set_pending(HashMap::new());
+        let deltas = bp.reconcile();
+
+        assert!(deltas.pause.is_empty());
+        assert_eq!(deltas.resume, vec![5]);
+        assert!(bp.held_partitions().is_empty());
+        assert_eq!(bp.paused_count(), 0);
+    }
+
+    #[test]
+    fn a_still_full_partition_stays_paused_with_no_delta() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([(5, vec![event(10)])]));
+        assert_eq!(bp.reconcile().pause, vec![5]);
+
+        // Retry-flush leaves it full: reinstated verbatim, no pause/resume churn.
+        let held = bp.take_held();
+        bp.set_pending(held.into_iter().collect());
+        let deltas = bp.reconcile();
+
+        assert!(deltas.pause.is_empty() && deltas.resume.is_empty());
+        assert!(bp.held_partitions().contains(&5));
+    }
+
+    #[test]
+    fn a_revoked_paused_partition_is_pruned_and_never_resumed() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([(5, vec![event(10)])]));
+        assert_eq!(bp.reconcile().pause, vec![5]);
+
+        // Partition 5 revoked: drop its holdover and pause-tracking, don't resume (new owner replays).
+        bp.prune_revoked(&set([9]));
+        let deltas = bp.reconcile();
+
+        assert!(deltas.pause.is_empty());
+        assert!(
+            deltas.resume.is_empty(),
+            "a revoked partition is not resumed"
+        );
+        assert!(bp.held_partitions().is_empty());
+        assert_eq!(bp.paused_count(), 0);
+    }
+
+    #[test]
+    fn absorb_coalesces_fresh_events_after_the_existing_holdover_in_offset_order() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([(5, vec![event(10), event(11)])]));
+        // A straggler that arrived after the pause queues behind the older held offsets.
+        bp.absorb(HashMap::from([(5, vec![event(12)])]));
+
+        let held: HashMap<i32, Vec<ShuffleMessage>> = bp.take_held().into_iter().collect();
+        assert_eq!(offsets(&held[&5]), vec![10, 11, 12]);
+    }
+
+    #[test]
+    fn held_event_count_sums_across_partitions() {
+        let mut bp = Backpressure::new();
+        bp.absorb(HashMap::from([
+            (5, vec![event(10), event(11)]),
+            (6, vec![event(20)]),
+        ]));
+        assert_eq!(bp.held_event_count(), 3);
+    }
+}

--- a/rust/cohort-stream-processor/src/partitions/backpressure.rs
+++ b/rust/cohort-stream-processor/src/partitions/backpressure.rs
@@ -87,7 +87,7 @@ impl Backpressure {
         self.paused.len()
     }
 
-    /// Total events held across all paused partitions. Feeds the `pending_subbatches` gauge.
+    /// Total events held across all paused partitions. Feeds the `pending_held_events` gauge.
     pub fn held_event_count(&self) -> usize {
         self.pending.values().map(Vec::len).sum()
     }

--- a/rust/cohort-stream-processor/src/partitions/mod.rs
+++ b/rust/cohort-stream-processor/src/partitions/mod.rs
@@ -14,7 +14,7 @@ pub mod rebalance;
 pub mod router;
 pub mod shuffle_message;
 
-pub use backpressure::{Backpressure, PauseDeltas};
+pub use backpressure::Backpressure;
 pub use follower::{Follower, FollowerSet, PartitionMirror};
 pub use offset_tracker::{MarkOutcome, OffsetTracker};
 pub use partitioner::{

--- a/rust/cohort-stream-processor/src/partitions/mod.rs
+++ b/rust/cohort-stream-processor/src/partitions/mod.rs
@@ -5,21 +5,25 @@
 //! long-lived worker that owns the `Receiver` from [`router::PartitionRouter::add_partition`] and
 //! runs the Stage 1 loop lives in [`crate::workers`].
 
+pub mod backpressure;
 pub mod follower;
 pub mod offset_tracker;
 pub mod partitioner;
+pub mod pause;
 pub mod rebalance;
 pub mod router;
 pub mod shuffle_message;
 
+pub use backpressure::{Backpressure, PauseDeltas};
 pub use follower::{Follower, FollowerSet, PartitionMirror};
 pub use offset_tracker::{MarkOutcome, OffsetTracker};
 pub use partitioner::{
     merge_partition_key, murmur2, partition_for, partition_of, COHORT_PARTITION_COUNT,
 };
+pub use pause::{ConsumerPauser, PartitionPauser};
 pub use rebalance::{
     run_rebalance_worker, CohortConsumerContext, ConsumerCommand, ConsumerCommandReceiver,
     ConsumerCommandSender, RebalanceEvent, RebalanceEventReceiver,
 };
-pub use router::{PartitionRouter, RouteError};
+pub use router::{PartitionRouter, RouteError, SendOutcome};
 pub use shuffle_message::ShuffleMessage;

--- a/rust/cohort-stream-processor/src/partitions/pause.rs
+++ b/rust/cohort-stream-processor/src/partitions/pause.rs
@@ -1,10 +1,6 @@
-//! Per-partition Kafka pause/resume for the events consumer.
-//!
-//! When a partition worker's channel fills, the consume loop pauses that partition on the broker so
-//! backpressure surfaces as lag on that partition alone, never a stalled heartbeat. Trait-based so the
-//! loop's state machine is unit-testable without a broker; the production impl is [`ConsumerPauser`],
-//! mirroring the [`PartitionMirror`](super::follower::PartitionMirror) posture (warn-and-skip on
-//! error, since a missed pause only grows the holdover and a missed resume only defers a drain).
+//! Per-partition Kafka pause/resume for the events consumer, so a full worker channel surfaces as lag
+//! on that partition alone. Trait-based for broker-free tests; the prod impl [`ConsumerPauser`] warns
+//! and skips on error — a missed pause only grows the holdover, a missed resume only defers a drain.
 
 use std::sync::Arc;
 
@@ -16,9 +12,7 @@ use crate::partitions::rebalance::CohortConsumerContext;
 
 /// Pause/resume Kafka fetching for specific partitions of the events topic.
 pub trait PartitionPauser: Send + Sync {
-    /// Stop fetching these partitions until a matching [`resume`](Self::resume).
     fn pause(&self, partitions: &[i32]);
-    /// Resume fetching these partitions.
     fn resume(&self, partitions: &[i32]);
 }
 

--- a/rust/cohort-stream-processor/src/partitions/pause.rs
+++ b/rust/cohort-stream-processor/src/partitions/pause.rs
@@ -1,0 +1,73 @@
+//! Per-partition Kafka pause/resume for the events consumer.
+//!
+//! When a partition worker's channel fills, the consume loop pauses that partition on the broker so
+//! backpressure surfaces as lag on that partition alone, never a stalled heartbeat. Trait-based so the
+//! loop's state machine is unit-testable without a broker; the production impl is [`ConsumerPauser`],
+//! mirroring the [`PartitionMirror`](super::follower::PartitionMirror) posture (warn-and-skip on
+//! error, since a missed pause only grows the holdover and a missed resume only defers a drain).
+
+use std::sync::Arc;
+
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::TopicPartitionList;
+use tracing::warn;
+
+use crate::partitions::rebalance::CohortConsumerContext;
+
+/// Pause/resume Kafka fetching for specific partitions of the events topic.
+pub trait PartitionPauser: Send + Sync {
+    /// Stop fetching these partitions until a matching [`resume`](Self::resume).
+    fn pause(&self, partitions: &[i32]);
+    /// Resume fetching these partitions.
+    fn resume(&self, partitions: &[i32]);
+}
+
+/// Production [`PartitionPauser`]: drives `pause`/`resume` on the events `StreamConsumer`.
+pub struct ConsumerPauser {
+    consumer: Arc<StreamConsumer<CohortConsumerContext>>,
+    topic: String,
+}
+
+impl ConsumerPauser {
+    pub fn new(consumer: Arc<StreamConsumer<CohortConsumerContext>>, topic: String) -> Self {
+        Self { consumer, topic }
+    }
+
+    fn tpl(&self, partitions: &[i32]) -> TopicPartitionList {
+        let mut tpl = TopicPartitionList::new();
+        for &partition in partitions {
+            tpl.add_partition(&self.topic, partition);
+        }
+        tpl
+    }
+}
+
+impl PartitionPauser for ConsumerPauser {
+    fn pause(&self, partitions: &[i32]) {
+        if partitions.is_empty() {
+            return;
+        }
+        if let Err(err) = self.consumer.pause(&self.tpl(partitions)) {
+            warn!(
+                topic = %self.topic,
+                ?partitions,
+                error = %err,
+                "failed to pause partitions; the holdover grows until the next attempt",
+            );
+        }
+    }
+
+    fn resume(&self, partitions: &[i32]) {
+        if partitions.is_empty() {
+            return;
+        }
+        if let Err(err) = self.consumer.resume(&self.tpl(partitions)) {
+            warn!(
+                topic = %self.topic,
+                ?partitions,
+                error = %err,
+                "failed to resume partitions; surfaces as lag until the next attempt",
+            );
+        }
+    }
+}

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -43,9 +43,8 @@ pub enum RouteError {
 /// backpressure — the events are returned to be held and retried — not a drop.
 #[derive(Debug)]
 pub enum SendOutcome {
-    /// Delivered. `max_offset` is the highest event offset — used to raise the dispatch ceiling, and
-    /// `None` for a batch that carries no events (no offset to ceiling on); `count` the number of
-    /// messages delivered.
+    /// Delivered. `max_offset` is the highest event offset (raises the dispatch ceiling), or `None` if
+    /// the batch carries no events; `count` is the number delivered.
     Sent {
         max_offset: Option<i64>,
         count: usize,
@@ -209,8 +208,8 @@ impl PartitionRouter {
             return SendOutcome::NoWorker;
         };
         let count = batch.len();
-        // `None` for a batch carrying no events. Carried through as-is rather than defaulted to 0, so a
-        // future non-Event caller can't fabricate a ceiling; `route_and_fold` only marks when `Some`.
+        // `None` for an event-less batch — carried through, not defaulted to 0, so a future non-Event
+        // caller can't fabricate a ceiling (`route_and_fold` only marks when `Some`).
         let max_offset = batch.iter().filter_map(ShuffleMessage::event_offset).max();
         match sender.try_send(batch) {
             Ok(()) => {

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -43,9 +43,13 @@ pub enum RouteError {
 /// backpressure — the events are returned to be held and retried — not a drop.
 #[derive(Debug)]
 pub enum SendOutcome {
-    /// Delivered. `max_offset` is the highest event offset (for the dispatch ceiling); `count` the
-    /// number of messages delivered.
-    Sent { max_offset: i64, count: usize },
+    /// Delivered. `max_offset` is the highest event offset — used to raise the dispatch ceiling, and
+    /// `None` for a batch that carries no events (no offset to ceiling on); `count` the number of
+    /// messages delivered.
+    Sent {
+        max_offset: Option<i64>,
+        count: usize,
+    },
     /// Channel full: carries the un-sent sub-batch to hold, pause, and redispatch. No drop recorded.
     Full(Vec<ShuffleMessage>),
     /// No worker registered (never assigned, or revoked): dropped and recorded; Kafka replays.
@@ -205,19 +209,13 @@ impl PartitionRouter {
             return SendOutcome::NoWorker;
         };
         let count = batch.len();
-        // Events-only path: every message carries an offset, so `max` is `Some` for a non-empty batch.
+        // `None` for a batch carrying no events. Carried through as-is rather than defaulted to 0, so a
+        // future non-Event caller can't fabricate a ceiling; `route_and_fold` only marks when `Some`.
         let max_offset = batch.iter().filter_map(ShuffleMessage::event_offset).max();
-        debug_assert!(
-            max_offset.is_some(),
-            "try_route_batch routes event messages only",
-        );
         match sender.try_send(batch) {
             Ok(()) => {
                 self.emit_channel_depth(partition, &sender);
-                SendOutcome::Sent {
-                    max_offset: max_offset.unwrap_or_default(),
-                    count,
-                }
+                SendOutcome::Sent { max_offset, count }
             }
             Err(TrySendError::Full(returned)) => {
                 counter!(PARTITION_CHANNEL_FULL_TOTAL, "partition" => partition.to_string())
@@ -508,13 +506,13 @@ mod tests {
 
         match outcomes.remove(&5) {
             Some(SendOutcome::Sent { max_offset, count }) => {
-                assert_eq!((max_offset, count), (3, 2));
+                assert_eq!((max_offset, count), (Some(3), 2));
             }
             other => panic!("expected Sent for 5, got {other:?}"),
         }
         match outcomes.remove(&6) {
             Some(SendOutcome::Sent { max_offset, count }) => {
-                assert_eq!((max_offset, count), (2, 1));
+                assert_eq!((max_offset, count), (Some(2), 1));
             }
             other => panic!("expected Sent for 6, got {other:?}"),
         }

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -14,11 +14,13 @@ use futures::future::join_all;
 use metrics::{counter, gauge};
 use thiserror::Error;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use tracing::warn;
 
 use super::shuffle_message::ShuffleMessage;
 use crate::observability::metrics::{
-    PARTITIONS_ACTIVE, PARTITION_CHANNEL_DEPTH, PARTITION_ROUTE_DROPPED_TOTAL,
+    PARTITIONS_ACTIVE, PARTITION_CHANNEL_DEPTH, PARTITION_CHANNEL_FULL_TOTAL,
+    PARTITION_ROUTE_DROPPED_TOTAL,
 };
 
 const REASON_NO_WORKER: &str = "no_worker";
@@ -35,6 +37,23 @@ pub enum RouteError {
     /// The channel exists but its receiver was dropped, so the worker has stopped.
     #[error("worker channel for partition {partition} is closed ({dropped} message(s) dropped)")]
     ChannelClosed { partition: i32, dropped: usize },
+}
+
+/// The result of a non-blocking [`try_route_batch`](PartitionRouter::try_route_batch) send of one
+/// partition's sub-batch. Unlike [`RouteError`], `Full` is backpressure — the events are handed back
+/// intact to be held and retried — not a drop.
+#[derive(Debug)]
+pub enum SendOutcome {
+    /// Delivered to the worker. `max_offset` is the highest event offset in the sub-batch (for the
+    /// dispatch ceiling); `count` is the number of messages delivered.
+    Sent { max_offset: i64, count: usize },
+    /// The worker channel was full. Carries the un-sent sub-batch verbatim so the caller can hold it,
+    /// pause the partition, and redispatch once the channel drains. No drop is recorded.
+    Full(Vec<ShuffleMessage>),
+    /// No worker registered (never assigned, or revoked): dropped and recorded; Kafka replays.
+    NoWorker,
+    /// The worker channel is closed (worker exited): dropped and recorded; Kafka replays.
+    ChannelClosed,
 }
 
 /// Routes per-partition sub-batches to long-lived per-partition worker channels.
@@ -159,6 +178,56 @@ impl PartitionRouter {
                     partition,
                     dropped: returned.len(),
                 })
+            }
+        }
+    }
+
+    /// Non-blocking sibling of [`route_batch`](Self::route_batch): group a batch by partition and
+    /// `try_send` each sub-batch, never awaiting. Returns per-partition [`SendOutcome`] so the caller
+    /// can advance the dispatch ceiling for what landed, hold and pause the partitions whose channel
+    /// was full, and treat a missing/closed worker as a drop. Used only on the hot events path, whose
+    /// heartbeat must not be gated on downstream drain.
+    pub fn try_route_batch(
+        &self,
+        messages: Vec<(i32, ShuffleMessage)>,
+    ) -> HashMap<i32, SendOutcome> {
+        if messages.is_empty() {
+            return HashMap::new();
+        }
+        let mut by_partition: HashMap<i32, Vec<ShuffleMessage>> = HashMap::new();
+        for (partition, message) in messages {
+            by_partition.entry(partition).or_default().push(message);
+        }
+        by_partition
+            .into_iter()
+            .map(|(partition, batch)| (partition, self.try_send_to_partition(partition, batch)))
+            .collect()
+    }
+
+    fn try_send_to_partition(&self, partition: i32, batch: Vec<ShuffleMessage>) -> SendOutcome {
+        let Some(sender) = self.sender_for(partition) else {
+            self.record_drop(partition, batch.len(), REASON_NO_WORKER);
+            return SendOutcome::NoWorker;
+        };
+        // `max_offset`/`count` before the move into `try_send`; the sub-batch is events-only here.
+        let count = batch.len();
+        let max_offset = batch.iter().filter_map(ShuffleMessage::event_offset).max();
+        match sender.try_send(batch) {
+            Ok(()) => {
+                self.emit_channel_depth(partition, &sender);
+                SendOutcome::Sent {
+                    max_offset: max_offset.unwrap_or_default(),
+                    count,
+                }
+            }
+            Err(TrySendError::Full(returned)) => {
+                counter!(PARTITION_CHANNEL_FULL_TOTAL, "partition" => partition.to_string())
+                    .increment(returned.len() as u64);
+                SendOutcome::Full(returned)
+            }
+            Err(TrySendError::Closed(returned)) => {
+                self.record_drop(partition, returned.len(), REASON_CHANNEL_CLOSED);
+                SendOutcome::ChannelClosed
             }
         }
     }
@@ -415,6 +484,102 @@ mod tests {
 
         assert!(router.route_batch(vec![(5, event(7))]).await.is_empty());
         assert_eq!(tags(&rx_new.recv().await.unwrap()), vec![7]);
+    }
+
+    /// An event whose `cse_offset` (what `try_route_batch` reads for the dispatch ceiling) matches its
+    /// `source_offset` tag, so [`tags`] and `max_offset` assertions line up.
+    fn event_off(cse_offset: i64) -> ShuffleMessage {
+        match event(cse_offset) {
+            ShuffleMessage::Event { event, .. } => ShuffleMessage::Event { event, cse_offset },
+            other => other,
+        }
+    }
+
+    #[tokio::test]
+    async fn try_route_batch_delivers_and_reports_the_max_offset_and_count() {
+        let router = PartitionRouter::new(16);
+        let mut rx5 = router.add_partition(5).unwrap();
+        let mut rx6 = router.add_partition(6).unwrap();
+
+        let mut outcomes = router.try_route_batch(vec![
+            (5, event_off(1)),
+            (6, event_off(2)),
+            (5, event_off(3)),
+        ]);
+
+        match outcomes.remove(&5) {
+            Some(SendOutcome::Sent { max_offset, count }) => {
+                assert_eq!((max_offset, count), (3, 2));
+            }
+            other => panic!("expected Sent for 5, got {other:?}"),
+        }
+        match outcomes.remove(&6) {
+            Some(SendOutcome::Sent { max_offset, count }) => {
+                assert_eq!((max_offset, count), (2, 1));
+            }
+            other => panic!("expected Sent for 6, got {other:?}"),
+        }
+        assert_eq!(tags(&rx5.try_recv().unwrap()), vec![1, 3]);
+        assert_eq!(tags(&rx6.try_recv().unwrap()), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn try_route_batch_returns_the_batch_on_full_without_recording_a_drop() {
+        let router = PartitionRouter::new(1);
+        let mut rx = router.add_partition(1).unwrap();
+
+        // Saturate the single channel slot, then the next try must hand the batch back untouched.
+        assert!(matches!(
+            router.try_route_batch(vec![(1, event_off(100))]).remove(&1),
+            Some(SendOutcome::Sent { .. }),
+        ));
+
+        match router.try_route_batch(vec![(1, event_off(7))]).remove(&1) {
+            Some(SendOutcome::Full(returned)) => assert_eq!(tags(&returned), vec![7]),
+            other => panic!("expected Full, got {other:?}"),
+        }
+        // The holdover is recoverable: the first batch is still the only thing queued.
+        assert_eq!(tags(&rx.try_recv().unwrap()), vec![100]);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn try_route_batch_reports_no_worker_and_channel_closed() {
+        let router = PartitionRouter::new(16);
+        assert!(matches!(
+            router.try_route_batch(vec![(9, event_off(1))]).remove(&9),
+            Some(SendOutcome::NoWorker),
+        ));
+
+        let rx = router.add_partition(3).unwrap();
+        drop(rx);
+        assert!(matches!(
+            router.try_route_batch(vec![(3, event_off(1))]).remove(&3),
+            Some(SendOutcome::ChannelClosed),
+        ));
+    }
+
+    #[tokio::test]
+    async fn try_route_batch_isolates_a_full_partition_from_a_free_one() {
+        let router = PartitionRouter::new(1);
+        let mut rx2 = router.add_partition(2).unwrap();
+        let _rx1 = router.add_partition(1).unwrap();
+        // Fill partition 1 only.
+        router.try_route_batch(vec![(1, event_off(100))]);
+
+        let mut outcomes = router.try_route_batch(vec![(1, event_off(1)), (2, event_off(2))]);
+        assert!(matches!(outcomes.remove(&1), Some(SendOutcome::Full(_))));
+        assert!(matches!(
+            outcomes.remove(&2),
+            Some(SendOutcome::Sent { .. })
+        ));
+        assert_eq!(tags(&rx2.try_recv().unwrap()), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn try_route_batch_is_empty_for_an_empty_batch() {
+        let router = PartitionRouter::new(16);
+        assert!(router.try_route_batch(vec![]).is_empty());
     }
 
     #[tokio::test]

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -205,7 +205,12 @@ impl PartitionRouter {
             return SendOutcome::NoWorker;
         };
         let count = batch.len();
+        // Events-only path: every message carries an offset, so `max` is `Some` for a non-empty batch.
         let max_offset = batch.iter().filter_map(ShuffleMessage::event_offset).max();
+        debug_assert!(
+            max_offset.is_some(),
+            "try_route_batch routes event messages only",
+        );
         match sender.try_send(batch) {
             Ok(()) => {
                 self.emit_channel_depth(partition, &sender);

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -39,20 +39,18 @@ pub enum RouteError {
     ChannelClosed { partition: i32, dropped: usize },
 }
 
-/// The result of a non-blocking [`try_route_batch`](PartitionRouter::try_route_batch) send of one
-/// partition's sub-batch. Unlike [`RouteError`], `Full` is backpressure — the events are handed back
-/// intact to be held and retried — not a drop.
+/// Per-partition result of [`try_route_batch`](PartitionRouter::try_route_batch). `Full` is
+/// backpressure — the events are returned to be held and retried — not a drop.
 #[derive(Debug)]
 pub enum SendOutcome {
-    /// Delivered to the worker. `max_offset` is the highest event offset in the sub-batch (for the
-    /// dispatch ceiling); `count` is the number of messages delivered.
+    /// Delivered. `max_offset` is the highest event offset (for the dispatch ceiling); `count` the
+    /// number of messages delivered.
     Sent { max_offset: i64, count: usize },
-    /// The worker channel was full. Carries the un-sent sub-batch verbatim so the caller can hold it,
-    /// pause the partition, and redispatch once the channel drains. No drop is recorded.
+    /// Channel full: carries the un-sent sub-batch to hold, pause, and redispatch. No drop recorded.
     Full(Vec<ShuffleMessage>),
     /// No worker registered (never assigned, or revoked): dropped and recorded; Kafka replays.
     NoWorker,
-    /// The worker channel is closed (worker exited): dropped and recorded; Kafka replays.
+    /// Worker channel closed (worker exited): dropped and recorded; Kafka replays.
     ChannelClosed,
 }
 
@@ -182,11 +180,8 @@ impl PartitionRouter {
         }
     }
 
-    /// Non-blocking sibling of [`route_batch`](Self::route_batch): group a batch by partition and
-    /// `try_send` each sub-batch, never awaiting. Returns per-partition [`SendOutcome`] so the caller
-    /// can advance the dispatch ceiling for what landed, hold and pause the partitions whose channel
-    /// was full, and treat a missing/closed worker as a drop. Used only on the hot events path, whose
-    /// heartbeat must not be gated on downstream drain.
+    /// Non-blocking sibling of [`route_batch`](Self::route_batch): group by partition and `try_send`
+    /// each sub-batch, returning the per-partition [`SendOutcome`] instead of awaiting a drain.
     pub fn try_route_batch(
         &self,
         messages: Vec<(i32, ShuffleMessage)>,
@@ -209,7 +204,6 @@ impl PartitionRouter {
             self.record_drop(partition, batch.len(), REASON_NO_WORKER);
             return SendOutcome::NoWorker;
         };
-        // `max_offset`/`count` before the move into `try_send`; the sub-batch is events-only here.
         let count = batch.len();
         let max_offset = batch.iter().filter_map(ShuffleMessage::event_offset).max();
         match sender.try_send(batch) {
@@ -486,8 +480,8 @@ mod tests {
         assert_eq!(tags(&rx_new.recv().await.unwrap()), vec![7]);
     }
 
-    /// An event whose `cse_offset` (what `try_route_batch` reads for the dispatch ceiling) matches its
-    /// `source_offset` tag, so [`tags`] and `max_offset` assertions line up.
+    /// An event whose `cse_offset` matches its `source_offset` tag, so [`tags`] and `max_offset`
+    /// assertions line up.
     fn event_off(cse_offset: i64) -> ShuffleMessage {
         match event(cse_offset) {
             ShuffleMessage::Event { event, .. } => ShuffleMessage::Event { event, cse_offset },
@@ -528,7 +522,7 @@ mod tests {
         let router = PartitionRouter::new(1);
         let mut rx = router.add_partition(1).unwrap();
 
-        // Saturate the single channel slot, then the next try must hand the batch back untouched.
+        // Saturate the slot, then the next try hands the batch back untouched.
         assert!(matches!(
             router.try_route_batch(vec![(1, event_off(100))]).remove(&1),
             Some(SendOutcome::Sent { .. }),
@@ -538,7 +532,6 @@ mod tests {
             Some(SendOutcome::Full(returned)) => assert_eq!(tags(&returned), vec![7]),
             other => panic!("expected Full, got {other:?}"),
         }
-        // The holdover is recoverable: the first batch is still the only thing queued.
         assert_eq!(tags(&rx.try_recv().unwrap()), vec![100]);
         assert!(rx.try_recv().is_err());
     }
@@ -564,7 +557,6 @@ mod tests {
         let router = PartitionRouter::new(1);
         let mut rx2 = router.add_partition(2).unwrap();
         let _rx1 = router.add_partition(1).unwrap();
-        // Fill partition 1 only.
         router.try_route_batch(vec![(1, event_off(100))]);
 
         let mut outcomes = router.try_route_batch(vec![(1, event_off(1)), (2, event_off(2))]);

--- a/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
+++ b/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
@@ -49,6 +49,22 @@ pub enum ShuffleMessage {
     },
 }
 
+impl ShuffleMessage {
+    /// The `cohort_stream_events` offset an event carries, used to raise the dispatch ceiling on the
+    /// non-blocking events path. `None` for the maintenance variants, which are never routed there.
+    pub fn event_offset(&self) -> Option<i64> {
+        match self {
+            ShuffleMessage::Event { cse_offset, .. } => Some(*cse_offset),
+            ShuffleMessage::Sweep { .. }
+            | ShuffleMessage::Merge { .. }
+            | ShuffleMessage::Transfer { .. }
+            | ShuffleMessage::Cascade { .. }
+            | ShuffleMessage::RedrivePendingTransfers
+            | ShuffleMessage::MergeCfGc { .. } => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
+++ b/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
@@ -50,8 +50,7 @@ pub enum ShuffleMessage {
 }
 
 impl ShuffleMessage {
-    /// The `cohort_stream_events` offset an event carries, used to raise the dispatch ceiling on the
-    /// non-blocking events path. `None` for the maintenance variants, which are never routed there.
+    /// The offset an [`Event`](Self::Event) carries; `None` for the maintenance variants.
     pub fn event_offset(&self) -> Option<i64> {
         match self {
             ShuffleMessage::Event { cse_offset, .. } => Some(*cse_offset),


### PR DESCRIPTION
## Problem

The cohort stream processor runs one Kafka consume loop that reports its liveness heartbeat only after a blocking downstream dispatch returns.
When a per partition worker channel fills under overload the dispatch blocks, the heartbeat stops, and the lifecycle stall detector self exits the process.
Each restart cold boots, reloads the backlog, and stalls again, so overload becomes a crash loop instead of lag.

## Changes

* Made the events dispatch non blocking so a full worker channel can never gate the heartbeat.
Added `try_route_batch` on the router, which `try_send`s each partition sub batch and returns a per partition outcome instead of awaiting a drain.
* When a channel is full the loop holds those events, pauses that Kafka partition, and redispatches once it drains, so a slow partition produces lag on that partition alone and never a process exit.
* Offset correctness holds because the commit watermark advances only for what a worker actually received, and held events queue behind older ones in offset order.
* Added a pure `Backpressure` state machine for the hold and pause bookkeeping, a `PartitionPauser` seam over the consumer, and metrics for paused partitions and held events.
* The follower consumers keep the existing blocking path.

## How did you test this code?

The tests cover the router `try_send` outcomes, the `Backpressure` transitions, the offset walk proving a held batch never advances the commit ceiling until it flushes, and that a saturated channel returns synchronously without blocking the loop.

## Docs update

No.