### PR TITLE
feat(usage-reports): add day_offset input and daily finalizer schedule

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -622,8 +622,9 @@ async def create_run_usage_reports_schedule(client: Client):
 async def create_finalize_usage_reports_schedule(client: Client):
     """Daily finalizer for the usage reports v2 flow, 03:00 UTC.
 
-    Reports *yesterday* (`day_offset=1`) once the day is complete — billing
-    treats a `day_offset >= 1` pointer as the final numbers for that date.
+    Reports *yesterday* (`day_offset=1`) once the day is complete — its
+    pointer carries `report_completeness="complete"`, billing's signal that
+    the numbers are final for that date.
     03:00 leaves 3 hours for ingestion lag after midnight while staying clear
     of the legacy Celery run at 03:45 UTC. Unlike the intraday schedule this
     run has no later slot to supersede it, so the retry policy keeps

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -620,17 +620,19 @@ async def create_run_usage_reports_schedule(client: Client):
 
 
 async def create_finalize_usage_reports_schedule(client: Client):
-    """Daily finalizer for the usage reports v2 flow, 03:00 UTC.
+    """Daily finalizer for the usage reports v2 flow, 02:45 UTC.
 
     Reports *yesterday* (`day_offset=1`) once the day is complete — its
     pointer carries `report_completeness="complete"`, billing's signal that
     the numbers are final for that date.
-    03:00 leaves 3 hours for ingestion lag after midnight while staying clear
-    of the legacy Celery run at 03:45 UTC. Unlike the intraday schedule this
-    run has no later slot to supersede it, so the retry policy keeps
-    re-running it across the day (5m, 10m, ... capped at 2h) until it
-    succeeds. Anything longer than that is a manual backfill: trigger the
-    workflow with `day_offset=N` for the missed day.
+    02:45 leaves ~2.75 hours for ingestion lag after midnight, gives the
+    01:45 intraday slot a full hour to finish (the two schedules' SKIP
+    policies don't see each other, so spacing is the only concurrency
+    control), and stays ahead of the legacy Celery run at 03:45 UTC. Unlike
+    the intraday schedule this run has no later slot to supersede it, so the
+    retry policy keeps re-running it across the day (5m, 10m, ... capped at
+    2h) until it succeeds. Anything longer than that is a manual backfill:
+    trigger the workflow with `day_offset=N` for the missed day.
     """
     finalize_usage_reports_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
@@ -647,9 +649,9 @@ async def create_finalize_usage_reports_schedule(client: Client):
         spec=ScheduleSpec(
             calendars=[
                 ScheduleCalendarSpec(
-                    comment="Daily at 03:00 UTC",
-                    hour=[ScheduleRange(start=3, end=3)],
-                    minute=[ScheduleRange(start=0, end=0)],
+                    comment="Daily at 02:45 UTC",
+                    hour=[ScheduleRange(start=2, end=2)],
+                    minute=[ScheduleRange(start=45, end=45)],
                 )
             ]
         ),

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -577,19 +577,21 @@ async def cleanup_legacy_session_summarization_schedules(client: Client):
 
 
 async def create_run_usage_reports_schedule(client: Client):
-    """Temporal-based usage report run every 3 hours at minute 45 (8 times a day).
+    """Intraday usage report run every 3 hours at minute 45 (8 times a day).
 
