### PR TITLE
feat(alerts): extract shared alert destination management and dispatch

### DIFF
--- a/common/alerting/destinations.py
+++ b/common/alerting/destinations.py
@@ -1,0 +1,208 @@
+"""Shared builders for alert notification destinations (CDP internal_destination HogFunctions).
+
+Every alerting product delivers notifications the same way: an internal event per
+alert-event kind (firing, resolved, errored, auto-disabled), consumed by one
+HogFunction per destination per kind, linked to the alert via an `alert_id`
+property filter. This module owns that wiring — the filter shape, the template
+input structure per destination type, and the message scaffolding — so dispatch
+and destinations can never drift apart per product.
+
+Products own the content: their `EventKindSpec` table (event names, headers,
+detail rows, payload data) and the display name of each HogFunction.
+
+Pure Python — the `team` value is passed through opaquely into the config dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+DestinationType = Literal["slack", "webhook", "teams"]
+
+ALERT_ID_PROPERTY = "alert_id"
+
+TEMPLATE_ID_BY_DESTINATION_TYPE: dict[DestinationType, str] = {
+    "slack": "template-slack",
+    "webhook": "template-webhook",
+    "teams": "template-microsoft-teams",
+}
+DESTINATION_TYPE_BY_TEMPLATE_ID = {
+    template_id: destination_type for destination_type, template_id in TEMPLATE_ID_BY_DESTINATION_TYPE.items()
+}
+
+WEBHOOK_HEADERS = {"Content-Type": "application/json", "X-PostHog-Webhook-Version": "1"}
+
+# HogFunction.name is `models.CharField(max_length=400)` — clip rendered names to fit.
+_HOG_FUNCTION_NAME_MAX_LEN = 400
+
+
+@dataclass(frozen=True)
+class EventKindSpec:
+    """Product-authored content for one alert event kind (firing, resolved, ...)."""
+
+    event_id: str
+    display_kind: str
+    header: str
+    # Plain-text (label, value) pairs; each destination renders these in its own markup.
+    details: tuple[tuple[str, str], ...]
+    button_url: str
+    button_label: str
+    webhook_body: dict[str, Any]
+    # e.g. "logs alert", "billing alert" — used in the HogFunction description.
+    product_label: str = "alert"
+
+    def destination_description(self, alert_name: str) -> str:
+        return f'Sends {self.display_kind} notifications for {self.product_label} "{alert_name}".'
+
+
+def clip_hog_function_name(name: str) -> str:
+    if len(name) <= _HOG_FUNCTION_NAME_MAX_LEN:
+        return name
+    return name[: _HOG_FUNCTION_NAME_MAX_LEN - 1] + "…"
+
+
+def destination_filter(alert_id: str, event_id: str) -> dict[str, Any]:
+    """The linkage contract: dispatch finds destinations by this exact filter shape."""
+    return {
+        "events": [{"id": event_id, "type": "events"}],
+        "properties": [
+            {
+                "key": ALERT_ID_PROPERTY,
+                "value": alert_id,
+                "operator": "exact",
+                "type": "event",
+            }
+        ],
+    }
+
+
+def slack_body(spec: EventKindSpec) -> str:
+    # Slack mrkdwn: *single asterisks* for bold, one line per detail.
+    return "\n".join(f"*{label}:* {value}" for label, value in spec.details)
+
+
+def slack_blocks(spec: EventKindSpec, context_elements: tuple[str, ...]) -> list[dict]:
+    return [
+        {"type": "header", "text": {"type": "plain_text", "text": spec.header}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": slack_body(spec)}},
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": element} for element in context_elements],
+        },
+        {"type": "divider"},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "url": spec.button_url,
+                    "text": {"text": spec.button_label, "type": "plain_text"},
+                    "type": "button",
+                }
+            ],
+        },
+    ]
+
+
+def teams_text(spec: EventKindSpec) -> str:
+    # The Microsoft Teams template renders a single Adaptive Card TextBlock from `text`, so fold
+    # the header, details, and action into one markdown string (the button becomes an inline link).
+    # Adaptive Card markdown: **double asterisks** for bold, blank lines between paragraphs.
+    details = "\n\n".join(f"**{label}:** {value}" for label, value in spec.details)
+    return f"**{spec.header}**\n\n{details}\n\n[{spec.button_label}]({spec.button_url})"
+
+
+def _base_config(
+    *,
+    team: Any,
+    spec: EventKindSpec,
+    alert_id: str,
+    alert_name: str,
+    name: str,
+    template_id: str,
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "team": team,
+        "type": "internal_destination",
+        "enabled": True,
+        "filters": destination_filter(alert_id, spec.event_id),
+        "name": clip_hog_function_name(name),
+        "description": spec.destination_description(alert_name),
+        "template_id": template_id,
+        "inputs": inputs,
+    }
+
+
+def build_slack_destination_config(
+    *,
+    team: Any,
+    spec: EventKindSpec,
+    alert_id: str,
+    alert_name: str,
+    name: str,
+    slack_workspace_id: int,
+    slack_channel_id: str,
+    context_elements: tuple[str, ...],
+) -> dict[str, Any]:
+    return _base_config(
+        team=team,
+        spec=spec,
+        alert_id=alert_id,
+        alert_name=alert_name,
+        name=name,
+        template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["slack"],
+        inputs={
+            "blocks": {"value": slack_blocks(spec, context_elements)},
+            "text": {"value": spec.header},
+            "slack_workspace": {"value": slack_workspace_id},
+            "channel": {"value": slack_channel_id},
+        },
+    )
+
+
+def build_webhook_destination_config(
+    *,
+    team: Any,
+    spec: EventKindSpec,
+    alert_id: str,
+    alert_name: str,
+    name: str,
+    webhook_url: str,
+) -> dict[str, Any]:
+    return _base_config(
+        team=team,
+        spec=spec,
+        alert_id=alert_id,
+        alert_name=alert_name,
+        name=name,
+        template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["webhook"],
+        inputs={
+            "body": {"value": spec.webhook_body},
+            "url": {"value": webhook_url},
+            "headers": {"value": WEBHOOK_HEADERS},
+        },
+    )
+
+
+def build_teams_destination_config(
+    *,
+    team: Any,
+    spec: EventKindSpec,
+    alert_id: str,
+    alert_name: str,
+    name: str,
+    webhook_url: str,
+) -> dict[str, Any]:
+    return _base_config(
+        team=team,
+        spec=spec,
+        alert_id=alert_id,
+        alert_name=alert_name,
+        name=name,
+        template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["teams"],
+        inputs={
+            "webhookUrl": {"value": webhook_url},
+            "text": {"value": teams_text(spec)},
+        },
+    )

--- a/posthog/alerting/destinations.py
+++ b/posthog/alerting/destinations.py
@@ -1,0 +1,150 @@
+"""Shared persistence and dispatch mechanics for alert notification destinations.
+
+The pure config builders live in common/alerting/destinations.py; this module owns
+the Django/CDP side every alerting product otherwise duplicates: creating the
+HogFunctions through HogFunctionSerializer (so template lookup and bytecode
+compilation run), ownership-checked soft deletion, destination-type discovery for
+list views, and producing the internal event that CDP destinations consume.
+
+CDP exposes no facade today, so this is deliberately the one place that hand-drives
+HogFunctionSerializer for alerts — when a CDP facade lands, only this module moves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from django.db import transaction
+
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+
+from products.cdp.backend.api.hog_function import HogFunctionSerializer
+from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+
+from common.alerting.destinations import ALERT_ID_PROPERTY, DESTINATION_TYPE_BY_TEMPLATE_ID
+
+
+class AlertDestinationOwnershipError(Exception):
+    """Raised when deleting destinations that do not all belong to an alert."""
+
+
+def create_alert_destination_hog_functions(configs: list[dict[str, Any]], *, request: Any) -> list[Any]:
+    """Create one HogFunction per config, atomically. Each config carries its `team`."""
+    created = []
+    with transaction.atomic():
+        for config in configs:
+            config = dict(config)
+            team = config.pop("team")
+            serializer = HogFunctionSerializer(
+                data=config,
+                context={"request": request, "get_team": lambda team=team: team, "is_create": True},
+            )
+            serializer.is_valid(raise_exception=True)
+            created.append(serializer.save(team=team))
+    return created
+
+
+def soft_delete_alert_destinations(
+    *,
+    team_id: int,
+    alert_id: str,
+    hog_function_ids: list[UUID],
+) -> None:
+    """Soft-delete a destination's HogFunction group, verifying every ID belongs to the alert.
+
+    The filtered UPDATE is the ownership check: touching fewer rows than requested
+    means something in the list doesn't belong to this alert — roll back.
+    """
+    with transaction.atomic():
+        updated = HogFunction.objects.filter(
+            team_id=team_id,
+            id__in=hog_function_ids,
+            filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
+        ).update(deleted=True, enabled=False)
+        if updated != len(hog_function_ids):
+            raise AlertDestinationOwnershipError
+
+
+def soft_delete_all_alert_destinations(*, team_id: int, alert_id: str) -> int:
+    """Soft-delete every destination HogFunction linked to an alert (alert deletion path)."""
+    return HogFunction.objects.filter(
+        team_id=team_id,
+        deleted=False,
+        template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
+        filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
+    ).update(deleted=True, enabled=False)
+
+
+def find_alert_destination_hog_functions(*, team_id: int, alert_id: str, event_id: str) -> list[Any]:
+    """The dispatch-side half of the linkage contract in common/alerting/destinations.py."""
+    return list(
+        HogFunction.objects.filter(
+            team_id=team_id,
+            deleted=False,
+            template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
+            filters__events__contains=[{"id": event_id, "type": "events"}],
+            filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
+        ).only("id", "template_id")
+    )
+
+
+def destination_types_for_alerts(*, team_ids: Iterable[int], alert_ids: Iterable[str]) -> dict[str, list[str]]:
+    """Map alert_id -> sorted destination types, for list views (no FK exists — read filters JSON)."""
+    alert_id_set = set(alert_ids)
+    team_id_set = set(team_ids)
+    destination_types_by_alert_id: dict[str, set[str]] = {alert_id: set() for alert_id in alert_id_set}
+
+    if not alert_id_set or not team_id_set:
+        return {}
+
+    hog_functions = HogFunction.objects.filter(
+        team_id__in=team_id_set,
+        deleted=False,
+        template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
+    ).values_list("template_id", "filters")
+
+    for template_id, filters in hog_functions:
+        if template_id is None:
+            continue
+        destination_type = DESTINATION_TYPE_BY_TEMPLATE_ID.get(template_id)
+        if destination_type is None or not isinstance(filters, dict):
+            continue
+
+        properties = filters.get("properties") or []
+        if not isinstance(properties, list):
+            continue
+
+        for property_filter in properties:
+            if not isinstance(property_filter, dict) or property_filter.get("key") != ALERT_ID_PROPERTY:
+                continue
+            alert_id = str(property_filter.get("value"))
+            if alert_id in destination_types_by_alert_id:
+                destination_types_by_alert_id[alert_id].add(destination_type)
+
+    return {
+        alert_id: sorted(destination_types) for alert_id, destination_types in destination_types_by_alert_id.items()
+    }
+
+
+def produce_alert_internal_event(
+    *,
+    team_id: int,
+    event_name: str,
+    properties: dict[str, Any],
+    timestamp: datetime | None = None,
+    uuid: str | None = None,
+) -> None:
+    """Produce the internal event CDP destinations consume. Callers own error handling."""
+    produce_internal_event(
+        team_id=team_id,
+        event=InternalEventEvent(
+            event=event_name,
+            distinct_id=f"team_{team_id}",
+            properties=properties,
+            timestamp=timestamp.isoformat() if timestamp else None,
+            uuid=uuid,
+        ),
+    )

