### PR TITLE
feat(mcp): add deterministic eval probe runner

### DIFF
--- a/services/mcp/evals/runner/probe.ts
+++ b/services/mcp/evals/runner/probe.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic probe runner — no LLM. Connects to a LIVE MCP server,
+ * verifies every tool the benchmark references is advertised, executes each
+ * task's read-only probe call, and prints/writes a score summary.
+ *
+ * Usage:
+ *   LIVE_MCP_URL=http://localhost:9876 LIVE_MCP_TOKEN=phx_... \
+ *     pnpm exec tsx evals/runner/probe.ts [--out score.json]
+ *
+ * Exit code is non-zero when any referenced tool is missing or any probe
+ * fails, so the campaign (or CI) can gate on it directly.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { writeFileSync } from 'node:fs'
+import process from 'node:process'
+
+import { loadBenchmark, referencedTools, type BenchmarkTask } from '../benchmark/schema'
+import { formatSummary, summarize, type ProbeResult, type ToolMiss } from './results'
+
+interface AdvertisedTool {
+    name: string
+    annotations?: { readOnlyHint?: boolean }
+}
+
+async function runProbe(
+    client: Client,
+    task: BenchmarkTask,
+    advertised: Map<string, AdvertisedTool>
+): Promise<ProbeResult> {
+    const probe = task.probe!
+    const base = { task_id: task.id, tool: probe.tool }
+    const tool = advertised.get(probe.tool)
+    if (!tool) {
+        return { ...base, status: 'skipped_not_advertised' }
+    }
+    // Enforce read-only from the LIVE advertisement, not just the fixture —
+    // an annotation regression must fail the probe rather than mutate data.
+    if (tool.annotations?.readOnlyHint !== true) {
+        return { ...base, status: 'refused_not_read_only' }
+    }
+
+    const startedAt = Date.now()
+    try {
+        const result = await client.callTool({ name: probe.tool, arguments: probe.args }, undefined, {
+            timeout: probe.max_ms,
+        })
+        const latency = Date.now() - startedAt
+        if (result.isError) {
+            const content = Array.isArray(result.content) ? result.content : []
+            const text = content
+                .map((item) => (item && typeof item === 'object' && 'text' in item ? String(item.text) : ''))
+                .join(' ')
+            return { ...base, status: 'tool_error', latency_ms: latency, error_snippet: text.slice(0, 200) }
+        }
+        return { ...base, status: 'ok', latency_ms: latency }
+    } catch (error) {
+        const latency = Date.now() - startedAt
+        const message = error instanceof Error ? error.message : String(error)
+        const status = latency >= probe.max_ms ? 'timeout' : 'transport_error'
+        return { ...base, status, latency_ms: latency, error_snippet: message.slice(0, 200) }
+    }
+}
+
+async function main(): Promise<void> {
+    const url = process.env.LIVE_MCP_URL ?? 'http://localhost:9876'
+    const token = process.env.LIVE_MCP_TOKEN
+    if (!token) {
+        console.error('LIVE_MCP_TOKEN is required (a personal API key for the target instance)')
+        process.exit(2)
+    }
+    const outFlagIndex = process.argv.indexOf('--out')
+    const outPath = outFlagIndex === -1 ? null : process.argv[outFlagIndex + 1]
+
+    const benchmark = loadBenchmark()
+    const transport = new StreamableHTTPClientTransport(new URL('/mcp', url), {
+        requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    })
+    const client = new Client({ name: 'mcp-eval-probe', version: '0.0.0' }, { capabilities: {} })
+    await client.connect(transport)
+
+    try {
+        const listed = await client.listTools()
+        const advertised = new Map<string, AdvertisedTool>(
+            listed.tools.map((tool) => [tool.name, tool as AdvertisedTool])
+        )
+
+        const toolMisses: ToolMiss[] = benchmark.tasks.flatMap((task) =>
+            referencedTools(task)
+                .filter((tool) => !advertised.has(tool))
+                .map((tool) => ({ task_id: task.id, tool }))
+        )
+
+        const probes: ProbeResult[] = []
+        for (const task of benchmark.tasks.filter((candidate) => candidate.probe)) {
+            probes.push(await runProbe(client, task, advertised))
+        }
+
+        const summary = summarize({
+            benchmarkVersion: benchmark.version,
+            tasksTotal: benchmark.tasks.length,
+            toolsReferenced: new Set(benchmark.tasks.flatMap(referencedTools)).size,
+            toolMisses,
+            probes,
+        })
+
+        // stdout directly: the summary IS the program output (oxlint strips console.log).
+        process.stdout.write(formatSummary(summary) + '\n')
+        if (outPath) {
+            writeFileSync(outPath, JSON.stringify(summary, null, 2))
+            process.stdout.write(`wrote ${outPath}\n`)
+        }
+        process.exit(summary.tool_misses.length > 0 || summary.probes_failed > 0 ? 1 : 0)
+    } finally {
+        await client.close().catch(() => undefined)
+    }
+}
+
+void main()