-    The 04:45 UTC slot runs an hour after the existing Celery beat for
-    `send_all_org_usage_reports` (03:45 UTC) so ClickHouse has breathing room
-    while both flows run side by side. The workflow writes per-org usage data
-    to S3 and sends a single SQS pointer to the billing service.
+    Reports *today's* usage so far (`day_offset=0`) so billing gets fresh
+    numbers throughout the day. A failed slot is superseded by the next one
+    3 hours later, so no retries. The complete-day capture is handled by the
+    daily finalizer schedule (`create_finalize_usage_reports_schedule`). The
+    workflow writes per-org usage data to S3 and sends a single SQS pointer
+    to the billing service.
     """
     run_usage_reports_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
             "run-usage-reports",
             # `RunUsageReportsInputs` is a pydantic model, not a dataclass —
             # `dataclasses.asdict` would TypeError on registration.
-            RunUsageReportsInputs().model_dump(mode="json"),
+            RunUsageReportsInputs(day_offset=0).model_dump(mode="json"),
             id="run-usage-reports-schedule",
             task_queue=settings.BILLING_TASK_QUEUE,
             retry_policy=common.RetryPolicy(maximum_attempts=1),
@@ -613,6 +615,53 @@ async def create_run_usage_reports_schedule(client: Client):
             client,
             "run-usage-reports-schedule",
             run_usage_reports_schedule,
+            trigger_immediately=False,
+        )
+
+
+async def create_finalize_usage_reports_schedule(client: Client):
+    """Daily finalizer for the usage reports v2 flow, 03:00 UTC.
+
+    Reports *yesterday* (`day_offset=1`) once the day is complete — billing
+    treats a `day_offset >= 1` pointer as the final numbers for that date.
+    03:00 leaves 3 hours for ingestion lag after midnight while staying clear
+    of the legacy Celery run at 03:45 UTC. Unlike the intraday schedule this
+    run has no later slot to supersede it, so the retry policy keeps
+    re-running it across the day (5m, 10m, ... capped at 2h) until it
+    succeeds. Anything longer than that is a manual backfill: trigger the
+    workflow with `day_offset=N` for the missed day.
+    """
+    finalize_usage_reports_schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            "run-usage-reports",
+            RunUsageReportsInputs(day_offset=1).model_dump(mode="json"),
+            id="finalize-usage-reports-schedule",
+            task_queue=settings.BILLING_TASK_QUEUE,
+            retry_policy=common.RetryPolicy(
+                maximum_attempts=8,
+                initial_interval=timedelta(minutes=5),
+                maximum_interval=timedelta(hours=2),
+            ),
+        ),
+        spec=ScheduleSpec(
+            calendars=[
+                ScheduleCalendarSpec(
+                    comment="Daily at 03:00 UTC",
+                    hour=[ScheduleRange(start=3, end=3)],
+                    minute=[ScheduleRange(start=0, end=0)],
+                )
+            ]
+        ),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, "finalize-usage-reports-schedule"):
+        await a_update_schedule(client, "finalize-usage-reports-schedule", finalize_usage_reports_schedule)
+    else:
+        await a_create_schedule(
+            client,
+            "finalize-usage-reports-schedule",
+            finalize_usage_reports_schedule,
             trigger_immediately=False,
         )
 
@@ -744,6 +793,7 @@ if settings.CLOUD_DEPLOYMENT:
     schedules.append(create_gemini_cleanup_sweep_schedule)
     schedules.append(create_replay_vision_gemini_cleanup_sweep_schedule)
     schedules.append(create_run_usage_reports_schedule)
+    schedules.append(create_finalize_usage_reports_schedule)
 
 if settings.EE_AVAILABLE:
     schedules.append(create_schedule_all_subscriptions_schedule)

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -24,16 +24,16 @@ from posthog.temporal.usage_report.aggregator import (
     load_all_data,
     sort_org_reports,
 )
-from posthog.temporal.usage_report.types import Manifest, RunQueryToS3Result, WorkflowContext
+from posthog.temporal.usage_report.types import Manifest, ReportCompleteness, RunQueryToS3Result, WorkflowContext
 
 
-def _ctx(run_id: str = "abc", day_offset: int = 0) -> WorkflowContext:
+def _ctx(run_id: str = "abc", report_completeness: ReportCompleteness = "partial") -> WorkflowContext:
     return WorkflowContext(
         run_id=run_id,
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",
-        day_offset=day_offset,
+        report_completeness=report_completeness,
     )
 
 
@@ -190,7 +190,7 @@ def test_iter_chunk_lines_emits_id_and_report() -> None:
 
 
 def test_build_manifest_returns_typed_manifest() -> None:
-    ctx = _ctx(run_id="run-1", day_offset=1)
+    ctx = _ctx(run_id="run-1", report_completeness="complete")
     with (
         patch("posthog.temporal.usage_report.aggregator.settings") as mock_settings,
         patch("posthog.temporal.usage_report.aggregator.bucket", return_value="posthog-billing-usage-reports"),
@@ -211,7 +211,7 @@ def test_build_manifest_returns_typed_manifest() -> None:
     assert manifest.date == "2026-05-04"
     assert manifest.period_start == ctx.period_start
     assert manifest.period_end == ctx.period_end
-    assert manifest.day_offset == 1
+    assert manifest.report_completeness == "complete"
     assert manifest.region == "US"
     assert manifest.site_url == "https://us.posthog.com"
     assert manifest.bucket == "posthog-billing-usage-reports"

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -27,12 +27,13 @@ from posthog.temporal.usage_report.aggregator import (
 from posthog.temporal.usage_report.types import Manifest, RunQueryToS3Result, WorkflowContext
 
 
-def _ctx(run_id: str = "abc") -> WorkflowContext:
+def _ctx(run_id: str = "abc", day_offset: int = 0) -> WorkflowContext:
     return WorkflowContext(
         run_id=run_id,
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",
+        day_offset=day_offset,
     )
 
 
@@ -189,7 +190,7 @@ def test_iter_chunk_lines_emits_id_and_report() -> None:
 
 
 def test_build_manifest_returns_typed_manifest() -> None:
-    ctx = _ctx(run_id="run-1")
+    ctx = _ctx(run_id="run-1", day_offset=1)
     with (
         patch("posthog.temporal.usage_report.aggregator.settings") as mock_settings,
         patch("posthog.temporal.usage_report.aggregator.bucket", return_value="posthog-billing-usage-reports"),
@@ -210,6 +211,7 @@ def test_build_manifest_returns_typed_manifest() -> None:
     assert manifest.date == "2026-05-04"
     assert manifest.period_start == ctx.period_start
     assert manifest.period_end == ctx.period_end
+    assert manifest.day_offset == 1
     assert manifest.region == "US"
     assert manifest.site_url == "https://us.posthog.com"
     assert manifest.bucket == "posthog-billing-usage-reports"

--- a/posthog/temporal/tests/usage_report/test_pointer_activity.py
+++ b/posthog/temporal/tests/usage_report/test_pointer_activity.py
@@ -25,6 +25,7 @@ def _ctx() -> WorkflowContext:
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",
+        day_offset=1,
     )
 
 
@@ -82,6 +83,7 @@ async def test_pointer_uses_v2_queue_and_correct_payload(activity_environment) -
         "date": "2026-05-04",
         "period_start": "2026-05-04T00:00:00+00:00",
         "period_end": "2026-05-04T23:59:59.999999+00:00",
+        "day_offset": 1,
         "region": "US",
         "site_url": "https://us.posthog.com",
         "bucket": "posthog-billing-usage-reports",

--- a/posthog/temporal/tests/usage_report/test_pointer_activity.py
+++ b/posthog/temporal/tests/usage_report/test_pointer_activity.py
@@ -25,7 +25,7 @@ def _ctx() -> WorkflowContext:
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",
-        day_offset=1,
+        report_completeness="complete",
     )
 
 
@@ -83,7 +83,7 @@ async def test_pointer_uses_v2_queue_and_correct_payload(activity_environment) -
         "date": "2026-05-04",
         "period_start": "2026-05-04T00:00:00+00:00",
         "period_end": "2026-05-04T23:59:59.999999+00:00",
-        "day_offset": 1,
+        "report_completeness": "complete",
         "region": "US",
         "site_url": "https://us.posthog.com",
         "bucket": "posthog-billing-usage-reports",

--- a/posthog/temporal/tests/usage_report/test_schedule.py
+++ b/posthog/temporal/tests/usage_report/test_schedule.py
@@ -1,4 +1,4 @@
-"""Regression tests for `create_run_usage_reports_schedule`.
+"""Regression tests for the usage-report schedule builders.
 
 The previous version of this code passed `dataclasses.asdict(...)` on
 `RunUsageReportsInputs` *after* it was migrated to pydantic — that
@@ -6,9 +6,10 @@ silently raised `TypeError` the first time the worker registered the
 schedule, and *no* test caught it because nothing in the suite ever
 imported and called the schedule-creation function.
 
-These tests close that gap: they actually invoke the function with a
-mocked client and assert it (a) doesn't raise and (b) hands Temporal a
-JSON-serializable input.
+These tests close that gap: they actually invoke the functions with a
+mocked client and assert they (a) don't raise, (b) hand Temporal a
+JSON-serializable input, and (c) carry the right `day_offset` — the
+intraday schedule reports today, the finalizer reports yesterday.
 """
 
 import json
