### PR TITLE
chore(insights): fix "wether" typo in comments

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -160,7 +160,7 @@ function InsightCardInternal(
     const { ref: inViewRef, inView } = useInView({ rootMargin: '500px' })
     const { isVisible: isPageVisible } = usePageVisibility()
 
-    /** Wether the page is active and the line graph is currently in view. Used to free resources, by not rendering
+    /** Whether the page is active and the line graph is currently in view. Used to free resources, by not rendering
      * insight cards that aren't visible. See also https://wiki.whatwg.org/wiki/Canvas_Context_Loss_and_Restoration.
      *
      * We add an extra check to make sure all insights are visible in Storybook.

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -1033,7 +1033,7 @@ export function setLatestVersionsOnQuery<T = any>(node: T, options?: { recursion
     return cloned as T
 }
 
-/** Checks wether a given query node satisfies all latest versions of the query schema. */
+/** Checks whether a given query node satisfies all latest versions of the query schema. */
 export function checkLatestVersionsOnQuery(node: any): boolean {
     if (node === null || typeof node !== 'object') {
         return true

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -358,7 +358,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     return []
                 }
 
-                // we need to check wether results are an array, since isTimeToConvertFunnel can be false,
+                // we need to check whether results are an array, since isTimeToConvertFunnel can be false,
                 // while still having "time-to-convert" results in insightData
                 if (!isTimeToConvertFunnel && Array.isArray(results) && results.length > 0) {
                     // STEPS compare: the runner returns both periods' steps as a flat tagged list.

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -608,7 +608,7 @@ export function getTrendDatasetPosition(dataset: IndexedTrendResult): number {
     return dataset.seriesIndex ?? dataset.colorIndex ?? ((dataset as any).index as number)
 }
 
-/** Type guard to determine wether we have a FunnelStepWithConversionMetrics or a FlattenedFunnelStepByBreakdown */
+/** Type guard to determine whether we have a FunnelStepWithConversionMetrics or a FlattenedFunnelStepByBreakdown */
 function isFunnelStepWithConversionMetrics(
     dataset: FlattenedFunnelStepByBreakdown | FunnelStepWithConversionMetrics
 ): dataset is FunnelStepWithConversionMetrics {

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -200,7 +200,7 @@ type CommonFiltersType = {
     [K in CommonFiltersTypeKeys]: FilterType[K]
 }
 
-/** Heuristic for determining wether this is a new insight, usually set by url.
+/** Heuristic for determining whether this is a new insight, usually set by url.
  * In the most basic case something like `/insights/new?insight=TRENDS`. */
 const isNewInsight = (filters: Partial<AnyFilterType>): boolean => {
     if (Object.keys(filters).length === 0) {

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -53,7 +53,7 @@ export function FunnelStepsTable(): JSX.Element | null {
 
     /** :HACKY: We don't want to allow changing of colors in experiments (they can't be
     saved there). Therefore we use the `disable_baseline` prop on the cached insight passed
-    in by experiments as a measure of detecting wether we are in an experiment context.
+    in by experiments as a measure of detecting whether we are in an experiment context.
     Likely this can be done in a better way once experiments are re-written to use their own
     queries. */
     const showCustomizationIcon = !insightProps.cachedInsight?.disable_baseline


### PR DESCRIPTION
## Problem

Six comments across the insights, funnels, and query code misspell "whether" as "wether" (a wether is a castrated ram, not a conditional). Small thing, but it hurts readability and code search.

## Changes

Corrected "wether" to "whether" in six code comments. Comments only, no runtime behavior touched.

- `frontend/src/scenes/insights/utils.tsx`
- `frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx`
- `frontend/src/scenes/insights/utils/cleanFilters.ts`
- `frontend/src/scenes/funnels/funnelDataLogic.ts`
- `frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx`
- `frontend/src/queries/utils.ts`

## How did you test this code?

No tests needed. The change is limited to comment text, so runtime behavior is unchanged. lint-staged ran the JS formatter on the touched files at commit time.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (PostHog Code, running Claude) to sweep out a batch of small, safe cleanups. I found the misspellings with a targeted `rg` search for common typos and confirmed each hit was a plain comment before editing. No skills were needed since nothing here touches serializers, migrations, or API types.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
