### PR TITLE
fix(metrics): default counter metrics to increase, expose rate/increase in viewer

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -16,7 +16,13 @@ import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { MetricsChartLegend } from './MetricsChartLegend'
 import { MetricStatPanel } from './MetricStatPanel'
-import { LIVE_REFRESH_MS, MetricAggregation, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
+import {
+    LIVE_REFRESH_MS,
+    MetricAggregation,
+    metricsViewerLogic,
+    MetricsViewMode,
+    RECOMMENDED_AGGREGATION_BY_TYPE,
+} from './metricsViewerLogic'
 
 const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
     { value: 'chart', label: 'Chart' },
@@ -35,18 +41,9 @@ const AGGREGATION_OPTIONS: { value: MetricAggregation; label: string }[] = [
     { value: 'avg', label: 'Average' },
     { value: 'count', label: 'Count' },
     { value: 'p95', label: 'p95' },
+    { value: 'rate', label: 'Rate (/s)' },
+    { value: 'increase', label: 'Increase' },
 ]
-
-// Recommended aggregation per OTel metric type. Used for an inline hint —
-// we don't auto-switch the user's choice (hint, don't overwrite).
-const RECOMMENDED_AGGREGATION_BY_TYPE: Record<string, MetricAggregation> = {
-    gauge: 'avg',
-    sum: 'sum',
-    counter: 'sum',
-    histogram: 'p95',
-    summary: 'p95',
-    exponential_histogram: 'p95',
-}
 
 // Mirrors the curated set used by `LogsViewer/Filters/DateRangeFilter`.
 const DATE_OPTIONS: DateMappingOption[] = [

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -1,0 +1,55 @@
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { metricNamePickerLogic } from './metricNamePickerLogic'
+import { metricsViewerLogic } from './metricsViewerLogic'
+
+const PICKER_ITEMS = [
+    { name: 'requests_total', metric_type: 'sum' },
+    { name: 'queue_depth', metric_type: 'gauge' },
+    { name: 'request_duration', metric_type: 'histogram' },
+    { name: 'mystery_metric', metric_type: 'unknown_type' },
+]
+
+describe('metricsViewerLogic', () => {
+    let logic: ReturnType<typeof metricsViewerLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.spyOn(api.metrics, 'values').mockResolvedValue({ results: PICKER_ITEMS })
+        logic = metricsViewerLogic()
+        logic.mount()
+        metricNamePickerLogic.actions.loadItemsSuccess(PICKER_ITEMS)
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    // Regression: the viewer defaulted every metric to `sum`, so selecting a
+    // cumulative counter summed raw monotonic readings across pods and buckets —
+    // a huge meaningless total instead of the actual increase.
+    it.each([
+        ['requests_total', 'increase'],
+        ['queue_depth', 'avg'],
+        ['request_duration', 'p95'],
+    ])('selecting %s applies the type-appropriate aggregation %s', (metricName, expected) => {
+        logic.actions.setMetricName(metricName)
+        expect(logic.values.aggregation).toBe(expected)
+    })
+
+    it('keeps a manual aggregation pick until the metric changes', () => {
+        logic.actions.setMetricName('requests_total')
+        logic.actions.setAggregation('rate')
+        expect(logic.values.aggregation).toBe('rate')
+        logic.actions.setMetricName('queue_depth')
+        expect(logic.values.aggregation).toBe('avg')
+    })
+
+    it('leaves aggregation untouched for unknown metric types', () => {
+        logic.actions.setMetricName('requests_total')
+        logic.actions.setMetricName('mystery_metric')
+        expect(logic.values.aggregation).toBe('increase')
+    })
+})

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -15,10 +15,11 @@ import type {
     MetricAnomalyDirectionEnumApi,
 } from 'products/metrics/frontend/generated/api.schemas'
 
+import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { formatSeriesName, seriesColor } from './metricsSeries'
 import type { metricsViewerLogicType } from './metricsViewerLogicType'
 
-export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95'
+export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95' | 'rate' | 'increase'
 
 // `chart` shows the time series; `stat` shows a single headline value + change pill (a Grafana "stat" panel).
 export type MetricsViewMode = 'chart' | 'stat'
@@ -35,6 +36,19 @@ export interface MetricsAnomalyBadge {
 }
 
 const DEFAULT_AGGREGATION: MetricAggregation = 'sum'
+
+// Aggregation applied automatically when a metric of this type is selected.
+// Cumulative counters (OTel type 'sum') summed raw give meaningless ever-growing
+// totals — 'increase' is the honest default and is temporality-aware server-side
+// (delta samples are summed as-is), so it's correct for delta producers too.
+export const RECOMMENDED_AGGREGATION_BY_TYPE: Record<string, MetricAggregation> = {
+    gauge: 'avg',
+    sum: 'increase',
+    counter: 'increase',
+    histogram: 'p95',
+    summary: 'p95',
+    exponential_histogram: 'p95',
+}
 const DEFAULT_DATE_FROM = '-1h'
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling the previous one'
 // The anomaly badge characterizes the most recent slice of the selected window against the rest.
@@ -62,7 +76,7 @@ const resolveDate = (value: string | null | undefined): string | null => {
 export const metricsViewerLogic = kea<metricsViewerLogicType>([
     path(['products', 'metrics', 'frontend', 'components', 'metricsViewerLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], metricNamePickerLogic, ['items']],
     })),
     actions({
         setMetricName: (metricName: string) => ({ metricName }),
@@ -101,6 +115,15 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         ],
     }),
     listeners(({ actions, values, cache }) => ({
+        setMetricName: ({ metricName }) => {
+            // Each metric type has one sensible default; a manual aggregation pick
+            // holds only until the next metric switch.
+            const metricType = values.items.find((item) => item.name === metricName)?.metric_type
+            const recommended = metricType ? RECOMMENDED_AGGREGATION_BY_TYPE[metricType] : undefined
+            if (recommended && recommended !== values.aggregation) {
+                actions.setAggregation(recommended)
+            }
+        },
         cancelInProgressQuery: ({ controller }) => {
             if (values.queryAbortController !== null) {
                 values.queryAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)


### PR DESCRIPTION
> [!NOTE]
> **Found by: metrics push-model dogfood validation** — part of a systematic first-time-user pass over the new OTLP push ingestion path.

## Problem

Selecting a cumulative counter in the metrics viewer shows a huge meaningless number. Observed on real data: the stat card reported **873,951,528 (+2,988.9%)** for a counter whose true hourly volume — confirmed against an independent pipeline counting the same events — is **~13.8M**.

Three compounding gaps:

1. The viewer's aggregation type omits `rate` and `increase` entirely, so a counter-correct aggregation could not even be selected — even though the API and query runner support both.
2. The default aggregation is `sum`, which for a cumulative counter sums raw monotonic readings across pods and time buckets.
3. The "recommended aggregation" hint recommends `sum` for `sum`/`counter` types — the recommendation *is* the broken aggregation, so the hint never renders for the case that needs it most.

## Changes

- Add `Rate (/s)` and `Increase` to the viewer's aggregation options (`MetricAggregation` union + dropdown). Both already exist in the generated API enum and the backend runner.
- Fix the recommendation map: `sum`/`counter` → `increase`. `increase` is temporality-aware server-side (delta samples are summed as-is), so it's correct for both cumulative and delta producers.
- Auto-apply the recommended aggregation when a metric is selected, instead of rendering a passive gray hint. A manual aggregation pick holds until the next metric switch; unknown metric types leave the aggregation untouched. The hint still renders when the user manually diverges.

## How did you test this code?

New `metricsViewerLogic.test.ts` (kea logic tests, no rendering): selecting a `sum`-type metric applies `increase` (fails on master — no listener exists, aggregation stays `sum`), gauge → `avg`, histogram → `p95`, manual pick persists until metric switch, unknown type untouched. No existing test covered aggregation selection. 5/5 pass; kea typegen regenerated.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) hit this as a first-time user comparing the viewer's stat card against the same metric in Grafana (13.8M vs 874M for the same hour) during the push-pipeline reconciliation. Skills invoked: /writing-tests, /get-stamp. Considered defaulting only the initial value vs auto-applying on every metric switch — chose auto-apply-per-switch because each metric type has one sensible default and a stale manual pick from a previous metric is a foot-gun (the exact one this PR fixes).
