### PR TITLE
fix(customer-analytics): gate expanded-row account snapshots on expansion content

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
@@ -13,7 +13,10 @@ import { AccountBillingKind, accountBillingLogic } from './accountBillingLogic'
 function BillingInsightNotFound({ kind }: { kind: AccountBillingKind }): JSX.Element {
     const Hog = kind === 'spend' ? BurningMoneyHog : HedgehogMagnifyingGlass
     return (
-        <div className="flex flex-col items-center justify-center gap-2 p-8 text-center">
+        <div
+            className="flex flex-col items-center justify-center gap-2 p-8 text-center"
+            data-attr="account-billing-insight-not-found"
+        >
             <Hog className="w-24 h-24" />
             <h4 className="mb-0">No billing {kind} insight here</h4>
             <p className="text-secondary max-w-sm mb-0">

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -177,7 +177,10 @@ export function AccountNotebooksExpansion({
     ]
 
     return (
-        <div className="sticky left-0 w-[100cqw] max-w-full overflow-x-hidden p-3 bg-bg-light">
+        <div
+            className="sticky left-0 w-[100cqw] max-w-full overflow-x-hidden p-3 bg-bg-light"
+            data-attr="account-expansion"
+        >
             <div className="flex gap-4">
                 <div className="w-fit shrink-0">
                     <UsefulLinks accountId={accountId} />

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
@@ -201,6 +201,13 @@ async function expandAndOpenTab(canvasElement: HTMLElement, tab: 'Usage' | 'Spen
     await userEvent.click(await canvas.findByRole('tab', { name: tab }))
 }
 
+// The snapshot fires well after `play` (page-ready waits, forced reflows, a dispatched resize),
+// and the meta-level waitForSelector is satisfied by a collapsed table. Gating the snapshot on the
+// expanded-row content turns a lost expansion into a retry instead of a flaky collapsed capture.
+const EXPANDED_ROW_TEST_OPTIONS = {
+    waitForSelector: ['[data-attr="accounts-refresh"]', '[data-attr="account-expansion"]'],
+}
+
 function mockAccountsQuery(rows: AccountRow[]): (info: MockResolverInfo) => Promise<[number, unknown] | undefined> {
     return async ({ request }) => {
         const body = (await request.json()) as { query?: { kind?: string } }
@@ -269,6 +276,7 @@ export const FeatureGateOff: Story = {
 
 export const RowExpandedEmpty: Story = {
     render: () => <App />,
+    parameters: { testOptions: EXPANDED_ROW_TEST_OPTIONS },
     decorators: [
         mswDecorator({
             get: {
@@ -287,6 +295,7 @@ export const RowExpandedEmpty: Story = {
 
 export const RowExpandedWithNote: Story = {
     render: () => <App />,
+    parameters: { testOptions: EXPANDED_ROW_TEST_OPTIONS },
     decorators: [
         mswDecorator({
             get: {
@@ -337,6 +346,7 @@ export const RowExpandedWithNote: Story = {
 
 export const RowExpandedLinksDisabled: Story = {
     render: () => <App />,
+    parameters: { testOptions: EXPANDED_ROW_TEST_OPTIONS },
     decorators: [
         mswDecorator({
             get: {
@@ -355,6 +365,11 @@ export const RowExpandedLinksDisabled: Story = {
 
 export const RowExpandedUsageNotFound: Story = {
     render: () => <App />,
+    parameters: {
+        testOptions: {
+            waitForSelector: ['[data-attr="accounts-refresh"]', '[data-attr="account-billing-insight-not-found"]'],
+        },
+    },
     decorators: billingTabDecorators(EMPTY_INSIGHTS, mockAccountsQuery(SINGLE_ROW)),
     play: async ({ canvasElement }) => {
         await expandAndOpenTab(canvasElement, 'Usage')


### PR DESCRIPTION
## Problem

The `RowExpandedUsageNotFound` accounts story flaked in visual review ([run fe131470](https://us.posthog.com/project/2/visual_review/runs/fe131470-3bb4-4576-9259-4c61a47a56e8), on #67941): the capture showed a collapsed row instead of the expanded Usage tab. The snapshot fires well after `play` completes (page-ready waits, forced reflows, a dispatched resize event), and the meta-level `waitForSelector` (`[data-attr="accounts-refresh"]`) is satisfied by a collapsed table — so a lost expansion ships a broken screenshot instead of retrying.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Gate the four expanded-row story snapshots on the expanded content, so a lost expansion fails and retries instead of capturing a collapsed row (same mechanism `RowExpandedUsagePopulated` already uses with its chart canvas)
- Add `data-attr="account-expansion"` to the expanded-row container and `data-attr="account-billing-insight-not-found"` to the billing empty state as stable selectors

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Existing VR/storybook CI on this PR exercises the changed stories; the guarded selectors match the states the plays already await. No new tests — this only hardens snapshot timing.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code) after triaging the VR flake on #67941: baseline vs current PNGs showed the expansion missing entirely (825→710px height), the triggering commit only added a jest test, and the same code captured clean in sibling runs — so the fix targets snapshot gating, not the stories' play functions (which already await the expanded content).

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
