### PR TITLE
chore(ci): upload storybook and frontend jest junit to trunk

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -646,6 +646,8 @@ jobs:
                   SHARD_COUNT: 2
                   MODE: ${{ needs.select-jest-tests.outputs.mode }}
                   CHANGED_FILES: ${{ needs.select-jest-tests.outputs.changed_files }}
+                  JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results
+                  JEST_JUNIT_OUTPUT_NAME: junit-${{ matrix.segment }}-${{ matrix.chunk }}.xml
               run: |
                   if [ "$MODE" = "selective" ]; then
                       # --findRelatedTests walks jest's import graph from the changed
@@ -667,6 +669,14 @@ jobs:
                   else
                       bin/turbo run test --filter=@posthog/frontend -- --maxWorkers=2
                   fi
+
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: junit-results-frontend-${{ matrix.segment }}-${{ matrix.chunk }}
+                  path: junit-results/junit-*.xml
+                  if-no-files-found: ignore
 
     calculate-running-time:
         name: Calculate running time
@@ -741,3 +751,31 @@ jobs:
                     exit 1
                   fi
                   echo "Frontend TypeScript checks passed."
+
+    trunk-upload:
+        name: Upload test results to Trunk
+        # jest shards emit and upload junit-results-frontend-* artifacts; this feeds them to
+        # Trunk (flaky-test detection) once. Trusted non-pull_request events only (master push),
+        # so the secret token never runs in a PR-controlled context; the uploader is a pinned
+        # external action, not a local one.
+        needs: [jest]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        timeout-minutes: 10
+        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request'
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+            - name: Download JUnit artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              continue-on-error: true
+              with:
+                  path: ./junit-artifacts
+                  pattern: junit-results-frontend-*
+            - name: Upload to Trunk
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-artifacts/**/*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -781,9 +781,20 @@ jobs:
               with:
                   path: ./junit-artifacts
                   pattern: junit-results-frontend-*
-            - name: Upload to Trunk
+            # FOSS and EE run the same test files, so a single upload would give one test id
+            # both segments' outcomes and a segment-specific failure would look like a flake.
+            # Upload each segment under its own Trunk variant to keep their histories distinct.
+            - name: Upload FOSS results to Trunk
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
-                  junit-paths: junit-artifacts/**/*.xml
+                  junit-paths: junit-artifacts/**/junit-FOSS-*.xml
                   org-slug: posthog-inc
+                  variant: FOSS
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
+            - name: Upload EE results to Trunk
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-artifacts/**/junit-EE-*.xml
+                  org-slug: posthog-inc
+                  variant: EE
                   token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -648,6 +648,10 @@ jobs:
                   CHANGED_FILES: ${{ needs.select-jest-tests.outputs.changed_files }}
                   JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results
                   JEST_JUNIT_OUTPUT_NAME: junit-${{ matrix.segment }}-${{ matrix.chunk }}.xml
+                  # Trunk attributes flakes by test file; jest-junit's default suite name is the
+                  # top-level describe, which collides across files. Anchor identity to the file.
+                  JEST_JUNIT_SUITE_NAME: '{filepath}'
+                  JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
               run: |
                   if [ "$MODE" = "selective" ]; then
                       # --findRelatedTests walks jest's import graph from the changed
@@ -677,6 +681,7 @@ jobs:
                   name: junit-results-frontend-${{ matrix.segment }}-${{ matrix.chunk }}
                   path: junit-results/junit-*.xml
                   if-no-files-found: ignore
+                  retention-days: 1
 
     calculate-running-time:
         name: Calculate running time
@@ -762,13 +767,16 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: true
         timeout-minutes: 10
-        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request'
+        # != 'skipped' (not == 'success'): a failed shard still emits junit, and failing
+        # results are exactly the flake signal Trunk needs. Only bail when jest never ran.
+        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request' && needs.jest.result != 'skipped'
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 1
+                  persist-credentials: false
             - name: Download JUnit artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
               continue-on-error: true
               with:
                   path: ./junit-artifacts

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -894,13 +894,17 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: true
         timeout-minutes: 10
