### PR TITLE
fix(groups): align first seen date with its label in group caption

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4573,13 +4573,13 @@ snapshots:
     replay-scenes-group--group-events-tab-with-modal-not-found--light:
         hash: v1.k794b7964.5f0d3637bb88545b108cb0a9b4d0756170ac227e93195ad571d46b53fbaeaea8.zuDIrma83LynXxvWHyFbQUXbrjWayRdiqZoebEB0TlY
     replay-scenes-group--group-recording-tab-empty--dark:
-        hash: v1.k794b7964.f1deb627bf6848abf50a0eef0cce1413643a4f1260bab1e0f92a192465b9a95d.7JFpW5ZWtSmFu182l64fE9YypIkJ_bYttM8LWIbWe-Y
+        hash: v1.k794b7964.d0642838acc78c42c685bc62c70961c499a82f8f4fb06f0a69273d9b4510a6b4.WJsbrKbxcsY8wnqQbGH5Aizdxf67uH3Zm5oo8tVkYKI
     replay-scenes-group--group-recording-tab-empty--light:
-        hash: v1.k794b7964.9277ae174a62b01665c4e77d032d04ae93b73b8fd15447e47e7ca1915397d11f.kJffVl3sofs8zSMyHH78rt5FFhCOBeAKh1Z7MfnTvwc
+        hash: v1.k794b7964.8f52b909618c4841561ad095b6d41d50185d101c9474b9ff045726af2699f9b9.BALgt1AYKPyXcsHZk8QU1iXDxSLoJzIbHJjrvFWEDYU
     replay-scenes-group--group-recording-tab-multiple-and-not-found--dark:
-        hash: v1.k794b7964.2a78cbbe5769ee76bff2695f22fda47e249bd070c94a40cff1b3020496022911.d5Wj-TfFawHiOLkliwUw40GOsUOGdg-CJAH5fknbLKI
+        hash: v1.k794b7964.968db5d7df21d676937b7899eb1ee83d70b09d7b89db8bd7c14ff1a3ed7a4830.RcxhXMimDQGP08GIXNgMedBGbjzTW6Sq8bFzdNawM0M
     replay-scenes-group--group-recording-tab-multiple-and-not-found--light:
-        hash: v1.k794b7964.d8056449450e1b9fca8334a799cc94c07c1f822da9f89286d0e87c5ffb7347f7.2Mj0yI-YAk501nE-4iQlOTqLRw6h8NBK8D_3gJRjQVA
+        hash: v1.k794b7964.9fcb4e53f68df62e347f8295388a814023512aef111d39a2bbe5e6ea02ad7f0c.yD8COhsvFt3Z_mzyPDRQk-CZLEaEAeFF4vlcmtxoaWM
     replay-scenes-person--person-recording-tab-empty--dark:
         hash: v1.k794b7964.43e828f5b46ddc1083a260cd4be8de2850990821fc36977fcd851ba68198ed25.FzBCtfzt5Kfgr1E63iZCpq3wjR5ecj6uOOkE7HkEVEk
     replay-scenes-person--person-recording-tab-empty--light:

--- a/frontend/src/scenes/groups/components/GroupCaption.tsx
+++ b/frontend/src/scenes/groups/components/GroupCaption.tsx
@@ -24,8 +24,8 @@ export function GroupCaption({ groupData, groupTypeName }: GroupCaptionProps): J
                     {groupData.group_key}
                 </CopyToClipboardInline>
             </div>
-            <div>
-                <span className="text-secondary">First seen:</span>{' '}
+            <div className="flex items-center gap-1">
+                <span className="text-secondary">First seen:</span>
                 {groupData.created_at ? <TZLabel time={groupData.created_at} /> : 'unknown'}
             </div>
         </div>


### PR DESCRIPTION
## Problem

On the group detail page, the "First seen" relative date (e.g. "a year ago") rendered slightly lower than and misaligned with its "First seen:" label. Reported in [this Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783032014618749?thread_ts=1783032014.618749&cid=C0ACRAMJUAG).

## Changes

The date is rendered via `TZLabel`, whose span carries `align-middle` inline vertical-align plus a dotted bottom border. Sitting inline next to the label text, that dropped it below the baseline. I made that row a `flex items-center gap-1` container so the label and the date are vertically centered together, matching how the neighboring rows read.

## How did you test this code?

Visual/CSS-only change. I (the PostHog Slack app agent) did not run the app or take screenshots in this environment. No automated tests were added — this is a one-line layout tweak with no logic to regress.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent at Sufi's request, from a Slack thread reporting the misalignment. I traced the layout to `GroupCaption.tsx`, identified that `TZLabel`'s `align-middle` + dotted underline caused the vertical offset, and switched the row to a centered flex container rather than tweaking `TZLabel` itself (which is shared across many surfaces). No skills were required for this CSS-only change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783032014618749?thread_ts=1783032014.618749&cid=C0ACRAMJUAG)*
