### PR TITLE
fix(signals): mark autostarted implementation tasks as internal

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -143,6 +143,10 @@ def _create_implementation_task_if_absent(
             repository=repository,
             branch=base_branch,
             signal_report_id=report_id,
+            # Pipeline-spawned implementation tasks are internal — they should not appear in the
+            # default PostHog Code task list. User-initiated Create PR goes through the tasks API
+            # and stays external (internal defaults to False there).
+            internal=True,
             # Full scopes so the implementation agent can log its work on the report (notes,
             # code references) via the task:write artefact tools.
             posthog_mcp_scopes="full",

--- a/products/signals/backend/test/test_auto_start.py
+++ b/products/signals/backend/test/test_auto_start.py
@@ -159,6 +159,7 @@ def test_create_implementation_task_if_absent_is_idempotent(organization, team):
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["origin_product"] == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
     assert call_kwargs["ai_stage"] == "implementation"
+    assert call_kwargs["internal"] is True
     # The gate the second evaluation observed is the legacy SignalReportTask implementation link,
     # written in the same transaction as the task; the task_run artefact is the work-log entry
     # alongside.


### PR DESCRIPTION
## Summary
- Pass `internal=True` when the signals autostart pipeline creates an implementation task via `_create_implementation_task_if_absent`
- Assert the flag in the autostart idempotency unit test

User-initiated **Create PR** from PostHog Code still goes through `POST /tasks/` without an `internal` flag, so those tasks remain external and visible in the sidebar.

## Test plan
- [x] `pytest products/signals/backend/test/test_auto_start.py::test_create_implementation_task_if_absent_is_idempotent`
- [ ] Confirm autostarted implementation tasks are excluded from the default tasks list (`internal=false` filter)
- [ ] Confirm manual inbox Create PR tasks still appear in the default tasks list