@@ -16,14 +17,22 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from posthog.temporal.schedule import create_finalize_usage_reports_schedule, create_run_usage_reports_schedule
+
+SCHEDULE_CASES = [
+    (create_run_usage_reports_schedule, "run-usage-reports-schedule", 0),
+    (create_finalize_usage_reports_schedule, "finalize-usage-reports-schedule", 1),
+]
+
 
 @pytest.mark.asyncio
-async def test_create_run_usage_reports_schedule_does_not_raise() -> None:
-    """The schedule-builder must not blow up when called — covers both the
+@pytest.mark.parametrize("create_schedule_fn,schedule_id,expected_day_offset", SCHEDULE_CASES)
+async def test_create_usage_reports_schedules_do_not_raise(
+    create_schedule_fn, schedule_id, expected_day_offset
+) -> None:
+    """The schedule-builders must not blow up when called — covers both the
     `a_schedule_exists is False` (create) and `True` (update) branches.
     """
-    from posthog.temporal.schedule import create_run_usage_reports_schedule
-
     client = MagicMock()
 
     # First-time registration: schedule doesn't exist → `a_create_schedule` runs.
@@ -32,7 +41,7 @@ async def test_create_run_usage_reports_schedule_does_not_raise() -> None:
         patch("posthog.temporal.schedule.a_create_schedule", new=AsyncMock()) as create_mock,
         patch("posthog.temporal.schedule.a_update_schedule", new=AsyncMock()) as update_mock,
     ):
-        await create_run_usage_reports_schedule(client)
+        await create_schedule_fn(client)
         create_mock.assert_awaited_once()
         update_mock.assert_not_awaited()
 
@@ -42,21 +51,26 @@ async def test_create_run_usage_reports_schedule_does_not_raise() -> None:
         patch("posthog.temporal.schedule.a_create_schedule", new=AsyncMock()) as create_mock,
         patch("posthog.temporal.schedule.a_update_schedule", new=AsyncMock()) as update_mock,
     ):
-        await create_run_usage_reports_schedule(client)
+        await create_schedule_fn(client)
         update_mock.assert_awaited_once()
         create_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_run_usage_reports_schedule_input_is_json_serializable() -> None:
+@pytest.mark.parametrize("create_schedule_fn,schedule_id,expected_day_offset", SCHEDULE_CASES)
+async def test_usage_reports_schedule_input_is_json_serializable(
+    create_schedule_fn, schedule_id, expected_day_offset
+) -> None:
     """Temporal serializes the `ScheduleActionStartWorkflow` input via the
     data converter. Even with the pydantic data converter, JSON-encoding
     must round-trip — otherwise registration fails the moment it hits
     the wire. Catches the original `dataclasses.asdict(pydantic_model)`
     bug that landed on this branch.
