### PR TITLE
chore(query): fix "wether" typo in query schema descriptions

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5618,7 +5618,7 @@
                     "type": "string"
                 },
                 "hasMore": {
-                    "description": "Wether more breakdown values are available.",
+                    "description": "Whether more breakdown values are available.",
                     "type": "boolean"
                 },
                 "hogql": {
@@ -11472,7 +11472,7 @@
                     "type": "string"
                 },
                 "hasMore": {
-                    "description": "Wether more breakdown values are available.",
+                    "description": "Whether more breakdown values are available.",
                     "type": "boolean"
                 },
                 "hogql": {
@@ -12611,7 +12611,7 @@
                     "type": "string"
                 },
                 "hasMore": {
-                    "description": "Wether more breakdown values are available.",
+                    "description": "Whether more breakdown values are available.",
                     "type": "boolean"
                 },
                 "hogql": {
@@ -37208,7 +37208,7 @@
                             "type": "string"
                         },
                         "hasMore": {
-                            "description": "Wether more breakdown values are available.",
+                            "description": "Whether more breakdown values are available.",
                             "type": "boolean"
                         },
                         "hogql": {
@@ -46246,7 +46246,7 @@
                 "resultCustomizationBy": {
                     "$ref": "#/definitions/ResultCustomizationBy",
                     "default": "value",
-                    "description": "Wether result datasets are associated by their values or by their order."
+                    "description": "Whether result datasets are associated by their values or by their order."
                 },
                 "resultCustomizations": {
                     "anyOf": [
@@ -46553,7 +46553,7 @@
                     "type": "string"
                 },
                 "hasMore": {
-                    "description": "Wether more breakdown values are available.",
+                    "description": "Whether more breakdown values are available.",
                     "type": "boolean"
                 },
                 "hogql": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1515,7 +1515,7 @@ export type TrendsFilter = {
     showMultipleYAxes?: TrendsFilterLegacy['show_multiple_y_axes']
     hiddenLegendIndexes?: integer[]
     /**
-     * Wether result datasets are associated by their values or by their order.
+     * Whether result datasets are associated by their values or by their order.
      * @default value
      **/
     resultCustomizationBy?: ResultCustomizationBy
@@ -1615,7 +1615,7 @@ export interface BoxPlotDatum {
 
 export interface TrendsQueryResponse extends AnalyticsQueryResponseBase {
     results: Record<string, any>[]
-    /** Wether more breakdown values are available. */
+    /** Whether more breakdown values are available. */
     hasMore?: boolean
     /** @deprecated Box plot data is now returned in results. This field is no longer populated. */
     boxplot_data?: BoxPlotDatum[]
@@ -1665,7 +1665,7 @@ export interface TrendsQuery extends InsightsQueryBase<TrendsQueryResponse> {
 
 export interface CalendarHeatmapResponse extends AnalyticsQueryResponseBase {
     results: EventsHeatMapStructuredResult
-    /** Wether more breakdown values are available. */
+    /** Whether more breakdown values are available. */
     hasMore?: boolean
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8017,7 +8017,7 @@ class TrendsFilter(BaseModel):
     movingAverageIntervals: float | None = None
     resultCustomizationBy: ResultCustomizationBy | None = Field(
         default=ResultCustomizationBy.VALUE,
-        description=("Wether result datasets are associated by their values or by their order."),
+        description=("Whether result datasets are associated by their values or by their order."),
     )
     resultCustomizations: dict[str, ResultCustomizationByValue] | dict[str, ResultCustomizationByPosition] | None = (
         Field(
@@ -8059,7 +8059,7 @@ class TrendsQueryResponse(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
+    hasMore: bool | None = Field(default=None, description="Whether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
@@ -10291,7 +10291,7 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
+    hasMore: bool | None = Field(default=None, description="Whether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
     last_refresh: AwareDatetime
@@ -13070,7 +13070,7 @@ class CachedTrendsQueryResponse(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
+    hasMore: bool | None = Field(default=None, description="Whether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
     last_refresh: AwareDatetime
@@ -13615,7 +13615,7 @@ class CalendarHeatmapResponse(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
+    hasMore: bool | None = Field(default=None, description="Whether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
@@ -20069,7 +20069,7 @@ class QueryResponseAlternative67(BaseModel):
             "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
         ),
     )
-    hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
+    hasMore: bool | None = Field(default=None, description="Whether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1490,7 +1490,7 @@ export interface TrendsQueryResponseApi {
     boxplot_data?: BoxPlotDatumApi[] | null
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
     error?: string | null
-    /** Wether more breakdown values are available. */
+    /** Whether more breakdown values are available. */
     hasMore?: boolean | null
     /** Generated HogQL query. */
     hogql?: string | null
@@ -2282,7 +2282,7 @@ export interface TrendsFilterApi {
     metricSummary?: MetricSummaryApi | null
     minDecimalPlaces?: number | null
     movingAverageIntervals?: number | null
-    /** Wether result datasets are associated by their values or by their order. */
+    /** Whether result datasets are associated by their values or by their order. */
     resultCustomizationBy?: ResultCustomizationByApi | null
     /** Customizations for the appearance of result datasets. */
     resultCustomizations?: TrendsFilterApiResultCustomizations

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -827,7 +827,7 @@ export interface TrendsQueryResponseApi {
     boxplot_data?: BoxPlotDatumApi[] | null
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
     error?: string | null
-    /** Wether more breakdown values are available. */
+    /** Whether more breakdown values are available. */
     hasMore?: boolean | null
     /** Generated HogQL query. */
     hogql?: string | null
@@ -1619,7 +1619,7 @@ export interface TrendsFilterApi {
     metricSummary?: MetricSummaryApi | null
     minDecimalPlaces?: number | null
     movingAverageIntervals?: number | null
-    /** Wether result datasets are associated by their values or by their order. */
+    /** Whether result datasets are associated by their values or by their order. */
     resultCustomizationBy?: ResultCustomizationByApi | null
     /** Customizations for the appearance of result datasets. */
     resultCustomizations?: TrendsFilterApiResultCustomizations

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2199,7 +2199,7 @@ export namespace Schemas {
       boxplot_data?: BoxPlotDatum[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
-      /** Wether more breakdown values are available. */
+      /** Whether more breakdown values are available. */
       hasMore?: boolean | null;
       /** Generated HogQL query. */
       hogql?: string | null;
@@ -2495,7 +2495,7 @@ export namespace Schemas {
       metricSummary?: MetricSummary | null;
       minDecimalPlaces?: number | null;
       movingAverageIntervals?: number | null;
-      /** Wether result datasets are associated by their values or by their order. */
+      /** Whether result datasets are associated by their values or by their order. */
       resultCustomizationBy?: ResultCustomizationBy | null;
       /** Customizations for the appearance of result datasets. */
       resultCustomizations?: TrendsFilterResultCustomizations;
@@ -12005,7 +12005,7 @@ export namespace Schemas {
     export interface CalendarHeatmapResponse {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
-      /** Wether more breakdown values are available. */
+      /** Whether more breakdown values are available. */
       hasMore?: boolean | null;
       /** Generated HogQL query. */
       hogql?: string | null;
@@ -46399,7 +46399,7 @@ export namespace Schemas {
       boxplot_data?: BoxPlotDatum[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
-      /** Wether more breakdown values are available. */
+      /** Whether more breakdown values are available. */
       hasMore?: boolean | null;
       /** Generated HogQL query. */
       hogql?: string | null;


### PR DESCRIPTION
## Problem

Several query response schema fields describe themselves as "Wether more breakdown values are available" and "Wether result datasets are associated...". These descriptions are not internal comments. They flow into the generated frontend types, the OpenAPI spec, and the MCP tool schemas, so the typo is visible to anyone reading our API types or tool definitions.

## Changes

Fixed "Wether" to "Whether" at the source in `frontend/src/queries/schema/schema-general.ts` (`TrendsQueryResponse.hasMore`, `CalendarHeatmapResponse.hasMore`, and the result-customization-by description), then regenerated the downstream artifacts:

- `frontend/src/queries/schema.json` and `posthog/schema.py` via `hogli build:schema`
- `products/product_analytics/frontend/generated/api.schemas.ts`, `products/dashboards/frontend/generated/api.schemas.ts`, and `services/mcp/src/api/generated.ts` via `hogli build:openapi`

Every changed line is the same one-word description fix. No field names, types, or behavior change.

## How did you test this code?

I (PostHog Code, running Claude) ran `hogli build:schema` and `hogli build:openapi` and confirmed the full diff contains only the "Wether" to "Whether" description change with no unrelated regeneration drift. The pre-commit hook ran ruff, the Python formatter, and `ty check` on the touched Python file without errors. No runtime behavior is affected, so no functional tests were needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No standalone docs, but the corrected text is the API/type documentation itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me to sweep small, safe cleanups. I found this one via an `rg` typo search, traced the generated `schema.py` occurrences back to their source in `schema-general.ts`, fixed the source, and regenerated rather than hand-editing generated files. I verified the regen was deterministic and scoped to just the description strings before committing. No repo skills were required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
