### PR TITLE
fix(data-imports): handle sources without schema discovery in database_schema

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -2660,6 +2660,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
         try:
             schemas = source.get_schemas(source_config, self.team_id)
+        except NotImplementedError:
+            # Source doesn't implement schema discovery (e.g. an unreleased source), so there are
+            # no tables to list — a caller mistake, not a server error worth capturing. Mirrors `setup`.
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"Source type '{source_type}' does not support schema discovery."},
+            )
         except Exception as e:
             error_message, is_expected_source_error = _classify_refresh_schemas_error(source, e)
             if not is_expected_source_error:

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -4061,6 +4061,32 @@ class TestExternalDataSource(APIBaseTest):
             assert response.json()["message"] == str(error)
             mock_capture_exception.assert_not_called()
 
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
+    def test_database_schema_rejects_source_without_schema_discovery(self, mock_get_source, mock_capture_exception):
+        # Unreleased sources inherit the base get_schemas, which raises NotImplementedError. The endpoint
+        # must return a clean 400 without capturing it as a server error, mirroring `setup`.
+        from products.warehouse_sources.backend.temporal.data_imports.sources.amazon_cloudwatch.source import (
+            AmazonCloudWatchSource,
+        )
+
+        source = AmazonCloudWatchSource()
+        mock_get_source.return_value = source
+
+        with (
+            patch.object(source, "validate_config", return_value=(True, [])),
+            patch.object(source, "parse_config", return_value=None),
+            patch.object(source, "validate_credentials", return_value=(True, None)),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+                data={"source_type": "AmazonCloudWatch"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Source type 'AmazonCloudWatch' does not support schema discovery."
+        mock_capture_exception.assert_not_called()
+
     def test_database_schema_stripe_surfaces_per_endpoint_permission_errors(self):
         """Schema-selection step calls get_endpoint_permissions and merges the per-endpoint
         result into each schema row so the UI can disable tables the credentials can't reach."""

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -4064,13 +4064,11 @@ class TestExternalDataSource(APIBaseTest):
     @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
     @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
     def test_database_schema_rejects_source_without_schema_discovery(self, mock_get_source, mock_capture_exception):
-        # Unreleased sources inherit the base get_schemas, which raises NotImplementedError. The endpoint
+        # AmazonS3 deliberately omits get_schemas, so the base raises NotImplementedError. The endpoint
         # must return a clean 400 without capturing it as a server error, mirroring `setup`.
-        from products.warehouse_sources.backend.temporal.data_imports.sources.amazon_cloudwatch.source import (
-            AmazonCloudWatchSource,
-        )
+        from products.warehouse_sources.backend.temporal.data_imports.sources.amazon_s3.source import AmazonS3Source
 
-        source = AmazonCloudWatchSource()
+        source = AmazonS3Source()
         mock_get_source.return_value = source
 
         with (
@@ -4080,11 +4078,11 @@ class TestExternalDataSource(APIBaseTest):
         ):
             response = self.client.post(
                 f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
-                data={"source_type": "AmazonCloudWatch"},
+                data={"source_type": "AmazonS3"},
             )
 
         assert response.status_code == 400
-        assert response.json()["message"] == "Source type 'AmazonCloudWatch' does not support schema discovery."
+        assert response.json()["message"] == "Source type 'AmazonS3' does not support schema discovery."
         mock_capture_exception.assert_not_called()
 
     def test_database_schema_stripe_surfaces_per_endpoint_permission_errors(self):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `NotImplementedError` with no message, captured as an unexpected server error, coming out of the data-warehouse import pipeline:

- Raised in `get_schemas` at `products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py`
- Reached through the `database_schema` API endpoint (`ExternalDataSourceViewSet.database_schema`)
- Triggered for an unreleased source type

Issue: https://us.posthog.com/project/2/error_tracking/019f261a-ca75-75a3-9837-182e94289ce6

The base `_BaseSource.get_schemas` raises a bare `NotImplementedError` for any source that doesn't implement schema discovery (unreleased stubs that inherit `SimpleSource` directly, e.g. Amazon CloudWatch). The `database_schema` endpoint wrapped the `get_schemas` call in a broad `except Exception`, and since a bare `NotImplementedError` matches none of the expected-error patterns in `_classify_refresh_schemas_error`, it fell through to `capture_exception` and returned the generic "Could not fetch schemas from source." message.

This is our code being fragile, not a user credential or upstream problem. There is nothing to retry — the source simply has no schema discovery — so it should degrade gracefully rather than page us.

## Changes

Add an `except NotImplementedError` branch to `database_schema` that returns a clean `400` with a clear message and does not capture the exception. This mirrors the guard the sibling `setup` endpoint already has for the same base `NotImplementedError`, so the two schema-discovery entry points now behave consistently.

No behavior change for sources that implement `get_schemas`.

## How did you test this code?

Added `test_database_schema_rejects_source_without_schema_discovery`, which posts a source type that inherits the base `get_schemas` to the endpoint and asserts a `400` with the friendly message and that `capture_exception` is not called. Before this change that path captured the `NotImplementedError` and returned the generic fallback message. No existing test covered `database_schema` for a source without schema discovery — the sibling case (`test_setup_rejects_source_without_schema_discovery`) only exercises the `setup` endpoint, and `test_database_schema_captures_only_unexpected_source_errors` mocks `get_schemas` rather than raising the real base error.

I (Claude) could not run the Django test suite in this environment — pytest's backing databases are not provisioned here (the pre-existing sibling test fails the same way on connection). I ran `ruff check` and `ruff format --check` over both touched files (both clean), and statically verified the source hierarchy: `AmazonCloudWatchSource` inherits `SimpleSource` without overriding `get_schemas`, so the base raises `NotImplementedError`. The new test mirrors the already-passing `setup` guard test.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) found this while triaging an error-tracking issue in the data-warehouse import pipeline. I confirmed the issue via the PostHog error-tracking tools (full stack trace, single occurrence, top in-app frame at `base.py` `get_schemas`), traced the call path from `database_schema` into the shared base source, and classified it as a fixable fragility rather than a user/upstream error worth adding to `NonRetryableErrors`.

I invoked `/improving-drf-endpoints` and `/writing-tests` while shaping the change. I chose the view-layer fix (rather than touching the shared base or the classifier) because the `setup` endpoint already establishes exactly this pattern for the same exception, so mirroring it keeps the two entry points consistent and the change obviously correct. I checked open PRs (including the maintainer's own) for duplicates: #68098 guards the same endpoint but for a different root cause (unknown source type raising `ValueError`), and #67605 touches the `setup` path and MCP classification, not this `get_schemas` call site.
