### PR TITLE
chore(data-warehouse): fix typos in test docstrings and a comment

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
@@ -277,7 +277,7 @@ def test_nested_to_config_with_flat_dict_default_prefix():
 
 
 def test_to_config_override_alias():
-    """Test `config.to_config` with overriden lookup names.
+    """Test `config.to_config` with overridden lookup names.
 
     Lookup names in the flat dictionary can be specified when using
     `config.value`.
@@ -304,8 +304,8 @@ def test_to_config_override_alias():
 
 
 def test_to_config_override_alias_fallback():
-    """Test `config.to_config` with overriden lookup names but
-    fallback to the original name if the alias key os missing.
+    """Test `config.to_config` with overridden lookup names but
+    fallback to the original name if the alias key is missing.
 
     Lookup names in the flat dictionary can be specified when using
     `config.value`.

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -127,7 +127,7 @@ pub struct Job {
 
     // The job maintains a copy of the job state, outside of the model,
     // because process in a pipelined fashion, and to do that we need to
-    // seperate "in-memory job state" from "database job state"
+    // separate "in-memory job state" from "database job state"
     pub state: Mutex<JobState>,
     // We also maintain a copy of the model. This and the above are wrapped in a mutex
     // because we simultaneously modify both, modifying our in-memory state when we


### PR DESCRIPTION
## Problem

The warehouse source config test docstrings say "overriden lookup names" and "if the alias key os missing", and a batch-import-worker comment says "seperate". Small readability nits.

## Changes

- `products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py` - "overriden" to "overridden" (two docstrings) and "os missing" to "is missing"
- `rust/batch-import-worker/src/job/mod.rs` - "seperate" to "separate" in a comment

## How did you test this code?

No tests needed. Only test docstrings and a comment changed, so behavior is unchanged. The pre-commit hook ran ruff and `ty check` on the Python file without errors. I did not build the Rust crate since the change is a comment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (PostHog Code, running Claude) for a batch of small, safe cleanups. Grouped by area (data warehouse / ingestion). Found via an `rg` typo search; noticed the adjacent "os missing" typo while reading the docstring and fixed it in the same pass. Comment-only test edits are exempt from the test-writing gate, so no repo skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