-        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request'
+        # Storybook CI is skipped on merge_group, so visual-regression won't run there;
+        # != 'skipped' keeps this from spinning a runner that downloads nothing, while still
+        # uploading failed-test results (the flake signal Trunk needs) on master push.
+        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request' && needs.visual-regression.result != 'skipped'
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 1
+                  persist-credentials: false
             - name: Download JUnit artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
               continue-on-error: true
               with:
                   path: ./junit-artifacts

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -883,3 +883,31 @@ jobs:
                   EOF
                       echo "SELECTION_METRICS: $(echo "$RESULT" | jq -c '{mode, reason, total: .total_story_count}')"
                   fi
+
+    trunk-upload:
+        name: Upload test results to Trunk
+        # visual-regression shards already emit and upload junit-results-storybook-* artifacts;
+        # this feeds them to Trunk (flaky-test detection) once. Trusted non-pull_request events
+        # only (master push), so the secret token never runs in a PR-controlled context; the
+        # uploader is a pinned external action, not a local one.
+        needs: [visual-regression]
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        timeout-minutes: 10
+        if: always() && github.repository == 'PostHog/posthog' && github.event_name != 'pull_request'
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+            - name: Download JUnit artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              continue-on-error: true
+              with:
+                  path: ./junit-artifacts
+                  pattern: junit-results-storybook-*
+            - name: Upload to Trunk
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-artifacts/**/*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -508,6 +508,7 @@ jobs:
                   name: junit-results-storybook-${{ matrix.browser }}-${{ matrix.shard }}
                   path: common/storybook/junit.xml
                   if-no-files-found: ignore
+                  retention-days: 1
 
     # Verify changed story files are stable by re-running them multiple times.
     # Catches flaky snapshots before they land on master.

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -910,9 +910,20 @@ jobs:
               with:
                   path: ./junit-artifacts
                   pattern: junit-results-storybook-*
