### PR TITLE
fix(max): offload conversation sse serialization off the asgi loop

### DIFF
--- a/ee/hogai/stream/redis_stream.py
+++ b/ee/hogai/stream/redis_stream.py
@@ -25,6 +25,7 @@ from posthog.redis import get_async_client
 
 from products.posthog_ai.backend.models.assistant import Conversation
 
+from ee.hogai.utils.aio import OFFLOAD_LATENCY_BUCKETS, run_maybe_offloaded
 from ee.hogai.utils.types import AssistantOutput
 from ee.hogai.utils.types.base import ApprovalPayload, AssistantStreamedMessageUnion
 
@@ -53,6 +54,13 @@ REDIS_STREAM_INIT_ITERATION_LATENCY_HISTOGRAM = Histogram(
     "posthog_ai_redis_stream_init_iteration_latency_seconds",
     "Time between iterations in the stream initialization wait loop",
     buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")],
+)
+
+REDIS_DESERIALIZE_LATENCY_HISTOGRAM = Histogram(
+    "posthog_ai_redis_deserialize_latency_seconds",
+    "Time spent deserializing (pickle.loads) a Redis stream chunk, labeled by whether it ran off the event loop",
+    ["offloaded"],
+    buckets=OFFLOAD_LATENCY_BUCKETS,
 )
 
 # Redis stream configuration
@@ -322,7 +330,12 @@ class ConversationRedisStream:
                 for _, stream_messages in messages:
                     for stream_id, message in stream_messages:
                         current_id = stream_id
-                        data = self._serializer.deserialize(message)
+                        # pickle.loads is CPU-bound and runs on the ASGI loop that also answers
+                        # the liveness probe; run_maybe_offloaded can push it to a worker thread.
+                        # Ordering is preserved: we await before yielding.
+                        data = await run_maybe_offloaded(
+                            self._serializer.deserialize, message, histogram=REDIS_DESERIALIZE_LATENCY_HISTOGRAM
+                        )
 
                         latency = time.time() - data.timestamp
                         REDIS_TO_CLIENT_LATENCY_HISTOGRAM.observe(latency)

--- a/ee/hogai/stream/test/test_redis_stream.py
+++ b/ee/hogai/stream/test/test_redis_stream.py
@@ -6,7 +6,10 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import AsyncMock, patch
 
+from django.test import override_settings
+
 import redis.exceptions as redis_exceptions
