### PR TITLE
chore(ci): minimize superseded bot comments on PRs

### DIFF
--- a/.github/scripts/minimize-superseded-comments.mjs
+++ b/.github/scripts/minimize-superseded-comments.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Minimizes superseded bot comments on a PR so only the latest of each kind stays
+// visible. Some bots post a NEW top-level comment or review on every push instead of
+// updating in place — each is correct when posted, but only the newest matters, and
+// the pile-up buries the human conversation. The sibling job in this workflow resolves
+// outdated bot review THREADS; this covers top-level comments and per-push reviews,
+// collapsing the older ones as OUTDATED (still expandable, never deleted).
+//
+// Best-effort throughout: any fetch or mutation failure warns and moves on — hiding
+// stale bot noise is never worth a red check.
+//
+// Env: GITHUB_TOKEN (or GH_TOKEN), GITHUB_REPOSITORY, PR_NUMBER.
+
+// Keep-newest groups. A comment/review belongs to a group when its author matches and
+// its body (leading whitespace ignored) starts with the prefix — bots occasionally pad
+// the front of the body with blank lines.
+const COMMENT_GROUPS = [
+    // stamphog's per-push "kept your approval" notes (pr-approval-agent.yml)
+    { author: 'github-actions[bot]', prefix: 'Retaining stamphog approval' },
+    // commit-snapshots' "branch advanced" skip notices
+    { author: 'github-actions[bot]', prefix: '⏭️ Skipped snapshot commit' },
+]
+const REVIEW_GROUPS = [
+    // Codex posts a fresh review per reviewed commit
+    { author: 'chatgpt-codex-connector', prefix: '### 💡 Codex Review' },
+]
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+const repo = process.env.GITHUB_REPOSITORY
+const prNumber = Number.parseInt(process.env.PR_NUMBER ?? '', 10)
+if (!token || !repo || !Number.isFinite(prNumber)) {
+    console.warn('Missing GITHUB_TOKEN/GITHUB_REPOSITORY/PR_NUMBER — skipping.')
+    process.exit(0)
+}
+const [owner, name] = repo.split('/')
+
+async function graphql(query, variables) {
+    const response = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+    })
+    const payload = await response.json()
+    if (!response.ok || payload.errors) {
+        throw new Error(`GraphQL failed: ${JSON.stringify(payload.errors ?? payload)}`.slice(0, 500))
+    }
+    return payload.data
+}
+
+async function fetchAll(field) {
+    const nodes = []
+    let cursor = null
+    do {
+        const data = await graphql(
+            `query($owner: String!, $name: String!, $pr: Int!, $cursor: String) {
+                repository(owner: $owner, name: $name) {
+                    pullRequest(number: $pr) {
+                        ${field}(first: 100, after: $cursor) {
+                            pageInfo { hasNextPage endCursor }
+                            nodes { id body createdAt isMinimized author { login } }
+                        }
+                    }
+                }
+            }`,
+            { owner, name, pr: prNumber, cursor }
+        )
+        const page = data.repository.pullRequest[field]
+        nodes.push(...page.nodes)
+        cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
+    } while (cursor)
+    return nodes
+}
+
+function supersededIn(nodes, groups) {
+    const superseded = []
+    for (const group of groups) {
+        const matches = nodes
+            .filter((n) => n.author?.login === group.author && n.body?.trimStart().startsWith(group.prefix))
+            .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+        // Everything but the newest is superseded; already-minimized ones are done.
+        superseded.push(...matches.slice(0, -1).filter((n) => !n.isMinimized))
+    }
+    return superseded
+}
+
+let targets = []
+try {
+    targets = [
+        ...supersededIn(await fetchAll('comments'), COMMENT_GROUPS),
+        ...supersededIn(await fetchAll('reviews'), REVIEW_GROUPS),
+    ]
+} catch (err) {
+    console.warn(`Could not fetch PR comments/reviews: ${err.message}`)
+    process.exit(0)
+}
+
+if (!targets.length) {
+    console.info('No superseded bot comments to minimize.')
+    process.exit(0)
+}
+
+console.info(`Minimizing ${targets.length} superseded bot comment(s)/review(s).`)
+for (const target of targets) {
+    try {
+        await graphql(
+            `mutation($id: ID!) {
+                minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                }
+            }`,
+            { id: target.id }
+        )
+        console.info(`Minimized ${target.id} (${target.createdAt}).`)
+    } catch (err) {
+        console.warn(`Could not minimize ${target.id}: ${err.message}`)
+    }
+}

