### PR TITLE
fix(customer-analytics): Read all matched rows in custom property sync

### DIFF
--- a/products/customer_analytics/backend/logic/custom_property_sync.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync.py
@@ -80,16 +80,19 @@ def sync_custom_property_values(*, team_id: int, saved_query_id: str | UUID) -> 
     ordered = sorted(selected_columns)
     column_index = {column: position for position, column in enumerate(ordered)}
     account_ids_by_external_id = _get_account_ids_by_external_id(team_id)
-    key_columns = sorted({source.key_column for source in usable})
     external_ids = sorted(account_ids_by_external_id)
-    rows = _read_view(Team.objects.get(id=team_id), saved_query.name, ordered, key_columns, external_ids)
+    team = Team.objects.get(id=team_id)
+    rows_by_key_column = {
+        key_column: _read_view(team, saved_query.name, ordered, key_column, external_ids)
+        for key_column in sorted({source.key_column for source in usable})
+    }
     result.accounts_total = len(account_ids_by_external_id)
-    result.rows_fetched = len(rows)
+    result.rows_fetched = sum(len(rows) for rows in rows_by_key_column.values())
 
     unmatched: set[Any] = set()
     for source in usable:
         key_index, value_index = column_index[source.key_column], column_index[source.source_column]
-        for row in rows:
+        for row in rows_by_key_column[source.key_column]:
             key = row[key_index]
             if key is None:
                 continue
