### PR TITLE
chore(ci): collapse ci-report sections into details blocks

### DIFF
--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -80,7 +80,7 @@ export function parseSections(body) {
 
 export function upsertSection(sections, { id, status = 'info', summary = '', body }) {
     const next = new Map(sections)
-    next.set(id, { status, summary, inner: body })
+    next.set(id, { status, summary: String(summary).replace(/\s+/g, ' '), inner: body })
     return next
 }
 

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -2,11 +2,12 @@
 import fs from 'node:fs'
 
 // One sticky comment shared by every frontend CI check. Each check owns a delimited
-// section and updates only its own; the header list and section order are rebuilt from
-// the fixed SECTIONS registry every time, so the layout never shifts between runs and
-// readers learn where each check lives. Safe as a plain read-modify-write only because
-// every writer runs sequentially in the single frontend-bundle-size job — do not call
-// this from parallel jobs without a locking strategy.
+// section and updates only its own; the collapsed summary lines and section order are
+// rebuilt from the fixed SECTIONS registry every time, so the layout never shifts
+// between runs and readers learn where each check lives. Safe as a plain
+// read-modify-write only because every writer runs sequentially in the single
+// frontend-bundle-size job — do not call this from parallel jobs without a locking
+// strategy.
 export const MARKER = '<!-- posthog-ci-report -->'
 
 // The single source of truth for which sections exist and the order they render in.
@@ -28,17 +29,6 @@ function titleFor(id) {
     return SECTIONS.find((s) => s.id === id)?.title ?? id
 }
 
-// GitHub derives a heading anchor by lowercasing, dropping anything that is not a word
-// char/space/hyphen, and turning spaces into hyphens. The section headings are plain
-// (no emoji), so the same transform yields the anchor the header list links to.
-export function slugify(title) {
-    return title
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .trim()
-        .replace(/\s+/g, '-')
-}
-
 function encodeMeta(meta) {
     return Buffer.from(JSON.stringify(meta), 'utf-8').toString('base64')
 }
@@ -54,9 +44,23 @@ function decodeMeta(encoded) {
 const SECTION_RE =
     /<!-- ci-report:section:([\w-]+):([A-Za-z0-9+/=]*) -->\n([\s\S]*?)\n<!-- ci-report:section-end:\1 -->/g
 
+// The details wrapper and heading are presentation that renderComment regenerates from
+// the marker meta every time, so parsing strips them back off — re-rendering an
+// untouched section must never wrap it twice. The greedy body capture matters: section
+// bodies can end with their own nested </details>. The heading form covers comments
+// written before sections became collapsible.
+const RENDERED_INNER_RE = /^<details>\n<summary>.*<\/summary>\n\n([\s\S]*)\n\n<\/details>$/
+function stripPresentation(inner) {
+    const details = inner.match(RENDERED_INNER_RE)
+    if (details) {
+        return details[1]
+    }
+    return inner.replace(/^## .+\n\n/, '')
+}
+
 // Parse an existing comment body back into a map of id -> { status, summary, inner }.
-// `inner` is the rendered section content, kept verbatim so sections this run does not
-// touch are re-emitted byte-for-byte.
+// `inner` is the section body as its check posted it; sections this run does not touch
+// are re-emitted from it unchanged.
 export function parseSections(body) {
     const sections = new Map()
     if (!body) {
@@ -65,14 +69,18 @@ export function parseSections(body) {
     for (const match of body.matchAll(SECTION_RE)) {
         const [, id, encodedMeta, inner] = match
         const meta = decodeMeta(encodedMeta)
-        sections.set(id, { status: meta.status ?? 'info', summary: meta.summary ?? '', inner })
+        sections.set(id, {
+            status: meta.status ?? 'info',
+            summary: meta.summary ?? '',
+            inner: stripPresentation(inner),
+        })
     }
     return sections
 }
 
 export function upsertSection(sections, { id, status = 'info', summary = '', body }) {
     const next = new Map(sections)
-    next.set(id, { status, summary, inner: `## ${titleFor(id)}\n\n${body}` })
+    next.set(id, { status, summary, inner: body })
     return next
 }
 
@@ -85,23 +93,26 @@ function orderedIds(sections) {
     return [...known, ...unknown]
 }
 
+// Each section renders as a collapsed <details> block whose summary line carries the
+// status, title, and one-line summary — collapsed, the sections ARE the at-a-glance
+// list, and the comment stays short no matter how many checks join.
 export function renderComment(sections) {
     const ids = orderedIds(sections)
-    const header = ids.map((id) => {
-        const { status, summary } = sections.get(id)
-        const title = titleFor(id)
-        const suffix = summary ? ` — ${summary}` : ''
-        return `- ${emojiFor(status)} [${title}](#${slugify(title)})${suffix}`
-    })
     const blocks = ids.map((id) => {
         const { status, summary, inner } = sections.get(id)
+        const suffix = summary ? ` — ${summary}` : ''
         return [
             `<!-- ci-report:section:${id}:${encodeMeta({ status, summary })} -->`,
+            '<details>',
+            `<summary>${emojiFor(status)} <b>${titleFor(id)}</b>${suffix}</summary>`,
+            '',
             inner,
+            '',
+            '</details>',
             `<!-- ci-report:section-end:${id} -->`,
         ].join('\n')
     })
-    return [MARKER, '## 🤖 CI report', '', ...header, '', ...blocks].join('\n')
+    return [MARKER, '## 🤖 CI report', '', ...blocks].join('\n')
 }
 
 export async function gh(token, url, options = {}) {

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -99,12 +99,12 @@ function orderedIds(sections) {
 export function renderComment(sections) {
     const ids = orderedIds(sections)
     const blocks = ids.map((id) => {
-        const { status, inner } = sections.get(id)
+        const { status, summary: rawSummary, inner } = sections.get(id)
         // The summary renders inline in <summary>…</summary>, which must stay on one line
         // or the strip regex misses the wrapper on re-parse and the section nests another
         // <details> every run. Normalize at the consumption point so summaries replayed
         // from persisted meta are covered as well as freshly upserted ones.
-        const summary = String(sections.get(id).summary ?? '')
+        const summary = String(rawSummary ?? '')
             .replace(/\s+/g, ' ')
             .trim()
         const suffix = summary ? ` — ${summary}` : ''

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -80,7 +80,7 @@ export function parseSections(body) {
 
 export function upsertSection(sections, { id, status = 'info', summary = '', body }) {
     const next = new Map(sections)
-    next.set(id, { status, summary: String(summary).replace(/\s+/g, ' '), inner: body })
+    next.set(id, { status, summary, inner: body })
     return next
 }
 
@@ -99,7 +99,14 @@ function orderedIds(sections) {
 export function renderComment(sections) {
     const ids = orderedIds(sections)
     const blocks = ids.map((id) => {
-        const { status, summary, inner } = sections.get(id)
+        const { status, inner } = sections.get(id)
+        // The summary renders inline in <summary>…</summary>, which must stay on one line
+        // or the strip regex misses the wrapper on re-parse and the section nests another
+        // <details> every run. Normalize at the consumption point so summaries replayed
+        // from persisted meta are covered as well as freshly upserted ones.
+        const summary = String(sections.get(id).summary ?? '')
+            .replace(/\s+/g, ' ')
+            .trim()
         const suffix = summary ? ` — ${summary}` : ''
         return [
             `<!-- ci-report:section:${id}:${encodeMeta({ status, summary })} -->`,

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -24,6 +24,19 @@ function sectionMeta(meta: { status: string; summary: string }): string {
     return Buffer.from(JSON.stringify(meta), 'utf-8').toString('base64')
 }
 
+function legacyComment(summary: string, body = 'old body'): string {
+    return [
+        MARKER,
+        '## 🤖 CI report',
+        '',
+        `<!-- ci-report:section:bundle-size:${sectionMeta({ status: 'ok', summary })} -->`,
+        '## Bundle size',
+        '',
+        body,
+        '<!-- ci-report:section-end:bundle-size -->',
+    ].join('\n')
+}
+
 describe('ci-report section helper', () => {
     it('renders collapsed section blocks in fixed registry order regardless of write order', () => {
         // Written eager-graph -> dist-size -> bundle-size; registry order is the reverse.
@@ -91,33 +104,13 @@ describe('ci-report section helper', () => {
     )
 
     it('normalizes a multi-line summary replayed from persisted meta, not just fresh upserts', () => {
-        const persisted = [
-            MARKER,
-            '## 🤖 CI report',
-            '',
-            `<!-- ci-report:section:bundle-size:${sectionMeta({ status: 'ok', summary: 'line1\nline2' })} -->`,
-            '## Bundle size',
-            '',
-            'old body',
-            '<!-- ci-report:section-end:bundle-size -->',
-        ].join('\n')
-        const rendered: string = renderComment(parseSections(persisted))
+        const rendered: string = renderComment(parseSections(legacyComment('line1\nline2')))
         expect(rendered).toContain('<b>Bundle size</b> — line1 line2</summary>')
         expect(renderComment(parseSections(rendered))).toBe(rendered)
     })
 
     it('strips the in-body heading from sections written before the collapsible layout', () => {
-        const legacy = [
-            MARKER,
-            '## 🤖 CI report',
-            '',
-            `<!-- ci-report:section:bundle-size:${sectionMeta({ status: 'ok', summary: 'b' })} -->`,
-            '## Bundle size',
-            '',
-            'old body',
-            '<!-- ci-report:section-end:bundle-size -->',
-        ].join('\n')
-        const sections = parseSections(legacy)
+        const sections = parseSections(legacyComment('b'))
         expect(get(sections, 'bundle-size').inner).toBe('old body')
         expect(renderComment(sections)).not.toContain('## Bundle size')
     })

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -77,6 +77,35 @@ describe('ci-report section helper', () => {
         }
     )
 
+    it.each([
+        ['a summary containing newlines', 'over\nbudget', ' — over budget'],
+        ['a null summary', null as unknown as string, ''],
+        ['a whitespace-only summary', ' \n ', ''],
+    ])(
+        'renders %s on a single line so the wrapper survives re-parse',
+        (_name: string, summary: string, suffix: string) => {
+            const rendered: string = renderComment(build([{ id: 'bundle-size', status: 'ok', summary, body: 'x' }]))
+            expect(rendered).toContain(`<summary>${STATUS_EMOJI.ok} <b>Bundle size</b>${suffix}</summary>`)
+            expect(renderComment(parseSections(rendered))).toBe(rendered)
+        }
+    )
+
+    it('normalizes a multi-line summary replayed from persisted meta, not just fresh upserts', () => {
+        const persisted = [
+            MARKER,
+            '## 🤖 CI report',
+            '',
+            `<!-- ci-report:section:bundle-size:${sectionMeta({ status: 'ok', summary: 'line1\nline2' })} -->`,
+            '## Bundle size',
+            '',
+            'old body',
+            '<!-- ci-report:section-end:bundle-size -->',
+        ].join('\n')
+        const rendered: string = renderComment(parseSections(persisted))
+        expect(rendered).toContain('<b>Bundle size</b> — line1 line2</summary>')
+        expect(renderComment(parseSections(rendered))).toBe(rendered)
+    })
+
     it('strips the in-body heading from sections written before the collapsible layout', () => {
         const legacy = [
             MARKER,

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -1,4 +1,4 @@
-import { MARKER, parseSections, renderComment, slugify, STATUS_EMOJI, upsertSection } from './update-ci-report.mjs'
+import { MARKER, parseSections, renderComment, STATUS_EMOJI, upsertSection } from './update-ci-report.mjs'
 
 type SectionEntry = { status: string; summary: string; inner: string }
 type SectionState = Map<string, SectionEntry>
@@ -20,8 +20,12 @@ function get(sections: SectionState, id: string): SectionEntry {
     return entry
 }
 
+function sectionMeta(meta: { status: string; summary: string }): string {
+    return Buffer.from(JSON.stringify(meta), 'utf-8').toString('base64')
+}
+
 describe('ci-report section helper', () => {
-    it('renders header and section blocks in fixed registry order regardless of write order', () => {
+    it('renders collapsed section blocks in fixed registry order regardless of write order', () => {
         // Written eager-graph -> dist-size -> bundle-size; registry order is the reverse.
         const rendered: string = renderComment(
             build([
@@ -30,8 +34,8 @@ describe('ci-report section helper', () => {
                 { id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' },
             ])
         )
-        const headerOrder = [...rendered.matchAll(/- .+? \[(.+?)\]/g)].map((m) => m[1])
-        expect(headerOrder).toEqual(['Bundle size', 'Eager graph', 'Dist folder size'])
+        const summaryOrder = [...rendered.matchAll(/<summary>.+?<b>(.+?)<\/b>/g)].map((m) => m[1])
+        expect(summaryOrder).toEqual(['Bundle size', 'Eager graph', 'Dist folder size'])
         expect(rendered.indexOf('BUNDLE')).toBeLessThan(rendered.indexOf('EAGER'))
         expect(rendered.indexOf('EAGER')).toBeLessThan(rendered.indexOf('DIST'))
         expect(rendered.startsWith(MARKER)).toBe(true)
@@ -50,19 +54,53 @@ describe('ci-report section helper', () => {
         })
         const sections = parseSections(renderComment(updated))
         expect(get(sections, 'bundle-size')).toEqual(get(original, 'bundle-size'))
-        expect(get(sections, 'eager-graph').inner).toBe('## Eager graph\n\nNEW EAGER BODY')
-        expect(get(sections, 'eager-graph').status).toBe('fail')
-        expect(get(sections, 'eager-graph').summary).toBe('over budget')
+        expect(get(sections, 'eager-graph')).toEqual({
+            status: 'fail',
+            summary: 'over budget',
+            inner: 'NEW EAGER BODY',
+        })
     })
 
-    it('round-trips status and summary so the header reflects sections written by other runs', () => {
-        // A later run parses the persisted comment to rebuild the header — the status of a
-        // section it did not write must survive encode/decode, or the summary list lies.
+    it.each([
+        ['a plain body', 'plain body'],
+        ['a multi-paragraph body', 'intro\n\n| a | b |\n| - | - |\n| 1 | 2 |'],
+        [
+            'a body ending in its own nested details block',
+            'intro\n\n<details><summary>Largest files</summary>\n\n| file |\n\n</details>',
+        ],
+    ])(
+        're-rendering a parsed comment is stable for %s (never wraps a section twice)',
+        (_name: string, body: string) => {
+            const rendered: string = renderComment(build([{ id: 'bundle-size', status: 'warn', summary: 's', body }]))
+            expect(get(parseSections(rendered), 'bundle-size').inner).toBe(body)
+            expect(renderComment(parseSections(rendered))).toBe(rendered)
+        }
+    )
+
+    it('strips the in-body heading from sections written before the collapsible layout', () => {
+        const legacy = [
+            MARKER,
+            '## 🤖 CI report',
+            '',
+            `<!-- ci-report:section:bundle-size:${sectionMeta({ status: 'ok', summary: 'b' })} -->`,
+            '## Bundle size',
+            '',
+            'old body',
+            '<!-- ci-report:section-end:bundle-size -->',
+        ].join('\n')
+        const sections = parseSections(legacy)
+        expect(get(sections, 'bundle-size').inner).toBe('old body')
+        expect(renderComment(sections)).not.toContain('## Bundle size')
+    })
+
+    it('round-trips status and summary so the collapsed line reflects sections written by other runs', () => {
+        // A later run parses the persisted comment to re-render every section — the status
+        // of a section it did not write must survive encode/decode, or the summary line lies.
         const persisted: string = renderComment(
             build([{ id: 'bundle-size', status: 'warn', summary: '+120 KiB (2.1%)', body: 'x' }])
         )
         const reparsed: string = renderComment(parseSections(persisted))
-        expect(reparsed).toContain(`- ${STATUS_EMOJI.warn} [Bundle size](#bundle-size) — +120 KiB (2.1%)`)
+        expect(reparsed).toContain(`<summary>${STATUS_EMOJI.warn} <b>Bundle size</b> — +120 KiB (2.1%)</summary>`)
     })
 
     it.each([
@@ -71,30 +109,22 @@ describe('ci-report section helper', () => {
         ['fail', STATUS_EMOJI.fail],
         ['info', STATUS_EMOJI.info],
         ['unknown-status', STATUS_EMOJI.info],
-    ])('header maps status %s to its emoji', (status: string, emoji: string) => {
+    ])('collapsed line maps status %s to its emoji', (status: string, emoji: string) => {
         const rendered: string = renderComment(build([{ id: 'bundle-size', status, summary: '', body: 'x' }]))
-        expect(rendered).toContain(`- ${emoji} [Bundle size](#bundle-size)`)
+        expect(rendered).toContain(`<summary>${emoji} <b>Bundle size</b>`)
     })
 
     it('omits the summary suffix when there is no summary', () => {
         const rendered: string = renderComment(build([{ id: 'bundle-size', status: 'ok', body: 'x' }]))
-        expect(rendered).toContain(`- ${STATUS_EMOJI.ok} [Bundle size](#bundle-size)\n`)
-        expect(rendered).not.toContain('[Bundle size](#bundle-size) —')
-    })
-
-    it.each([
-        ['Bundle size', 'bundle-size'],
-        ['Dist folder size', 'dist-folder-size'],
-        ['🕸️ Eager graph', 'eager-graph'],
-    ])('slugify(%s) matches the GitHub heading anchor %s', (title: string, slug: string) => {
-        expect(slugify(title)).toBe(slug)
+        expect(rendered).toContain(`<summary>${STATUS_EMOJI.ok} <b>Bundle size</b></summary>`)
+        expect(rendered).not.toContain('<b>Bundle size</b> —')
     })
 
     it('keeps an unregistered section instead of dropping it, ordered after known ones', () => {
         const withLegacy = build([{ id: 'bundle-size', status: 'ok', summary: '', body: 'x' }])
-        withLegacy.set('legacy-check', { status: 'info', summary: 'old', inner: '## Legacy\n\nold body' })
+        withLegacy.set('legacy-check', { status: 'info', summary: 'old', inner: 'old body' })
         const rendered: string = renderComment(withLegacy)
         expect(rendered).toContain('old body')
-        expect(rendered.indexOf('#bundle-size')).toBeLessThan(rendered.indexOf('legacy-check'))
+        expect(rendered.indexOf('<b>Bundle size</b>')).toBeLessThan(rendered.indexOf('legacy-check'))
     })
 })


### PR DESCRIPTION
## Problem

The consolidated CI report comment (#67325) grows linearly with every check that joins it — three sections is already a long comment, and the plan is to fold more bots in (snapshots, Playwright, MCP UI apps sizes, CH migration SQL). It also renders each check's status twice: once in a header list and again as a section heading.

## Changes

Each section now renders as a collapsed `<details>` block whose `<summary>` line carries the status emoji, title, and one-line summary. Collapsed, the sections **are** the at-a-glance list — so the separate header list (and the `slugify` anchors it linked with) is gone, and the comment stays a handful of lines no matter how many checks join. Expanding a section shows the full table/detail as before.

Rendered shape:

```
## 🤖 CI report

▸ ✅ Bundle size — 🟢 -19.5 KiB (-6.7%)
▸ ⚠️ Eager graph — 1 over budget
▸ ℹ️ Dist folder size — no base branch to compare
```

The details wrapper is presentation regenerated from the section markers on every render; parsing strips it back off, so re-rendering a section another run wrote never double-wraps it. Comments written by the pre-collapsible layout (in-body `## Title` headings) are normalized on first parse.

Stacked on #67325.

## How did you test this code?

Jest unit tests on the engine (14 pass). New/changed coverage catches, per case:
- re-render stability (`parse(render(x))` byte-identical): if the presentation-strip regex breaks, untouched sections get nested `<details><details>` on every run — includes a body that itself ends in `</details>` (eager-graph's does), which a non-greedy strip would truncate
- legacy normalization: a comment written by the current (pre-collapsible) engine keeps its body but sheds its in-body heading — without it, upgraded runs render the old heading inside the new block
- existing order/round-trip/emoji tests adapted to the new summary-line surface (same regressions: registry-order shuffling, meta corruption across runs)

Also rendered a realistic three-section comment locally and eyeballed the markdown.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — CI tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @pauldambra: "as this grows we should probably have each section have an expandable details block so the comment doesn't become too long — a summary and then expandable if people want more." Follow-up in the ci-report consolidation stack; next planned step is cross-workflow write safety so non-frontend checks can join the comment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*