+from parameterized import parameterized
 
 from posthog.schema import (
     AssistantEventType,
@@ -97,6 +100,52 @@ class TestRedisStream(BaseTest):
 
             self.assertEqual(len(chunks), 1)
             self.assertEqual(chunks[0].event.type, AssistantEventType.MESSAGE)
+
+    @parameterized.expand([("offload_on", True), ("offload_off", False)])
+    @pytest.mark.asyncio
+    async def test_read_stream_deserializes_identically_regardless_of_offload(self, _name: str, offload: bool):
+        import pickle
+
+        test_event = StreamEvent(
+            event=MessageEvent(type=AssistantEventType.MESSAGE, payload=AssistantMessage(content="test"))
+        )
+        with patch.object(self.redis_stream, "_redis_client") as mock_client:
+            mock_client.xread = AsyncMock(
+                return_value=[(self.stream_key, [(b"1234-0", {b"data": pickle.dumps(test_event)})])]
+            )
+
+            with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=offload):
+                chunks = []
+                async for chunk in self.redis_stream.read_stream():
+                    chunks.append(chunk)
+                    break
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].event.type, AssistantEventType.MESSAGE)
+        payload = cast(AssistantMessage, chunks[0].event.payload)
+        self.assertEqual(payload.content, "test")
+
+    @parameterized.expand([("offload_on", True, 1), ("offload_off", False, 0)])
+    @pytest.mark.asyncio
+    async def test_read_stream_offloads_deserialization_to_thread_only_when_enabled(
+        self, _name: str, offload: bool, expected_calls: int
+    ):
+        import pickle
+
+        test_event = StreamEvent(
+            event=MessageEvent(type=AssistantEventType.MESSAGE, payload=AssistantMessage(content="test"))
+        )
+        with patch.object(self.redis_stream, "_redis_client") as mock_client:
+            mock_client.xread = AsyncMock(
+                return_value=[(self.stream_key, [(b"1234-0", {b"data": pickle.dumps(test_event)})])]
+            )
+
+            with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=offload):
+                with patch("ee.hogai.utils.aio.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread:
+                    async for _ in self.redis_stream.read_stream():
+                        break
+
+        self.assertEqual(mock_to_thread.call_count, expected_calls)
 
     @pytest.mark.asyncio
     async def test_read_stream_completion_status(self):

--- a/ee/hogai/utils/aio.py
+++ b/ee/hogai/utils/aio.py
@@ -1,12 +1,66 @@
+import time
 import asyncio
 import threading
 from collections.abc import AsyncGenerator, Callable, Generator
 from queue import Queue
-from typing import Any
+from typing import Any, TypeVar
+
+from django.conf import settings
 
 import structlog
+from prometheus_client import Histogram
 
 logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+# Shared buckets for the "offloaded (de)serialization latency" histograms. The high end runs to
+# 30s on purpose: the slow serializations this instrumentation exists to catch (the per-token
+# re-serialization of the full accumulated assistant message, which grows O(n^2) over a long
+# stream) can be multi-second, and a lower ceiling would dump them all into +Inf and saturate p99.
+OFFLOAD_LATENCY_BUCKETS = [
+    0.0005,
+    0.001,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    float("inf"),
+]
+
+
+async def run_maybe_offloaded(fn: Callable[[T], R], arg: T, *, histogram: Histogram) -> R:
+    """Run a CPU-bound `fn(arg)`, optionally on a worker thread, and record how long it took.
+
+    Gated by `settings.MAX_AI_STREAM_OFFLOAD_SERIALIZATION` (read per call so it stays
+    toggleable at runtime and in tests). When enabled, the work runs via `asyncio.to_thread`.
+
+    This does NOT give true CPU parallelism — under the GIL the worker thread still holds the
+    interpreter lock for Python / pydantic-core work — but it lets the serving event loop preempt
+    at the GIL switch interval instead of being blocked for the whole serialization, which is what
+    keeps the dependency-free liveness probe answering under streaming load.
+
+    Ordering is the caller's responsibility: await the result before yielding the next item.
+    `histogram` must declare a single `offloaded` label; timing is observed in a `finally`, so
+    failures are measured too (the loop was blocked for that time regardless of outcome).
+    """
+    offload = settings.MAX_AI_STREAM_OFFLOAD_SERIALIZATION
+    start = time.perf_counter()
+    try:
+        if offload:
+            return await asyncio.to_thread(fn, arg)
+        return fn(arg)
+    finally:
+        histogram.labels(offloaded="true" if offload else "false").observe(time.perf_counter() - start)
 
 
 def async_to_sync(async_handler: Callable[[], AsyncGenerator[Any]]) -> Generator[Any]:

--- a/ee/hogai/utils/sse.py
+++ b/ee/hogai/utils/sse.py
@@ -1,6 +1,8 @@
 import json
 from typing import cast
 
+from prometheus_client import Histogram
+
 from posthog.schema import AssistantEventType, AssistantGenerationStatusEvent, AssistantUpdateEvent, SubagentUpdateEvent
 
 from posthog.sync import database_sync_to_async
@@ -8,20 +10,40 @@ from posthog.sync import database_sync_to_async
 from products.posthog_ai.backend.models.assistant import Conversation
 
 from ee.hogai.api.serializers import ConversationMinimalSerializer
+from ee.hogai.utils.aio import OFFLOAD_LATENCY_BUCKETS, run_maybe_offloaded
 from ee.hogai.utils.types import AssistantMessageUnion, AssistantOutput
+
+SSE_SERIALIZE_LATENCY_HISTOGRAM = Histogram(
+    "posthog_ai_sse_serialize_latency_seconds",
+    "Time spent serializing an SSE event payload (model_dump_json), labeled by whether it ran off the event loop",
+    ["offloaded"],
+    buckets=OFFLOAD_LATENCY_BUCKETS,
+)
 
 
 class AssistantSSESerializer:
     async def dumps(self, event: AssistantOutput) -> str:
         event_type, event_data = event
         if event_type == AssistantEventType.MESSAGE:
-            return self._serialize_message(cast(AssistantMessageUnion, event_data))
+            return await run_maybe_offloaded(
+                self._serialize_message,
+                cast(AssistantMessageUnion, event_data),
+                histogram=SSE_SERIALIZE_LATENCY_HISTOGRAM,
+            )
         elif event_type == AssistantEventType.CONVERSATION:
             return await self._serialize_conversation(cast(Conversation, event_data))
         elif event_type == AssistantEventType.STATUS:
-            return self._serialize_status(cast(AssistantGenerationStatusEvent, event_data))
+            return await run_maybe_offloaded(
+                self._serialize_status,
+                cast(AssistantGenerationStatusEvent, event_data),
+                histogram=SSE_SERIALIZE_LATENCY_HISTOGRAM,
+            )
         elif event_type == AssistantEventType.UPDATE:
-            return self._serialize_update(cast(AssistantUpdateEvent | SubagentUpdateEvent, event_data))
+            return await run_maybe_offloaded(
+                self._serialize_update,
+                cast(AssistantUpdateEvent | SubagentUpdateEvent, event_data),
+                histogram=SSE_SERIALIZE_LATENCY_HISTOGRAM,
+            )
         else:
             raise ValueError(f"Unknown event type: {event_type}")
 

--- a/ee/hogai/utils/test/test_sse.py
+++ b/ee/hogai/utils/test/test_sse.py
@@ -1,0 +1,120 @@
+import asyncio
+from typing import cast
+
+import pytest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from parameterized import parameterized
+from prometheus_client import REGISTRY
+
+from posthog.schema import (
+    AssistantEventType,
+    AssistantGenerationStatusEvent,
+    AssistantGenerationStatusType,
+    AssistantMessage,
+    AssistantUpdateEvent,
+)
+
+from ee.hogai.utils.sse import AssistantSSESerializer
+from ee.hogai.utils.types import AssistantOutput
+
+
+# Pure-CPU serializer paths (MESSAGE/STATUS/UPDATE) — no DB needed, so no Django TestCase base.
+class TestAssistantSSESerializer:
+    def setup_method(self):
+        self.serializer = AssistantSSESerializer()
+
+    def _message_event(self) -> AssistantOutput:
+        return cast(AssistantOutput, (AssistantEventType.MESSAGE, AssistantMessage(content="hello world")))
+
+    @parameterized.expand([("offload_on", True), ("offload_off", False)])
+    @pytest.mark.asyncio
+    async def test_message_serialization_identical_regardless_of_offload(self, _name: str, offload: bool):
+        message = AssistantMessage(content="hello world")
+        event = cast(AssistantOutput, (AssistantEventType.MESSAGE, message))
+
+        with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=offload):
+            result = await self.serializer.dumps(event)
+
+        assert result == f"event: {AssistantEventType.MESSAGE}\ndata: {message.model_dump_json(exclude_none=True)}\n\n"
+
+    @parameterized.expand(
+        [
+            (
+                "status",
+                lambda: (
+                    AssistantEventType.STATUS,
+                    AssistantGenerationStatusEvent(type=AssistantGenerationStatusType.GENERATION_ERROR),
+                ),
+            ),
+            (
+                "update",
+                lambda: (
+                    AssistantEventType.UPDATE,
+                    AssistantUpdateEvent(content="thinking", id="msg-1", tool_call_id="tc-1"),
+                ),
+            ),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_other_event_types_serialize_with_offload_enabled(self, _name, build_event):
+        event_type, payload = build_event()
+        event = cast(AssistantOutput, (event_type, payload))
+
+        with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=True):
+            result = await self.serializer.dumps(event)
+
+        assert result == f"event: {event_type}\ndata: {payload.model_dump_json(exclude_none=True)}\n\n"
+
+    @pytest.mark.asyncio
+    async def test_offload_routes_serialization_through_thread_pool(self):
+        with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=True):
+            with patch("ee.hogai.utils.aio.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread:
+                result = await self.serializer.dumps(self._message_event())
+
+        mock_to_thread.assert_called_once()
+        assert result.startswith(f"event: {AssistantEventType.MESSAGE}\n")
+
+    @pytest.mark.asyncio
+    async def test_no_offload_keeps_serialization_on_the_loop(self):
+        with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=False):
+            with patch("ee.hogai.utils.aio.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread:
+                await self.serializer.dumps(self._message_event())
+
+        mock_to_thread.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown event type"):
+            await self.serializer.dumps(cast(AssistantOutput, ("NOT_AN_EVENT", AssistantMessage(content="x"))))
+
+    @staticmethod
+    def _serialize_count(offloaded: str) -> float:
+        return (
+            REGISTRY.get_sample_value("posthog_ai_sse_serialize_latency_seconds_count", {"offloaded": offloaded}) or 0.0
+        )
+
+    @parameterized.expand([("offload_on", True, "true"), ("offload_off", False, "false")])
+    @pytest.mark.asyncio
+    async def test_latency_histogram_records_with_offloaded_label(self, _name: str, offload: bool, label: str):
+        before = self._serialize_count(label)
+
+        with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=offload):
+            await self.serializer.dumps(self._message_event())
+
+        assert self._serialize_count(label) == before + 1
+
+    @parameterized.expand([("offload_on", True, "true"), ("offload_off", False, "false")])
+    @pytest.mark.asyncio
+    async def test_serializer_failure_propagates_and_is_still_timed(self, _name: str, offload: bool, label: str):
+        # Timing is observed in a finally, so a failed serialization must still be measured and re-raised.
+        before = self._serialize_count(label)
+
+        with patch.object(self.serializer, "_serialize_message", side_effect=ValueError("boom")):
+            with override_settings(MAX_AI_STREAM_OFFLOAD_SERIALIZATION=offload):
+                with pytest.raises(ValueError, match="boom"):
+                    await self.serializer.dumps(self._message_event())
+
+        assert self._serialize_count(label) == before + 1

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -59,6 +59,15 @@ if E2E_TESTING:
 IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"
 SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type_cast=str)
 
