### PR TITLE
feat(infra): factory-level sse killswitch for every streaming endpoint

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -604,6 +604,7 @@ class ConversationViewSet(
             if settings.SERVER_GATEWAY_INTERFACE == "ASGI"
             else async_to_sync(lambda: async_stream(workflow_inputs)),
             endpoint="max_conversation",
+            killswitch_flag="max-ai-sse-killswitch",
         )
 
     @action(detail=True, methods=["GET", "POST"], url_path="queue")

--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -603,6 +603,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         return sse_streaming_response(
             async_stream() if settings.SERVER_GATEWAY_INTERFACE == "ASGI" else async_generator_to_sync(async_stream),
             endpoint="session_summaries",
+            killswitch_flag="session-summaries-sse-killswitch",
         )
 
     @extend_schema(

--- a/ee/hogai/sandbox/executor.py
+++ b/ee/hogai/sandbox/executor.py
@@ -16,7 +16,7 @@ from rest_framework import exceptions
 
 from posthog.schema import AssistantEventType, AssistantMessage, HumanMessage
 
-from posthog.api.streaming import sse_streaming_response
+from posthog.api.streaming import sse_killswitch_rejection, sse_streaming_response
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.temporal.common.client import sync_connect
@@ -57,6 +57,13 @@ def handle_sandbox_message(
     """Handle a sandbox-mode message: create/resume a task run and stream events back."""
     if not settings.DEBUG and not has_sandbox_mode_feature_flag(team, user):
         raise exceptions.PermissionDenied("Sandbox mode is not enabled for this user.")
+
+    # Everything below has side effects (conversation writes, task runs,
+    # Temporal workflow launches), so the killswitch must answer first; the
+    # copy inside sse_streaming_response would fire only after that work ran.
+    rejection = sse_killswitch_rejection("sandbox_execute", "sandbox-sse-killswitch")
+    if rejection is not None:
+        return rejection
 
     if is_new_conversation:
         conversation.title = content[:80]
@@ -192,6 +199,7 @@ def _make_streaming_response(
         if settings.SERVER_GATEWAY_INTERFACE == "ASGI"
         else async_to_sync(async_generator_factory),
         endpoint="sandbox_execute",
+        killswitch_flag="sandbox-sse-killswitch",
     )
 
 

--- a/ee/hogai/test/test_sandbox_executor.py
+++ b/ee/hogai/test/test_sandbox_executor.py
@@ -1,0 +1,38 @@
+from unittest import mock
+
+from django.test import override_settings
+
+from ee.hogai.sandbox.executor import handle_sandbox_message
+
+
+class TestSandboxKillswitch:
+    @override_settings(DEBUG=False)
+    def test_killswitch_answers_before_any_side_effect(self):
+        # Everything past the killswitch launches work (conversation writes,
+        # task runs, Temporal workflows). If the check drifts back after those,
+        # a kill only discards the response while callers keep triggering the
+        # work on every reconnect.
+        conversation = mock.Mock()
+        with (
+            mock.patch("ee.hogai.sandbox.executor.has_sandbox_mode_feature_flag", return_value=True),
+            mock.patch(
+                "posthog.api.streaming.posthoganalytics.feature_enabled",
+                side_effect=lambda flag, *args, **kwargs: flag == "sandbox-sse-killswitch",
+            ),
+            mock.patch("ee.hogai.sandbox.executor.get_sandbox_mapping") as get_mapping,
+            mock.patch("ee.hogai.sandbox.executor.tasks_facade") as facade,
+            mock.patch("ee.hogai.sandbox.executor.execute_task_processing_workflow") as workflow,
+        ):
+            response = handle_sandbox_message(
+                conversation=conversation,
+                conversation_id="cid",
+                content="hello",
+                user=mock.Mock(),
+                team=mock.Mock(),
+                is_new_conversation=True,
+            )
+        assert response.status_code == 204
+        conversation.save.assert_not_called()
+        get_mapping.assert_not_called()
+        facade.create_run.assert_not_called()
+        workflow.assert_not_called()

--- a/posthog/api/streaming.py
+++ b/posthog/api/streaming.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db import connections
 from django.http import HttpResponse, StreamingHttpResponse
 
+import posthoganalytics
 from prometheus_client import Counter, Gauge, Histogram
 
 # What StreamingHttpResponse actually accepts: sync or async iterables of bytes or
@@ -88,6 +89,53 @@ def _record_stream_close(endpoint: str, outcome: str, started_at: float) -> None
     SSE_OPEN_CONNECTIONS_GAUGE.labels(endpoint=endpoint).dec()
     SSE_STREAM_CLOSED_COUNTER.labels(endpoint=endpoint, outcome=outcome).inc()
     SSE_STREAM_DURATION_HISTOGRAM.labels(endpoint=endpoint).observe(time.monotonic() - started_at)
+
+
+SSE_KILLSWITCH_REJECTED_COUNTER = Counter(
+    "posthog_sse_killswitch_rejected_total",
+    "SSE streams answered with 204 because the endpoint's killswitch flag is on",
+    labelnames=["endpoint"],
+)
+
+
+def _killswitch_enabled(flag: str, distinct_id: str) -> bool:
+    """Evaluate an SSE killswitch flag locally, failing open.
+
+    Local-only evaluation: no per-request decide call on a hot endpoint (flag
+    definitions are served via HyperCache). Killswitches are meant to be
+    all-or-nothing flags, so the distinct_id rarely matters; it is accepted so
+    endpoints can pass their user for partial rollouts of a kill.
+    """
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                flag,
+                distinct_id,
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        return False
+
+
+def sse_killswitch_rejection(
+    endpoint: str,
+    flag: str,
+    distinct_id: str = "sse-killswitch",
+) -> HttpResponse | None:
+    """Return the killswitch 204 when ``flag`` is on, else ``None``.
+
+    ``sse_streaming_response`` already applies the killswitch, but only at
+    response-construction time. Views that do side-effecting work before
+    building their stream (launching a workflow, invoking an upstream service)
+    must call this first, or a kill only discards the response while the work
+    keeps happening on every reconnect.
+    """
+    if _killswitch_enabled(flag, distinct_id):
+        SSE_KILLSWITCH_REJECTED_COUNTER.labels(endpoint=endpoint).inc()
+        return HttpResponse(status=HTTPStatus.NO_CONTENT)
+    return None
 
 
 class _StreamSlotReservation:
@@ -306,6 +354,8 @@ def sse_streaming_response(
     stream: StreamContent,
     *,
     endpoint: str = "unknown",
+    killswitch_flag: str | None = None,
+    killswitch_distinct_id: str = "sse-killswitch",
     status: int = HTTPStatus.OK,
     headers: dict[str, str] | None = None,
 ) -> StreamingHttpResponse | HttpResponse:
@@ -349,7 +399,20 @@ def sse_streaming_response(
     returned, so parallel admissions cannot overshoot the cap; the slot is
     released when the stream ends, when a never-consumed response is closed,
     or by a GC backstop when the response is dropped without being closed.
+
+    Killswitch: when ``killswitch_flag`` names a feature flag that evaluates
+    true, the stream is answered with ``204 No Content`` before any other work,
+    without reserving a cap slot. Per the SSE spec, 204 moves ``EventSource``
+    to ``CLOSED`` and it stops reconnecting, the only server-side signal that
+    reaches clients whose tabs are already open. A client-side flag cannot do
+    this: it is read at render time and open tabs never re-check it.
+    Killswitch flags follow the ``<product>-sse-killswitch`` naming convention
+    and fail open if evaluation errors.
     """
+    if killswitch_flag is not None:
+        rejection = sse_killswitch_rejection(endpoint, killswitch_flag, killswitch_distinct_id)
+        if rejection is not None:
+            return rejection
     reservation = _try_reserve_stream_slot()
     if reservation is None:
         return _stream_cap_rejection(endpoint)

--- a/posthog/api/test/test_streaming.py
+++ b/posthog/api/test/test_streaming.py
@@ -340,3 +340,41 @@ class TestSSEConcurrencyCap:
                 "posthog_sse_rejected_over_cap_total", {"endpoint": "test_cap_zero"}
             )
             assert rejected_count is not None and rejected_count >= 1.0
+
+
+class TestSSEKillswitch:
+    # The killswitch is the only server-side signal that reaches already-open
+    # EventSource clients (204 => CLOSED, no reconnect). These tests pin that a
+    # kill never opens the stream and that flag-evaluation failures fail open.
+
+    def test_killswitch_on_returns_204_without_opening_the_stream(self):
+        slot_baseline = streaming._active_stream_count
+        with mock.patch("posthog.api.streaming.posthoganalytics.feature_enabled", return_value=True) as feature_enabled:
+            response = sse_streaming_response(_gen(), endpoint="test_kill_on", killswitch_flag="test-sse-killswitch")
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert not isinstance(response, StreamingHttpResponse)
+        assert _open_connections("test_kill_on") == 0.0
+        # The kill is decided before admission: a killed request must not
+        # reserve (or leak) a cap slot.
+        assert streaming._active_stream_count == slot_baseline
+        assert REGISTRY.get_sample_value("posthog_sse_killswitch_rejected_total", {"endpoint": "test_kill_on"}) == 1.0
+        feature_enabled.assert_called_once_with(
+            "test-sse-killswitch",
+            "sse-killswitch",
+            only_evaluate_locally=True,
+            send_feature_flag_events=False,
+        )
+
+    def test_killswitch_off_streams_normally(self):
+        with mock.patch("posthog.api.streaming.posthoganalytics.feature_enabled", return_value=False):
+            response = sse_streaming_response(_gen(), endpoint="test_kill_off", killswitch_flag="test-sse-killswitch")
+        assert isinstance(response, StreamingHttpResponse)
+        assert b"".join(_sync_content(response)) == b"data: hello\n\n"
+
+    def test_flag_evaluation_error_fails_open(self):
+        with mock.patch(
+            "posthog.api.streaming.posthoganalytics.feature_enabled", side_effect=RuntimeError("flags down")
+        ):
+            response = sse_streaming_response(_gen(), endpoint="test_kill_err", killswitch_flag="test-sse-killswitch")
+        assert isinstance(response, StreamingHttpResponse)
+        assert b"".join(_sync_content(response)) == b"data: hello\n\n"

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1731,6 +1731,7 @@ class SessionRecordingViewSet(
                 session_id, user, tracking_id, product_context, custom_tags, force_restart=force_restart
             ),
             endpoint="session_recording_summary",
+            killswitch_flag="session-recordings-sse-killswitch",
         )
 
     @extend_schema(exclude=True)

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -2325,7 +2325,12 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
     @patch("posthog.session_recordings.session_recording_api.execute_summarize_session_video_stream")
     @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    @patch("posthoganalytics.feature_enabled", return_value=True)
+    @patch(
+        "posthoganalytics.feature_enabled",
+        # Keep the summarize gate on without also flipping the SSE killswitch,
+        # which would answer the stream with 204 before the view runs.
+        side_effect=lambda flag, *args, **kwargs: not flag.endswith("-sse-killswitch"),
+    )
     def test_summarize_uses_video_based_path(
         self,
         mock_feature_enabled: MagicMock,
@@ -2377,7 +2382,12 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
     @patch("posthog.session_recordings.session_recording_api.execute_summarize_session_video_stream")
     @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    @patch("posthoganalytics.feature_enabled", return_value=True)
+    @patch(
+        "posthoganalytics.feature_enabled",
+        # Keep the summarize gate on without also flipping the SSE killswitch,
+        # which would answer the stream with 204 before the view runs.
+        side_effect=lambda flag, *args, **kwargs: not flag.endswith("-sse-killswitch"),
+    )
     def test_summarize_threads_force_restart_through_body(
         self,
         _name: str,

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -5155,7 +5155,9 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
         super().setUp()
         materialize("events", "$exception_values")
 
-        # Clear existing Django data
+        # Clear existing Django data. Projects explicitly too: team creation
+        # auto-creates a project with the team's pk, so a project 2 left over
+        # from earlier tests in the run collides with the analytics team below.
         Team.objects.all().delete()
         Project.objects.all().delete()
         Organization.objects.all().delete()

--- a/products/ai_observability/backend/api/proxy.py
+++ b/products/ai_observability/backend/api/proxy.py
@@ -197,7 +197,9 @@ class LLMProxyViewSet(viewsets.ViewSet):
     def _create_streaming_response(self, stream: Generator[bytes]) -> HttpResponseBase:
         """Creates a properly configured SSE streaming response"""
         astream = SyncIterableToAsync(stream) if SERVER_GATEWAY_INTERFACE == "ASGI" else stream
-        return sse_streaming_response(astream, endpoint="ai_observability_proxy")
+        return sse_streaming_response(
+            astream, endpoint="ai_observability_proxy", killswitch_flag="ai-observability-sse-killswitch"
+        )
 
     def _handle_completion_request(self, request: Request) -> HttpResponseBase | Response:
         """Handler for completion requests using unified Client"""

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2424,6 +2424,7 @@ class DashboardsViewSet(
             if settings.SERVER_GATEWAY_INTERFACE == "ASGI"
             else async_to_sync(lambda: async_tile_stream_generator()),
             endpoint="dashboard_tile_stream",
+            killswitch_flag="dashboards-sse-killswitch",
         )
 
     def _get_layout_size_from_request(self, request: Request) -> str:

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -9,7 +9,7 @@ from django.http.response import HttpResponseBase
 import httpx
 import structlog
 
-from posthog.api.streaming import sse_streaming_response
+from posthog.api.streaming import sse_killswitch_rejection, sse_streaming_response
 from posthog.security.url_validation import is_url_allowed
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 
@@ -372,6 +372,14 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     if mcp_session_id:
         headers["Mcp-Session-Id"] = mcp_session_id
 
+    # The upstream invocation itself is the cost (the tool call executes on
+    # the MCP server, and whether the reply is SSE is unknown until it comes
+    # back), so the killswitch must answer before the request is sent; the
+    # copy inside sse_streaming_response would only discard the response.
+    rejection = sse_killswitch_rejection("mcp_store_proxy", "mcp-store-sse-killswitch")
+    if rejection is not None:
+        return rejection
+
     client = httpx.Client(timeout=UPSTREAM_TIMEOUT)
     try:
         upstream_response, upstream_url = send_mcp_request_with_same_origin_redirect(
@@ -445,7 +453,7 @@ def _stream_upstream(upstream_response: httpx.Response, client: httpx.Client) ->
 def _build_sse_response(upstream_response: httpx.Response, client: httpx.Client) -> HttpResponseBase:
     stream = _stream_upstream(upstream_response, client)
     astream = SyncIterableToAsync(stream) if SERVER_GATEWAY_INTERFACE == "ASGI" else stream
-    response = sse_streaming_response(astream, endpoint="mcp_store_proxy")
+    response = sse_streaming_response(astream, endpoint="mcp_store_proxy", killswitch_flag="mcp-store-sse-killswitch")
 
     if not isinstance(response, StreamingHttpResponse):
         # Over-cap rejection: the generator that owns these resources never

--- a/products/mcp_store/backend/test/test_proxy.py
+++ b/products/mcp_store/backend/test/test_proxy.py
@@ -95,6 +95,26 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert kwargs["headers"]["Authorization"] == "Bearer sk-test-key"
 
     @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_killswitch_answers_before_the_upstream_request_is_sent(self, mock_client_cls):
+        # The upstream tool call executes on the MCP server the moment the
+        # request is sent, so a kill that only discards the response would let
+        # callers keep invoking tools. Pin that no upstream client is created.
+        installation = self._create_installation(
+            sensitive_configuration={"api_key": "sk-test-key"},
+        )
+        with patch(
+            "posthog.api.streaming.posthoganalytics.feature_enabled",
+            side_effect=lambda flag, *args, **kwargs: flag == "mcp-store-sse-killswitch",
+        ):
+            response = self.client.post(
+                self._proxy_url(installation.id),
+                data={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                format="json",
+            )
+        assert response.status_code == 204
+        mock_client_cls.assert_not_called()
+
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
     def test_proxy_forwards_json_rpc_with_oauth_token(self, mock_client_cls):
         installation = self._create_oauth_installation()
         mock_response = MagicMock()

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -938,7 +938,9 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
                 yield f"event: error\ndata: {payload_json}\n\n".encode()
 
         streaming_content = SyncIterableToAsync(stream()) if SERVER_GATEWAY_INTERFACE == "ASGI" else stream()
-        return sse_streaming_response(streaming_content, endpoint="notebook_stream")
+        return sse_streaming_response(
+            streaming_content, endpoint="notebook_stream", killswitch_flag="notebooks-sse-killswitch"
+        )
 
     @action(methods=["GET"], url_path="kernel/dataframe", detail=True)
     def kernel_dataframe(self, request: Request, **kwargs):
@@ -1498,6 +1500,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
                 lambda: collab_stream.stream_collab_sse(team_id, notebook_id, last_event_id=last_event_id)
             ),
             endpoint="notebook_collab",
+            killswitch_flag="notebooks-sse-killswitch",
         )
 
     @action(methods=["GET"], detail=False)

--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -857,4 +857,8 @@ class SessionReplayObservationViewSet(ReplayObservationViewSet):
         if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
             raise RuntimeError("observation progress stream requires ASGI.")
         observation = self.get_object()
-        return sse_streaming_response(stream_observation_progress(observation), endpoint="replay_vision_observation")
+        return sse_streaming_response(
+            stream_observation_progress(observation),
+            endpoint="replay_vision_observation",
+            killswitch_flag="replay-vision-sse-killswitch",
+        )

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -39,9 +39,13 @@ from products.signals.backend.models import SignalSourceConfig
 class _VisionAPITestCase(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
+        # The patch target is the shared posthoganalytics module, so a plain
+        # return_value=True would also flip the SSE killswitch on and turn
+        # every progress stream into a 204; keep the product gate on and the
+        # killswitch off, as in production.
         self.flag_patcher = patch(
             "products.replay_vision.backend.feature_flag.posthoganalytics.feature_enabled",
-            return_value=True,
+            side_effect=lambda flag, *args, **kwargs: not flag.endswith("-sse-killswitch"),
         )
         self.flag_patcher.start()
         # Scanner saves recompute the volume estimate against ClickHouse; keep CRUD tests off that path.

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2018,6 +2018,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         return sse_streaming_response(
             async_stream() if settings.SERVER_GATEWAY_INTERFACE == "ASGI" else async_to_sync(lambda: async_stream()),
             endpoint="task_run_log",
+            killswitch_flag="tasks-sse-killswitch",
         )
 
     @staticmethod

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.http.response import HttpResponseBase
 
 import structlog
@@ -190,16 +190,18 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         return Response(WizardSessionSerializer(dto).data)
 
-    def _killswitch_active(self, request: Request) -> bool:
-        # Shared by `latest` and `stream` so flipping the incident flag quiets both the
-        # SSE stream and the 60s REST poll — otherwise the fleet keeps hitting `latest`.
+    def _killswitch_distinct_id(self, request: Request) -> str:
         user = getattr(request, "user", None)
-        distinct_id = (
+        return (
             str(user.distinct_id)
             if user is not None and not user.is_anonymous and getattr(user, "distinct_id", None)
             else f"team:{self.team_id}"
         )
-        return _wizard_sync_killswitch_enabled(distinct_id)
+
+    def _killswitch_active(self, request: Request) -> bool:
+        # Shared by `latest` and `stream` so flipping the incident flag quiets both the
+        # SSE stream and the 60s REST poll — otherwise the fleet keeps hitting `latest`.
+        return _wizard_sync_killswitch_enabled(self._killswitch_distinct_id(request))
 
     @extend_schema(
         description=(
@@ -320,19 +322,10 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(detail=False, methods=["get"], url_path="stream", renderer_classes=[EventStreamRenderer])
     def stream(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponseBase:
-        # Killswitch first, before any other work: a 204 tells EventSource to stop
-        # reconnecting, severing the self-reconnect loop for already-open tabs.
-        if self._killswitch_active(request):
-            return HttpResponse(status=204)
-
         workflow_id = request.query_params.get("workflow_id")
         skill_id = request.query_params.get("skill_id") or None
         if not workflow_id:
             raise ValidationError({"detail": "workflow_id is required."})
-
-        # The generator is `async def` — WSGI can't consume an async iterator.
-        if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
-            raise RuntimeError("wizard_sessions.stream requires ASGI.")
 
         generator = _wizard_session_event_stream(
             team_id=self.team_id,
@@ -342,7 +335,25 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         # Releases the request-thread DB connection (auth, team resolution) before
         # the long-lived stream begins — see sse_streaming_response.
-        return sse_streaming_response(generator, endpoint="wizard_session")
+        # The killswitch 204 tells EventSource to stop reconnecting, severing the
+        # self-reconnect loop for already-open tabs; it must answer even when the
+        # stream itself could not be served, so it is decided before the gateway
+        # check below.
+        response = sse_streaming_response(
+            generator,
+            endpoint="wizard_session",
+            killswitch_flag=WIZARD_SYNC_KILLSWITCH_FLAG,
+            killswitch_distinct_id=self._killswitch_distinct_id(request),
+        )
+        # The generator is `async def` — WSGI can't consume an async iterator.
+        # Close the unserved stream so its admission slot is released eagerly.
+        if (
+            isinstance(response, StreamingHttpResponse)
+            and getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI"
+        ):
+            response.close()
+            raise RuntimeError("wizard_sessions.stream requires ASGI.")
+        return response
 
 
 async def _wizard_session_event_stream(


### PR DESCRIPTION
## Problem

Only the wizard SSE endpoint has a server-side killswitch today. A 204 response is the only signal that makes an already-connected `EventSource` stop reconnecting (a client-side flag is read at render time, so open tabs never see it turn off). Every other streaming endpoint (Max conversations, task run logs, session summaries, dashboards, notebooks, sandbox, proxies, replay vision, recording summaries) has no way to shed its connected clients when needed.

Part of the SSE infrastructure work tracked in Linear (GROW-108, PR 4 of a series). **Stacked on #67945** (concurrency cap), which stacks on #67931 (SSE metrics); only the last commit is new here.

## Changes

- `sse_streaming_response()` gains `killswitch_flag` and `killswitch_distinct_id` parameters. When the flag evaluates true (locally, `only_evaluate_locally=True`, no decide call, fail-open on errors) the stream is answered with `204 No Content` before any other work, and `posthog_sse_killswitch_rejected_total{endpoint}` is incremented. The killswitch check runs before the concurrency cap check, so a kill always wins over a 503.
- The wizard stream endpoint migrates from its inline check to the factory parameter, keeping the existing `onboarding-wizard-sync-killswitch` flag name and per-user distinct id. The `latest` REST endpoint keeps its inline check (it is not a stream).
- Every other SSE endpoint gets a killswitch flag following the `<product>-sse-killswitch` convention:

| Endpoint | Flag |
|---|---|
| wizard_session | onboarding-wizard-sync-killswitch (unchanged) |
| max_conversation | max-ai-sse-killswitch |
| task_run_log | tasks-sse-killswitch |
| session_summaries | session-summaries-sse-killswitch |
| dashboard_tile_stream | dashboards-sse-killswitch |
| notebook_stream, notebook_collab | notebooks-sse-killswitch |
| sandbox_execute | sandbox-sse-killswitch |
| session_recording_summary | session-recordings-sse-killswitch |
| replay_vision_observation | replay-vision-sse-killswitch |
| mcp_store_proxy | mcp-store-sse-killswitch |
| ai_observability_proxy | ai-observability-sse-killswitch |
| query_progress_stub | none (empty backward-compat stub) |

  The flags do not need to exist ahead of time: an undefined flag evaluates false and the endpoint behaves normally. Creating the flag and turning it on is the whole activation procedure.
- View return annotations widened to `HttpResponseBase` where the factory's `StreamingHttpResponse | HttpResponse` union surfaced through typed helpers.
- No new CI guard: direct `StreamingHttpResponse` construction is already blocked by the existing semgrep rule (`.semgrep/rules/no-direct-streaming-http-response`), and all SSE endpoints were already on the factory.

## How did you test this code?

Automated only:
- `pytest posthog/api/test/test_streaming.py` passed all 16 tests. The three new killswitch tests pin: a kill returns 204 without ever opening the stream (gauge untouched, counter incremented, flag evaluated with local-only kwargs), flag-off streams normally, and flag evaluation errors fail open.
- `ruff` and the pre-commit `ty check` pass on all changed files.
- Wizard suite errors in this environment are pre-existing local fixture issues (missing sqlx binary at test setup); CI runs them fully.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: internal reliability control. Flag naming convention documented in the factory docstring.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Planned in the Linear project "SSE Infrastructure Isolation" (GROW-108, PR 4 of 9). Managed with Graphite as part of the metrics, cap, killswitch stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #74312