### PR TITLE
feat(insights): freeze header row in scrollable HogQL tables

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -380,4 +380,20 @@ body:not(.storybook-test-runner) {
             box-shadow: -16px 0 16px 16px rgb(0 0 0 / 25%);
         }
     }
+
+    // Pin the header row to the top while the body scrolls. The header th needs its own
+    // background so scrolling rows don't show through, and a z-index above the sticky/pinned
+    // body cells (z-index 6) so it stays on top as rows pass underneath.
+    .LemonTable--sticky-header .LemonTable__content > table > thead > tr > th {
+        position: sticky;
+        top: 0;
+        z-index: 7;
+        background: var(--lemon-table-background-color);
+    }
+
+    // The corner cell (a header that is also horizontally pinned) must sit above both.
+    .LemonTable--sticky-header .LemonTable__header--sticky,
+    .LemonTable--sticky-header .LemonTable__header--pinned {
+        z-index: 8;
+    }
 }

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -383,8 +383,9 @@ body:not(.storybook-test-runner) {
 
     // Pin the header row to the top while the body scrolls. The header th needs its own
     // background so scrolling rows don't show through, and a z-index above the sticky/pinned
-    // body cells (z-index 6) so it stays on top as rows pass underneath.
-    .LemonTable--sticky-header .LemonTable__content > table > thead > tr > th {
+    // body cells (z-index 6) so it stays on top as rows pass underneath. Only the last header
+    // row sticks — when column groups add a second row, both pinning to top: 0 would overlap.
+    .LemonTable--sticky-header .LemonTable__content > table > thead > tr:last-child > th {
         position: sticky;
         top: 0;
         z-index: 7;

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -89,6 +89,9 @@ export interface LemonTableProps<T extends Record<string, any>, K extends BulkSe
     footer?: React.ReactNode
     /** Whether the first column should always remain visible when scrolling horizontally. */
     firstColumnSticky?: boolean
+    /** Whether the header row should stay pinned to the top while the table body scrolls vertically.
+     *  Only has a visible effect when the table scrolls internally (see `allowContentScroll`). */
+    stickyHeader?: boolean
     /** Array of column keys to pin (make sticky). Columns won't be pinned in order. */
     pinnedColumns?: string[]
     // Max width for the column headers
@@ -140,6 +143,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
     'data-attr': dataAttr,
     footer,
     firstColumnSticky,
+    stickyHeader,
     pinnedColumns,
     maxHeaderWidth,
     hideScrollbar,
@@ -372,6 +376,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                     rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                     stealth && 'LemonTable--stealth',
                     !uppercaseHeader && 'LemonTable--lowercase-header',
+                    stickyHeader && 'LemonTable--sticky-header',
                     allowContentScroll && 'h-full min-h-0 overflow-hidden',
                     className
                 )}

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -892,7 +892,7 @@ export function DataTable({
                         <div className="absolute right-0 z-10 p-1">{editorButton}</div>
                     ) : null}
                     {showResultsTable && (
-                        <div className="relative">
+                        <div className={clsx('relative', embedded && 'flex flex-col flex-1 min-h-0')}>
                             {usedWebAnalyticsLazyPrecompute ? (
                                 <PreAggregatedBadge
                                     variant="precomputed"
@@ -918,6 +918,10 @@ export function DataTable({
                                 }}
                                 sorting={null}
                                 useURLForSorting={false}
+                                // Inside constrained containers (dashboard tiles, embedded views) let the
+                                // body scroll and keep the column headers pinned to the top.
+                                allowContentScroll={embedded}
+                                stickyHeader={embedded}
                                 emptyState={
                                     responseError ? (
                                         sourceFeatures.has(QueryFeature.displayResponseError) ? (


### PR DESCRIPTION
## Problem

When scrolling through a HogQL insight table on a dashboard, the column headers scroll out of view, so you lose track of what each column represents. This came from a dashboards satisfaction survey response asking for the ability to freeze header rows while scrolling table content.

## Changes

- Add an opt-in `stickyHeader` prop to `LemonTable`. When set, the header row is pinned to the top (`position: sticky`) while the body scrolls, with the header cells given their own background and a z-index above the sticky/pinned body cells so they stay on top as rows pass underneath. The rule lives inside the existing `body:not(.storybook-test-runner)` block, so header stickiness is disabled in visual snapshots (same as the existing column-pinning stickiness) to avoid snapshot flakiness.
- Enable `stickyHeader` together with internal content scroll for the `DataTable` when it's embedded (dashboard tiles, embedded views), and let the results wrapper participate in the flex height chain so the body actually scrolls within the constrained tile. This mirrors the existing `allowContentScroll` pattern already used by the trends `InsightsTable`.

The prop is opt-in and inert unless the table scrolls internally, so non-embedded tables (events explorer, standalone SQL results) are unaffected.

## How did you test this code?

I (the agent) was not able to run the app or the frontend test/typecheck suite in this environment (no `node_modules` available), so this has not been manually verified in a browser yet — worth a visual check on a dashboard with a tall HogQL table before merge. No automated tests were added; the change is presentational (CSS positioning + a boolean prop).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The request originated from a dashboards satisfaction survey asking to freeze table header rows while scrolling.

Approach: explored how HogQL result tables render (`DataTable` → `LemonTable`) and how dashboard tiles embed them (`InsightCard` → `Query` with `embedded`). Found that the trends `InsightsTable` already enables `allowContentScroll` in dashboard/embedded contexts but no table pins its header (the `thead` was `position: relative`, with a pre-existing comment noting the header border box-shadow was set up "to support sticky headers"). Chose a small opt-in `stickyHeader` prop on the shared `LemonTable` rather than making all tables sticky, to keep the blast radius narrow, and wired it into the embedded `DataTable` path along with a flex height-chain fix so the body scrolls inside the bounded tile. No repo skills were applicable to this presentational frontend change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ASA4U0AG3/p1782757934691479?thread_ts=1782757934.691479&cid=C0ASA4U0AG3)*
