### PR TITLE
chore(error-tracking): fix "overriden" typo in log and comment

### DIFF
--- a/posthog/management/commands/sync_exceptions_to_clickhouse.py
+++ b/posthog/management/commands/sync_exceptions_to_clickhouse.py
@@ -110,6 +110,6 @@ class Command(BaseCommand):
                 logger.info("fingerprint not found")
                 not_found_fingerprints.append(fingerprint["fingerprint"])
 
-        logger.info(f"fingerprint overriden {found_issues_count}")
+        logger.info(f"fingerprint overridden {found_issues_count}")
         logger.info(f"fingerprints not found {not_found_fingerprints}")
         flush_all_producers(5 * 60)

--- a/rust/cymbal/src/core/types/langs/js.rs
+++ b/rust/cymbal/src/core/types/langs/js.rs
@@ -221,7 +221,7 @@ impl From<(&RawJSFrame, SourceLocation<'_>, usize)> for Frame {
         let suspicious = source.as_ref().is_some_and(|s| s.contains("posthog-js@"));
 
         let mut res = Self {
-            frame_id: FrameId::placeholder(), // We use placeholders here, as they're overriden at the RawFrame level
+            frame_id: FrameId::placeholder(), // We use placeholders here, as they're overridden at the RawFrame level
             mangled_name: raw_frame.fn_name.clone(),
             line: Some(token.line()),
             column: Some(token.column()),


### PR DESCRIPTION
## Problem

The exceptions-to-ClickHouse sync command logs "fingerprint overriden ...", and a cymbal frame carries the same misspelling in a comment. The log line in particular is worth fixing since it shows up in real output where the typo is visible.

## Changes

Corrected "overriden" to "overridden" in two spots:

- `posthog/management/commands/sync_exceptions_to_clickhouse.py` - the `logger.info` message
- `rust/cymbal/src/core/types/langs/js.rs` - a frame-id placeholder comment

## How did you test this code?

No tests needed. One log-string literal and one comment changed, so behavior is unchanged. The pre-commit hook ran ruff and `ty check` on the Python file without errors. I did not build the Rust crate since the change is a comment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (PostHog Code, running Claude) for a batch of small, safe cleanups. Grouped these two by product area (error tracking). Found via an `rg` typo search. No repo skills required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
