### PR TITLE
feat(toolbar): enable clickmaps by default in the heatmap menu

### DIFF
--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -745,16 +745,16 @@ export const toolbarLogic = kea<toolbarLogicType>([
                             const payload = e.data.payload
                             actions.setIsEmbeddedInApp(true)
                             actions.toggleClickmapsEnabled(false)
-                            if (payload?.filters !== undefined) {
+                            if (payload?.filters != null) {
                                 actions.patchHeatmapFilters(payload.filters)
                             }
-                            if (payload?.colorPalette !== undefined) {
+                            if (payload?.colorPalette != null) {
                                 actions.setHeatmapColorPalette(payload.colorPalette)
                             }
-                            if (payload?.fixedPositionMode !== undefined) {
+                            if (payload?.fixedPositionMode != null) {
                                 actions.setHeatmapFixedPositionMode(payload.fixedPositionMode)
                             }
-                            if (payload?.commonFilters !== undefined) {
+                            if (payload?.commonFilters != null) {
                                 actions.setCommonFilters(payload.commonFilters)
                             }
                             // it's ok to use we use a wildcard for the origin bc data isn't sensitive

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -746,8 +746,8 @@ export const toolbarLogic = kea<toolbarLogicType>([
                             actions.patchHeatmapFilters(e.data.payload.filters)
                             actions.setHeatmapColorPalette(e.data.payload.colorPalette)
                             actions.setHeatmapFixedPositionMode(e.data.payload.fixedPositionMode)
-                            actions.setCommonFilters(e.data.payload.commonFilters)
                             actions.toggleClickmapsEnabled(false)
+                            actions.setCommonFilters(e.data.payload.commonFilters)
                             // it's ok to use we use a wildcard for the origin bc data isn't sensitive
                             // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
                             window.parent.postMessage({ type: PostHogAppToolbarEvent.PH_TOOLBAR_READY }, '*')

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -741,25 +741,27 @@ export const toolbarLogic = kea<toolbarLogicType>([
                     }
 
                     switch (type) {
-                        case PostHogAppToolbarEvent.PH_APP_INIT:
+                        case PostHogAppToolbarEvent.PH_APP_INIT: {
+                            const payload = e.data.payload
                             actions.setIsEmbeddedInApp(true)
                             actions.toggleClickmapsEnabled(false)
-                            if (e.data.payload?.filters !== undefined) {
-                                actions.patchHeatmapFilters(e.data.payload.filters)
+                            if (payload?.filters !== undefined) {
+                                actions.patchHeatmapFilters(payload.filters)
                             }
-                            if (e.data.payload?.colorPalette !== undefined) {
-                                actions.setHeatmapColorPalette(e.data.payload.colorPalette)
+                            if (payload?.colorPalette !== undefined) {
+                                actions.setHeatmapColorPalette(payload.colorPalette)
                             }
-                            if (e.data.payload?.fixedPositionMode !== undefined) {
-                                actions.setHeatmapFixedPositionMode(e.data.payload.fixedPositionMode)
+                            if (payload?.fixedPositionMode !== undefined) {
+                                actions.setHeatmapFixedPositionMode(payload.fixedPositionMode)
                             }
-                            if (e.data.payload?.commonFilters !== undefined) {
-                                actions.setCommonFilters(e.data.payload.commonFilters)
+                            if (payload?.commonFilters !== undefined) {
+                                actions.setCommonFilters(payload.commonFilters)
                             }
                             // it's ok to use we use a wildcard for the origin bc data isn't sensitive
                             // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
                             window.parent.postMessage({ type: PostHogAppToolbarEvent.PH_TOOLBAR_READY }, '*')
                             return
+                        }
                         case PostHogAppToolbarEvent.PH_ELEMENT_SELECTOR:
                             if (e.data.payload.enabled) {
                                 actions.enableInspect()

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -743,11 +743,19 @@ export const toolbarLogic = kea<toolbarLogicType>([
                     switch (type) {
                         case PostHogAppToolbarEvent.PH_APP_INIT:
                             actions.setIsEmbeddedInApp(true)
-                            actions.patchHeatmapFilters(e.data.payload.filters)
-                            actions.setHeatmapColorPalette(e.data.payload.colorPalette)
-                            actions.setHeatmapFixedPositionMode(e.data.payload.fixedPositionMode)
                             actions.toggleClickmapsEnabled(false)
-                            actions.setCommonFilters(e.data.payload.commonFilters)
+                            if (e.data.payload?.filters !== undefined) {
+                                actions.patchHeatmapFilters(e.data.payload.filters)
+                            }
+                            if (e.data.payload?.colorPalette !== undefined) {
+                                actions.setHeatmapColorPalette(e.data.payload.colorPalette)
+                            }
+                            if (e.data.payload?.fixedPositionMode !== undefined) {
+                                actions.setHeatmapFixedPositionMode(e.data.payload.fixedPositionMode)
+                            }
+                            if (e.data.payload?.commonFilters !== undefined) {
+                                actions.setCommonFilters(e.data.payload.commonFilters)
+                            }
                             // it's ok to use we use a wildcard for the origin bc data isn't sensitive
                             // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
                             window.parent.postMessage({ type: PostHogAppToolbarEvent.PH_TOOLBAR_READY }, '*')

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -128,5 +128,14 @@ describe('heatmapToolbarMenuLogic', () => {
             }).toDispatchActions(['getElementStats', 'getElementStatsSuccess'])
             expect(toolbarApi.elementStats.list).not.toHaveBeenCalled()
         })
+
+        it('keeps heatmapEnabled true after a stats fetch failure so the menu stays open', async () => {
+            jest.spyOn(toolbarApi.elementStats, 'list').mockRejectedValue(new Error('network error'))
+            await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions([
+                'getElementStats',
+                'getElementStatsFailure',
+            ])
+            expect(logic.values.heatmapEnabled).toBe(true)
+        })
     })
 })

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -137,5 +137,15 @@ describe('heatmapToolbarMenuLogic', () => {
             ])
             expect(logic.values.heatmapEnabled).toBe(true)
         })
+
+        it('retries the initial load via load more after a stats fetch failure', async () => {
+            jest.spyOn(toolbarApi.elementStats, 'list').mockRejectedValueOnce(new Error('network error'))
+            await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions(['getElementStatsFailure'])
+            await expectLogic(logic, () => logic.actions.loadMoreElementStats()).toDispatchActions([
+                'getElementStats',
+                'getElementStatsSuccess',
+            ])
+            expect(toolbarApi.elementStats.list).toHaveBeenCalledTimes(2)
+        })
     })
 })

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -120,5 +120,13 @@ describe('heatmapToolbarMenuLogic', () => {
                 'getElementStats',
             ])
         })
+
+        it('does not fetch element stats when clickmaps are toggled off while the request is debouncing', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.enableHeatmap()
+                logic.actions.toggleClickmapsEnabled(false)
+            }).toDispatchActions(['getElementStats', 'getElementStatsSuccess'])
+            expect(toolbarApi.elementStats.list).not.toHaveBeenCalled()
+        })
     })
 })

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -1,6 +1,11 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { toolbarApi } from '~/toolbar/toolbarApi'
+import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { ElementsEventType } from '~/toolbar/types'
 
