### PR TITLE
chore(mcp-analytics): add improving-mcp-tools campaign skill

### DIFF
--- a/products/mcp_analytics/skills/improving-mcp-tools/SKILL.md
+++ b/products/mcp_analytics/skills/improving-mcp-tools/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: improving-mcp-tools
+description: >
+  Run an improve-my-MCP campaign: an autoresearch-style loop that measures the
+  MCP agent experience with the eval harness, picks the highest-impact tool
+  problem from production data, makes one bounded fix, and keeps it only if
+  before/after scores improve. Use when asked to "improve my MCP", run an MCP
+  improvement campaign, fix tool discoverability or descriptions based on
+  evidence, or prepare an eval-backed PR for a tool change. Every shipped
+  change must carry eval evidence; guardrails below are hard rules.
+---
+
+# Improving MCP tools
+
+An MCP server gets better only in ways you can measure. This skill is the
+campaign procedure: score the current agent experience, fix the biggest
+problem, re-score, and only ship changes the numbers justify. It is the
+operating manual for the "improve my MCP" loop — one iteration per pass,
+journaled so a later iteration (or a different agent) can resume without
+repeating work.
+
+## The objective function
+
+`services/mcp/evals/` is the harness. `benchmark/tasks.yaml` is a fixed set of
+agent tasks with `expected_tools` and `success_criteria`; scores are only
+comparable across runs of the same benchmark `version`.
+
+- **Probe mode** (deterministic, no LLM):
+  `LIVE_MCP_URL=... LIVE_MCP_TOKEN=... pnpm exec tsx evals/runner/probe.ts --out score.json`
+  from `services/mcp/`. Reports tool-presence misses (discoverability), probe
+  failures, and latency p50/p95. Non-zero exit = regression.
+- **Agent mode** (LLM replay + judge): scores task success and tool-selection
+  accuracy. Use it for description/discoverability changes — probes cannot
+  detect that an agent picks the wrong tool.
+
+Run the harness against a **seeded local or devbox stack**, never against a
+customer project. Local recipe: `NODE_ENV=development PORT=9876
+POSTHOG_API_BASE_URL=http://localhost:8000 pnpm dev:hono`, personal API key as
+`LIVE_MCP_TOKEN`.
+
+## One iteration
+
+1. **Measure.** Run the harness for a baseline. Pull production evidence with
+   the MCP analytics tools (`query-mcp-tool-stats`, `query-mcp-tool-failures`,
+   `query-mcp-tool-descriptions`, `query-mcp-tool-sample-intents`) and the
+   lenses in the signals scout cookbook
+   (`products/signals/skills/signals-scout-mcp-tool-calls/references/queries.md`):
+   failure leaderboard, retry/struggle, latency, intents that matched no tool.
+2. **Pick one issue.** Rank by reach × severity. Skip anything the journal
+   shows with two failed attempts. One issue per iteration — a PR that fixes
+   three things can't be attributed to any of them when scores move.
+3. **Fix, bounded.** Only files inside the allowlist (below). Typical fixes:
+   sharpen a tool description so the right intent finds it, tighten an input
+   schema that agents keep getting wrong, fix an annotation, update a skill.
+4. **Validate.** Re-run the affected benchmark slice plus a no-regression
+   sample. Keep the change only if the target metric improves and nothing else
+   degrades. A discarded change is a normal outcome — journal it and move on.
+5. **Ship.** One PR per iteration with before/after scores in the body (format
+   in [references/campaign-journal.md](references/campaign-journal.md)). Keep
+   it stampable: ≤400 changed lines, no deny-listed files, apply the
+   `stamphog` label. Autonomy level comes from the campaign config — default
+   is **draft PR for human review**; only arm auto-merge when the operator has
+   explicitly enabled the self-driving experiment (see guardrails).
+6. **Journal.** Append the iteration record before ending the pass.
+
+## Hard guardrails
+
+These are not suggestions; violating any of them ends the campaign pass.
+
+- **Allowlist** — a campaign PR may only touch: `products/*/mcp/tools.yaml`,
+  `products/*/skills/**`, `services/mcp/evals/**`, regenerated tool files
+  produced by the standard codegen, and docs. Anything else (handler code,
+  package manifests, workflows, migrations, auth paths) → stop and hand the
+  finding to a human as a draft PR or report instead.
+- **Read-only against data.** The harness and all production queries are
+  read-only. Never create, mutate, or delete customer-visible objects while
+  measuring.
+- **Evidence or it didn't happen.** No PR without a baseline score, an after
+  score, and the exact harness commands used.
+- **Benchmark integrity.** Never edit `benchmark/tasks.yaml` in the same PR as
+  a fix it validates — changing the exam and the answer together proves
+  nothing. Benchmark changes are their own PR and bump `version`.
+- **Budgets.** Respect the operator's iteration/token/PR caps (default: stop
+  after 3 open unmerged campaign PRs). Two failed attempts on an issue parks
+  it permanently.
+- **Kill switch.** If the campaign config, its feature flag, or the operator
+  says stop — stop mid-iteration, journal state, end cleanly.
+
+## Failure modes to expect
+
+- A description change that helps one intent can steal traffic from the right
+  tool for another — that's why the no-regression sample is mandatory.
+- Probe latency varies with stack warmth; compare medians across ≥3 runs
+  before attributing a latency change to your fix.
+- Tool-presence misses can be feature-flag gating, not catalog absence —
+  check `getToolsForFeatures` gating before "fixing" discoverability.