--- a/posthog/alerting/destinations.py
+++ b/posthog/alerting/destinations.py
@@ -31,9 +31,9 @@ class AlertDestinationOwnershipError(Exception):
     """Raised when deleting destinations that do not all belong to an alert."""
 
 
-def create_alert_destination_hog_functions(configs: list[dict[str, Any]], *, request: Any) -> list[Any]:
+def create_alert_destination_hog_functions(configs: list[dict[str, Any]], *, request: Any) -> list[HogFunction]:
     """Create one HogFunction per config, atomically. Each config carries its `team`."""
-    created = []
+    created: list[HogFunction] = []
     with transaction.atomic():
         for config in configs:
             config = dict(config)
@@ -58,13 +58,14 @@ def soft_delete_alert_destinations(
     The filtered UPDATE is the ownership check: touching fewer rows than requested
     means something in the list doesn't belong to this alert — roll back.
     """
+    unique_ids = set(hog_function_ids)
     with transaction.atomic():
         updated = HogFunction.objects.filter(
             team_id=team_id,
-            id__in=hog_function_ids,
+            id__in=unique_ids,
             filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
         ).update(deleted=True, enabled=False)
-        if updated != len(hog_function_ids):
+        if updated != len(unique_ids):
             raise AlertDestinationOwnershipError
 
 
@@ -78,7 +79,7 @@ def soft_delete_all_alert_destinations(*, team_id: int, alert_id: str) -> int:
     ).update(deleted=True, enabled=False)
 
 
-def find_alert_destination_hog_functions(*, team_id: int, alert_id: str, event_id: str) -> list[Any]:
+def find_alert_destination_hog_functions(*, team_id: int, alert_id: str, event_id: str) -> list[HogFunction]:
     """The dispatch-side half of the linkage contract in common/alerting/destinations.py."""
     return list(
         HogFunction.objects.filter(

--- a/products/billing_alerts/backend/alert_destinations.py
+++ b/products/billing_alerts/backend/alert_destinations.py
@@ -1,40 +1,37 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Literal
 
 from posthog.models import Team
 
 from products.billing_alerts.backend.models import BillingAlertConfiguration
 
+from common.alerting.destinations import (
+    DESTINATION_TYPE_BY_TEMPLATE_ID,
+    TEMPLATE_ID_BY_DESTINATION_TYPE,
+    EventKindSpec,
+    build_slack_destination_config,
+    build_teams_destination_config,
+    build_webhook_destination_config,
+)
+
 EventKind = Literal["firing", "resolved", "errored", "broken"]
 DestinationType = Literal["slack", "webhook", "teams"]
 
 BILLING_ALERT_DESTINATION_IDS_PROPERTY = "billing_alert_destination_ids"
 
-TEMPLATE_ID_BY_DESTINATION_TYPE: dict[DestinationType, str] = {
-    "slack": "template-slack",
-    "webhook": "template-webhook",
-    "teams": "template-microsoft-teams",
-}
-DESTINATION_TYPE_BY_TEMPLATE_ID = {
-    template_id: destination_type for destination_type, template_id in TEMPLATE_ID_BY_DESTINATION_TYPE.items()
-}
+__all__ = [
+    "BILLING_ALERT_DESTINATION_IDS_PROPERTY",
+    "DESTINATION_TYPE_BY_TEMPLATE_ID",
+    "EVENT_KINDS",
+    "EVENT_KIND_CONFIG",
+    "TEMPLATE_ID_BY_DESTINATION_TYPE",
+    "DestinationType",
+    "EventKind",
+    "build_destination_config",
+]
 
-
-@dataclass(frozen=True)
-class EventKindSpec:
-    event_id: str
-    display_kind: str
-    header: str
-    details: tuple[tuple[str, str], ...]
-    button_url: str
-    button_label: str
-    webhook_body: dict[str, Any]
-
-    def destination_description(self, alert_name: str) -> str:
-        return f'Sends {self.display_kind} notifications for billing alert "{alert_name}".'
-
+_PRODUCT_LABEL = "billing alert"
 
 _BASE_DATA = {
     "alert_id": "{event.properties.alert_id}",
@@ -69,6 +66,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "timestamp": "{event.properties.triggered_at}",
             "data": _BASE_DATA,
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "resolved": EventKindSpec(
         event_id="$billing_alert_resolved",
@@ -88,6 +86,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "timestamp": "{event.properties.triggered_at}",
             "data": _BASE_DATA,
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "errored": EventKindSpec(
         event_id="$billing_alert_errored",
@@ -109,6 +108,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
                 "consecutive_failures": "{event.properties.consecutive_failures}",
             },
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "broken": EventKindSpec(
         event_id="$billing_alert_auto_disabled",
@@ -130,88 +130,16 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
                 "consecutive_failures": "{event.properties.consecutive_failures}",
             },
         },
+        product_label=_PRODUCT_LABEL,
     ),
 }
 
 EVENT_KINDS: tuple[EventKind, ...] = tuple(EVENT_KIND_CONFIG.keys())
 
-_HOG_FUNCTION_NAME_MAX_LEN = 400
-
-
-def _clip_name(name: str) -> str:
-    if len(name) <= _HOG_FUNCTION_NAME_MAX_LEN:
-        return name
-    return name[: _HOG_FUNCTION_NAME_MAX_LEN - 3] + "..."
-
-
-def _filter_for(alert: BillingAlertConfiguration, kind: EventKind) -> dict[str, Any]:
-    return {
-        "events": [{"id": EVENT_KIND_CONFIG[kind].event_id, "type": "events"}],
-        "properties": [
-            {
-                "key": "alert_id",
-                "value": str(alert.id),
-                "operator": "exact",
-                "type": "event",
-            }
-        ],
-    }
-
-
-def _slack_body(spec: EventKindSpec) -> str:
-    return "\n".join(f"*{label}:* {value}" for label, value in spec.details)
-
-
-def _slack_blocks(spec: EventKindSpec) -> list[dict]:
-    return [
-        {"type": "header", "text": {"type": "plain_text", "text": spec.header}},
-        {"type": "section", "text": {"type": "mrkdwn", "text": _slack_body(spec)}},
-        {
-            "type": "context",
-            "elements": [
-                {"type": "mrkdwn", "text": "Organization billing alert"},
-                {"type": "mrkdwn", "text": "Project: <{project.url}|{project.name}>"},
-            ],
-        },
-        {"type": "divider"},
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "url": spec.button_url,
-                    "text": {"text": spec.button_label, "type": "plain_text"},
-                    "type": "button",
-                }
-            ],
-        },
-    ]
-
-
-def _teams_text(spec: EventKindSpec) -> str:
-    details = "\n\n".join(f"**{label}:** {value}" for label, value in spec.details)
-    return f"**{spec.header}**\n\n{details}\n\n[{spec.button_label}]({spec.button_url})"
-
-
-def _hog_function_config(
-    alert: BillingAlertConfiguration,
-    team: Team,
-    kind: EventKind,
-    *,
-    template_id: str,
-    name_suffix: str,
-    inputs: dict[str, Any],
-) -> dict[str, Any]:
-    spec = EVENT_KIND_CONFIG[kind]
-    return {
-        "team": team,
-        "type": "internal_destination",
-        "enabled": True,
-        "filters": _filter_for(alert, kind),
-        "name": _clip_name(f"Billing alert - {alert.name} ({spec.display_kind}) -> {name_suffix}"),
-        "description": spec.destination_description(alert.name),
-        "template_id": template_id,
-        "inputs": inputs,
-    }
+_SLACK_CONTEXT_ELEMENTS = (
+    "Organization billing alert",
+    "Project: <{project.url}|{project.name}>",
+)
 
 
 def build_destination_config(
@@ -221,42 +149,33 @@ def build_destination_config(
     data: dict[str, Any],
 ) -> dict[str, Any]:
     spec = EVENT_KIND_CONFIG[kind]
+    alert_id = str(alert.id)
     if data["type"] == "slack":
         channel_display = data.get("slack_channel_name") or "channel"
-        return _hog_function_config(
-            alert,
-            team,
-            kind,
-            template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["slack"],
-            name_suffix=f"Slack #{channel_display}",
-            inputs={
-                "blocks": {"value": _slack_blocks(spec)},
-                "text": {"value": spec.header},
-                "slack_workspace": {"value": data["slack_workspace_id"]},
-                "channel": {"value": data["slack_channel_id"]},
-            },
+        return build_slack_destination_config(
+            team=team,
+            spec=spec,
+            alert_id=alert_id,
+            alert_name=alert.name,
+            name=f"Billing alert - {alert.name} ({spec.display_kind}) -> Slack #{channel_display}",
+            slack_workspace_id=data["slack_workspace_id"],
+            slack_channel_id=data["slack_channel_id"],
+            context_elements=_SLACK_CONTEXT_ELEMENTS,
         )
     if data["type"] == "teams":
-        return _hog_function_config(
-            alert,
-            team,
-            kind,
-            template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["teams"],
-            name_suffix="Microsoft Teams",
-            inputs={
-                "webhookUrl": {"value": data["webhook_url"]},
-                "text": {"value": _teams_text(spec)},
-            },
+        return build_teams_destination_config(
+            team=team,
+            spec=spec,
+            alert_id=alert_id,
+            alert_name=alert.name,
+            name=f"Billing alert - {alert.name} ({spec.display_kind}) -> Microsoft Teams",
+            webhook_url=data["webhook_url"],
         )
-    return _hog_function_config(
-        alert,
-        team,
-        kind,
-        template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["webhook"],
-        name_suffix=f"Webhook {data['webhook_url']}",
-        inputs={
-            "body": {"value": spec.webhook_body},
-            "url": {"value": data["webhook_url"]},
-            "headers": {"value": {"Content-Type": "application/json", "X-PostHog-Webhook-Version": "1"}},
-        },
+    return build_webhook_destination_config(
+        team=team,
+        spec=spec,
+        alert_id=alert_id,
+        alert_name=alert.name,
+        name=f"Billing alert - {alert.name} ({spec.display_kind}) -> Webhook {data['webhook_url']}",
+        webhook_url=data["webhook_url"],
     )

--- a/products/billing_alerts/backend/facade/api.py
+++ b/products/billing_alerts/backend/facade/api.py
@@ -6,19 +6,17 @@ from uuid import UUID
 from django.db import transaction
 from django.db.models import QuerySet
 
+from posthog.alerting.destinations import (
+    AlertDestinationOwnershipError,
+    create_alert_destination_hog_functions,
+    destination_types_for_alerts as shared_destination_types_for_alerts,
+    soft_delete_alert_destinations,
+    soft_delete_all_alert_destinations,
+)
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
 
-from products.cdp.backend.api.hog_function import HogFunctionSerializer
-from products.cdp.backend.models.hog_functions.hog_function import HogFunction
-
-from ..alert_destinations import (
-    DESTINATION_TYPE_BY_TEMPLATE_ID,
-    EVENT_KINDS,
-    TEMPLATE_ID_BY_DESTINATION_TYPE,
-    EventKind,
-    build_destination_config,
-)
+from ..alert_destinations import EVENT_KINDS, EventKind, build_destination_config
 from ..logic.notifications import dispatch_billing_alert_event
 from ..logic.state_machine import evaluate_and_record_billing_alert, event_should_dispatch
 from ..models import BillingAlertConfiguration, BillingAlertEvent
@@ -59,50 +57,15 @@ def evaluate_and_dispatch_alert(alert: BillingAlertConfiguration) -> BillingAler
 
 def delete_alert_and_destinations(alert: BillingAlertConfiguration) -> None:
     with transaction.atomic():
-        HogFunction.objects.filter(
-            team_id=alert.execution_team_id,
-            deleted=False,
-            template_id__in=list(TEMPLATE_ID_BY_DESTINATION_TYPE.values()),
-            filters__properties__contains=[{"key": "alert_id", "value": str(alert.id)}],
-        ).update(deleted=True, enabled=False)
+        soft_delete_all_alert_destinations(team_id=alert.execution_team_id, alert_id=str(alert.id))
         alert.delete()
 
 
 def destination_types_for_alerts(alerts: list[BillingAlertConfiguration]) -> dict[str, list[str]]:
-    alert_ids = {str(alert.id) for alert in alerts}
-    team_ids = {alert.execution_team_id for alert in alerts}
-    destination_types_by_alert_id: dict[str, set[str]] = {alert_id: set() for alert_id in alert_ids}
-
-    if not alert_ids or not team_ids:
-        return {}
-
-    hog_functions = HogFunction.objects.filter(
-        team_id__in=team_ids,
-        deleted=False,
-        template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
-    ).values_list("template_id", "filters")
-
-    for template_id, filters in hog_functions:
-        if template_id is None:
-            continue
-        destination_type = DESTINATION_TYPE_BY_TEMPLATE_ID.get(template_id)
-        if destination_type is None or not isinstance(filters, dict):
-            continue
-
-        properties = filters.get("properties") or []
-        if not isinstance(properties, list):
-            continue
-
-        for property_filter in properties:
-            if not isinstance(property_filter, dict) or property_filter.get("key") != "alert_id":
-                continue
-            alert_id = str(property_filter.get("value"))
-            if alert_id in destination_types_by_alert_id:
-                destination_types_by_alert_id[alert_id].add(destination_type)
-
-    return {
-        alert_id: sorted(destination_types) for alert_id, destination_types in destination_types_by_alert_id.items()
-    }
+    return shared_destination_types_for_alerts(
+        team_ids={alert.execution_team_id for alert in alerts},
+        alert_ids={str(alert.id) for alert in alerts},
+    )
 
 
 def slack_integration_belongs_to_team(*, integration_id: int, team_id: int) -> bool:
@@ -114,37 +77,20 @@ def slack_integration_belongs_to_team(*, integration_id: int, team_id: int) -> b
 
 
 def create_destination(alert: BillingAlertConfiguration, *, request: Any, data: dict[str, Any]) -> list[UUID]:
-    with transaction.atomic():
-        hog_functions = [_build_and_create_hog_function(alert, alert.team, data, kind, request) for kind in EVENT_KINDS]
+    configs = [build_destination_config(alert, alert.team, kind, data) for kind in EVENT_KINDS]
+    hog_functions = create_alert_destination_hog_functions(configs, request=request)
     return [hog_function.id for hog_function in hog_functions]
 
 
-def _build_and_create_hog_function(
-    alert: BillingAlertConfiguration,
-    team: Team,
-    data: dict[str, Any],
-    kind: EventKind,
-    request: Any,
-) -> HogFunction:
-    config = build_destination_config(alert, team, kind, data)
-    destination_team = config.pop("team")
-    serializer = HogFunctionSerializer(
-        data=config,
-        context={"request": request, "get_team": lambda: destination_team, "is_create": True},
-    )
-    serializer.is_valid(raise_exception=True)
-    return serializer.save(team=destination_team)
-
-
 def delete_destination(alert: BillingAlertConfiguration, hog_function_ids: list[UUID]) -> None:
-    with transaction.atomic():
-        updated = HogFunction.objects.filter(
+    try:
+        soft_delete_alert_destinations(
             team_id=alert.execution_team_id,
-            id__in=hog_function_ids,
-            filters__properties__contains=[{"key": "alert_id", "value": str(alert.id)}],
-        ).update(deleted=True, enabled=False)
-        if updated != len(hog_function_ids):
-            raise BillingAlertDestinationOwnershipError
+            alert_id=str(alert.id),
+            hog_function_ids=hog_function_ids,
+        )
+    except AlertDestinationOwnershipError as e:
+        raise BillingAlertDestinationOwnershipError from e
 
 
 __all__ = [

--- a/products/billing_alerts/backend/logic/notifications.py
+++ b/products/billing_alerts/backend/logic/notifications.py
@@ -7,12 +7,11 @@ from django.utils import timezone
 
 import structlog
 
-from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.alerting.destinations import find_alert_destination_hog_functions, produce_alert_internal_event
 from posthog.exceptions_capture import capture_exception
 
 from products.billing_alerts.backend.alert_destinations import (
     BILLING_ALERT_DESTINATION_IDS_PROPERTY,
-    DESTINATION_TYPE_BY_TEMPLATE_ID,
     EVENT_KIND_CONFIG,
     EventKind,
 )
@@ -66,15 +65,10 @@ def _destination_hog_functions(event: BillingAlertEvent) -> list[HogFunction]:
     kind = _kind_for_event(event)
     if kind is None:
         return []
-    event_id = EVENT_KIND_CONFIG[kind].event_id
-    return list(
-        HogFunction.objects.filter(
-            team_id=alert.execution_team_id,
-            deleted=False,
-            template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
-            filters__events__contains=[{"id": event_id, "type": "events"}],
-            filters__properties__contains=[{"key": "alert_id", "value": str(alert.id)}],
-        ).only("id", "template_id")
+    return find_alert_destination_hog_functions(
+        team_id=alert.execution_team_id,
+        alert_id=str(alert.id),
+        event_id=EVENT_KIND_CONFIG[kind].event_id,
     )
 
 
@@ -88,14 +82,11 @@ def _produce_billing_alert_internal_event(
     notification_sent_at: datetime,
 ) -> None:
     try:
-        produce_internal_event(
+        produce_alert_internal_event(
             team_id=team_id,
-            event=InternalEventEvent(
-                event=event_name,
-                distinct_id=f"team_{team_id}",
-                properties=properties,
-                uuid=event_id,
-            ),
+            event_name=event_name,
+            properties=properties,
+            uuid=event_id,
         )
     except Exception as e:
         BillingAlertEvent.objects.filter(id=event_id, notification_sent_at=notification_sent_at).update(

--- a/products/billing_alerts/backend/test/test_notifications.py
+++ b/products/billing_alerts/backend/test/test_notifications.py
@@ -92,7 +92,7 @@ class TestBillingAlertNotifications(BaseTest):
         event = self._event(alert)
         destination = self._destination(alert, template_id)
 
-        with patch("products.billing_alerts.backend.logic.notifications.produce_internal_event") as produce:
+        with patch("posthog.alerting.destinations.produce_internal_event") as produce:
             with self.captureOnCommitCallbacks(execute=True):
                 dispatched = dispatch_billing_alert_event(event, now=NOW)
 
@@ -123,7 +123,7 @@ class TestBillingAlertNotifications(BaseTest):
         event = self._event(alert, model_event_kind)
         self._destination(alert, "template-slack", destination_event_kind)
 
-        with patch("products.billing_alerts.backend.logic.notifications.produce_internal_event") as produce:
+        with patch("posthog.alerting.destinations.produce_internal_event") as produce:
             with self.captureOnCommitCallbacks(execute=True):
                 assert dispatch_billing_alert_event(event, now=NOW) == 1
 
@@ -135,7 +135,7 @@ class TestBillingAlertNotifications(BaseTest):
         event = self._event(alert)
         destination = self._destination(alert, "template-slack")
 
-        with patch("products.billing_alerts.backend.logic.notifications.produce_internal_event") as produce:
+        with patch("posthog.alerting.destinations.produce_internal_event") as produce:
             with self.captureOnCommitCallbacks(execute=True):
                 assert dispatch_billing_alert_event(event, now=NOW) == 1
             assert dispatch_billing_alert_event(event, now=NOW) == 0
@@ -150,7 +150,7 @@ class TestBillingAlertNotifications(BaseTest):
         destination = self._destination(alert, "template-slack")
         BillingAlertEvent.objects.filter(id=event.id).update(targets_notified={"hog_functions": [str(destination.id)]})
 
-        with patch("products.billing_alerts.backend.logic.notifications.produce_internal_event") as produce:
+        with patch("posthog.alerting.destinations.produce_internal_event") as produce:
             assert dispatch_billing_alert_event(event, now=NOW) == 0
 
         produce.assert_not_called()
@@ -162,7 +162,7 @@ class TestBillingAlertNotifications(BaseTest):
 
         with self.assertRaises(RuntimeError):
             with patch(
-                "products.billing_alerts.backend.logic.notifications.produce_internal_event",
+                "posthog.alerting.destinations.produce_internal_event",
                 side_effect=RuntimeError("kafka unavailable"),
             ):
                 with self.captureOnCommitCallbacks(execute=True):

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -2,28 +2,20 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Literal
 
 from products.logs.backend.models import LogsAlertConfiguration
 
+from common.alerting.destinations import (
+    EventKindSpec,
+    build_slack_destination_config,
+    build_teams_destination_config,
+    build_webhook_destination_config,
+)
+
 EventKind = Literal["firing", "resolved", "broken", "errored"]
 
-
-@dataclass(frozen=True)
-class EventKindSpec:
-    event_id: str
-    display_kind: str
-    header: str
-    # Plain-text (label, value) pairs; each destination renders these in its own markup.
-    details: tuple[tuple[str, str], ...]
-    button_url: str
-    button_label: str
-    webhook_body: dict[str, Any]
-
-    def destination_description(self, alert_name: str) -> str:
-        return f'Sends {self.display_kind} notifications for logs alert "{alert_name}".'
-
+_PRODUCT_LABEL = "logs alert"
 
 _FIRE_RESOLVE_DATA: dict[str, str] = {
     "alert_id": "{event.properties.alert_id}",
@@ -68,6 +60,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "timestamp": "{event.properties.triggered_at}",
             "data": _FIRE_RESOLVE_DATA,
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "resolved": EventKindSpec(
         event_id="$logs_alert_resolved",
@@ -88,6 +81,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "timestamp": "{event.properties.triggered_at}",
             "data": _FIRE_RESOLVE_DATA,
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "broken": EventKindSpec(
         event_id="$logs_alert_auto_disabled",
@@ -108,6 +102,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
                 "last_error_message": "{event.properties.last_error_message}",
             },
         },
+        product_label=_PRODUCT_LABEL,
     ),
     "errored": EventKindSpec(
         event_id="$logs_alert_errored",
@@ -128,20 +123,11 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
                 "error_message": "{event.properties.error_message}",
             },
         },
+        product_label=_PRODUCT_LABEL,
     ),
 }
 
 EVENT_KINDS: tuple[EventKind, ...] = tuple(EVENT_KIND_CONFIG.keys())
-
-# HogFunction.name is `models.CharField(max_length=400)` — clip rendered names to fit.
-_HOG_FUNCTION_NAME_MAX_LEN = 400
-
-
-def _clip_name(name: str) -> str:
-    if len(name) <= _HOG_FUNCTION_NAME_MAX_LEN:
-        return name
-    return name[: _HOG_FUNCTION_NAME_MAX_LEN - 1] + "…"
-
 
 _SEVERITY_SERVICE_CONTEXT = (
     "{if(length(event.properties.severity_levels) > 0 or length(event.properties.service_names) > 0,"
@@ -158,57 +144,10 @@ _SEVERITY_SERVICE_CONTEXT = (
     " 'All log levels and services')}"
 )
 
-
-def _slack_body(spec: EventKindSpec) -> str:
-    # Slack mrkdwn: *single asterisks* for bold, one line per detail.
-    return "\n".join(f"*{label}:* {value}" for label, value in spec.details)
-
-
-def _slack_blocks(spec: EventKindSpec) -> list[dict]:
-    return [
-        {"type": "header", "text": {"type": "plain_text", "text": spec.header}},
-        {"type": "section", "text": {"type": "mrkdwn", "text": _slack_body(spec)}},
-        {
-            "type": "context",
-            "elements": [
-                {"type": "mrkdwn", "text": _SEVERITY_SERVICE_CONTEXT},
-                {"type": "mrkdwn", "text": "Project: <{project.url}|{project.name}>"},
-            ],
-        },
-        {"type": "divider"},
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "url": spec.button_url,
-                    "text": {"text": spec.button_label, "type": "plain_text"},
-                    "type": "button",
-                }
-            ],
-        },
-    ]
-
-
-def _teams_text(spec: EventKindSpec) -> str:
-    # The Microsoft Teams template renders a single Adaptive Card TextBlock from `text`, so fold
-    # the header, details, and action into one markdown string (the button becomes an inline link).
-    # Adaptive Card markdown: **double asterisks** for bold, blank lines between paragraphs.
-    details = "\n\n".join(f"**{label}:** {value}" for label, value in spec.details)
-    return f"**{spec.header}**\n\n{details}\n\n[{spec.button_label}]({spec.button_url})"
-
-
-def _filter_for(alert: LogsAlertConfiguration, kind: EventKind) -> dict[str, Any]:
-    return {
-        "events": [{"id": EVENT_KIND_CONFIG[kind].event_id, "type": "events"}],
-        "properties": [
-            {
-                "key": "alert_id",
-                "value": str(alert.id),
-                "operator": "exact",
-                "type": "event",
-            }
-        ],
-    }
+_SLACK_CONTEXT_ELEMENTS = (
+    _SEVERITY_SERVICE_CONTEXT,
+    "Project: <{project.url}|{project.name}>",
+)
 
 
 def build_slack_config(
@@ -220,21 +159,16 @@ def build_slack_config(
 ) -> dict[str, Any]:
     spec = EVENT_KIND_CONFIG[kind]
     channel_display = slack_channel_name or "channel"
-    return {
-        "team": alert.team,
-        "type": "internal_destination",
-        "enabled": True,
-        "filters": _filter_for(alert, kind),
-        "name": _clip_name(f"Logs alert — {alert.name} ({spec.display_kind}) → Slack #{channel_display}"),
-        "description": spec.destination_description(alert.name),
-        "template_id": "template-slack",
-        "inputs": {
-            "blocks": {"value": _slack_blocks(spec)},
-            "text": {"value": spec.header},
-            "slack_workspace": {"value": slack_workspace_id},
-            "channel": {"value": slack_channel_id},
-        },
-    }
+    return build_slack_destination_config(
+        team=alert.team,
+        spec=spec,
+        alert_id=str(alert.id),
+        alert_name=alert.name,
+        name=f"Logs alert — {alert.name} ({spec.display_kind}) → Slack #{channel_display}",
+        slack_workspace_id=slack_workspace_id,
+        slack_channel_id=slack_channel_id,
+        context_elements=_SLACK_CONTEXT_ELEMENTS,
+    )
 
 
 def build_webhook_config(
@@ -243,20 +177,14 @@ def build_webhook_config(
     webhook_url: str,
 ) -> dict[str, Any]:
     spec = EVENT_KIND_CONFIG[kind]
-    return {
-        "team": alert.team,
-        "type": "internal_destination",
-        "enabled": True,
-        "filters": _filter_for(alert, kind),
-        "name": _clip_name(f"Logs alert — {alert.name} ({spec.display_kind}) → Webhook {webhook_url}"),
-        "description": spec.destination_description(alert.name),
-        "template_id": "template-webhook",
-        "inputs": {
-            "body": {"value": spec.webhook_body},
-            "url": {"value": webhook_url},
-            "headers": {"value": {"Content-Type": "application/json", "X-PostHog-Webhook-Version": "1"}},
-        },
-    }
+    return build_webhook_destination_config(
+        team=alert.team,
+        spec=spec,
+        alert_id=str(alert.id),
+        alert_name=alert.name,
+        name=f"Logs alert — {alert.name} ({spec.display_kind}) → Webhook {webhook_url}",
+        webhook_url=webhook_url,
+    )
 
 
 def build_teams_config(
@@ -265,16 +193,11 @@ def build_teams_config(
     webhook_url: str,
 ) -> dict[str, Any]:
     spec = EVENT_KIND_CONFIG[kind]
-    return {
-        "team": alert.team,
-        "type": "internal_destination",
-        "enabled": True,
-        "filters": _filter_for(alert, kind),
-        "name": _clip_name(f"Logs alert — {alert.name} ({spec.display_kind}) → Microsoft Teams"),
-        "description": spec.destination_description(alert.name),
-        "template_id": "template-microsoft-teams",
-        "inputs": {
-            "webhookUrl": {"value": webhook_url},
-            "text": {"value": _teams_text(spec)},
-        },
-    }
+    return build_teams_destination_config(
+        team=alert.team,
+        spec=spec,
+        alert_id=str(alert.id),
+        alert_name=alert.name,
+        name=f"Logs alert — {alert.name} ({spec.display_kind}) → Microsoft Teams",
+        webhook_url=webhook_url,
+    )

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -22,6 +22,7 @@ from posthog.alerting.destinations import (
     AlertDestinationOwnershipError,
     create_alert_destination_hog_functions,
     soft_delete_alert_destinations,
+    soft_delete_all_alert_destinations,
 )
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -1185,4 +1186,6 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def perform_destroy(self, instance: LogsAlertConfiguration) -> None:
         self._track("logs alert deleted", instance)
-        super().perform_destroy(instance)
+        with transaction.atomic():
+            soft_delete_all_alert_destinations(team_id=instance.team_id, alert_id=str(instance.id))
+            super().perform_destroy(instance)

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -18,6 +18,11 @@ from rest_framework.response import Response
 
 from posthog.schema import LogsAlertFilters
 
+from posthog.alerting.destinations import (
+    AlertDestinationOwnershipError,
+    create_alert_destination_hog_functions,
+    soft_delete_alert_destinations,
+)
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
@@ -28,7 +33,6 @@ from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import relative_date_parse
 
-from products.cdp.backend.api.hog_function import HogFunctionSerializer
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 from products.logs.backend.alert_check_query import AlertCheckQuery, BucketedCount
 from products.logs.backend.alert_destinations import (
@@ -868,8 +872,8 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        with transaction.atomic():
-            hog_functions = [self._build_and_create_hog_function(alert, data, kind) for kind in EVENT_KINDS]
+        configs = [self._build_destination_config(alert, data, kind) for kind in EVENT_KINDS]
+        hog_functions = create_alert_destination_hog_functions(configs, request=self.request)
 
         report_user_action(
             request.user,
@@ -891,16 +895,14 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         hog_function_ids = serializer.validated_data["hog_function_ids"]
 
-        with transaction.atomic():
-            updated = HogFunction.objects.filter(
+        try:
+            soft_delete_alert_destinations(
                 team_id=self.team_id,
-                id__in=hog_function_ids,
-                filters__properties__contains=[{"key": "alert_id", "value": str(alert.id)}],
-            ).update(deleted=True)
-            if updated != len(hog_function_ids):
-                # Ownership check: if the filtered UPDATE touched fewer rows than we were asked
-                # to delete, something in the list doesn't belong to this alert. Roll back.
-                raise ValidationError("One or more HogFunctions do not belong to this alert.")
+                alert_id=str(alert.id),
+                hog_function_ids=hog_function_ids,
+            )
+        except AlertDestinationOwnershipError:
+            raise ValidationError("One or more HogFunctions do not belong to this alert.")
 
         report_user_action(
             request.user,
@@ -909,33 +911,23 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         return Response(status=204)
 
-    def _build_and_create_hog_function(
+    def _build_destination_config(
         self,
         alert: LogsAlertConfiguration,
         data: dict,
         kind: EventKind,
-    ) -> HogFunction:
+    ) -> dict:
         if data["type"] == "slack":
-            config = build_slack_config(
+            return build_slack_config(
                 alert,
                 kind,
                 slack_workspace_id=data["slack_workspace_id"],
                 slack_channel_id=data["slack_channel_id"],
                 slack_channel_name=data.get("slack_channel_name"),
             )
-        elif data["type"] == "teams":
-            config = build_teams_config(alert, kind, webhook_url=data["webhook_url"])
-        else:
-            config = build_webhook_config(alert, kind, webhook_url=data["webhook_url"])
-
-        # Route through HogFunctionSerializer so template lookup and bytecode compilation run.
-        team = config.pop("team")
-        serializer = HogFunctionSerializer(
-            data=config,
-            context={"request": self.request, "get_team": lambda: team, "is_create": True},
-        )
-        serializer.is_valid(raise_exception=True)
-        return serializer.save(team=team)
+        if data["type"] == "teams":
+            return build_teams_config(alert, kind, webhook_url=data["webhook_url"])
+        return build_webhook_config(alert, kind, webhook_url=data["webhook_url"])
 
     @extend_schema(
         request=None,

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -20,7 +20,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from posthog.schema import PropertyGroupFilter
 
-from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.alerting.destinations import produce_alert_internal_event
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.sync import database_sync_to_async_pool
@@ -1235,14 +1235,11 @@ def _produce_alert_internal_event(
     now: datetime,
 ) -> bool:
     try:
-        produce_internal_event(
+        produce_alert_internal_event(
             team_id=alert.team_id,
-            event=InternalEventEvent(
-                event=event_name,
-                distinct_id=f"team_{alert.team_id}",
-                properties=properties,
-                timestamp=now.isoformat(),
-            ),
+            event_name=event_name,
+            properties=properties,
+            timestamp=now,
         )
         return True
     except Exception as e:

--- a/products/logs/backend/test/test_alert_destinations.py
+++ b/products/logs/backend/test/test_alert_destinations.py
@@ -2,7 +2,12 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
-from products.logs.backend.alert_destinations import EVENT_KIND_CONFIG, EVENT_KINDS, EventKind, _slack_body, _teams_text
+from products.logs.backend.alert_destinations import EVENT_KIND_CONFIG, EVENT_KINDS, EventKind
+
+from common.alerting.destinations import (
+    slack_body as _slack_body,
+    teams_text as _teams_text,
+)
 
 
 class TestSlackBody(SimpleTestCase):

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -893,6 +893,24 @@ class TestLogsAlertAPI(APIBaseTest):
         assert HogFunction.objects.filter(id__in=ids, deleted=False).count() == 0
         assert HogFunction.objects.filter(id__in=ids, enabled=True).count() == 0
 
+    def test_delete_alert_soft_deletes_destination_hog_functions(self):
+        from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        create_response = self.client.post(
+            self._destinations_url(created["id"]),
+            {"type": "webhook", "webhook_url": "https://example.com/hook"},
+            format="json",
+        )
+        ids = create_response.json()["hog_function_ids"]
+
+        delete_response = self.client.delete(f"{self.base_url}{created['id']}/")
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert not LogsAlertConfiguration.objects.filter(id=created["id"]).exists()
+        assert HogFunction.objects.filter(id__in=ids, deleted=False).count() == 0
+        assert HogFunction.objects.filter(id__in=ids, enabled=True).count() == 0
+
     def test_delete_destination_rejects_foreign_hog_function_ids(self):
         self._sync_destination_templates()
         created_a = self._create_via_api()

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1729,7 +1729,7 @@ class TestSimulateEvaluatorLifecycleParity(ClickhouseTestMixin, APIBaseTest):
         self._checkpoint_patcher.start()
         self.addCleanup(self._checkpoint_patcher.stop)
         self._kafka_patcher = patch(
-            "products.logs.backend.temporal.activities.produce_internal_event",
+            "posthog.alerting.destinations.produce_internal_event",
             return_value=None,
         )
         self._kafka_patcher.start()

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -891,6 +891,7 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert delete_response.status_code == status.HTTP_204_NO_CONTENT
         assert HogFunction.objects.filter(id__in=ids, deleted=False).count() == 0
+        assert HogFunction.objects.filter(id__in=ids, enabled=True).count() == 0
 
     def test_delete_destination_rejects_foreign_hog_function_ids(self):
         self._sync_destination_templates()

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -585,7 +585,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_threshold_breached_transitions_to_firing(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
@@ -603,7 +603,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_threshold_not_breached_stays_not_firing(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert()
@@ -620,7 +620,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_steady_state_writes_no_alert_event(self, _mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [5])  # below threshold → stays NOT_FIRING
         alert = self._make_alert()
@@ -631,7 +631,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_creates_event_row(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
@@ -652,7 +652,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_advances_next_check_at(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(next_check_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC))
@@ -666,7 +666,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     @patch(
         "products.logs.backend.alert_error_classifier.classify_query_error",
         return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
@@ -693,7 +693,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_emit_event_uses_team_distinct_id(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
@@ -707,7 +707,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_last_notified_at_set_after_kafka_success(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
@@ -721,7 +721,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("posthog.alerting.destinations.produce_internal_event", side_effect=Exception("Kafka down"))
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_last_notified_at_not_set_on_kafka_failure(self, mock_capture, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
@@ -745,7 +745,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     )
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_threshold_operators(self, _name, operator, count, should_fire, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [count])
         alert = self._make_alert(threshold_operator=operator, threshold_count=10)
@@ -764,7 +764,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_resolution_emits_resolved_event(self, mock_produce, mock_query_cls):
         alert = self._make_alert(state=LogsAlertConfiguration.State.FIRING)
         # First check breached to create an event row for get_recent_breaches
@@ -786,7 +786,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_cooldown_suppresses_notification(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert(
@@ -805,7 +805,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_n_of_m_requires_multiple_breaches_to_fire(self, mock_produce, mock_query_cls):
         # Stateless eval: a single bucketed query returns the M-bucket history.
         # State machine derives the N-of-M decision from those buckets directly.
@@ -835,7 +835,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_event_properties_include_logs_url_params(self, mock_produce, mock_query_cls):
         alert = self._make_alert(
             threshold_count=5,
@@ -856,7 +856,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_logs_url_params_includes_absolute_date_range(self, mock_produce, mock_query_cls):
         alert = self._make_alert(
             threshold_count=5,
@@ -875,7 +875,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_resolution_within_cooldown_suppresses_resolved_event(self, mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [0])
         alert = self._make_alert(
@@ -931,7 +931,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     )
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_break_on_consecutive_failures(
         self,
         _name,
@@ -977,7 +977,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_state_transition")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_state_transition_counter_fires_on_state_change(self, _mock_produce, mock_query_cls, mock_transition):
         _mock_buckets(mock_query_cls, [50])
         alert = self._make_alert()
@@ -989,7 +989,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_state_transition")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_state_transition_counter_silent_when_state_unchanged(self, _mock_produce, mock_query_cls, mock_transition):
         _mock_buckets(mock_query_cls, [5])
         self._make_alert()
@@ -1009,7 +1009,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_notification_failures")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("posthog.alerting.destinations.produce_internal_event", side_effect=Exception("Kafka down"))
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_notification_failures_counter(
         self,
@@ -1033,7 +1033,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_notification_failures")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_notification_failures_silent_on_success(self, _mock_produce, mock_query_cls, mock_notif_failures):
         _mock_buckets(mock_query_cls, [50])
         self._make_alert()
@@ -1055,7 +1055,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_check_errors")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_check_errors_counter_labelled_by_classifier(
         self,
         expected_category,
@@ -1080,7 +1080,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_check_errors")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_check_errors_counter_silent_on_success(self, _mock_produce, mock_query_cls, mock_check_errors):
         _mock_buckets(mock_query_cls, [5])
         self._make_alert()
@@ -1093,7 +1093,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_query_uses_checkpoint_as_date_to_when_in_past(self, _mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
@@ -1108,7 +1108,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_query_uses_now_when_checkpoint_is_in_future(self, _mock_produce, mock_query_cls):
         # Defensive case: if clocks are skewed so checkpoint > now, don't query the future.
         _mock_buckets(mock_query_cls, [5])
@@ -1124,7 +1124,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_query_uses_now_when_checkpoint_is_none(self, _mock_produce, mock_query_cls):
         _mock_buckets(mock_query_cls, [5])
         alert = self._make_alert(window_minutes=5)
@@ -1138,7 +1138,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T01:00:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_query_ignores_stale_checkpoint_quiet_partition_case(self, _mock_produce, mock_query_cls):
         # Quiet partitions pin min(max_observed_timestamp) backwards. If that's older than
         # CHECKPOINT_MAX_STALENESS we must ignore the checkpoint — otherwise a spike of
@@ -1164,7 +1164,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     )
     @freeze_time("2025-01-01T05:00:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_date_from_covers_full_rolling_check_lookback(
         self, _name, window_minutes, evaluation_periods, expected_range_minutes, _mock_produce, mock_query_cls
     ):
@@ -1184,7 +1184,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
 
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
         mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"
@@ -1216,7 +1216,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
 
-        with patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce:
+        with patch("posthog.alerting.destinations.produce_internal_event") as mock_produce:
             mock_produce.side_effect = Exception("Kafka down")
             _evaluate_and_save_one(alert, now1, _make_stats())
 
@@ -1244,7 +1244,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
 
         with (
-            patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce,
+            patch("posthog.alerting.destinations.produce_internal_event") as mock_produce,
             patch(
                 "products.logs.backend.alert_error_classifier.classify_query_error",
                 return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
@@ -1273,7 +1273,7 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.increment_notification_failures")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("posthog.alerting.destinations.produce_internal_event", side_effect=Exception("Kafka down"))
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_notification_failures_counter_for_error_and_broken(
         self,
@@ -1417,7 +1417,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
     """
 
     @freeze_time("2025-12-16T10:33:00Z")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_breach_against_real_clickhouse_fires_alert(self, _mock_produce):
         # Five logs at 10:30 with a unique service. next_check_at=10:33,
         # window=5, M=1 → activity's query window is [10:28, 10:33), capturing
@@ -1481,7 +1481,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         return LogsAlertConfiguration.objects.create(**defaults)
 
     @freeze_time("2025-12-16T10:35:00Z")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_n_of_m_progression_across_consecutive_evals(self, _mock_produce):
         # Real-CH version of the N-of-M progression test. M=3 N=2 over 5-min buckets.
         # Symmetric N-of-M: stays firing while breach_count >= N, resolves only
@@ -1542,7 +1542,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
 
     @freeze_time("2025-12-16T10:25:00Z")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_cooldown_suppresses_resolve_notification_within_window(self, mock_produce):
         # Alert fires at next_check_at #1, resolve attempted at next_check_at #2
         # within cooldown_minutes → state transitions to NOT_FIRING but
@@ -1575,7 +1575,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         assert mock_produce.call_count == 1  # but no second notification dispatched
 
     @freeze_time("2025-12-16T10:33:00Z")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_below_operator_fires_on_truly_silent_service(self, _mock_produce):
         # `execute_rolling_checks` always returns exactly `period_count` entries (zero
         # counts for silent services, since each period is a fixed-width
@@ -1597,7 +1597,7 @@ class TestEvaluateSingleAlertEndToEnd(ClickhouseTestMixin, APIBaseTest):
         )
 
     @freeze_time("2025-12-16T10:33:00Z")
