### PR TITLE
feat(customer-analytics): Notes tab in customer analytics scene

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4889,13 +4889,13 @@ snapshots:
     scenes-app-batchexports--runs-with-data--light:
         hash: v1.k794b7964.144b41b97a76df864203804f6bf0b956998d6f0e6e4d81c4102c52dadce11813.DeXap8kCLxs-8UrwnfoTk5PIbkan4hrzxPCfyN_htME
     scenes-app-customer-analytics-accounts--default--dark:
-        hash: v1.k794b7964.8dee1c5495b4bf2b8946bf107f6fcad200632a9905ade27510486535a737a959.oMs-LHry1y5jQeEQPYtZ9NuBX57GjqdVYQo9MDJnVPo
+        hash: v1.k794b7964.6cd8b44854e9b3fba45cbd64a6511d7eabe97c7f2ccf2bbeb5b2e059a9d501a1.DxoOOyw70dy9WuQmmcDhLd6fdgDHbyZkcmA9j79-YIc
     scenes-app-customer-analytics-accounts--default--light:
-        hash: v1.k794b7964.d3d5aff5a454a0d12d1caf042138b4fec9bccc22eb0864cf8ea02fe731ec9b11.a1mKciSBMLACivrzuv10n85UzU5tL9ddUx-I9jQs3h8
+        hash: v1.k794b7964.313667b895fb13da06fd151024b127ae7afdb0877d5111acc88ced9c1c90a543.WFeCmyRCSveUnxCMhGk_q6VHRSMEODj35wJpjfA7Io0
     scenes-app-customer-analytics-accounts--empty--dark:
-        hash: v1.k794b7964.fd876018908374ed70f6b33223582ba628934a217720b10ac1c9bd964442d7d3.hI1w37iscAvSQJPoZcvZKabIbk13bp4ausw1azme4EI
+        hash: v1.k794b7964.92297962d237959293e4c1289c1e5742fe5e8313ea12f7e00df1b81ffeb0c200.cNCidY7BOaKo38JMRDzslfVq-ykcaOu8omdtuxoxRN0
     scenes-app-customer-analytics-accounts--empty--light:
-        hash: v1.k794b7964.1384b7f44d0a9ed38859992a8d91bdbaf3d02da24fed766b2c359d41c6e1bc88.0IxTKv58B9NMAIM__pVqQaHW_UbWBbJLH4oRGNpccrg
+        hash: v1.k794b7964.6a953fbd445c3d41543568a4b7345613381d6b5add4c6278c2bd08a5c9e5a84d.IzJDAUfGm_rEBbrP8RuKk50qAV3lJfcHEYSp9rURN8Y
     scenes-app-customer-analytics-accounts--feature-gate-off--dark:
         hash: v1.k794b7964.7750bce37ad591ab773135ad1a9b8738ac790727774c03d3aa7b5abbfc42fab0.KbXf74dR5pSVh6Wc8mSjrNGqL8LbTcsMl78W7WVvTXU
     scenes-app-customer-analytics-accounts--feature-gate-off--light:
@@ -4905,9 +4905,9 @@ snapshots:
     scenes-app-customer-analytics-accounts--row-expanded-empty--light:
         hash: v1.k794b7964.904bd5b939f99d43408ae3a8a814a3c299bd57bf13a0fd1d98ff6033fd66e343.K1Z16ICEF6-O9kIej8kGnYyarloq2oZH5rdtmx-8Hu0
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--dark:
-        hash: v1.k794b7964.dbe806f797399ea2451bdf08b2a0bc1a413ea4d65e1a244e859a6f17a330005d.i8IfnQ9ONhYyodW5HPR_2GSN7q1dcVA3cPUtXyNi_ro
+        hash: v1.k794b7964.e9ae25bbbbde36eb5f7f095726b21bf3f076ec89fab67df5e6671e8ba4b32351.RrF7jJW9IjD2dhcPxtZ4XrNhjC9mwnyd7uVAz3Adchw
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--light:
-        hash: v1.k794b7964.f82e5d3d3f153d31ba1ef5b668ebb5ab8aab000fe4acb42252f89e9f56a838bc.GkNSIp0tMmvNDlRasel6bRQBgice_VcLKHISDWHGnnU
+        hash: v1.k794b7964.3df17af670a653895eb47235466a6e2659ae6d7171800a5182d4bf12228c0e8c.Ap8UzCxHbKLhxpCtW6H1ofhfBOWuzoF9OKTC6mYMvsk
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--dark:
         hash: v1.k794b7964.a474327553350a89a474582bce8f33ecfea94cdc7cbf34afb26a4030fc439be8.xDoymdxmJOJUHR7BTM4NuH-Cp3L8VnDa_BSRgexhmA8
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--light:

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -218,6 +218,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/customer_analytics/accounts': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
     '/customer_analytics/accounts/:accountId': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
     '/customer_analytics/accounts/:accountId/:tab': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