--- a/products/mcp_analytics/skills/improving-mcp-tools/SKILL.md
+++ b/products/mcp_analytics/skills/improving-mcp-tools/SKILL.md
@@ -57,10 +57,11 @@ POSTHOG_API_BASE_URL=http://localhost:8000 pnpm dev:hono`, personal API key as
    degrades. A discarded change is a normal outcome — journal it and move on.
 5. **Ship.** One PR per iteration with before/after scores in the body (format
    in [references/campaign-journal.md](references/campaign-journal.md)). Keep
-   it stampable: ≤400 changed lines, no deny-listed files, apply the
-   `stamphog` label. Autonomy level comes from the campaign config — default
-   is **draft PR for human review**; only arm auto-merge when the operator has
-   explicitly enabled the self-driving experiment (see guardrails).
+   it stampable: ≤400 changed lines, only files inside the allowlist below,
+   apply the `stamphog` label. Autonomy level comes from the campaign config —
+   default is **draft PR for human review**; only arm auto-merge when the
+   operator has explicitly enabled the self-driving experiment (see
+   guardrails).
 6. **Journal.** Append the iteration record before ending the pass.
 
 ## Hard guardrails
@@ -68,10 +69,12 @@ POSTHOG_API_BASE_URL=http://localhost:8000 pnpm dev:hono`, personal API key as
 These are not suggestions; violating any of them ends the campaign pass.
 
 - **Allowlist** — a campaign PR may only touch: `products/*/mcp/tools.yaml`,
-  `products/*/skills/**`, `services/mcp/evals/**`, regenerated tool files
-  produced by the standard codegen, and docs. Anything else (handler code,
-  package manifests, workflows, migrations, auth paths) → stop and hand the
-  finding to a human as a draft PR or report instead.
+  `products/*/skills/**`, `services/mcp/evals/**`, the codegen outputs of
+  `pnpm generate-tools` / `scaffold-yaml` (`services/mcp/src/tools/generated/**`
+  and `services/mcp/schema/generated-tool-definitions.json`), and docs.
+  Anything else (handler code, package manifests, workflows, migrations, auth
+  paths) → stop and hand the finding to a human as a draft PR or report
+  instead.
 - **Read-only against data.** The harness and all production queries are
   read-only. Never create, mutate, or delete customer-visible objects while
   measuring.