--- a/services/mcp/evals/runner/probe.ts
+++ b/services/mcp/evals/runner/probe.ts
@@ -13,6 +13,7 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { writeFileSync } from 'node:fs'
 import process from 'node:process'
 
@@ -58,8 +59,15 @@ async function runProbe(
     } catch (error) {
         const latency = Date.now() - startedAt
         const message = error instanceof Error ? error.message : String(error)
-        const status = latency >= probe.max_ms ? 'timeout' : 'transport_error'
-        return { ...base, status, latency_ms: latency, error_snippet: message.slice(0, 200) }
+        // The SDK raises a typed timeout when RequestOptions.timeout elapses —
+        // classify on that, not on wall-clock heuristics.
+        const isTimeout = error instanceof McpError && error.code === ErrorCode.RequestTimeout
+        return {
+            ...base,
+            status: isTimeout ? 'timeout' : 'transport_error',
+            latency_ms: latency,
+            error_snippet: message.slice(0, 200),
+        }
     }
 }
 
@@ -71,7 +79,11 @@ async function main(): Promise<void> {
         process.exit(2)
     }
     const outFlagIndex = process.argv.indexOf('--out')
-    const outPath = outFlagIndex === -1 ? null : process.argv[outFlagIndex + 1]
+    const outPath = outFlagIndex === -1 ? null : (process.argv[outFlagIndex + 1] ?? null)
+    if (outFlagIndex !== -1 && outPath === null) {
+        console.error('--out requires a file path')
+        process.exit(2)
+    }
 
     const benchmark = loadBenchmark()
     const transport = new StreamableHTTPClientTransport(new URL('/mcp', url), {

--- a/services/mcp/evals/runner/results.ts
+++ b/services/mcp/evals/runner/results.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure result types + aggregation for eval runs. Kept free of I/O so the
+ * scoring math is unit-testable — campaign keep/discard decisions ride on
+ * these numbers.
+ */
+
+export type ProbeStatus =
+    | 'ok'
+    | 'tool_error' // server answered with isError: true
+    | 'transport_error' // request failed or threw
+    | 'timeout'
+    | 'refused_not_read_only' // advertised annotations don't mark the tool read-only
+    | 'skipped_not_advertised'
+
+export interface ToolMiss {
+    task_id: string
+    tool: string
+}
+
+export interface ProbeResult {
+    task_id: string
+    tool: string
+    status: ProbeStatus
+    latency_ms?: number
+    error_snippet?: string
+}
+
+export interface ProbeRunSummary {
+    benchmark_version: number
+    tasks_total: number
+    tools_referenced: number
+    /** Referenced tools the server did not advertise — discoverability misses. */
+    tool_misses: ToolMiss[]
+    probes_total: number
+    probes_ok: number
+    probes_failed: number
+    latency_p50_ms: number | null
+    latency_p95_ms: number | null
+    probes: ProbeResult[]
+}
+
+export function percentile(sortedValues: number[], p: number): number | null {
+    if (sortedValues.length === 0) {
+        return null
+    }
+    const rank = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil((p / 100) * sortedValues.length) - 1))
+    return sortedValues[rank] ?? null
+}
+
+export function summarize(input: {
+    benchmarkVersion: number
+    tasksTotal: number
+    toolsReferenced: number
+    toolMisses: ToolMiss[]
+    probes: ProbeResult[]
+}): ProbeRunSummary {
+    const latencies = input.probes
+        .map((probe) => probe.latency_ms)
+        .filter((value): value is number => typeof value === 'number')
+        .sort((a, b) => a - b)
+    const ok = input.probes.filter((probe) => probe.status === 'ok').length
+
+    return {
+        benchmark_version: input.benchmarkVersion,
+        tasks_total: input.tasksTotal,
+        tools_referenced: input.toolsReferenced,
+        tool_misses: input.toolMisses,
+        probes_total: input.probes.length,
+        probes_ok: ok,
+        probes_failed: input.probes.length - ok,
+        latency_p50_ms: percentile(latencies, 50),
+        latency_p95_ms: percentile(latencies, 95),
+        probes: input.probes,
+    }
+}
+
+export function formatSummary(summary: ProbeRunSummary): string {
+    const lines = [
+        `benchmark v${summary.benchmark_version}: ${summary.tasks_total} tasks, ${summary.tools_referenced} referenced tools`,
+        `tool presence: ${summary.tool_misses.length === 0 ? 'all advertised' : `${summary.tool_misses.length} MISSING`}`,
+        ...summary.tool_misses.map((miss) => `  MISSING ${miss.tool} (task ${miss.task_id})`),
+        `probes: ${summary.probes_ok}/${summary.probes_total} ok` +
+            (summary.latency_p50_ms !== null
+                ? ` (p50 ${summary.latency_p50_ms}ms, p95 ${summary.latency_p95_ms}ms)`
+                : ''),
+        ...summary.probes
+            .filter((probe) => probe.status !== 'ok')
+            .map(
+                (probe) =>
+                    `  ${probe.status.toUpperCase()} ${probe.tool} (task ${probe.task_id})${probe.error_snippet ? `: ${probe.error_snippet}` : ''}`
+            ),
+    ]
+    return lines.join('\n')
+}

