### PR TITLE
perf(marketing-analytics): remove N+1 queries in adapter factory

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -318,8 +318,9 @@ class MarketingSourceFactory:
                 if not source_map:
                     continue
 
-                # For non-native: use schema ID to match frontend (table.schema?.id || table.source?.id || table.id)
-                schema = table.externaldataschema_set.first()
+                # For non-native: use schema ID to match frontend (table.schema?.id || table.source?.id || table.id).
+                # Iterate the prefetched set — `.first()` issues a fresh query and bypasses the prefetch cache.
+                schema = next(iter(table.externaldataschema_set.all()), None)
                 source_id = str(schema.id) if schema else str(table.id)
 
                 config = ExternalConfig(

--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -1,5 +1,6 @@
 # Marketing Source Adapter Factory
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Optional
 
 import structlog
@@ -155,9 +156,22 @@ class MarketingSourceFactory:
         database = self.context.database or Database.create_for(
             team=self.context.team, bypass_warehouse_access_control=True
         )
-        self._warehouse_tables = DataWarehouseTable.objects.filter(
-            team_id=self.context.team.pk, deleted=False, name__in=database.get_warehouse_table_names()
-        ).prefetch_related("externaldataschema_set")
+        # Evaluate the warehouse tables once, pulling the owning source (select_related) and schema set
+        # (prefetch_related) in the same round-trip. The per-source adapter loops below then read from
+        # memory: previously each `._warehouse_tables.filter(external_data_source=source)` re-ran the
+        # `name__in=<all table names>` query once per source, which dominated adapter construction.
+        self._warehouse_tables = list(
+            DataWarehouseTable.objects.filter(
+                team_id=self.context.team.pk, deleted=False, name__in=database.get_warehouse_table_names()
+            )
+            .select_related("external_data_source")
+            .prefetch_related("externaldataschema_set")
+        )
+        self._tables_by_source_id: dict[str, list[DataWarehouseTable]] = defaultdict(list)
+        for table in self._warehouse_tables:
+            if table.external_data_source_id is not None:
+                self._tables_by_source_id[str(table.external_data_source_id)].append(table)
+        self._external_sources = list(ExternalDataSource.objects.filter(team_id=self.context.team.pk))
         self._sources_map = self.context.team.marketing_analytics_config.sources_map_typed
 
     @classmethod
@@ -183,13 +197,12 @@ class MarketingSourceFactory:
         """Create adapters for native marketing sources"""
 
         adapters = []
-        external_sources = ExternalDataSource.objects.filter(team_id=self.context.team.pk)
 
-        for source in external_sources:
+        for source in self._external_sources:
             if source.source_type not in VALID_NATIVE_MARKETING_SOURCES:
                 continue
 
-            tables = list(self._warehouse_tables.filter(external_data_source=source))
+            tables = self._tables_by_source_id.get(str(source.id), [])
             if not tables:
                 continue
 
@@ -288,16 +301,15 @@ class MarketingSourceFactory:
     def _create_external_adapters(self) -> list[MarketingSourceAdapter]:
         """Create adapters for non-native marketing sources"""
         adapters = []
-        external_sources = ExternalDataSource.objects.filter(team_id=self.context.team.pk)
 
-        for source in external_sources:
+        for source in self._external_sources:
             if source.source_type not in VALID_NON_NATIVE_MARKETING_SOURCES:
                 continue
             adapter_class = self._adapter_registry.get(source.source_type)
             if not adapter_class:
                 continue
 
-            tables = list(self._warehouse_tables.filter(external_data_source=source))
+            tables = self._tables_by_source_id.get(str(source.id), [])
             if not tables:
                 continue
 


### PR DESCRIPTION
## Problem

Fine-grained timing on the marketing analytics query (prod, instrumentation from the sub-span PR) showed that building the source adapters — not I/O, not ClickHouse — dominates the query build:

```
ma_adapters_create        1.333s   ← MarketingSourceFactory.create_adapters
ma_precompute_adapters    1.234s   ← the precompute path rebuilds adapters
ma_precompute_ensure      0.009s   ← job readiness I/O is basically free
clickhouse_execute        0.049s
```

Reading `create_adapters`, the cost is an N+1 against Postgres. `MarketingSourceFactory._warehouse_tables` was a lazy `QuerySet`, and both `_create_native_adapters` and `_create_external_adapters` ran `self._warehouse_tables.filter(external_data_source=source)` **inside the per-source loop** — one query per source, each re-executing the `name__in=<all warehouse table names>` filter. `_create_self_managed_adapters` then touched `table.external_data_source` per row, which wasn't prefetched (only `externaldataschema_set` was), adding another N+1. Both `_create_native_adapters` and `_create_external_adapters` also each re-ran `ExternalDataSource.objects.filter(team_id=...)`. On a team with many sources and hundreds of warehouse tables this is the ~1.2s.

## Changes

Resolve the warehouse data once in `__init__` and have the loops read from memory:

- Evaluate `_warehouse_tables` a single time, adding `select_related("external_data_source")` alongside the existing `prefetch_related("externaldataschema_set")` so the owning source comes in the same round-trip.
- Group tables into `_tables_by_source_id` once; the per-source loops do a dict lookup instead of `.filter(...)`.
- Cache `ExternalDataSource.objects.filter(team_id=...)` once as `_external_sources`.

Net: from ~2·(sources) + (tables) queries down to a small constant. No behavior change — the same adapters are produced.

This targets the precompute path (`ma_precompute_adapters`) that the companion "skip adapter build on precompute hit" PR does not cover, so the two compound.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Automated:

- `test_factory.py`, `test_marketing_analytics_table_query_runner.py`, `test_marketing_costs_precompute.py`: **94 passed** (incl. 1 snapshot) — same adapters/queries produced.
- `ruff check` and `ty check` clean.

No new test added, deliberately: the only meaningful regression guard is "adapter-build queries don't scale with source count", which needs real `ExternalDataSource` + linked `DataWarehouseTable` fixtures that the current test scaffolding doesn't provide (the factory tests are Mock-based, so an `assertNumQueries` there is trivially green with or without the bug). Escalating to heavy DB fixtures for a fragile perf assertion isn't worth it; the existing 94 behavior tests lock in that the same adapters are produced, and the win is validated by re-reading prod timings after deploy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, human-directed, during a latency investigation into the post-precompute marketing analytics query. The instrumentation PR narrowed the cost to `create_adapters`; reading it surfaced the per-source `.filter()` N+1. Invoked the `/writing-tests` skill to decide on test coverage and concluded (documented above) that a robust regression test would require DB fixtures the current scaffolding lacks. Companion PRs from the same investigation: fine-grained timing sub-spans (merged) and "skip adapter build on precompute hit" (open). Remaining large item after this: `warehouse_foreign_keys` (~1.8s), which lives in HogQL core and needs coordination with @PostHog/hogql.

Note: the pre-commit hook (`bin/hogli lint:python:fix`) can't run in the worktree due to a stale shared venv (`hogli` moved to `tools/hogli/`); lint/typecheck were run manually and pass. CI runs the full suite.