-            - name: Upload to Trunk
+            # chromium and webkit run the same stories, so a single upload would give one test id
+            # both browsers' outcomes and a browser-specific failure would look like a flake.
+            # Upload each browser under its own Trunk variant to keep their histories distinct.
+            - name: Upload chromium results to Trunk
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
-                  junit-paths: junit-artifacts/**/*.xml
+                  junit-paths: junit-artifacts/junit-results-storybook-chromium-*/*.xml
                   org-slug: posthog-inc
+                  variant: chromium
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
+            - name: Upload webkit results to Trunk
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-artifacts/junit-results-storybook-webkit-*/*.xml
+                  org-slug: posthog-inc
+                  variant: webkit
                   token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -237,8 +237,7 @@ const config: Config = {
     // Run tests from one or more projects
     // projects: undefined,
 
-    // Emit JUnit XML for Trunk flaky-test detection only when the workflow sets
-    // JEST_JUNIT_OUTPUT_DIR; local runs keep the default reporter and write no files.
+    // Emit JUnit XML for Trunk flaky-test detection only when JEST_JUNIT_OUTPUT_DIR is set.
     reporters: process.env.JEST_JUNIT_OUTPUT_DIR ? ['default', 'jest-junit'] : ['default'],
 
     // Automatically reset mock state between every test

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -237,8 +237,9 @@ const config: Config = {
     // Run tests from one or more projects
     // projects: undefined,
 
-    // Use this configuration option to add custom reporters to Jest
-    // reporters: undefined,
+    // Emit JUnit XML for Trunk flaky-test detection only when the workflow sets
+    // JEST_JUNIT_OUTPUT_DIR; local runs keep the default reporter and write no files.
+    reporters: process.env.JEST_JUNIT_OUTPUT_DIR ? ['default', 'jest-junit'] : ['default'],
 
     // Automatically reset mock state between every test
     // resetMocks: false,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -322,6 +322,7 @@
         "jest-canvas-mock": "^2.4.0",
         "jest-environment-jsdom": "^29.3.1",
         "jest-image-snapshot": "^6.1.0",
+        "jest-junit": "^16.0.0",
         "kea-typegen": "3.7.1",
         "less": "^3.12.2",
         "lint-staged": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1300,6 +1300,9 @@ importers:
       jest-image-snapshot:
         specifier: ^6.1.0
         version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
       kea-typegen:
         specifier: 3.7.1
         version: 3.7.1(typescript@6.0.3)

--- a/turbo.json
+++ b/turbo.json
@@ -64,7 +64,11 @@
                 "REDIS_URL",
                 "NODE_OPTIONS",
                 "PERSONS_DATABASE_URL",
-                "PERSONS_READONLY_DATABASE_URL"
+                "PERSONS_READONLY_DATABASE_URL",
+                "JEST_JUNIT_OUTPUT_DIR",
+                "JEST_JUNIT_OUTPUT_NAME",
+                "JEST_JUNIT_SUITE_NAME",
+                "JEST_JUNIT_ADD_FILE_ATTRIBUTE"
             ]
         },
         "start": {


### PR DESCRIPTION
## Problem

We recently wired the backend and Playwright E2E suites into [Trunk Flaky Tests](https://docs.trunk.io/flaky-tests) (#67433), but the two remaining high-value frontend suites still don't feed it: the Storybook visual-regression tests and the frontend jest suite. Both are places flakes actually show up, so leaving them out is a real gap in flake detection.

## Changes

Follows the exact pattern from #67433: aggregate JUnit into a dedicated `trunk-upload` job, upload on trusted non-`pull_request` events only, use the pinned external uploader. Reuses the existing `TRUNK_API_TOKEN` secret and `posthog-inc` org slug, so no new setup.

**Storybook (`ci-storybook.yml`)** — the quick win. The `visual-regression` shards already emit and upload `junit-results-storybook-*` artifacts, so this is purely additive: a new `trunk-upload` job downloads them and uploads once. No changes to any test step.

**Frontend jest (`ci-frontend.yml` + config)** — needed reporter wiring, since jest wasn't emitting JUnit at all:

- `frontend/jest.config.ts` adds the `jest-junit` reporter, but only when the workflow sets `JEST_JUNIT_OUTPUT_DIR`. Local `jest` runs keep the default reporter and write no files.
- `frontend/package.json` gains `jest-junit` as a devDependency. It already existed in the lockfile as a transitive dep of the Storybook test-runner, so the `pnpm-lock.yaml` change is 3 lines.
- The jest job sets the output dir/name and uploads `junit-results-frontend-*` artifacts across all four FOSS/EE × chunk shards.
- A new `trunk-upload` job aggregates those and feeds them to Trunk.

Both `trunk-upload` jobs are `continue-on-error` and gated on `github.event_name != 'pull_request'`, so the secret never materializes in a PR-controlled run and a Trunk hiccup never fails a job.

## How did you test this code?

I (Claude, via PostHog Code) verified locally:

- Smoke-tested the jest reporter both ways: with `JEST_JUNIT_OUTPUT_DIR` set, jest writes valid JUnit XML at the configured path; without it, no file is written (no local litter).
- Confirmed `jest-junit` resolves from the `@posthog/frontend` package and that `pnpm --filter=@posthog/frontend install --frozen-lockfile` passes with the 3-line lockfile change.
- `oxlint` on `jest.config.ts` is clean; both workflow YAMLs parse and the `trunk-upload` jobs are wired correctly.
- `hogli ci:preflight --strict` passes (lockfile + workflow-lint, 0 failures).

I could not exercise the actual Trunk upload — like #67433 that can only be confirmed once a master/merge run completes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul asked to extend the Trunk wiring from #67433 to the Storybook and frontend suites; I (Claude, via PostHog Code) implemented it. The Storybook side was trivial since the JUnit artifacts already existed. The frontend side needed the `jest-junit` reporter, gated behind an env var so it stays CI-only. A full `pnpm install` re-resolved unrelated peer contexts across ~300 lockfile lines, so I reverted that and added the single importer entry by hand (`jest-junit@16.0.0` was already present transitively), keeping the lockfile diff to 3 lines. I also caught and reverted two unrelated files that an interrupted `oxlint --fix` run had auto-edited before they reached the commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