+# When serving Max conversation SSE over ASGI, per-chunk payload (de)serialization
+# (pydantic `model_dump_json`, `pickle.loads`) is CPU-bound and runs on the single event
+# loop that also answers the liveness probe. On by default: offloads that work to a
+# thread pool (`asyncio.to_thread`) so the loop stays responsive under streaming load.
+# Kept as an env-driven opt-out so it can be disabled without a deploy.
+MAX_AI_STREAM_OFFLOAD_SERIALIZATION: bool = get_from_env(
+    "MAX_AI_STREAM_OFFLOAD_SERIALIZATION", True, type_cast=str_to_bool
+)
+
 # GitHub secret alert relay URL - set in US deployment to forward alerts to EU
 GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RELAY_URL", optional=True)
 


### PR DESCRIPTION
## Problem

Per-chunk payload work on the Max conversation SSE path is CPU-bound and runs on the single ASGI event loop that also answers health probes: every streamed chunk pays a pydantic `model_dump_json` on the way out and a `pickle.loads` on the way in, and the stream re-emits the full accumulated message per token, so the cost grows with message length. Under concurrent streaming load this starves the loop and delays everything sharing it, including `/_livez`.

This work originally landed as #61639, which was closed without merging. This PR revives it rebased on current master and enables it by default.

