### PR TITLE
chore(ci): fold the MCP UI apps size report into the ci-report comment

### DIFF
--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -107,64 +107,20 @@ jobs:
                   fi
                   echo "All UI Apps built successfully."
 
-            - name: Post size report comment
+            # Writes the size table into the shared ci-report PR comment (one comment for
+            # all CI checks), then clears any leftover standalone size comment from before
+            # the consolidation. Guarded for unrebased branches that predate the scripts.
+            - name: Post size report to CI report comment
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      const fs = require('fs');
-                      const path = require('path');
-                      const marker = '<!-- mcp-ui-apps-size-report -->';
-
-                      const distDir = 'services/mcp/public/ui-apps';
-                      const rows = [];
-
-                      // Recursively collect app dirs (those containing main.js)
-                      function collectApps(dir) {
-                          for (const entry of fs.readdirSync(dir).sort()) {
-                              const full = path.join(dir, entry);
-                              if (!fs.statSync(full).isDirectory()) continue;
-                              const jsPath = path.join(full, 'main.js');
-                              if (fs.existsSync(jsPath)) {
-                                  const cssPath = path.join(full, 'styles.css');
-                                  const jsSize = (fs.statSync(jsPath).size / 1024).toFixed(1);
-                                  const cssSize = fs.existsSync(cssPath) ? (fs.statSync(cssPath).size / 1024).toFixed(1) : '—';
-                                  rows.push(`| ${entry} | ${jsSize} KB | ${cssSize} KB |`);
-                              } else {
-                                  collectApps(full);
-                              }
-                          }
-                      }
-                      collectApps(distDir);
-
-                      if (rows.length === 0) return;
-
-                      const table = `| App | JS | CSS |\n|-----|-----|-----|\n${rows.join('\n')}`;
-                      const body = `${marker}\n### MCP UI Apps size report\n\n${table}`;
-
-                      const { data: comments } = await github.rest.issues.listComments({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: context.issue.number,
-                      });
-                      const existing = comments.find(c => c.body.includes(marker));
-
-                      if (existing) {
-                          await github.rest.issues.updateComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              comment_id: existing.id,
-                              body,
-                          });
-                      } else {
-                          await github.rest.issues.createComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              issue_number: context.issue.number,
-                              body,
-                          });
-                      }
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  if [ -f services/mcp/scripts/post-ui-apps-size-section.mjs ]; then
+                      node services/mcp/scripts/post-ui-apps-size-section.mjs
+                      node frontend/bin/ci-report/delete-legacy-comments.mjs
+                  else
+                      echo "Skipping size report section — script not present on this checkout"
+                  fi
 
     ci_mcp_ui_apps:
         needs: [changes, build-and-report]

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -41,6 +41,7 @@ jobs:
                         - 'services/mcp/vite.ui-apps.config.ts'
                         - 'services/mcp/scripts/build-ui-apps.ts'
                         - 'services/mcp/scripts/generate-ui-apps.ts'
+                        - 'services/mcp/scripts/post-ui-apps-size-section.mjs'
                         - 'services/mcp/scripts/yaml-config-schema.ts'
                         - 'products/*/mcp/**'
                         - 'services/mcp/definitions/*.yaml'

