### PR TITLE
test(batch-import): prove staging reads reconstruct across record boundaries

### DIFF
--- a/rust/batch-import-worker/src/staging/backend.rs
+++ b/rust/batch-import-worker/src/staging/backend.rs
@@ -302,6 +302,47 @@ pub(crate) async fn stage_bytes(
     backend.stage_part(key, stream).await
 }
 
+/// Prove a backend's reads reconstruct the staged bytes exactly across arbitrary,
+/// record-misaligned offsets — the property the job loop relies on when it re-reads a
+/// partial trailing record. Stages `body`, reads it back in tiny (7-byte) slices whose
+/// boundaries do not align with record boundaries, asserts the concatenation equals
+/// `body`, and asserts a single read spanning more than one slice returns the exact span.
+///
+/// Shared across backends so both `LocalDiskBackend` and `TempBucketBackend` are held to
+/// the identical read contract.
+#[cfg(test)]
+pub(crate) async fn assert_reads_reconstruct(backend: &dyn StagingBackend, key: &str, body: &[u8]) {
+    let size = stage_bytes(backend, key, body).await.unwrap();
+    assert_eq!(size, body.len() as u64);
+
+    // Reassemble via small, deliberately record-misaligned reads.
+    const SLICE: u64 = 7;
+    let mut reconstructed = Vec::with_capacity(body.len());
+    let mut offset = 0u64;
+    loop {
+        let chunk = backend.read(key, offset, SLICE).await.unwrap();
+        if chunk.is_empty() {
+            break;
+        }
+        assert!(
+            chunk.len() as u64 <= SLICE,
+            "read returned more than requested"
+        );
+        reconstructed.extend_from_slice(&chunk);
+        offset += chunk.len() as u64;
+    }
+    assert_eq!(
+        reconstructed, body,
+        "misaligned reads must reconstruct the body"
+    );
+
+    // A single read wider than a slice returns exactly the requested span.
+    if body.len() >= 20 {
+        let span = backend.read(key, 5, 15).await.unwrap();
+        assert_eq!(span, &body[5..20]);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -433,6 +474,14 @@ mod tests {
             .await
             .unwrap();
         assert!(entries.next_entry().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn misaligned_reads_reconstruct_body() {
+        let root = TempDir::new().unwrap();
+        let be = backend(root.path());
+        let body = b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n{\"id\":4}\n";
+        assert_reads_reconstruct(&be, "k", body).await;
     }
 
     #[tokio::test]

--- a/rust/batch-import-worker/src/staging/temp_bucket.rs
+++ b/rust/batch-import-worker/src/staging/temp_bucket.rs
@@ -252,6 +252,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn misaligned_reads_reconstruct_body() {
+        let be = backend();
+        let body = b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n{\"id\":4}\n";
+        crate::staging::backend::assert_reads_reconstruct(&be, "2024-01-01:00", body).await;
+    }
+
+    #[tokio::test]
     async fn cross_backend_byte_identity_with_local_disk() {
         // The load-bearing guarantee: the same compressed part staged through the pipeline
         // yields identical bytes + size on both backends, so a part's offsets stay valid


### PR DESCRIPTION
## Problem

The temp-bucket staging backends read staged part data back by byte offset, and the job loop relies on those reads being exact across arbitrary, record-misaligned boundaries (it re-reads a partial trailing record after each parse). This adds a durable proof of that contract. Stacked on #67578.

## Changes

- Add a shared assert_reads_reconstruct test helper: stage a multi-record body, read it back in tiny 7-byte record-misaligned slices, assert the concatenation equals the body, and assert a wider read returns the exact span.
- Exercise it against both LocalDiskBackend and TempBucketBackend so both are held to the same offset-read contract.

Test-only change; no production code touched.

## How did you test this code?

I am an agent (Cursor, agent-assisted). Automated only. cargo fmt, cargo clippy --all-targets (clean), cargo test -p batch-import-worker (all staging tests pass, including the two new misaligned_reads_reconstruct_body cases).

This closes a gap the existing tests did not cover directly: prior read tests used hand-picked offsets and full reads; this proves reconstruction for arbitrary boundaries that do not line up with record delimiters, which is what the parser depends on.

## Agent context

Autonomy: Human-driven (agent-assisted)

- Built with Cursor, as the durable read-contract proof from a boundary-correctness review of the streaming/temp-bucket work. The related producer-panic and oversized-record fixes live in the upstream streaming/guard PRs (#67149 / #67157); this PR covers the temp-bucket backend read contract.
- No mandatory repo skills applied (Rust service; no DRF/migration/frontend surface).
