### PR TITLE
fix(experiments): allow clearing metric conversion window input

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -79,7 +79,7 @@ export interface LemonInputPropsText extends LemonInputPropsBase {
 export interface LemonInputPropsNumber
     extends LemonInputPropsBase, Pick<React.InputHTMLAttributes<HTMLInputElement>, 'step' | 'min' | 'max'> {
     type: 'number'
-    value?: number
+    value?: number | ''
     defaultValue?: number
     onChange?: (newValue: number | undefined) => void
 }

--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+
+import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
+import { FunnelConversionWindowTimeUnit } from '~/types'
+
+import { ExperimentMetricConversionWindowFilter } from './ExperimentMetricConversionWindowFilter'
+
+describe('ExperimentMetricConversionWindowFilter', () => {
+    const initialMetric: ExperimentMetric = {
+        kind: NodeKind.ExperimentMetric,
+        metric_type: ExperimentMetricType.MEAN,
+        source: {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+        },
+        conversion_window: 14,
+        conversion_window_unit: FunnelConversionWindowTimeUnit.Day,
+    }
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('keeps the conversion window input blank when cleared', () => {
+        const handleSetMetric = jest.fn()
+
+        function TestHarness(): JSX.Element {
+            const [metric, setMetric] = useState(initialMetric)
+
+            return (
+                <ExperimentMetricConversionWindowFilter
+                    metric={metric}
+                    handleSetMetric={(newMetric) => {
+                        handleSetMetric(newMetric)
+                        setMetric(newMetric)
+                    }}
+                />
+            )
+        }
+
+        const { container } = render(<TestHarness />)
+        const input = container.querySelector<HTMLInputElement>(
+            'input[data-attr="experiment-metric-conversion-window-input"]'
+        )
+
+        expect(input).not.toBeNull()
+        expect(input).toHaveValue(14)
+
+        fireEvent.change(input!, { target: { value: '' } })
+
+        expect(handleSetMetric).toHaveBeenLastCalledWith(expect.objectContaining({ conversion_window: undefined }))
+        expect(input).toHaveValue(null)
+        expect(input).not.toHaveValue(1)
+    })
+})

--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -74,9 +74,13 @@ export function ExperimentMetricConversionWindowFilter({
                             fullWidth={false}
                             min={intervalBounds[0]}
                             max={intervalBounds[1]}
-                            value={metric.conversion_window || 1}
+                            value={metric.conversion_window ?? ''}
+                            data-attr="experiment-metric-conversion-window-input"
                             onChange={(value) => {
-                                handleSetMetric({ ...metric, conversion_window: value || undefined })
+                                handleSetMetric({
+                                    ...metric,
+                                    conversion_window: value === undefined || Number.isNaN(value) ? undefined : value,
+                                })
                             }}
                         />
                         <LemonSelect


### PR DESCRIPTION
## Problem

The experiment metric conversion window number input forced the value back to `1` when users cleared it. That made ordinary edits awkward, for example changing `14` to `5` required typing around the forced fallback.

Closes #67942

## Changes

Updated the experiment metric conversion window input so a blank field stays blank while the metric state stores `conversion_window` as `undefined`.

Also updated the `LemonInput` number value type to allow the native blank value, keeping the input controlled without React warnings.

## How did you test this code?

Added `ExperimentMetricConversionWindowFilter.test.tsx` to cover the regression where clearing the number input used to render `1` again instead of staying blank.

Ran:

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.test.tsx --runInBand
pnpm exec oxlint frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.test.tsx
```

I also ran `pnpm --filter=@posthog/frontend typescript:check`, but it failed on existing generated-type setup issues unrelated to this patch, starting with missing modules such as `src/exporter/ExporterLoginType` and multiple `*LogicType` files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This fixes form editing behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change in the local PostHog checkout after the user chose issue #67942 as the PR target. I invoked `/writing-tests` before adding the Jest regression test.

I kept the fix narrow: remove the truthy `|| 1` display fallback, normalize blank numeric input to `undefined`, and keep the input controlled with a blank native value. The regression test exercises the controlled parent rerender path so it catches the original behavior rather than only checking a helper.