### PR TITLE
perf(hogql): opt-in flag to skip postgres FK lazy joins

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1055,6 +1055,7 @@ class Database(BaseModel):
         timings: HogQLTimings | None = None,
         connection_id: str | None = None,
         bypass_warehouse_access_control: bool = False,
+        build_postgres_foreign_keys: bool = True,
     ) -> "Database":
         if timings is None:
             timings = HogQLTimings()
@@ -1069,7 +1070,9 @@ class Database(BaseModel):
             connection_id=connection_id,
             bypass_warehouse_access_control=bypass_warehouse_access_control,
         )
-        return Database._build_from_sources(sources, timings=timings)
+        return Database._build_from_sources(
+            sources, timings=timings, build_postgres_foreign_keys=build_postgres_foreign_keys
+        )
 
     @staticmethod
     def _fetch_sources(
@@ -1323,7 +1326,11 @@ class Database(BaseModel):
         )
 
     @staticmethod
-    def _build_from_sources(sources: HogQLDatabaseSources, timings: HogQLTimings | None = None) -> "Database":
+    def _build_from_sources(
+        sources: HogQLDatabaseSources,
+        timings: HogQLTimings | None = None,
+        build_postgres_foreign_keys: bool = True,
+    ) -> "Database":
         """Construct the HogQL Database purely from already-fetched sources. Performs no I/O: every
         Postgres query and feature-flag check was done up front in Database._fetch_sources."""
         if timings is None:
@@ -1744,14 +1751,15 @@ class Database(BaseModel):
         database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
         database._add_views(views)
 
-        with timings.measure("warehouse_foreign_keys", emit_span=True):
-            for hogql_table, warehouse_table_model in warehouse_tables_to_process:
-                add_postgres_foreign_key_lazy_joins(
-                    hogql_table=hogql_table,
-                    warehouse_table=warehouse_table_model,
-                    database=database,
-                    schemas=_get_active_external_data_schemas(warehouse_table_model),
-                )
+        if build_postgres_foreign_keys:
+            with timings.measure("warehouse_foreign_keys", emit_span=True):
+                for hogql_table, warehouse_table_model in warehouse_tables_to_process:
+                    add_postgres_foreign_key_lazy_joins(
+                        hogql_table=hogql_table,
+                        warehouse_table=warehouse_table_model,
+                        database=database,
+                        schemas=_get_active_external_data_schemas(warehouse_table_model),
+                    )
 
         with timings.measure("data_warehouse_joins", emit_span=True):
             for join in sources.data_warehouse_joins:

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -151,7 +151,13 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         # filter_system_tables_for_user, saved queries, revenue views, …) surface in the query's
         # timings instead of a discarded HogQLTimings — otherwise this whole build shows as an
         # opaque flat span.
-        return Database.create_for(team=self.team, user=self.user, modifiers=modifiers, timings=self.timings)
+        return Database.create_for(
+            team=self.team,
+            user=self.user,
+            modifiers=modifiers,
+            timings=self.timings,
+            build_postgres_foreign_keys=False,
+        )
 
     @cached_property
     def _shared_hogql_context(self) -> HogQLContext:


### PR DESCRIPTION
## Problem

Building the HogQL `Database` for a team is proportional to the team's warehouse-table count, and it happens on every request. On a marketing-analytics dashboard query for a team with a large warehouse, `Database.create_for` spends ~1.8s in one span — `warehouse_foreign_keys` — constructing Postgres FK lazy-join fields (the `orders.customer` → `customers` navigation sugar) for **every** warehouse table, in **every** request. Marketing analytics never uses those joins: it reads direct columns from ad-stats tables and joins conversion goals to `events` by person. So that ~1.8s is pure setup for a feature this query doesn't touch, paid whether or not cost precompute serves the query.

This is the last large block in a series of marketing-analytics query-build optimizations (adapter skip + adapter-factory N+1 fix already shipped, taking the query from 5.6s → 3.5s). The remaining time is now dominated by `Database` construction, and FK-join building is the biggest slice of that.

<img width="388" height="237" alt="image" src="https://github.com/user-attachments/assets/ce5fd1f8-c651-4360-9ba6-0146fd86de4e" />

## Changes

Add an **opt-in** `build_postgres_foreign_keys: bool = True` parameter to `Database.create_for` / `_build_from_sources`. The FK-join loop is gated on it.

- **Default is `True`** → every existing caller behaves **identically**. No behavior change for trends, funnels, insights, the SQL editor, or anything else.
- Marketing analytics passes `build_postgres_foreign_keys=False` when building its shared database, skipping the ~1.8s it never uses.

This is deliberately the smallest possible change in HogQL core: one parameter with a preserving default plus one `if`. It's a door only marketing analytics walks through, not a change to how the database is built for everyone.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Verified that marketing analytics does not depend on Postgres FK joins from two independent angles:

- **Static:** grepped all of `products/marketing_analytics/backend` — no reference to `FOREIGN_KEY` / `LazyJoin` / FK-join navigation anywhere. Every warehouse-table access is a direct column (`chain=[field]`), never a relation walk (`chain=[table, relation, field]`); conversion goals join to `events` by person.
- **Empirical:** ran ~326 tests with the flag OFF for MA — `test_marketing_analytics_table_query_runner` + `aggregated` + `costs_precompute` (66), all conversion-goal suites incl. `DataWarehouseNode` e2e (159), and HogQL core `test_database` (101, unchanged since the default is `True`). All pass, snapshots included.
- `ruff` and `ty` clean.

**No new regression test added**, and I'd like the HogQL team's steer here. A meaningful test would assert that `create_for(..., build_postgres_foreign_keys=False)` produces a database *without* the FK-join fields that `True` produces — which needs a warehouse-table-with-FK-metadata fixture. There's no reusable scaffolding for that today (no dedicated `add_postgres_foreign_key_lazy_joins` test; `test_postgres_table.py` hand-builds tables that bypass that path), and the cheap alternative (`@patch(...).assert_not_called()`) is a change-detector that's also trivially green without warehouse fixtures. Happy to add one with whatever FK-join fixture pattern you'd prefer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, human-directed, as the final step of a marketing-analytics query-latency investigation. Instrumentation traced the remaining cost to `ma_build_database` → `warehouse_foreign_keys`; the design question was how to avoid it for MA without changing core HogQL behavior. Chose the opt-in flag over (a) lazy-defer in the resolver (touches how all queries resolve — high risk) and (b) caching the whole `Database` (serialization + invalidation complexity), because the flag is the smallest change with a preserving default. Invoked `/writing-tests` and concluded the regression test needs FK-metadata fixtures that don't exist reusably — flagged above for your call.

Requesting @PostHog/hogql review since this touches `posthog/hogql/database/`. The MA-side change is a one-line flag pass.

Note: pre-commit hook (`bin/hogli lint:python:fix`) couldn't run in the worktree (stale shared venv, `hogli` moved to `tools/hogli/`); lint/typecheck run manually and pass. CI runs the full suite.
