### PR TITLE
fix(bigquery): treat readsessions.getData denial as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -110,6 +110,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # grant the missing permission (e.g. the BigQuery Read Session User role). Matched on the
             # stable permission name rather than the volatile project id.
             "bigquery.readsessions.create": "BigQuery denied access to the Storage Read API: your service account is missing the bigquery.readsessions.create permission. Please grant it (for example via the BigQuery Read Session User role) on the project you're syncing, then reconnect the source.",
+            # Raised while reading rows from a Storage Read API stream (see `get_rows` in `bigquery.py`)
+            # when the service account can create a read session but lacks `bigquery.readsessions.getData`,
+            # the separate permission required to pull data from the session's streams. The
+            # google.api_core PermissionDenied stringifies as "there was an error operating on
+            # 'projects/<id>/.../streams/<id>': the user does not have 'bigquery.readsessions.getData'
+            # permission for '...'", so neither the "Access Denied:"/403 keys nor the readsessions.create
+            # key cover this wording, and it retries forever. Same IAM config fix as create — the BigQuery
+            # Read Session User role grants both. Matched on the stable permission name rather than the
+            # volatile session/stream ids.
+            "bigquery.readsessions.getData": "BigQuery denied access to the Storage Read API: your service account is missing the bigquery.readsessions.getData permission needed to read data from a read session. Please grant it (for example via the BigQuery Read Session User role) on the project you're syncing, then reconnect the source.",
             # Raised from query jobs when the configured dataset/table doesn't exist in the location
             # we query — the dataset was deleted or renamed, or it lives in a different region than the
             # one we run against. The google exception stringifies as "404 Not found: Dataset ... was

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -855,6 +855,18 @@ def test_bigquery_build_pipeline_trims_whitespace_in_destination_table():
                 "permission for 'projects/some-project'"
             )
         ),
+        # Storage Read API stream-read denial — the session can be created but the account lacks
+        # `bigquery.readsessions.getData`. `str(PermissionDenied)` is "there was an error operating
+        # on '.../streams/...': the user does not have 'bigquery.readsessions.getData' permission for
+        # '...'", which neither the "Access Denied:" / "403 request failed" nor the readsessions.create
+        # keys cover.
+        str(
+            PermissionDenied(
+                "there was an error operating on 'projects/some-project/locations/us/sessions/sess/"
+                "streams/strm': the user does not have 'bigquery.readsessions.getData' permission for "
+                "'projects/some-project/locations/us/sessions/sess/streams/strm'"
+            )
+        ),
     ],
 )
 def test_non_retryable_errors_match_permission_denied(observed_error):


### PR DESCRIPTION
## Problem

The BigQuery import source retried forever on a permission error it should have stopped on. When a service account can create a Storage Read API read session but is missing `bigquery.readsessions.getData` (the separate permission needed to actually pull data from the session's streams), the read fails in `get_rows` with a `PermissionDenied` whose message is:

```
there was an error operating on 'projects/<redacted>/.../streams/<redacted>': the user does not have 'bigquery.readsessions.getData' permission for '<redacted>'
```

None of the source's existing non-retryable keys catch this wording. `Access Denied:` and `PermissionDenied: 403 request failed` match BigQuery's own IAM phrasings, and there's a `bigquery.readsessions.create` key, but the Read API's `getData` denial uses this "there was an error operating on ..." shape and slips through. So the sync kept retrying an IAM misconfiguration that retrying can never fix, spamming error tracking.

Surfaced by error tracking: [PermissionDenied in `get_rows`](https://us.posthog.com/project/2/error_tracking/019f244a-66ac-71f3-b847-fedd87d65b3e).

## Changes

Added `bigquery.readsessions.getData` to the source's `get_non_retryable_errors`, matching on the stable permission name (not the volatile session/stream ids). The friendly message points the user at the same fix as the existing `create` key: grant the BigQuery Read Session User role, which covers both permissions.

This is a customer IAM config problem, not a bug in our code, so the right call is to stop retrying and give the user actionable guidance rather than change any code path.

## How did you test this code?

I (Claude) couldn't run the suite in this environment (Python deps aren't installed here), so I verified the files compile with `py_compile`, ran `ruff check` and `ruff format --check` (both clean), and sanity-checked the substring match in plain Python: the new key matches the observed message and the existing `readsessions.create` key does not falsely match it.

I extended the existing parameterized `test_non_retryable_errors_match_permission_denied` with a redacted case carrying the `getData` message shape. It catches the regression where this exact Storage Read API denial silently becomes retryable again. No existing case covered this message shape (they cover `readsessions.create` and the `Access Denied:` forms). The negative tests (`test_non_retryable_errors_does_not_match_transient*`) still guard against the new key catching transient errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BigQuery data-warehouse source. I confirmed the failure originates in `get_rows` under `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/`, read the Storage Read API read path, and judged it a user/upstream IAM error (missing permission) rather than a fixable bug. Chose to extend `NonRetryableErrors` mirroring the neighbouring `bigquery.readsessions.create` entry rather than touch any code path. Invoked the `/writing-tests` skill before adding the test case. Checked for duplicate open PRs (including the maintainer's own) before opening this one; none addressed this permission.
