### PR TITLE
fix(data-warehouse): return a clear error for unknown source types when validating schemas

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -2628,7 +2628,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         if secret_ref_response is not None:
             return secret_ref_response
 
-        source_type_model = ExternalDataSourceType(source_type)
+        try:
+            source_type_model = ExternalDataSourceType(source_type)
+        except ValueError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"Unknown source_type '{source_type}'"},
+            )
         source = SourceRegistry.get_source(source_type_model)
         is_valid, errors = source.validate_config(request.data)
         if not is_valid:

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -3949,6 +3949,15 @@ class TestExternalDataSource(APIBaseTest):
 
         postgres_connection.close()
 
+    def test_database_schema_unknown_source_type(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+            data={"source_type": "GoogleAds-"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["message"] == "Unknown source_type 'GoogleAds-'"
+
     def test_database_schema_stripe_credentials(self):
         with (
             patch(


### PR DESCRIPTION
## Problem

When Replay Vision watched real users go through the data-warehouse new-source onboarding flow, one recurring failure mode was an unknown source type reaching the backend (for example from a stale or malformed connect link where the source type had a trailing character).

The `database_schema` endpoint parses the source type with a bare `ExternalDataSourceType(source_type)` call. An unknown value raises a raw `ValueError` that is not a DRF exception, so it surfaces as an HTTP 500 with no message body instead of an actionable error. That is the endpoint the wizard hits on the "Link your data source" step, so a bad source type there just fails opaquely.

The sibling `connect_link` endpoint already guards the same parse and returns a clean 400 with `Unknown source_type '<value>'`.

## Changes

Wrap the `ExternalDataSourceType(source_type)` parse in `database_schema` in a `try/except ValueError` and return a 400 with the same message shape `connect_link` uses. No behavior change for valid source types.

## How did you test this code?

Added `test_database_schema_unknown_source_type`, which posts an unknown source type to the endpoint and asserts a 400 with the message body. Before this change that path raised a `ValueError` and returned a 500; the test locks in the 400. No existing test exercised `database_schema` with an unknown source type (only `connect_link` had one).

I (Claude) could not run the Django test suite in this environment — pytest and the backing databases are not provisioned here. I ran `ruff check` and `ruff format --check` over both touched files (both clean) and byte-compiled them. The change mirrors the already-tested `connect_link` guard exactly.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) found this while triaging session-replay summaries of the data-warehouse onboarding flow for low-risk friction fixes. I invoked `/improving-drf-endpoints` and `/writing-tests` while shaping the change. The fix is deliberately a straight copy of the existing `connect_link` guard rather than anything new, to keep it obviously correct and self-contained.
