### PR TITLE
chore(ci): format CODEOWNERS-soft as CODEOWNERS on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,10 @@
 .github/ export-ignore
 CONTRIBUTING.md export-ignore
 CODE_OF_CONDUCT.md export-ignore
+
+# Format the soft CODEOWNERS file with CODEOWNERS syntax highlighting on GitHub.
+.github/CODEOWNERS-soft linguist-language=CODEOWNERS
+
 # Generated code: exclude from GitHub Linguist stats and suppress diffs.
 frontend/src/generated/** linguist-generated
 frontend/src/lib/posthog-typed.ts linguist-generated


### PR DESCRIPTION
## Problem

`.github/CODEOWNERS-soft` uses the exact same syntax as `.github/CODEOWNERS`, but GitHub Linguist only auto-detects files literally named `CODEOWNERS`. So the soft variant renders as plain text with no syntax highlighting.

## Changes

Add a `linguist-language=CODEOWNERS` override in `.gitattributes` for `.github/CODEOWNERS-soft` so GitHub formats it with CODEOWNERS syntax highlighting, matching the real file.

## How did you test this code?

No automated tests apply. This is a Linguist attribute change that only affects how GitHub renders the file. It takes effect once merged to the default branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael asked me (Claude) to update `.gitattributes` so `CODEOWNERS-soft` is formatted as CODEOWNERS on GitHub. I added a single `linguist-language=CODEOWNERS` override for the path, since Linguist only auto-detects the canonical `CODEOWNERS` filename.
