### PR TITLE
fix(conversations): reclaim email domains stranded in Mailgun

### DIFF
--- a/products/conversations/backend/api/email_settings.py
+++ b/products/conversations/backend/api/email_settings.py
@@ -97,6 +97,11 @@ def _release_domain_if_unused(team: Team, domain: str) -> None:
 
     Left in place, the registration would make every future connect for this
     domain fail with a domain conflict.
+
+    The `exists()` check narrows but cannot fully close a TOCTOU window: a
+    concurrent connect could persist a config on this domain between the check and
+    the delete. Mailgun calls run outside the team-row lock by design, so we accept
+    that window; the loser at worst re-registers on its next verify.
     """
     if EmailChannel.objects.filter(domain=domain).exists():
         return
@@ -123,6 +128,8 @@ def _try_reclaim_stranded_domain(team: Team, domain: str) -> dict | None:
     if EmailChannel.objects.filter(domain=domain).exists():
         return None
 
+    # Decision phase (reads only). A lookup/verify failure here must leave the
+    # original conflict standing, not delete anything.
     try:
         mg_domain = mailgun_get_domain(domain)
         if mg_domain is None:
@@ -134,13 +141,29 @@ def _try_reclaim_stranded_domain(team: Team, domain: str) -> dict | None:
             # A stranded domain can sit "active" long after its DNS records were
             # removed — re-verify before treating it as genuinely in use.
             state = mailgun_verify_domain(domain).get("state")
-        if state != "unverified":
-            return None
+    except Exception:
+        logger.exception("email_connect_reclaim_lookup_failed", team_id=team.id, domain=domain)
+        return None
 
+    if state != "unverified":
+        return None
+
+    # Re-check immediately before the destructive delete. A concurrent connect for the
+    # same brand-new domain may have registered it and be persisting a config since our
+    # first check (Mailgun calls run outside the team-row lock by design). This narrows
+    # — does not close — that window, but the read-only decision phase above is where
+    # most of the latency sits, so the remaining window is small.
+    if EmailChannel.objects.filter(domain=domain).exists():
+        return None
+
+    # Mutation phase. If the delete lands but the re-add fails, the stale registration
+    # is already gone, so the next connect registers the now-absent domain cleanly. Emit
+    # a distinct signal so that half-completed state is diagnosable.
+    try:
         mailgun_delete_domain(domain)
         dns_records = mailgun_add_domain(domain)
     except Exception:
-        logger.exception("email_connect_reclaim_domain_failed", team_id=team.id, domain=domain)
+        logger.exception("email_connect_reclaim_rewrite_failed", team_id=team.id, domain=domain)
         return None
 
     logger.info("email_connect_reclaimed_stranded_domain", team_id=team.id, domain=domain)

--- a/products/conversations/backend/api/email_settings.py
+++ b/products/conversations/backend/api/email_settings.py
@@ -26,6 +26,7 @@ from products.conversations.backend.mailgun import (
     MailgunNotConfigured,
     add_domain as mailgun_add_domain,
     delete_domain as mailgun_delete_domain,
+    get_domain as mailgun_get_domain,
     send_mime,
     verify_domain as mailgun_verify_domain,
 )
@@ -89,6 +90,61 @@ def _config_to_dict(config: EmailChannel, inbound_domain: str | None = None) -> 
         "domain_verified": config.domain_verified,
         "dns_records": config.dns_records,
     }
+
+
+def _release_domain_if_unused(team: Team, domain: str) -> None:
+    """Best-effort removal of a Mailgun registration that no config ended up using.
+
+    Left in place, the registration would make every future connect for this
+    domain fail with a domain conflict.
+    """
+    if EmailChannel.objects.filter(domain=domain).exists():
+        return
+    try:
+        mailgun_delete_domain(domain)
+    except Exception:
+        logger.exception("email_connect_release_domain_failed", team_id=team.id, domain=domain)
+
+
+def _try_reclaim_stranded_domain(team: Team, domain: str) -> dict | None:
+    """Recover a domain stranded in our Mailgun account with no config referencing it.
+
+    A connect that registered the domain but failed to persist a config, or a
+    disconnect whose Mailgun delete failed, leaves such a registration behind —
+    and every reconnect then fails with a domain conflict. Reclaiming is only
+    safe while Mailgun cannot verify the domain: in that state it cannot send,
+    and re-registering issues fresh DNS records, so whoever reclaims it still
+    has to prove DNS control. Verified (or disabled) domains are left for
+    operators to reconcile.
+
+    Returns fresh DNS records when the domain was reclaimed, None when the
+    conflict stands.
+    """
+    if EmailChannel.objects.filter(domain=domain).exists():
+        return None
+
+    try:
+        mg_domain = mailgun_get_domain(domain)
+        if mg_domain is None:
+            # Not in our account — the domain is claimed by another Mailgun account.
+            return None
+
+        state = mg_domain.get("state")
+        if state != "unverified":
+            # A stranded domain can sit "active" long after its DNS records were
+            # removed — re-verify before treating it as genuinely in use.
+            state = mailgun_verify_domain(domain).get("state")
+        if state != "unverified":
+            return None
+
+        mailgun_delete_domain(domain)
+        dns_records = mailgun_add_domain(domain)
+    except Exception:
+        logger.exception("email_connect_reclaim_domain_failed", team_id=team.id, domain=domain)
+        return None
+
+    logger.info("email_connect_reclaimed_stranded_domain", team_id=team.id, domain=domain)
+    return dns_records
 
 
 class EmailConnectSerializer(serializers.Serializer):
@@ -166,14 +222,17 @@ class EmailConnectView(APIView):
                 logger.info("email_connect_mailgun_not_configured", team_id=team.id, domain=domain)
                 return Response({"error": "Mailgun API key not configured"}, status=400)
             except MailgunDomainConflict as e:
-                logger.info("email_connect_mailgun_domain_conflict", team_id=team.id, domain=domain, error=str(e))
-                return Response(
-                    {
-                        "error": "This domain cannot be registered for sending. "
-                        "It may already be claimed by another account."
-                    },
-                    status=400,
-                )
+                reclaimed = _try_reclaim_stranded_domain(team, domain)
+                if reclaimed is None:
+                    logger.info("email_connect_mailgun_domain_conflict", team_id=team.id, domain=domain, error=str(e))
+                    return Response(
+                        {
+                            "error": "This domain cannot be registered for sending. "
+                            "It may already be claimed by another account."
+                        },
+                        status=400,
+                    )
+                dns_records = reclaimed
             except Exception:
                 logger.exception("email_connect_mailgun_add_domain_failed", team_id=team.id, domain=domain)
                 return Response(
@@ -181,6 +240,8 @@ class EmailConnectView(APIView):
                     status=502,
                 )
 
+        config: EmailChannel | None = None
+        failure: Response | None = None
         try:
             with transaction.atomic():
                 # Lock team row to serialize concurrent connects and enforce the config limit
@@ -188,23 +249,31 @@ class EmailConnectView(APIView):
 
                 current_count = EmailChannel.objects.filter(team=team).count()
                 if current_count >= MAX_EMAIL_CONFIGS_PER_TEAM:
-                    return Response(
+                    failure = Response(
                         {"error": f"Maximum of {MAX_EMAIL_CONFIGS_PER_TEAM} email addresses per team."},
                         status=400,
                     )
-
-                config = EmailChannel.objects.create(
-                    team=team,
-                    inbound_token=secrets.token_hex(16),
-                    from_email=from_email,
-                    from_name=from_name,
-                    domain=domain,
-                    dns_records=dns_records,
-                    domain_verified=sibling.domain_verified if sibling else False,
-                )
-                _set_email_enabled(team, enabled=True)
+                else:
+                    config = EmailChannel.objects.create(
+                        team=team,
+                        inbound_token=secrets.token_hex(16),
+                        from_email=from_email,
+                        from_name=from_name,
+                        domain=domain,
+                        dns_records=dns_records,
+                        domain_verified=sibling.domain_verified if sibling else False,
+                    )
+                    _set_email_enabled(team, enabled=True)
         except IntegrityError:
-            return Response({"error": "This email address is already connected."}, status=409)
+            failure = Response({"error": "This email address is already connected."}, status=409)
+
+        if config is None:
+            # Failure responses are deferred to here so the Mailgun cleanup call
+            # doesn't run inside the atomic block while the team row is locked.
+            if not sibling:
+                _release_domain_if_unused(team, domain)
+            assert failure is not None
+            return failure
 
         logger.info(
             "email_channel_connected",

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -357,20 +357,22 @@ class TestEmailMultiConfig(BaseTest):
         # Domain NOT deleted from Mailgun since billing@ still uses it
         mock_delete.assert_not_called()
 
+    @patch("products.conversations.backend.api.email_settings.mailgun_get_domain", return_value=None)
     @patch(
         "products.conversations.backend.api.email_settings.mailgun_add_domain",
-        side_effect=MailgunDomainConflict("Domain example.com already exists"),
+        side_effect=MailgunDomainConflict("Domain example.com is already registered by another Mailgun account"),
     )
     @patch("products.conversations.backend.api.email_settings.mailgun_delete_domain")
     @patch(
         "products.conversations.backend.api.email_settings.get_instance_setting",
         return_value="mg.posthog.com",
     )
-    def test_connect_rejects_preexisting_mailgun_domain(
+    def test_connect_rejects_domain_claimed_by_another_mailgun_account(
         self,
         _mock_setting: MagicMock,
         mock_mailgun_delete: MagicMock,
         _mock_mailgun_add: MagicMock,
+        _mock_get_domain: MagicMock,
     ):
         response = self.client.post(
             "/api/conversations/v1/email/connect",
@@ -385,6 +387,83 @@ class TestEmailMultiConfig(BaseTest):
         self.team.refresh_from_db()
         settings = self.team.conversations_settings or {}
         assert settings.get("email_enabled") is not True
+
+    @parameterized.expand(
+        [
+            ("already_unverified", "unverified", "unverified", 200),
+            ("stale_active_reverifies_unverified", "active", "unverified", 200),
+            ("still_active_after_reverify", "active", "active", 400),
+            ("disabled", "disabled", "disabled", 400),
+        ]
+    )
+    @patch("products.conversations.backend.api.email_settings.mailgun_verify_domain")
+    @patch("products.conversations.backend.api.email_settings.mailgun_delete_domain")
+    @patch("products.conversations.backend.api.email_settings.mailgun_get_domain")
+    @patch("products.conversations.backend.api.email_settings.mailgun_add_domain")
+    @patch(
+        "products.conversations.backend.api.email_settings.get_instance_setting",
+        return_value="mg.posthog.com",
+    )
+    def test_connect_reclaims_stranded_mailgun_domain(
+        self,
+        _name,
+        mailgun_state,
+        reverified_state,
+        expected_status,
+        _mock_setting: MagicMock,
+        mock_add: MagicMock,
+        mock_get_domain: MagicMock,
+        mock_delete: MagicMock,
+        mock_verify: MagicMock,
+    ):
+        fresh_records = {"sending_dns_records": [{"record_type": "TXT", "name": "example.com", "value": "v=spf1"}]}
+        mock_add.side_effect = [MailgunDomainConflict("Domain example.com already exists"), fresh_records]
+        mock_get_domain.return_value = {"name": "example.com", "state": mailgun_state}
+        mock_verify.return_value = {"state": reverified_state}
+
+        response = self.client.post(
+            "/api/conversations/v1/email/connect",
+            {"from_email": "support@example.com", "from_name": "Support"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == expected_status
+        if expected_status == 200:
+            config = EmailChannel.objects.get(team=self.team)
+            assert config.dns_records == fresh_records
+            mock_delete.assert_called_once_with("example.com")
+        else:
+            assert "cannot be registered" in response.json()["error"]
+            assert not EmailChannel.objects.filter(team=self.team).exists()
+            mock_delete.assert_not_called()
+
+    @patch(
+        "products.conversations.backend.api.email_settings.mailgun_get_domain",
+        side_effect=RuntimeError("mailgun unavailable"),
+    )
+    @patch(
+        "products.conversations.backend.api.email_settings.mailgun_add_domain",
+        side_effect=MailgunDomainConflict("Domain example.com already exists"),
+    )
+    @patch(
+        "products.conversations.backend.api.email_settings.get_instance_setting",
+        return_value="mg.posthog.com",
+    )
+    def test_connect_conflict_stands_when_reclaim_lookup_fails(
+        self,
+        _mock_setting: MagicMock,
+        _mock_mailgun_add: MagicMock,
+        _mock_get_domain: MagicMock,
+    ):
+        response = self.client.post(
+            "/api/conversations/v1/email/connect",
+            {"from_email": "support@example.com", "from_name": "Support"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "cannot be registered" in response.json()["error"]
+        assert EmailChannel.objects.filter(team=self.team).count() == 0
 
     @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
     @patch(
@@ -410,12 +489,13 @@ class TestEmailMultiConfig(BaseTest):
         emails = {c["from_email"] for c in data["configs"]}
         assert emails == {"support@example.com", "billing@example.com"}
 
+    @patch("products.conversations.backend.api.email_settings.mailgun_delete_domain")
     @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
     @patch(
         "products.conversations.backend.api.email_settings.get_instance_setting",
         return_value="mg.posthog.com",
     )
-    def test_config_limit_enforced(self, _mock_setting: MagicMock, _mock_mailgun: MagicMock):
+    def test_config_limit_enforced(self, _mock_setting: MagicMock, _mock_mailgun: MagicMock, mock_delete: MagicMock):
         from products.conversations.backend.models.team_conversations_email_config import MAX_EMAIL_CONFIGS_PER_TEAM
 
         for i in range(MAX_EMAIL_CONFIGS_PER_TEAM):
@@ -426,6 +506,8 @@ class TestEmailMultiConfig(BaseTest):
             )
             assert r.status_code == 200, f"Failed to connect config {i}: {r.json()}"
 
+        # A failed Mailgun release must not mask the limit error
+        mock_delete.side_effect = RuntimeError("mailgun unavailable")
         r = self.client.post(
             "/api/conversations/v1/email/connect",
             {"from_email": "overflow@overflow.com", "from_name": "Overflow"},
@@ -433,6 +515,8 @@ class TestEmailMultiConfig(BaseTest):
         )
         assert r.status_code == 400
         assert "Maximum" in r.json()["error"]
+        # The rejected connect releases its Mailgun registration instead of stranding the domain
+        mock_delete.assert_called_once_with("overflow.com")
 
     @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
     @patch(

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from io import BytesIO
 
 from posthog.test.base import BaseTest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
@@ -517,6 +517,52 @@ class TestEmailMultiConfig(BaseTest):
         assert "Maximum" in r.json()["error"]
         # The rejected connect releases its Mailgun registration instead of stranding the domain
         mock_delete.assert_called_once_with("overflow.com")
+
+    @patch("products.conversations.backend.api.email_settings.mailgun_delete_domain")
+    @patch("products.conversations.backend.api.email_settings.mailgun_get_domain")
+    @patch("products.conversations.backend.api.email_settings.mailgun_add_domain")
+    @patch(
+        "products.conversations.backend.api.email_settings.get_instance_setting",
+        return_value="mg.posthog.com",
+    )
+    def test_config_limit_releases_reclaimed_domain(
+        self,
+        _mock_setting: MagicMock,
+        mock_add: MagicMock,
+        mock_get_domain: MagicMock,
+        mock_delete: MagicMock,
+    ):
+        from products.conversations.backend.models.team_conversations_email_config import MAX_EMAIL_CONFIGS_PER_TEAM
+
+        fresh_records = {"sending_dns_records": []}
+        # First MAX connects register cleanly; the overflow connect hits a Mailgun
+        # conflict, reclaims a stranded unverified domain, then fails on the limit.
+        mock_add.side_effect = [{}] * MAX_EMAIL_CONFIGS_PER_TEAM + [
+            MailgunDomainConflict("Domain overflow.com already exists"),
+            fresh_records,
+        ]
+        mock_get_domain.return_value = {"name": "overflow.com", "state": "unverified"}
+
+        for i in range(MAX_EMAIL_CONFIGS_PER_TEAM):
+            r = self.client.post(
+                "/api/conversations/v1/email/connect",
+                {"from_email": f"addr{i}@example{i}.com", "from_name": f"Name {i}"},
+                content_type="application/json",
+            )
+            assert r.status_code == 200, f"Failed to connect config {i}: {r.json()}"
+
+        r = self.client.post(
+            "/api/conversations/v1/email/connect",
+            {"from_email": "overflow@overflow.com", "from_name": "Overflow"},
+            content_type="application/json",
+        )
+
+        assert r.status_code == 400
+        assert "Maximum" in r.json()["error"]
+        assert not EmailChannel.objects.filter(domain="overflow.com").exists()
+        # overflow.com is deleted twice: once churning the stranded registration during
+        # reclaim, once releasing the fresh registration after the limit rejection.
+        assert mock_delete.call_args_list == [call("overflow.com"), call("overflow.com")]
 
     @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
     @patch(

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -534,7 +534,7 @@ class TestEmailMultiConfig(BaseTest):
     ):
         from products.conversations.backend.models.team_conversations_email_config import MAX_EMAIL_CONFIGS_PER_TEAM
 
-        fresh_records = {"sending_dns_records": []}
+        fresh_records: dict = {"sending_dns_records": []}
         # First MAX connects register cleanly; the overflow connect hits a Mailgun
         # conflict, reclaims a stranded unverified domain, then fails on the limit.
         mock_add.side_effect = [{}] * MAX_EMAIL_CONFIGS_PER_TEAM + [

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -85,6 +85,14 @@ class TestGetDomain:
 
         assert get_domain("example.com") is None
 
+    @pytest.mark.parametrize("body", [{}, {"domain": {}}, {"domain": None}])
+    def test_returns_none_when_payload_has_no_domain_object(
+        self, mock_get: MagicMock, _mock_key: MagicMock, body: dict
+    ):
+        mock_get.return_value = _mailgun_response(200, body)
+
+        assert get_domain("example.com") is None
+
 
 @patch("products.conversations.backend.mailgun.get_instance_setting", return_value="")
 class TestGetApiKey:

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -80,7 +80,7 @@ class TestGetDomain:
 
     def test_returns_none_when_not_registered_here(self, mock_get: MagicMock, _mock_key: MagicMock):
         resp = _mailgun_response(404, {"message": "domain not found"})
-        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
         mock_get.return_value = resp
 
         assert get_domain("example.com") is None

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -10,6 +10,7 @@ from products.conversations.backend.mailgun import (
     MailgunPermanentError,
     MailgunTransientError,
     add_domain,
+    get_domain,
     send_mime,
 )
 
@@ -67,6 +68,22 @@ class TestAddDomain:
 
         with pytest.raises(RuntimeError, match="http 400"):
             add_domain("example.com")
+
+
+@patch("products.conversations.backend.mailgun.get_instance_setting", return_value="fake-api-key")
+@patch("products.conversations.backend.mailgun.requests.get")
+class TestGetDomain:
+    def test_returns_domain_info(self, mock_get: MagicMock, _mock_key: MagicMock):
+        mock_get.return_value = _mailgun_response(200, {"domain": {"name": "example.com", "state": "unverified"}})
+
+        assert get_domain("example.com") == {"name": "example.com", "state": "unverified"}
+
+    def test_returns_none_when_not_registered_here(self, mock_get: MagicMock, _mock_key: MagicMock):
+        resp = _mailgun_response(404, {"message": "domain not found"})
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+        mock_get.return_value = resp
+
+        assert get_domain("example.com") is None
 
 
 @patch("products.conversations.backend.mailgun.get_instance_setting", return_value="")

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -127,7 +127,11 @@ def add_domain(domain: str) -> dict[str, Any]:
 
 
 def get_domain(domain: str) -> dict[str, Any] | None:
-    """Fetch a domain's info from our Mailgun account. Returns None if it isn't registered here."""
+    """Fetch a domain's info from our Mailgun account.
+
+    Returns None when the domain isn't registered here — or when the response
+    carries no domain object, so bad Mailgun data never looks like a registration.
+    """
     resp = requests.get(
         f"{MAILGUN_API_BASE}/domains/{domain}",
         auth=("api", _get_api_key()),
@@ -136,7 +140,7 @@ def get_domain(domain: str) -> dict[str, Any] | None:
     if resp.status_code == 404:
         return None
     resp.raise_for_status()
-    return resp.json().get("domain", {})
+    return resp.json().get("domain") or None
 
 
 def get_domain_dns_records(domain: str) -> dict[str, Any]:

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -126,6 +126,19 @@ def add_domain(domain: str) -> dict[str, Any]:
     return {}
 
 
+def get_domain(domain: str) -> dict[str, Any] | None:
+    """Fetch a domain's info from our Mailgun account. Returns None if it isn't registered here."""
+    resp = requests.get(
+        f"{MAILGUN_API_BASE}/domains/{domain}",
+        auth=("api", _get_api_key()),
+        timeout=15,
+    )
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json().get("domain", {})
+
+
 def get_domain_dns_records(domain: str) -> dict[str, Any]:
     """Fetch DNS records for an existing Mailgun domain."""
     resp = requests.get(


### PR DESCRIPTION
## Problem

The support email connect flow registers the sending domain with Mailgun *before* persisting the `EmailChannel` config, and the disconnect flow deletes the config *before* its best-effort Mailgun delete. If either second step fails (config limit hit, duplicate-address race, Mailgun delete error), the domain stays registered in the Mailgun account with no config referencing it.

From then on, every connect attempt for that domain fails with "This domain cannot be registered for sending. It may already be claimed by another account." — even for the domain's rightful owner, with no self-serve way out. A customer reconnecting their own domain hit exactly this dead end.

## Changes

- **Reclaim stranded domains on connect**: when Mailgun reports a domain conflict, the connect flow now checks whether the domain sits in our own Mailgun account with no `EmailChannel` referencing it. If a forced re-verification confirms the domain is `unverified` (it can't send in that state), the stale registration is deleted and the domain re-registered fresh — new DNS records are issued, so the connecting team must still prove DNS control. Verified/disabled domains and domains claimed by other Mailgun accounts keep the existing conflict error for operators to reconcile.
- **Stop creating new strands**: a connect that registers a domain but then fails to persist the config (per-team limit, `IntegrityError`) now releases the registration it just created, outside the team-row lock.
- New `get_domain` helper in the Mailgun client (`None` when the domain isn't in our account).

## How did you test this code?

Automated tests only — I could not run them in this environment (no dev stack); draft CI will run them.

- `test_connect_reclaims_stranded_mailgun_domain` (parameterized over Mailgun domain states): catches removing the reclaim path (owners locked out again), trusting a stale `active` state without re-verifying, and — the security-critical inverse — reclaiming domains that are genuinely verified or disabled.
- `test_connect_rejects_domain_claimed_by_another_mailgun_account` (updated): conflicts originating outside our account still fail closed.
- `test_connect_conflict_stands_when_reclaim_lookup_fails`: a Mailgun error during reclaim degrades to the original 400, not a 500.
- `test_config_limit_enforced` (extended): the rejected overflow connect releases its Mailgun registration, and a failed release doesn't mask the limit error.
- `TestGetDomain`: `get_domain` returns domain info, and `None` on 404 instead of raising.

Ran `ruff check` / `ruff format` locally on the touched files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the connect error paths; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored in a PostHog Code session directed by @darkopia, investigating a customer-reported reconnect lockout. Skills consulted: `/writing-tests`, `/improving-drf-endpoints` (no serializer/schema surface changed).
- Chose delete-and-re-register over adopting the existing registration: adoption would reuse the old DKIM keys, letting anyone verify via DNS records lingering from the previous owner; fresh registration issues new keys so DNS control must be re-proven.
- Reclaim is gated on a forced re-verification returning `unverified` (not the stored state), both to unlock stale-`active` strands and to protect genuinely verified domains; `disabled` domains are deliberately not reclaimable.
- Mailgun cleanup calls were moved outside the `transaction.atomic()` block per repo guidance on external calls under row locks.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