--- a/services/mcp/tests/evals/results.test.ts
+++ b/services/mcp/tests/evals/results.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { percentile, summarize, type ProbeResult } from '../../evals/runner/results'
+
+describe('eval result aggregation', () => {
+    it.each([
+        { values: [], p: 95, expected: null },
+        { values: [100], p: 50, expected: 100 },
+        { values: [100], p: 95, expected: 100 },
+        { values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], p: 50, expected: 5 },
+        { values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], p: 95, expected: 10 },
+        { values: [1, 2, 3, 4], p: 95, expected: 4 },
+    ])('percentile(p$p) of $values is $expected', ({ values, p, expected }) => {
+        expect(percentile(values, p)).toBe(expected)
+    })
+
+    it('counts every non-ok status as failed and keeps latency math to ok+errored calls only', () => {
+        const probes: ProbeResult[] = [
+            { task_id: 'a', tool: 't1', status: 'ok', latency_ms: 100 },
+            { task_id: 'b', tool: 't2', status: 'tool_error', latency_ms: 300 },
+            { task_id: 'c', tool: 't3', status: 'refused_not_read_only' },
+            { task_id: 'd', tool: 't4', status: 'skipped_not_advertised' },
+        ]
+
+        const summary = summarize({
+            benchmarkVersion: 0,
+            tasksTotal: 4,
+            toolsReferenced: 4,
+            toolMisses: [{ task_id: 'd', tool: 't4' }],
+            probes,
+        })
+
+        expect(summary.probes_total).toBe(4)
+        expect(summary.probes_ok).toBe(1)
+        expect(summary.probes_failed).toBe(3)
+        expect(summary.latency_p50_ms).toBe(100)
+        expect(summary.latency_p95_ms).toBe(300)
+        expect(summary.tool_misses).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
## Problem

The eval benchmark (#67947) defines what a competent agent should achieve against the MCP server, but nothing executes it. The improve-my-mcp campaign needs a deterministic, no-LLM scorer it can run before and after every proposed change.

## Changes

Stacks on #67947 (base branch; only the two runner commits are new here).

- `evals/runner/probe.ts` - connects an official MCP SDK client to a live server (`LIVE_MCP_URL`/`LIVE_MCP_TOKEN`), verifies every benchmark-referenced tool is advertised (misses = discoverability findings), executes each task's probe, and exits non-zero on any miss or failure so CI and the campaign can gate on it directly. Read-only is enforced from the live tool advertisement, not just the fixture - an annotation regression fails the probe instead of mutating data.
- `evals/runner/results.ts` - pure aggregation (status taxonomy, p50/p95, summary formatting), kept free of I/O so the scoring math is unit-testable.

## How did you test this code?

- `pnpm exec vitest run tests/evals/` - 11 passed. The new `results.test.ts` covers the percentile math (empty/single/boundary cases) and that every non-ok status counts as failed - the campaign's keep/discard decisions ride on these numbers and nothing else tests them.
- Package typecheck clean for the new files (`tsc --noEmit`).
- Not yet run against a live server in this PR; that's the local validation recipe documented in the README and exercised in the campaign follow-up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by Daniel. Skills invoked: /pr-slicing, /writing-tests, /get-stamp.
- Connection pattern reuses the existing integration-suite approach (`tests/integration/mcp-protocol-suite.ts`), so no new dependencies were added.
- One gotcha worth knowing: the lint-staged oxlint autofix strips `console.log` on commit, which silently deleted the runner's summary output - switched to `process.stdout.write` since the summary is the program's output, not debug logging.
