### PR TITLE
fix(replay): scope session retention cache key by team

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/retention/retention-service.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/retention/retention-service.test.ts
@@ -79,8 +79,8 @@ describe('RetentionService', () => {
             expect(results.get(2, 'b')).toEqual({ resolved: true, retentionPeriod: '1y' })
             expect(mockRedisClient.mget).toHaveBeenCalledTimes(1)
             expect(mockRedisClient.mget).toHaveBeenCalledWith([
-                '@posthog/replay/session-retention-a',
-                '@posthog/replay/session-retention-b',
+                '@posthog/replay/session-retention-1-a',
+                '@posthog/replay/session-retention-2-b',
             ])
             expect(mockTeamService.getRetentionPeriodByTeamId).not.toHaveBeenCalled()
             expect(mockPipeline.set).not.toHaveBeenCalled()
@@ -102,13 +102,13 @@ describe('RetentionService', () => {
             // Each resolved value is written back to its own key with a TTL.
             expect(mockPipeline.set).toHaveBeenCalledTimes(3)
             expect(mockPipeline.set).toHaveBeenCalledWith(
-                '@posthog/replay/session-retention-a',
+                '@posthog/replay/session-retention-1-a',
                 '30d',
                 'EX',
                 24 * 60 * 60
             )
             expect(mockPipeline.set).toHaveBeenCalledWith(
-                '@posthog/replay/session-retention-c',
+                '@posthog/replay/session-retention-2-c',
                 '1y',
                 'EX',
                 24 * 60 * 60
@@ -151,8 +151,32 @@ describe('RetentionService', () => {
             // Only the miss is written back to Redis.
             expect(mockPipeline.set).toHaveBeenCalledTimes(1)
             expect(mockPipeline.set).toHaveBeenCalledWith(
-                '@posthog/replay/session-retention-miss',
+                '@posthog/replay/session-retention-1-miss',
                 '30d',
+                'EX',
+                24 * 60 * 60
+            )
+        })
+
+        it('scopes the cache key by team so the same session id across teams cannot collide', async () => {
+            // Same session id under two teams: team 1 hits the cache (30d), team 2 misses (→ 1y).
+            mockRedisClient.mget = jest.fn().mockResolvedValue(['30d', null])
+
+            const results = await retentionService.resolveSessionRetentions(sessionSet([1, 's'], [2, 's']))
+
+            // The shared session id is read under two distinct, team-scoped keys.
+            expect(mockRedisClient.mget).toHaveBeenCalledWith([
+                '@posthog/replay/session-retention-1-s',
+                '@posthog/replay/session-retention-2-s',
+            ])
+            // Each team resolves to its own retention — no cross-team bleed from the cache.
+            expect(results.get(1, 's')).toEqual({ resolved: true, retentionPeriod: '30d' })
+            expect(results.get(2, 's')).toEqual({ resolved: true, retentionPeriod: '1y' })
+            // Only team 2's miss is written back, under its own team-scoped key.
+            expect(mockPipeline.set).toHaveBeenCalledTimes(1)
+            expect(mockPipeline.set).toHaveBeenCalledWith(
+                '@posthog/replay/session-retention-2-s',
+                '1y',
                 'EX',
                 24 * 60 * 60
             )

--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/retention/retention-service.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/retention/retention-service.ts
@@ -21,8 +21,10 @@ export class RetentionService {
         private keyPrefix = '@posthog/replay/'
     ) {}
 
-    private generateRedisKey(sessionId: string): string {
-        return `${this.keyPrefix}session-retention-${sessionId}`
+    private generateRedisKey(teamId: TeamId, sessionId: string): string {
+        // Retention is a per-team property, so the cache key must be scoped by team — a session id is
+        // only unique within a team and can collide across teams.
+        return `${this.keyPrefix}session-retention-${teamId}-${sessionId}`
     }
 
     /**
@@ -44,7 +46,7 @@ export class RetentionService {
         const startTime = performance.now()
         const client = await this.redisPool.acquire()
         try {
-            const redisKeys = unique.map(({ sessionId }) => this.generateRedisKey(sessionId))
+            const redisKeys = unique.map(({ teamId, sessionId }) => this.generateRedisKey(teamId, sessionId))
             const cached = await client.mget(redisKeys)
 
             const missIndexes: number[] = []


### PR DESCRIPTION
## Problem

Session replay retention is a per-team property, but the Redis cache in `RetentionService` keyed entries on the session id alone (`session-retention-<sessionId>`). A session id is only unique within a team, so the same id can legitimately exist under two teams.

That opens a cross-team cache collision. Anyone who can submit replay traffic for one project can pick a session id that also occurs in another project and seed the shared 24h retention entry with their own team's retention. The other team's subsequent chunks for that id then get recorded with the wrong storage retention and key expiry.

## Changes

Include the team id in the cache key: `session-retention-<teamId>-<sessionId>`. Entries can no longer collide across teams. This matches every other keyed store in the session replay pipeline (session filter, session tracker, keystore caches, rate limiter, session map), all of which already scope by `(teamId, sessionId)` — `RetentionService` was the lone exception.

Old session-only entries are left to expire on their own (24h TTL). No migration or cleanup needed, since a wrong-team read from a stale entry is exactly the bug we're closing and the new key simply won't hit those entries.

I also reviewed the rest of the session replay pipeline for the same class of bug: `RetentionService` was the only place missing the team id in its key.

## How did you test this code?

Automated tests only (I, Claude, ran these; no manual/staging testing):

- Updated the `RetentionService` unit tests to expect team-scoped keys, and added a regression case: the same session id under two teams reads two distinct keys and resolves each team to its own retention with no cross-team bleed. This is the specific regression the fix closes and no existing test covered it (the prior per-team test used distinct session ids per team, so it never exercised a collision).
- `pnpm test` for `retention-service.test.ts` — 8 passed.
- `pnpm build` (full tsc) and `eslint` on the changed files — clean.

The real-Redis integration test (`retention-service.integration.test.ts`) needs the local infra stack and wasn't run here; it exercises the service through its public API and doesn't assert literal key strings, so it's unaffected by the key format change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paweł flagged a bot review comment about the retention cache crossing teams and asked me (Claude) to fix it on a fresh branch off master, plus sweep the rest of the session replay pipeline for other spots missing the team id. I grepped every Redis/cache/local-map key generator under `sessionreplay/` and confirmed `RetentionService` was the only offender — the rest already key on `(teamId, sessionId)`. Fix is a one-line key change plus test updates; we agreed not to bother migrating old session-only cache entries since they just expire.
