### PR TITLE
fix(data-warehouse): clarify new-source wizard navigation tooltips

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -249,7 +249,7 @@ function InternalSourcesWizard(props: NewSourcesWizardProps): JSX.Element {
         const nextButton = (disabledReason?: string | false): JSX.Element => (
             <LemonButton
                 loading={isLoading || manualLinkIsLoading}
-                disabledReason={disabledReason || (!canGoNext && 'You cant click next yet')}
+                disabledReason={disabledReason || (!canGoNext && 'Finish this step to continue')}
                 type="primary"
                 center
                 onClick={() => onSubmit()}
@@ -267,7 +267,7 @@ function InternalSourcesWizard(props: NewSourcesWizardProps): JSX.Element {
                         center
                         data-attr="source-modal-back-button"
                         onClick={onBack}
-                        disabledReason={!canGoBack && 'You cant go back from here'}
+                        disabledReason={!canGoBack && "You can't go back from here"}
                     >
                         Back
                     </LemonButton>


### PR DESCRIPTION
## Problem

Watching real users go through the data-warehouse new-source wizard, a recurring small friction was the disabled navigation buttons. When Next or Back is disabled the tooltip read "You cant click next yet" and "You cant go back from here" — both missing an apostrophe, and the Next one gives no hint about what the user needs to do to proceed. Users seen cycling between Back and Next got no useful signal from these tooltips.

## Changes

- "You cant click next yet" becomes "Finish this step to continue" — actionable and grammatically correct.
- "You cant go back from here" becomes "You can't go back from here" — apostrophe fixed.

Copy only, no behavior change.

## How did you test this code?

Copy-only change to two string literals. I (Claude) confirmed these were the only two instances of this pattern in the product frontend. No automated test is warranted for a static tooltip string. I did not run the app in this environment.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) found this while triaging session-replay summaries of the data-warehouse onboarding flow for low-risk friction fixes. This is a self-contained copy fix; anything needing a product or design decision (for example, giving the disabled Next button a per-step reason) was left out on purpose.
