### PR TITLE
fix(sql-editor): embedded suggestion diff state sync and diff editor disposal

### DIFF
--- a/frontend/src/lib/monaco/CodeEditorImpl.tsx
+++ b/frontend/src/lib/monaco/CodeEditorImpl.tsx
@@ -411,6 +411,7 @@ export function CodeEditor({
     }
 
     const editorOnMount = (editor: importedEditor.IStandaloneCodeEditor, monaco: Monaco): void => {
+        diffEditorRef.current = null
         editorRef.current = editor
         trackEditorModels(editor, monaco)
         setMonacoAndEditor([monaco, editor])
@@ -549,6 +550,8 @@ export function CodeEditor({
                     theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
                     original={originalValue}
                     modified={value}
+                    keepCurrentOriginalModel
+                    keepCurrentModifiedModel
                     options={{
                         ...editorOptions,
                         renderSideBySide: false,

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -411,11 +411,11 @@ export function tabModelPath(tabId: string): string {
 // suggestion: @monaco-editor/react reuses the existing model on remount without re-applying
 // the `value` prop, so the content has to be written onto the model directly. No-ops when the
 // editor isn't mounted yet or the content already matches.
-function applyUndoableModelEdit(monaco: Monaco | null | undefined, uri: Uri | undefined, text: string): void {
-    if (!monaco || !uri) {
+function applyUndoableModelEdit(uri: Uri | undefined, text: string): void {
+    if (!uri) {
         return
     }
-    const model = monaco.editor.getModel(uri)
+    const model = editor.getModel(uri)
     if (!model || model.getValue() === text) {
         return
     }
@@ -566,6 +566,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         _setSuggestionPayload: (payload: SuggestionPayload | null) => ({
             payload,
         }),
+        overwriteQueryInput: (queryInput: string) => ({ queryInput }),
         setSuggestedQueryInput: (suggestedQueryInput: string, source?: SuggestionPayload['source']) => ({
             suggestedQueryInput,
             source,
@@ -973,6 +974,14 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 editor.focus()
             },
+            overwriteQueryInput: ({ queryInput }) => {
+                if (values.suggestionPayload) {
+                    actions._setSuggestionPayload(null)
+                }
+                actions.setQueryInput(queryInput)
+                const uri = values.activeTab?.uri ?? Uri.parse(tabModelPath(props.tabId))
+                applyUndoableModelEdit(uri, queryInput)
+            },
             setSuggestedQueryInput: ({ suggestedQueryInput, source }) => {
                 // If there's no active tab, create one first to ensure Monaco Editor is available.
                 // Embedded mode has no tabs at all — falling into createTab would replace the query
@@ -1006,7 +1015,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 // edit. The model survives the diff <-> editor swap (keepCurrentModel), so its
                 // existing undo history is preserved and cmd+z walks back through the accepted
                 // query to the pre-AI query and the rest of the edit history.
-                applyUndoableModelEdit(props.monaco, values.activeTab?.uri, values.queryInput ?? '')
+                const acceptUri = values.activeTab?.uri ?? Uri.parse(tabModelPath(props.tabId))
+                applyUndoableModelEdit(acceptUri, values.queryInput ?? '')
 
                 posthog.capture('sql-editor-accepted-suggestion', {
                     source: values.suggestedSource,
@@ -1019,7 +1029,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 // Keep the persistent model's content in sync with the reverted query (the
                 // suggestion was shown in a throwaway diff model, not this one). This is a
                 // no-op when the model already matches, so rejecting adds no undo step.
-                applyUndoableModelEdit(props.monaco, values.activeTab?.uri, values.queryInput ?? '')
+                const rejectUri = values.activeTab?.uri ?? Uri.parse(tabModelPath(props.tabId))
+                applyUndoableModelEdit(rejectUri, values.queryInput ?? '')
 
                 posthog.capture('sql-editor-rejected-suggestion', {
                     source: values.suggestedSource,

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -30,7 +30,7 @@ export const EndpointSceneHeader = (): JSX.Element => {
     } = useValues(endpointSceneLogic)
     const { endpointName, endpointDescription } = useValues(endpointLogic)
     const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic)
-    const { setLocalQuery, setDataFreshness, setIsMaterialized, resetBucketOverrides, setDebugInfoExpanded } =
+    const { setDataFreshness, setIsMaterialized, resetBucketOverrides, setDebugInfoExpanded, discardQueryChanges } =
         useActions(endpointSceneLogic)
     const { superpowersEnabled } = useValues(superpowersLogic)
 
@@ -97,7 +97,7 @@ export const EndpointSceneHeader = (): JSX.Element => {
         setEndpointDescription(sourceDescription || '')
         setDataFreshness(sourceDataFreshness)
         setIsMaterialized(null)
-        setLocalQuery(null)
+        discardQueryChanges()
         resetBucketOverrides(viewingVersion?.bucket_overrides ?? endpoint.bucket_overrides ?? {})
     }
 

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -155,6 +155,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         closeMaterializationSuggestionModal: true,
         regenerateMaterializationSuggestion: true,
         applyMaterializationSuggestion: true,
+        discardQueryChanges: true,
     }),
     reducers({
         localQuery: [
@@ -495,6 +496,21 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             editorLogic?.actions.setSuggestedQueryInput(suggestion.suggested_query, 'materialization_fix')
             lemonToast.success('Review the suggested changes in the editor — accept to apply them')
             actions.closeMaterializationSuggestionModal()
+        },
+        discardQueryChanges: () => {
+            const base = values.viewingVersion?.query ?? values.endpoint?.query
+            const editorLogic = cache.sqlEditorTabId
+                ? sqlEditorLogic.findMounted({ tabId: cache.sqlEditorTabId, mode: SQLEditorMode.Embedded })
+                : null
+            if (editorLogic && base && isHogQLQuery(base)) {
+                editorLogic.actions.overwriteQueryInput(base.query || '')
+                editorLogic.actions.setSourceQuery({
+                    kind: NodeKind.DataVisualizationNode,
+                    source: { ...base },
+                    display: ChartDisplayType.ActionsLineGraph,
+                } as DataVisualizationNode)
+            }
+            actions.setLocalQuery(null)
         },
         toggleMaterializationFromMenu: () => {
             if (!values.endpoint?.name) {


### PR DESCRIPTION
> Part 3/3 — the split left only the SQL editor / Monaco fixes here (backend #68682, frontend #68683). Older review comments refer to code that now lands via those PRs; all have replies.

## Problem

The Optimize with AI flow (#68683) reviews rewrites through the embedded SQL editor's accept/reject diff, which surfaced pre-existing bugs: suggestions silently overwrote embedded editors, accepted text visually reverted when the diff closed, "Discard changes" left the discarded text on screen, and every accept/reject threw an unhandled `TextModel got disposed before DiffEditorWidget model got reset` Monaco error.

## Changes

- Embedded editors (no tabs) now render suggestions as the accept/reject diff instead of bailing into `createTab` — also fixes Max SQL suggestions there.
- Accept/reject resolve the model URI from `tabModelPath(tabId)` when there's no active tab, so the result is written onto the persistent Monaco model and survives the diff→editor swap.
- New `overwriteQueryInput` action (set text + sync model + drop any open diff); the endpoint scene's discard uses it to push the saved query back into the editor.
- `keepCurrentOriginalModel`/`keepCurrentModifiedModel` on the DiffEditor: the library disposes models before the widget on unmount (the source of the Monaco error); our existing tracked-model cleanup disposes them widget-first instead. Stale `diffEditorRef` cleared when a regular editor mounts after the swap.

## How did you test this code?

Headless-browser E2E against the local dev stack (suggestion API mocked): diff renders with decorations, accept persists and enables Update/Discard, discard reverts the editor, a second apply→accept→update round creates a new version, and the dispose pageerror (previously thrown on every accept) is gone.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the SQL editor's suggestion internals.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by Claude Code ([session 1](https://claude.ai/code/session_0188GjAozDCdb3wfsFfaJRCL), [session 2](https://claude.ai/code/session_01Mqveu8fDf5XNxme7Hm8d7c)), directed by @sakce. Bugs were found by driving the flow in a headless browser; the initial invisible-diff symptom turned out to be a local-env gap (Monaco worker bundles aren't built in the Vite dev flow — reported to devex), the rest were real and fixed here. Dispose order verified against the installed `@monaco-editor/react` source.
