### PR TITLE
fix(bigquery): surface job-creation permission guidance as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -81,6 +81,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # config problem — retrying can't grant the permission. Matched on the stable permission name,
             # not the volatile dataset id.
             "bigquery.tables.create": "BigQuery denied permission to create a temporary table PostHog needs in your dataset. PostHog copies query results into temporary tables before reading them, so read access alone isn't enough. Please grant your service account permission to create tables (for example the BigQuery Data Editor role) on the dataset where these temporary tables are created — your main dataset, or the temporary dataset if you configured one — then reconnect the source.",
+            # BigQuery rejects query-job creation (POST .../jobs) with "Access Denied: Project <id>:
+            # User does not have bigquery.jobs.create permission in project <id>." when the service
+            # account can read the data but can't run query jobs in the project the jobs bill to. We
+            # create query jobs throughout the sync (primary-key discovery, row counts, temp-table
+            # copies), so this fails before any rows are read. Like the tables.update key above, the
+            # generic "Access Denied:" key would match first and misdirect the customer to grant
+            # *read* access (Data Viewer), which can't grant job creation — so keep this key above it.
+            # Deterministic IAM config problem; retrying can't grant the permission. Matched on the
+            # stable permission name, not the volatile project id.
+            "bigquery.jobs.create": "BigQuery denied your service account permission to run query jobs — it's missing the bigquery.jobs.create permission on the project it queries. Read access alone isn't enough, because PostHog runs query jobs to sync your data. Please grant your service account permission to run jobs (for example the BigQuery Job User role) on that project, then reconnect the source.",
             # BigQuery prefixes every IAM/permission failure with "Access Denied:" — e.g.
             # "Access Denied: Table <id>: Permission bigquery.tables.getData denied on table <id>
             # (or it may not exist).". The matched string above only covers the REST client's

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -947,6 +947,24 @@ def test_temp_table_write_denial_surfaces_write_permission_guidance(observed_err
     assert expected_word in friendly
 
 
+def test_job_create_denial_surfaces_job_permission_guidance():
+    # A bigquery.jobs.create denial also contains "Access Denied:", so both keys match.
+    # external_data_job surfaces the first matching key's message, so the job-creation key must sit
+    # above "Access Denied:" — otherwise the customer is told to grant read access to fix a failure
+    # that read access can't resolve.
+    observed_error = str(
+        Forbidden(
+            "POST https://bigquery.googleapis.com/bigquery/v2/projects/p/jobs?prettyPrint=false: "
+            "Access Denied: Project p: User does not have bigquery.jobs.create permission in project p."
+        )
+    )
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
+    assert first_key == "bigquery.jobs.create"
+    assert friendly is not None
+    assert "run query jobs" in friendly
+
+
 @pytest.mark.parametrize(
     "observed_error",
     [


### PR DESCRIPTION
## Problem

BigQuery imports for a source were failing with a `Forbidden` raised from our code ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f244a-d825-7c41-a81c-c90f7358037e)):

```
POST .../projects/<project>/jobs?prettyPrint=false: Access Denied: Project <project>: User does not have bigquery.jobs.create permission in project <project>.
```

The stack originates in `bigquery.py` (`_get_primary_keys_for_table` → `client.query(...)`, which POSTs to `.../jobs`). The service account can read the data but isn't allowed to run query jobs in the project the jobs bill to. We create query jobs all over the sync (primary-key discovery, row counts, temp-table copies), so this fails before any rows are read.

This denial already contained `Access Denied:`, so it was already classified as non-retryable and stopped retrying — good. The problem is the surfaced message. The generic `Access Denied:` key tells the customer to grant *read* access (BigQuery Data Viewer / `bigquery.tables.getData`). Read access can't grant job creation, so following that guidance leaves the source broken.

## Changes

Add a `bigquery.jobs.create` key to `BigQuerySource.get_non_retryable_errors()`, placed **above** the generic `Access Denied:` key. `external_data_job` surfaces the first matching key's message, so ordering it first means the customer now gets job-creation guidance (grant the ability to run jobs, e.g. the BigQuery Job User role) instead of read-access guidance that can't fix the failure.

This mirrors the existing `bigquery.tables.update` key, which sits above `Access Denied:` for the same reason (a write denial that read-access guidance can't fix).

Matched on the stable permission name `bigquery.jobs.create`, not the volatile project id or URL.

## How did you test this code?

Added `test_job_create_denial_surfaces_job_permission_guidance`, mirroring the existing `test_temp_table_write_denial_surfaces_write_permission_guidance`. It asserts that for a realistic `jobs.create` denial (which also contains `Access Denied:`), the first matching non-retryable key is `bigquery.jobs.create` and its message points at running query jobs — not read access.

I (Claude) ran the full `bigquery/tests/test_source.py` suite (113 passed) plus `ruff check` and `ruff format --check` on both changed files. No manual end-to-end run.

## Docs update

No docs change — internal error-classification behavior only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue in error tracking, pulled the full stack trace to verify the failure originates in `bigquery/bigquery.py`, and traced the call path (`build_pipeline` → `_build_source_response` → `_get_primary_keys_for_table` → `client.query`).

Decision: user/upstream IAM error, not a code bug. The retry behavior was already correct (matched by `Access Denied:`), so the fix is purely to correct the surfaced guidance. I chose to add a more specific key above the generic one rather than widen or reword `Access Denied:`, following the established `bigquery.tables.update` precedent in the same file. No skills were required for this change.
