### PR TITLE
fix(bigquery): surface write-access guidance for tables.create denial

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -71,6 +71,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # Matched on the stable permission name (also covers `bigquery.tables.updateData`), not
             # the volatile temp-table id.
             "bigquery.tables.update": "BigQuery denied write access to a temporary table PostHog creates in your dataset. PostHog copies query results into temporary tables before reading them, so read access alone isn't enough. Please grant your service account write access (for example the BigQuery Data Editor role) on the dataset where these temporary tables are created — your main dataset, or the temporary dataset if you configured one — then reconnect the source.",
+            # Before it can write into the `__posthog_import_...` temp tables, `_run_destination_query_with_job_retry`
+            # (WRITE_TRUNCATE, on incremental / view / row-filtered reads) needs to *create* them in the
+            # dataset they live in. A service account with only read access is denied with "Permission
+            # bigquery.tables.create denied on dataset <id>". Like `bigquery.tables.update` this is a
+            # write-side denial, distinct from the read-side ones the "Access Denied:" key below covers —
+            # and that key would match this message first and misdirect the customer to grant *read* access
+            # (Data Viewer), which can't create a table. Keep this key above "Access Denied:" so the
+            # write-specific guidance wins. Deterministic IAM config problem — retrying can't grant the
+            # permission. Matched on the stable permission name, not the volatile dataset id.
+            "bigquery.tables.create": "BigQuery denied permission to create a temporary table in your dataset. PostHog copies query results into temporary tables before reading them, so read access alone isn't enough. Please grant your service account write access (for example the BigQuery Data Editor role) on the dataset where these temporary tables are created — your main dataset, or the temporary dataset if you configured one — then reconnect the source.",
             # BigQuery prefixes every IAM/permission failure with "Access Denied:" — e.g.
             # "Access Denied: Table <id>: Permission bigquery.tables.getData denied on table <id>
             # (or it may not exist).". The matched string above only covers the REST client's

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -880,6 +880,24 @@ def test_temp_table_write_denial_surfaces_write_permission_guidance():
     assert "write access" in friendly
 
 