--- a/products/mcp_analytics/skills/improving-mcp-tools/references/campaign-journal.md
+++ b/products/mcp_analytics/skills/improving-mcp-tools/references/campaign-journal.md
@@ -1,0 +1,57 @@
+# Campaign journal and PR evidence format
+
+The journal is the campaign's memory. It lives wherever the campaign runner
+persists state (a task artefact, a repo-side `campaign-journal.md` on the
+campaign branch, or the operator's chosen store) — the format is what matters,
+because a later iteration or a different agent must be able to resume from it
+without repeating attempted work.
+
+## Iteration record
+
+Append one block per iteration, including discarded ones:
+
+```markdown
+## Iteration 7 — 2026-07-02T14:05Z
+
+issue: execute-sql schema confusion — agents pass `sql` instead of `query` (reach: 86k failed calls/30d)
+source: query-mcp-tool-failures + benchmark task sql-daily-event-volume
+attempt: clarified input description in products/data_warehouse/mcp/tools.yaml (execute-sql.query)
+baseline: probes 24/26 ok, p95 2100ms; agent-mode task success 19/27, tool-selection 22/27
+after: probes 26/26 ok, p95 2050ms; agent-mode task success 22/27, tool-selection 25/27
+verdict: KEEP → PR #67991 (stamphog)
+```
+
+Discarded example:
+
+```markdown
+## Iteration 8 — 2026-07-02T15:12Z
+
+issue: query-funnel discoverability for "conversion" intents
+attempt: description rewrite emphasizing conversion phrasing
+after: tool-selection unchanged (22/27), task success -1
+verdict: DISCARD (no improvement; attempt 1 of 2)
+```
+
+## Parked issues
+
+Maintain a `parked` list at the top of the journal: issue key + why (two
+failed attempts, needs handler code, needs human decision). Never re-pick a
+parked issue.
+
+## PR evidence block
+
+Every campaign PR body must contain this section, verbatim numbers from the
+harness:
+
+```markdown
+## Eval evidence
+
+- Benchmark: v0 (27 tasks), harness at <commit>
+- Baseline: `<exact command>` → probes 24/26 ok, p95 2100ms, task success 19/27
+- After: same command → probes 26/26 ok, p95 2050ms, task success 22/27
+- No-regression sample: tasks <ids>, unchanged
+- Journal: iteration 7
+```
+
+A PR without this block is not a campaign PR and must not carry the campaign
+label.


### PR DESCRIPTION
## Problem

The improve-my-MCP campaign (an autoresearch-style loop: measure the MCP agent experience, fix one thing, re-measure, keep only what improves) needs an operating manual an agent can follow. Without a skill encoding the procedure and its guardrails, every campaign run reinvents the loop - and the guardrails live nowhere.

## Changes

New skill `products/mcp_analytics/skills/improving-mcp-tools/`:

- `SKILL.md` - the campaign procedure: objective function (the eval harness from #67947/#67949), the one-issue-per-iteration loop, and the hard guardrails: file allowlist, read-only measurement, eval evidence required on every PR, never changing the benchmark and a fix in the same PR, budgets, and the kill switch. Default autonomy is draft-PR-for-human; auto-merge only when the operator has explicitly armed the self-driving experiment.
- `references/campaign-journal.md` - the journal format (iteration records including discards, parked issues) and the PR evidence block every campaign PR must carry.

Pairs with #67947 (benchmark) and #67949 (probe runner); references their paths but has no code dependency.

## How did you test this code?

`hogli lint:skills` - 102 skills pass (the one advisory warning is pre-existing in signals). Markdown only; no runtime code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by Daniel. Skills invoked: /writing-skills, /pr-slicing, /get-stamp.
- Named `improving-mcp-tools` (gerund convention, consistent with the product's `exploring-mcp-*` skills) rather than the "improve-my-mcp" toggle branding.
- The guardrails section deliberately encodes the one-human-in-the-loop default; flipping to auto-merge is an operator decision outside this skill, so the skill stays true under both autonomy levels.