--- a/frontend/bin/ci-report/delete-legacy-comments.mjs
+++ b/frontend/bin/ci-report/delete-legacy-comments.mjs
@@ -18,8 +18,12 @@ if (!context) {
 const { token, repo, prNumber } = context
 
 try {
-    const stale = (await listPrComments(context)).filter((c) =>
-        LEGACY_MARKERS.some((marker) => c.body?.includes(marker))
+    // Same ownership rule as isReportComment in update-ci-report.mjs: every legacy
+    // check posted its marker as the first line under the workflow token's identity,
+    // and matching on substring alone would let a human comment that quotes or pastes
+    // a marker be deleted by CI.
+    const stale = (await listPrComments(context)).filter(
+        (c) => c.user?.login === 'github-actions[bot]' && LEGACY_MARKERS.some((marker) => c.body?.startsWith(marker))
     )
     for (const comment of stale) {
         await gh(token, `/repos/${repo}/issues/comments/${comment.id}`, { method: 'DELETE' })

--- a/frontend/bin/ci-report/delete-legacy-comments.mjs
+++ b/frontend/bin/ci-report/delete-legacy-comments.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import { gh, listPrComments, resolvePrContext } from './update-ci-report.mjs'
 
-// The frontend checks used to each post their own PR comment. They now share one
+// The CI checks used to each post their own PR comment. They now share one
 // ci-report comment, so delete any leftover standalone comments once, on the first
 // consolidated run, to stop a PR from showing both. Transitional — safe to remove
 // after all open PRs have re-run.
-const LEGACY_MARKERS = ['<!-- posthog-eager-graph-check -->', '<!-- posthog-bundle-size-check -->']
+const LEGACY_MARKERS = [
+    '<!-- posthog-eager-graph-check -->',
+    '<!-- posthog-bundle-size-check -->',
+    '<!-- mcp-ui-apps-size-report -->',
+]
 
 const context = resolvePrContext('cleanup')
 if (!context) {

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -133,11 +133,10 @@ export async function gh(token, url, options = {}) {
         },
     })
     if (!response.ok) {
-        const error = new Error(
-            `GitHub API ${options.method || 'GET'} ${url} -> ${response.status}: ${await response.text()}`
+        throw Object.assign(
+            new Error(`GitHub API ${options.method || 'GET'} ${url} -> ${response.status}: ${await response.text()}`),
+            { status: response.status }
         )
-        error.status = response.status
-        throw error
     }
     return response.status === 204 ? null : response.json()
 }

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -17,6 +17,7 @@ export const SECTIONS = [
     { id: 'bundle-size', title: 'Bundle size' },
     { id: 'eager-graph', title: 'Eager graph' },
     { id: 'dist-size', title: 'Dist folder size' },
+    { id: 'mcp-ui-apps', title: 'MCP UI apps size' },
 ]
 
 export const STATUS_EMOJI = { ok: '✅', warn: '⚠️', fail: '❌', info: 'ℹ️' }

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -274,8 +274,15 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
         }
 
         try {
+            // Success means this section is durable in the primary (oldest) comment —
+            // every racing writer converges on the same primary, so that is where a
+            // re-read must find it. Healing duplicates is best-effort: a duplicate whose
+            // DELETE keeps failing must not burn retries against a write that landed.
             const after = (await listPrComments(context)).filter(isReportComment)
-            if (after.length === 1 && sectionEquals(parseSections(after[0].body).get(id), expected)) {
+            if (after.length > 0 && sectionEquals(parseSections(after[0].body).get(id), expected)) {
+                if (after.length > 1) {
+                    console.warn(`CI report still has ${after.length - 1} duplicate comment(s) on PR #${prNumber}.`)
+                }
                 console.info(`Wrote CI report section "${id}" on PR #${prNumber} (attempt ${attempt}).`)
                 return
             }

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 
-// One sticky comment shared by every frontend CI check. Each check owns a delimited
-// section and updates only its own; the collapsed summary lines and section order are
-// rebuilt from the fixed SECTIONS registry every time, so the layout never shifts
-// between runs and readers learn where each check lives. Safe as a plain
-// read-modify-write only because every writer runs sequentially in the single
-// frontend-bundle-size job — do not call this from parallel jobs without a locking
-// strategy.
+// One sticky comment shared by every CI check that joins it. Each check owns a
+// delimited section and updates only its own; the collapsed summary lines and section
+// order are rebuilt from the fixed SECTIONS registry every time, so the layout never
+// shifts between runs and readers learn where each check lives. Writers may run in
+// parallel jobs and workflows: GitHub has no compare-and-set for comment edits, so
+// postSection verifies its write survived and retries when a concurrent writer
+// clobbered it, and heals duplicate comments left by two writers racing to create.
 export const MARKER = '<!-- posthog-ci-report -->'
 
 // The single source of truth for which sections exist and the order they render in.
@@ -168,41 +168,87 @@ export async function listPrComments({ token, repo, prNumber }) {
     return all
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function sectionEquals(a, b) {
+    return !!a && !!b && a.status === b.status && a.summary === b.summary && a.inner === b.inner
+}
+
 // Post or update this run's section into the shared comment. Fork PRs run with a
 // read-only token, so a failure to read or write is warned and swallowed — the comment
 // is a nicety, never worth a red job.
-export async function postSection({ id, status, summary, body }) {
+//
+// Concurrent writers (other jobs, other workflows) race on the same comment with no
+// compare-and-set, so this is read-modify-write plus verify-and-retry: after writing,
+// re-read and check this section survived; if a concurrent writer clobbered it (they
+// read before our write and wrote after), merge again and rewrite. Two writers racing
+// to CREATE the comment can leave duplicates — every attempt merges all marker
+// comments' sections into the oldest and deletes the rest.
+export async function postSection({ id, status, summary, body }, { maxAttempts = 3, retryDelayMs = 1000 } = {}) {
     const context = resolvePrContext('comment')
     if (!context) {
         return
     }
     const { token, repo, prNumber } = context
+    // Round-trip the section through render/parse to get the form a re-read returns —
+    // renderComment normalizes summaries, so comparing against the raw input would
+    // never verify for a summary that needed normalizing.
+    const expected = parseSections(renderComment(upsertSection(new Map(), { id, status, summary, body }))).get(id)
 
-    let existing = null
-    try {
-        existing = (await listPrComments(context)).find((c) => c.body?.includes(MARKER)) ?? null
-    } catch (err) {
-        console.warn(`Could not read PR comments (read-only token on fork PRs?): ${err.message}`)
-        return
-    }
-
-    const sections = upsertSection(parseSections(existing?.body ?? ''), { id, status, summary, body })
-    const rendered = renderComment(sections)
-    try {
-        if (existing) {
-            await gh(token, `/repos/${repo}/issues/comments/${existing.id}`, {
-                method: 'PATCH',
-                body: JSON.stringify({ body: rendered }),
-            })
-            console.info(`Updated CI report section "${id}" on comment ${existing.id} (PR #${prNumber}).`)
-        } else {
-            await gh(token, `/repos/${repo}/issues/${prNumber}/comments`, {
-                method: 'POST',
-                body: JSON.stringify({ body: rendered }),
-            })
-            console.info(`Posted CI report with section "${id}" on PR #${prNumber}.`)
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        let reportComments
+        try {
+            reportComments = (await listPrComments(context)).filter((c) => c.body?.includes(MARKER))
+        } catch (err) {
+            console.warn(`Could not read PR comments (read-only token on fork PRs?): ${err.message}`)
+            return
         }
-    } catch (err) {
-        console.warn(`Could not post CI report (read-only token on fork PRs?): ${err.message}`)
+
+        const merged = new Map()
+        for (const comment of reportComments) {
+            for (const [sectionId, section] of parseSections(comment.body)) {
+                merged.set(sectionId, section)
+            }
+        }
+        const rendered = renderComment(upsertSection(merged, { id, status, summary, body }))
+        const [primary, ...duplicates] = reportComments
+
+        try {
+            for (const duplicate of duplicates) {
+                await gh(token, `/repos/${repo}/issues/comments/${duplicate.id}`, { method: 'DELETE' })
+                console.info(`Merged and deleted duplicate CI report comment ${duplicate.id} (PR #${prNumber}).`)
+            }
+            if (primary) {
+                await gh(token, `/repos/${repo}/issues/comments/${primary.id}`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({ body: rendered }),
+                })
+            } else {
+                await gh(token, `/repos/${repo}/issues/${prNumber}/comments`, {
+                    method: 'POST',
+                    body: JSON.stringify({ body: rendered }),
+                })
+            }
+        } catch (err) {
+            console.warn(`Could not post CI report (read-only token on fork PRs?): ${err.message}`)
+            return
+        }
+
+        try {
+            const after = (await listPrComments(context)).filter((c) => c.body?.includes(MARKER))
+            if (after.length === 1 && sectionEquals(parseSections(after[0].body).get(id), expected)) {
+                console.info(`Wrote CI report section "${id}" on PR #${prNumber} (attempt ${attempt}).`)
+                return
+            }
+        } catch (err) {
+            console.warn(`Could not verify CI report write: ${err.message}`)
+            return
+        }
+
+        if (attempt < maxAttempts) {
+            console.info(`CI report section "${id}" was clobbered by a concurrent writer — retrying.`)
+            await sleep(retryDelayMs)
+        }
     }
+    console.warn(`Gave up writing CI report section "${id}" after ${maxAttempts} attempts — a later run will heal it.`)
 }

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -133,7 +133,11 @@ export async function gh(token, url, options = {}) {
         },
     })
     if (!response.ok) {
-        throw new Error(`GitHub API ${options.method || 'GET'} ${url} -> ${response.status}: ${await response.text()}`)
+        const error = new Error(
+            `GitHub API ${options.method || 'GET'} ${url} -> ${response.status}: ${await response.text()}`
+        )
+        error.status = response.status
+        throw error
     }
     return response.status === 204 ? null : response.json()
 }
@@ -174,6 +178,21 @@ function sectionEquals(a, b) {
     return !!a && !!b && a.status === b.status && a.summary === b.summary && a.inner === b.inner
 }
 
+// Only the report comments this tooling wrote itself. The marker alone is not enough:
+// anyone can comment on a public-repo PR, and a human "Quote reply" of the report keeps
+// the marker inside `> ` prefixes — matching on substring would adopt, merge, or DELETE
+// comments we do not own.
+function isReportComment(comment) {
+    return comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(MARKER)
+}
+
+// A concurrent writer racing us can delete or replace the comment between our read and
+// write — that conflict surfaces as a 404 and is retryable. Anything else (403 on a
+// fork's read-only token, 5xx) is not worth retrying for a nicety comment.
+function isWriteConflict(err) {
+    return err.status === 404
+}
+
 // Post or update this run's section into the shared comment. Fork PRs run with a
 // read-only token, so a failure to read or write is warned and swallowed — the comment
 // is a nicety, never worth a red job.
@@ -182,8 +201,9 @@ function sectionEquals(a, b) {
 // compare-and-set, so this is read-modify-write plus verify-and-retry: after writing,
 // re-read and check this section survived; if a concurrent writer clobbered it (they
 // read before our write and wrote after), merge again and rewrite. Two writers racing
-// to CREATE the comment can leave duplicates — every attempt merges all marker
-// comments' sections into the oldest and deletes the rest.
+// to CREATE the comment can leave duplicates — every attempt merges all report
+// comments' sections into the oldest and deletes the rest, writing the merged content
+// BEFORE deleting so a cancelled job never loses sections that lived only in a duplicate.
 export async function postSection({ id, status, summary, body }, { maxAttempts = 3, retryDelayMs = 1000 } = {}) {
     const context = resolvePrContext('comment')
     if (!context) {
@@ -198,7 +218,7 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         let reportComments
         try {
-            reportComments = (await listPrComments(context)).filter((c) => c.body?.includes(MARKER))
+            reportComments = (await listPrComments(context)).filter(isReportComment)
         } catch (err) {
             console.warn(`Could not read PR comments (read-only token on fork PRs?): ${err.message}`)
             return
@@ -214,10 +234,6 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
         const [primary, ...duplicates] = reportComments
 
         try {
-            for (const duplicate of duplicates) {
-                await gh(token, `/repos/${repo}/issues/comments/${duplicate.id}`, { method: 'DELETE' })
-                console.info(`Merged and deleted duplicate CI report comment ${duplicate.id} (PR #${prNumber}).`)
-            }
             if (primary) {
                 await gh(token, `/repos/${repo}/issues/comments/${primary.id}`, {
                     method: 'PATCH',
@@ -230,12 +246,27 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
                 })
             }
         } catch (err) {
+            if (isWriteConflict(err)) {
+                console.info(`CI report comment changed under section "${id}" — re-reading and retrying.`)
+                continue
+            }
             console.warn(`Could not post CI report (read-only token on fork PRs?): ${err.message}`)
             return
         }
 
+        for (const duplicate of duplicates) {
+            try {
+                await gh(token, `/repos/${repo}/issues/comments/${duplicate.id}`, { method: 'DELETE' })
+                console.info(`Merged and deleted duplicate CI report comment ${duplicate.id} (PR #${prNumber}).`)
+            } catch (err) {
+                if (!isWriteConflict(err)) {
+                    console.warn(`Could not delete duplicate CI report comment ${duplicate.id}: ${err.message}`)
+                }
+            }
+        }
+
         try {
-            const after = (await listPrComments(context)).filter((c) => c.body?.includes(MARKER))
+            const after = (await listPrComments(context)).filter(isReportComment)
             if (after.length === 1 && sectionEquals(parseSections(after[0].body).get(id), expected)) {
                 console.info(`Wrote CI report section "${id}" on PR #${prNumber} (attempt ${attempt}).`)
                 return
@@ -247,8 +278,12 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
 
         if (attempt < maxAttempts) {
             console.info(`CI report section "${id}" was clobbered by a concurrent writer — retrying.`)
-            await sleep(retryDelayMs)
+            // Jitter so two writers that clobbered each other do not retry in lockstep
+            // and re-collide on every attempt.
+            await sleep(retryDelayMs * (0.5 + Math.random()))
         }
     }
-    console.warn(`Gave up writing CI report section "${id}" after ${maxAttempts} attempts — a later run will heal it.`)
+    console.warn(
+        `Gave up writing CI report section "${id}" after ${maxAttempts} attempts — its next run will restore it.`
+    )
 }

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -180,14 +180,17 @@ function sectionEquals(a, b) {
 // Only the report comments this tooling wrote itself. The marker alone is not enough:
 // anyone can comment on a public-repo PR, and a human "Quote reply" of the report keeps
 // the marker inside `> ` prefixes — matching on substring would adopt, merge, or DELETE
-// comments we do not own.
+// comments we do not own. The login is the identity behind the `github.token` the
+// posting workflow steps pass — moving them to a custom app token changes the login and
+// would orphan every existing report comment, so handle that transition here too.
 function isReportComment(comment) {
     return comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(MARKER)
 }
 
-// A concurrent writer racing us can delete or replace the comment between our read and
-// write — that conflict surfaces as a 404 and is retryable. Anything else (403 on a
-// fork's read-only token, 5xx) is not worth retrying for a nicety comment.
+// A concurrent healer racing us can delete the comment between our read and our write —
+// that surfaces as a 404 and is retryable. (A concurrent PATCH never 404s; the verify
+// pass catches it.) Anything else (403 on a fork's read-only token, 5xx) is not worth
+// retrying for a nicety comment.
 function isWriteConflict(err) {
     return err.status === 404
 }
@@ -213,6 +216,9 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
     // renderComment normalizes summaries, so comparing against the raw input would
     // never verify for a summary that needed normalizing.
     const expected = parseSections(renderComment(upsertSection(new Map(), { id, status, summary, body }))).get(id)
+    // Jittered so two writers that collided do not retry in lockstep and re-collide on
+    // every attempt.
+    const backoff = () => sleep(retryDelayMs * (0.5 + Math.random()))
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         let reportComments
@@ -247,6 +253,9 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
         } catch (err) {
             if (isWriteConflict(err)) {
                 console.info(`CI report comment changed under section "${id}" — re-reading and retrying.`)
+                if (attempt < maxAttempts) {
+                    await backoff()
+                }
                 continue
             }
             console.warn(`Could not post CI report (read-only token on fork PRs?): ${err.message}`)
@@ -277,9 +286,7 @@ export async function postSection({ id, status, summary, body }, { maxAttempts =
 
         if (attempt < maxAttempts) {
             console.info(`CI report section "${id}" was clobbered by a concurrent writer — retrying.`)
-            // Jitter so two writers that clobbered each other do not retry in lockstep
-            // and re-collide on every attempt.
-            await sleep(retryDelayMs * (0.5 + Math.random()))
+            await backoff()
         }
     }
     console.warn(

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -282,9 +282,9 @@ describe('ci-report section helper', () => {
             }
             await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
             expect(github.comments).toHaveLength(1)
-            const sections = parseSections(github.comments[0].body)
+            const sections = parseSections(github.comments[0].body) as SectionState
             expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
-            expect(get(sections as SectionState, 'eager-graph').inner).toBe('EAGER')
+            expect(get(sections, 'eager-graph').inner).toBe('EAGER')
         })
 
         it('merges duplicate report comments into the oldest and deletes the rest', async () => {

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -155,47 +155,72 @@ describe('ci-report section helper', () => {
     })
 
     describe('postSection concurrency', () => {
-        type StoredComment = { id: number; body: string }
+        type StoredComment = { id: number; body: string; author: string }
+        type FireOnceHook = { fn: (() => void) | null }
         // An in-memory GitHub issue-comments API — the network is the boundary being
         // faked; assertions are on the surviving comment state, not call choreography.
-        function fakeGitHub(initialBodies: string[] = []): {
+        // Missing-id writes 404 like real GitHub so the conflict paths are expressible;
+        // the fire-once hooks inject a concurrent writer at the two race points.
+        function fakeGitHub(initial: Array<{ body: string; author?: string }> = []): {
             comments: StoredComment[]
-            afterWrite: { fn: (() => void) | null }
+            afterNextWrite: FireOnceHook
+            afterNextRead: FireOnceHook
         } {
             let nextId = 100
-            const comments: StoredComment[] = initialBodies.map((body) => ({ id: ++nextId, body }))
-            const afterWrite: { fn: (() => void) | null } = { fn: null }
+            const comments: StoredComment[] = initial.map(({ body, author }) => ({
+                id: ++nextId,
+                body,
+                author: author ?? 'github-actions[bot]',
+            }))
+            const afterNextWrite: FireOnceHook = { fn: null }
+            const afterNextRead: FireOnceHook = { fn: null }
+            const fireOnce = (hook: FireOnceHook): void => {
+                const fn = hook.fn
+                hook.fn = null
+                fn?.()
+            }
             const json = (data: unknown): Response =>
                 ({ ok: true, status: 200, json: async () => data, text: async () => '' }) as unknown as Response
+            const notFound = (): Response =>
+                ({
+                    ok: false,
+                    status: 404,
+                    json: async () => ({}),
+                    text: async () => 'not found',
+                }) as unknown as Response
             globalThis.fetch = async (url: RequestInfo | URL, options: RequestInit = {}): Promise<Response> => {
                 const method = options.method ?? 'GET'
-                const fireAfterWrite = (): void => {
-                    afterWrite.fn?.()
-                    afterWrite.fn = null
-                }
                 if (method === 'GET') {
                     const page = Number(new URL(String(url)).searchParams.get('page') ?? '1')
-                    return json(page === 1 ? [...comments] : [])
+                    const snapshot = comments.map(({ id, body, author }) => ({ id, body, user: { login: author } }))
+                    fireOnce(afterNextRead)
+                    return json(page === 1 ? snapshot : [])
                 }
                 if (method === 'POST') {
-                    comments.push({ id: ++nextId, body: JSON.parse(String(options.body)).body })
-                    fireAfterWrite()
+                    comments.push({
+                        id: ++nextId,
+                        body: JSON.parse(String(options.body)).body,
+                        author: 'github-actions[bot]',
+                    })
+                    fireOnce(afterNextWrite)
                     return json(comments.at(-1))
                 }
                 const id = Number(String(url).split('/').pop())
                 if (method === 'PATCH') {
                     const target = comments.find((c) => c.id === id)
-                    if (target) {
-                        target.body = JSON.parse(String(options.body)).body
+                    if (!target) {
+                        return notFound()
                     }
-                    fireAfterWrite()
+                    target.body = JSON.parse(String(options.body)).body
+                    fireOnce(afterNextWrite)
                     return json({})
                 }
                 if (method === 'DELETE') {
-                    comments.splice(
-                        comments.findIndex((c) => c.id === id),
-                        1
-                    )
+                    const index = comments.findIndex((c) => c.id === id)
+                    if (index === -1) {
+                        return notFound()
+                    }
+                    comments.splice(index, 1)
                     return {
                         ok: true,
                         status: 204,
@@ -203,14 +228,9 @@ describe('ci-report section helper', () => {
                         text: async () => '',
                     } as unknown as Response
                 }
-                return {
-                    ok: false,
-                    status: 404,
-                    json: async () => ({}),
-                    text: async () => 'not found',
-                } as unknown as Response
+                return notFound()
             }
-            return { comments, afterWrite }
+            return { comments, afterNextWrite, afterNextRead }
         }
 
         const realFetch = globalThis.fetch
@@ -249,7 +269,7 @@ describe('ci-report section helper', () => {
             // it — its render is missing our section. The verify pass must catch that
             // and re-merge, or cross-workflow sections silently vanish.
             const github = fakeGitHub([
-                renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])),
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
             ])
             const clobber = renderComment(
                 build([
@@ -257,7 +277,7 @@ describe('ci-report section helper', () => {
                     { id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' },
                 ])
             )
-            github.afterWrite.fn = () => {
+            github.afterNextWrite.fn = () => {
                 github.comments[0].body = clobber
             }
             await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
@@ -269,13 +289,91 @@ describe('ci-report section helper', () => {
 
         it('merges duplicate report comments into the oldest and deletes the rest', async () => {
             const github = fakeGitHub([
-                renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])),
-                renderComment(build([{ id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' }])),
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
+                { body: renderComment(build([{ id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' }])) },
             ])
             await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
             expect(github.comments).toHaveLength(1)
             const sections = parseSections(github.comments[0].body)
             expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
+        })
+
+        it('never adopts, merges, or deletes a human comment that carries the marker', async () => {
+            // Anyone can comment on a public-repo PR: a "Quote reply" of the report keeps
+            // the marker inside `> ` prefixes, and a pasted report body is a full match.
+            // Neither belongs to the bot — adopting one launders content under the bot's
+            // identity, and healing one DELETES a human's comment permanently.
+            const quoted = `> ${MARKER}\n> ## 🤖 CI report\n\nwow, look at this bundle jump`
+            const pasted = renderComment(
+                build([{ id: 'bundle-size', status: 'fail', summary: 'forged', body: 'FORGED' }])
+            )
+            const github = fakeGitHub([
+                { body: quoted, author: 'some-human' },
+                { body: pasted, author: 'some-human' },
+            ])
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(3)
+            expect(github.comments[0]).toMatchObject({ body: quoted, author: 'some-human' })
+            expect(github.comments[1]).toMatchObject({ body: pasted, author: 'some-human' })
+            const bot = github.comments[2]
+            expect(bot.author).toBe('github-actions[bot]')
+            expect([...parseSections(bot.body).keys()]).toEqual(['eager-graph'])
+        })
+
+        it('retries the write when the primary comment is deleted underneath it', async () => {
+            // A concurrent healer can delete the comment between our read and our PATCH.
+            // The 404 must re-enter the retry loop, not take the give-up path — otherwise
+            // the section is silently lost for the whole run.
+            const github = fakeGitHub([
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
+            ])
+            github.afterNextRead.fn = () => {
+                github.comments.splice(0)
+            }
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(1)
+            expect([...parseSections(github.comments[0].body).keys()]).toEqual(['eager-graph'])
+        })
+
+        it('swallows a duplicate that another healer already deleted', async () => {
+            // Two workflows can heal the same duplicate concurrently; the loser's DELETE
+            // 404s. That is success (the duplicate is gone), not a reason to abort.
+            const github = fakeGitHub([
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
+                { body: renderComment(build([{ id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' }])) },
+            ])
+            const duplicateId = github.comments[1].id
+            github.afterNextRead.fn = () => {
+                github.comments.splice(
+                    github.comments.findIndex((c) => c.id === duplicateId),
+                    1
+                )
+            }
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(1)
+            const sections = parseSections(github.comments[0].body)
+            expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
+        })
+
+        it('gives up cleanly when a concurrent writer keeps clobbering', async () => {
+            // The comment is a nicety — exhausting maxAttempts must warn and resolve,
+            // never throw, or a comment race reddens the whole job.
+            const github = fakeGitHub([
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
+            ])
+            const clobber = renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }]))
+            const persist = (): void => {
+                github.comments[0].body = clobber
+                github.afterNextWrite.fn = persist
+            }
+            github.afterNextWrite.fn = persist
+            await expect(
+                postSection(
+                    { id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' },
+                    { ...opts, maxAttempts: 2 }
+                )
+            ).resolves.toBeUndefined()
+            expect([...parseSections(github.comments[0].body).keys()]).toEqual(['bundle-size'])
         })
     })
 })

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -165,6 +165,7 @@ describe('ci-report section helper', () => {
             comments: StoredComment[]
             afterNextWrite: FireOnceHook
             afterNextRead: FireOnceHook
+            state: { patches: number; denyDeletes: boolean }
         } {
             let nextId = 100
             const comments: StoredComment[] = initial.map(({ body, author }) => ({
@@ -174,6 +175,7 @@ describe('ci-report section helper', () => {
             }))
             const afterNextWrite: FireOnceHook = { fn: null }
             const afterNextRead: FireOnceHook = { fn: null }
+            const state = { patches: 0, denyDeletes: false }
             const fireOnce = (hook: FireOnceHook): void => {
                 const fn = hook.fn
                 hook.fn = null
@@ -211,11 +213,20 @@ describe('ci-report section helper', () => {
                     if (!target) {
                         return notFound()
                     }
+                    state.patches += 1
                     target.body = JSON.parse(String(options.body)).body
                     fireOnce(afterNextWrite)
                     return json({})
                 }
                 if (method === 'DELETE') {
+                    if (state.denyDeletes) {
+                        return {
+                            ok: false,
+                            status: 403,
+                            json: async () => ({}),
+                            text: async () => 'forbidden',
+                        } as unknown as Response
+                    }
                     const index = comments.findIndex((c) => c.id === id)
                     if (index === -1) {
                         return notFound()
@@ -230,7 +241,7 @@ describe('ci-report section helper', () => {
                 }
                 return notFound()
             }
-            return { comments, afterNextWrite, afterNextRead }
+            return { comments, afterNextWrite, afterNextRead, state }
         }
 
         const realFetch = globalThis.fetch
@@ -353,6 +364,25 @@ describe('ci-report section helper', () => {
             expect(github.comments).toHaveLength(1)
             const sections = parseSections(github.comments[0].body)
             expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
+        })
+
+        it('succeeds without burning retries when a duplicate cannot be deleted', async () => {
+            // Healing is best-effort: the section landed in the primary, which is what
+            // success means. Requiring the duplicate count to reach one would re-PATCH
+            // identical content on every attempt and log a lying give-up.
+            const github = fakeGitHub([
+                { body: renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])) },
+                { body: renderComment(build([{ id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' }])) },
+            ])
+            github.state.denyDeletes = true
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(2)
+            expect([...parseSections(github.comments[0].body).keys()]).toEqual([
+                'bundle-size',
+                'eager-graph',
+                'dist-size',
+            ])
+            expect(github.state.patches).toBe(1)
         })
 
         it('gives up cleanly when a concurrent writer keeps clobbering', async () => {

--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -1,4 +1,8 @@
-import { MARKER, parseSections, renderComment, STATUS_EMOJI, upsertSection } from './update-ci-report.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { MARKER, parseSections, postSection, renderComment, STATUS_EMOJI, upsertSection } from './update-ci-report.mjs'
 
 type SectionEntry = { status: string; summary: string; inner: string }
 type SectionState = Map<string, SectionEntry>
@@ -148,5 +152,130 @@ describe('ci-report section helper', () => {
         const rendered: string = renderComment(withLegacy)
         expect(rendered).toContain('old body')
         expect(rendered.indexOf('<b>Bundle size</b>')).toBeLessThan(rendered.indexOf('legacy-check'))
+    })
+
+    describe('postSection concurrency', () => {
+        type StoredComment = { id: number; body: string }
+        // An in-memory GitHub issue-comments API — the network is the boundary being
+        // faked; assertions are on the surviving comment state, not call choreography.
+        function fakeGitHub(initialBodies: string[] = []): {
+            comments: StoredComment[]
+            afterWrite: { fn: (() => void) | null }
+        } {
+            let nextId = 100
+            const comments: StoredComment[] = initialBodies.map((body) => ({ id: ++nextId, body }))
+            const afterWrite: { fn: (() => void) | null } = { fn: null }
+            const json = (data: unknown): Response =>
+                ({ ok: true, status: 200, json: async () => data, text: async () => '' }) as unknown as Response
+            globalThis.fetch = async (url: RequestInfo | URL, options: RequestInit = {}): Promise<Response> => {
+                const method = options.method ?? 'GET'
+                const fireAfterWrite = (): void => {
+                    afterWrite.fn?.()
+                    afterWrite.fn = null
+                }
+                if (method === 'GET') {
+                    const page = Number(new URL(String(url)).searchParams.get('page') ?? '1')
+                    return json(page === 1 ? [...comments] : [])
+                }
+                if (method === 'POST') {
+                    comments.push({ id: ++nextId, body: JSON.parse(String(options.body)).body })
+                    fireAfterWrite()
+                    return json(comments.at(-1))
+                }
+                const id = Number(String(url).split('/').pop())
+                if (method === 'PATCH') {
+                    const target = comments.find((c) => c.id === id)
+                    if (target) {
+                        target.body = JSON.parse(String(options.body)).body
+                    }
+                    fireAfterWrite()
+                    return json({})
+                }
+                if (method === 'DELETE') {
+                    comments.splice(
+                        comments.findIndex((c) => c.id === id),
+                        1
+                    )
+                    return {
+                        ok: true,
+                        status: 204,
+                        json: async () => null,
+                        text: async () => '',
+                    } as unknown as Response
+                }
+                return {
+                    ok: false,
+                    status: 404,
+                    json: async () => ({}),
+                    text: async () => 'not found',
+                } as unknown as Response
+            }
+            return { comments, afterWrite }
+        }
+
+        const realFetch = globalThis.fetch
+        let tmpDir: string
+
+        beforeAll(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-report-test-'))
+            const eventPath = path.join(tmpDir, 'event.json')
+            fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 1 } }))
+            process.env.GITHUB_TOKEN = 'test-token'
+            process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
+            process.env.GITHUB_EVENT_PATH = eventPath
+        })
+
+        afterAll(() => {
+            globalThis.fetch = realFetch
+            fs.rmSync(tmpDir, { recursive: true, force: true })
+            delete process.env.GITHUB_TOKEN
+            delete process.env.GITHUB_REPOSITORY
+            delete process.env.GITHUB_EVENT_PATH
+        })
+
+        const opts = { retryDelayMs: 0 }
+
+        it('creates the comment when none exists, then a second writer joins it', async () => {
+            const github = fakeGitHub()
+            await postSection({ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }, opts)
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(1)
+            const sections = parseSections(github.comments[0].body)
+            expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph'])
+        })
+
+        it('retries when a concurrent writer clobbers the section, keeping both', async () => {
+            // The other writer read the comment before our PATCH landed and wrote after
+            // it — its render is missing our section. The verify pass must catch that
+            // and re-merge, or cross-workflow sections silently vanish.
+            const github = fakeGitHub([
+                renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])),
+            ])
+            const clobber = renderComment(
+                build([
+                    { id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' },
+                    { id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' },
+                ])
+            )
+            github.afterWrite.fn = () => {
+                github.comments[0].body = clobber
+            }
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(1)
+            const sections = parseSections(github.comments[0].body)
+            expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
+            expect(get(sections as SectionState, 'eager-graph').inner).toBe('EAGER')
+        })
+
+        it('merges duplicate report comments into the oldest and deletes the rest', async () => {
+            const github = fakeGitHub([
+                renderComment(build([{ id: 'bundle-size', status: 'ok', summary: 'b', body: 'BUNDLE' }])),
+                renderComment(build([{ id: 'dist-size', status: 'info', summary: 'd', body: 'DIST' }])),
+            ])
+            await postSection({ id: 'eager-graph', status: 'warn', summary: 'e', body: 'EAGER' }, opts)
+            expect(github.comments).toHaveLength(1)
+            const sections = parseSections(github.comments[0].body)
+            expect([...sections.keys()]).toEqual(['bundle-size', 'eager-graph', 'dist-size'])
+        })
     })
 })

--- a/services/mcp/scripts/post-ui-apps-size-section.mjs
+++ b/services/mcp/scripts/post-ui-apps-size-section.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { postSection } from '../../../frontend/bin/ci-report/update-ci-report.mjs'
+
+const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'public', 'ui-apps')
+
+// App dirs are the ones containing main.js; wrapper dirs (e.g. generated/) recurse.
+function collectApps(dir) {
+    const apps = []
+    for (const entry of fs.readdirSync(dir).sort()) {
+        const full = path.join(dir, entry)
+        if (!fs.statSync(full).isDirectory()) {
+            continue
+        }
+        const jsPath = path.join(full, 'main.js')
+        if (fs.existsSync(jsPath)) {
+            const cssPath = path.join(full, 'styles.css')
+            apps.push({
+                app: entry,
+                jsKb: fs.statSync(jsPath).size / 1024,
+                cssKb: fs.existsSync(cssPath) ? fs.statSync(cssPath).size / 1024 : null,
+            })
+        } else {
+            apps.push(...collectApps(full))
+        }
+    }
+    return apps
+}
+
+const apps = fs.existsSync(distDir) ? collectApps(distDir) : []
+if (!apps.length) {
+    console.info('No built UI apps found — nothing to post.')
+    process.exit(0)
+}
+
+const totalJsKb = apps.reduce((total, { jsKb }) => total + jsKb, 0)
+const body = [
+    'Built size of each MCP UI app (`main.js` + `styles.css`).',
+    '',
+    '| App | JS | CSS |',
+    '| --- | --- | --- |',
+    ...apps.map(
+        ({ app, jsKb, cssKb }) =>
+            `| ${app} | ${jsKb.toFixed(1)} KB | ${cssKb === null ? '—' : `${cssKb.toFixed(1)} KB`} |`
+    ),
+].join('\n')
+
+await postSection({
+    id: 'mcp-ui-apps',
+    status: 'info',
+    summary: `${apps.length} app(s), ${totalJsKb.toFixed(1)} KB JS`,
+    body,
+})


### PR DESCRIPTION
## Problem

PR conversations are cluttered with per-check bot comments. The frontend size checks already share one consolidated CI report comment; the MCP UI apps size report still posts its own standalone sticky comment from `ci-mcp-ui-apps.yml` via ~55 lines of inline `github-script`.

## Changes

First cross-workflow migrant into the shared report, exercising the write-safety layer from #67995 (this workflow runs concurrently with frontend CI on PRs touching both):

- `services/mcp/scripts/post-ui-apps-size-section.mjs` — walks the built apps and posts an `mcp-ui-apps` section (status `info`, summary like `2 app(s), 20.1 KB JS`) via the shared `postSection`
- `SECTIONS` registry gains the `mcp-ui-apps` slot (renders after the frontend size sections)
- the old `<!-- mcp-ui-apps-size-report -->` marker joins `LEGACY_MARKERS`, and the workflow runs the transitional cleanup after posting, so existing PRs lose the standalone comment on their next run
- the inline `github-script` block is deleted from the workflow

The workflow step is guarded on script presence, so unrebased branches degrade to a skip instead of failing.

Stacked on #67995 (cross-workflow write safety) — must merge after it.

## How did you test this code?

- Smoke-tested end to end with a fixture dist tree and a stubbed GitHub API: the walker recurses through wrapper dirs (`generated/`), the table matches the old comment's, and the rendered section landed correctly in the report comment. The stub's inconsistent read also incidentally exercised the postSection retry loop.
- Engine unit tests still pass (21/21) — the registry addition doesn't disturb ordering tests.
- No new unit tests: the script is CI glue with the same shape as the existing section posters, and the engine behavior it relies on is already covered.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — CI tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @pauldambra: reduce multi-bot comment noise on PRs. This is step one of the migration order agreed for the consolidated report (next: snapshot-update and AI-eval comments, which currently post a NEW comment per push).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*