### PR TITLE
fix(postgres): retry Supavisor authenticated-state socket close in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -232,15 +232,14 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 # Supavisor also surfaces a backend socket that closed mid-session — after the client authenticated
 # — as "Internal error (authenticated): :closed", where ":closed" is the Erlang gen_tcp reason for a
 # peer-closed socket (its DbHandler lost the backend connection to an idle cull, restart, or
-# failover). There's no error code here, so match the "internal error (authenticated)" wrapper: it's
-# emitted only by the pooler's own proxy loop once the client is past auth, so a fresh reconnect
-# re-establishes a new session — the same transient class. Scoping to the "(authenticated)" state
-# excludes auth-time rejections, and backend SQL errors pass through with their real SQLSTATE, not
-# this wrapper.
+# failover). There's no error code here, so match the full phrase including the ":closed" reason: a
+# fresh reconnect re-establishes a new session — the same transient class. Matching only the
+# "(authenticated)" wrapper would be too broad: a non-:closed "Internal error (authenticated): ..."
+# could be a permanent pooler/protocol failure that should surface immediately, not be retried.
 _POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     "edbhandlerexited",
     "echeckoutretries",
-    "internal error (authenticated)",
+    "internal error (authenticated): :closed",
 )
 
 # Connect-time capacity errors: the source refuses a *new* connection because it has hit a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -228,7 +228,20 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 #     exhausted or every backend was busy. A slot frees the moment another session returns one.
 # Both are the same transient class as the libpq drops above and recover on reconnect. Genuine
 # XX000 internal errors (data corruption, etc.) carry a different code and stay non-recoverable.
-_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited", "echeckoutretries")
+#
+# Supavisor also surfaces a backend socket that closed mid-session — after the client authenticated
+# — as "Internal error (authenticated): :closed", where ":closed" is the Erlang gen_tcp reason for a
+# peer-closed socket (its DbHandler lost the backend connection to an idle cull, restart, or
+# failover). There's no error code here, so match the "internal error (authenticated)" wrapper: it's
+# emitted only by the pooler's own proxy loop once the client is past auth, so a fresh reconnect
+# re-establishes a new session — the same transient class. Scoping to the "(authenticated)" state
+# excludes auth-time rejections, and backend SQL errors pass through with their real SQLSTATE, not
+# this wrapper.
+_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
+    "edbhandlerexited",
+    "echeckoutretries",
+    "internal error (authenticated)",
+)
 
 # Connect-time capacity errors: the source refuses a *new* connection because it has hit a
 # connection limit, not because anything is misconfigured. PostgreSQL raises "sorry, too many

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1117,7 +1117,7 @@ class TestIsConnectionDroppedError:
             # Supavisor loses the backend socket mid-session (idle cull, restart, failover) and, once
             # the client is past auth, surfaces it as an XX000 InternalError_ "Internal error
             # (authenticated): :closed" — ":closed" being the Erlang gen_tcp peer-closed reason. No
-            # error code, so it's matched on the "internal error (authenticated)" wrapper; same
+            # error code, so it's matched on the full phrase including the ":closed" reason; same
             # transient class as the pooler drops above and recovers on reconnect.
             psycopg.errors.InternalError_("Internal error (authenticated): :closed"),
             # Supavisor reports a transient timeout reaching the upstream backend as a
@@ -1160,6 +1160,10 @@ class TestIsConnectionDroppedError:
             # non-recoverable — the InternalError_ match is scoped to the known pooler codes
             # ("(EDBHANDLEREXITED)" / "(ECHECKOUTRETRIES)"), not every XX000.
             psycopg.errors.InternalError_("XX000: internal error: something went wrong"),
+            # The Supavisor authenticated-state match is scoped to the ":closed" socket-drop reason.
+            # Any other "Internal error (authenticated): ..." reason could be a permanent pooler or
+            # protocol failure that must surface immediately, so it must NOT be treated as a drop.
+            psycopg.errors.InternalError_("Internal error (authenticated): :protocol_error"),
             # libpq's bare English "Connection refused" is a permanent wrong-host/port
             # misconfiguration (non-retryable in source.py) and must NOT be confused with Supavisor's
             # transient Erlang-tuple "{:error, :econnrefused}" — broadening the match to a plain

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1114,6 +1114,12 @@ class TestIsConnectionDroppedError:
             # retrying internally. Same transient pooler class as EDBHANDLEREXITED; recovers on
             # reconnect once a session returns a connection to the pool.
             psycopg.errors.InternalError_("(ECHECKOUTRETRIES) failed to check out a connection after multiple retries"),
