### PR TITLE
fix(surveys): hide wizard schedule when survey repeats on every event

### DIFF
--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -200,11 +200,11 @@ function SurveyIterationOptions(): JSX.Element {
 export function SurveyRepeatSchedule(): JSX.Element {
     const { survey } = useValues(surveyLogic)
 
-    const canSurveyBeRepeated = doesSurveyRepeatOnEveryEvent(survey)
+    const repeatsOnEveryEvent = doesSurveyRepeatOnEveryEvent(survey)
 
     return (
         <div className="mt-4">
-            {canSurveyBeRepeated ? (
+            {repeatsOnEveryEvent ? (
                 <span className="font-medium">
                     <h3 className="mb-0">How often should we show this survey to a person?</h3>
                     <IconInfo className="mr-0.5" /> This survey is displayed whenever the&nbsp;

--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -10,6 +10,7 @@ import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { pluralize } from 'lib/utils/strings'
 import { LinkToSurveyFormSection } from 'scenes/surveys/components/LinkToSurveyFormSection'
 import { SURVEY_FORM_INPUT_IDS } from 'scenes/surveys/constants'
+import { doesSurveyRepeatOnEveryEvent } from 'scenes/surveys/utils'
 
 import { Survey, SurveySchedule, SurveyType } from '~/types'
 
@@ -199,9 +200,7 @@ function SurveyIterationOptions(): JSX.Element {
 export function SurveyRepeatSchedule(): JSX.Element {
     const { survey } = useValues(surveyLogic)
 
-    const canSurveyBeRepeated = Boolean(
-        survey.conditions?.events?.repeatedActivation && survey.conditions?.events?.values?.length > 0
-    )
+    const canSurveyBeRepeated = doesSurveyRepeatOnEveryEvent(survey)
 
     return (
         <div className="mt-4">

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1450,17 +1450,17 @@ describe('doesSurveyRepeatOnEveryEvent', () => {
     it.each([
         [
             'repeated activation with a trigger event',
-            { values: [{ name: 'purchase' }], repeatedActivation: true },
             true,
+            { values: [{ name: 'purchase' }], repeatedActivation: true },
         ],
-        ['repeated activation without trigger events', { values: [], repeatedActivation: true }, false],
+        ['repeated activation without trigger events', false, { values: [], repeatedActivation: true }],
         [
             'trigger events without repeated activation',
-            { values: [{ name: 'purchase' }], repeatedActivation: false },
             false,
+            { values: [{ name: 'purchase' }], repeatedActivation: false },
         ],
-        ['no events object', null, false],
-    ])('%s -> %s', (_name, events, expected) => {
+        ['no events object', false, null],
+    ])('%s -> %s', (_name, expected, events) => {
         const survey = { conditions: events ? { events } : null } as Pick<Survey, 'conditions'>
         expect(doesSurveyRepeatOnEveryEvent(survey)).toBe(expected)
     })

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -24,6 +24,7 @@ import {
     buildSurveyTimestampFilter,
     calculateNpsBreakdown,
     createAnswerFilterHogQLExpression,
+    doesSurveyRepeatOnEveryEvent,
     getSurveyNotificationFilters,
     getResolvedSurveyDateRange,
     getSurveyAudienceSummaryValue,
@@ -1442,5 +1443,25 @@ describe('splitChoicesOnPaste', () => {
 
     it('preserves the open-ended "Other" entry when pasting into the open-ended slot itself', () => {
         expect(splitChoicesOnPaste('two\nthree', ['one', 'Other'], 1, true)).toEqual(['one', 'two', 'three', 'Other'])
+    })
+})
+
+describe('doesSurveyRepeatOnEveryEvent', () => {
+    it.each([
+        [
+            'repeated activation with a trigger event',
+            { values: [{ name: 'purchase' }], repeatedActivation: true },
+            true,
+        ],
+        ['repeated activation without trigger events', { values: [], repeatedActivation: true }, false],
+        [
+            'trigger events without repeated activation',
+            { values: [{ name: 'purchase' }], repeatedActivation: false },
+            false,
+        ],
+        ['no events object', null, false],
+    ])('%s -> %s', (_name, events, expected) => {
+        const survey = { conditions: events ? { events } : null } as Pick<Survey, 'conditions'>
+        expect(doesSurveyRepeatOnEveryEvent(survey)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -536,6 +536,10 @@ export function canUseSurveyWizard(survey: Survey | NewSurvey): boolean {
     return true
 }
 
+export function doesSurveyRepeatOnEveryEvent(survey: Pick<Survey, 'conditions'>): boolean {
+    return !!(survey.conditions?.events?.repeatedActivation && (survey.conditions?.events?.values?.length ?? 0) > 0)
+}
+
 export function doesSurveyHaveDisplayConditions(survey: Survey | NewSurvey): boolean {
     const conditions = sanitizeSurveyDisplayConditions(survey.conditions)
     if (!conditions) {

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { NEW_SURVEY } from 'scenes/surveys/constants'
+
+import { initKeaTests } from '~/test/init'
+import { Survey, SurveySchedule } from '~/types'
+
+import { SuccessStep } from './SuccessStep'
+
+jest.mock('../../SurveyAppearancePreview', () => ({
+    SurveyAppearancePreview: () => <div data-testid="survey-preview" />,
+}))
+
+const createLaunchedSurvey = (overrides: Partial<Survey>): Survey =>
+    ({ ...NEW_SURVEY, id: 'test-survey', ...overrides }) as Survey
+
+describe('SuccessStep', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('summarizes frequency as event-driven when the survey repeats on every event', () => {
+        render(
+            <SuccessStep
+                survey={createLaunchedSurvey({
+                    conditions: {
+                        actions: null,
+                        events: { values: [{ name: 'payment_completed' }], repeatedActivation: true },
+                    },
+                    // Stored cadence left over from a template — must not be presented as the effective frequency
+                    schedule: SurveySchedule.Recurring,
+                    iteration_count: 10,
+                    iteration_frequency_days: 30,
+                })}
+            />
+        )
+
+        expect(screen.getByText('Every time a trigger event is captured')).toBeInTheDocument()
+        expect(screen.queryByText(/Up to 10 times/)).not.toBeInTheDocument()
+    })
+
+    it('summarizes the stored cadence when the survey does not repeat on events', () => {
+        render(
+            <SuccessStep
+                survey={createLaunchedSurvey({
+                    schedule: SurveySchedule.Recurring,
+                    iteration_count: 2,
+                    iteration_frequency_days: 90,
+                })}
+            />
+        )
+
+        expect(screen.getByText('Up to 2 times, every 90 days')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { doesSurveyRepeatOnEveryEvent } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { Survey, SurveySchedule, SurveyType } from '~/types'
@@ -88,9 +89,11 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                         <div className="flex justify-between">
                             <dt className="text-secondary">Frequency</dt>
                             <dd>
-                                {survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
-                                    ? 'Once ever'
-                                    : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
+                                {doesSurveyRepeatOnEveryEvent(survey)
+                                    ? 'Every time a trigger event is captured'
+                                    : survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
+                                      ? 'Once ever'
+                                      : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
                             </dd>
                         </div>
                         {survey.conditions?.seenSurveyWaitPeriodInDays != null && (

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -18,6 +18,7 @@ interface SuccessStepProps {
 
 export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
     const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
+    const repeatsOnEveryEvent = doesSurveyRepeatOnEveryEvent(survey)
     const [countdown, setCountdown] = useState(5)
 
     useEffect(() => {
@@ -89,7 +90,7 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                         <div className="flex justify-between">
                             <dt className="text-secondary">Frequency</dt>
                             <dd>
-                                {doesSurveyRepeatOnEveryEvent(survey)
+                                {repeatsOnEveryEvent
                                     ? 'Every time a trigger event is captured'
                                     : survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
                                       ? 'Once ever'

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, Survey, SurveyPosition, SurveyQuestionType, SurveySchedule, SurveyType } from '~/types'
+
+import { surveyLogic } from '../../surveyLogic'
+import { WhenStep } from './WhenStep'
+
+jest.mock('lib/components/PropertyFilters/PropertyFilters', () => ({
+    PropertyFilters: () => <div data-testid="property-filters" />,
+}))
+
+const createEventTriggeredSurvey = (repeatedActivation: boolean): Survey => ({
+    id: 'test-survey',
+    name: 'Test survey',
+    description: '',
+    type: SurveyType.Popover,
+    linked_flag: null,
+    linked_flag_id: null,
+    targeting_flag: null,
+    questions: [
+        {
+            type: SurveyQuestionType.Open,
+            question: 'What do you think?',
+            description: '',
+            buttonText: 'Submit',
+        },
+    ],
+    conditions: {
+        actions: null,
+        events: { values: [{ name: 'payment_completed' }], repeatedActivation },
+    },
+    appearance: {
+        position: SurveyPosition.Right,
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    created_by: null,
+    start_date: null,
+    end_date: null,
+    archived: false,
+    targeting_flag_filters: undefined,
+    responses_limit: null,
+    schedule: SurveySchedule.Once,
+    user_access_level: AccessControlLevel.Editor,
+})
+
+const surveyMocks = (survey: Survey): Parameters<typeof useMocks>[0] => ({
+    get: {
+        '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+        '/api/projects/:team/surveys/test-survey/': () => [200, survey],
+        '/api/projects/:team/surveys/responses_count': () => [200, {}],
+    },
+})
+
+describe('WhenStep', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    const renderWhenStep = (): void => {
+        render(
+            <Provider>
+                <BindLogic logic={surveyLogic} props={{ id: 'test-survey' }}>
+                    <WhenStep />
+                </BindLogic>
+            </Provider>
+        )
+    }
+
+    it('replaces the schedule options with an explanation when the survey shows on every event capture', async () => {
+        useMocks(surveyMocks(createEventTriggeredSurvey(true)))
+        renderWhenStep()
+
+        expect(await screen.findByText(/these settings are not applicable/)).toBeInTheDocument()
+        expect(screen.queryByText('Once ever')).not.toBeInTheDocument()
+        // The wait period and response limit still apply at runtime, so they stay configurable
+        expect(
+            screen.getByText("Don't show this survey if another one was shown to the user in the last")
+        ).toBeInTheDocument()
+        expect(screen.getByText('Stop after')).toBeInTheDocument()
+    })
+
+    it('keeps the schedule options for event-triggered surveys that show once per user', async () => {
+        useMocks(surveyMocks(createEventTriggeredSurvey(false)))
+        renderWhenStep()
+
+        expect(await screen.findByText('payment_completed')).toBeInTheDocument()
+        expect(screen.getByText('Once ever')).toBeInTheDocument()
+        expect(screen.queryByText(/these settings are not applicable/)).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
@@ -79,7 +79,7 @@ describe('WhenStep', () => {
         useMocks(surveyMocks(createEventTriggeredSurvey(true)))
         renderWhenStep()
 
-        expect(await screen.findByText(/these settings are not applicable/)).toBeInTheDocument()
+        expect(await screen.findByText(/the schedule options don't apply/)).toBeInTheDocument()
         expect(screen.queryByText('Once ever')).not.toBeInTheDocument()
         // The wait period and response limit still apply at runtime, so they stay configurable
         expect(
@@ -94,6 +94,6 @@ describe('WhenStep', () => {
 
         expect(await screen.findByText('payment_completed')).toBeInTheDocument()
         expect(screen.getByText('Once ever')).toBeInTheDocument()
-        expect(screen.queryByText(/these settings are not applicable/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/the schedule options don't apply/)).not.toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -7,6 +7,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { AddEventButton } from 'scenes/surveys/AddEventButton'
+import { doesSurveyRepeatOnEveryEvent } from 'scenes/surveys/utils'
 
 import {
     AnyPropertyFilter,
@@ -50,9 +51,11 @@ export function WhenStep(): JSX.Element {
     const triggerMode = conditions.events !== null && conditions.events !== undefined ? 'event' : 'pageview'
     const repeatedActivation = conditions.events?.repeatedActivation ?? false
     // Repeated event activation makes the SDK re-show the survey on every trigger-event capture,
-    // bypassing the schedule — so don't render the schedule as configurable (same treatment as
-    // SurveyRepeatSchedule in the full editor).
-    const canSurveyBeRepeated = repeatedActivation && triggerEvents.length > 0
+    // bypassing the schedule — so render the schedule as not applicable, the same treatment as
+    // SurveyRepeatSchedule in the full editor (the explanation is deliberately not shared with it:
+    // the contexts differ too much). The stored schedule/iteration fields are left untouched so
+    // unchecking the box restores the previous cadence.
+    const repeatsOnEveryEvent = doesSurveyRepeatOnEveryEvent(survey)
     const delaySeconds = appearance.surveyPopupDelaySeconds ?? 0
     const excludedObjectProperties = useExcludedObjectProperties()
     // Derive frequency strictly from the iteration model — the universal wait-period is a separate
@@ -281,13 +284,13 @@ export function WhenStep(): JSX.Element {
                 description="How many times the same user can see this survey, and how often."
                 descriptionClassName="text-sm"
             >
-                {canSurveyBeRepeated ? (
-                    <div className="text-sm">
+                {repeatsOnEveryEvent ? (
+                    <div className="text-sm" data-attr="survey-schedule-repeats-on-event-note">
                         <IconInfo className="mr-0.5" />
                         This survey is displayed whenever the{' '}
                         <LemonSnack>{triggerEvents.map((event) => event.name).join(', ')}</LemonSnack>{' '}
-                        {triggerEvents.length === 1 ? 'event is' : 'events are'} captured, so these settings are not
-                        applicable. To set a schedule instead, uncheck 'Show every time the event is captured' above.
+                        {triggerEvents.length === 1 ? 'event is' : 'events are'} captured, so the schedule options don't
+                        apply. To set a schedule instead, uncheck 'Show every time the event is captured' above.
                     </div>
                 ) : (
                     <>

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
-import { IconX } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { IconInfo, IconX } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton, LemonSnack } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -49,6 +49,10 @@ export function WhenStep(): JSX.Element {
     // Check if events object exists (even if empty) to determine mode
     const triggerMode = conditions.events !== null && conditions.events !== undefined ? 'event' : 'pageview'
     const repeatedActivation = conditions.events?.repeatedActivation ?? false
+    // Repeated event activation makes the SDK re-show the survey on every trigger-event capture,
+    // bypassing the schedule — so don't render the schedule as configurable (same treatment as
+    // SurveyRepeatSchedule in the full editor).
+    const canSurveyBeRepeated = repeatedActivation && triggerEvents.length > 0
     const delaySeconds = appearance.surveyPopupDelaySeconds ?? 0
     const excludedObjectProperties = useExcludedObjectProperties()
     // Derive frequency strictly from the iteration model — the universal wait-period is a separate
@@ -277,37 +281,51 @@ export function WhenStep(): JSX.Element {
                 description="How many times the same user can see this survey, and how often."
                 descriptionClassName="text-sm"
             >
-                <LemonSegmentedButton
-                    value={frequency}
-                    onChange={setFrequency}
-                    options={FREQUENCY_OPTIONS.map((opt) => ({
-                        ...opt,
-                        tooltip:
-                            opt.value === recommendedFrequency.value ? `Recommended for this survey type` : undefined,
-                    }))}
-                    fullWidth
-                />
-
-                {recommendedFrequency.value === frequency && (
-                    <p className="text-sm text-success mt-2 mb-0">{recommendedFrequency.reason}</p>
-                )}
-
-                {frequency !== 'once' && (
-                    <div className="flex flex-wrap items-center gap-2 text-sm mt-5">
-                        <span>Show up to</span>
-                        <LemonInput
-                            type="number"
-                            min={MIN_ITERATION_COUNT}
-                            max={MAX_ITERATION_COUNT}
-                            value={iterationCount}
-                            onChange={(val) => setIterationCount(val ?? undefined)}
-                            onBlur={commitIterationCount}
-                            className="w-20 tabular-nums"
-                        />
-                        <span className="text-secondary">
-                            times in total ({MIN_ITERATION_COUNT}–{MAX_ITERATION_COUNT}).
-                        </span>
+                {canSurveyBeRepeated ? (
+                    <div className="text-sm">
+                        <IconInfo className="mr-0.5" />
+                        This survey is displayed whenever the{' '}
+                        <LemonSnack>{triggerEvents.map((event) => event.name).join(', ')}</LemonSnack>{' '}
+                        {triggerEvents.length === 1 ? 'event is' : 'events are'} captured, so these settings are not
+                        applicable. To set a schedule instead, uncheck 'Show every time the event is captured' above.
                     </div>
+                ) : (
+                    <>
+                        <LemonSegmentedButton
+                            value={frequency}
+                            onChange={setFrequency}
+                            options={FREQUENCY_OPTIONS.map((opt) => ({
+                                ...opt,
+                                tooltip:
+                                    opt.value === recommendedFrequency.value
+                                        ? `Recommended for this survey type`
+                                        : undefined,
+                            }))}
+                            fullWidth
+                        />
+
+                        {recommendedFrequency.value === frequency && (
+                            <p className="text-sm text-success mt-2 mb-0">{recommendedFrequency.reason}</p>
+                        )}
+
+                        {frequency !== 'once' && (
+                            <div className="flex flex-wrap items-center gap-2 text-sm mt-5">
+                                <span>Show up to</span>
+                                <LemonInput
+                                    type="number"
+                                    min={MIN_ITERATION_COUNT}
+                                    max={MAX_ITERATION_COUNT}
+                                    value={iterationCount}
+                                    onChange={(val) => setIterationCount(val ?? undefined)}
+                                    onBlur={commitIterationCount}
+                                    className="w-20 tabular-nums"
+                                />
+                                <span className="text-secondary">
+                                    times in total ({MIN_ITERATION_COUNT}–{MAX_ITERATION_COUNT}).
+                                </span>
+                            </div>
+                        )}
+                    </>
                 )}
 
                 <div className="flex flex-wrap items-center gap-2 text-sm mt-5">


### PR DESCRIPTION
## Problem

The guided survey editor and the full editor describe the same configuration differently. When a survey is triggered by an event and "Show every time the event is captured" is checked, the full editor hides the schedule radio and explains that the event now controls repetition. The guided editor kept its "How often should this survey show?" selector fully interactive in that state and, because the stored schedule fields match none of its options, highlighted "Once ever" right below the checked checkbox.

That state is contradictory twice over: within the wizard itself, and between the two editors. At runtime repeated activation wins (the SDK bypasses the once/recurring gates, and only the survey wait period still throttles display), so a schedule picked alongside the checkbox silently does nothing. This has confused users into support requests about which behavior is real.

## Changes

- `WhenStep` now mirrors `SurveyRepeatSchedule` from the full editor: when "Show every time the event is captured" is on and trigger events exist, the frequency selector and iteration count are replaced with the same "these settings are not applicable" explanation, pointing back at the checkbox.
- The survey wait period and response limit rows stay visible, since both still apply at runtime.
- Display-only change: nothing is written to the survey on toggle, matching how the full editor treats the same state.

No screenshot, sorry - this was authored in a cloud sandbox without a running app. In the gated state the section renders an info line ("This survey is displayed whenever the `<event>` event is captured, so these settings are not applicable...") in place of the segmented control.

## How did you test this code?

- Added `WhenStep.test.tsx` (jest, same setup as `SurveyAudienceFilters.test.tsx`). Regressions caught: (1) the wizard again rendering the schedule selector (highlighting "Once ever") for a survey that repeats on every event capture, while wait period and response limit must stay configurable; (2) the gate over-hiding, i.e. schedule options disappearing for event-triggered surveys that do not repeat.
- Ran locally (by the agent): the new test file and the full `frontend/src/scenes/surveys/wizard/` jest suite (4 suites, 18 tests, all passing), plus oxlint and oxfmt on the changed files.
- `typescript:check` could not complete meaningfully in the sandbox (kea typegen artifacts are not generated there, producing thousands of pre-existing `Cannot find module './...Type'` errors, none in the changed files) - relying on CI for the authoritative check. No manual browser testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No page under `docs/` covers the wizard's scheduling section (searched for the affected copy), so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Driven by Ben Lea (PostHog support) in a PostHog Code cloud session with Claude Code. I (the agent) could not verify his GitHub handle from this session, so the PR is left unassigned for him to self-assign.
- Skills invoked: `debugging-surveys` (diagnosis), `writing-tests` (before adding the jest test).
- Origin: a support request where the two editors appeared to disagree about a survey's display frequency. Root cause: the wizard's frequency selector derives only from `schedule` + `iteration_frequency_days` and ignores `conditions.events.repeatedActivation`.
- Considered adding an "every time the event fires" option to the segmented control instead; rejected it to keep repetition owned by the trigger checkbox and stay consistent with the full editor.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
