### PR TITLE
feat(usage-reports): add workflow start time to v2 pointer

### DIFF
--- a/posthog/temporal/tests/usage_report/conftest.py
+++ b/posthog/temporal/tests/usage_report/conftest.py
@@ -45,6 +45,7 @@ def minio_workflow_ctx() -> Iterator[WorkflowContext]:
     """A `WorkflowContext` whose run-prefix gets nuked from MinIO at teardown."""
     ctx = WorkflowContext(
         run_id=f"test-{uuid.uuid4().hex[:12]}",
+        workflow_started_at=datetime(2026, 5, 5, 1, 45, 0, tzinfo=UTC),
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str=f"test-{uuid.uuid4().hex[:8]}",

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -30,6 +30,7 @@ from posthog.temporal.usage_report.types import Manifest, ReportCompleteness, Ru
 def _ctx(run_id: str = "abc", report_completeness: ReportCompleteness = "partial") -> WorkflowContext:
     return WorkflowContext(
         run_id=run_id,
+        workflow_started_at=datetime(2026, 5, 5, 1, 45, 0, tzinfo=UTC),
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",

--- a/posthog/temporal/tests/usage_report/test_parity.py
+++ b/posthog/temporal/tests/usage_report/test_parity.py
@@ -213,6 +213,7 @@ def test_end_to_end_parity_celery_task_vs_temporal_activity(
     # ---- Temporal path ----
     ctx = WorkflowContext(
         run_id="e2e-parity-test",
+        workflow_started_at=period_start,
         period_start=period_start,
         period_end=period_end,
         date_str=period_start.strftime("%Y-%m-%d"),

--- a/posthog/temporal/tests/usage_report/test_pointer_activity.py
+++ b/posthog/temporal/tests/usage_report/test_pointer_activity.py
@@ -22,6 +22,7 @@ from posthog.temporal.usage_report.types import AggregateResult, EnqueuePointerI
 def _ctx() -> WorkflowContext:
     return WorkflowContext(
         run_id="run-test",
+        workflow_started_at=datetime(2026, 5, 5, 1, 45, 0, tzinfo=UTC),
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str="2026-05-04",
@@ -80,6 +81,7 @@ async def test_pointer_uses_v2_queue_and_correct_payload(activity_environment) -
     assert body == {
         "version": SQS_POINTER_VERSION,
         "run_id": "run-test",
+        "workflow_started_at": "2026-05-05T01:45:00+00:00",
         "date": "2026-05-04",
         "period_start": "2026-05-04T00:00:00+00:00",
         "period_end": "2026-05-04T23:59:59.999999+00:00",

--- a/posthog/temporal/tests/usage_report/test_pointer_activity.py
+++ b/posthog/temporal/tests/usage_report/test_pointer_activity.py
@@ -105,6 +105,41 @@ async def test_pointer_uses_v2_queue_and_correct_payload(activity_environment) -
 
 
 @pytest.mark.asyncio
+async def test_pointer_omits_workflow_started_at_for_legacy_ctx(activity_environment) -> None:
+    """An activity input serialized before `workflow_started_at` existed (field
+    is None) must still send a valid pointer, just without the key. Guards the
+    backwards-compat rollout: an in-flight or retried old payload crossing a
+    deploy can't crash the enqueue, and billing skips the metric via `.get(...)`.
+    """
+    legacy_ctx = WorkflowContext(
+        run_id="run-legacy",
+        period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
+        period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
+        date_str="2026-05-04",
+    )
+    fake_producer = MagicMock()
+    fake_producer.send_message.return_value = {"MessageId": "abc"}
+
+    with (
+        patch("posthog.temporal.usage_report.activities.settings") as mock_settings,
+        patch("posthog.temporal.usage_report.activities.bucket", return_value="posthog"),
+        patch("ee.sqs.SQSProducer.get_sqs_producer", return_value=fake_producer),
+        patch("posthog.temporal.usage_report.activities.get_instance_region", return_value="US"),
+    ):
+        mock_settings.EE_AVAILABLE = True
+        mock_settings.SITE_URL = "https://us.posthog.com"
+
+        await activity_environment.run(
+            enqueue_pointer_message,
+            EnqueuePointerInputs(ctx=legacy_ctx, aggregate=_agg()),
+        )
+
+    fake_producer.send_message.assert_called_once()
+    body = json.loads(fake_producer.send_message.call_args.kwargs["message_body"])
+    assert "workflow_started_at" not in body
+
+
+@pytest.mark.asyncio
 async def test_pointer_skipped_when_ee_unavailable(activity_environment) -> None:
     """Self-hosted (no EE) → activity is a no-op, no SQS import or call."""
     fake_producer = MagicMock()

--- a/posthog/temporal/tests/usage_report/test_storage.py
+++ b/posthog/temporal/tests/usage_report/test_storage.py
@@ -33,6 +33,7 @@ def _ctx(run_id: str = "abc-123", date_str: str = "2026-05-04") -> WorkflowConte
 
     return WorkflowContext(
         run_id=run_id,
+        workflow_started_at=datetime(2026, 5, 5, 1, 45, 0, tzinfo=UTC),
         period_start=datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC),
         period_end=datetime(2026, 5, 4, 23, 59, 59, 999999, tzinfo=UTC),
         date_str=date_str,

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -218,7 +218,6 @@ async def enqueue_pointer_message(inputs: EnqueuePointerInputs) -> None:
         pointer = {
             "version": SQS_POINTER_VERSION,
             "run_id": inputs.ctx.run_id,
-            "workflow_started_at": inputs.ctx.workflow_started_at.isoformat(),
             "date": inputs.ctx.date_str,
             "period_start": inputs.ctx.period_start.isoformat(),
             "period_end": inputs.ctx.period_end.isoformat(),
@@ -234,6 +233,10 @@ async def enqueue_pointer_message(inputs: EnqueuePointerInputs) -> None:
             "total_orgs": inputs.aggregate.total_orgs,
             "total_orgs_with_usage": inputs.aggregate.total_orgs_with_usage,
         }
+        # Omit the key for legacy contexts (field absent pre-deploy); billing
+        # reads it with `.get(...)` and skips the flow-latency metric when None.
+        if inputs.ctx.workflow_started_at is not None:
+            pointer["workflow_started_at"] = inputs.ctx.workflow_started_at.isoformat()
 
         @sync_to_async
         def send() -> None:

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -218,6 +218,7 @@ async def enqueue_pointer_message(inputs: EnqueuePointerInputs) -> None:
         pointer = {
             "version": SQS_POINTER_VERSION,
             "run_id": inputs.ctx.run_id,
+            "workflow_started_at": inputs.ctx.workflow_started_at.isoformat(),
             "date": inputs.ctx.date_str,
             "period_start": inputs.ctx.period_start.isoformat(),
             "period_end": inputs.ctx.period_end.isoformat(),

--- a/posthog/temporal/usage_report/types.py
+++ b/posthog/temporal/usage_report/types.py
@@ -32,6 +32,7 @@ class WorkflowContext(BaseModel):
     """Snapshot of the workflow run, threaded through every activity."""
 
     run_id: str
+    workflow_started_at: datetime
     period_start: datetime
     period_end: datetime
     date_str: str

--- a/posthog/temporal/usage_report/types.py
+++ b/posthog/temporal/usage_report/types.py
@@ -32,7 +32,10 @@ class WorkflowContext(BaseModel):
     """Snapshot of the workflow run, threaded through every activity."""
 
     run_id: str
-    workflow_started_at: datetime
+    # Optional so an activity input serialized before this field existed
+    # (in-flight or retried across a deploy) still decodes through the pydantic
+    # converter. New runs always populate it in build_context.
+    workflow_started_at: Optional[datetime] = None
     period_start: datetime
     period_end: datetime
     date_str: str

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -53,12 +53,16 @@ def build_context(inputs: RunUsageReportsInputs, run_id: str, now: datetime) -> 
     `now`. For `day_offset=0` (today) the tail of the window is in the
     future and simply matches no events, so intraday and finalizer runs
     share one code path.
+
+    `now` (the workflow start instant) also rides along on the context to
+    billing so it can measure end-to-end flow latency.
     """
     report_day = (now.astimezone(UTC) - timedelta(days=inputs.day_offset)).date()
     period_start = datetime.combine(report_day, time.min, tzinfo=UTC)
     period_end = datetime.combine(report_day, time.max, tzinfo=UTC)
     return WorkflowContext(
         run_id=run_id,
+        workflow_started_at=now,
         period_start=period_start,
         period_end=period_end,
         date_str=period_start.strftime("%Y-%m-%d"),
@@ -85,7 +89,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
         started_at = workflow.now()
         status = "FAILED"
         try:
-            ctx = build_context(inputs, run_id=workflow.info().run_id, now=workflow.now())
+            ctx = build_context(inputs, run_id=workflow.info().run_id, now=started_at)
             workflow.logger.info(
                 "Starting usage reports workflow",
                 extra={


### PR DESCRIPTION
## Problem

The usage reports v2 Temporal workflow hands off to billing through a single SQS pointer, but nothing ties a workflow run to when billing finishes processing it. We can measure each side's latency in isolation. We cannot measure the full flow from workflow start to pointer processed.

## Changes

- Add `workflow_started_at` to `WorkflowContext`, anchored to the workflow's start instant (`workflow.now()`). This reuses the same value already captured for the internal workflow latency metric, so there is a single source of truth.
- Forward it in the SQS pointer body so billing can compute end-to-end latency on its side.
- `build_context` now takes a required `now` and drops the redundant `Optional` branch.

The field is additive and read defensively by the consumer, so no pointer version bump is needed and deploy order does not matter.

Companion PR with the consumer and the metric: PostHog/billing#2008.

## How did you test this code?

I (Claude) ran the affected Temporal tests locally: `test_pointer_activity.py` (now asserts the new field in the exact pointer body), `test_aggregator.py`, and `test_workflow.py`. All pass. The MinIO-backed `test_storage.py` cases need object storage that was not available in my sandbox. Their pure key-formatting cases pass. ruff is clean. I could not run the full dev stack.

Tests changed: extended the existing exact pointer-body assertion to cover `workflow_started_at` (catches the field being dropped or mis-serialized, which would silently break the billing metric), and updated the five `WorkflowContext` fixtures for the new required field.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marce drove this; I (Claude, via Claude Code) implemented it. Skills invoked: `/marce-development`, `/writing-tests`, `/rs-self-review`, `/rs-adversarial-review`.

Shape decisions worth flagging for review: I chose to measure from workflow start rather than reuse SQS `SentTimestamp`, because `SentTimestamp` is stamped at enqueue and would miss the query and aggregation phase that makes up most of the runtime. The anchor is the deterministic `workflow.now()` so the value is stable across activity retries. I kept the pointer at version 2 since the field is additive and the consumer reads it defensively. A self-review and adversarial pass turned up no correctness bug. The honest caveat is that the billing companion's consumer test could not run without Postgres in my sandbox, so CI is the first real run of that side.
