### PR TITLE
chore: fix assorted spelling typos in comments and docs

### DIFF
--- a/ee/hogai/README.md
+++ b/ee/hogai/README.md
@@ -265,7 +265,7 @@ class YourToolkit(TaxonomyAgentToolkit):
         return [final_answer, hello_world]
 
     # Optional: prefer YAML over XML for property lists, but not a must to override
-    # If not overriden XML will be used
+    # If not overridden XML will be used
     def _format_properties(self, props: list[tuple[str, str | None, str | None]]) -> str:
         return self._format_properties_yaml(props)
 ```

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1646,7 +1646,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         for index in range(0, 19):
             created_ids.append(str(index + 100))
-            create_person(  # creating without _create_person to guarentee created_at ordering
+            create_person(  # creating without _create_person to guarantee created_at ordering
                 team=self.team,
                 distinct_ids=[str(index + 100)],
                 properties={"$browser": "whatever", "$os": "Windows"},
@@ -1700,7 +1700,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(set(paged), expected)  # union of pages == full set, gapless and dup-free
 
     def test_retrieve_person(self):
-        person = create_person(  # creating without _create_person to guarentee created_at ordering
+        person = create_person(  # creating without _create_person to guarantee created_at ordering
             team=self.team, distinct_ids=["123456789"]
         )
 
@@ -1711,7 +1711,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response["distinct_ids"] == ["123456789"]
 
     def test_retrieve_person_by_uuid(self):
-        person = create_person(  # creating without _create_person to guarentee created_at ordering
+        person = create_person(  # creating without _create_person to guarantee created_at ordering
             team=self.team, distinct_ids=["123456789"]
         )
 
@@ -2078,7 +2078,7 @@ class TestPersonFromClickhouse(TestPerson):
 
         for index in range(0, 19):
             created_ids.append(str(index + 100))
-            create_person(  # creating without _create_person to guarentee created_at ordering
+            create_person(  # creating without _create_person to guarantee created_at ordering
                 team=self.team,
                 distinct_ids=[str(index + 100)],
                 properties={"$browser": "whatever", "$os": "Windows"},

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -195,7 +195,7 @@ class _KafkaProducer:
             logger.info(f"KafkaProducer stack: {traceback.format_stack()}")
 
         if settings.TEST:
-            test = True  # Set at runtime so that overriden settings.TEST is supported
+            test = True  # Set at runtime so that overridden settings.TEST is supported
         default_profile = settings.KAFKA_PROFILES["default"]
         if kafka_security_protocol is None:
             kafka_security_protocol = default_profile.security_protocol

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -271,7 +271,7 @@ def return_given_error_or_random(error: Optional[Exception] = None):
 def simulate_postgres_error():
     """
     Causes any call to cursor to raise the upper most Error in djangos db
-    Exception hierachy
+    Exception hierarchy
     """
     with patch.object(connections[DEFAULT_DB_ALIAS], "cursor") as cursor_mock:
         cursor_mock.side_effect = return_given_error_or_random(DjangoDatabaseError("failed to connect"))

--- a/products/feature_flags/backend/api/test/test_organization_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_organization_feature_flag.py
@@ -624,7 +624,7 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
             deleted=True,
         )
 
-        # The following instances must be overriden for a soft-deleted flag
+        # The following instances must be overridden for a soft-deleted flag
         Survey.objects.create(team=self.team, created_by=self.user, linked_flag=existing_deleted_flag)
 
         analytics_dashboard = Dashboard.objects.create(


### PR DESCRIPTION
## Problem

A last sweep of small spelling mistakes in comments and docs: "guarentee", "hierachy", and a few more "overriden"s. Individually tiny, but they add up and hurt code search.

## Changes

- `posthog/api/test/test_person.py` - "guarentee" to "guarantee" (four identical comments)
- `posthog/test/test_health.py` - "hierachy" to "hierarchy" in a docstring
- `posthog/kafka_client/client.py` - "overriden" to "overridden" in a comment
- `products/feature_flags/backend/api/test/test_organization_feature_flag.py` - "overriden" to "overridden" in a comment
- `ee/hogai/README.md` - "overriden" to "overridden"

## How did you test this code?

No tests needed. Only comments, a docstring, and a README line changed, so behavior is unchanged. The pre-commit hook ran ruff, `ty check`, and the markdown formatter without errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The hogai README change is the doc update, and it is in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (PostHog Code, running Claude) for a batch of small, safe cleanups. This PR collects the leftover typos that did not fit a single product area into one sweep. Found via an `rg` typo search. Comment-only test edits are exempt from the test-writing gate, so no repo skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
