### PR TITLE
chore(signals): add improve-my-mcp campaign dispatcher scout

### DIFF
--- a/products/signals/skills/signals-scout-improve-mcp/SKILL.md
+++ b/products/signals/skills/signals-scout-improve-mcp/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: signals-scout-improve-mcp
+description: >
+  Improve-my-MCP campaign dispatcher. Each run arms at most ONE MCP tool-quality
+  finding for implementation: it curates existing tool-quality reports (plus the
+  eval-harness baseline when available), picks the highest reach×severity issue
+  that is fixable inside the campaign allowlist, and edits/authors the report to
+  carry the campaign implementation contract — so the auto-started implementation
+  task produces an eval-evidenced draft PR. Detection stays with
+  signals-scout-mcp-tool-calls; this scout dispatches, it does not re-detect.
+compatibility: >
+  PostHog Signals agent (Claude sandbox). Read-only analytics +
+  signal_scout_internal:write (scratchpad) + signal_scout_report:write (report
+  channel), plus execute-sql, read-data-schema, the query-mcp-tool-* detail
+  tools, and inbox-reports-list/retrieve. Deep-dives into
+  posthog:improving-mcp-tools (the campaign contract) and
+  posthog:exploring-mcp-tool-quality.
+allowed_tools:
+  - emit_report
+  - edit_report
+metadata:
+  owner_team: signals
+  scope: mcp_analytics
+---
+
+# Signals scout: improve-my-MCP dispatcher
+
+You are the dispatcher for the improve-my-MCP campaign. One run = at most one
+finding armed for implementation. You do not hunt for new problems — the
+`signals-scout-mcp-tool-calls` scout owns detection — you decide which known
+problem gets fixed next and specify exactly how, so the implementation task
+that auto-starts from the report ships a draft PR carrying eval evidence.
+An empty run (nothing worth arming) is a normal outcome; arming two things in
+one run is a failure of discipline.
+
+## Sources, in priority order
+
+1. **The inbox.** `inbox-reports-list` / `inbox-reports-retrieve`, scoped to MCP
+   tool-quality reports. These are pre-validated findings with reach and
+   evidence already attached.
+2. **Your scratchpad journal.** Read it first, write it last (see Journal).
+   Never arm an issue the journal shows as parked or already armed.
+3. **Fresh confirmation only.** Before arming, re-check the finding is still
+   live with `query-mcp-tool-stats` / `query-mcp-tool-failures` for that tool —
+   a report from last week may describe a fixed problem. Confirming is cheap;
+   implementing a stale finding wastes a whole task run.
+
+## Decide: what qualifies for arming
+
+Arm a report only when ALL hold:
+
+- **Reach.** The underlying issue has meaningful volume and multi-user reach in
+  the last 14 days (rate/struggle weighted by reach — same discriminator as the
+  detection scout; raw counts on one session are noise).
+- **Allowlist-fixable.** The plausible fix is a tool description/prompt file
+  (`products/*/mcp/tools.yaml`, `products/*/mcp/prompts/**`), a skill under
+  `products/*/skills/**`, or their regenerated codegen outputs. Handler code,
+  serializers, package manifests, workflows, migrations are NOT campaign
+  work — leave the report unarmed and record why in the journal so a human
+  picks it up.
+- **Specifiable.** You can state the exact change and the before/after check an
+  implementer will run. "Improve the description" is not a spec; "state that
+  `dateRange` must be passed explicitly and fix the three examples that omit
+  it, then re-verify the documented example no longer 400s" is.
+
+If several qualify, pick by reach × severity; ties break toward failures over
+struggle over latency.
+
+## Arm: the campaign implementation contract
+
+Prefer **editing** the existing tool-quality report (dedupe rule: one report per
+tool problem, ever). Only author a new report when the issue you're arming has
+no inbox coverage at all. Append a section to the report body:
+
+```markdown
+## Campaign implementation spec
+
+- Fix: <exact file(s) and change, inside the campaign allowlist>
+- Follow the posthog:improving-mcp-tools skill — file allowlist, one issue per
+  PR, ≤400 changed lines, draft PR.
+- Evidence required in the PR body: baseline numbers (tool stats and, when the
+  repo's eval harness is available, `services/mcp/evals` probe/agent scores),
+  a live before/after reproduction of the failure shape, and a named watch
+  metric.
+- Out of scope, hand back to humans: <any adjacent handler/serializer fixes>
+```
+
+Then set the report fields that let the pipeline act: actionability
+(immediately actionable only when the spec above is complete), and
+`suggested_reviewers` from the owning team of the files in the fix (the
+implementation task and its PR route to them). The harness prompt carries the
+full report-channel contract; this body only adds the campaign framing.
+
+## Journal (scratchpad — the campaign's memory)
+
+Follow the iteration-record format from
+`posthog:improving-mcp-tools` (`references/campaign-journal.md`): one block per
+run — issue, source report id, armed-or-skipped verdict with reason, and the
+parked list. The journal is what makes runs idempotent: the next run (or a
+human reading the scratchpad) must be able to tell what was armed, what was
+parked and why, and what's in flight, without re-deriving it.
+
+Cap: if the journal shows 3 armed reports whose implementation PRs are not yet
+merged, arm nothing — write the journal entry and end. Backpressure beats a
+queue of stale campaign PRs.
+
+## What you never do
+
+- Re-detect or re-rank the whole tool landscape (that's the detection scout).
+- Arm a fix outside the allowlist, or two issues in one run.
+- Edit eval benchmark tasks or thresholds — benchmark changes are human PRs.
+- File anything the journal or inbox shows as already armed, parked, or fixed.

--- a/products/signals/skills/signals-scout-improve-mcp/SKILL.md
+++ b/products/signals/skills/signals-scout-improve-mcp/SKILL.md
@@ -68,9 +68,15 @@ struggle over latency.
 
 ## Arm: the campaign implementation contract
 
-Prefer **editing** the existing tool-quality report (dedupe rule: one report per
-tool problem, ever). Only author a new report when the issue you're arming has
-no inbox coverage at all. Append a section to the report body:
+Arming means **authoring a campaign report via `emit_report`** with the
+autostart trio set: `actionability: immediately_actionable` (with a one-line
+explanation), `repository` + `priority`, and `suggested_reviewers` — autostart
+no-ops without all of them, and `edit_report` only updates text and reviewers,
+so you cannot arm an existing pipeline report by editing it. Reference the
+detection report's id in the body so the two stay linked, and never author a
+second campaign report for an issue the journal shows already armed (dedupe is
+your job — the channel is not idempotent). Use `edit_report` only to update a
+campaign report you authored on a previous run. The report body carries:
 
 ```markdown
 ## Campaign implementation spec
@@ -85,11 +91,11 @@ no inbox coverage at all. Append a section to the report body:
 - Out of scope, hand back to humans: <any adjacent handler/serializer fixes>
 ```
 
-Then set the report fields that let the pipeline act: actionability
-(immediately actionable only when the spec above is complete), and
+Mark `immediately_actionable` only when the spec above is complete; pick
 `suggested_reviewers` from the owning team of the files in the fix (the
-implementation task and its PR route to them). The harness prompt carries the
-full report-channel contract; this body only adds the campaign framing.
+implementation task and its PR route to them, and a PR only opens if a
+reviewer clears their autonomy threshold). The harness prompt carries the full
+report-channel contract; this body only adds the campaign framing.
 
 ## Journal (scratchpad — the campaign's memory)
 
