### PR TITLE
fix(tasks): show useful info on task and run not-found pages

### DIFF
--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { IconExternal, IconGithub, IconPlay } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -25,14 +26,40 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
     const { runTask, deleteTask, loadTask } = useActions(sceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { activeCreation } = useValues(taskTrackerSceneLogic)
+    const { searchParams } = useValues(router)
     const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
+    // A task can 404 in ways the generic "deleted / sharing settings changed" copy doesn't explain: tasks are
+    // scoped to the project in the URL, so a link built for another project 404s here, and a run that failed
+    // before the task finished starting up may never have created the task row. Surface the ids and the real
+    // causes instead — this page is often reached from a Slack "task failed" link with a ?runId deep-link.
+    const linkedRunId = typeof searchParams.runId === 'string' ? searchParams.runId : null
+    const taskNotFoundCaption = (
+        <>
+            We couldn't load this task in the current project.
+            <br />
+            Task ID: <span className="font-mono">{taskId}</span>
+            {linkedRunId ? (
+                <>
+                    <br />
+                    Linked run: <span className="font-mono">{linkedRunId}</span>
+                </>
+            ) : null}
+            <br />
+            <br />
+            Tasks are scoped to the project in the URL, so this usually means the task belongs to a different
+            project, or it was archived. If it came from a Slack thread whose run failed before it finished
+            starting up, the task may never have been created — check the run's Temporal workflow for the
+            underlying error.
+        </>
+    )
+
     if (taskNotFound && !task) {
-        return <NotFound object="task" />
+        return <NotFound object="task" caption={taskNotFoundCaption} />
     }
 
     if (!isTaskPending && !task && !taskError) {
-        return <NotFound object="task" />
+        return <NotFound object="task" caption={taskNotFoundCaption} />
     }
 
     const latestRun = runs.length > 0 ? runs[0] : null

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -47,10 +47,9 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
             ) : null}
             <br />
             <br />
-            Tasks are scoped to the project in the URL, so this usually means the task belongs to a different
-            project, or it was archived. If it came from a Slack thread whose run failed before it finished
-            starting up, the task may never have been created — check the run's Temporal workflow for the
-            underlying error.
+            Tasks are scoped to the project in the URL, so this usually means the task belongs to a different project,
+            or it was archived. If it came from a Slack thread whose run failed before it finished starting up, the task
+            may never have been created — check the run's Temporal workflow for the underlying error.
         </>
     )
 

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
@@ -80,9 +80,8 @@ export function TaskRunLog({
                         ) : null}
                         <br />
                         <br />
-                        The run may belong to a different task, or it failed before it was recorded. Pick
-                        another run from the list, or check the run's Temporal workflow for the underlying
-                        error.
+                        The run may belong to a different task, or it failed before it was recorded. Pick another run
+                        from the list, or check the run's Temporal workflow for the underlying error.
                     </>
                 }
             />

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
@@ -63,7 +63,30 @@ export function TaskRunLog({
         )
     }
     if (selectedRunNotFound) {
-        return <NotFound object="task run" className="m-0 py-8" />
+        // Reached via a ?runId deep-link (e.g. a Slack "task failed" link) that no longer resolves. The generic
+        // "deleted / sharing settings changed" copy is misleading for a run — name the id and the real causes.
+        return (
+            <NotFound
+                object="task run"
+                className="m-0 py-8"
+                caption={
+                    <>
+                        We couldn't find this run on the task.
+                        {selectedRunId ? (
+                            <>
+                                <br />
+                                Run ID: <span className="font-mono">{selectedRunId}</span>
+                            </>
+                        ) : null}
+                        <br />
+                        <br />
+                        The run may belong to a different task, or it failed before it was recorded. Pick
+                        another run from the list, or check the run's Temporal workflow for the underlying
+                        error.
+                    </>
+                }
+            />
+        )
     }
     if (isRunPending) {
         return <RunLogSkeleton />


### PR DESCRIPTION
## Problem

Clicking a task link like `/project/2/tasks/<id>?runId=<run>` where the task can't be loaded shows a generic "Task not found — it might be lost in space. It's possible this task has been deleted or its sharing settings have changed." That copy is wrong for tasks and tells you nothing useful.

Tasks are scoped to the project in the URL, so a link built for another project 404s here even though the task exists. And a run that fails before the task row is created never resolves. In both cases the page hides the one thing you need (which task/run, and why) behind boilerplate about sharing settings that tasks don't even have. Same for a `?runId` deep-link whose run no longer resolves — it hit the same generic "task run" not-found copy.

Raised from a Slack thread where a failed run's link landed on this dead-end page.

## Changes

Both not-found states in the task detail scene now pass an informative `caption` to `NotFound` instead of relying on the generic default:

- **Task-level** (`TaskDetailPage`): names the task id, the linked run id from `?runId` when present, and explains the real causes — the task likely belongs to a different project or was archived, or (if it came from a Slack thread whose run failed before it started up) the task row may never have been created. Points at the run's Temporal workflow for the underlying error.
- **Run-level** (`TaskRunLog`): for a `?runId` that no longer resolves, names the run id and explains it may belong to a different task or failed before it was recorded, and suggests picking another run or checking the Temporal workflow.

Purely presentational — no logic or API changes. The existing `TaskNotFound` and `TaskRunNotFound` Storybook stories now render the improved copy.

## How did you test this code?

I (Claude, via the PostHog Slack app) made the change but could not run the frontend toolchain in this environment — the working clone had no `node_modules`, so I did not run `typescript:check`, the formatter, or Storybook. The change is small and presentational (adds a `caption` prop and reads `router.searchParams.runId`). Please run typecheck/format in CI. No automated tests were added — the change is copy only, and the existing not-found stories exercise the code paths.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ian asked (via the PostHog Slack app) why a failed task's link showed nothing useful, then to make that page actually informative. I traced the failing run through error tracking to the generic `TaskRun reached terminal status=failed (cause: Activity task failed) — no agent message` wrapper, confirmed the frontend renders `NotFound` with its default caption, and confirmed `TaskViewSet` is team-scoped (so a cross-project link 404s). Fix is limited to the two not-found captions. No skills were invoked (copy-only frontend change, no serializer/migration/API surface touched). I could not run typecheck or format locally (no `node_modules`).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783028915149649?thread_ts=1783028915.149649&cid=C09SK2PAGKF)*