-    """
-    from posthog.temporal.schedule import create_run_usage_reports_schedule
 
+    Also pins each schedule's `day_offset`: the intraday schedule must
+    report today (0) and the finalizer yesterday (1) — swapping or
+    dropping these silently sends billing the wrong day.
+    """
     captured: dict = {}
 
     async def fake_create_schedule(client, schedule_id, schedule, trigger_immediately=False):
@@ -67,9 +81,9 @@ async def test_run_usage_reports_schedule_input_is_json_serializable() -> None:
         patch("posthog.temporal.schedule.a_schedule_exists", new=AsyncMock(return_value=False)),
         patch("posthog.temporal.schedule.a_create_schedule", new=fake_create_schedule),
     ):
-        await create_run_usage_reports_schedule(MagicMock())
+        await create_schedule_fn(MagicMock())
 
-    assert captured["schedule_id"] == "run-usage-reports-schedule"
+    assert captured["schedule_id"] == schedule_id
 
     # Pull the args out of the schedule action — Temporal stores positional
     # args as a list; the workflow input lives at index 0.
@@ -87,4 +101,26 @@ async def test_run_usage_reports_schedule_input_is_json_serializable() -> None:
 
     revived = RunUsageReportsInputs(**decoded)
     assert revived.organization_ids is None
-    assert revived.at is None
+    assert revived.day_offset == expected_day_offset
+
+
+@pytest.mark.asyncio
+async def test_finalizer_schedule_retries_until_the_day_is_captured() -> None:
+    """The finalizer has no later slot to supersede a failed run — a single
+    attempt would silently leave yesterday incomplete (the bug the finalizer
+    exists to prevent). Its schedule action must allow multiple attempts.
+    """
+    captured: dict = {}
+
+    async def fake_create_schedule(client, schedule_id, schedule, trigger_immediately=False):
+        captured["schedule"] = schedule
+
+    with (
+        patch("posthog.temporal.schedule.a_schedule_exists", new=AsyncMock(return_value=False)),
+        patch("posthog.temporal.schedule.a_create_schedule", new=fake_create_schedule),
+    ):
+        await create_finalize_usage_reports_schedule(MagicMock())
+
+    retry_policy = captured["schedule"].action.retry_policy
+    assert retry_policy is not None
+    assert retry_policy.maximum_attempts > 1