+    '/customer_analytics/notes': ['CustomerAnalytics', 'customerAnalyticsNotes'],
     '/customer_analytics/journeys/new': ['CustomerJourneyBuilder', 'customerJourneyBuilder'],
     '/customer_analytics/journeys/templates': ['CustomerJourneyTemplates', 'customerJourneyTemplates'],
     '/customer_analytics/journeys/:id/edit': ['CustomerJourneyBuilder', 'customerJourneyEdit'],
@@ -982,6 +983,7 @@ export const productUrls = {
     customerAnalyticsAccounts: (): string => '/customer_analytics/accounts',
     customerAnalyticsAccount: (accountId: string, tab?: string): string =>
         `/customer_analytics/accounts/${accountId}${tab ? `/${tab}` : ''}`,
+    customerAnalyticsNotes: (): string => '/customer_analytics/notes',
     customerAnalyticsJourneys: (): string => '/customer_analytics/journeys',
     customerAnalyticsConfiguration: (): string => '/customer_analytics/configuration',
     customerJourneyBuilder: (): string => '/customer_analytics/journeys/new',

--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -28,6 +28,7 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { SessionInsights } from 'products/customer_analytics/frontend/components/Insights/SessionInsights'
 
+import { AccountNotesTabContent } from './components/AccountNotes/AccountNotesTabContent'
 import { AccountsTabContent } from './components/Accounts/AccountsTabContent'
 import { CustomerJourneys } from './components/CustomerJourneys/CustomerJourneys'
 import { CustomerJourneySelect } from './components/CustomerJourneys/CustomerJourneySelect'
@@ -77,9 +78,9 @@ function CustomerAnalyticsSceneContent(): JSX.Element {
         reportCustomerAnalyticsViewed()
     })
 
-    // Accounts is gated by CUSTOMER_ANALYTICS_CSP; without it the tab does not
-    // exist, so a guessed `/customer_analytics/accounts` URL is a 404.
-    if (activeTab === 'accounts' && !featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP]) {
+    // Accounts and Notes are gated by CUSTOMER_ANALYTICS_CSP; without it the tabs do not
+    // exist, so guessed `/customer_analytics/accounts` / `/customer_analytics/notes` URLs are 404s.
+    if ((activeTab === 'accounts' || activeTab === 'notes') && !featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP]) {
         return <NotFound object="page" />
     }
 
@@ -108,6 +109,12 @@ function CustomerAnalyticsSceneContent(): JSX.Element {
             label: 'Accounts',
             content: <AccountsTabContent />,
             link: combineUrl(urls.customerAnalyticsAccounts(), searchParams).url,
+        })
+        tabs.push({
+            key: 'notes',
+            label: 'Notes',
+            content: <AccountNotesTabContent />,
+            link: combineUrl(urls.customerAnalyticsNotes(), searchParams).url,
         })
     }
 

