### PR TITLE
fix(surveys): resolve current person name in survey response cards

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -196,7 +196,7 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
 }
 
 export function SurveyQuestionVisualization({ question, questionIndex, demoData }: Props): JSX.Element | null {
-    const { enrichedConsolidatedSurveyResults, isAnyResultsLoading, resultsRequeryInProgress } = useValues(surveyLogic)
+    const { consolidatedSurveyResults, isAnyResultsLoading, resultsRequeryInProgress } = useValues(surveyLogic)
 
     if (demoData) {
         return (
@@ -243,7 +243,7 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
     }
 
     const processedData: QuestionProcessedResponses | undefined =
-        enrichedConsolidatedSurveyResults?.responsesByQuestion[question.id]
+        consolidatedSurveyResults?.responsesByQuestion[question.id]
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
 
     if (!processedData) {

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -2308,10 +2308,11 @@ describe('processOpenEndedResults', () => {
         const columnMap: OpenEndedColumnMap = {
             'open-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.Open },
         }
+        // Column layout: [...responses, distinct_id, person_display_name, timestamp, session_id]
         const rows = [
-            ['Great product!', 'user123', '2024-01-15T10:30:00Z', 'session-abc'],
-            ['Could be better', 'user456', '2024-01-15T11:45:00Z', ''],
-            ['', 'user789', '2024-01-15T12:00:00Z', 'session-xyz'],
+            ['Great product!', 'user123', 'John Doe', '2024-01-15T10:30:00Z', 'session-abc'],
+            ['Could be better', 'user456', '', '2024-01-15T11:45:00Z', ''],
+            ['', 'user789', 'Anon', '2024-01-15T12:00:00Z', 'session-xyz'],
         ]
 
         const result = processOpenEndedResults(questions, columnMap, rows)
@@ -2322,12 +2323,14 @@ describe('processOpenEndedResults', () => {
         expect(openData.data).toHaveLength(2)
         expect(openData.data[0]).toEqual({
             distinctId: 'user123',
+            personDisplayName: 'John Doe',
             response: 'Great product!',
             timestamp: '2024-01-15T10:30:00Z',
             sessionId: 'session-abc',
         })
         expect(openData.data[1]).toEqual({
             distinctId: 'user456',
+            personDisplayName: undefined,
             response: 'Could be better',
             timestamp: '2024-01-15T11:45:00Z',
             sessionId: undefined,
@@ -2347,10 +2350,11 @@ describe('processOpenEndedResults', () => {
         const columnMap: OpenEndedColumnMap = {
             'choice-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.SingleChoice },
         }
+        // Column layout: [response, distinct_id, person_display_name, timestamp]
         const rows = [
-            ['Yes', 'user1', '2024-01-15T10:00:00Z'],
-            ['Something custom', 'user2', '2024-01-15T11:00:00Z'],
-            ['No', 'user3', '2024-01-15T12:00:00Z'],
+            ['Yes', 'user1', 'Alice', '2024-01-15T10:00:00Z'],
+            ['Something custom', 'user2', 'Bob', '2024-01-15T11:00:00Z'],
+            ['No', 'user3', 'Carol', '2024-01-15T12:00:00Z'],
         ]
 
         const result = processOpenEndedResults(questions, columnMap, rows)
@@ -2359,6 +2363,7 @@ describe('processOpenEndedResults', () => {
         expect(choiceData.data).toHaveLength(1)
         expect(choiceData.data[0].label).toBe('Something custom')
         expect(choiceData.data[0].distinctId).toBe('user2')
+        expect(choiceData.data[0].personDisplayName).toBe('Bob')
     })
 
     it('collects non-predefined "Other" text from multiple choice with hasOpenChoice', () => {
@@ -2374,9 +2379,10 @@ describe('processOpenEndedResults', () => {
         const columnMap: OpenEndedColumnMap = {
             'multi-q1': { columnIndex: 0, questionIndex: 0, type: SurveyQuestionType.MultipleChoice },
         }
+        // Column layout: [response, distinct_id, person_display_name, timestamp]
         const rows = [
-            [['A', 'Custom text'], 'user1', '2024-01-15T10:00:00Z'],
-            [['B'], 'user2', '2024-01-15T11:00:00Z'],
+            [['A', 'Custom text'], 'user1', 'Dave', '2024-01-15T10:00:00Z'],
+            [['B'], 'user2', 'Eve', '2024-01-15T11:00:00Z'],
         ]
 
         const result = processOpenEndedResults(questions, columnMap, rows)
@@ -2384,6 +2390,7 @@ describe('processOpenEndedResults', () => {
 
         expect(choiceData.data).toHaveLength(1)
         expect(choiceData.data[0].label).toBe('Custom text')
+        expect(choiceData.data[0].personDisplayName).toBe('Dave')
     })
 
     it('returns empty object for null rows', () => {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -9,7 +9,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { FEATURE_FLAGS, PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
@@ -505,6 +505,7 @@ function collectOpenChoiceResponses(
     rows: any[][],
     columnIndex: number,
     distinctIdIdx: number,
+    personDisplayNameIdx: number,
     timestampIdx: number
 ): ChoiceQuestionResponseData[] {
     const predefined = new Set(question.choices ?? [])
@@ -531,6 +532,7 @@ function collectOpenChoiceResponses(
                     value: 1,
                     isPredefined: false,
                     distinctId: row[distinctIdIdx] as string,
+                    personDisplayName: (row[personDisplayNameIdx] as string) || undefined,
                     timestamp: row[timestampIdx] as string,
                 })
             }
@@ -551,8 +553,9 @@ export function processOpenEndedResults(
 
     const numCols = Object.keys(columnMap).length
     const distinctIdIdx = numCols
-    const timestampIdx = numCols + 1
-    const sessionIdIdx = numCols + 2
+    const personDisplayNameIdx = numCols + 1
+    const timestampIdx = numCols + 2
+    const sessionIdIdx = numCols + 3
     const result: ResponsesByQuestion = {}
 
     for (const [questionId, { columnIndex, type }] of Object.entries(columnMap)) {
@@ -565,6 +568,7 @@ export function processOpenEndedResults(
                 }
                 data.push({
                     distinctId: row[distinctIdIdx] as string,
+                    personDisplayName: (row[personDisplayNameIdx] as string) || undefined,
                     response: value,
                     timestamp: row[timestampIdx] as string,
                     sessionId: (row[sessionIdIdx] as string) || undefined,
@@ -576,7 +580,15 @@ export function processOpenEndedResults(
             if (!question) {
                 continue
             }
-            const otherData = collectOpenChoiceResponses(question, type, rows, columnIndex, distinctIdIdx, timestampIdx)
+            const otherData = collectOpenChoiceResponses(
+                question,
+                type,
+                rows,
+                columnIndex,
+                distinctIdIdx,
+                personDisplayNameIdx,
+                timestampIdx
+            )
             if (otherData.length > 0) {
                 result[questionId] = { type, data: otherData, totalResponses: 0, noResponseCount: 0 }
             }
@@ -713,7 +725,6 @@ export const surveyLogic = kea<surveyLogicType>([
             enabled,
         }),
         deleteSurveyNotification: (notification: HogFunctionType) => ({ notification }),
-        setPersonNames: (personNames: Record<string, string>) => ({ personNames }),
         generateTranslationDrafts: (language: string, overwrite: boolean = true) => ({ language, overwrite }),
         setGeneratingTranslationDrafts: (generating: boolean) => ({ generating }),
         setAiGeneratedTranslationFields: (paths: string[]) => ({ paths }),
@@ -994,7 +1005,15 @@ export const surveyLogic = kea<surveyLogicType>([
                     queryParams: { filters: { properties: values.propertyFilters } },
                 }
                 const aggregateQuery = buildAggregateQuery(survey, queryFilters, values.dateRange)
-                const openEndedResult = buildOpenEndedQuery(survey, queryFilters, values.dateRange)
+                const personDisplayNameProperties =
+                    teamLogic.values.currentTeam?.person_display_name_properties ??
+                    PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
+                const openEndedResult = buildOpenEndedQuery(
+                    survey,
+                    queryFilters,
+                    values.dateRange,
+                    personDisplayNameProperties
+                )
 
                 const startMs = performance.now()
                 let aggregateDuration = 0
@@ -1213,55 +1232,9 @@ export const surveyLogic = kea<surveyLogicType>([
                     actions.loadSurveyDismissedAndSentCount()
                 }
             },
-            loadConsolidatedSurveyResultsSuccess: async ({ consolidatedSurveyResults }) => {
-                const distinctIds = new Set<string>()
-                for (const data of Object.values(consolidatedSurveyResults.responsesByQuestion)) {
-                    for (const r of data.data) {
-                        const id = 'distinctId' in r ? r.distinctId : undefined
-                        if (id) {
-                            distinctIds.add(id)
-                        }
-                    }
-                }
-
-                if (distinctIds.size === 0) {
-                    maybeCompleteResultsRequery()
-                    return
-                }
-
-                const teamId = teamLogic.values.currentTeamId
-                if (!teamId) {
-                    maybeCompleteResultsRequery()
-                    return
-                }
-
-                try {
-                    const allIds = Array.from(distinctIds)
-                    const BATCH_SIZE = 200
-                    const personNames: Record<string, string> = {}
-
-                    for (let i = 0; i < allIds.length; i += BATCH_SIZE) {
-                        const batch = allIds.slice(i, i + BATCH_SIZE)
-                        const response = await api.create(`api/environments/${teamId}/persons/batch_by_distinct_ids/`, {
-                            distinct_ids: batch,
-                        })
-
-                        for (const [distinctId, person] of Object.entries(
-                            response.results as Record<string, { name: string }>
-                        )) {
-                            if (person.name) {
-                                personNames[distinctId] = person.name
-                            }
-                        }
-                    }
-
-                    if (Object.keys(personNames).length > 0) {
-                        actions.setPersonNames(personNames)
-                    }
-                } catch {
-                    // Person enrichment is best-effort — don't block survey results
-                }
-
+            loadConsolidatedSurveyResultsSuccess: () => {
+                // Person display names are resolved directly in the open-ended query
+                // (see buildPersonDisplayNameExpression), so no follow-up enrichment is needed.
                 maybeCompleteResultsRequery()
             },
             loadConsolidatedSurveyResultsFailure: () => {
@@ -1549,12 +1522,6 @@ export const surveyLogic = kea<surveyLogicType>([
             SurveyTab.SUMMARY as SurveyTab,
             {
                 setActiveTab: (_, { tab }) => tab,
-            },
-        ],
-        personNames: [
-            {} as Record<string, string>,
-            {
-                setPersonNames: (state, { personNames }) => ({ ...state, ...personNames }),
             },
         ],
         expandedResponseUuids: [
@@ -1942,27 +1909,6 @@ export const surveyLogic = kea<surveyLogicType>([
         ],
     }),
     selectors({
-        enrichedConsolidatedSurveyResults: [
-            (s) => [s.consolidatedSurveyResults, s.personNames],
-            (results: ConsolidatedSurveyResults, personNames: Record<string, string>): ConsolidatedSurveyResults => {
-                if (!results?.responsesByQuestion || Object.keys(personNames).length === 0) {
-                    return results
-                }
-
-                const enriched: ResponsesByQuestion = {}
-                for (const [qid, data] of Object.entries(results.responsesByQuestion)) {
-                    enriched[qid] = {
-                        ...data,
-                        data: data.data.map((r) => {
-                            const id = 'distinctId' in r ? r.distinctId : undefined
-                            return id && personNames[id] ? { ...r, personDisplayName: personNames[id] } : r
-                        }),
-                    } as typeof data
-                }
-
-                return { responsesByQuestion: enriched }
-            },
-        ],
         timestampFilter: [
             (s) => [s.survey, s.dateRange],
             (survey: Survey, dateRange: SurveyDateRange): string => {
@@ -2925,7 +2871,7 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
         formattedOpenEndedResponses: [
-            (s) => [s.enrichedConsolidatedSurveyResults, s.survey],
+            (s) => [s.consolidatedSurveyResults, s.survey],
             (
                 consolidatedResults: ConsolidatedSurveyResults,
                 survey: Survey | NewSurvey

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1446,22 +1446,22 @@ describe('splitChoicesOnPaste', () => {
     })
 
     describe('buildPersonDisplayNameExpression', () => {
-        it('uses dot access for simple identifiers and falls back to distinct_id', () => {
+        it('uses dot access for simple identifiers, nullIfs empty strings, and falls back to distinct_id', () => {
             expect(buildPersonDisplayNameExpression(['email', 'name'])).toBe(
-                'coalesce(toString(person.properties.email), toString(person.properties.name), toString(events.distinct_id))'
+                "coalesce(nullIf(toString(person.properties.email), ''), nullIf(toString(person.properties.name), ''), toString(events.distinct_id))"
             )
         })
 
         it('backtick-quotes property names that are not plain identifiers', () => {
             expect(buildPersonDisplayNameExpression(['first-name'])).toBe(
-                'coalesce(toString(person.properties.`first-name`), toString(events.distinct_id))'
+                "coalesce(nullIf(toString(person.properties.`first-name`), ''), toString(events.distinct_id))"
             )
         })
 
         it('escapes a literal backtick in a property name so the HogQL stays valid', () => {
             // Without doubling, the closing backtick would terminate the identifier early and break the query
             expect(buildPersonDisplayNameExpression(['my`prop'])).toBe(
-                'coalesce(toString(person.properties.`my``prop`), toString(events.distinct_id))'
+                "coalesce(nullIf(toString(person.properties.`my``prop`), ''), toString(events.distinct_id))"
             )
         })
     })

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -18,6 +18,7 @@ import {
 } from '~/types'
 
 import {
+    buildPersonDisplayNameExpression,
     buildSurveyExampleInvocationGlobals,
     buildPartialResponsesFilter,
     buildSurveyOptionalBooleanPropertyFilter,
@@ -1442,5 +1443,26 @@ describe('splitChoicesOnPaste', () => {
 
     it('preserves the open-ended "Other" entry when pasting into the open-ended slot itself', () => {
         expect(splitChoicesOnPaste('two\nthree', ['one', 'Other'], 1, true)).toEqual(['one', 'two', 'three', 'Other'])
+    })
+
+    describe('buildPersonDisplayNameExpression', () => {
+        it('uses dot access for simple identifiers and falls back to distinct_id', () => {
+            expect(buildPersonDisplayNameExpression(['email', 'name'])).toBe(
+                'coalesce(toString(person.properties.email), toString(person.properties.name), toString(events.distinct_id))'
+            )
+        })
+
+        it('backtick-quotes property names that are not plain identifiers', () => {
+            expect(buildPersonDisplayNameExpression(['first-name'])).toBe(
+                'coalesce(toString(person.properties.`first-name`), toString(events.distinct_id))'
+            )
+        })
+
+        it('escapes a literal backtick in a property name so the HogQL stays valid', () => {
+            // Without doubling, the closing backtick would terminate the identifier early and break the query
+            expect(buildPersonDisplayNameExpression(['my`prop'])).toBe(
+                'coalesce(toString(person.properties.`my``prop`), toString(events.distinct_id))'
+            )
+        })
     })
 })

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -722,7 +722,8 @@ export function buildPersonDisplayNameExpression(personDisplayNameProperties: st
     const propertyExpressions = personDisplayNameProperties.map((prop) =>
         /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)
             ? `toString(person.properties.${prop})`
-            : `toString(person.properties.\`${prop}\`)`
+            : // Backtick-quote non-identifier names; escape any backtick by doubling it (ClickHouse rule)
+              `toString(person.properties.\`${prop.replace(/`/g, '``')}\`)`
     )
     return `coalesce(${[...propertyExpressions, 'toString(events.distinct_id)'].join(', ')})`
 }

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -718,13 +718,18 @@ export function buildAggregateQuery(
 // their properties (in the team's configured precedence), falling back to the
 // distinct_id. Reading person.properties resolves the current person, so the name stays
 // correct after identify/alias merges — unlike a distinct_id captured at response time.
+// Mirrors the backend helper person_display_name_property_exprs
+// (posthog/hogql_queries/utils/person_display_name.py): each property is wrapped in
+// nullIf(toString(...), '') so an empty-string value falls through to the next property,
+// matching asDisplay's truthiness (only "" is falsy).
 export function buildPersonDisplayNameExpression(personDisplayNameProperties: string[]): string {
-    const propertyExpressions = personDisplayNameProperties.map((prop) =>
-        /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)
-            ? `toString(person.properties.${prop})`
+    const propertyExpressions = personDisplayNameProperties.map((prop) => {
+        const access = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)
+            ? `person.properties.${prop}`
             : // Backtick-quote non-identifier names; escape any backtick by doubling it (ClickHouse rule)
-              `toString(person.properties.\`${prop.replace(/`/g, '``')}\`)`
-    )
+              `person.properties.\`${prop.replace(/`/g, '``')}\``
+        return `nullIf(toString(${access}), '')`
+    })
     return `coalesce(${[...propertyExpressions, 'toString(events.distinct_id)'].join(', ')})`
 }
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -2,6 +2,7 @@ import DOMPurify from 'dompurify'
 import { DeepPartialMap, ValidationErrorType } from 'kea-forms'
 import posthog from 'posthog-js'
 
+import { PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { getAppContext } from 'lib/utils/getAppContext'
@@ -713,10 +714,24 @@ export function buildAggregateQuery(
     return `SELECT question_id, label, cnt FROM (${branches.join('\nUNION ALL\n')}) LIMIT 50000`
 }
 
+// Builds a coalesce() expression that resolves a person's current display name from
+// their properties (in the team's configured precedence), falling back to the
+// distinct_id. Reading person.properties resolves the current person, so the name stays
+// correct after identify/alias merges — unlike a distinct_id captured at response time.
+export function buildPersonDisplayNameExpression(personDisplayNameProperties: string[]): string {
+    const propertyExpressions = personDisplayNameProperties.map((prop) =>
+        /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)
+            ? `toString(person.properties.${prop})`
+            : `toString(person.properties.\`${prop}\`)`
+    )
+    return `coalesce(${[...propertyExpressions, 'toString(events.distinct_id)'].join(', ')})`
+}
+
 export function buildOpenEndedQuery(
     survey: Survey,
     filters: SurveyQueryFilters,
     dateRange?: SurveyDateRange | null,
+    personDisplayNameProperties: string[] = PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES,
     limit: number = 50000
 ): { query: string; columnMap: OpenEndedColumnMap } | null {
     const dedupFilter = buildPartialResponsesFilter(survey, dateRange)
@@ -749,6 +764,7 @@ export function buildOpenEndedQuery(
     const query = `SELECT
             ${openColumns.join(',\n')},
             events.distinct_id,
+            ${buildPersonDisplayNameExpression(personDisplayNameProperties)} AS person_display_name,
             events.timestamp,
             events.properties.$session_id
         FROM events


### PR DESCRIPTION
## Problem

On a survey's Responses tab, the open-ended and open-choice response cards show the raw distinct ID instead of the person's name. Clicking the person opens a popover that correctly shows the name, so the mismatch is confusing. It's worse for identified users: the card keeps showing the id even after the person is named, and it doesn't reflect identify/alias merges.

Closes #68007

## Changes

The open-ended results query only selected `events.distinct_id`. The display name was filled in afterwards by a best-effort `batch_by_distinct_ids` lookup (added in #49006 to speed up the consolidated query). That lookup doesn't reliably resolve the *current* person for anonymous or aliased distinct IDs, so the card falls back to the raw id. The popover works because it resolves the person a different way (`api.persons.list`, which follows person merges).

This resolves the display name directly in the open-ended query again, via a `coalesce()` over `person.properties` in the team's configured display-name precedence, falling back to the distinct ID. Reading `person.properties` resolves the current person, so the name stays correct after a name change or an identify/alias merge - the same resolution the working popover uses. This restores the approach from #45621 that #49006 replaced, scoped to the open-ended query.

With the name resolved in the query, the async enrichment is redundant, so I removed it: the `setPersonNames` action, the `personNames` reducer, the `enrichedConsolidatedSurveyResults` selector, and the per-load `batch_by_distinct_ids` round-trip. Net -31 lines.

**Tradeoff worth a reviewer's eye:** this re-adds a person join to the open-ended query, which #49006 deliberately removed for performance. The important structural win from #49006 stays (the heavy consolidated query is still split into a lean aggregate query plus this open-ended query, run in parallel), and the join is now only on the open-ended query rather than the whole consolidated one. But for surveys with a very large number of open-text responses this is a real cost, so I'm opening as draft for the surveys team to weigh in on whether the correctness fix is worth it here or should live in the enrichment path instead.

I couldn't reproduce against the reporting customer's project (no access from this session), so the root cause is from reading the code and the #49006 / #45621 history rather than a live repro.

## How did you test this code?

I (the agent) updated and rely on the `processOpenEndedResults` unit tests in `surveyLogic.test.ts` to lock in that `person_display_name` is parsed from the new column into `personDisplayName` for open-text and open-choice responses - the exact regression this fixes. I did not run the frontend test suite or typecheck locally (no `node_modules` in this environment); CI will run jest and typescript. No manual UI testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Opus 4.8) at the request of Phillip Ramirez, who pointed it at issue #68007.

How I got here: I traced the two person-display surfaces on the Responses tab (the `DataTableNode` `person` column and the `VirtualizedResponseList` cards), confirmed via the issue screenshot that the affected surface is the cards (the "View recording" card from #58430), then walked the data flow: `buildOpenEndedQuery` selects only `distinct_id`, and `personDisplayName` is populated by an async `batch_by_distinct_ids` enrichment. Reading the git history showed #45621 originally resolved the name in-query with a COALESCE, and #49006 removed the person join for performance and moved to the batch lookup - that swap is the regression. I chose to restore in-query resolution scoped to the open-ended query rather than patch the batch lookup, because it uses the same current-person resolution the working popover uses and removes a fragile async path; the perf tradeoff is called out above for review.

Skills invoked: `/debugging-surveys`, `/writing-tests`.