+def test_temp_table_create_denial_surfaces_write_permission_guidance():
+    # A tables.create denial on the dataset PostHog writes temp tables into also contains
+    # "Access Denied:", so both keys match. external_data_job surfaces the first matching key's
+    # message, so the create key must sit above "Access Denied:" — otherwise the customer is told
+    # to grant read access to fix a failure that needs create-table (write) permission.
+    observed_error = str(
+        Forbidden(
+            "Access Denied: Dataset prj:ds: Permission bigquery.tables.create denied on dataset "
+            "prj:ds (or it may not exist)."
+        )
+    )
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
+    assert first_key == "bigquery.tables.create"
+    assert friendly is not None
+    assert "write access" in friendly
+
+
 @pytest.mark.parametrize(
     "observed_error",
     [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -862,38 +862,38 @@ def test_non_retryable_errors_match_permission_denied(observed_error):
     assert any(key in observed_error for key in non_retryable_errors)
 
 
-def test_temp_table_write_denial_surfaces_write_permission_guidance():
-    # A tables.update denial on a PostHog temp table also contains "Access Denied:", so both keys
-    # match. external_data_job surfaces the first matching key's message, so the write-specific key
-    # must sit above "Access Denied:" — otherwise the customer is told to grant read access to fix a
-    # write failure.
-    observed_error = str(
-        Forbidden(
-            "Access Denied: Table prj:ds.__posthog_import_abc_123: Permission bigquery.tables.update "
-            "denied on table prj:ds.__posthog_import_abc_123 (or it may not exist)."
-        )
-    )
+@pytest.mark.parametrize(
+    "observed_error,expected_key",
+    [
+        # Writing into a PostHog temp table needs bigquery.tables.update...
+        (
+            str(
+                Forbidden(
+                    "Access Denied: Table prj:ds.__posthog_import_abc_123: Permission bigquery.tables.update "
+                    "denied on table prj:ds.__posthog_import_abc_123 (or it may not exist)."
+                )
+            ),
+            "bigquery.tables.update",
+        ),
+        # ...and creating it needs bigquery.tables.create.
+        (
+            str(
+                Forbidden(
+                    "Access Denied: Dataset prj:ds: Permission bigquery.tables.create denied on dataset "
+                    "prj:ds (or it may not exist)."
+                )
+            ),
+            "bigquery.tables.create",
+        ),
+    ],
+)
+def test_temp_table_write_denial_surfaces_write_permission_guidance(observed_error, expected_key):
+    # These denials also contain "Access Denied:", so both keys match. external_data_job surfaces the
+    # first matching key's message, so each write-specific key must sit above "Access Denied:" —
+    # otherwise the customer is told to grant read access to fix a write failure.
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
     first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
-    assert first_key == "bigquery.tables.update"
-    assert friendly is not None
-    assert "write access" in friendly
-
-
-def test_temp_table_create_denial_surfaces_write_permission_guidance():
-    # A tables.create denial on the dataset PostHog writes temp tables into also contains
-    # "Access Denied:", so both keys match. external_data_job surfaces the first matching key's
-    # message, so the create key must sit above "Access Denied:" — otherwise the customer is told
-    # to grant read access to fix a failure that needs create-table (write) permission.
-    observed_error = str(
-        Forbidden(
-            "Access Denied: Dataset prj:ds: Permission bigquery.tables.create denied on dataset "
-            "prj:ds (or it may not exist)."
-        )
-    )
-    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
-    first_key, friendly = next((key, msg) for key, msg in non_retryable_errors.items() if key in observed_error)
-    assert first_key == "bigquery.tables.create"
+    assert first_key == expected_key
     assert friendly is not None
     assert "write access" in friendly
 


### PR DESCRIPTION
## Problem

BigQuery import syncs are hitting a `Forbidden` error that gives customers the wrong fix.

When PostHog runs an incremental, view, or row-filtered read, it copies query results into a temporary table it creates in the customer's dataset (`WRITE_TRUNCATE` in `_run_destination_query_with_job_retry`). Creating that temp table needs the `bigquery.tables.create` permission. A service account with only read access on the dataset is denied with:

```
Access Denied: Dataset <id>: Permission bigquery.tables.create denied on dataset <id> (or it may not exist).
```

That message contains `Access Denied:`, so it already matches our non-retryable `"Access Denied:"` key and correctly stops retrying. The problem is the guidance. `external_data_job` surfaces the first matching key's friendly message, and the generic `"Access Denied:"` key tells the customer to grant read access (BigQuery Data Viewer) - which can never fix a create-table failure. This is the same misdirection the existing `bigquery.tables.update` key was added to fix, but `create` produces a different permission string so it slipped through to the read-side guidance.

Observed in error tracking: https://us.posthog.com/project/2/error_tracking/019f2448-3300-71f2-aef3-abd3a932b76a - raised from `get_rows` → `_run_destination_query_with_job_retry` in `sources/bigquery/bigquery.py`.

## Changes

Added a dedicated `bigquery.tables.create` key to `BigQuerySource.get_non_retryable_errors`, placed above `"Access Denied:"` (right next to the sibling `bigquery.tables.update` key) so the write-specific guidance wins the friendly message. It points the customer at granting write access (for example the BigQuery Data Editor role) on the dataset where temp tables are created, matching the `update` guidance.

Matched on the stable permission name, not the volatile dataset id.

This is a user/upstream IAM configuration error - retrying can't grant a permission - so it belongs in `NonRetryableErrors`. Retryability is unchanged (the `Access Denied:` key already caught it); this only corrects the remediation message.

## How did you test this code?

Added `test_temp_table_create_denial_surfaces_write_permission_guidance`, mirroring the existing `bigquery.tables.update` test. It asserts that for a `bigquery.tables.create` denial the first matching key is `bigquery.tables.create` (not `Access Denied:`) and that its message mentions write access. This guards the ordering regression: if the key were moved below `Access Denied:`, the customer would again be told to grant read access.

Ran the bigquery source suite locally (non-retryable / permission cases): 38 passed. `ruff check` and `ruff format --check` clean on both files. I (Claude) did not run the change against a live BigQuery source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue and pulled the stack trace via the PostHog error-tracking MCP tools, read the bigquery source and the `external_data_job` error-matching logic, and checked open PRs (including the maintainer's own) to rule out a duplicate.

Decision: user/upstream error (IAM misconfiguration), not a code bug - so the fix extends `NonRetryableErrors` rather than changing sync logic. The subtlety is that the error was already non-retryable via `Access Denied:`; the real defect was the misdirected remediation message, which the codebase already treats as worth a dedicated key (see `bigquery.tables.update`). Invoked the `/writing-tests` skill before adding the regression test.
