### PR TITLE
chore(ci): retire the dedicated async-migrations test job

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1558,7 +1558,7 @@ jobs:
                   CORE_FILES: ${{ needs.select-tests.outputs.core_files }}
                   POE_FILES: ${{ needs.select-tests.outputs.poe_files }}
               shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
-              run: | # async_migrations covered in ci-async-migrations.yml
+              run: |
                   unset GITHUB_TOKEN # reserved var injected by Depot CI; can't override via env: (see workflow env note)
                   set +e
                   # Pick the split algorithm and granularity at runtime: optimal_chunks + file
@@ -1729,8 +1729,6 @@ jobs:
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
         outputs:
-            # Oldest supported version for main Django tests (JSON array for matrix)
-            oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
             # Oldest supported version as plain string (for comparisons)
             oldest_supported_image: ${{ steps.read-versions.outputs.oldest_supported_image }}
             # Fully expanded compat matrix (version x shard group)
@@ -1746,13 +1744,12 @@ jobs:
                   compat_shards="2"
                   echo "Using $compat_shards shard(s) per compat version"
 
-                  # Oldest supported version for main Django tests (for max compatibility, as JSON array for matrix)
+                  # Oldest supported version for main Django tests (for max compatibility)
                   oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
                     echo "::error::No oldest_supported version found in .github/clickhouse-versions.json"
                     exit 1
                   fi
-                  echo "oldest_supported=[\"$oldest_supported\"]" >> $GITHUB_OUTPUT
                   echo "oldest_supported_image=$oldest_supported" >> $GITHUB_OUTPUT
                   echo "Oldest supported version for Django tests: $oldest_supported"
 
@@ -1791,7 +1788,7 @@ jobs:
                   fi
     # Job just to collate the status of the matrix jobs for requiring passing status
     django_tests:
-        needs: [sample, django, check-migrations, async-migrations, turbo-discover, turbo-tests, repo-checks]
+        needs: [sample, django, check-migrations, turbo-discover, turbo-tests, repo-checks]
         name: '[optional, does not block merge] Django Tests Pass'
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
         timeout-minutes: 5
@@ -1807,7 +1804,6 @@ jobs:
                     echo "| --- | --- |"
                     echo "| django | ${{ needs.django.result }} |"
                     echo "| check-migrations | ${{ needs.check-migrations.result }} |"
-                    echo "| async-migrations | ${{ needs.async-migrations.result }} |"
                     echo "| repo-checks | ${{ needs.repo-checks.result }} |"
                     echo "| turbo-discover | ${{ needs.turbo-discover.result }} |"
                     echo "| turbo-tests | ${{ needs.turbo-tests.result }} |"
@@ -1834,125 +1830,9 @@ jobs:
 
                   check_required_result "Django test matrix" "${{ needs.django.result }}"
                   check_required_result "Migration checks" "${{ needs.check-migrations.result }}"
-                  check_required_result "Async migration tests" "${{ needs.async-migrations.result }}"
                   check_required_result "Repo checks" "${{ needs.repo-checks.result }}"
                   check_required_result "Turbo discover" "${{ needs.turbo-discover.result }}"
                   check_required_result "Product/Turbo tests" "${{ needs.turbo-tests.result }}"
 
                   echo "All backend and product checks passed."