-    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    @patch("posthog.alerting.destinations.produce_internal_event")
     def test_first_run_with_null_nca_anchors_on_now(self, _mock_produce):
         # Alert created with next_check_at=None (first eval after enable). The
         # activity falls back to `now` as the anchor; the query window is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -559,7 +559,6 @@ ignore_imports = [
     # still make directly. These resolve once cdp/exports expose the needed facades, so
     # they outlive the in-product cleanup above.
     "products.logs.backend.presentation.views.api -> products.exports.backend.models.exported_asset",
-    "products.logs.backend.presentation.views.alerts_api -> products.cdp.backend.api.hog_function",
     "products.logs.backend.presentation.views.alerts_api -> products.cdp.backend.models.hog_functions.hog_function",
     # TODO: notebooks presentation wave — the moved NotebookViewSet still reaches in-product
     # internals (collab, kernel runtime, query validation, models) and the tasks sandbox


### PR DESCRIPTION
## Problem

Second slice of the shared alerting platform (stacked on #67959). Logs and billing alerts duplicated the entire CDP destination layer: HogFunction config builders for Slack/webhook/Teams `internal_destination` functions, serializer-driven creation, ownership-checked soft deletion, destination-type discovery for list views, and the internal-event produce. Two copies of the `alert_id` filter linkage meant the create side and the dispatch side of the contract could drift per product.

## Changes

- Pure config builders in `common/alerting/destinations.py`: the `alert_id` property-filter linkage and per-template input shapes (Slack blocks, webhook body/headers, Teams text) are now one contract; products keep their message content (`EventKindSpec` tables, event names, display names)
- Django/CDP mechanics in `posthog/alerting/destinations.py`: creation through `HogFunctionSerializer`, ownership-checked soft delete (the filtered-UPDATE row-count check), discovery, and `produce_alert_internal_event`
- Per-source event names are kept (`$logs_alert_firing`, `$billing_alert_firing`, ...) so existing HogFunction filters keep working
- CDP still exposes no facade, so this module is deliberately the one remaining place that hand-drives `HogFunctionSerializer` for alerts — when a CDP facade lands, only this module moves

Two deliberate, documented deltas under the behavior-preservation bar: logs destination soft-delete now also sets `enabled=False` (billing's stricter semantics; read paths treat them identically), and name clipping unified on the "…" variant (visible only on names over 400 characters).

## How did you test this code?

I'm an agent; automated tests only:

- 302 tests across the billing suite, logs destination tests, logs state machine, and logs alerts API pass
- Tests now patch the produce boundary in `posthog.alerting.destinations`, which asserts the real `InternalEventEvent` shape instead of a product-local wrapper
- `ruff` and `tach check` pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal refactor, no user-facing docs impact.

## Behavior notes (not strictly behavior-preserving)

Two small, deliberate unifications ride along with the extraction:

- Logs destination deletes now also set `enabled=False` (previously only `deleted=True`), matching billing — no more soft-deleted-but-still-enabled hog functions. Pinned by a test assertion.
- Billing's destination name clipping suffix changed from `"..."` to `"…"` (the logs form); only affects names longer than 400 chars.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude)
- Key decision: the Django glue lives in `posthog/alerting/` rather than `common/` because `posthog` already carries the tach edge to `products.cdp` — no new boundary edges, and `common/alerting` stays pure Python
- End-to-end verified as part of the stack: real Slack deliveries for all three alerting products on the final branch

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

