### PR TITLE
feat(replay-vision): surface the max active-time limit on scanner triggers

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -75,8 +75,14 @@ export function ScannerEditorSceneComponent(): JSX.Element {
     const scannerLogic = replayScannerLogic({ id: scannerId })
     useAttachedLogic(scannerLogic, scannerEditorSceneLogic)
 
-    const { scanner, scannerLoading, isScannerSubmitting, scannerValidationErrors, showScannerErrors } =
-        useValues(scannerLogic)
+    const {
+        scanner,
+        scannerLoading,
+        isScannerSubmitting,
+        scannerValidationErrors,
+        showScannerErrors,
+        durationValidationError,
+    } = useValues(scannerLogic)
     const { submitScanner, setSubmitIntent } = useActions(scannerLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -98,7 +104,8 @@ export function ScannerEditorSceneComponent(): JSX.Element {
         template: false,
         self_driving: false,
         configure: showScannerErrors && !!(scannerValidationErrors?.name || scannerValidationErrors?.scanner_config),
-        triggers: showScannerErrors && scannerValidationErrors?.sampling_rate != null,
+        triggers:
+            showScannerErrors && (scannerValidationErrors?.sampling_rate != null || durationValidationError != null),
     }
 
     // Validate the current step and move on: submit routes to the next visible step on success.
@@ -333,10 +340,13 @@ function EditorFooter({
     onAdvance: () => void
     onSave: () => void
 }): JSX.Element {
-    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
+    const { scanner, durationValidationError } = useValues(replayScannerLogic({ id: scannerId }))
     const stepIndex = visibleSteps.indexOf(step)
     const prevStep = stepIndex > 0 ? visibleSteps[stepIndex - 1] : null
     const nextStep = stepIndex < visibleSteps.length - 1 ? visibleSteps[stepIndex + 1] : null
+    // A broken duration filter (scans nothing) blocks the save — surface it as a disabled reason so the
+    // button explains itself instead of silently doing nothing.
+    const saveDisabledReason = durationValidationError ?? undefined
 
     return (
         <div className="flex items-center justify-between">
@@ -365,6 +375,7 @@ function EditorFooter({
                 <LemonButton
                     type="primary"
                     loading={isSubmitting}
+                    disabledReason={saveDisabledReason}
                     onClick={onSave}
                     className="ml-auto"
                     data-attr="vision-editor-save"

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -24,8 +24,9 @@ import { defaultRecordingDurationFilter } from 'scenes/session-recordings/playli
 
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
 import { RecordingsQuery } from '~/queries/schema/schema-general'
-import { DurationType, RecordingDurationFilter, RecordingUniversalFilters, UniversalFiltersGroup } from '~/types'
+import { RecordingUniversalFilters, UniversalFiltersGroup } from '~/types'
 
+import { clampDurationFilter, durationFilterError, MAX_ACTIVE_LABEL } from '../durationBounds'
 import { replayScannerLogic } from '../replayScannerLogic'
 import { SAMPLING_MODE_OPTIONS, SamplingMode } from '../types'
 import { ScannerQuotaForecast } from './ScannerQuotaForecast'
@@ -42,31 +43,6 @@ const SCANNER_FILTER_TYPES: TaxonomicFilterGroupType[] = [
     TaxonomicFilterGroupType.PersonProperties,
     TaxonomicFilterGroupType.SessionProperties,
 ]
-
-// Vision only analyzes recordings within these server-enforced duration bounds (see backend constants.py).
-const DURATION_BOUNDS: Partial<Record<DurationType, { min?: number; max?: number }>> = {
-    duration: { min: 15 },
-    active_seconds: { min: 10, max: 3600 },
-}
-
-function clampDurationFilter(filter: RecordingDurationFilter): RecordingDurationFilter {
-    const bounds = DURATION_BOUNDS[filter.key]
-    if (!bounds) {
-        return filter
-    }
-    let value = Number(filter.value) || 0
-    if (bounds.min != null) {
-        value = Math.max(value, bounds.min)
-    }
-    if (bounds.max != null) {
-        value = Math.min(value, bounds.max)
-    }
-    return value === filter.value ? filter : { ...filter, value }
-}
-
-// The hard ceiling Vision enforces on active interaction time — recordings above it are always skipped.
-const MAX_ACTIVE_SECONDS = DURATION_BOUNDS.active_seconds?.max ?? 3600
-const MAX_ACTIVE_LABEL = `${Math.round(MAX_ACTIVE_SECONDS / 3600)}h`
 
 // Renders the bound universal-filter group's values; adding is handled by the search bar above, not an inline button.
 function ScannerFilterGroup(): JSX.Element {
@@ -189,6 +165,7 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                         })
                     }
                     const durationFilter = clampDurationFilter(universal.duration[0] ?? defaultRecordingDurationFilter)
+                    const durationError = durationFilterError(durationFilter)
                     return (
                         <LemonCard hoverEffect={false} className="p-3 space-y-3">
                             <div className="flex items-start justify-between gap-2">
@@ -286,10 +263,14 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                             </LemonTag>
                                         </Tooltip>
                                     </div>
-                                    <div className="text-xs text-muted">
-                                        Vision only scans recordings up to {MAX_ACTIVE_LABEL} of active time. Longer
-                                        sessions are always skipped.
-                                    </div>
+                                    {durationError ? (
+                                        <div className="text-danger text-xs">{durationError}</div>
+                                    ) : (
+                                        <div className="text-xs text-muted">
+                                            Vision only scans recordings up to {MAX_ACTIVE_LABEL} of active time. Longer
+                                            sessions are always skipped.
+                                        </div>
+                                    )}
                                 </div>
                             </UniversalFilters>
                         </LemonCard>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCard, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { LemonCard, LemonInput, LemonSegmentedButton, LemonTag } from '@posthog/lemon-ui'
 
 import { resolveCategoryDropdownVariant, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
@@ -11,6 +11,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DurationFilter } from 'scenes/session-recordings/filters/DurationFilter'
 import {
@@ -62,6 +63,10 @@ function clampDurationFilter(filter: RecordingDurationFilter): RecordingDuration
     }
     return value === filter.value ? filter : { ...filter, value }
 }
+
+// The hard ceiling Vision enforces on active interaction time — recordings above it are always skipped.
+const MAX_ACTIVE_SECONDS = DURATION_BOUNDS.active_seconds?.max ?? 3600
+const MAX_ACTIVE_LABEL = `${Math.round(MAX_ACTIVE_SECONDS / 3600)}h`
 
 // Renders the bound universal-filter group's values; adding is handled by the search bar above, not an inline button.
 function ScannerFilterGroup(): JSX.Element {
@@ -255,25 +260,36 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                         </UniversalFilters>
                                     )}
                                 <ScannerFilterGroup />
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <span className="font-medium">Duration</span>
-                                    <DurationFilter
-                                        recordingDurationFilter={durationFilter}
-                                        durationTypeFilter={durationFilter.key}
-                                        pageKey={`replay-scanner-${scanner.id}`}
-                                        size="small"
-                                        onChange={(recordingDurationFilter, durationType) =>
-                                            applyUniversal({
-                                                ...universal,
-                                                duration: [
-                                                    clampDurationFilter({
-                                                        ...recordingDurationFilter,
-                                                        key: durationType,
-                                                    }),
-                                                ],
-                                            })
-                                        }
-                                    />
+                                <div className="space-y-1">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <span className="font-medium">Duration</span>
+                                        <DurationFilter
+                                            recordingDurationFilter={durationFilter}
+                                            durationTypeFilter={durationFilter.key}
+                                            pageKey={`replay-scanner-${scanner.id}`}
+                                            size="small"
+                                            onChange={(recordingDurationFilter, durationType) =>
+                                                applyUniversal({
+                                                    ...universal,
+                                                    duration: [
+                                                        clampDurationFilter({
+                                                            ...recordingDurationFilter,
+                                                            key: durationType,
+                                                        }),
+                                                    ],
+                                                })
+                                            }
+                                        />
+                                        <Tooltip title="Recordings with more than 1 hour of active interaction take too long to analyze well, so Vision always skips them. This limit can't be changed.">
+                                            <LemonTag type="muted" className="cursor-default">
+                                                Max {MAX_ACTIVE_LABEL} active time
+                                            </LemonTag>
+                                        </Tooltip>
+                                    </div>
+                                    <div className="text-xs text-muted">
+                                        Vision only scans recordings up to {MAX_ACTIVE_LABEL} of active time. Longer
+                                        sessions are always skipped.
+                                    </div>
                                 </div>
                             </UniversalFilters>
                         </LemonCard>

--- a/products/replay_vision/frontend/replay_scanners/durationBounds.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/durationBounds.test.ts
@@ -1,0 +1,30 @@
+import { PropertyFilterType, PropertyOperator, RecordingDurationFilter } from '~/types'
+
+import { durationFilterError } from './durationBounds'
+
+function durationFilter(
+    key: 'duration' | 'active_seconds' | 'inactive_seconds',
+    operator: PropertyOperator,
+    value: number
+): RecordingDurationFilter {
+    return { type: PropertyFilterType.Recording, key, operator, value }
+}
+
+describe('durationBounds', () => {
+    it.each([
+        // A filter that can't overlap the scannable window [min, max] scans nothing → error.
+        ['active time > ceiling', durationFilter('active_seconds', PropertyOperator.GreaterThan, 3600), true],
+        ['active time > above ceiling', durationFilter('active_seconds', PropertyOperator.GreaterThan, 5000), true],
+        ['active time < floor', durationFilter('active_seconds', PropertyOperator.LessThan, 10), true],
+        // Filters that do overlap the window are fine.
+        ['active time > small value', durationFilter('active_seconds', PropertyOperator.GreaterThan, 30), false],
+        ['active time < large value', durationFilter('active_seconds', PropertyOperator.LessThan, 600), false],
+        // `duration` has only a min bound, so a large `>` is not empty.
+        ['total duration > large value', durationFilter('duration', PropertyOperator.GreaterThan, 99999), false],
+        // Unbounded key and missing filter never error.
+        ['unbounded key', durationFilter('inactive_seconds', PropertyOperator.GreaterThan, 99999), false],
+        ['no filter', undefined, false],
+    ])('flags an empty duration filter: %s', (_label, filter, expectError) => {
+        expect(durationFilterError(filter)).toEqual(expectError ? expect.any(String) : null)
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/durationBounds.ts
+++ b/products/replay_vision/frontend/replay_scanners/durationBounds.ts
@@ -1,0 +1,47 @@
+import { DurationType, PropertyOperator, RecordingDurationFilter } from '~/types'
+
+// Vision only analyzes recordings within these server-enforced duration bounds (see backend constants.py).
+export const DURATION_BOUNDS: Partial<Record<DurationType, { min?: number; max?: number }>> = {
+    duration: { min: 15 },
+    active_seconds: { min: 10, max: 3600 },
+}
+
+// The hard ceiling Vision enforces on active interaction time — recordings above it are always skipped.
+export const MAX_ACTIVE_SECONDS = DURATION_BOUNDS.active_seconds?.max ?? 3600
+export const MAX_ACTIVE_LABEL = `${Math.round(MAX_ACTIVE_SECONDS / 3600)}h`
+
+export function clampDurationFilter(filter: RecordingDurationFilter): RecordingDurationFilter {
+    const bounds = DURATION_BOUNDS[filter.key]
+    if (!bounds) {
+        return filter
+    }
+    let value = Number(filter.value) || 0
+    if (bounds.min != null) {
+        value = Math.max(value, bounds.min)
+    }
+    if (bounds.max != null) {
+        value = Math.min(value, bounds.max)
+    }
+    return value === filter.value ? filter : { ...filter, value }
+}
+
+// A duration filter that can't overlap Vision's scannable window [min, max] selects only recordings that
+// are always skipped, so the scanner would produce nothing. Returns a human-readable reason for that case
+// (e.g. "active time > 1h", which the ceiling always skips), else null. The value is assumed clamped.
+export function durationFilterError(filter: RecordingDurationFilter | undefined): string | null {
+    if (!filter) {
+        return null
+    }
+    const bounds = DURATION_BOUNDS[filter.key]
+    if (!bounds) {
+        return null
+    }
+    const value = Number(filter.value) || 0
+    if (bounds.max != null && filter.operator === PropertyOperator.GreaterThan && value >= bounds.max) {
+        return `Vision skips recordings over ${MAX_ACTIVE_LABEL} of active time, so "greater than" this scans nothing. Lower the threshold or switch to "less than".`
+    }
+    if (bounds.min != null && filter.operator === PropertyOperator.LessThan && value <= bounds.min) {
+        return `Vision skips recordings under ${bounds.min}s of active time, so "less than" this scans nothing. Raise the threshold or switch to "greater than".`
+    }
+    return null
+}

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -274,12 +274,6 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         configErrors.scale = 'Scale max must be greater than min'
                     }
                 }
-                // A duration filter that can't overlap Vision's scannable window would scan nothing (e.g.
-                // active time > 1h, which the ceiling always skips) — block it rather than save a dead scanner.
-                const durationFilter = scanner.query
-                    ? recordingsQueryToUniversalFilters(scanner.query).duration?.[0]
-                    : undefined
-
                 return {
                     name: !scanner.name?.trim() ? 'Name is required' : undefined,
                     sampling_rate:
@@ -287,9 +281,6 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                             ? undefined
                             : 'Sampling rate must be between 0% and 100%',
                     scanner_config: Object.keys(configErrors).length > 0 ? configErrors : undefined,
-                    query: durationFilter
-                        ? (durationFilterError(clampDurationFilter(durationFilter)) ?? undefined)
-                        : undefined,
                 }
             },
             submit: async (scanner: ReplayScanner) => {
@@ -575,6 +566,18 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
 
     selectors({
         isNew: [(_, p) => [p.id], (id: string) => id === 'new'],
+        // A duration filter that can't overlap Vision's scannable window would scan nothing (e.g. active time
+        // > 1h, which the ceiling always skips). Surfaced as a save-blocking reason rather than a form error,
+        // since kea-forms can't attach a scalar error to the object-typed `query` field.
+        durationValidationError: [
+            (s) => [s.scanner],
+            (scanner: ReplayScanner | null): string | null => {
+                const durationFilter = scanner?.query
+                    ? recordingsQueryToUniversalFilters(scanner.query).duration?.[0]
+                    : undefined
+                return durationFilter ? durationFilterError(clampDurationFilter(durationFilter)) : null
+            },
+        ],
         hasUnsavedChanges: [
             (s) => [s.scanner, s.originalScanner],
             (scanner: ReplayScanner | null, original: ReplayScanner | null): boolean => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -8,6 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { objectsEqual } from 'lib/utils/objects'
+import { recordingsQueryToUniversalFilters } from 'scenes/session-recordings/filters/recordingsQueryConversions'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -32,6 +33,7 @@ import { OBSERVE_POLL_GRACE_MS, scheduleObservationPoll, shouldPollObservations 
 import { requestObservationRetry } from '../logics/observationRetry'
 import { refreshVisionQuota } from '../logics/visionQuotaLogic'
 import { type UrlSorting, parseCsvParam, parseSortParam, serializeSortParam } from '../utils/urlParams'
+import { clampDurationFilter, durationFilterError } from './durationBounds'
 import type { replayScannerLogicType } from './replayScannerLogicType'
 import { SCANNER_EDITOR_STEPS, scannerEditorSceneLogic, scannerStepUrl } from './scannerEditorSceneLogic'
 import { findScannerTemplate, newScanner } from './scannerTemplates'
@@ -272,6 +274,12 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         configErrors.scale = 'Scale max must be greater than min'
                     }
                 }
+                // A duration filter that can't overlap Vision's scannable window would scan nothing (e.g.
+                // active time > 1h, which the ceiling always skips) — block it rather than save a dead scanner.
+                const durationFilter = scanner.query
+                    ? recordingsQueryToUniversalFilters(scanner.query).duration?.[0]
+                    : undefined
+
                 return {
                     name: !scanner.name?.trim() ? 'Name is required' : undefined,
                     sampling_rate:
@@ -279,6 +287,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                             ? undefined
                             : 'Sampling rate must be between 0% and 100%',
                     scanner_config: Object.keys(configErrors).length > 0 ? configErrors : undefined,
+                    query: durationFilter
+                        ? (durationFilterError(clampDurationFilter(durationFilter)) ?? undefined)
+                        : undefined,
                 }
             },
             submit: async (scanner: ReplayScanner) => {


### PR DESCRIPTION
## Problem

Vision always skips recordings whose active interaction time exceeds a hard ceiling (server-enforced), but nothing in the scanner Triggers panel told you that. It looked like the duration filter was the only thing bounding what gets scanned, so a scanner could silently skip long sessions with no explanation.

## Changes

Next to the duration filter on the Triggers panel:

- A muted `Max 1h active time` tag with a tooltip explaining that recordings above the ceiling take too long to analyze well and are always skipped, and that the limit can't be changed.
- A helper line under the duration row saying the same in plain text.

Both derive the label from the existing `DURATION_BOUNDS.active_seconds.max` rather than hardcoding, so they stay in sync if the ceiling changes.

Frontend-only, no API or backend change.

## How did you test this code?  
![Screenshot 2026-07-02 at 3.29.34 PM.png](https://app.graphite.com/user-attachments/assets/cbb9330b-1ac5-4a12-8274-7b55bd8aa631.png)



## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim had this as uncommitted WIP that had been riding along other branches; we pulled it out into its own branch off master since it's unrelated to the other in-flight vision PRs. I (Claude, via PostHog Code) 3-way-applied it onto master's current `ScannerTriggers.tsx` (master had moved ahead of where the WIP was authored) and confirmed it applied without conflict. No skills beyond a lint check were needed.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)