-    async-migrations:
-        name: Async migrations tests -  ${{ matrix.clickhouse-server-image }} (depot-ubuntu-latest)
-        needs: [changes, turbo-discover, get_clickhouse_versions]
-        strategy:
-            fail-fast: false
-            matrix:
-                clickhouse-server-image: ${{ fromJson(needs.get_clickhouse_versions.outputs.oldest_supported) }}
-        # Run if legacy code changed, product changes affect legacy, or turbo-discover failed
-        if: |
-            always() &&
-            github.event_name != 'push' &&
-            needs.changes.outputs.backend == 'true' &&
-            (needs.changes.outputs.legacy == 'true' ||
-             needs.turbo-discover.outputs.run_legacy == 'true' ||
-             (needs.turbo-discover.result != 'success' && needs.turbo-discover.result != 'skipped'))
-        runs-on: depot-ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - name: 'Checkout repo'
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  fetch-depth: 1
-                  clean: false
-            - name: Clean up data directories with container permissions
-              run: |
-                  # Use docker to clean up files created by containers
-                  [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
-              continue-on-error: true
-            - name: Log in to Docker Hub
-              if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
-            - name: Start stack with Docker Compose
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-              run: |
-                  # nohup detaches the launch so it survives Depot's step-shell teardown
-                  # (which SIGHUPs a plain `&` subshell). Isolated here; bin/ci-wait-for-docker stays == master.
-                  nohup bin/ci-wait-for-docker launch --background --down \
-                    </dev/null >"${RUNNER_TEMP:-/tmp}/compose-launch.log" 2>&1
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version-file: 'pyproject.toml'
-            - name: Install uv
-              id: setup-uv-async
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
-            - name: Install SAML (python3-saml) dependencies
-              if: steps.setup-uv-async.outputs.cache-hit != 'true'
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
-            - name: Install sqlx-cli
-              uses: ./.depot/actions/setup-sqlx-cli
-            - name: Install python dependencies
-              shell: bash
-              run: |
-                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
-            - name: Add service hostnames to /etc/hosts
-              run: sudo echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
-            - name: Set up needed files
-              run: |
-                  mkdir -p frontend/dist
-                  touch frontend/dist/index.html
-                  touch frontend/dist/layout.html
-                  touch frontend/dist/exporter.html
-            - name: Wait for Docker services
-              shell: bash
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-              run: |
-                  bin/ci-wait-for-docker wait objectstorage \
-                    || { echo "::group::compose launch log"; cat "${RUNNER_TEMP:-/tmp}/compose-launch.log" 2>/dev/null || true; echo "::endgroup::"; exit 1; }
-            - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: schema.sql.gz
-                  # Prefer the shared content key; fall back to the exact merge-base SHA key.
-                  key: ${{ needs.turbo-discover.outputs.schema_migrations_key || needs.turbo-discover.outputs.schema_cache_key }}
-                  restore-keys: |
-                      ${{ needs.turbo-discover.outputs.schema_cache_key }}
-            - name: Prime test_posthog from cached schema
-              # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
-              if: ${{ github.event_name == 'pull_request' }}
-              run: |
-                  if [ ! -f schema.sql.gz ]; then
-                      echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"
-                      exit 0
-                  fi
-                  mkdir -p .postgres-backups
-                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  if ! ./bin/hogli db:restore-test-db; then
-                      echo "::warning::Schema restore failed (stale/incompatible cached dump?) — pytest --reuse-db will run a full migrate"
-                  fi
-            - name: Run async migrations tests
-              run: |
-                  # Scope async migration tests directly and reuse the primed test database.
-                  pytest posthog/async_migrations/test -m "async_migrations" --reuse-db --reruns 2 --reruns-delay 1 --durations=100 --durations-min=1.0 --junitxml=junit.xml
     # Shadow trial: calculate-running-time job stripped (would poison trial metrics).

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -49,7 +49,7 @@ def _testcase(
     [
         ("junit-results-backend-core-29", ("backend", "core", 29)),
         ("junit-results-llm-gateway", ("llm-gateway", "llm-gateway", None)),
-        ("junit-results-temporal", ("temporal", "temporal", None)),
+        ("junit-results-hogli", ("hogli", "hogli", None)),
     ],
 )
 def test_derive_suite_segment_and_group(dir_name: str, expected: tuple[str, str, int | None]) -> None:

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -48,8 +48,8 @@ def _testcase(
     "dir_name,expected",
     [
         ("junit-results-backend-core-29", ("backend", "core", 29)),
-        ("junit-results-async-migrations", ("async-migrations", "async-migrations", None)),
         ("junit-results-llm-gateway", ("llm-gateway", "llm-gateway", None)),
+        ("junit-results-temporal", ("temporal", "temporal", None)),
     ],
 )
 def test_derive_suite_segment_and_group(dir_name: str, expected: tuple[str, str, int | None]) -> None:
@@ -429,7 +429,7 @@ def _artifact(suite: str, segment: str, group: int | None) -> report_test_timing
     [
         ("backend", "core", 29, "Backend CI / core (29)"),
         ("backend", "temporal", 1, "Backend CI / temporal (1)"),
-        ("async-migrations", "async-migrations", None, "Backend CI / async-migrations"),
+        ("llm-gateway", "llm-gateway", None, "Backend CI / llm-gateway"),
     ],
 )
 def test_job_trace_name(suite: str, segment: str, group: int | None, expected: str) -> None:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2462,7 +2462,7 @@ jobs:
               # until the runner's 10s SIGKILL — which sometimes misses
               # detached descendants entirely. Installed earlier on PATH.
               shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