--- a/posthog/temporal/tests/usage_report/test_schedule.py
+++ b/posthog/temporal/tests/usage_report/test_schedule.py
@@ -13,6 +13,7 @@ intraday schedule reports today, the finalizer reports yesterday.
 """
 
 import json
+from datetime import timedelta
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -108,7 +109,8 @@ async def test_usage_reports_schedule_input_is_json_serializable(
 async def test_finalizer_schedule_retries_until_the_day_is_captured() -> None:
     """The finalizer has no later slot to supersede a failed run — a single
     attempt would silently leave yesterday incomplete (the bug the finalizer
-    exists to prevent). Its schedule action must allow multiple attempts.
+    exists to prevent). Its schedule action must keep retrying across a good
+    part of the day, not give up minutes after 03:00.
     """
     captured: dict = {}
 
@@ -123,4 +125,9 @@ async def test_finalizer_schedule_retries_until_the_day_is_captured() -> None:
 
     retry_policy = captured["schedule"].action.retry_policy
     assert retry_policy is not None
-    assert retry_policy.maximum_attempts > 1
+    # Lower bounds, not exact values, so tuning the policy doesn't break the
+    # test — but a token retry (2 quick attempts) or an uncapped-backoff
+    # misconfig can't sneak through either.
+    assert retry_policy.maximum_attempts >= 5
+    assert retry_policy.maximum_interval is not None
+    assert retry_policy.maximum_interval >= timedelta(hours=1)

--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -13,7 +13,9 @@ import pytest
 import temporalio.worker
 from parameterized import parameterized
 from temporalio import activity
+from temporalio.client import WorkflowFailureError
 from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
@@ -50,6 +52,40 @@ def test_build_context_reports_full_day_at_offset(
     assert ctx.report_completeness == expected_completeness
     assert ctx.period_start.isoformat() == f"{expected_date}T00:00:00+00:00"
     assert ctx.period_end.isoformat() == f"{expected_date}T23:59:59.999999+00:00"
+
+
+@pytest.mark.asyncio
+async def test_workflow_rejects_negative_day_offset() -> None:
+    # Without the guard, a manual-trigger typo like day_offset=-1 reports a
+    # future empty day and marks it "complete" for billing.
+    ran_queries: list[str] = []
+
+    @activity.defn(name="run-usage-report-query")
+    async def query_mock(inputs: RunQueryToS3Inputs) -> RunQueryToS3Result:
+        ran_queries.append(inputs.query_name)
+        return RunQueryToS3Result(query_name=inputs.query_name, s3_key="unused", duration_ms=1)
+
+    async with await WorkflowEnvironment.start_time_skipping(data_converter=pydantic_data_converter) as env:
+        async with Worker(
+            env.client,
+            task_queue=str(uuid.uuid4()),
+            workflows=[RunUsageReportsWorkflow],
+            activities=[query_mock],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ) as worker:
+            with pytest.raises(WorkflowFailureError) as exc_info:
+                await env.client.execute_workflow(
+                    RunUsageReportsWorkflow.run,
+                    RunUsageReportsInputs(day_offset=-1),
+                    id=str(uuid.uuid4()),
+                    task_queue=worker.task_queue,
+                )
+
+    cause = exc_info.value.cause
+    assert isinstance(cause, ApplicationError)
+    assert cause.non_retryable
+    assert "day_offset" in str(cause)
+    assert ran_queries == []
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -31,21 +31,23 @@ from posthog.temporal.usage_report.workflow import RunUsageReportsWorkflow, buil
 
 @parameterized.expand(
     [
-        # (day_offset, now, expected_date) — intraday run mid-day reports today
-        (0, datetime(2026, 5, 4, 13, 45, tzinfo=UTC), "2026-05-04"),
+        # (day_offset, now, expected_date, expected_completeness) — intraday run mid-day reports today
+        (0, datetime(2026, 5, 4, 13, 45, tzinfo=UTC), "2026-05-04", "partial"),
         # intraday run just after midnight still reports the new day, not yesterday
-        (0, datetime(2026, 5, 4, 1, 45, tzinfo=UTC), "2026-05-04"),
+        (0, datetime(2026, 5, 4, 1, 45, tzinfo=UTC), "2026-05-04", "partial"),
         # finalizer run early morning reports the completed previous day
-        (1, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-03"),
-        # manual backfill of an older day
-        (3, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-01"),
+        (1, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-03", "complete"),
+        # manual backfill of an older day is also complete
+        (3, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-01", "complete"),
     ]
 )
-def test_build_context_reports_full_day_at_offset(day_offset: int, now: datetime, expected_date: str) -> None:
+def test_build_context_reports_full_day_at_offset(
+    day_offset: int, now: datetime, expected_date: str, expected_completeness: str
+) -> None:
     ctx = build_context(RunUsageReportsInputs(day_offset=day_offset), run_id="run-1", now=now)
 
     assert ctx.date_str == expected_date
-    assert ctx.day_offset == day_offset
+    assert ctx.report_completeness == expected_completeness
     assert ctx.period_start.isoformat() == f"{expected_date}T00:00:00+00:00"
     assert ctx.period_end.isoformat() == f"{expected_date}T23:59:59.999999+00:00"
 

--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -6,10 +6,12 @@ can be verified without standing up real ClickHouse / Postgres / S3.
 """
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 
 import temporalio.worker
+from parameterized import parameterized
 from temporalio import activity
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.testing import WorkflowEnvironment
@@ -24,7 +26,28 @@ from posthog.temporal.usage_report.types import (
     RunQueryToS3Result,
     RunUsageReportsInputs,
 )