Part of the SSE infrastructure work tracked in Linear (GROW-109, PR 5 of a series).

## Changes

- `run_maybe_offloaded` in `ee/hogai/utils/aio.py`: awaits CPU-bound work via `asyncio.to_thread` when `MAX_AI_STREAM_OFFLOAD_SERIALIZATION` is on, inline otherwise, with a labeled latency histogram either way so operators can compare paths. Ordering is preserved (the offloaded result is awaited before yield).
- `AssistantSSESerializer` (`ee/hogai/utils/sse.py`) offloads `model_dump_json`; the conversation Redis stream reader (`ee/hogai/stream/redis_stream.py`) offloads `pickle.loads`.
- `MAX_AI_STREAM_OFFLOAD_SERIALIZATION` now defaults to **true**, kept env-driven as an opt-out that needs no deploy.
- No behavior change to stream content or ordering; this only moves where serialization executes.

Not in this PR: streaming token deltas instead of the full accumulated message, which removes the quadratic cost at the source. That is a breaking frontend contract change (the client must accumulate rather than replace, and reconnect resumability must be preserved under the Redis stream's `maxlen` trim), and needs coordination with the Max AI team. Tracked in the same Linear issue.

## How did you test this code?

Automated only:
- `pytest ee/hogai/utils/test/test_sse.py` passed 11 tests, covering serialization equivalence between offloaded and inline paths, exception propagation, and histogram labeling
- `ruff check` and `ruff format` clean; pre-commit `ty check` passed
- The redis stream offload tests (`ee/hogai/stream/test/test_redis_stream.py`) require the DB harness and run in CI

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: internal performance change, no user-facing behavior difference.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Planned in the Linear project "SSE Infrastructure Isolation" (GROW-109, PR 5 of 9). The original implementation and its review hardening come from #61639 (squashed, attribution in that PR); this PR rebases it and flips the default from off to on. The delta streaming follow-up is deliberately excluded pending Max AI team coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #74312