-import { dedupeByChainIdentity } from './heatmapToolbarMenuLogic'
+import { dedupeByChainIdentity, heatmapToolbarMenuLogic } from './heatmapToolbarMenuLogic'
 
 function statsRow(overrides: Partial<ElementsEventType>): ElementsEventType {
     return {
@@ -12,44 +17,108 @@ function statsRow(overrides: Partial<ElementsEventType>): ElementsEventType {
     } as ElementsEventType
 }
 
-describe('dedupeByChainIdentity', () => {
-    const cases = [
-        {
-            name: 'keeps distinct chains when a legacy server returns hash null',
-            events: [
-                statsRow({ elements: [{ tag_name: 'button', attributes: {} }] as ElementsEventType['elements'] }),
-                statsRow({ elements: [{ tag_name: 'a', attributes: {} }] as ElementsEventType['elements'] }),
-            ],
-            expectedCount: 2,
-        },
-        {
-            name: 'drops a null-hash chain repeated across paginated pages, keeping the first occurrence',
-            events: [statsRow({ count: 10 }), statsRow({ count: 3 })],
-            expectedCount: 1,
-        },
-        {
-            name: 'keeps identical chains that differ by event type',
-            events: [statsRow({ type: '$autocapture' }), statsRow({ type: '$rageclick' })],
-            expectedCount: 2,
-        },
-        {
-            name: 'keeps distinct hashes even when attribute trimming made the chains serialize identically',
-            events: [statsRow({ hash: 'abc123' }), statsRow({ hash: 'def456' })],
-            expectedCount: 2,
-        },
-        {
-            name: 'drops a repeated hash across paginated pages, keeping the first occurrence',
-            events: [statsRow({ hash: 'abc123', count: 10 }), statsRow({ hash: 'abc123', count: 3 })],
-            expectedCount: 1,
-        },
-    ]
+describe('heatmapToolbarMenuLogic', () => {
+    describe('dedupeByChainIdentity', () => {
+        const cases = [
+            {
+                name: 'keeps distinct chains when a legacy server returns hash null',
+                events: [
+                    statsRow({ elements: [{ tag_name: 'button', attributes: {} }] as ElementsEventType['elements'] }),
+                    statsRow({ elements: [{ tag_name: 'a', attributes: {} }] as ElementsEventType['elements'] }),
+                ],
+                expectedCount: 2,
+            },
+            {
+                name: 'drops a null-hash chain repeated across paginated pages, keeping the first occurrence',
+                events: [statsRow({ count: 10 }), statsRow({ count: 3 })],
+                expectedCount: 1,
+            },
+            {
+                name: 'keeps identical chains that differ by event type',
+                events: [statsRow({ type: '$autocapture' }), statsRow({ type: '$rageclick' })],
+                expectedCount: 2,
+            },
+            {
+                name: 'keeps distinct hashes even when attribute trimming made the chains serialize identically',
+                events: [statsRow({ hash: 'abc123' }), statsRow({ hash: 'def456' })],
+                expectedCount: 2,
+            },
+            {
+                name: 'drops a repeated hash across paginated pages, keeping the first occurrence',
+                events: [statsRow({ hash: 'abc123', count: 10 }), statsRow({ hash: 'abc123', count: 3 })],
+                expectedCount: 1,
+            },
+        ]
 
-    it.each(cases)('$name', ({ events, expectedCount }) => {
-        expect(dedupeByChainIdentity(events)).toHaveLength(expectedCount)
+        it.each(cases)('$name', ({ events, expectedCount }) => {
+            expect(dedupeByChainIdentity(events)).toHaveLength(expectedCount)
+        })
+
+        it('keeps the first occurrence of a duplicated chain', () => {
+            const [kept] = dedupeByChainIdentity([statsRow({ count: 10 }), statsRow({ count: 3 })])
+            expect(kept.count).toBe(10)
+        })
     })
 
-    it('keeps the first occurrence of a duplicated chain', () => {
-        const [kept] = dedupeByChainIdentity([statsRow({ count: 10 }), statsRow({ count: 3 })])
-        expect(kept.count).toBe(10)
+    describe('clickmap loading', () => {
+        let logic: ReturnType<typeof heatmapToolbarMenuLogic.build>
+
+        beforeEach(() => {
+            global.IntersectionObserver = class {
+                observe(): void {}
+                unobserve(): void {}
+                disconnect(): void {}
+            } as any
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ results: [] }),
+                } as any as Response)
+            )
+            jest.spyOn(toolbarApi.elementStats, 'list').mockResolvedValue({
+                ok: true,
+                status: 200,
+                data: { results: [], next: null, previous: null },
+            } as any)
+
+            initKeaTests()
+            toolbarConfigLogic
+                .build({
+                    apiURL: 'http://localhost',
+                    accessToken: 'test-token',
+                    refreshToken: 'test-refresh',
+                    clientId: 'test-client',
+                })
+                .mount()
+            logic = heatmapToolbarMenuLogic()
+            logic.mount()
+        })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('loads element stats as soon as the heatmap menu opens, without toggling clickmaps', async () => {
+            await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions([
+                'getElementStats',
+                'getElementStatsSuccess',
+            ])
+            expect(toolbarApi.elementStats.list).toHaveBeenCalled()
+        })
+
+        it('does not fetch element stats on navigation while the heatmap menu is closed', async () => {
+            await expectLogic(logic, () =>
+                logic.actions.setHref('https://example.com/other')
+            ).toNotHaveDispatchedActions(['getElementStats'])
+            expect(toolbarApi.elementStats.list).not.toHaveBeenCalled()
+        })
+
+        it('fetches element stats on navigation while the heatmap menu is open', async () => {
+            await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions(['getElementStats'])
+            await expectLogic(logic, () => logic.actions.setHref('https://example.com/other')).toDispatchActions([
+                'getElementStats',
+            ])
+        })
     })
 })

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -620,6 +620,9 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         loadMoreElementStats: () => {
             if (values.elementStats?.next) {
                 actions.getElementStats(values.elementStats.next)
+            } else if (!values.elementStats) {
+                // the initial load failed, so the button doubles as the retry affordance
+                actions.maybeLoadClickmap()
             }
         },
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -274,6 +274,10 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 getElementStats: async ({ url, limit }, breakpoint) => {
                     await breakpoint(150)
 
+                    if (!values.heatmapEnabled || !values.clickmapsEnabled) {
+                        return emptyElementsStatsPages
+                    }
+
                     const { href, wildcardHref } = values
                     // We re-raise below to drive getElementStatsFailure; let the global
                     // loader handler report it once rather than capturing twice.
@@ -629,7 +633,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             // the first page painted; fetch the rest in one background request. Only the initial
             // trigger refetches, so an auto-load result can never re-trigger itself.
-            if (trigger === 'initial' && elementStats?.next && values.clickmapsEnabled) {
+            if (trigger === 'initial' && elementStats?.next && values.heatmapEnabled && values.clickmapsEnabled) {
                 actions.getElementStats(null, ELEMENT_STATS_AUTO_LOAD_LIMIT)
             }
         },

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -274,6 +274,8 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 getElementStats: async ({ url, limit }, breakpoint) => {
                     await breakpoint(150)
 
+                    // the gates can flip while we sit in the breakpoint (the embedded app sends
+                    // toggleClickmapsEnabled(false) just after mount), so re-check before fetching
                     if (!values.heatmapEnabled || !values.clickmapsEnabled) {
                         return emptyElementsStatsPages
                     }
@@ -604,7 +606,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
         toggleClickmapsEnabled: () => {
             if (values.clickmapsEnabled) {
-                actions.getElementStats()
+                actions.maybeLoadClickmap()
             } else {
                 actions.stopElementObservation()
                 actions.resetElementStats()

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -200,7 +200,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             {
                 enableHeatmap: () => true,
                 disableHeatmap: () => false,
-                getElementStatsFailure: () => false,
             },
         ],
         clickmapsEnabled: [
@@ -277,7 +276,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                     // the gates can flip while we sit in the breakpoint (the embedded app sends
                     // toggleClickmapsEnabled(false) just after mount), so re-check before fetching
                     if (!values.heatmapEnabled || !values.clickmapsEnabled) {
-                        return emptyElementsStatsPages
+                        return values.elementStats ?? emptyElementsStatsPages
                     }
 
                     const { href, wildcardHref } = values

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -204,7 +204,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             },
         ],
         clickmapsEnabled: [
-            false,
+            true,
             {
                 toggleClickmapsEnabled: (_, { enabled }) => enabled,
             },
@@ -563,7 +563,9 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
 
         maybeLoadClickmap: async () => {
-            if (values.clickmapsEnabled) {
+            // this logic stays mounted while the heatmap menu is closed, so navigation
+            // must not fetch stats until the user is actually looking
+            if (values.heatmapEnabled && values.clickmapsEnabled) {
                 actions.getElementStats()
             }
         },


### PR DESCRIPTION
## Problem

Opening the toolbar's heatmap menu loads the heatmap immediately, but clickmaps start disabled — every session begins with an extra toggle before autocapture click data appears. That default made sense when loading and rendering the clickmap was slow; after the recent matching rewrite, server-side serialization fix, and background auto-load, it no longer does.

## Changes

- `clickmapsEnabled` now defaults to `true`, so opening the heatmap menu loads heatmap and clickmap together. Turning clickmaps off still works and sticks for the session, and the embedded app browser still disables them explicitly on init.
- `maybeLoadClickmap` now also requires heatmap mode to be active. The logic stays mounted while the menu is closed, and `setHref` fires on every SPA navigation - without this gate the new default would fetch element stats on every navigation even when nobody is looking at the heatmap. (This was already latently reachable if you toggled clickmaps on and closed the menu.)

## How did you test this code?

Added three kea logic tests in `heatmapToolbarMenuLogic.test.ts` (mounted logic, mocked `toolbarApi`):

- opening the heatmap menu dispatches `getElementStats` without any clickmap toggle - catches a revert of the default to `false`
- navigation with the menu closed does not dispatch `getElementStats` - catches removal of the `heatmapEnabled` gate (verified this test fails against the ungated version)
- navigation with the menu open still dispatches `getElementStats` - catches over-gating

No existing test mounted this logic; the previous file only covered the pure `dedupeByChainIdentity` helper, now nested alongside under a single top-level describe.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude). Skills invoked: /writing-tests. Stacked on #68063 (clickmap auto-load) since both touch the same logic file. Considered persisting the toggle across sessions but dropped it: the embedded app browser calls `toggleClickmapsEnabled(false)` on init, and persisting that write from an iframe could bleed a "clickmaps off" preference into real on-site sessions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*