+            # Supavisor loses the backend socket mid-session (idle cull, restart, failover) and, once
+            # the client is past auth, surfaces it as an XX000 InternalError_ "Internal error
+            # (authenticated): :closed" — ":closed" being the Erlang gen_tcp peer-closed reason. No
+            # error code, so it's matched on the "internal error (authenticated)" wrapper; same
+            # transient class as the pooler drops above and recovers on reconnect.
+            psycopg.errors.InternalError_("Internal error (authenticated): :closed"),
             # Supavisor reports a transient timeout reaching the upstream backend as a
             # ConnectionFailure (08006, an OperationalError) carrying the Erlang-tuple reason
             # "{:error, :etimedout}" — a transient drop the in-process recovery must catch.


### PR DESCRIPTION
## Problem

Error tracking surfaced a `psycopg.errors.InternalError_: Internal error (authenticated): :closed` failing a Postgres import ([issue](https://us.posthog.com/project/2/error_tracking/019f24c0-21f3-7ee2-a412-cdc0522a6b90)). The stack originates in this source: `source_for_pipeline` → `postgres_source` → `_get_table`, raised from `cursor.execute` while running the schema-discovery metadata query.

This is a Supabase Supavisor pooler message. The pooler loses its backend socket mid-session (idle cull, backend restart, failover) and, once the client is past auth, reports it as a generic XX000 `InternalError_` where `:closed` is the Erlang `gen_tcp` peer-closed reason. It's the same transient connection-drop class we already recover from in-process for the pooler's `(EDBHANDLEREXITED)` / `(ECHECKOUTRETRIES)` codes and its `{:error, :etimedout}` / `{:error, :econnrefused}` reasons.

The problem: this particular signature wasn't recognised. `_is_connection_dropped_error` only matched the pooler error codes, so the `:closed` message fell through, the setup loop re-raised it, the whole activity failed, and it got captured as error-tracking noise, instead of the bounded reconnect-and-retry kicking in like it does for every other Supavisor drop.

## Changes

Added `"internal error (authenticated)"` to `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS` so the existing in-process recovery treats this as the transient drop it is.

There's no error code in this message to match on, so I match the `internal error (authenticated)` wrapper instead. That's emitted only by Supavisor's own proxy loop once the client is authenticated, so it's specifically the post-auth backend-socket-drop class, not a credential rejection. Scoping to the `(authenticated)` state keeps auth-time failures out, and genuine backend SQL errors pass through with their real SQLSTATE rather than this wrapper, so they stay non-recoverable. Even if the match were slightly broad, the recovery is bounded (`_MAX_SETUP_CONNECTION_DROPPED_RETRIES`) and re-raises after N attempts, so nothing is swallowed permanently.

Decision: this is a transient infrastructure error, so it stays retryable. It is **not** added to `get_non_retryable_errors`.

## How did you test this code?

Added one parameterized case to `TestIsConnectionDroppedError::test_connection_dropped_errors_are_detected` asserting `InternalError_("Internal error (authenticated): :closed")` is detected as a drop. No existing case covered the `:closed` / authenticated-wrapper signature; the existing negative case (a plain `XX000: internal error: something went wrong`) still asserts non-detection, confirming the match doesn't over-broaden to every XX000.

Ran locally (`.venv/bin/python -m pytest`):
- `TestIsConnectionDroppedError` + `TestRaiseIfSetupConnectionBroken` — 32 passed
- full file filtered on `dropped or pooler or setup_probes or retryable or non_retryable` — 161 passed

`ruff format` + `ruff check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue via the PostHog error-tracking MCP tools (pulled the stack trace and a representative event), traced the failure to `_get_table` during setup metadata probes, and read the existing Supavisor pooler-drop handling in `postgres.py`. Invoked `/writing-tests` before adding the test. Checked open PRs (including the maintainer's) and recent merged PRs to rule out a duplicate — this follows the same in-process-recovery pattern as merged PRs #66510 and #64680, for a new pooler-drop reason.
