### PR TITLE
fix(metrics): emit gap instead of quantile 0 when window has no bucket increase

### DIFF
--- a/products/metrics/backend/metric_query_runner.py
+++ b/products/metrics/backend/metric_query_runner.py
@@ -322,6 +322,11 @@ class MetricQueryRunner:
         for row in response.results:
             bounds = list(row[1 + group_count])
             counts = list(row[3 + group_count])
+            if sum(counts) <= 0:
+                # No computable increase in this bucket (e.g. a cumulative
+                # series' first sample has nothing to diff against). A gap is
+                # honest; a fabricated quantile of 0 reads as "p95 is 0s".
+                continue
             rows.append(
                 {
                     "time": row[0].isoformat() if isinstance(row[0], dt.datetime) else row[0],

--- a/products/metrics/backend/tests/test_metric_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_query_runner.py
@@ -921,6 +921,14 @@ class TestHistogramQuantileRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(rows), 1)
         self.assertAlmostEqual(rows[0]["value"], 0.3)
 
+    def test_cumulative_lone_sample_emits_no_point(self):
+        # A cumulative histogram's first (and only) sample has no predecessor
+        # to diff against — the window has no computable increase. That must
+        # be a gap, not a fabricated p95 of 0 (which reads as "p95 is 0s").
+        self._seed_histogram([(self.anchor, [1, 1, 1, 0])], temporality="cumulative")
+        rows = self._run(0.95)
+        self.assertEqual(rows, [])
+
     def test_mismatched_bounds_raise(self):
         self._seed_histogram([(self.anchor + dt.timedelta(seconds=0), [1, 1, 1, 0])], temporality="delta")
         self._seed_histogram(


### PR DESCRIPTION
> [!NOTE]
> **Found by: metrics push-model dogfood validation** — part of a systematic first-time-user pass over the new OTLP push ingestion path.

## Problem

`histogram_quantile` fabricates a data point of `0` for any time bucket where the metric's histogram has no computable increase. The most common trigger: a cumulative histogram's first sample in the query window has no predecessor to diff against, so its window contribution is all zeros — and `_histogram_quantile` maps an empty distribution to `0.0`.

To a user this reads as "p95 latency was 0 seconds", which is indistinguishable from a genuinely instant operation. Prometheus's `histogram_quantile` over `rate()` produces a gap (`NaN`/no point) in this situation, which is the honest answer.

Observed against real pushed data: querying p95 of a cumulative OTLP histogram (`e2e_probe_duration_seconds`, buckets `[0.1, 0.5, 1.0]`) with a single sample in the window returned a point with value `0`. Two consecutive samples returned the correct quantile.

## Changes

In `_run_histogram_quantile`, skip rows whose summed bucket counts are `<= 0` instead of emitting a fabricated `0` point. Windows with real increases are unaffected.

## How did you test this code?

Added `test_cumulative_lone_sample_emits_no_point`: seeds a single cumulative histogram sample and asserts no point is returned. It fails on master (a `value: 0` row comes back) and passes with the fix — no existing test covered the lone-sample window. Full `test_metric_query_runner.py` suite passes (89/89).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) found this while dogfooding the metrics push pipeline end to end: fired synthetic OTLP cumulative histograms at a live environment, queried quantiles back through the API, and compared against Prometheus semantics. Skills invoked: /writing-tests, /get-stamp. The fix deliberately produces a gap rather than interpolating or carrying forward — matching Prometheus so dashboards read the same way users expect.
