### PR TITLE
feat(alerts): extract shared alert sweep scheduling helpers

### DIFF
--- a/common/alerting/scheduling.py
+++ b/common/alerting/scheduling.py
@@ -1,0 +1,113 @@
+"""Shared scheduling math for alert check sweeps.
+
+Alerting products run the same sweep shape — a Temporal cron discovers due alerts
+(`next_check_at <= now`), evaluates them in batches, and advances `next_check_at`.
+This module owns the pure per-alert cadence math; the Django-side due-alert
+predicate lives in posthog/alerting/scheduling.py.
+
+Pure Python — no Django, no product imports.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID
+
+# How often a sweep schedule typically fires. Drives shard granularity in
+# `compute_shard_offset_seconds` — schedule fires every N seconds, so a
+# cadence of M seconds has `M // N` shard slots available.
+DEFAULT_SCHEDULE_INTERVAL_SECONDS = 60
+
+
+def compute_shard_offset_seconds(
+    alert_id: UUID,
+    check_interval_minutes: int,
+    *,
+    schedule_interval_seconds: int = DEFAULT_SCHEDULE_INTERVAL_SECONDS,
+) -> int:
+    """Deterministic per-alert offset within the cadence period.
+
+    Spreads alerts across `cadence / schedule_interval_seconds` slots so cron
+    fires pick up roughly equal slices instead of the whole fleet at once. With
+    a 60s schedule interval and a 5-min cadence, alerts distribute over
+    5 buckets at offsets [0, 60, 120, 180, 240] seconds.
+
+    `alert_id.int` is stable across pod restarts (process-local `hash()` is not).
+    For UUIDv7 IDs, the low bits are the random portion — the modulus operation
+    naturally lands on those bits, so distribution is uniform.
+    Cadences ≤ schedule interval get 1 shard (no spread possible).
+    """
+    cadence_seconds = check_interval_minutes * 60
+    shard_count = max(1, cadence_seconds // schedule_interval_seconds)
+    shard_index = alert_id.int % shard_count
+    return shard_index * schedule_interval_seconds
+
+
+def advance_next_check_at(
+    current_next_check_at: datetime | None,
+    check_interval_minutes: int,
+    now: datetime,
+    *,
+    shard_offset_seconds: int = 0,
+) -> datetime:
+    """Schedule-relative advancement, snapped to the canonical cadence grid.
+
+    The scheduler cron fires every minute. A sub-minute offset on the returned
+    `next_check_at` (e.g. 12:05:30) makes the cron skip a full tick waiting for
+    it — the alert is picked up at 12:06:00, ~30s late, every cycle. Snapping
+    to the cadence grid (every 5-min alert lands on :00/:05/:10/..., every
+    10-min on :00/:10/:20/..., etc.) eliminates that lag AND aligns every alert
+    sharing a cadence onto the same canonical grid regardless of when it was
+    created.
+
+    `shard_offset_seconds` shifts the canonical grid per-alert to spread load
+    across cron fires (see `compute_shard_offset_seconds`). With offset=120 and
+    a 5-min cadence, the alert lands on :02/:07/:12/... instead of :00/:05/:10.
+    Default 0 = no shard, alert sits on the canonical grid.
+
+    Any drifted `next_check_at` — sub-minute drift OR minute-level offset (e.g.
+    legacy alerts on a per-creation-time grid) — self-heals to canonical on its
+    next return. Existing alerts heal lazily, one transient short-gap each (the
+    state machine handles the brief overlap window via N-of-M dedup).
+
+    Inter-eval gaps are exactly `check_interval_minutes` in steady state. The
+    only "shorter than cadence" gaps are (1) creation-to-first-eval and (2)
+    the one-time heal cycle for a previously-drifted alert. Both are
+    cosmetic — alert eval windows tile correctly because they're anchored
+    on `date_to`, not on prior eval time.
+    """
+    if check_interval_minutes <= 0:
+        raise ValueError(f"check_interval_minutes must be positive, got {check_interval_minutes}")
+    interval = timedelta(minutes=check_interval_minutes)
+
+    if current_next_check_at is None:
+        next_at = now + interval
+    else:
+        next_at = current_next_check_at + interval
+        if next_at <= now:
+            elapsed = (now - next_at).total_seconds()
+            intervals_to_skip = int(elapsed // interval.total_seconds()) + 1
+            next_at += interval * intervals_to_skip
+
+    # Bump by full interval (not 1 cadence-grid slot upward) when the floor
+    # lands at/before `now`, so the alert stays on its canonical cadence grid.
+    snapped = _floor_to_cadence_grid(next_at, check_interval_minutes) + timedelta(seconds=shard_offset_seconds)
+    if snapped <= now:
+        snapped += interval
+    return snapped
+
+
+def _floor_to_cadence_grid(t: datetime, cadence_minutes: int) -> datetime:
+    """Floor to the previous cadence-grid slot, anchored at midnight of `t`.
+
+    For divisors of 60 (1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60), this is
+    "every cadence minutes within the hour" — the grid an operator expects
+    (5-min alerts on :00/:05/:10, 15-min on :00/:15/:30/:45, etc.). Cadences
+    > 60 that divide 1440 (90, 120, 240, 360, 480, 720, 1440) also tile
+    cleanly. Cadences that divide neither 60 nor 1440 (e.g. 7, 11, 100) get
+    a discontinuity at midnight where the grid re-anchors — fine in practice
+    because alert UI almost certainly constrains cadence to common values.
+    """
+    total_minutes = t.hour * 60 + t.minute
+    floored_minutes = (total_minutes // cadence_minutes) * cadence_minutes
+    return t.replace(hour=floored_minutes // 60, minute=floored_minutes % 60, second=0, microsecond=0)

--- a/posthog/alerting/scheduling.py
+++ b/posthog/alerting/scheduling.py
@@ -1,0 +1,28 @@
+"""Django-side scheduling helpers for alert check sweeps.
+
+The pure cadence math lives in common/alerting/scheduling.py; this module owns the
+due-alert predicate every sweep's discover phase shares.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.db.models import Q
+
+
+def due_alerts_q(now: datetime, *, broken_state: str, snoozed_state: str | None = None) -> Q:
+    """Predicate for alerts due a check: enabled, `next_check_at` reached (or never
+    set), not broken, and not actively snoozed.
+
+    Snooze exclusion differs deliberately per product: logs parks snoozed alerts in
+    a SNOOZED state and keeps evaluating them once `snooze_until` passes (pass
+    `snoozed_state`); billing skips any alert with a future `snooze_until`
+    regardless of state (leave `snoozed_state` unset).
+    """
+    q = Q(enabled=True) & (Q(next_check_at__lte=now) | Q(next_check_at__isnull=True)) & ~Q(state=broken_state)
+    if snoozed_state is not None:
+        q &= ~Q(state=snoozed_state, snooze_until__gt=now)
+    else:
+        q &= Q(snooze_until__isnull=True) | Q(snooze_until__lte=now)
+    return q