-              run: | # async_migrations covered in ci-async-migrations.yml
+              run: |
                   set +e
                   # Pick the split algorithm and granularity at runtime: optimal_chunks +
                   # file granularity only when the installed pytest-split offers them, else
@@ -2701,8 +2701,6 @@ jobs:
         runs-on: depot-ubuntu-latest
         timeout-minutes: 5
         outputs:
-            # Oldest supported version for main Django tests (JSON array for matrix)
-            oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
             # Oldest supported version as plain string (for comparisons)
             oldest_supported_image: ${{ steps.read-versions.outputs.oldest_supported_image }}
             # Fully expanded compat matrix (version x shard group)
@@ -2718,13 +2716,12 @@ jobs:
                   compat_shards="2"
                   echo "Using $compat_shards shard(s) per compat version"
 
-                  # Oldest supported version for main Django tests (for max compatibility, as JSON array for matrix)
+                  # Oldest supported version for main Django tests (for max compatibility)
                   oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
                     echo "::error::No oldest_supported version found in .github/clickhouse-versions.json"
                     exit 1
                   fi
-                  echo "oldest_supported=[\"$oldest_supported\"]" >> $GITHUB_OUTPUT
                   echo "oldest_supported_image=$oldest_supported" >> $GITHUB_OUTPUT
                   echo "Oldest supported version for Django tests: $oldest_supported"
 
@@ -2835,16 +2832,7 @@ jobs:
     # Must depend on handle-snapshots to prevent auto-merge before commits complete
     django_tests:
         needs:
-            [
-                django,
-                check-migrations,
-                check-openapi-types,
-                async-migrations,
-                turbo-discover,
-                turbo-tests,
-                handle-snapshots,
-                repo-checks,
-            ]
+            [django, check-migrations, check-openapi-types, turbo-discover, turbo-tests, handle-snapshots, repo-checks]
         name: Django Tests Pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -2860,7 +2848,6 @@ jobs:
                     echo "| check-openapi-types | ${{ needs.check-openapi-types.result }} |"
                     echo "| django | ${{ needs.django.result }} |"
                     echo "| check-migrations | ${{ needs.check-migrations.result }} |"
-                    echo "| async-migrations | ${{ needs.async-migrations.result }} |"
                     echo "| turbo-discover | ${{ needs.turbo-discover.result }} |"
                     echo "| turbo-tests | ${{ needs.turbo-tests.result }} |"
                     echo "| handle-snapshots | ${{ needs.handle-snapshots.result }} |"
@@ -2920,7 +2907,6 @@ jobs:
                   check_required_result "OpenAPI type checks" "${{ needs.check-openapi-types.result }}"
                   check_required_result "Django test matrix" "${{ needs.django.result }}"
                   check_required_result "Migration checks" "${{ needs.check-migrations.result }}"
