### PR TITLE
fix(taxonomic-filter): give person properties a distinct icon

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -62,6 +62,7 @@ import { toParams } from 'lib/utils/url'
 import {
     getEventDefinitionIcon,
     getEventMetadataDefinitionIcon,
+    getPersonPropertyDefinitionIcon,
     getPropertyDefinitionIcon,
     getRevenueAnalyticsDefinitionIcon,
 } from 'scenes/data-management/events/DefinitionHeader'
@@ -1128,6 +1129,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         propertyAllowList:
                             propertyAllowList?.[TaxonomicFilterGroupType.PersonProperties]?.filter(isString),
                         ...propertyTaxonomicGroupProps(CORE_FILTER_DEFINITIONS_BY_GROUP.person_properties),
+                        getIcon: getPersonPropertyDefinitionIcon,
                     },
                     {
                         name: 'Person metadata',

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -25,6 +25,7 @@ import { pluralize } from 'lib/utils/strings'
 import {
     getEventDefinitionIcon,
     getEventMetadataDefinitionIcon,
+    getPersonPropertyDefinitionIcon,
     getPropertyDefinitionIcon,
     getRevenueAnalyticsDefinitionIcon,
 } from 'scenes/data-management/events/DefinitionHeader'
@@ -658,6 +659,7 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             getValue: (personProperty: PersonProperty) => personProperty.name,
             propertyAllowList: propertyAllowList?.[TaxonomicFilterGroupType.PersonProperties]?.filter(isString),
             ...propertyTaxonomicGroupProps(CORE_FILTER_DEFINITIONS_BY_GROUP.person_properties),
+            getIcon: getPersonPropertyDefinitionIcon,
         },
         {
             name: 'Person metadata',

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -8,6 +8,7 @@ import {
     IconLeave,
     IconList,
     IconLogomark,
+    IconPerson,
     IconPlay,
     IconServer,
 } from '@posthog/icons'
@@ -67,6 +68,29 @@ export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.E
         <IconWithBadge
             icon={<IconList />}
             tooltipTitle="Event property"
+            className="taxonomy-icon taxonomy-icon-muted"
+            verified={definition.verified}
+            hidden={definition.hidden}
+        />
+    )
+}
+
+export function getPersonPropertyDefinitionIcon(definition: PropertyDefinition): JSX.Element {
+    if (CORE_FILTER_DEFINITIONS_BY_GROUP.person_properties[definition.name]) {
+        return (
+            <IconWithBadge
+                icon={<IconLogomark />}
+                tooltipTitle="PostHog person property"
+                className="taxonomy-icon taxonomy-icon-muted"
+                verified={definition.verified}
+                hidden={definition.hidden}
+            />
+        )
+    }
+    return (
+        <IconWithBadge
+            icon={<IconPerson />}
+            tooltipTitle="Person property"
             className="taxonomy-icon taxonomy-icon-muted"
             verified={definition.verified}
             hidden={definition.hidden}


### PR DESCRIPTION
## Problem

In the property selector (TaxonomicFilter), an event property and a person property with the same name render the exact same icon and tooltip. When a property exists as both, both rows show the generic list icon labelled "Event property", so there is no way to tell which is which. Users mix up the two frequently.

## Changes

Person property rows reused `getPropertyDefinitionIcon`, which only ever checks `event_properties` and falls back to the "Event property" list icon regardless of the group rendering it. I added a dedicated `getPersonPropertyDefinitionIcon` that uses `IconPerson` with a "Person property" tooltip (and `IconLogomark` / "PostHog person property" for core person properties), then wired the `PersonProperties` group to use it. `IconPerson` is already the person-property icon elsewhere (`PropertyFilterIcon`), so this stays consistent.

Now the two rows are visually distinct: person properties get the person icon, event properties keep the list icon.

## How did you test this code?

I (the PostHog Slack app agent) could not run the frontend formatter or typecheck in this environment — `node_modules` isn't installed here. The change mirrors the existing `getPropertyDefinitionIcon` function one-for-one (same `IconWithBadge` wrapper, imports, and lookup pattern), and both `IconPerson` and `CORE_FILTER_DEFINITIONS_BY_GROUP.person_properties` are already used in the codebase. Please run `pnpm --filter=@posthog/frontend format` and `typescript:check` on CI before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul D'Ambra reported the icon collision from a Slack thread and directed the fix; I (the PostHog Slack app, running Claude) traced it and made the change. An exploration pass located the root cause across `buildTaxonomicGroups.tsx` (the `PersonProperties` group set `getIcon: getPropertyDefinitionIcon`) and `DefinitionHeader.tsx` (the icon function is hardcoded to `event_properties`). I chose to add a sibling icon function rather than parameterize the existing one, keeping each group's icon logic explicit and matching the pattern already used for event/revenue/metadata definition icons. No skills were required for this pure-frontend change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1783028571955449?thread_ts=1783028571.955449&cid=C03PB072FMJ)*