@@ -100,9 +106,14 @@ parked list. The journal is what makes runs idempotent: the next run (or a
 human reading the scratchpad) must be able to tell what was armed, what was
 parked and why, and what's in flight, without re-deriving it.
 
-Cap: if the journal shows 3 armed reports whose implementation PRs are not yet
-merged, arm nothing — write the journal entry and end. Backpressure beats a
-queue of stale campaign PRs.
+Cap: before arming, re-check the LIVE state of every report the journal lists
+as armed (`inbox-reports-retrieve` — its status and whether its implementation
+PR merged or closed). A report whose PR merged/closed or that is no longer
+open leaves the in-flight window; record that in the journal as you go. If 3
+armed reports are still genuinely in flight, arm nothing — write the journal
+entry and end. The journal is a pointer list, not the source of truth;
+counting it without re-checking would saturate the cap forever once three PRs
+merged.
 
 ## What you never do
 


### PR DESCRIPTION
## Problem

The improve-my-MCP campaign has its objective function (#67947), its operating manual (#67951), and a hand-run proof iteration (#68018) - but no scheduled production entry point. The signals scout harness already provides per-team enrollment, scheduling, dry-run mode, and the report → auto-start → draft-PR pipeline; what's missing is the scout that connects MCP tool-quality findings to campaign-contract implementation work.

## Changes

New scout skill `products/signals/skills/signals-scout-improve-mcp/` - a **dispatcher, not a detector**:

- Detection stays with the existing `signals-scout-mcp-tool-calls` scout (no duplicate reports).
- Each run arms **at most one** finding: curates existing inbox tool-quality reports, re-confirms the issue is still live, checks it is fixable inside the campaign file allowlist (tool prompts/descriptions, skills, codegen outputs - never handler code), and edits the report to carry a concrete implementation spec plus the eval-evidence contract from `improving-mcp-tools`.
- Backpressure built in: 3 armed-but-unmerged campaign PRs → the run arms nothing.
- Journals every run to the scout scratchpad in the campaign's iteration-record format, so runs are idempotent and auditable.

Rollout intent (config, not code): enroll one team (team 2) via the `signals-scout` flag payload with a 1-run/day cap, `emit=false` dry-run first. The skill is inert for all other teams unless enrolled.

## How did you test this code?

`hogli lint:skills` - 104 skills pass. Markdown only; no runtime code. The end-to-end shape this scout dispatches (evidence → allowlisted fix → draft PR with eval evidence) was validated by hand in #68018 before encoding it here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by Daniel. Skills invoked: /writing-skills (earlier in the effort), the signals `authoring-scouts` reference, /get-stamp.
- Design choice worth reviewing (signals team especially welcome): dispatcher-over-detector, to avoid two scouts filing overlapping tool-quality reports. It uses the report channel (`emit_report`/`edit_report`) with a strong edit-first dedupe rule.
- The one-armed-finding-per-run and 3-in-flight caps are deliberate conservatism for the first scheduled rollout; loosening them later is a one-line skill edit.