-from posthog.temporal.usage_report.workflow import RunUsageReportsWorkflow
+from posthog.temporal.usage_report.workflow import RunUsageReportsWorkflow, build_context
+
+
+@parameterized.expand(
+    [
+        # (day_offset, now, expected_date) — intraday run mid-day reports today
+        (0, datetime(2026, 5, 4, 13, 45, tzinfo=UTC), "2026-05-04"),
+        # intraday run just after midnight still reports the new day, not yesterday
+        (0, datetime(2026, 5, 4, 1, 45, tzinfo=UTC), "2026-05-04"),
+        # finalizer run early morning reports the completed previous day
+        (1, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-03"),
+        # manual backfill of an older day
+        (3, datetime(2026, 5, 4, 3, 0, tzinfo=UTC), "2026-05-01"),
+    ]
+)
+def test_build_context_reports_full_day_at_offset(day_offset: int, now: datetime, expected_date: str) -> None:
+    ctx = build_context(RunUsageReportsInputs(day_offset=day_offset), run_id="run-1", now=now)
+
+    assert ctx.date_str == expected_date
+    assert ctx.day_offset == day_offset
+    assert ctx.period_start.isoformat() == f"{expected_date}T00:00:00+00:00"
+    assert ctx.period_end.isoformat() == f"{expected_date}T23:59:59.999999+00:00"
 
 
 @pytest.mark.asyncio
@@ -71,7 +94,7 @@ async def test_workflow_runs_query_then_aggregate() -> None:
         ):
             result = await env.client.execute_workflow(
                 RunUsageReportsWorkflow.run,
-                RunUsageReportsInputs(at="2026-05-04T12:00:00+00:00"),
+                RunUsageReportsInputs(day_offset=1),
                 id=workflow_id,
                 task_queue=task_queue,
             )

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -221,9 +221,9 @@ async def enqueue_pointer_message(inputs: EnqueuePointerInputs) -> None:
             "date": inputs.ctx.date_str,
             "period_start": inputs.ctx.period_start.isoformat(),
             "period_end": inputs.ctx.period_end.isoformat(),
-            # >= 1 tells billing the reported day was already complete when
-            # queried — its signal to treat the numbers as final.
-            "day_offset": inputs.ctx.day_offset,
+            # "complete" tells billing the reported day was already over when
+            # queried — its signal to treat the numbers as final for that date.
+            "report_completeness": inputs.ctx.report_completeness,
             "region": get_instance_region(),
             "site_url": settings.SITE_URL,
             "bucket": bucket(),

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -221,6 +221,9 @@ async def enqueue_pointer_message(inputs: EnqueuePointerInputs) -> None:
             "date": inputs.ctx.date_str,
             "period_start": inputs.ctx.period_start.isoformat(),
             "period_end": inputs.ctx.period_end.isoformat(),
+            # >= 1 tells billing the reported day was already complete when
+            # queried — its signal to treat the numbers as final.
+            "day_offset": inputs.ctx.day_offset,
             "region": get_instance_region(),
             "site_url": settings.SITE_URL,
             "bucket": bucket(),