--- a/.github/scripts/minimize-superseded-comments.mjs
+++ b/.github/scripts/minimize-superseded-comments.mjs
@@ -35,7 +35,7 @@ const REVIEW_GROUPS = [
 
 const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
 const repo = process.env.GITHUB_REPOSITORY
-const prNumber = Number.parseInt(process.env.PR_NUMBER ?? '', 10)
+const prNumber = Number.parseInt(process.env.PR_NUMBER, 10)
 if (!token || !repo || !Number.isFinite(prNumber)) {
     console.warn('Missing GITHUB_TOKEN/GITHUB_REPOSITORY/PR_NUMBER — skipping.')
     process.exit(0)
@@ -97,10 +97,8 @@ function supersededIn(nodes, groups) {
 
 let targets = []
 try {
-    targets = [
-        ...supersededIn(await fetchAll('comments'), COMMENT_GROUPS),
-        ...supersededIn(await fetchAll('reviews'), REVIEW_GROUPS),
-    ]
+    const [comments, reviews] = await Promise.all([fetchAll('comments'), fetchAll('reviews')])
+    targets = [...supersededIn(comments, COMMENT_GROUPS), ...supersededIn(reviews, REVIEW_GROUPS)]
 } catch (err) {
     console.warn(`Could not fetch PR comments/reviews: ${err.message}`)
     process.exit(0)

--- a/.github/scripts/minimize-superseded-comments.mjs
+++ b/.github/scripts/minimize-superseded-comments.mjs
@@ -14,14 +14,22 @@
 // Keep-newest groups. A comment/review belongs to a group when its author matches and
 // its body (leading whitespace ignored) starts with the prefix — bots occasionally pad
 // the front of the body with blank lines.
+//
+// Author logins are the GraphQL form, WITHOUT the "[bot]" suffix — GraphQL reports
+// bot authors as e.g. "github-actions" where REST reports "github-actions[bot]".
+// Each prefix is coupled to the exact wording the named source emits; if the source
+// rewords its message the group silently stops matching, so the zero-match log below
+// is the breadcrumb that says a prefix has drifted.
 const COMMENT_GROUPS = [
-    // stamphog's per-push "kept your approval" notes (pr-approval-agent.yml)
-    { author: 'github-actions[bot]', prefix: 'Retaining stamphog approval' },
-    // commit-snapshots' "branch advanced" skip notices
-    { author: 'github-actions[bot]', prefix: '⏭️ Skipped snapshot commit' },
+    // stamphog's per-push "kept your approval" notes ("Note retained approval" step
+    // in .github/workflows/pr-approval-agent.yml)
+    { author: 'github-actions', prefix: 'Retaining stamphog approval' },
+    // "branch advanced" skip notices ("Post skip comment" step in
+    // .github/actions/commit-snapshots/action.yml)
+    { author: 'github-actions', prefix: '⏭️ Skipped snapshot commit' },
 ]
 const REVIEW_GROUPS = [
-    // Codex posts a fresh review per reviewed commit
+    // Codex (third-party, wording not ours) posts a fresh review per reviewed commit
     { author: 'chatgpt-codex-connector', prefix: '### 💡 Codex Review' },
 ]
 
@@ -77,6 +85,10 @@ function supersededIn(nodes, groups) {
         const matches = nodes
             .filter((n) => n.author?.login === group.author && n.body?.trimStart().startsWith(group.prefix))
             .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+        if (matches.length === 0) {
+            console.info(`Group "${group.prefix}" matched nothing — fine on most PRs, a drifted prefix if unexpected.`)
+            continue
+        }
         // Everything but the newest is superseded; already-minimized ones are done.
         superseded.push(...matches.slice(0, -1).filter((n) => !n.isMinimized))
     }

--- a/.github/scripts/minimize-superseded-comments.mjs
+++ b/.github/scripts/minimize-superseded-comments.mjs
@@ -42,41 +42,66 @@ if (!token || !repo || !Number.isFinite(prNumber)) {
 }
 const [owner, name] = repo.split('/')
 
-async function graphql(query, variables) {
+// Returns { data, errors } without throwing, so batched mutations can succeed partially.
+async function graphqlRaw(query, variables) {
     const response = await fetch('https://api.github.com/graphql', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ query, variables }),
     })
     const payload = await response.json()
-    if (!response.ok || payload.errors) {
-        throw new Error(`GraphQL failed: ${JSON.stringify(payload.errors ?? payload)}`.slice(0, 500))
-    }
-    return payload.data
+    return { ok: response.ok, data: payload.data, errors: payload.errors }
 }
 
-async function fetchAll(field) {
-    const nodes = []
-    let cursor = null
-    do {
+async function graphql(query, variables) {
+    const { ok, data, errors } = await graphqlRaw(query, variables)
+    if (!ok || errors) {
+        throw new Error(`GraphQL failed: ${JSON.stringify(errors ?? data)}`.slice(0, 500))
+    }
+    return data
+}
+
+// One request fetches both comments and reviews (they're sibling fields on the same PR
+// node); @include drops a connection from the query once its pages are exhausted, so a PR
+// that fits under 100 of each — the common case — costs exactly one round trip.
+async function fetchCommentsAndReviews() {
+    const comments = []
+    const reviews = []
+    let needComments = true
+    let needReviews = true
+    let commentsCursor = null
+    let reviewsCursor = null
+    while (needComments || needReviews) {
         const data = await graphql(
-            `query($owner: String!, $name: String!, $pr: Int!, $cursor: String) {
+            `query($owner: String!, $name: String!, $pr: Int!, $commentsCursor: String, $reviewsCursor: String, $needComments: Boolean!, $needReviews: Boolean!) {
                 repository(owner: $owner, name: $name) {
                     pullRequest(number: $pr) {
-                        ${field}(first: 100, after: $cursor) {
+                        comments(first: 100, after: $commentsCursor) @include(if: $needComments) {
+                            pageInfo { hasNextPage endCursor }
+                            nodes { id body createdAt isMinimized author { login } }
+                        }
+                        reviews(first: 100, after: $reviewsCursor) @include(if: $needReviews) {
                             pageInfo { hasNextPage endCursor }
                             nodes { id body createdAt isMinimized author { login } }
                         }
                     }
                 }
             }`,
-            { owner, name, pr: prNumber, cursor }
+            { owner, name, pr: prNumber, commentsCursor, reviewsCursor, needComments, needReviews }
         )
-        const page = data.repository.pullRequest[field]
-        nodes.push(...page.nodes)
-        cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null
-    } while (cursor)
-    return nodes
+        const pr = data.repository.pullRequest
+        if (pr.comments) {
+            comments.push(...pr.comments.nodes)
+            needComments = pr.comments.pageInfo.hasNextPage
+            commentsCursor = pr.comments.pageInfo.endCursor
+        }
+        if (pr.reviews) {
+            reviews.push(...pr.reviews.nodes)
+            needReviews = pr.reviews.pageInfo.hasNextPage
+            reviewsCursor = pr.reviews.pageInfo.endCursor
+        }
+    }
+    return { comments, reviews }
 }
 
 function supersededIn(nodes, groups) {
@@ -97,7 +122,7 @@ function supersededIn(nodes, groups) {
 
 let targets = []
 try {
-    const [comments, reviews] = await Promise.all([fetchAll('comments'), fetchAll('reviews')])
+    const { comments, reviews } = await fetchCommentsAndReviews()
     targets = [...supersededIn(comments, COMMENT_GROUPS), ...supersededIn(reviews, REVIEW_GROUPS)]
 } catch (err) {
     console.warn(`Could not fetch PR comments/reviews: ${err.message}`)
@@ -109,19 +134,39 @@ if (!targets.length) {
     process.exit(0)
 }
 
+// Batch minimizations into aliased mutations so one HTTP request collapses many nodes —
+// a comment-heavy first run stops being a per-node request storm (and stays clear of the
+// secondary rate limit on content-generating calls). Chunked to keep query complexity
+// bounded. GraphQL runs aliased mutations serially and returns partial data on failure,
+// so a single bad node warns without dropping the rest of its batch.
+const CHUNK = 50
 console.info(`Minimizing ${targets.length} superseded bot comment(s)/review(s).`)
-for (const target of targets) {
+for (let start = 0; start < targets.length; start += CHUNK) {
+    const batch = targets.slice(start, start + CHUNK)
+    const query = `mutation(${batch.map((_, i) => `$id${i}: ID!`).join(', ')}) {
+        ${batch
+            .map(
+                (_, i) =>
+                    `m${i}: minimizeComment(input: { subjectId: $id${i}, classifier: OUTDATED }) { minimizedComment { isMinimized } }`
+            )
+            .join('\n')}
+    }`
+    const variables = Object.fromEntries(batch.map((t, i) => [`id${i}`, t.id]))
+    let result
     try {
-        await graphql(
-            `mutation($id: ID!) {
-                minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
-                    minimizedComment { isMinimized }
-                }
-            }`,
-            { id: target.id }
-        )
-        console.info(`Minimized ${target.id} (${target.createdAt}).`)
+        result = await graphqlRaw(query, variables)
     } catch (err) {
-        console.warn(`Could not minimize ${target.id}: ${err.message}`)
+        console.warn(`Could not minimize batch of ${batch.length}: ${err.message}`)
+        continue
+    }
+    batch.forEach((target, i) => {
+        if (result.data?.[`m${i}`]?.minimizedComment?.isMinimized) {
+            console.info(`Minimized ${target.id} (${target.createdAt}).`)
+        } else {
+            console.warn(`Could not minimize ${target.id}.`)
+        }
+    })
+    if (result.errors) {
+        console.warn(`Some minimizations failed: ${JSON.stringify(result.errors).slice(0, 300)}`)
     }
 }

--- a/.github/workflows/pr-resolve-outdated-bot-comments.yml
+++ b/.github/workflows/pr-resolve-outdated-bot-comments.yml
@@ -26,6 +26,11 @@ jobs:
                   client-id: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
 
+            - name: Checkout scripts
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts
+
             - name: Resolve outdated bot threads
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -89,3 +94,17 @@ jobs:
                         }
                       }' -f id="$thread_id" || echo "::warning::failed to resolve thread $thread_id"
                   done
+
+            # Sibling concern to the thread resolver above: bots that post a NEW top-level
+            # comment or review per push (instead of updating in place) bury the human
+            # conversation. Collapse all but the newest of each kind as outdated.
+            - name: Minimize superseded bot comments
+              env:
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  if [ -f .github/scripts/minimize-superseded-comments.mjs ]; then
+                      node .github/scripts/minimize-superseded-comments.mjs
+                  else
+                      echo "Skipping — script not present on this checkout"
+                  fi

--- a/.github/workflows/pr-resolve-outdated-bot-comments.yml
+++ b/.github/workflows/pr-resolve-outdated-bot-comments.yml
@@ -26,14 +26,16 @@ jobs:
                   client-id: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
 
-            - name: Checkout scripts from the trusted base branch
+            - name: Checkout scripts from the trusted default branch
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   # NEVER the default merge ref: the step below runs this script with the
                   # privileged app token, and the merge ref contains PR-controlled code — a
-                  # same-repo PR could edit the script to exfiltrate the token. The base
-                  # branch is write-gated, so script changes only take effect once merged.
-                  ref: ${{ github.event.pull_request.base.ref }}
+                  # same-repo PR could edit the script to exfiltrate the token. The default
+                  # branch is protected (not just any base branch — a stacked PR's base is
+                  # unreviewed), so script changes only take effect once merged there. The
+                  # script is self-contained; it never needs to match the PR's base.
+                  ref: ${{ github.event.repository.default_branch }}
                   persist-credentials: false
                   sparse-checkout: .github/scripts
 

--- a/.github/workflows/pr-resolve-outdated-bot-comments.yml
+++ b/.github/workflows/pr-resolve-outdated-bot-comments.yml
@@ -26,9 +26,15 @@ jobs:
                   client-id: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
 
-            - name: Checkout scripts
+            - name: Checkout scripts from the trusted base branch
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  # NEVER the default merge ref: the step below runs this script with the
+                  # privileged app token, and the merge ref contains PR-controlled code — a
+                  # same-repo PR could edit the script to exfiltrate the token. The base
+                  # branch is write-gated, so script changes only take effect once merged.
+                  ref: ${{ github.event.pull_request.base.ref }}
+                  persist-credentials: false
                   sparse-checkout: .github/scripts
 
             - name: Resolve outdated bot threads


### PR DESCRIPTION
## Problem

The final piece of the PR-comment noise cleanup. The consolidated CI report (#67323 → #68078) covers the bots we control, but some bots post a **new** top-level comment or review on every push instead of updating in place:

- stamphog's "Retaining stamphog approval — delta classified as …" notes (one per push on labeled PRs)
- commit-snapshots' "⏭️ Skipped snapshot commit because branch advanced" notices
- Codex's "💡 Codex Review — Reviewed commit `<sha>`" reviews (one per reviewed commit)

Each is correct when posted, but only the newest matters — the pile-up buries the human conversation.

## Changes

The existing `pr-resolve-outdated-bot-comments` workflow (which already resolves outdated bot review *threads* on every push) gains a sibling step: `minimize-superseded-comments.mjs` groups comments/reviews by author + body prefix, keeps the newest of each kind, and collapses the rest as **outdated** via GitHub's `minimizeComment` mutation — still expandable in the timeline, never deleted. Adding a bot to the sweep is one line in the `COMMENT_GROUPS` / `REVIEW_GROUPS` tables.

Best-effort throughout: any fetch or mutation failure warns and moves on — hiding stale bot noise is never worth a red check. Runs under the same app token, same-repo PRs only, and the step is `[ -f ]`-guarded for unrebased branches.

## How did you test this code?

- Smoke-tested against a stubbed GraphQL API: with 3 stamphog notes, 1 singleton skip notice, 2 Codex reviews, 1 already-minimized note, and 1 human comment, it minimized exactly the two older stamphog notes and the older Codex review — kept the newest of each group, skipped the already-minimized one, and never touched the human comment or the singleton.
- `node --check` on the script; workflow YAML validated.
- Not exercised against real GitHub yet — the first `synchronize` event on any PR after merge is the live test; failure mode is a logged warning, not a red check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — CI tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @pauldambra as the last item of the PR-comment noise cleanup: "a cleanup step could minimize superseded bot comments via GitHub's minimizeComment mutation — the repo already auto-resolves outdated bot review threads; extending that to stale top-level comments is the same idea."

One consideration for review: the app behind `GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER` needs write access for the `minimizeComment` mutation — it already resolves review threads, which requires the same PR write scope, so this should Just Work, but the first live run will confirm.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*