### PR TITLE
feat(data-warehouse): promote linkedin ads source to ga

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -97,7 +98,7 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             keywords=["linkedin advertising"],
             label="LinkedIn Ads",
             caption="Ensure you have granted PostHog access to your LinkedIn Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/linkedin-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/linkedin.png",
             docsUrl="https://posthog.com/docs/cdp/sources/linkedin-ads",
             fields=cast(


### PR DESCRIPTION
## Problem

The LinkedIn Ads (`LinkedinAds`) data warehouse source has been running in Beta. It now clears the bar for general availability, so keeping the Beta label undersells a connector people already rely on.

Current metrics (7-day window):

| Signal | Threshold | Now |
| --- | --- | --- |
| Adoption (100+ teams or live 3+ months) | 100 teams or 3 months | 489 teams · live 9.8 months |
| Import error rate (last 7d) | < 2.5% | 0.5% |

## Changes

Flip the LinkedIn Ads source's `releaseStatus` from Beta to GA. That's the single field `/api/public_source_configs/` surfaces for `LinkedinAds`, so the frontend picks up the new status with no other wiring.

While here, I switched the value from the bare `"beta"` string literal to the `ReleaseStatus.GA` enum from `posthog.schema`, which is the convention every other source follows (the `implementing-warehouse-sources` skill calls for the enum, never a string literal).

No behavior, schema, or sync-logic changes. The source has no `unreleasedSource` flag or gating `featureFlag`, so there's nothing else to unwind for the stage change. This is a status promotion only.

## How did you test this code?

No manual testing. I (Claude) confirmed `ReleaseStatus.GA` serializes to `"ga"` (it's a `StrEnum`), that no test asserts on the LinkedIn Ads release status, and that `ruff check` / `ruff format` pass on the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8). Invoked the `/implementing-warehouse-sources` skill for the source-config conventions — it's the reason the value moved to the `ReleaseStatus` enum rather than staying a string. Before opening this I searched open PRs (LinkedIn, "releaseStatus", "promote", and the maintainer's own open PRs) to rule out a duplicate promotion; none touched the LinkedIn Ads release status.
