### PR TITLE
feat(data-warehouse): enable warehouse_sources contract-check, drop temporal segment + data-import hack

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -184,10 +184,6 @@ jobs:
             schema: ${{ steps.filter.outputs.schema || 'true' }}
             product_yamls: ${{ steps.filter.outputs.product_yamls || 'false' }}
             product_yamls_files: ${{ steps.filter.outputs.product_yamls_files }}
-            # True only when every backend-relevant changed file is a data
-            # warehouse import source — lets build_django_matrix drop the
-            # Core/CorePOE/compat segments. Defaults false (full matrix).
-            data_import_sources_only: ${{ steps.sources.outputs.data_import_sources_only || 'false' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -367,50 +363,6 @@ jobs:
                         - 'services/mcp/schema/generated-tool-definitions.json'
                         - 'services/mcp/schema/tool-definitions-all.json'
 
-            # Detect PRs whose backend changes are confined to data warehouse
-            # import sources that NO Django Core/CorePOE-collected code imports.
-            # Such a PR is exercised only by the Temporal segment (Core/CorePOE
-            # --ignore=posthog/temporal), so those segments add no coverage.
-            # The `coupled` sources are reverse-imported at runtime by Core tests
-            # (e.g. posthog/hogql/test/test_direct_postgres_query.py imports
-            # postgres) — a PR touching them must run the full matrix or it would
-            # silently skip those tests. `coupled` is kept complete by the guard
-            # test products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py.
-            # Fails OPEN: empty/non-source/coupled file list → false → full matrix.
-            # PR events only; push and merge_group always run everything.
-            # continue-on-error keeps the fail-open promise even when the runner can't
-            # start the step at all: a very large PR (e.g. a big rename) makes
-            # BACKEND_FILES exceed the process env limit ("Argument list too long"),
-            # which would otherwise hard-fail this job and skip every dependent test job.
-            # On that failure the job output below defaults to false → full matrix.
-            - name: Determine if only data warehouse sources changed
-              id: sources
-              continue-on-error: true
-              if: github.event_name == 'pull_request'
-              env:
-                  BACKEND_FILES: ${{ steps.filter.outputs.backend_files }}
-              run: |
-                  prefix="products/warehouse_sources/backend/temporal/data_imports/sources/"
-                  # Space-separated, double-quoted, single line — parsed by the guard test.
-                  coupled="common google_search_console mysql postgres salesforce stripe"
-                  only_sources=false
-                  if [ -n "$BACKEND_FILES" ]; then
-                      only_sources=true
-                      for f in $BACKEND_FILES; do
-                          case "$f" in
-                              "$prefix"*) ;;
-                              *) only_sources=false; break ;;
-                          esac
-                          rest=${f#"$prefix"}    # path within sources/
-                          top=${rest%%/*}        # vendor dir (or top-level filename)
-                          case " $coupled " in
-                              *" $top "*) only_sources=false; break ;;
-                          esac
-                      done
-                  fi
-                  echo "data_import_sources_only=$only_sources" >> "$GITHUB_OUTPUT"
-                  echo "Only data warehouse import sources changed: $only_sources"
-
             # A change that only touches Markdown docs (e.g. a README under
             # posthog/) still matches the broad backend globs above, needlessly
             # running the whole backend suite. Drop the backend signal when
@@ -563,12 +515,6 @@ jobs:
                   TURBO_SCM_HEAD: ${{ github.sha }}
                   # Kill switch — drop comma-separated products from the matrix; empty = run all.
                   SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS || '' }}
-                  # When only (non-coupled) data-warehouse import sources changed, the Temporal
-                  # segment is the sole coverage (build_django_matrix trims Django to it). Those
-                  # source connectors are facade-isolated, so no other product's tests exercise
-                  # them — narrow the product matrix to warehouse_sources alone instead of the
-                  # full all-products fan-out. Guarded + fail-open in the `changes` job above.
-                  DATA_IMPORT_SOURCES_ONLY: ${{ github.event_name != 'pull_request' && 'false' || needs.changes.outputs.data_import_sources_only }}
               run: |
                   # turbo-discover.js uses Turbo's Git affectedness to detect
                   # changed products. Non-isolated product changes trigger the
@@ -703,16 +649,16 @@ jobs:
                   #   Core POE on:    posthog/clickhouse, posthog/queries, posthog/api/test/test_insight*,
                   #                   posthog/api/test/dashboards/test_dashboard.py, ee/clickhouse/
                   #   Temporal:       posthog/temporal, products/{batch_exports,tasks}/backend/temporal,
-                  #                   products/warehouse_sources/backend/temporal, products/signals/backend/emission
+                  #                   products/signals/backend/emission
                   # Files outside posthog/ and ee/ (e.g. products/foo/backend/test_*) are not in this
-                  # matrix — turbo-tests handles them.
+                  # matrix — turbo-tests handles them (warehouse_sources runs its own temporal suite there).
                   core=()
                   poe=()
                   temporal=()
                   while IFS= read -r f; do
                       [[ -z "$f" ]] && continue
                       case "$f" in
-                          posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/warehouse_sources/backend/temporal/*|products/signals/backend/emission/*)
+                          posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/signals/backend/emission/*)
                               temporal+=("$f")
                               ;;
                           posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*|products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
@@ -1211,7 +1157,6 @@ jobs:
                   RUN_POE: ${{ needs.select-tests.outputs.run_poe }}
                   RUN_TEMPORAL: ${{ needs.select-tests.outputs.run_temporal }}
                   CORE_FILES: ${{ needs.select-tests.outputs.core_files }}
-                  DATA_IMPORT_SOURCES_ONLY: ${{ needs.changes.outputs.data_import_sources_only }}
                   IS_DRAFT: ${{ github.event.pull_request.draft }}
                   FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'run-ci-backend') }}
               run: |
@@ -1351,19 +1296,12 @@ jobs:
                       ')
                   fi
 
-                  if [ "$DATA_IMPORT_SOURCES_ONLY" = "true" ]; then
-                    # Only data warehouse import sources changed — the Temporal
-                    # segment already covers posthog/temporal, so skip Core/CorePOE/compat.
-                    echo "Only data warehouse import sources changed — running Temporal segment only"
-                    include="$temporal"
-                  else
-                    include=$(jq -cn \
-                      --argjson core "$core" \
-                      --argjson core_persons_on_events "$core_persons_on_events" \
-                      --argjson temporal "$temporal" \
-                      --argjson compat "$compat" \
-                      '$core + $core_persons_on_events + $temporal + $compat')
-                  fi
+                  include=$(jq -cn \
+                    --argjson core "$core" \
+                    --argjson core_persons_on_events "$core_persons_on_events" \
+                    --argjson temporal "$temporal" \
+                    --argjson compat "$compat" \
+                    '$core + $core_persons_on_events + $temporal + $compat')
 
                   echo "include=$include" >> "$GITHUB_OUTPUT"
                   echo "Django matrix size: $(jq -r 'length' <<< "$include") (mode=$MODE)"
@@ -1753,7 +1691,7 @@ jobs:
                       # No per-test pytest --timeout; rely on the job-level timeout-minutes as the single
                       # safety net (matches canonical — the per-test guillotine added nothing over it,
                       # since --timeout-method=thread os._exit()s the whole process anyway).
-                      pytest -v --tb=short --reuse-db -o junit_duration_report=call posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal products/warehouse_sources/backend/temporal products/signals/backend/emission -m "not async_migrations" \
+                      pytest -v --tb=short --reuse-db -o junit_duration_report=call posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal products/signals/backend/emission -m "not async_migrations" \
                           --deselect "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_with_minio_bucket" \
                           --deselect "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_timeout_does_not_pause_schedule_without_consecutive_failures" \
                           --deselect "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_timeout_pauses_schedule_after_5_consecutive_failures" \

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -496,20 +496,6 @@ if (legacyChanged) {
     }
 }
 
-// Data-warehouse import sources are facade-isolated and covered solely by the Temporal
-// Django segment (build_django_matrix trims Django to it when data_import_sources_only).
-// No other product's tests exercise those source connectors, so when the `changes` job
-// confirmed the change is confined to non-coupled sources, run only warehouse_sources'
-// own product tests instead of the full all-products fan-out. runLegacy stays true so
-// Django (trimmed to Temporal) still provides the source coverage. Gated to NOT apply when
-// legacy or schema changed (those affect everyone); fail-open (flag defaults to false).
-const dataImportSourcesOnly = process.env.DATA_IMPORT_SOURCES_ONLY === 'true'
-if (dataImportSourcesOnly && !legacyChanged && !schemaChanged && allProducts.includes('warehouse-sources')) {
-    console.error('Only data-warehouse import sources changed — narrowing product matrix to warehouse-sources, keeping Django (Temporal)')
-    products = ['warehouse-sources']
-    runLegacy = true
-}
-
 // Kill switch: products named in the SKIP_PRODUCT_TESTS repo variable (comma-
 // separated) are dropped from the matrix without a code change — use it to stop
 // running, and blocking on, a product whose tests are temporarily too flaky.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -91,10 +91,6 @@ jobs:
             product_yamls: ${{ steps.filter.outputs.product_yamls || 'false' }}
             product_yamls_files: ${{ steps.filter.outputs.product_yamls_files }}
             timing_scripts: ${{ steps.filter.outputs.timing_scripts }}
-            # True only when every backend-relevant changed file is a data
-            # warehouse import source — lets build_django_matrix drop the
-            # Core/CorePOE/compat segments. Defaults false (full matrix).
-            data_import_sources_only: ${{ steps.sources.outputs.data_import_sources_only || 'false' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -287,50 +283,6 @@ jobs:
                         - 'services/mcp/schema/generated-tool-definitions.json'
                         - 'services/mcp/schema/tool-definitions-all.json'
 
-            # Detect PRs whose backend changes are confined to data warehouse
-            # import sources that NO Django Core/CorePOE-collected code imports.
-            # Such a PR is exercised only by the Temporal segment (Core/CorePOE
-            # --ignore=posthog/temporal), so those segments add no coverage.
-            # The `coupled` sources are reverse-imported at runtime by Core tests
-            # (e.g. posthog/hogql/test/test_direct_postgres_query.py imports
-            # postgres) — a PR touching them must run the full matrix or it would
-            # silently skip those tests. `coupled` is kept complete by the guard
-            # test products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py.
-            # Fails OPEN: empty/non-source/coupled file list → false → full matrix.
-            # PR events only; push and merge_group always run everything.
-            # continue-on-error keeps the fail-open promise even when the runner can't
-            # start the step at all: a very large PR (e.g. a big rename) makes
-            # BACKEND_FILES exceed the process env limit ("Argument list too long"),
-            # which would otherwise hard-fail this job and skip every dependent test job.
-            # On that failure the job output below defaults to false → full matrix.
-            - name: Determine if only data warehouse sources changed
-              id: sources
-              continue-on-error: true
-              if: github.event_name == 'pull_request'
-              env:
-                  BACKEND_FILES: ${{ steps.filter.outputs.backend_files }}
-              run: |
-                  prefix="products/warehouse_sources/backend/temporal/data_imports/sources/"
-                  # Space-separated, double-quoted, single line — parsed by the guard test.
-                  coupled="common google_search_console mysql postgres salesforce snowflake stripe"
-                  only_sources=false
-                  if [ -n "$BACKEND_FILES" ]; then
-                      only_sources=true
-                      for f in $BACKEND_FILES; do
-                          case "$f" in
-                              "$prefix"*) ;;
-                              *) only_sources=false; break ;;
-                          esac
-                          rest=${f#"$prefix"}    # path within sources/
-                          top=${rest%%/*}        # vendor dir (or top-level filename)
-                          case " $coupled " in
-                              *" $top "*) only_sources=false; break ;;
-                          esac
-                      done
-                  fi
-                  echo "data_import_sources_only=$only_sources" >> "$GITHUB_OUTPUT"
-                  echo "Only data warehouse import sources changed: $only_sources"
-
             # A change that only touches Markdown docs (e.g. a README under
             # posthog/) still matches the broad backend globs above, needlessly
             # running the whole backend suite. Drop the backend signal when
@@ -504,12 +456,6 @@ jobs:
                   TURBO_SCM_HEAD: ${{ github.sha }}
                   # Kill switch — drop comma-separated products from the matrix; empty = run all.
                   SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS || '' }}
-                  # When only (non-coupled) data-warehouse import sources changed, the Temporal
-                  # segment is the sole coverage (build_django_matrix trims Django to it). Those
-                  # source connectors are facade-isolated, so no other product's tests exercise
-                  # them — narrow the product matrix to warehouse_sources alone instead of the
-                  # full all-products fan-out. Guarded + fail-open in the `changes` job above.
-                  DATA_IMPORT_SOURCES_ONLY: ${{ github.event_name != 'pull_request' && 'false' || needs.changes.outputs.data_import_sources_only }}
               run: |
                   # turbo-discover.js uses Turbo's Git affectedness to detect
                   # changed products. Non-isolated product changes trigger the
@@ -640,16 +586,16 @@ jobs:
                   #   Core POE on:    posthog/clickhouse, posthog/queries, posthog/api/test/test_insight*,
                   #                   posthog/api/test/dashboards/test_dashboard.py, ee/clickhouse/
                   #   Temporal:       posthog/temporal, products/{batch_exports,tasks}/backend/temporal,
-                  #                   products/warehouse_sources/backend/temporal, products/signals/backend/emission
+                  #                   products/signals/backend/emission
                   # Files outside posthog/ and ee/ (e.g. products/foo/backend/test_*) are not in this
-                  # matrix — turbo-tests handles them.
+                  # matrix — turbo-tests handles them (warehouse_sources runs its own temporal suite there).
                   core=()
                   poe=()
                   temporal=()
                   while IFS= read -r f; do
                       [[ -z "$f" ]] && continue
                       case "$f" in
-                          posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/warehouse_sources/backend/temporal/*|products/signals/backend/emission/*)
+                          posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/signals/backend/emission/*)
                               temporal+=("$f")
                               ;;
                           posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*|products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
@@ -1988,7 +1934,6 @@ jobs:
                   RUN_POE: ${{ needs.select-tests.outputs.run_poe }}
                   RUN_TEMPORAL: ${{ needs.select-tests.outputs.run_temporal }}
                   CORE_FILES: ${{ needs.select-tests.outputs.core_files }}
-                  DATA_IMPORT_SOURCES_ONLY: ${{ needs.changes.outputs.data_import_sources_only }}
                   IS_DRAFT: ${{ github.event.pull_request.draft }}
                   FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'run-ci-backend') }}
               run: |
@@ -2131,19 +2076,12 @@ jobs:
                       ')
                   fi
 
-                  if [ "$DATA_IMPORT_SOURCES_ONLY" = "true" ]; then
-                    # Only data warehouse import sources changed — the Temporal
-                    # segment already covers posthog/temporal, so skip Core/CorePOE/compat.
-                    echo "Only data warehouse import sources changed — running Temporal segment only"
-                    include="$temporal"
-                  else
-                    include=$(jq -cn \
-                      --argjson core "$core" \
-                      --argjson core_persons_on_events "$core_persons_on_events" \
-                      --argjson temporal "$temporal" \
-                      --argjson compat "$compat" \
-                      '$core + $core_persons_on_events + $temporal + $compat')
-                  fi
+                  include=$(jq -cn \
+                    --argjson core "$core" \
+                    --argjson core_persons_on_events "$core_persons_on_events" \
+                    --argjson temporal "$temporal" \
+                    --argjson compat "$compat" \
+                    '$core + $core_persons_on_events + $temporal + $compat')
 
                   echo "include=$include" >> "$GITHUB_OUTPUT"
                   echo "Django matrix size: $(jq -r 'length' <<< "$include") (mode=$MODE)"
@@ -2635,7 +2573,7 @@ jobs:
                       # anyway, so the shard dies either way) and was the reason the
                       # transaction=True overhead in async tests looked like "the
                       # timeout problem" instead of a per-test cost worth fixing.
-                      pytest -v --tb=short --reuse-db -o junit_duration_report=call posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal products/warehouse_sources/backend/temporal products/signals/backend/emission -m "not async_migrations" \
+                      pytest -v --tb=short --reuse-db -o junit_duration_report=call posthog/temporal products/batch_exports/backend/tests/temporal products/tasks/backend/temporal products/signals/backend/emission -m "not async_migrations" \
                           --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                           --durations=100 --durations-min=1.0 --store-durations \
                           --pytest-durations=100 \

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py
@@ -1,13 +1,15 @@
-import re
 import ast
+import json
 from pathlib import Path
 
-# Guards the `data_import_sources_only` optimization in .github/workflows/ci-backend.yml.
-# That step trims a sources-only PR to the Django Temporal segment, dropping Core/CorePOE.
-# That is only safe for sources NOT imported by Core/CorePOE-collected code. The workflow
-# excludes the coupled ones via its `coupled` list; this test fails if a Core/CorePOE file
-# gains a runtime import of a source missing from that list — which would otherwise let a
-# sources-only PR silently skip the Core test that exercises it.
+# Guards the backend:contract-check isolation of warehouse_sources.
+# When only isolated-product internals change, turbo-discover.js skips the Django suite
+# (Core/CorePOE) — sound only for sources NOT reverse-imported by Core/CorePOE-collected
+# code. The ones that ARE reverse-imported must land in the product's turbo.json
+# contract-check `inputs`, so a change to them counts as a contract change and re-runs
+# Django. This test fails if a Core/CorePOE file gains a runtime import of a source vendor
+# missing from those inputs — which would otherwise let a change to it silently skip the
+# Core test that exercises it.
 #
 # Deliberately uses stdlib ast over a path walk, NOT the repo's `grimp` dependency: grimp
 # does not descend products/warehouse_sources/backend/temporal/data_imports/ (an implicit namespace package — no
@@ -66,16 +68,22 @@ def _runtime_imported_sources(tree: ast.AST) -> set[str]:
     return found
 
 
-def _workflow_coupled(root: Path) -> set[str]:
-    text = (root / ".github" / "workflows" / "ci-backend.yml").read_text()
-    match = re.search(r'coupled="([^"]*)"', text)
-    assert match, 'could not find `coupled="..."` in ci-backend.yml sources step'
-    coupled = set(match.group(1).split())
-    assert coupled, "parsed an empty `coupled` list from ci-backend.yml"
-    return coupled
+_INPUTS_PREFIX = "backend/temporal/data_imports/sources/"
 
 
-def test_core_coupled_sources_are_excluded_from_ci_trim():
+def _contract_covered_sources(root: Path) -> set[str]:
+    turbo = json.loads((root / "products" / "warehouse_sources" / "turbo.json").read_text())
+    inputs = turbo["tasks"]["backend:contract-check"]["inputs"]
+    covered = {
+        rest.split("/")[0]
+        for entry in inputs
+        if (rest := entry[len(_INPUTS_PREFIX) :]) and entry.startswith(_INPUTS_PREFIX) and "/" in rest
+    }
+    assert covered, "parsed no source-vendor inputs from turbo.json backend:contract-check"
+    return covered
+
+
+def test_core_coupled_sources_are_covered_by_contract_check():
     root = _repo_root()
     excluded = root / "posthog" / "temporal"  # the Temporal segment; always runs
 
@@ -96,10 +104,11 @@ def test_core_coupled_sources_are_excluded_from_ci_trim():
                 continue
             imported |= _runtime_imported_sources(tree)
 
-    coupled = _workflow_coupled(root)
-    missing = imported - coupled
+    covered = _contract_covered_sources(root)
+    missing = imported - covered
     assert not missing, (
-        f"Core/CorePOE code imports warehouse sources {sorted(missing)} not in the CI "
-        f"`coupled` list {sorted(coupled)}. A sources-only PR touching them would skip "
-        f"their Core tests. Add them to `coupled` in .github/workflows/ci-backend.yml."
+        f"Core/CorePOE code runtime-imports warehouse sources {sorted(missing)} not covered by "
+        f"products/warehouse_sources/turbo.json backend:contract-check inputs {sorted(covered)}. "
+        f"A change to those sources would skip the Core tests that exercise them. Add "
+        f"backend/temporal/data_imports/sources/<vendor>/** to the contract-check inputs."
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py
@@ -4,26 +4,36 @@ from pathlib import Path
 
 # Guards the backend:contract-check isolation of warehouse_sources.
 # When only isolated-product internals change, turbo-discover.js skips the Django suite
-# (Core/CorePOE) — sound only for sources NOT reverse-imported by Core/CorePOE-collected
-# code. The ones that ARE reverse-imported must land in the product's turbo.json
-# contract-check `inputs`, so a change to them counts as a contract change and re-runs
-# Django. This test fails if a Core/CorePOE file gains a runtime import of a source vendor
-# missing from those inputs — which would otherwise let a change to it silently skip the
-# Core test that exercises it.
+# (Core/CorePOE). That is sound only if every warehouse_sources source a Core/CorePOE file
+# depends on is also a contract-check `input` in the product's turbo.json — otherwise a
+# change to that source would skip the Core test that exercises it (a silent coverage hole).
+#
+# The coupling is NOT direct: dropping the backend.temporal.* tach interface means a direct
+# runtime `import ...sources.<vendor>` from Core is now an interface violation tach already
+# blocks. What remains is Core reaching source internals THROUGH the facade's lazy re-exports
+# (facade/source_management.py's _LAZY map, facade/sources.py's imports). This test resolves
+# every facade re-export a Core/CorePOE file actually consumes back to its source vendor and
+# fails if that vendor is missing from the turbo.json contract-check inputs.
+#
+# Limitation: `SourceRegistry.get_source(<type>)` is a dynamic lookup — the vendor it resolves
+# to at runtime isn't visible statically, so this guard can't cover it. Core's real coupling is
+# the concrete `PostgresSource`/`MySQLSource`/... symbols, which it CAN see; the direct-SQL
+# adapters import those explicitly alongside SourceRegistry.
 #
 # Deliberately uses stdlib ast over a path walk, NOT the repo's `grimp` dependency: grimp
 # does not descend products/warehouse_sources/backend/temporal/data_imports/ (an implicit namespace package — no
 # __init__.py), so its graph contains zero source modules and the guard would pass blind.
 
-# Only leaf imports (sources.<vendor>...) are counted. A bare
-# `from ...sources import SourceRegistry / load_all_sources` is intentionally NOT flagged:
-# the registry is lazy, so importing it loads no vendor module — only calling
-# load_all_sources() does (at worker boot), which the Temporal registry-load test covers.
-SOURCES_PKG = "products.warehouse_sources.backend.temporal.data_imports.sources."
+_FACADE_DIR = "products/warehouse_sources/backend/facade"
+_SOURCE_MGMT = "products.warehouse_sources.backend.facade.source_management"
+_SOURCES = "products.warehouse_sources.backend.facade.sources"
+_FACADE_MODULES = frozenset({_SOURCE_MGMT, _SOURCES})
 
 # Roots collected by the Django Core/CorePOE segments. posthog/temporal is excluded — it is
-# the Temporal segment, which always runs for a sources-only PR.
+# the Temporal segment, which always runs alongside the product's own temporal job.
 _SCAN_ROOTS = ("posthog", "ee", "products/product_analytics")
+
+_INPUTS_PREFIX = "backend/temporal/data_imports/sources/"
 
 
 def _repo_root() -> Path:
@@ -41,13 +51,71 @@ def _is_type_checking(test: ast.expr) -> bool:
     return False
 
 
-def _runtime_imported_sources(tree: ast.AST) -> set[str]:
+def _vendor_from_target(dotted: str) -> str | None:
+    """The source vendor a dotted module path re-exports, or None if it isn't a source module.
+    The vendor is the path segment right after the ``sources`` package, so this works on both
+    the relative _LAZY targets and the absolute imports in sources.py:
+
+    "sources.postgres.source" / "...data_imports.sources.stripe.constants" -> "postgres" / "stripe";
+    "sources" (the bare registry) / "cdc.adapters" / "...naming_convention" -> None.
+    """
+    parts = dotted.split(".")
+    if "sources" in parts:
+        i = parts.index("sources")
+        if i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def _facade_symbol_to_vendor(root: Path) -> dict[str, str]:
+    """Map each facade re-exported symbol to the source vendor it resolves to, across the two
+    facade modules that re-export source internals. Symbols whose target isn't a source module
+    (SourceRegistry, cdc adapters, NamingConvention) are omitted."""
+    mapping: dict[str, str] = {}
+
+    # source_management.py: `_LAZY = {"Symbol": "sources.<vendor>...."}` (relative to the
+    # data_imports package). Resolve each entry's target to its vendor.
+    sm_tree = ast.parse((root / _FACADE_DIR / "source_management.py").read_text())
+    for node in ast.walk(sm_tree):
+        if not (
+            isinstance(node, ast.Assign) and any(isinstance(t, ast.Name) and t.id == "_LAZY" for t in node.targets)
+        ):
+            continue
+        assert isinstance(node.value, ast.Dict)
+        for key, value in zip(node.value.keys, node.value.values):
+            if not (
+                isinstance(key, ast.Constant)
+                and isinstance(key.value, str)
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                continue
+            vendor = _vendor_from_target(value.value)
+            if vendor:
+                mapping[key.value] = vendor
+
+    # sources.py: `from products.warehouse_sources...sources.<vendor>... import (A, B, ...)`.
+    src_tree = ast.parse((root / _FACADE_DIR / "sources.py").read_text())
+    for node in ast.walk(src_tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+        vendor = _vendor_from_target(node.module)
+        if not vendor:
+            continue
+        for alias in node.names:
+            mapping[alias.asname or alias.name] = vendor
+
+    assert mapping, "parsed no source re-exports from the warehouse_sources facade"
+    return mapping
+
+
+def _core_consumed_facade_symbols(tree: ast.AST) -> set[str]:
+    """Names a module imports from the source-re-exporting facade modules, excluding
+    TYPE_CHECKING-only imports (those don't affect runtime test behavior)."""
     found: set[str] = set()
 
     class Visitor(ast.NodeVisitor):
         def visit_If(self, node: ast.If) -> None:
-            # Type-only imports don't affect runtime test behavior — skip the
-            # TYPE_CHECKING branch but still scan its else.
             if _is_type_checking(node.test):
                 for stmt in node.orelse:
                     self.visit(stmt)
@@ -55,39 +123,32 @@ def _runtime_imported_sources(tree: ast.AST) -> set[str]:
             self.generic_visit(node)
 
         def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-            module = node.module or ""
-            if module.startswith(SOURCES_PKG):
-                found.add(module[len(SOURCES_PKG) :].split(".")[0])
-
-        def visit_Import(self, node: ast.Import) -> None:
-            for alias in node.names:
-                if alias.name.startswith(SOURCES_PKG):
-                    found.add(alias.name[len(SOURCES_PKG) :].split(".")[0])
+            if node.module in _FACADE_MODULES:
+                for alias in node.names:
+                    found.add(alias.name)
 
     Visitor().visit(tree)
     return found
-
-
-_INPUTS_PREFIX = "backend/temporal/data_imports/sources/"
 
 
 def _contract_covered_sources(root: Path) -> set[str]:
     turbo = json.loads((root / "products" / "warehouse_sources" / "turbo.json").read_text())
     inputs = turbo["tasks"]["backend:contract-check"]["inputs"]
     covered = {
-        rest.split("/")[0]
+        rest.split("/")[0].removesuffix(".py")
         for entry in inputs
-        if (rest := entry[len(_INPUTS_PREFIX) :]) and entry.startswith(_INPUTS_PREFIX) and "/" in rest
+        if entry.startswith(_INPUTS_PREFIX) and (rest := entry[len(_INPUTS_PREFIX) :])
     }
     assert covered, "parsed no source-vendor inputs from turbo.json backend:contract-check"
     return covered
 
 
-def test_core_coupled_sources_are_covered_by_contract_check():
+def test_core_facade_coupled_sources_are_covered_by_contract_check():
     root = _repo_root()
     excluded = root / "posthog" / "temporal"  # the Temporal segment; always runs
+    symbol_to_vendor = _facade_symbol_to_vendor(root)
 
-    imported: set[str] = set()
+    consumed: set[str] = set()
     for rel in _SCAN_ROOTS:
         base = root / rel
         if not base.exists():
@@ -96,19 +157,20 @@ def test_core_coupled_sources_are_covered_by_contract_check():
             if file.is_relative_to(excluded):
                 continue
             text = file.read_text(errors="ignore")
-            if "data_imports.sources" not in text:
+            if "facade.source_management" not in text and "facade.sources" not in text:
                 continue
             try:
                 tree = ast.parse(text, filename=str(file))
             except SyntaxError:
                 continue
-            imported |= _runtime_imported_sources(tree)
+            consumed |= _core_consumed_facade_symbols(tree)
 
+    coupled_vendors = {symbol_to_vendor[s] for s in consumed if s in symbol_to_vendor}
     covered = _contract_covered_sources(root)
-    missing = imported - covered
+    missing = coupled_vendors - covered
     assert not missing, (
-        f"Core/CorePOE code runtime-imports warehouse sources {sorted(missing)} not covered by "
-        f"products/warehouse_sources/turbo.json backend:contract-check inputs {sorted(covered)}. "
-        f"A change to those sources would skip the Core tests that exercise them. Add "
-        f"backend/temporal/data_imports/sources/<vendor>/** to the contract-check inputs."
+        f"Core/CorePOE reaches warehouse sources {sorted(missing)} through the facade, but they are "
+        f"not covered by products/warehouse_sources/turbo.json backend:contract-check inputs "
+        f"{sorted(covered)}. A change to those sources would skip the Core tests that exercise them. "
+        f"Add backend/temporal/data_imports/sources/<vendor>/** to the contract-check inputs."
     )

--- a/products/warehouse_sources/package.json
+++ b/products/warehouse_sources/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@posthog/products-warehouse-sources",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -m 'not async_migrations' --reruns=2 --reruns-delay=1 -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -m 'not async_migrations' --reruns=2 --reruns-delay=1 -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/warehouse_sources/turbo.json
+++ b/products/warehouse_sources/turbo.json
@@ -1,0 +1,21 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "backend:contract-check": {
+            "inputs": [
+                "backend/facade/**",
+                "backend/models/**",
+                "backend/temporal/data_imports/sources/generated_configs.py",
+                "backend/temporal/data_imports/sources/common/**",
+                "backend/temporal/data_imports/sources/google_search_console/**",
+                "backend/temporal/data_imports/sources/mysql/**",
+                "backend/temporal/data_imports/sources/postgres/**",
+                "backend/temporal/data_imports/sources/salesforce/**",
+                "backend/temporal/data_imports/sources/snowflake/**",
+                "backend/temporal/data_imports/sources/stripe/**"
+            ],
+            "outputs": [],
+            "cache": true
+        }
+    }
+}

--- a/tach.toml
+++ b/tach.toml
@@ -814,18 +814,26 @@ from = [
     "products.mcp_store",
 ]
 
-# warehouse_sources — all production and non-test consumers route through backend.facade.* now
-# (models/types/sources/pipelines are facade-sealed). The one remaining leak is the core
-# data-import Temporal test suite under posthog/temporal/tests/data_imports/** — hundreds of
-# tests that import the temporal internals directly. tach excludes tests/ dirs so they don't
-# surface as violations, but they still reach internals, and they run in the Django Temporal
-# segment. That's why backend:contract-check stays OFF: the isolated-CI skip would drop that
-# segment on internal changes. The CI win comes instead from the narrowed product matrix in
-# .github/scripts/turbo-discover.js (DATA_IMPORT_SOURCES_ONLY). Sealing this fully means
-# relocating those tests into the product — future work.
+# isolation:permanent-interface
+# warehouse_sources' HogQL direct-SQL adapters and its system-table definitions depend on a
+# handful of source internals + models that the facade re-exports lazily — facade.source_management
+# is a thin PEP 562 re-export, so a change to the underlying source flows through to core. That
+# coupling can't be sealed by watching backend.facade alone, so these modules are declared
+# permanent and turbo.json keeps them in the contract-check inputs — any change to them still
+# re-runs the Django suite (IsolationChainCheck enforces that). The vendor set is exactly the
+# sources core reaches through the facade, guarded by test_ci_core_coupled_sources.py. All other
+# core coupling goes through backend.facade.
 [[interfaces]]
 expose = [
-    "backend\\.temporal.*",
+    "backend\\.models.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.common.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.generated_configs.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.google_search_console.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.mysql.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.postgres.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.salesforce.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.snowflake.*",
+    "backend\\.temporal\\.data_imports\\.sources\\.stripe.*",
 ]
 from = [
     "products.warehouse_sources",


### PR DESCRIPTION
> Stacked on #67840. Review that one first. The diff here is only the isolation/CI cleanup.

## Problem

Now that the data-import Temporal tests run inside the warehouse_sources product test job (#67840), the two CI workarounds we built around the old layout are dead weight, and the product can finally turn on `backend:contract-check`:

- The Django Temporal segment still ran `products/warehouse_sources/backend/temporal`, so those tests ran twice (segment plus product job).
- The `data_import_sources_only` hack narrowed the product matrix for sources-only PRs, with a hand-maintained `coupled` list and a guard test keeping it complete. Its whole premise (sources are covered by the Temporal segment) stops being true once the segment no longer runs them.
- `backend:contract-check` was held off because the temporal tests lived in core and reached internals directly.

## Changes

- **Turn on `backend:contract-check`.** Adds the marker script and a `turbo.json`. The facade seals all runtime coupling, so tach passes with the `backend.temporal.*` legacy-leak block removed.
- **Widen the contract-check inputs for the coupling that lives outside the facade import graph.** Core hogql `direct_sql` runtime-depends on a few source internals through the facade's lazy re-export, and hogql system tables read `backend/models`. So the inputs cover facade, models, and the coupled source dirs (common, google_search_console, mysql, postgres, salesforce, snowflake, stripe). A change to those re-runs the Django suite; every other source change gets the isolation skip. This is the same coverage the old hack gave, but done through real isolation.
- **Remove the warehouse_sources entry from the Django Temporal segment** in both `ci-backend.yml` copies, so the suite runs once.
- **Remove the `data_import_sources_only` mechanism** end to end: the changes-job step, its output, the two envs, the `build_django_matrix` branch, and the `turbo-discover.js` block.
- **Retarget the coupled-source guard test** from the removed shell `coupled` list to the `turbo.json` contract-check inputs. It still fails if a Core/CorePOE file gains a runtime import of a source vendor missing from the inputs.
- **Teach the isolation linter to allow widened inputs.** `has_narrowed_turbo_inputs` used to require every input be facade/presentation. It now rejects inert catch-alls (`backend/**`) and requires a facade/presentation anchor, but allows specific extra paths. That is the documented "widen for coupling outside the import graph" pattern the old whitelist rejected.

## How did you test this code?

The temporal test suite needs Python 3.13 and the full docker stack, which I can't run in this checkout, so verification was the pieces I could run locally plus CI on the branch:

- `tach check --dependencies --interfaces` passes with the leak block gone (all runtime coupling is through the facade; the `backend.temporal.*` imports in core are `TYPE_CHECKING`-only).
- `hogli product:lint warehouse_sources` passes, including the isolation chain.
- The isolation-linter tests (`test_checks.py`) pass with new cases for widened inputs and inert-glob rejection. Guards the linter change catching the exact combinations that should/shouldn't turn the skip on.
- The retargeted coupled-source guard test passes and reads the real `turbo.json` inputs. Guards a future Core runtime import of an uncovered source silently dropping its Core coverage.
- Both `ci-backend.yml` copies parse as YAML and have zero remaining references to the removed mechanism; `turbo-discover.js` passes `node --check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
