### PR TITLE
fix(warehouse): key pipedrive field schemas by stable key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/settings.py
@@ -29,13 +29,17 @@ PIPEDRIVE_ENDPOINTS: dict[str, PipedriveEndpointConfig] = {
     "leads": PipedriveEndpointConfig(name="leads", path="/api/v1/leads", pagination="offset"),
     "users": PipedriveEndpointConfig(name="users", path="/api/v1/users", pagination="offset", partition_key=None),
     "deal_fields": PipedriveEndpointConfig(
-        name="deal_fields", path="/api/v1/dealFields", pagination="offset", partition_key=None
+        name="deal_fields", path="/api/v1/dealFields", pagination="offset", primary_key="key", partition_key=None
     ),
     "person_fields": PipedriveEndpointConfig(
-        name="person_fields", path="/api/v1/personFields", pagination="offset", partition_key=None
+        name="person_fields", path="/api/v1/personFields", pagination="offset", primary_key="key", partition_key=None
     ),
     "organization_fields": PipedriveEndpointConfig(
-        name="organization_fields", path="/api/v1/organizationFields", pagination="offset", partition_key=None
+        name="organization_fields",
+        path="/api/v1/organizationFields",
+        pagination="offset",
+        primary_key="key",
+        partition_key=None,
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
@@ -204,19 +204,25 @@ class TestGetRows:
 
 class TestPipedriveSource:
     @pytest.mark.parametrize(
-        "endpoint, expected_partition_keys, expected_mode",
+        "endpoint, expected_primary_keys, expected_partition_keys, expected_mode",
         [
-            ("deals", ["add_time"], "datetime"),
-            ("activities", ["add_time"], "datetime"),
-            ("users", None, None),
-            ("deal_fields", None, None),
+            ("deals", ["id"], ["add_time"], "datetime"),
+            ("activities", ["id"], ["add_time"], "datetime"),
+            ("users", ["id"], None, None),
+            ("deal_fields", ["key"], None, None),
+            ("person_fields", ["key"], None, None),
+            ("organization_fields", ["key"], None, None),
         ],
     )
     def test_source_response_partitioning(
-        self, endpoint: str, expected_partition_keys: list[str] | None, expected_mode: str | None
+        self,
+        endpoint: str,
+        expected_primary_keys: list[str],
+        expected_partition_keys: list[str] | None,
+        expected_mode: str | None,
     ) -> None:
         response = pipedrive_source("acme", "token", endpoint, mock.MagicMock(), mock.MagicMock())
         assert response.name == endpoint
-        assert response.primary_keys == ["id"]
+        assert response.primary_keys == expected_primary_keys
         assert response.partition_keys == expected_partition_keys
         assert response.partition_mode == expected_mode


### PR DESCRIPTION
## Problem

Pipedrive field-schema syncs can crash when the v1 field endpoints return generated subfield rows with `id: null`. Those rows are valid Pipedrive metadata, but using nullable `id` as the schema primary key can send a null numeric key into pipeline partitioning.

Closes #67150

## Changes

Set the Pipedrive `deal_fields`, `person_fields`, and `organization_fields` endpoint configs to use `key` as their primary key instead of the default `id`.

Updated the existing Pipedrive source-response test so field-schema endpoints are locked to `key`, while normal entity endpoints keep `id`.

## How did you test this code?

- `./bin/hogli test products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py` (`40 passed`)
- `.venv/bin/ruff check products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/settings.py products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py`
- `.venv/bin/ruff format --check products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/settings.py products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py`
- `./bin/hogli ci:preflight --fix`

The changed test catches the regression where Pipedrive field-schema endpoints accidentally fall back to nullable `id` primary keys, which recreates the null-ID partitioning crash path.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This fixes connector metadata for existing Pipedrive tables and does not change the documented setup flow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change after checking the open issue against the current Pipedrive source implementation. Skills invoked: `/implementing-warehouse-sources` and `/writing-tests`.

I chose the connector-scoped fix from the issue: keep the existing v1 field endpoints but key field-schema tables by Pipedrive `key`, which is stable for generated subfield rows. I did not change shared pipeline partition fallback behavior because that would affect all warehouse sources and is broader than needed for this bug.
