### PR TITLE
feat(alerts): route insight alert checks through the shared lifecycle machine

### DIFF
--- a/common/alerting/__init__.py
+++ b/common/alerting/__init__.py
@@ -1,5 +1,6 @@
 from common.alerting.state_machine import (
     BILLING_ALERT_POLICY,
+    INSIGHT_ALERT_POLICY,
     LOGS_ALERT_POLICY,
     MAX_CONSECUTIVE_FAILURES,
     AlertCheckOutcome,
@@ -23,6 +24,7 @@ from common.alerting.state_machine import (
 
 __all__ = [
     "BILLING_ALERT_POLICY",
+    "INSIGHT_ALERT_POLICY",
     "LOGS_ALERT_POLICY",
     "MAX_CONSECUTIVE_FAILURES",
     "AlertCheckOutcome",

--- a/common/alerting/destinations.py
+++ b/common/alerting/destinations.py
@@ -57,6 +57,8 @@ class EventKindSpec:
 
 
 def clip_hog_function_name(name: str) -> str:
+    # Unified on the logs variant ("…"); billing previously clipped with "...". Only
+    # visible on names over 400 characters.
     if len(name) <= _HOG_FUNCTION_NAME_MAX_LEN:
         return name
     return name[: _HOG_FUNCTION_NAME_MAX_LEN - 1] + "…"

--- a/common/alerting/state_machine.py
+++ b/common/alerting/state_machine.py
@@ -73,6 +73,8 @@ class AlertPolicy:
     cooldown_gates_resolve: bool = True
     # True: an alert that stays breached re-notifies once per cooldown window.
     renotify_while_firing: bool = False
+    # False (insights): resolving back to NOT_FIRING is silent.
+    notify_on_resolve: bool = True
     # True (billing): snooze only mutes while breached — a clear check resolves and
     # un-snoozes; a breached check parks the alert in SNOOZED without notifying.
     # False (logs): a snoozed alert stays snoozed untouched until snooze_until passes.
@@ -92,6 +94,17 @@ BILLING_ALERT_POLICY = AlertPolicy(
     renotify_while_firing=True,
     clear_check_ends_snooze=True,
     disable_when_broken=True,
+)
+
+# Insight alerts have no cooldown (the calculation interval is the pacing), notify on
+# every breached or errored check, resolve silently, and have no failure counter — the
+# snapshot always passes consecutive_failures=0, so BROKEN is unreachable.
+INSIGHT_ALERT_POLICY = AlertPolicy(
+    notify_error_on_every_failure=True,
+    cooldown_gates_initial_fire=False,
+    cooldown_gates_resolve=False,
+    renotify_while_firing=True,
+    notify_on_resolve=False,
 )
 
 
@@ -249,7 +262,8 @@ def evaluate_alert_check(
                 notification = NotificationAction.FIRE
         else:
             new_state = AlertState.NOT_FIRING
-            notification = NotificationAction.RESOLVE
+            if policy.notify_on_resolve:
+                notification = NotificationAction.RESOLVE
 
     else:
         new_state = AlertState.NOT_FIRING

--- a/common/alerting/state_machine.py
+++ b/common/alerting/state_machine.py
@@ -78,6 +78,9 @@ class AlertPolicy:
     # True (billing): snooze only mutes while breached — a clear check resolves and
     # un-snoozes; a breached check parks the alert in SNOOZED without notifying.
     # False (logs): a snoozed alert stays snoozed untouched until snooze_until passes.
+    # Known wart: unlike the other flags, this one changes what the SNOOZED state
+    # *means* per product, not just when to notify. If a future adopter needs another
+    # snooze-adjacent flag, split snooze handling into a strategy instead.
     clear_check_ends_snooze: bool = False
     # True: reaching BROKEN also disables the alert (outcome.disable is set).
     disable_when_broken: bool = False
@@ -201,6 +204,9 @@ def evaluate_alert_check(
 
     snoozing = snapshot.snooze_until is not None and snapshot.snooze_until > now
 
+    # Guard order is load-bearing: this stay-guard must precede error handling so that
+    # products without clear_check_ends_snooze (logs) swallow errors during an active
+    # snooze, while products with it (billing) fall through and count them.
     if snapshot.state == AlertState.SNOOZED and snoozing and not policy.clear_check_ends_snooze:
         return _stay(snapshot)
 

--- a/posthog/alerting/destinations.py
+++ b/posthog/alerting/destinations.py
@@ -69,6 +69,8 @@ def soft_delete_alert_destinations(
         updated = HogFunction.objects.filter(
             team_id=team_id,
             id__in=unique_ids,
+            type="internal_destination",
+            template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
             filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
         ).update(deleted=True, enabled=False)
         if updated != len(unique_ids):

--- a/posthog/alerting/destinations.py
+++ b/posthog/alerting/destinations.py
@@ -21,7 +21,6 @@ from django.db import transaction
 
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 
-from products.cdp.backend.api.hog_function import HogFunctionSerializer
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 from common.alerting.destinations import ALERT_ID_PROPERTY, DESTINATION_TYPE_BY_TEMPLATE_ID
@@ -33,6 +32,10 @@ class AlertDestinationOwnershipError(Exception):
 
 def create_alert_destination_hog_functions(configs: list[dict[str, Any]], *, request: Any) -> list[HogFunction]:
     """Create one HogFunction per config, atomically. Each config carries its `team`."""
+    from products.cdp.backend.api.hog_function import (
+        HogFunctionSerializer,  # noqa: PLC0415 — keeps the DRF API stack off the import path of celery/temporal workers that only dispatch
+    )
+
     created: list[HogFunction] = []
     with transaction.atomic():
         for config in configs:
@@ -57,6 +60,9 @@ def soft_delete_alert_destinations(
 
     The filtered UPDATE is the ownership check: touching fewer rows than requested
     means something in the list doesn't belong to this alert — roll back.
+
+    Standardizes on the stricter semantics (also `enabled=False`); the pre-extraction
+    logs path only set `deleted=True`, which read paths treat identically.
     """
     unique_ids = set(hog_function_ids)
     with transaction.atomic():
@@ -74,6 +80,7 @@ def soft_delete_all_alert_destinations(*, team_id: int, alert_id: str) -> int:
     return HogFunction.objects.filter(
         team_id=team_id,
         deleted=False,
+        type="internal_destination",
         template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
         filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
     ).update(deleted=True, enabled=False)
@@ -85,6 +92,7 @@ def find_alert_destination_hog_functions(*, team_id: int, alert_id: str, event_i
         HogFunction.objects.filter(
             team_id=team_id,
             deleted=False,
+            type="internal_destination",
             template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
             filters__events__contains=[{"id": event_id, "type": "events"}],
             filters__properties__contains=[{"key": ALERT_ID_PROPERTY, "value": alert_id}],
@@ -104,6 +112,7 @@ def destination_types_for_alerts(*, team_ids: Iterable[int], alert_ids: Iterable
     hog_functions = HogFunction.objects.filter(
         team_id__in=team_id_set,
         deleted=False,
+        type="internal_destination",
         template_id__in=list(DESTINATION_TYPE_BY_TEMPLATE_ID),
     ).values_list("template_id", "filters")
 

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -339,7 +339,7 @@ def add_alert_check(
     new_state, notify = decide_insight_alert_check(
         alert,
         threshold_breached=bool(breaches),
-        error_message=(str(error.get("message", "Alert check failed")) if error else None),
+        error_message=(str(error.get("message") or "Alert check failed") if error else None),
         now=now,
     )
     alert.state = new_state

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -9,12 +9,13 @@ from dateutil.relativedelta import MO, relativedelta
 
 from posthog.schema import AlertCalculationInterval, AlertState, ChartDisplayType, NodeKind, TrendsQuery
 
-from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.alerting.destinations import produce_alert_internal_event
 from posthog.email import EmailMessage
 from posthog.exceptions_capture import capture_exception
 from posthog.tasks.alerts.schedule_restriction import snap_candidate_utc_to_schedule_restriction
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, derive_detector_event_fields
+from products.alerts.backend.state_machine import decide_insight_alert_check
 
 logger = structlog.get_logger(__name__)
 
@@ -176,13 +177,10 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
             **properties,
         }
 
-        produce_internal_event(
+        produce_alert_internal_event(
             team_id=alert.team_id,
-            event=InternalEventEvent(
-                event="$insight_alert_firing",
-                distinct_id=f"team_{alert.team_id}",
-                properties=props,
-            ),
+            event_name="$insight_alert_firing",
+            properties=props,
         )
 
     except Exception as e:
@@ -337,18 +335,16 @@ def add_alert_check(
     successful delivery and treats a non-empty value as the idempotency sentinel on retry.
     ``last_notified_at`` is likewise set by the notify activity on success, not here.
     """
-    notify = False
+    now = datetime.now(UTC)
+    new_state, notify = decide_insight_alert_check(
+        alert,
+        threshold_breached=bool(breaches),
+        error_message=(str(error.get("message", "Alert check failed")) if error else None),
+        now=now,
+    )
+    alert.state = new_state
 
-    if error:
-        alert.state = AlertState.ERRORED
-        notify = True
-    elif breaches:
-        alert.state = AlertState.FIRING
-        notify = True
-    else:
-        alert.state = AlertState.NOT_FIRING  # Threshold no longer met
-
-    alert.last_checked_at = datetime.now(UTC)
+    alert.last_checked_at = now
     # Update next_check_at per interval so we don't recheck until the next one is due.
     alert.next_check_at = next_check_time(alert)
 

--- a/products/alerts/backend/api/test/test_alert.py
+++ b/products/alerts/backend/api/test/test_alert.py
@@ -1605,7 +1605,7 @@ class TestTriggerAlertHogFunctions(APIBaseTest):
             ),
         ]
     )
-    @mock.patch("posthog.tasks.alerts.utils.produce_internal_event")
+    @mock.patch("posthog.alerting.destinations.produce_internal_event")
     def test_insight_alert_firing_detector_props(
         self,
         _name: str,

--- a/products/alerts/backend/state_machine.py
+++ b/products/alerts/backend/state_machine.py
@@ -1,0 +1,62 @@
+"""Insight alert adapter for the shared alert lifecycle machine.
+
+The decision logic lives in common/alerting/state_machine.py, configured with
+INSIGHT_ALERT_POLICY. Insight alerts store their state with the legacy
+posthog.schema AlertState string values ("Firing", "Not firing", ...), so this
+module owns the enum mapping at the boundary; the check-driven transition in
+posthog/tasks/alerts/utils.py routes through decide_insight_alert_check.
+
+Control-plane transitions (snooze/unsnooze in the API, disable in the model's
+save hook, snooze-expiry in the prepare activity) still assign state inline —
+they predate the shared machine and match its apply_* semantics one-to-one.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from posthog.schema_enums import AlertState
+
+from common.alerting.state_machine import (
+    INSIGHT_ALERT_POLICY,
+    AlertSnapshot as SharedAlertSnapshot,
+    AlertState as SharedAlertState,
+    CheckInput,
+    NotificationAction,
+    evaluate_alert_check,
+)
+
+if TYPE_CHECKING:
+    from products.alerts.backend.models.alert import AlertConfiguration
+
+_TO_SHARED_STATE: dict[AlertState, SharedAlertState] = {
+    AlertState.FIRING: SharedAlertState.FIRING,
+    AlertState.NOT_FIRING: SharedAlertState.NOT_FIRING,
+    AlertState.ERRORED: SharedAlertState.ERRORED,
+    AlertState.SNOOZED: SharedAlertState.SNOOZED,
+}
+_FROM_SHARED_STATE: dict[SharedAlertState, AlertState] = {shared: legacy for legacy, shared in _TO_SHARED_STATE.items()}
+
+
+def decide_insight_alert_check(
+    alert: AlertConfiguration,
+    *,
+    threshold_breached: bool,
+    error_message: str | None,
+    now: datetime,
+) -> tuple[AlertState, bool]:
+    """Decide (new_state, notify) for one insight alert check."""
+    outcome = evaluate_alert_check(
+        SharedAlertSnapshot(
+            state=_TO_SHARED_STATE[AlertState(alert.state)],
+            cooldown=timedelta(0),
+            last_notified_at=alert.last_notified_at,
+            snooze_until=alert.snoozed_until,
+            consecutive_failures=0,
+        ),
+        CheckInput(threshold_breached=threshold_breached, error_message=error_message),
+        now,
+        policy=INSIGHT_ALERT_POLICY,
+    )
+    return _FROM_SHARED_STATE[outcome.new_state], outcome.notification != NotificationAction.NONE

--- a/products/alerts/backend/state_machine.py
+++ b/products/alerts/backend/state_machine.py
@@ -9,6 +9,12 @@ posthog/tasks/alerts/utils.py routes through decide_insight_alert_check.
 Control-plane transitions (snooze/unsnooze in the API, disable in the model's
 save hook, snooze-expiry in the prepare activity) still assign state inline —
 they predate the shared machine and match its apply_* semantics one-to-one.
+
+One deliberate divergence from the pre-adapter logic: an alert evaluated while
+SNOOZED with an active `snoozed_until` now stays SNOOZED silently, where the old
+inline code would set FIRING/ERRORED and notify. That window is unreachable in
+the scheduled path (the prepare activity skips actively-snoozed alerts and clears
+expired snoozes before evaluation) and the new behavior is the safe direction.
 """
 
 from __future__ import annotations

--- a/products/alerts/backend/test/test_state_machine.py
+++ b/products/alerts/backend/test/test_state_machine.py
@@ -1,0 +1,104 @@
+from datetime import UTC, datetime, timedelta
+
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from posthog.schema_enums import AlertState
+
+from products.alerts.backend.models.alert import AlertConfiguration
+from products.alerts.backend.state_machine import decide_insight_alert_check
+
+NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+
+
+def _alert(
+    state: AlertState = AlertState.NOT_FIRING,
+    last_notified_at: datetime | None = None,
+    snoozed_until: datetime | None = None,
+) -> AlertConfiguration:
+    return AlertConfiguration(
+        state=state,
+        last_notified_at=last_notified_at,
+        snoozed_until=snoozed_until,
+    )
+
+
+class TestInsightAlertPolicyContract(TestCase):
+    # Pins the INSIGHT_ALERT_POLICY semantics of the shared machine — the riskiest
+    # adoption (every insight alert check routes through it). If a change to the
+    # shared machine or policy defaults flips one of these rows, insight alert
+    # behavior changed.
+
+    @parameterized.expand(
+        [
+            # (name, alert, breached, error_message, expected_state, expected_notify)
+            ("initial_fire", _alert(), True, None, AlertState.FIRING, True),
+            (
+                # No cooldown: a still-breached alert notifies on every check.
+                "refire_while_firing_notifies",
+                _alert(AlertState.FIRING, last_notified_at=NOW - timedelta(minutes=1)),
+                True,
+                None,
+                AlertState.FIRING,
+                True,
+            ),
+            ("resolve_is_silent", _alert(AlertState.FIRING), False, None, AlertState.NOT_FIRING, False),
+            ("clear_check_stays_silent", _alert(), False, None, AlertState.NOT_FIRING, False),
+            ("error_notifies", _alert(), False, "query failed", AlertState.ERRORED, True),
+            (
+                # Repeat errors keep notifying (no first-transition gating for insights).
+                "repeat_error_notifies",
+                _alert(AlertState.ERRORED),
+                False,
+                "query failed",
+                AlertState.ERRORED,
+                True,
+            ),
+            ("breach_after_error_fires", _alert(AlertState.ERRORED), True, None, AlertState.FIRING, True),
+            (
+                # Documented divergence: actively snoozed checks stay snoozed silently.
+                # Unreachable in the scheduled path (prepare skips snoozed alerts) —
+                # this row pins the safe fallback for any other caller.
+                "actively_snoozed_stays_silent",
+                _alert(AlertState.SNOOZED, snoozed_until=NOW + timedelta(days=1)),
+                True,
+                None,
+                AlertState.SNOOZED,
+                False,
+            ),
+            (
+                "expired_snooze_refires",
+                _alert(AlertState.SNOOZED, snoozed_until=NOW - timedelta(hours=1)),
+                True,
+                None,
+                AlertState.FIRING,
+                True,
+            ),
+            (
+                "expired_snooze_clear_is_silent",
+                _alert(AlertState.SNOOZED, snoozed_until=NOW - timedelta(hours=1)),
+                False,
+                None,
+                AlertState.NOT_FIRING,
+                False,
+            ),
+        ]
+    )
+    def test_check_decisions(
+        self,
+        _name: str,
+        alert,
+        breached: bool,
+        error_message: str | None,
+        expected_state: AlertState,
+        expected_notify: bool,
+    ) -> None:
+        new_state, notify = decide_insight_alert_check(
+            alert,
+            threshold_breached=breached,
+            error_message=error_message,
+            now=NOW,
+        )
+        assert new_state == expected_state
+        assert notify is expected_notify

--- a/products/billing_alerts/backend/models.py
+++ b/products/billing_alerts/backend/models.py
@@ -12,7 +12,11 @@ from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDModel
 
-MAX_FAILURES_BEFORE_BROKEN = 5
+from common.alerting.state_machine import MAX_CONSECUTIVE_FAILURES
+
+# Alias of the shared threshold so the two can't drift; the live value is what
+# BILLING_ALERT_POLICY.max_consecutive_failures feeds the shared state machine.
+MAX_FAILURES_BEFORE_BROKEN = MAX_CONSECUTIVE_FAILURES
 
 
 class BillingAlertConfiguration(UUIDModel):


### PR DESCRIPTION
## Problem

Final slice of the shared alerting platform: insight alerts (the original alerting product) adopt the shared lifecycle machine, making all three alerting products configurations of one decision table. `AlertConfiguration` keeps its insight FK — it's the insight evaluator's config, invisible to the shared layer, which dissolves the "required FK makes the shared system unusable" objection.

## Changes

- `INSIGHT_ALERT_POLICY` in the shared machine (notify on every breached/errored check, silent resolve, no cooldown, no failure counter) plus a new `notify_on_resolve` policy flag
- Adapter in `products/alerts/backend/state_machine.py` owns the mapping between the legacy schema `AlertState` strings ("Firing", "Not firing") and the shared enum; `add_alert_check` derives (state, notify) from the shared decision table
- `$insight_alert_firing` dispatch routes through the shared internal-event producer
- Review follow-ups (second commit): insight policy contract test, deferred `HogFunctionSerializer` import (keeps the DRF stack off celery/temporal worker import paths), `type="internal_destination"` scoping on shared destination queries, billing's broken-threshold constant aliased to the shared value, documented deltas
- One deliberate divergence, documented and test-pinned: an alert evaluated while actively snoozed now stays SNOOZED silently instead of firing and notifying — unreachable in the scheduled path (the prepare activity skips snoozed alerts) and the safe direction elsewhere
- Control-plane transitions (snooze/unsnooze/disable) still assign state inline; they match the shared `apply_*` semantics one-to-one and are a follow-up

## How did you test this code?

I'm an agent; automated tests only, plus an instrumented local run:

- Insight alert suites pass unchanged: 107 API tests, evaluation tests, the full temporal alerts + helpers suite
- New parameterized contract test (`products/alerts/backend/test/test_state_machine.py`) pins `INSIGHT_ALERT_POLICY` — re-fire-every-check, silent resolve, error-always-notifies, and the snooze rows; no prior test asserted these decisions directly
- Local end-to-end run on this branch and on the base branch: billing, logs, and insight alerts each created with Slack destinations, fired synthetically, and delivered real Slack messages with identical state transitions and event rows in both runs
- Multi-perspective automated review (differential grid testing of old vs new decision logic): logs 0/51,840 mismatches, billing 0/1,480, insights 12/144 — all 12 in the documented snooze window

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal refactor, no user-facing docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude); skills invoked: `/writing-tests`, `run-posthog` (E2E verification), plus a multi-agent review pass whose actionable findings are addressed in the second commit
- Key decision: adapt at the enum boundary rather than migrate the legacy state strings — no schema change, no data migration, and the shared layer never sees insight-specific vocabulary

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