--- a/products/billing_alerts/backend/temporal/activities.py
+++ b/products/billing_alerts/backend/temporal/activities.py
@@ -4,11 +4,12 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Any
 
-from django.db.models import F, Q
+from django.db.models import F
 
 import structlog
 import temporalio.activity
 
+from posthog.alerting.scheduling import due_alerts_q
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Organization
 from posthog.sync import database_sync_to_async
@@ -135,10 +136,8 @@ async def discover_due_billing_alerts_activity() -> list[BillingAlertInfo]:
         now = datetime.now(UTC)
         alerts = (
             BillingAlertConfiguration.objects.filter(
-                Q(enabled=True, next_check_at__lte=now) | Q(enabled=True, next_check_at__isnull=True)
+                due_alerts_q(now, broken_state=BillingAlertConfiguration.State.BROKEN)
             )
-            .filter(Q(snooze_until__isnull=True) | Q(snooze_until__lte=now))
-            .exclude(state=BillingAlertConfiguration.State.BROKEN)
             .order_by(F("next_check_at").asc(nulls_first=True))
             .values_list("id", flat=True)[:MAX_DUE_BILLING_ALERTS_PER_TICK]
         )

--- a/products/logs/backend/alert_utils.py
+++ b/products/logs/backend/alert_utils.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
 from uuid import UUID