-                  check_required_result "Async migration tests" "${{ needs.async-migrations.result }}"
                   check_required_result "Turbo discover" "${{ needs.turbo-discover.result }}"
                   check_required_result "Product/Turbo tests" "${{ needs.turbo-tests.result }}"
                   check_required_result "Snapshot commit job" "${{ needs.handle-snapshots.result }}" true
@@ -3007,154 +2993,9 @@ jobs:
                   path: /tmp/verdict/
                   retention-days: 90
 
-    async-migrations:
-        name: Async migrations tests -  ${{ matrix.clickhouse-server-image }} (depot-ubuntu-latest)
-        needs: [changes, turbo-discover, get_clickhouse_versions]
-        strategy:
-            fail-fast: false
-            matrix:
-                clickhouse-server-image: ${{ fromJson(needs.get_clickhouse_versions.outputs.oldest_supported) }}
-        # Run if legacy code changed, product changes affect legacy, or turbo-discover failed
-        if: |
-            always() &&
-            needs.changes.outputs.backend == 'true' &&
-            (needs.changes.outputs.legacy == 'true' ||
-             needs.turbo-discover.outputs.run_legacy == 'true' ||
-             (needs.turbo-discover.result != 'success' && needs.turbo-discover.result != 'skipped'))
-        runs-on: depot-ubuntu-latest
-        timeout-minutes: 30
-        env:
-            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
-            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        steps:
-            - name: 'Checkout repo'
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  fetch-depth: 1
-                  clean: false
-            - name: Clean up data directories with container permissions
-              run: |
-                  # Use docker to clean up files created by containers
-                  [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
-              continue-on-error: true
-
-            - name: Log in to Docker Hub
-              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-              with:
-                  username: ${{ vars.DOCKERHUB_USER }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            - name: Start stack with Docker Compose
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-              run: |
-                  bin/ci-wait-for-docker launch --background --down
-
-            - name: Mint setup-action GitHub token
-              id: setup-gh-token
-              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-              continue-on-error: true
-              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-              with:
-                  client-id: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID }}
-                  private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
-                  skip-token-revoke: true
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version-file: 'pyproject.toml'
-                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
-
-            - name: Install uv
-              id: setup-uv-async
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
-
-            - name: Install SAML (python3-saml) dependencies
-              if: steps.setup-uv-async.outputs.cache-hit != 'true'
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
-
-            - name: Install sqlx-cli
-              uses: ./.github/actions/setup-sqlx-cli
-
-            - name: Install python dependencies
-              shell: bash
-              run: |
-                  UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
-
-            - name: Add service hostnames to /etc/hosts
-              run: sudo echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
-
-            - name: Set up needed files
-              run: |
-                  mkdir -p frontend/dist
-                  touch frontend/dist/index.html
-                  touch frontend/dist/layout.html
-                  touch frontend/dist/exporter.html
-
-            - name: Wait for Docker services
-              shell: bash
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-              run: bin/ci-wait-for-docker wait
-
-            - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: schema.sql.gz
-                  # Prefer the shared content key; fall back to the exact merge-base SHA key.
-                  key: ${{ needs.turbo-discover.outputs.schema_migrations_key || needs.turbo-discover.outputs.schema_cache_key }}
-                  restore-keys: |
-                      ${{ needs.turbo-discover.outputs.schema_cache_key }}
-
-            - name: Prime test_posthog from cached schema
-              # Treat cache problems as misses; db:restore-test-db recreates the DB after failure.
-              if: ${{ github.event_name == 'pull_request' }}
-              run: |
-                  if [ ! -f schema.sql.gz ]; then
-                      echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"
-                      exit 0
-                  fi
-                  mkdir -p .postgres-backups
-                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  if ! ./bin/hogli db:restore-test-db; then
-                      echo "::warning::Schema restore failed (stale/incompatible cached dump?) — pytest --reuse-db will run a full migrate"
-                  fi
-
-            - name: Run async migrations tests
-              run: |
-                  # Scope async migration tests directly and reuse the primed test database.
-                  pytest posthog/async_migrations/test -m "async_migrations" --reuse-db --reruns 2 --reruns-delay 1 --durations=100 --durations-min=1.0 --junitxml=junit.xml
-
-            - name: Upload test results
-              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-              if: always()
-              with:
-                  name: junit-results-async-migrations
-                  path: junit.xml
-
     calculate-running-time:
         name: Calculate running time
