### PR TITLE
fix(metrics): make minute/second date ranges resolve — and roll from now

### DIFF
--- a/frontend/src/lib/utils/dateFilters.test.ts
+++ b/frontend/src/lib/utils/dateFilters.test.ts
@@ -212,6 +212,16 @@ describe('dateFilters utils', () => {
             expect(dateStringToDayJs('1999-12-31')?.utc(true).toISOString()).toEqual('1999-12-31T00:00:00.000Z')
         })
 
+        it('anchors sub-day units at now, not start of day', () => {
+            // frozen: 2012-03-02T11:38:49.321Z. A "-30M" range must mean 30
+            // minutes ago — day-anchoring would yield yesterday 23:30 and the
+            // metrics/logs "last N minutes" pickers would show a ~24h window.
+            expect(dateStringToDayJs('-30M')?.toISOString()).toEqual('2012-03-02T11:08:49.321Z')
+            expect(dateStringToDayJs('-5M')?.toISOString()).toEqual('2012-03-02T11:33:49.321Z')
+            expect(dateStringToDayJs('-1h')?.toISOString()).toEqual('2012-03-02T10:38:49.321Z')
+            expect(dateStringToDayJs('-45s')?.toISOString()).toEqual('2012-03-02T11:38:04.321Z')
+        })
+
         it('handles various units', () => {
             expect(dateStringToDayJs('d')?.utc(true).toISOString()).toEqual('2012-03-02T00:00:00.000Z')
             expect(dateStringToDayJs('m')?.utc(true).toISOString()).toEqual('2012-03-02T00:00:00.000Z')

--- a/frontend/src/lib/utils/dateFilters.ts
+++ b/frontend/src/lib/utils/dateFilters.ts
@@ -237,7 +237,7 @@ export type DateComponents = {
     clip: 'Start' | 'End'
 }
 
-export const isStringDateRegex = /^([-+]?)([0-9]*)([hdwmqy])(|Start|End)$/
+export const isStringDateRegex = /^([-+]?)([0-9]*)([hdwmqyMs])(|Start|End)$/
 
 export function dateStringToComponents(date: string | null): DateComponents | null {
     if (!date) {
@@ -306,7 +306,11 @@ export function dateStringToDayJs(date: string | null, timezone: string = 'UTC')
     if (!dateComponents) {
         return null
     }
-    const offset: dayjs.Dayjs = dayjs().tz(timezone).startOf('day')
+    // Calendar units anchor at the start of today; sub-day units are rolling
+    // windows from now ("-30M" must mean 30 minutes ago, not today 00:00 minus
+    // 30 minutes = yesterday 23:30) — matching the backend's relative_date_parse.
+    const isSubDay = ['hour', 'minute', 'second'].includes(dateComponents.unit)
+    const offset: dayjs.Dayjs = isSubDay ? dayjs().tz(timezone) : dayjs().tz(timezone).startOf('day')
     const response = componentsToDayJs(dateComponents, offset, timezone)
     return response
 }


### PR DESCRIPTION
> **Found by: metrics push-model dogfood validation** (first-time-user pass over the new SDK-push pipeline; reported symptom: viewer shows "No data" for last 5/30 minutes while storage has fresh rows).

## Problem

Picking **Last 5 minutes** or **Last 30 minutes** in the metrics viewer renders "No data" even when the metric has samples seconds old (verified: 5,070 rows in the window in ClickHouse while the UI showed nothing). Two stacked defects in `lib/utils/dateFilters`:

1. `isStringDateRegex` accepts `[hdwmqy]` only, but `dateOptionsMap` defines `M` (minute) and `s` (second). The viewer's minute options emit `-5M`/`-30M` → regex miss → `dateStringToDayJs` returns null → the viewer's `resolveDate` falls back to `dayjs('-30M')` (invalid) → the loader silently returns `[]`.
2. Even parsing wouldn't have made them correct: `dateStringToDayJs` anchors **every** relative date at `startOf('day')`, so `-30M` would mean *today 00:00 − 30 min = yesterday 23:30* — a ~24h window labeled "Last 30 minutes". This also means the working `-1h` option has been querying *since yesterday 23:00* while labeled "Last 1 hour".

## Changes

- Regex unit class gains `M` and `s` (both already in `dateOptionsMap` and `componentsToDayJs` — the regex was the only gap).
- Sub-day units (`hour`/`minute`/`second`) anchor at **now** (rolling window), matching the backend's `relative_date_parse`; calendar units (`d/w/m/q/y`) keep `startOf('day')` anchoring so insights behavior is untouched.

## How did you test this code?

- New frozen-time test locks both behaviors (`-30M`/`-5M`/`-1h`/`-45s` resolve to exact rolling instants). **Red without the fix** (1 failed / 39 passed), green with it (40/40) — the 39 pre-existing cases pin calendar-unit anchoring unchanged.
- Empirical cross-check: the same window that renders "No data" in the viewer returns 21 per-minute points via `query-metrics` — confirming data presence and isolating the bug to date resolution.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Part of the commissioned metrics-validation dogfood (DRI @DanielVisca): act as a first-time user of the push-model metrics product, chase every discrepancy to root cause, ship observed fixes.
- Note for reviewers outside metrics: this touches the shared date helper; the deliberate scope decision is that only sub-day units change semantics (previously either broken or nonsensically day-anchored), calendar units are pinned by existing tests.
