### PR TITLE
fix(logs): give each replica its own metric series via service.instance.id

### DIFF
--- a/nodejs/src/common/metrics/otel-metrics.ts
+++ b/nodejs/src/common/metrics/otel-metrics.ts
@@ -3,6 +3,7 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
+import { hostname } from 'os'
 
 import { defaultConfig } from '~/common/config/config'
 import { logger } from '~/common/utils/logger'
@@ -35,6 +36,10 @@ export const initMetrics = (): void => {
             [ATTR_SERVICE_NAME]:
                 defaultConfig.OTEL_SERVICE_NAME ?? `node-${defaultConfig.PLUGIN_SERVER_MODE ?? 'nodejs'}`,
             [ATTR_SERVICE_VERSION]: process.env.COMMIT_SHA ?? 'dev',
+            // Per-replica identity. Without it every pod shares one series, and
+            // their interleaved cumulative counters read as constant resets —
+            // rate()/increase() overcount by roughly the replica count.
+            'service.instance.id': hostname(),
         }),
         readers: [
             new PeriodicExportingMetricReader({


### PR DESCRIPTION
## Problem

The cross-pipeline validation for #68017 (comparing `increase(logs_pii_replacements_total)` against the same window's `pii_replacements` rows in `app_metrics2`) showed a ~15x overcount: 6,655,022 vs 451,804 over an identical 5-minute window.

Root cause: the `MeterProvider` resource carried only `service.name` + `service.version` — identical for every replica — so all ~60 logs-ingestion pods collapsed onto **one** metric series (single `series_fingerprint`, verified in `metric_series1`). Sixty independent cumulative counters interleaved in one series make every downward jump between pods look like a counter reset, and reset-safe `rate()`/`increase()` re-add the full value each flip.

Prometheus scraping never hits this because per-target labels carry replica identity implicitly; SDK push must carry it in the resource. Any customer running multiple replicas would reproduce this exactly — it's going in the onboarding docs as a named pitfall.

## Change

One resource attribute: `service.instance.id` (the OTel semconv attribute for replica identity) set from the pod hostname. Each replica becomes its own series; per-series counter math becomes correct; series cardinality grows by replica count, same as scraped metrics always had.

## How did you test this code?

Agent-authored. Existing `otel-metrics.test.ts` green (the counter path is unchanged — only the provider resource gains an attribute). The real validation is empirical and already staged: after deploy, re-run the two-pipeline reconciliation — `increase` over a settled window should match `app_metrics2`'s `SUM(count)` within timing skew, where today it's ~15x off.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Found minutes after the #68017 deploy by the planned reconciliation check (two independent pipelines measuring the same scrub events); DRI @DanielVisca.
- The bug class is the same one the metrics fingerprint work just fixed at the storage layer — insufficient series identity — recurring at the producer layer.