-        needs: [django_tests, async-migrations]
+        needs: [django_tests]
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)
@@ -3250,7 +3091,7 @@ jobs:
 
     trunk-upload:
         name: Upload test results to Trunk
-        # Core/Temporal/async-migrations already emit and upload junit-results-* artifacts;
+        # Core/Temporal already emit and upload junit-results-* artifacts;
         # this feeds them to Trunk (flaky-test detection) once. Trusted non-pull_request
         # events only (master push + merge queue), so the secret token never runs in a
         # PR-controlled context; the uploader is a pinned external action, not a local one.

--- a/posthog/async_migrations/test/test_0010_move_old_partitions.py
+++ b/posthog/async_migrations/test/test_0010_move_old_partitions.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 from posthog.async_migrations.setup import get_async_migration_definition
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 
-pytestmark = pytest.mark.async_migrations
+pytestmark = [
+    pytest.mark.async_migrations,
+    pytest.mark.skip(
+        reason="Async migrations are frozen for self-hosted backwards compat; only test_migrations_not_required still runs"
+    ),
+]
 
 MIGRATION_NAME = "0010_move_old_partitions"
 migration_module = importlib.import_module(f"posthog.async_migrations.migrations.{MIGRATION_NAME}")

--- a/posthog/async_migrations/test/test_definition.py
+++ b/posthog/async_migrations/test/test_definition.py
@@ -14,7 +14,12 @@ from posthog.async_migrations.setup import (
 from posthog.models.async_migration import AsyncMigration
 from posthog.version_requirement import ServiceVersionRequirement
 
-pytestmark = pytest.mark.async_migrations
+pytestmark = [
+    pytest.mark.async_migrations,
+    pytest.mark.skip(
+        reason="Async migrations are frozen for self-hosted backwards compat; only test_migrations_not_required still runs"
+    ),
+]
 
 
 class TestAsyncMigrationDefinition(SimpleTestCase):

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -3,6 +3,9 @@ from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 from posthog.clickhouse.client import sync_execute
 from posthog.models.person.sql import COMMENT_DISTINCT_ID_COLUMN_SQL
 
+# No pytest.mark.async_migrations here on purpose: the Core shards filter uses
+# -m "not async_migrations", so this guard must run there. Do not re-add the marker.
+
 
 # Async migrations are data migrations aimed at getting users from an old schema to a new schema
 # Fresh installs should have the new schema, however. So check that async migrations are being

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -1,11 +1,7 @@
-import pytest
-
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 from posthog.clickhouse.client import sync_execute
 from posthog.models.person.sql import COMMENT_DISTINCT_ID_COLUMN_SQL
-
-pytestmark = pytest.mark.async_migrations
 
 
 # Async migrations are data migrations aimed at getting users from an old schema to a new schema

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -15,7 +15,12 @@ from posthog.async_migrations.utils import update_async_migration
 from posthog.models.async_migration import AsyncMigration, AsyncMigrationError, MigrationStatus
 from posthog.models.utils import UUIDT
 
-pytestmark = pytest.mark.async_migrations
+pytestmark = [
+    pytest.mark.async_migrations,
+    pytest.mark.skip(
+        reason="Async migrations are frozen for self-hosted backwards compat; only test_migrations_not_required still runs"
+    ),
+]
 
 
 class TestRunner(AsyncMigrationBaseTest):

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -18,7 +18,12 @@ from posthog.async_migrations.utils import (
 from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigrationError, MigrationStatus
 
-pytestmark = pytest.mark.async_migrations
+pytestmark = [
+    pytest.mark.async_migrations,
+    pytest.mark.skip(
+        reason="Async migrations are frozen for self-hosted backwards compat; only test_migrations_not_required still runs"
+    ),
+]
 
 DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", rollback=None, timeout_seconds=10)
 


### PR DESCRIPTION
## Problem

Async migrations are effectively a frozen feature.
`FROZEN_POSTHOG_VERSION` is pinned at 1.43.0 ("frozen at the last self-hosted version, just for backwards compat now"), the last migration (0010) shipped years ago, and every migration capped below 1.43 can provably never run again.

Despite that, Backend CI still ran a dedicated `async-migrations` job (full docker stack, its own DB and ClickHouse bootstrap) on essentially every backend PR. Over the last 30 days, per our CI telemetry:

| Job | Runs | Total runner hours | Avg minutes |
| --- | ---: | ---: | ---: |
| Async migrations tests (clickhouse 26.3.10) | 16,129 | 1,694 | 6.3 |
| Async migrations tests (clickhouse 25.12.8) | 7,505 | 871 | 7.0 |

That's roughly **2,500 depot runner hours per month** spent almost entirely on stack setup, to run a handful of tests for machinery that no longer changes.

## Changes

- Delete the `async-migrations` job from `ci-backend.yml`, including its entry in the `Django Tests Pass` aggregator, `calculate-running-time`, and the now-unused `oldest_supported` matrix output. `Django Tests Pass` (the required status check per repo rulesets) is unaffected.
- Skip the tests for the frozen machinery (`test_0010`, `test_runner`, `test_utils`, `test_definition`; `test_0007` was already skipped).
- Keep the one test that still earns its place, `test_migrations_not_required`, and fold it into the main Core shards by dropping its `async_migrations` marker. It's the tripwire that stops a ClickHouse schema change from accidentally flipping an old migration's `is_required()` to True, which would make `setup_async_migrations()` raise at startup and brick fresh deploys. The Core shards already run against the oldest supported ClickHouse image, so it keeps the same coverage it had in the dedicated job.
- Deliberately keep the `-m "not async_migrations"` filters on the Core/Temporal pytest invocations. A workflow edit hits every open PR immediately, but unrebased branches still have marker-only test files without skip marks - without the filter they'd suddenly run the heavy runner tests inside Core shards. Once open PRs have rebased, the filters and the marker registration can be removed in a follow-up.

## How did you test this code?

- `pytest posthog/async_migrations/test --collect-only -m "not async_migrations"` collects exactly the one surviving guard test (31 deselected), confirming what the Core shards will pick up.
- Validated the workflow parses and that every `needs:` entry and `needs.*.outputs.*` expression still resolves after the job deletion (scripted check over the YAML).
- Confirmed via the GitHub rulesets API that `Django Tests Pass` is the required status check, not the deleted job, so merges are unaffected.
- I could not run the guard test locally (no docker stack available in this session); it is unchanged apart from the marker removal, and this PR's CI run exercises it in its new home.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The handbook page on async migrations describes the system itself and doesn't reference the CI job or its tests, so no doc changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with PostHog Code (Claude). Started as "why is this one test 9 minutes?" - the answer was that the test is fully mocked and takes milliseconds, but it was the first test to execute in the job (the file before it is entirely skipped), so the session-scoped DB/ClickHouse bootstrap was attributed to it in JUnit. An initial fix just added `-o junit_duration_report=call` to the job; Paul then asked whether the feature is dead and directed retiring the job instead, which superseded that fix.
- Runtime numbers come from the `posthog-ci-running-time-job` telemetry events that Backend CI already captures, queried via the PostHog MCP.
- No repo skills were invoked; the change removes tests and CI rather than adding them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