--- a/posthog/temporal/usage_report/aggregator.py
+++ b/posthog/temporal/usage_report/aggregator.py
@@ -113,7 +113,7 @@ def build_manifest(
         date=ctx.date_str,
         period_start=ctx.period_start,
         period_end=ctx.period_end,
-        day_offset=ctx.day_offset,
+        report_completeness=ctx.report_completeness,
         region=region,
         site_url=settings.SITE_URL,
         bucket=bucket(),

--- a/posthog/temporal/usage_report/aggregator.py
+++ b/posthog/temporal/usage_report/aggregator.py
@@ -113,6 +113,7 @@ def build_manifest(
         date=ctx.date_str,
         period_start=ctx.period_start,
         period_end=ctx.period_end,
+        day_offset=ctx.day_offset,
         region=region,
         site_url=settings.SITE_URL,
         bucket=bucket(),

--- a/posthog/temporal/usage_report/types.py
+++ b/posthog/temporal/usage_report/types.py
@@ -6,9 +6,14 @@ ISO-string round-tripping that plain dataclasses would force.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
+
+# What billing reads off the pointer/manifest: "partial" = intraday snapshot
+# of a day still in progress, "complete" = the day was already over when
+# queried (finalizer or backfill run), so the numbers are final for that date.
+ReportCompleteness = Literal["partial", "complete"]
 
 
 class RunUsageReportsInputs(BaseModel):
@@ -16,8 +21,7 @@ class RunUsageReportsInputs(BaseModel):
 
     `day_offset` selects which UTC day to report on, relative to the workflow's
     start time: 0 = today (intraday, data so far), 1 = yesterday (complete),
-    N = N days ago (manual backfills). Billing treats `day_offset >= 1` as
-    "this day is complete".
+    N = N days ago (manual backfills).
     """
 
     day_offset: int = 0
@@ -31,7 +35,7 @@ class WorkflowContext(BaseModel):
     period_start: datetime
     period_end: datetime
     date_str: str
-    day_offset: int = 0
+    report_completeness: ReportCompleteness = "partial"
     organization_ids: Optional[list[str]] = None
 
 
@@ -61,7 +65,7 @@ class Manifest(BaseModel):
     date: str
     period_start: datetime
     period_end: datetime
-    day_offset: int = 0
+    report_completeness: ReportCompleteness = "partial"
     region: str
     site_url: str
     bucket: str

--- a/posthog/temporal/usage_report/types.py
+++ b/posthog/temporal/usage_report/types.py
@@ -12,9 +12,15 @@ from pydantic import BaseModel
 
 
 class RunUsageReportsInputs(BaseModel):
-    """Top-level workflow input."""
+    """Top-level workflow input.
 
-    at: Optional[str] = None
+    `day_offset` selects which UTC day to report on, relative to the workflow's
+    start time: 0 = today (intraday, data so far), 1 = yesterday (complete),
+    N = N days ago (manual backfills). Billing treats `day_offset >= 1` as
+    "this day is complete".
+    """
+
+    day_offset: int = 0
     organization_ids: Optional[list[str]] = None
 
 
@@ -25,6 +31,7 @@ class WorkflowContext(BaseModel):
     period_start: datetime
     period_end: datetime
     date_str: str
+    day_offset: int = 0
     organization_ids: Optional[list[str]] = None
 
 
@@ -54,6 +61,7 @@ class Manifest(BaseModel):
     date: str
     period_start: datetime
     period_end: datetime
+    day_offset: int = 0
     region: str
     site_url: str
     bucket: str

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -16,10 +16,8 @@ remains in production until billing migrates to consume the S3 layout.
 
 import json
 import asyncio
-from datetime import datetime, timedelta
-from typing import Optional
+from datetime import UTC, datetime, time, timedelta
 
-from dateutil import parser
 from temporalio import common, workflow
 
 from posthog.exceptions_capture import capture_exception
@@ -40,26 +38,30 @@ from posthog.temporal.usage_report.types import (
     RunUsageReportsInputs,
     WorkflowContext,
 )
-from posthog.utils import get_previous_day
 
 # Cap concurrent gather queries so we don't overwhelm ClickHouse / Postgres
 # with ~40 simultaneous heavy queries.
 QUERY_CONCURRENCY = 4
 
 
-def build_context(inputs: RunUsageReportsInputs, run_id: str, now: Optional[datetime] = None) -> WorkflowContext:
+def build_context(inputs: RunUsageReportsInputs, run_id: str, now: datetime) -> WorkflowContext:
     """Compute the period and S3 layout context. Pure function so it's safe
     to call from the workflow body (no real-time access).
+
+    The period is always the full UTC day `inputs.day_offset` days before
+    `now`. For `day_offset=0` (today) the tail of the window is in the
+    future and simply matches no events, so intraday and finalizer runs
+    share one code path.
     """
-    at_date = parser.parse(inputs.at) if inputs.at else None
-    if at_date is None and now is not None:
-        at_date = now
-    period_start, period_end = get_previous_day(at=at_date)
+    report_day = (now.astimezone(UTC) - timedelta(days=inputs.day_offset)).date()
+    period_start = datetime.combine(report_day, time.min, tzinfo=UTC)
+    period_end = datetime.combine(report_day, time.max, tzinfo=UTC)
     return WorkflowContext(
         run_id=run_id,
         period_start=period_start,
         period_end=period_end,
         date_str=period_start.strftime("%Y-%m-%d"),
+        day_offset=inputs.day_offset,
         organization_ids=inputs.organization_ids,
     )
 
@@ -82,6 +84,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
                 extra={
                     "run_id": ctx.run_id,
                     "date_str": ctx.date_str,
+                    "day_offset": ctx.day_offset,
                     "period_start": ctx.period_start.isoformat(),
                     "period_end": ctx.period_end.isoformat(),
                     "spec_count": len(QUERIES),

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -19,6 +19,7 @@ import asyncio
 from datetime import UTC, datetime, time, timedelta
 
 from temporalio import common, workflow
+from temporalio.exceptions import ApplicationError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.base import PostHogWorkflow
@@ -75,6 +76,12 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, inputs: RunUsageReportsInputs) -> dict:
+        if inputs.day_offset < 0:
+            # A negative offset (manual-trigger typo) would report a future,
+            # empty day and mark it "complete" for billing. Fail fast;
+            # non_retryable so the schedule's retry policy doesn't re-run a
+            # validation error.
+            raise ApplicationError(f"day_offset must be >= 0, got {inputs.day_offset}", non_retryable=True)
         started_at = workflow.now()
         status = "FAILED"
         try:

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -61,7 +61,7 @@ def build_context(inputs: RunUsageReportsInputs, run_id: str, now: datetime) -> 
         period_start=period_start,
         period_end=period_end,
         date_str=period_start.strftime("%Y-%m-%d"),
-        day_offset=inputs.day_offset,
+        report_completeness="partial" if inputs.day_offset == 0 else "complete",
         organization_ids=inputs.organization_ids,
     )
 
@@ -84,7 +84,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
                 extra={
                     "run_id": ctx.run_id,
                     "date_str": ctx.date_str,
-                    "day_offset": ctx.day_offset,
+                    "report_completeness": ctx.report_completeness,
                     "period_start": ctx.period_start.isoformat(),
                     "period_end": ctx.period_end.isoformat(),
                     "spec_count": len(QUERIES),


### PR DESCRIPTION
## Problem

The usage reports v2 temporal workflow was recently moved to a 3-hourly schedule, but every run still reported *yesterday* (via `get_previous_day`). That meant the same complete day was re-queried 8 times a day, and billing never received fresh same-day usage.

Flipping the runs to report *today* alone isn't enough. The last intraday slot runs at 22:45 UTC, so the tail of each day would never be captured, and a single once-a-day "finalizer" run would be a single point of failure for the completeness of yesterday's numbers.

## Changes

Replaces the `at` workflow input with `day_offset` – each run reports the full UTC day `day_offset` days before the workflow's start time:

- **Intraday schedule** (existing, every 3h at :45) now passes `day_offset=0` and reports today so far. A failed slot needs no retries, the next slot 3 hours later supersedes it.
- **New finalizer schedule** at 02:45 UTC passes `day_offset=1` and captures the completed previous day. It has no later slot to supersede it, so its schedule action gets a real retry policy (8 attempts, 5m initial backoff capped at 2h) that keeps re-running it across the day until it succeeds. 02:45 leaves ~2.75h of ingestion-lag slack after midnight, gives the 01:45 intraday slot a full hour to finish (the two schedules’ SKIP policies don’t see each other, so spacing is the only concurrency control), and stays ahead of the legacy Celery run at 03:45 UTC.
- The SQS pointer message and the S3 manifest carry `report_completeness` – "partial" for an intraday snapshot of a day still in progress, "complete" when the day was already over at query time. Billing persists it and treats "complete" as the trigger for downstream final-day processing (companion PR: PostHog/billing#2007). `day_offset` stays producer-side vocabulary and does not travel in the message.
- The workflow rejects a negative `day_offset` with a non-retryable error before doing any work — a manual-trigger typo like `-1` would otherwise report a future, empty day and mark it "complete" for billing.
- Manual backfills of any past day are a workflow trigger with `day_offset=N`, which replaces the old `at` date override. Reports are idempotent per date on the billing side (latest pointer per date wins), so re-running a day is safe and corrections propagate.

The period is always the full calendar day (00:00 → 23:59:59.999999 UTC). For `day_offset=0` the future part of the window simply matches no events, so intraday and finalizer runs share one code path with no branching.

Backward compat: old scheduled inputs still carrying `{"at": null}` are ignored by pydantic (extra fields), so in-flight schedule actions won't crash before the schedules are re-registered at worker boot.

## How did you test this code?

Ran `pytest posthog/temporal/tests/usage_report/` – all unit-level tests pass (the `*_via_minio`, parity, and aggregate-activity tests need local ClickHouse/MinIO services and fail identically on master in this environment).

New/changed tests and the regression each catches:

- `test_build_context_reports_full_day_at_offset` (parameterized): someone reintroducing yesterday-hardcoding or breaking the offset arithmetic (including the just-after-midnight case) would send billing the wrong day.
- `test_schedule.py` (parameterized over both schedules): the finalizer registered with the wrong `day_offset`, or with a single-attempt retry policy, would silently break the completeness guarantee – `test_finalizer_schedule_retries_until_the_day_is_captured` pins the multi-attempt invariant.
- `test_workflow_rejects_negative_day_offset`: without the guard, a typo’d manual trigger emits a future-dated "complete" report — asserts the workflow fails non-retryably with zero query activities executed.
- Extended the exact pointer-body assertion and manifest test so dropping `report_completeness` from the SQS message or manifest fails loudly; the `build_context` cases also pin the offset-to-completeness mapping (backfills are "complete" too).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal temporal workflow only – no docs under `docs/` reference this flow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code task session), directed by @mcoll-posthog. Skills invoked: `/django-migrations` (for the billing companion PR), `/writing-tests`.

Design decisions along the way: an every-run-reports-both-days scheme was rejected as wasteful (it re-runs ~50 heavy queries against a finalized day 8x/day); a lag-based single finalizing run was rejected as fragile (one failed run loses the tail of yesterday). The landed design gets robustness from Temporal retries instead of redundant work. The billing consumer was verified to be fully date-driven (pointer streams keyed by date, generation-aware upserts), so backdated and corrected reports propagate correctly.


