### PR TITLE
chore(logs): point ingestion-logs at CDP redis in dev compose

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -605,6 +605,10 @@ services:
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
             LOGS_REDIS_HOST: redis7
+            # Hog log transformations: function health state lives on CDP redis, and
+            # encrypted function inputs need the salt keys (same as error tracking above)
+            CDP_REDIS_HOST: redis7
+            ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
 
     ingestion-traces:
         command: node nodejs/dist/index.js


### PR DESCRIPTION
## Problem

Bottom layer of the log transformations stack (#67608–#67611). The logs ingestion server gains a HogWatcher (function health state on CDP redis) and decrypts encrypted function inputs in #67610 — but the `ingestion-logs` dev compose service doesn't set `CDP_REDIS_HOST`, so the CDP redis pool falls back to its `127.0.0.1` default and the container crash-loops in Playwright E2E CI (observed on #67611, reproduced locally by running the PR's `posthog-node` image against the compose network).

## Changes

Two env vars on the `ingestion-logs` compose service, mirroring `ingestion-error-tracking` exactly: `CDP_REDIS_HOST: redis7` and the dev `ENCRYPTION_SALT_KEYS`.

Production note: the ingestion-logs deployment needs the same two env vars set in charts before #67610 ships.

## How did you test this code?

Reproduced the crash-loop with the PR image (`docker run` against the compose network → ECONNREFUSED 127.0.0.1:6379 retry loop from the `logs-cdp-redis` pool), then confirmed the same image boots to "All systems go" with `CDP_REDIS_HOST` provided. Playwright E2E on #67611 (which composes this file) is the CI-level verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) diagnosed the E2E failure ("Container for 'ingestion-logs' does not exist yet") by pulling the PR-built image and running it against a local compose network, which surfaced the redis fallback bug. Kept as its own tiny PR so the deny-listed compose file doesn't drag the code layers onto the human track.