@@ -132,39 +135,36 @@ def _write(*, team_id: int, account_id: Any, source: CustomPropertySource, value
     return False
 
 
-def _read_view(team: Team, view_name: str, columns: list[str], key_columns: list[str], external_ids: list[str]) -> list:
+def _read_view(team: Team, view_name: str, columns: list[str], key_column: str, external_ids: list[str]) -> list:
     """Reads only view rows whose key matches a known account external_id, batching the key filter to
     keep each query small. An unfiltered read would be silently capped by the HogQL default limit —
-    views are often orders of magnitude larger than the account set they enrich."""
+    views are often orders of magnitude larger than the account set they enrich. Filtering on a single
+    key column keeps batches disjoint: a row matches at most one batch, so no duplicates accumulate."""
     rows: list = []
-    for start in range(0, len(external_ids), _SYNC_KEYS_PER_QUERY):
-        batch = external_ids[start : start + _SYNC_KEYS_PER_QUERY]
-        key_matches = [
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.In,
-                left=ast.Call(name="toString", args=[ast.Field(chain=[key_column])]),
-                right=ast.Array(exprs=[ast.Constant(value=external_id) for external_id in batch]),
+    with tags_context(product=Product.CUSTOMER_ANALYTICS, feature=Feature.ACCOUNTS, team_id=team.pk):
+        for start in range(0, len(external_ids), _SYNC_KEYS_PER_QUERY):
+            batch = external_ids[start : start + _SYNC_KEYS_PER_QUERY]
+            query = ast.SelectQuery(
+                select=[ast.Field(chain=[column]) for column in columns],
+                select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
+                where=ast.CompareOperation(
+                    op=ast.CompareOperationOp.In,
+                    left=ast.Call(name="toString", args=[ast.Field(chain=[key_column])]),
+                    right=ast.Array(exprs=[ast.Constant(value=external_id) for external_id in batch]),
+                ),
+                limit=ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
             )
-            for key_column in key_columns
-        ]
-        query = ast.SelectQuery(
-            select=[ast.Field(chain=[column]) for column in columns],
-            select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
-            where=ast.Or(exprs=key_matches) if len(key_matches) > 1 else key_matches[0],
-            limit=ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
-        )
-        with tags_context(product=Product.CUSTOMER_ANALYTICS, feature=Feature.ACCOUNTS, team_id=team.pk):
             # Runs as a userless system sync, so bypass user-scoped warehouse-view access control
             # (it fails closed without a user); tenant isolation still holds via team.
             batch_rows = execute_hogql_query(query, team=team, bypass_warehouse_access_control=True).results or []
-        if len(batch_rows) >= MAX_SELECT_RETURNED_ROWS:
-            logger.warning(
-                "custom_property_sync.view_read_truncated",
-                team_id=team.pk,
-                view_name=view_name,
-                batch_keys=len(batch),
-            )
-        rows.extend(batch_rows)
+            if len(batch_rows) >= MAX_SELECT_RETURNED_ROWS:
+                logger.warning(
+                    "custom_property_sync.view_read_truncated",
+                    team_id=team.pk,
+                    view_name=view_name,
+                    batch_keys=len(batch),
+                )
+            rows.extend(batch_rows)
     return rows
 
 

--- a/products/customer_analytics/backend/logic/custom_property_sync.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync.py
@@ -110,7 +110,9 @@ def sync_custom_property_values(*, team_id: int, saved_query_id: str | UUID) -> 
 
 def _get_account_ids_by_external_id(team_id: int) -> dict[str, UUID]:
     accounts = Account.objects.for_team(team_id).exclude(external_id=None).exclude(external_id="")
-    return dict(accounts.values_list("external_id", "id"))
+    return {
+        external_id: account_id for external_id, account_id in accounts.values_list("external_id", "id") if external_id
+    }
 
 
 def _write(*, team_id: int, account_id: Any, source: CustomPropertySource, value: Any, result: SyncResult) -> bool:

--- a/products/customer_analytics/backend/logic/custom_property_sync.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync.py
@@ -13,7 +13,10 @@ from uuid import UUID
 from django.db import transaction
 from django.utils import timezone
 
+import structlog
+
 from posthog.hogql import ast
+from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
@@ -27,7 +30,10 @@ from products.customer_analytics.backend.logic.custom_property_values import (
 )
 from products.customer_analytics.backend.models import Account, CustomPropertySource
 
+logger = structlog.get_logger(__name__)
+
 _WRITE_CONFLICT_RETRIES = 3
+_SYNC_KEYS_PER_QUERY = 1000
 
 # Mirrors data_modeling's CONSECUTIVE_TIMEOUTS_TO_PAUSE: auto-disable a source that keeps failing.
 MAX_CONSECUTIVE_SYNC_FAILURES = 5
@@ -39,6 +45,8 @@ class SyncResult:
     view_found: bool
     written: int = 0
     unmatched_keys: int = 0
+    accounts_total: int = 0
+    rows_fetched: int = 0
     source_errors: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
@@ -71,8 +79,12 @@ def sync_custom_property_values(*, team_id: int, saved_query_id: str | UUID) -> 
 
     ordered = sorted(selected_columns)
     column_index = {column: position for position, column in enumerate(ordered)}
-    rows = _read_view(Team.objects.get(id=team_id), saved_query.name, ordered)
-    accounts = _accounts_by_external_id(team_id, rows, column_index, usable)
+    account_ids_by_external_id = _get_account_ids_by_external_id(team_id)
+    key_columns = sorted({source.key_column for source in usable})
+    external_ids = sorted(account_ids_by_external_id)
+    rows = _read_view(Team.objects.get(id=team_id), saved_query.name, ordered, key_columns, external_ids)
+    result.accounts_total = len(account_ids_by_external_id)
+    result.rows_fetched = len(rows)
 
     unmatched: set[Any] = set()
     for source in usable:
@@ -81,24 +93,21 @@ def sync_custom_property_values(*, team_id: int, saved_query_id: str | UUID) -> 
             key = row[key_index]
             if key is None:
                 continue
-            account = accounts.get(str(key))
-            if account is None:
+            account_id = account_ids_by_external_id.get(str(key))
+            if account_id is None:
                 unmatched.add(key)
                 continue
             if row[value_index] is None:
                 continue
-            if _write(team_id=team_id, account_id=account.id, source=source, value=row[value_index], result=result):
+            if _write(team_id=team_id, account_id=account_id, source=source, value=row[value_index], result=result):
                 result.written += 1
     result.unmatched_keys = len(unmatched)
     return result
 
 
-def _accounts_by_external_id(
-    team_id: int, rows: list, column_index: dict[str, int], sources: list[CustomPropertySource]
-) -> dict[str | None, Account]:
-    keys = {row[column_index[source.key_column]] for source in sources for row in rows}
-    external_ids = [str(key) for key in keys if key is not None]
-    return {a.external_id: a for a in Account.objects.for_team(team_id).filter(external_id__in=external_ids)}
+def _get_account_ids_by_external_id(team_id: int) -> dict[str, UUID]:
+    accounts = Account.objects.for_team(team_id).exclude(external_id=None).exclude(external_id="")
+    return dict(accounts.values_list("external_id", "id"))
 
 
 def _write(*, team_id: int, account_id: Any, source: CustomPropertySource, value: Any, result: SyncResult) -> bool:
@@ -123,15 +132,40 @@ def _write(*, team_id: int, account_id: Any, source: CustomPropertySource, value
     return False
 
 
-def _read_view(team: Team, view_name: str, columns: list[str]) -> list:
-    query = ast.SelectQuery(
-        select=[ast.Field(chain=[column]) for column in columns],
-        select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
-    )
-    with tags_context(product=Product.CUSTOMER_ANALYTICS, feature=Feature.ACCOUNTS, team_id=team.pk):
-        # Runs as a userless system sync, so bypass user-scoped warehouse-view access control
-        # (it fails closed without a user); tenant isolation still holds via team.
-        return execute_hogql_query(query, team=team, bypass_warehouse_access_control=True).results or []
+def _read_view(team: Team, view_name: str, columns: list[str], key_columns: list[str], external_ids: list[str]) -> list:
+    """Reads only view rows whose key matches a known account external_id, batching the key filter to
+    keep each query small. An unfiltered read would be silently capped by the HogQL default limit —
+    views are often orders of magnitude larger than the account set they enrich."""
+    rows: list = []
+    for start in range(0, len(external_ids), _SYNC_KEYS_PER_QUERY):
+        batch = external_ids[start : start + _SYNC_KEYS_PER_QUERY]
+        key_matches = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.In,
+                left=ast.Call(name="toString", args=[ast.Field(chain=[key_column])]),
+                right=ast.Array(exprs=[ast.Constant(value=external_id) for external_id in batch]),
+            )
+            for key_column in key_columns
+        ]
+        query = ast.SelectQuery(
+            select=[ast.Field(chain=[column]) for column in columns],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
+            where=ast.Or(exprs=key_matches) if len(key_matches) > 1 else key_matches[0],
+            limit=ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
+        )
+        with tags_context(product=Product.CUSTOMER_ANALYTICS, feature=Feature.ACCOUNTS, team_id=team.pk):
+            # Runs as a userless system sync, so bypass user-scoped warehouse-view access control
+            # (it fails closed without a user); tenant isolation still holds via team.
+            batch_rows = execute_hogql_query(query, team=team, bypass_warehouse_access_control=True).results or []
+        if len(batch_rows) >= MAX_SELECT_RETURNED_ROWS:
+            logger.warning(
+                "custom_property_sync.view_read_truncated",
+                team_id=team.pk,
+                view_name=view_name,
+                batch_keys=len(batch),
+            )
+        rows.extend(batch_rows)
+    return rows
 
 
 def record_sync_outcome(
@@ -188,5 +222,16 @@ def run_custom_property_sync(*, team_id: int, saved_query_id: str | UUID) -> Syn
         saved_query_id=saved_query_id,
         view_found=result.view_found,
         source_errors=result.source_errors,
+    )
+    logger.info(
+        "custom_property_sync.completed",
+        team_id=team_id,
+        saved_query_id=str(saved_query_id),
+        view_found=result.view_found,
+        written=result.written,
+        unmatched_keys=result.unmatched_keys,
+        accounts_total=result.accounts_total,
+        rows_fetched=result.rows_fetched,
+        source_errors=len(result.source_errors),
     )
     return result

--- a/products/customer_analytics/backend/logic/custom_property_sync_test.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync_test.py
@@ -137,6 +137,14 @@ class CustomPropertySyncTest(TeamScopedTestMixin, BaseTest):
         assert source.last_sync_error == "boom"
         mock_capture.assert_called_once()
 
+    def test_read_view_batches_key_filter_and_merges_rows(self):
+        batch_size = "products.customer_analytics.backend.logic.custom_property_sync._SYNC_KEYS_PER_QUERY"
+        responses = [_Response([(100.0, "acme")]), _Response([(200.0, "globex")])]
+        with patch(_EXECUTE, side_effect=responses), patch(batch_size, 1):
+            rows = _read_view(self.team, "billing_view", ["mrr", "org_id"], ["org_id"], ["acme", "globex"])
+
+        assert rows == [(100.0, "acme"), (200.0, "globex")]
+
 
 @patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
 class ReadViewAccessControlTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTest):
@@ -150,9 +158,30 @@ class ReadViewAccessControlTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTe
             columns={"org_id": "String", "health_score": "Int64"},
         )
 
-        rows = _read_view(self.team, view.name, ["health_score", "org_id"])
+        rows = _read_view(self.team, view.name, ["health_score", "org_id"], ["org_id"], ["acme"])
 
         assert rows == [(100, "acme")]
+
+
+class ReadViewLimitTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTest):
+    def test_reads_all_matching_rows_beyond_default_hogql_limit(self):
+        # An unfiltered, unlimited read gets capped at 100 rows by the HogQL default limit,
+        # silently dropping most of a large view. 120 matches > 100 proves the cap is gone;
+        # < 150 proves rows without a matching external_id are filtered out server-side.
+        view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="org_scores",
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT toString(number) AS org_id, number AS score FROM numbers(150)",
+            },
+            columns={"org_id": "String", "score": "Int64"},
+        )
+        external_ids = [str(n) for n in range(120)]
+
+        rows = _read_view(self.team, view.name, ["org_id", "score"], ["org_id"], external_ids)
+
+        assert len(rows) == 120
 
 
 class RecordSyncOutcomeTest(TeamScopedTestMixin, BaseTest):

--- a/products/customer_analytics/backend/logic/custom_property_sync_test.py
+++ b/products/customer_analytics/backend/logic/custom_property_sync_test.py
@@ -141,7 +141,7 @@ class CustomPropertySyncTest(TeamScopedTestMixin, BaseTest):
         batch_size = "products.customer_analytics.backend.logic.custom_property_sync._SYNC_KEYS_PER_QUERY"
         responses = [_Response([(100.0, "acme")]), _Response([(200.0, "globex")])]
         with patch(_EXECUTE, side_effect=responses), patch(batch_size, 1):
-            rows = _read_view(self.team, "billing_view", ["mrr", "org_id"], ["org_id"], ["acme", "globex"])
+            rows = _read_view(self.team, "billing_view", ["mrr", "org_id"], "org_id", ["acme", "globex"])
 
         assert rows == [(100.0, "acme"), (200.0, "globex")]
 
@@ -158,7 +158,7 @@ class ReadViewAccessControlTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTe
             columns={"org_id": "String", "health_score": "Int64"},
         )
 
-        rows = _read_view(self.team, view.name, ["health_score", "org_id"], ["org_id"], ["acme"])
+        rows = _read_view(self.team, view.name, ["health_score", "org_id"], "org_id", ["acme"])
 
         assert rows == [(100, "acme")]
 
@@ -179,7 +179,7 @@ class ReadViewLimitTest(ClickhouseTestMixin, TeamScopedTestMixin, BaseTest):
         )
         external_ids = [str(n) for n in range(120)]
 
-        rows = _read_view(self.team, view.name, ["org_id", "score"], ["org_id"], external_ids)
+        rows = _read_view(self.team, view.name, ["org_id", "score"], "org_id", external_ids)
 
         assert len(rows) == 120
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The custom property sync reads the source view with no LIMIT, so HogQL's default 100-row cap silently truncates it. On views larger than 100 rows most accounts never get values, while the source still reports a successful sync.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Filter the view read server-side to rows whose key matches an account `external_id`, batched 1,000 keys per query
- Set an explicit 50k limit per batch and log a warning if a batch ever hits it
- Fetch the `{external_id: account_id}` map in one query up front instead of deriving it from fetched rows
- Log the sync outcome (written, unmatched, accounts, rows fetched) after each run

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

Unit tests (20 passing in `custom_property_sync_test.py`, plus the facade and custom property value suites).
New ClickHouse-backed test reads a 150-row view with 120 matching accounts and asserts 120 rows back — fails on the default-limit cap and on broken key filtering; existing sync tests mock the HogQL boundary so neither regression was covered. A second test catches the batching loop dropping a batch.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code. Skills invoked: `/writing-tests`.
Root cause was diagnosed against production data before the fix (sync reported success in seconds on a large view; populated values matched the expected count for a 100-row read).
Reviewer suggested joining `system.accounts` in the view query instead of the IN filter; rejected because access-scoped system tables are removed from the HogQL database in userless contexts (this sync is a userless Celery task) and `PostgresTable` joins make ClickHouse query Postgres through the RDS proxy at runtime.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
