### PR TITLE
fix(bigquery): format incremental cursor to match DATE columns

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -750,14 +750,26 @@ def _get_query(
             last_value = db_incremental_field_last_value
 
         if isinstance(last_value, datetime):
-            # BigQuery DATETIME columns are timezone-naive and reject a literal that carries
-            # a UTC offset (e.g. `1970-01-01T00:00:00+00:00`), failing with "Could not cast
-            # literal ... to type DATETIME". The shared initial cursor value is tz-aware UTC,
-            # so drop the offset for DATETIME fields. TIMESTAMP columns are timezone-aware and
-            # keep it.
-            if incremental_field_type == IncrementalFieldType.DateTime and last_value.tzinfo is not None:
-                last_value = last_value.replace(tzinfo=None)
-            last_value = f"'{last_value.isoformat()}'"
+            # A DATE column rejects a datetime literal carrying a time component, failing with
+            # "Could not cast literal ... to type DATE". This happens when the stored incremental
+            # field type is DATETIME/TIMESTAMP but the actual column is DATE (e.g. it was recreated
+            # with a narrower type), so the cursor is a datetime while the column is a date. Read the
+            # column's real type and truncate to the date so the literal matches.
+            incremental_column_type = next(
+                (field.field_type.upper() for field in bq_table.schema if field.name == incremental_field),
+                None,
+            )
+            if incremental_column_type == "DATE":
+                last_value = f"'{last_value.date().isoformat()}'"
+            else:
+                # BigQuery DATETIME columns are timezone-naive and reject a literal that carries
+                # a UTC offset (e.g. `1970-01-01T00:00:00+00:00`), failing with "Could not cast
+                # literal ... to type DATETIME". The shared initial cursor value is tz-aware UTC,
+                # so drop the offset for DATETIME fields. TIMESTAMP columns are timezone-aware and
+                # keep it.
+                if incremental_field_type == IncrementalFieldType.DateTime and last_value.tzinfo is not None:
+                    last_value = last_value.replace(tzinfo=None)
+                last_value = f"'{last_value.isoformat()}'"
         elif isinstance(last_value, date):
             last_value = f"'{last_value.isoformat()}'"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -449,26 +449,35 @@ def test_bigquery_get_query_row_filters_compose_with_incremental():
 
 
 @pytest.mark.parametrize(
-    "field_type,last_value,expected_clause,offset_present",
+    "field_type,column_type,last_value,expected_clause,offset_present",
     [
         # DATETIME columns are timezone-naive — a tz-aware literal can't be cast and BigQuery rejects it
         # with "Could not cast literal ... to type DATETIME". On the first incremental sync the cursor
         # defaults to the 1970-01-01 UTC initial value, whose isoformat carries a '+00:00' offset; for a
         # DATETIME field the literal must be naive.
-        (IncrementalFieldType.DateTime, None, "WHERE `cursor` > '1970-01-01T00:00:00'", False),
+        (IncrementalFieldType.DateTime, "DATETIME", None, "WHERE `cursor` > '1970-01-01T00:00:00'", False),
         # A tz-aware value carried over from a previous sync is also rendered naive for DATETIME fields.
         (
             IncrementalFieldType.DateTime,
+            "DATETIME",
             parser.parse("2024-03-11T09:26:04+00:00"),
             "WHERE `cursor` > '2024-03-11T09:26:04'",
             False,
         ),
         # TIMESTAMP columns are timezone-aware, so the offset must be preserved in the literal.
-        (IncrementalFieldType.Timestamp, None, "WHERE `cursor` > '1970-01-01T00:00:00+00:00'", True),
+        (IncrementalFieldType.Timestamp, "TIMESTAMP", None, "WHERE `cursor` > '1970-01-01T00:00:00+00:00'", True),
+        # The column is actually a DATE while the stored incremental type is DATETIME (e.g. the column
+        # was recreated with a narrower type), so the cursor is a datetime. A datetime literal can't be
+        # cast to DATE — the literal must be truncated to the date, else BigQuery rejects the query with
+        # "Could not cast literal ... to type DATE".
+        (IncrementalFieldType.DateTime, "DATE", None, "WHERE `cursor` > '1970-01-01'", False),
     ],
 )
-def test_bigquery_get_query_datetime_cursor_timezone_offset(field_type, last_value, expected_clause, offset_present):
+def test_bigquery_get_query_datetime_cursor_timezone_offset(
+    field_type, column_type, last_value, expected_clause, offset_present
+):
     bq_table = mock.MagicMock(dataset_id="ds", table_id="t")
+    bq_table.schema = [SimpleNamespace(name="cursor", field_type=column_type)]
     sql, _ = _get_query(
         should_use_incremental_field=True,
         db_incremental_field_last_value=last_value,


### PR DESCRIPTION
## Problem

BigQuery imports were crashing on the incremental sync path with:

```
BadRequest: Could not cast literal "1970-01-01T00:00:00" to type DATE ...; reason: invalidQuery
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f244c-a51b-7603-8078-30632bf5550f

The stack originates in this source's own code, on the copy-to-temp-table step of an incremental run:

```
get_rows -> _run_destination_query_with_job_retry -> _with_job_not_found_retry -> _run  (bigquery.py)
```

The root cause is a type mismatch. When a schema's stored incremental field type is `DATETIME`/`TIMESTAMP` but the actual BigQuery column is `DATE` (for example the column was recreated with a narrower type after the field was selected), the cursor value is a `datetime`. `_get_query` then rendered it as a datetime-shaped literal (`'1970-01-01T00:00:00'` on the first sync, from the shared epoch initial value). BigQuery refuses to cast a datetime literal to a `DATE` column, so the query fails deterministically and the sync can never make progress.

## Changes

In `_get_query`, when the incremental cursor is a `datetime`, read the incremental column's real type from the table schema. If the column is `DATE`, truncate the literal to a date (`'1970-01-01'`) so it matches the column. The existing `DATETIME` (tz stripped) and `TIMESTAMP` (tz kept) behavior is unchanged.

This is a code fix rather than a `NonRetryableErrors` entry: we have the real column type available and can emit a compatible literal, so the sync should just work rather than stop retrying.

## How did you test this code?

Extended the existing parameterized `_get_query` cursor test (`test_bigquery_get_query_datetime_cursor_timezone_offset`) with a DATE-column case: a `DATETIME` stored type against a real `DATE` column must render `'1970-01-01'`, not `'1970-01-01T00:00:00'`. This is the exact regression that caused the crash and no existing case covered a DATE column. The existing DATETIME/TIMESTAMP cases now set a realistic table schema since the code reads the column type.

I (Claude) ran the full `test_source.py` suite for this source locally: 113 passed. Ruff check and format both clean. I did not run a real BigQuery sync.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BigQuery warehouse source. I (Claude) confirmed the issue in error tracking (pulled the stack trace and a representative event via the PostHog MCP tools), traced the call path into `_get_query`, and confirmed the datetime-vs-DATE mismatch as the root cause. I invoked the `/writing-tests` skill before extending the test.

Considered but rejected: adding this to `get_non_retryable_errors`. That would only stop the retries and surface an error to the user, when we can actually fix it, since the real column type is available at query-build time. Kept the change scoped to the datetime literal formatting; the operator and watermark handling are unchanged.