--- a/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
+++ b/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
@@ -1,0 +1,77 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonInput } from '@posthog/lemon-ui'
+
+import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { atColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+import type { AccountNoteApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import { accountNotesLogic } from './accountNotesLogic'
+
+export function AccountNotesTabContent(): JSX.Element {
+    const { accountNotes, accountNotesResponseLoading, search, pagination } = useValues(accountNotesLogic)
+    const { setSearch } = useActions(accountNotesLogic)
+
+    const columns: LemonTableColumns<AccountNoteApi> = [
+        {
+            title: 'Title',
+            dataIndex: 'title',
+            width: '100%',
+            render: function Render(title, note) {
+                return (
+                    <Link
+                        data-attr="account-note-title"
+                        to={urls.customerAnalyticsAccount(note.account_id, 'notes')}
+                        className="font-semibold"
+                    >
+                        {title || 'Untitled'}
+                    </Link>
+                )
+            },
+        },
+        {
+            title: 'Account',
+            dataIndex: 'account_name',
+            render: function Render(accountName, note) {
+                return (
+                    <Link data-attr="account-note-account" to={urls.customerAnalyticsAccount(note.account_id)}>
+                        {accountName}
+                    </Link>
+                )
+            },
+        },
+        atColumn<AccountNoteApi>('created_at', 'Created') as LemonTableColumn<
+            AccountNoteApi,
+            keyof AccountNoteApi | undefined
+        >,
+        atColumn<AccountNoteApi>('last_modified_at', 'Last modified') as LemonTableColumn<
+            AccountNoteApi,
+            keyof AccountNoteApi | undefined
+        >,
+    ]
+
+    return (
+        <div className="space-y-4">
+            <LemonInput
+                type="search"
+                placeholder="Search notes"
+                onChange={setSearch}
+                value={search}
+                data-attr="account-notes-search"
+            />
+            <LemonTable
+                data-attr="account-notes-table"
+                dataSource={accountNotes}
+                rowKey="short_id"
+                columns={columns}
+                loading={accountNotesResponseLoading}
+                pagination={pagination}
+                emptyState="No account notes yet. Create notes from an account's Notes tab."
+                nouns={['note', 'notes']}
+            />
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
+++ b/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
@@ -72,6 +72,8 @@ export function AccountNotesTabContent(): JSX.Element {
                 placeholder="Search notes"
                 onChange={setSearch}
                 value={search}
+                size="small"
+                className="min-w-64"
                 data-attr="account-notes-search"
             />
             <LemonTable

--- a/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
+++ b/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
@@ -5,6 +5,7 @@ import { LemonInput } from '@posthog/lemon-ui'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { atColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { Link } from 'lib/lemon-ui/Link'
+import { notebookPanelLogic } from 'scenes/notebooks/NotebookPanel/notebookPanelLogic'
 import { urls } from 'scenes/urls'
 
 import type { AccountNoteApi } from 'products/customer_analytics/frontend/generated/api.schemas'
@@ -14,6 +15,7 @@ import { accountNotesLogic } from './accountNotesLogic'
 export function AccountNotesTabContent(): JSX.Element {
     const { accountNotes, accountNotesResponseLoading, search, pagination } = useValues(accountNotesLogic)
     const { setSearch } = useActions(accountNotesLogic)
+    const { selectNotebook } = useActions(notebookPanelLogic)
 
     const columns: LemonTableColumns<AccountNoteApi> = [
         {
@@ -21,11 +23,17 @@ export function AccountNotesTabContent(): JSX.Element {
             dataIndex: 'title',
             width: '100%',
             render: function Render(title, note) {
+                // Plain click opens the note in the side panel (keeping the list mounted);
+                // the href stays so cmd/ctrl-click opens the full notebook page in a new tab.
                 return (
                     <Link
                         data-attr="account-note-title"
-                        to={urls.customerAnalyticsAccount(note.account_id, 'notes')}
+                        to={urls.notebook(note.short_id)}
                         className="font-semibold"
+                        onClick={(event) => {
+                            event.preventDefault()
+                            selectNotebook(note.short_id)
+                        }}
                     >
                         {title || 'Untitled'}
                     </Link>
@@ -37,7 +45,11 @@ export function AccountNotesTabContent(): JSX.Element {
             dataIndex: 'account_name',
             render: function Render(accountName, note) {
                 return (
-                    <Link data-attr="account-note-account" to={urls.customerAnalyticsAccount(note.account_id)}>
+                    <Link
+                        data-attr="account-note-account"
+                        to={urls.customerAnalyticsAccount(note.account_id)}
+                        className="whitespace-nowrap"
+                    >
                         {accountName}
                     </Link>
                 )

--- a/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
+++ b/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
@@ -83,7 +83,11 @@ export function AccountNotesTabContent(): JSX.Element {
                 columns={columns}
                 loading={accountNotesResponseLoading}
                 pagination={pagination}
-                emptyState="No account notes yet. Create notes from an account's Notes tab."
+                emptyState={
+                    search
+                        ? 'No notes matching your search'
+                        : "No account notes yet. Create notes from an account's Notes tab."
+                }
                 nouns={['note', 'notes']}
             />
         </div>

--- a/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
+++ b/products/customer_analytics/frontend/components/AccountNotes/AccountNotesTabContent.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonInput } from '@posthog/lemon-ui'
+import { LemonInput, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { atColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
@@ -13,7 +13,8 @@ import type { AccountNoteApi } from 'products/customer_analytics/frontend/genera
 import { accountNotesLogic } from './accountNotesLogic'
 
 export function AccountNotesTabContent(): JSX.Element {
-    const { accountNotes, accountNotesResponseLoading, search, pagination } = useValues(accountNotesLogic)
+    const { accountNotes, accountNotesResponse, accountNotesResponseLoading, search, pagination } =
+        useValues(accountNotesLogic)
     const { setSearch } = useActions(accountNotesLogic)
     const { selectNotebook } = useActions(notebookPanelLogic)
 
@@ -76,20 +77,26 @@ export function AccountNotesTabContent(): JSX.Element {
                 className="min-w-64"
                 data-attr="account-notes-search"
             />
-            <LemonTable
-                data-attr="account-notes-table"
-                dataSource={accountNotes}
-                rowKey="short_id"
-                columns={columns}
-                loading={accountNotesResponseLoading}
-                pagination={pagination}
-                emptyState={
-                    search
-                        ? 'No notes matching your search'
-                        : "No account notes yet. Create notes from an account's Notes tab."
-                }
-                nouns={['note', 'notes']}
-            />
+            {accountNotesResponse === null ? (
+                // Dedicated initial-load state (mirrors AccountOpportunitiesExpansion); the
+                // table's own loading overlay covers subsequent search/pagination fetches.
+                <LemonSkeleton className="h-64 w-full" />
+            ) : (
+                <LemonTable
+                    data-attr="account-notes-table"
+                    dataSource={accountNotes}
+                    rowKey="short_id"
+                    columns={columns}
+                    loading={accountNotesResponseLoading}
+                    pagination={pagination}
+                    emptyState={
+                        search
+                            ? 'No notes matching your search'
+                            : "No account notes yet. Create notes from an account's Notes tab."
+                    }
+                    nouns={['note', 'notes']}
+                />
+            )}
         </div>
     )
 }

--- a/products/customer_analytics/frontend/components/AccountNotes/accountNotesLogic.ts
+++ b/products/customer_analytics/frontend/components/AccountNotes/accountNotesLogic.ts
@@ -1,0 +1,78 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import { PaginationManual, lemonToast } from '@posthog/lemon-ui'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { accountNotesList } from 'products/customer_analytics/frontend/generated/api'
+import type {
+    AccountNoteApi,
+    PaginatedAccountNoteListApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import type { accountNotesLogicType } from './accountNotesLogicType'
+
+const RESULTS_PER_PAGE = 50
+
+export const accountNotesLogic = kea<accountNotesLogicType>([
+    path(['products', 'customer_analytics', 'frontend', 'components', 'AccountNotes', 'accountNotesLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        loadAccountNotes: true,
+        setSearch: (search: string) => ({ search }),
+        setPage: (page: number) => ({ page }),
+    }),
+    loaders(({ values }) => ({
+        accountNotesResponse: [
+            null as PaginatedAccountNoteListApi | null,
+            {
+                loadAccountNotes: async (_, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await accountNotesList(String(values.currentTeamId), {
+                        search: values.search || undefined,
+                        limit: RESULTS_PER_PAGE,
+                        offset: (values.page - 1) * RESULTS_PER_PAGE,
+                    })
+                    breakpoint()
+                    return response
+                },
+            },
+        ],
+    })),
+    reducers({
+        search: ['', { setSearch: (_, { search }) => search }],
+        page: [1, { setPage: (_, { page }) => page, setSearch: () => 1 }],
+    }),
+    selectors(({ actions }) => ({
+        accountNotes: [
+            (s) => [s.accountNotesResponse],
+            (response: PaginatedAccountNoteListApi | null): AccountNoteApi[] => response?.results ?? [],
+        ],
+        pagination: [
+            (s) => [s.page, s.accountNotesResponse],
+            (page: number, response: PaginatedAccountNoteListApi | null): PaginationManual => ({
+                controlled: true,
+                pageSize: RESULTS_PER_PAGE,
+                currentPage: page,
+                entryCount: response?.count ?? 0,
+                onBackward: () => actions.setPage(page - 1),
+                onForward: () => actions.setPage(page + 1),
+            }),
+        ],
+    })),
+    listeners(({ actions }) => ({
+        setSearch: () => actions.loadAccountNotes(),
+        setPage: () => actions.loadAccountNotes(),
+        loadAccountNotesFailure: ({ error }) => {
+            posthog.captureException(error)
+            lemonToast.error('Failed to load account notes')
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadAccountNotes()
+    }),
+])

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -139,12 +139,15 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
     selectors({
         activeTab: [
             (s) => [s.sceneKey],
-            (sceneKey): 'dashboard' | 'journeys' | 'accounts' => {
+            (sceneKey): 'dashboard' | 'journeys' | 'accounts' | 'notes' => {
                 if (sceneKey === 'customerAnalyticsJourneys') {
                     return 'journeys'
                 }
                 if (sceneKey === 'customerAnalyticsAccounts') {
                     return 'accounts'
+                }
+                if (sceneKey === 'customerAnalyticsNotes') {
+                    return 'notes'
                 }
                 return 'dashboard'
             },

--- a/products/customer_analytics/manifest.tsx
+++ b/products/customer_analytics/manifest.tsx
@@ -41,6 +41,7 @@ export const manifest: ProductManifest = {
         // as the list so the accounts tab activates; accountsLogic reads the params.
         '/customer_analytics/accounts/:accountId': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
         '/customer_analytics/accounts/:accountId/:tab': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
+        '/customer_analytics/notes': ['CustomerAnalytics', 'customerAnalyticsNotes'],
         '/customer_analytics/journeys/new': ['CustomerJourneyBuilder', 'customerJourneyBuilder'],
         '/customer_analytics/journeys/templates': ['CustomerJourneyTemplates', 'customerJourneyTemplates'],
         '/customer_analytics/journeys/:id/edit': ['CustomerJourneyBuilder', 'customerJourneyEdit'],
@@ -62,6 +63,7 @@ export const manifest: ProductManifest = {
         // Path-based deep link to one account: filters the list to it, expands it, opens `tab`.
         customerAnalyticsAccount: (accountId: string, tab?: string): string =>
             `/customer_analytics/accounts/${accountId}${tab ? `/${tab}` : ''}`,
+        customerAnalyticsNotes: (): string => '/customer_analytics/notes',
         customerAnalyticsJourneys: (): string => '/customer_analytics/journeys',
         customerAnalyticsConfiguration: (): string => '/customer_analytics/configuration',
         customerJourneyBuilder: (): string => '/customer_analytics/journeys/new',


### PR DESCRIPTION
## Problem

Notes linked to accounts are only visible one account at a time, inside the account row expansion. There is no place to browse or search a team's account notes across all accounts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add a Notes tab to Customer analytics at `/customer_analytics/notes`, behind the same flag as the Accounts tab
- List all account-linked notes with title, account, created, and last modified columns
- Search across note title/content and account name, with server-side pagination (50/page)
- Clicking a note opens it in the notebook side panel (cmd/ctrl-click opens the full notebook page); the account name links to the account
- 404 the route when the flag is off, matching the Accounts tab guard

Stacked on #67991 (the `account_notes` endpoint).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Endpoint behavior is covered by the tests in #67991. For this PR: full TypeScript check, and the existing jest suites for the touched scene logic (50 passed). No manual UI testing was done by the agent.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code). Skills invoked: /writing-kea-logics, /adopting-generated-api-types. The table mirrors the main Notebooks list; data flows through the generated `accountNotesList` client into `accountNotesLogic` (kea loader, debounced search, manual pagination). Side-panel open mirrors the per-account notes expansion pattern. Deliberately skipped per the agreed scope: created-by column, delete action, and note-creation UI (creation stays in the per-account notes tab).

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