+
+from common.alerting.scheduling import (
+    advance_next_check_at,
+    compute_shard_offset_seconds as shared_compute_shard_offset_seconds,
+)
+
+__all__ = [
+    "MAX_BYTES_TO_READ",
+    "SCHEDULE_INTERVAL_SECONDS",
+    "advance_next_check_at",
+    "compute_shard_offset_seconds",
+]
 
 # How often the Temporal schedule fires. Drives shard granularity in
 # `compute_shard_offset_seconds` — schedule fires every N seconds, so a
@@ -21,89 +32,8 @@ MAX_BYTES_TO_READ = int(os.environ.get("LOGS_ALERTING_MAX_BYTES_TO_READ", "53687
 
 
 def compute_shard_offset_seconds(alert_id: UUID, check_interval_minutes: int) -> int:
-    """Deterministic per-alert offset within the cadence period.
-
-    Spreads alerts across `cadence / SCHEDULE_INTERVAL_SECONDS` slots so cron
-    fires pick up roughly equal slices instead of the whole fleet at once. With
-    `SCHEDULE_INTERVAL_SECONDS=60` and a 5-min cadence, alerts distribute over
-    5 buckets at offsets [0, 60, 120, 180, 240] seconds.
-
-    `alert_id.int` is stable across pod restarts (process-local `hash()` is not).
-    For UUIDv7 IDs, the low bits are the random portion — the modulus operation
-    naturally lands on those bits, so distribution is uniform.
-    Cadences ≤ schedule interval get 1 shard (no spread possible).
-    """
-    cadence_seconds = check_interval_minutes * 60
-    shard_count = max(1, cadence_seconds // SCHEDULE_INTERVAL_SECONDS)
-    shard_index = alert_id.int % shard_count
-    return shard_index * SCHEDULE_INTERVAL_SECONDS
-
-
-def advance_next_check_at(
-    current_next_check_at: datetime | None,
-    check_interval_minutes: int,
-    now: datetime,
-    *,
-    shard_offset_seconds: int = 0,
-) -> datetime:
-    """Schedule-relative advancement, snapped to the canonical cadence grid.
-
-    The scheduler cron fires every minute. A sub-minute offset on the returned
-    `next_check_at` (e.g. 12:05:30) makes the cron skip a full tick waiting for
-    it — the alert is picked up at 12:06:00, ~30s late, every cycle. Snapping
-    to the cadence grid (every 5-min alert lands on :00/:05/:10/..., every
-    10-min on :00/:10/:20/..., etc.) eliminates that lag AND aligns every alert
-    sharing a cadence onto the same canonical grid regardless of when it was
-    created.
-
-    `shard_offset_seconds` shifts the canonical grid per-alert to spread load
-    across cron fires (see `compute_shard_offset_seconds`). With offset=120 and
-    a 5-min cadence, the alert lands on :02/:07/:12/... instead of :00/:05/:10.
-    Default 0 = no shard, alert sits on the canonical grid.
-
-    Any drifted `next_check_at` — sub-minute drift OR minute-level offset (e.g.
-    legacy alerts on a per-creation-time grid) — self-heals to canonical on its
-    next return. Existing alerts heal lazily, one transient short-gap each (the
-    state machine handles the brief overlap window via N-of-M dedup).
-
-    Inter-eval gaps are exactly `check_interval_minutes` in steady state. The
-    only "shorter than cadence" gaps are (1) creation-to-first-eval and (2)
-    the one-time heal cycle for a previously-drifted alert. Both are
-    cosmetic — alert eval windows tile correctly because they're anchored
-    on `date_to`, not on prior eval time.
-    """
-    if check_interval_minutes <= 0:
-        raise ValueError(f"check_interval_minutes must be positive, got {check_interval_minutes}")
-    interval = timedelta(minutes=check_interval_minutes)
-
-    if current_next_check_at is None:
-        next_at = now + interval
-    else:
-        next_at = current_next_check_at + interval
-        if next_at <= now:
-            elapsed = (now - next_at).total_seconds()
-            intervals_to_skip = int(elapsed // interval.total_seconds()) + 1
-            next_at += interval * intervals_to_skip
-
-    # Bump by full interval (not 1 cadence-grid slot upward) when the floor
-    # lands at/before `now`, so the alert stays on its canonical cadence grid.
-    snapped = _floor_to_cadence_grid(next_at, check_interval_minutes) + timedelta(seconds=shard_offset_seconds)
-    if snapped <= now:
-        snapped += interval
-    return snapped
-
-
-def _floor_to_cadence_grid(t: datetime, cadence_minutes: int) -> datetime:
-    """Floor to the previous cadence-grid slot, anchored at midnight of `t`.
-
-    For divisors of 60 (1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60), this is
-    "every cadence minutes within the hour" — the grid an operator expects
-    (5-min alerts on :00/:05/:10, 15-min on :00/:15/:30/:45, etc.). Cadences
-    > 60 that divide 1440 (90, 120, 240, 360, 480, 720, 1440) also tile
-    cleanly. Cadences that divide neither 60 nor 1440 (e.g. 7, 11, 100) get
-    a discontinuity at midnight where the grid re-anchors — fine in practice
-    because alert UI almost certainly constrains cadence to common values.
-    """
-    total_minutes = t.hour * 60 + t.minute
-    floored_minutes = (total_minutes // cadence_minutes) * cadence_minutes
-    return t.replace(hour=floored_minutes // 60, minute=floored_minutes % 60, second=0, microsecond=0)
+    return shared_compute_shard_offset_seconds(
+        alert_id,
+        check_interval_minutes,
+        schedule_interval_seconds=SCHEDULE_INTERVAL_SECONDS,
+    )

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -11,7 +11,6 @@ from datetime import UTC, datetime, timedelta
 from itertools import batched
 
 from django.db import transaction
-from django.db.models import Q
 from django.db.utils import IntegrityError
 
 import structlog
@@ -21,6 +20,7 @@ from pydantic import ValidationError as PydanticValidationError
 from posthog.schema import PropertyGroupFilter
 
 from posthog.alerting.destinations import produce_alert_internal_event
+from posthog.alerting.scheduling import due_alerts_q
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.sync import database_sync_to_async_pool
@@ -316,13 +316,12 @@ class EmitAlertSignalsInput:
 
 
 def _due_alerts_qs(now: datetime):
-    return (
-        LogsAlertConfiguration.objects.filter(
-            Q(enabled=True),
-            Q(next_check_at__lte=now) | Q(next_check_at__isnull=True),
+    return LogsAlertConfiguration.objects.filter(
+        due_alerts_q(
+            now,
+            broken_state=LogsAlertConfiguration.State.BROKEN,
+            snoozed_state=LogsAlertConfiguration.State.SNOOZED,
         )
-        .exclude(state=LogsAlertConfiguration.State.SNOOZED, snooze_until__gt=now)
-        .exclude(state=LogsAlertConfiguration.State.BROKEN)
     )
 
 

--- a/products/logs/backend/test/test_due_alerts_q.py
+++ b/products/logs/backend/test/test_due_alerts_q.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.alerting.scheduling import due_alerts_q
+
+from products.logs.backend.models import LogsAlertConfiguration
+
+NOW = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+PAST = NOW - timedelta(minutes=5)
+FUTURE = NOW + timedelta(minutes=5)
+
+State = LogsAlertConfiguration.State
+
+
+class TestDueAlertsQ(BaseTest):
+    def _is_due(self, alert: LogsAlertConfiguration, *, snoozed_state: str | None) -> bool:
+        q = due_alerts_q(NOW, broken_state=State.BROKEN, snoozed_state=snoozed_state)
+        return LogsAlertConfiguration.objects.filter(q, id=alert.id).exists()
+
+    @parameterized.expand(
+        [
+            # Shared gating — identical in both snooze modes
+            ("due_past_next_check", {"next_check_at": PAST}, State.SNOOZED, True),
+            ("due_never_checked", {"next_check_at": None}, State.SNOOZED, True),
+            ("not_due_future_next_check", {"next_check_at": FUTURE}, State.SNOOZED, False),
+            ("disabled", {"enabled": False}, State.SNOOZED, False),
+            ("broken", {"state": State.BROKEN}, State.SNOOZED, False),
+            ("due_past_next_check_field_only", {"next_check_at": PAST}, None, True),
+            ("due_never_checked_field_only", {"next_check_at": None}, None, True),
+            ("not_due_future_next_check_field_only", {"next_check_at": FUTURE}, None, False),
+            ("disabled_field_only", {"enabled": False}, None, False),
+            ("broken_field_only", {"state": State.BROKEN}, None, False),
+            # State+time snooze mode (logs): only the SNOOZED state with an active snooze is excluded
+            ("snoozed_state_active_snooze", {"state": State.SNOOZED, "snooze_until": FUTURE}, State.SNOOZED, False),
+            ("snoozed_state_expired_snooze", {"state": State.SNOOZED, "snooze_until": PAST}, State.SNOOZED, True),
+            ("snoozed_state_null_snooze", {"state": State.SNOOZED, "snooze_until": None}, State.SNOOZED, True),
+            (
+                "non_snoozed_state_ignores_snooze_until",
+                {"state": State.FIRING, "snooze_until": FUTURE},
+                State.SNOOZED,
+                True,
+            ),
+            # Field-only snooze mode (billing): any future snooze_until excludes, regardless of state
+            ("field_only_future_snooze", {"state": State.FIRING, "snooze_until": FUTURE}, None, False),
+            ("field_only_expired_snooze", {"state": State.FIRING, "snooze_until": PAST}, None, True),
+            ("field_only_null_snooze", {"snooze_until": None}, None, True),
+        ]
+    )
+    def test_due_alerts_q(self, _name: str, overrides: dict, snoozed_state: str | None, expected_due: bool) -> None:
+        fields: dict = {"team": self.team, "name": "alert", "next_check_at": PAST, **overrides}
+        alert = LogsAlertConfiguration.objects.create(**fields)
+        assert self._is_due(alert, snoozed_state=snoozed_state) == expected_due


### PR DESCRIPTION
## Problem

Third slice of the shared alerting platform (stacked on the destinations PR). Both alerting sweeps (logs, billing) discover due alerts with the same predicate and advance `next_check_at` with the same cadence math, in duplicated product-local code.

## Changes

- Pure cadence math in `common/alerting/scheduling.py`: grid-snapped `advance_next_check_at` and per-alert `compute_shard_offset_seconds` (lifted verbatim from logs, parameterized on the schedule interval)
- Due-alert `Q` predicate in `posthog/alerting/scheduling.py`, with the products' snooze-exclusion divergence expressed as a parameter (logs keys on the SNOOZED state, billing on `snooze_until` alone)
- The Temporal workflow structures stay product-owned on purpose: logs runs a minutely cron with in-workflow cohort batching, billing an hourly cron with child workflows — unifying those would rewrite workflow histories for no behavior gain

## How did you test this code?

I'm an agent; automated tests only: 167 tests across logs alert utils, logs alerting activities (discovery/snooze exclusion coverage), and the billing suite pass unchanged. `ruff` and `tach check` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal refactor, no user-facing docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude)
- Key decision: a full "sweep workflow factory" was scoped out as abstraction theater — the two workflows differ structurally (batching model, cadence, child workflows) and behavior preservation forbids restructuring their histories. The shared surface is the vocabulary both use, ready for insight alerts to adopt.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
