### PR TITLE
chore(query): fix spelling typos in hogql_queries comments

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -96,7 +96,7 @@ def unwrap_cohort(filter: Filter, team_id: int, team: Optional[Team] = None, coh
         if len(property_group.values):
             if isinstance(property_group.values[0], PropertyGroup):
                 # dealing with a list of property groups, so unwrap each one
-                # Propogate the negation to the children and handle as necessary with respect to deMorgan's law
+                # Propagate the negation to the children and handle as necessary with respect to deMorgan's law
                 if not negate_group:
                     return PropertyGroup(
                         type=property_group.type,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -97,7 +97,7 @@ class TestFunnelUnorderedStepsBreakdown(
     maxDiff = None
 
     def test_funnel_step_breakdown_event_single_person_events_with_multiple_properties(self):
-        # overriden from factory
+        # overridden from factory
 
         query = unordered_funnels_query(
             series=[

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -2214,7 +2214,7 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
         )
 
-        # date range is overriden
+        # date range is overridden
         assert query_runner.query.dateRange is not None
         assert query_runner.query.dateRange.date_from == "2024-07-07"
         assert query_runner.query.dateRange.date_to == "2024-07-14"

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -506,7 +506,7 @@ class TestTrendsDashboardFilters(BaseTest):
             )
         )
 
-        # date range is overriden
+        # date range is overridden
         assert query_runner.query.dateRange is not None
         assert query_runner.query.dateRange.date_from == "2024-07-07"
         assert query_runner.query.dateRange.date_to == "2024-07-14"

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -438,7 +438,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                 [j.start() for j in jobs]  # type:ignore
                 [j.join() for j in jobs]  # type:ignore
 
-        # Raise any errors raised in a seperate thread
+        # Raise any errors raised in a separate thread
         if len(errors) > 0:
             raise errors[0]
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1326,7 +1326,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         self.__post_init__()
 
     def __post_init__(self):
-        """Called after init, can by overriden by subclasses. Should be idempotent. Also called after dashboard overrides are set."""
+        """Called after init, can be overridden by subclasses. Should be idempotent. Also called after dashboard overrides are set."""
         pass
 
     def _on_user_changed(self) -> None:


### PR DESCRIPTION
## Problem

A handful of comments and one docstring under `posthog/hogql_queries/` carry small spelling mistakes: "overriden", "seperate", "Propogate", plus a "can by" that should read "can be". They hurt readability and code search.

## Changes

Corrected the typos. Comments and a docstring only, no logic touched.

- `query_runner.py` - "can by overriden" to "can be overridden" in the `_refresh_frequency` docstring
- `hogql_cohort_query.py` - "Propogate" to "Propagate"
- `insights/trends/trends_query_runner.py` - "seperate" to "separate"
- three test comments - "overriden" to "overridden"

## How did you test this code?

No tests needed. Only comment and docstring text changed, so runtime behavior is unchanged. The pre-commit hook ran ruff and `ty check` on the six files without errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (PostHog Code, running Claude) for a batch of small, safe cleanups. Found via an `rg` typo search, scoped to a single directory so the change stays coherent. No repo skills required (comment-only test edits are exempt from the test-writing gate).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
