### PR TITLE
fix(sharing): run shared resource queries as the artifact creator

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -706,8 +706,8 @@ def _compute_inline_query_results_for_shared_notebook(
     Mirrors the shared-insight path (`InsightSerializer.insight_result`) but for queries that
     live inline in node attrs rather than as a `SavedInsightNode`. Each query is executed under
     `shared_insights_execution_mode`, which uses the cache aggressively and refreshes async if
-    stale — the same throttle dashboards use. Queries run as ``execution_user`` — the shared
-    artifact's creator (see ``SharingConfiguration.effective_execution_user``).
+    stale — the same throttle dashboards use. Queries run as ``execution_user``, the notebook's
+    creator.
 
     Returns a map of ``nodeId -> serialized result dict``. Nodes whose query fails to execute
     are silently omitted; the frontend renders ``UnsupportedNodePlaceholder`` for any inline

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -934,6 +934,9 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
         shared_execution_user = (
             resource.effective_execution_user() if isinstance(resource, SharingConfiguration) else None
         )
+        shared_artifact_kind = (
+            resource.shared_artifact_kind() if isinstance(resource, SharingConfiguration) else "resource"
+        )
 
         context = {
             "view": self,
@@ -944,6 +947,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             "insight_variables": InsightVariable.objects.filter(team=resource.team).all(),
             "export_cache_keys": export_cache_keys,
             "shared_execution_user": shared_execution_user,
+            "shared_artifact_kind": shared_artifact_kind,
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -827,9 +827,12 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                 sharing_configuration = (
                     SharingConfiguration.objects.select_related(
                         "dashboard",
+                        "dashboard__created_by",
                         "insight",
+                        "insight__created_by",
                         "recording",
                         "notebook",
+                        "notebook__created_by",
                         "interviewee_context",
                         "interviewee_context__topic",
                     )

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -698,13 +698,16 @@ def custom_404_response(request):
     return render(request, "shared_resource_404.html", status=404)
 
 
-def _compute_inline_query_results_for_shared_notebook(notebook: Notebook, team: Team) -> dict[str, Any]:
+def _compute_inline_query_results_for_shared_notebook(
+    notebook: Notebook, team: Team, execution_user: Optional[User]
+) -> dict[str, Any]:
     """Pre-compute results for every inline (non-saved-insight) ``ph-query`` node in a notebook.
 
     Mirrors the shared-insight path (`InsightSerializer.insight_result`) but for queries that
     live inline in node attrs rather than as a `SavedInsightNode`. Each query is executed under
     `shared_insights_execution_mode`, which uses the cache aggressively and refreshes async if
-    stale — the same throttle dashboards use.
+    stale — the same throttle dashboards use. Queries run as ``execution_user`` — the shared
+    artifact's creator (see ``SharingConfiguration.effective_execution_user``).
 
     Returns a map of ``nodeId -> serialized result dict``. Nodes whose query fails to execute
     are silently omitted; the frontend renders ``UnsupportedNodePlaceholder`` for any inline
@@ -723,7 +726,7 @@ def _compute_inline_query_results_for_shared_notebook(notebook: Notebook, team: 
                 team,
                 query,
                 execution_mode=execution_mode,
-                user=None,
+                user=execution_user,
             )
             if isinstance(result, BaseModel):
                 serialized = result.model_dump(mode="json")
@@ -924,6 +927,14 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                     message="Failed to parse cache_keys parameter - continuing without it",
                 )
 
+        # Anonymous viewers execute queries as the shared artifact's creator, so access-control
+        # changes to the creator propagate to already-published links (fail-closed when the
+        # creator is gone). Only this share-token path resolves a creator principal —
+        # authenticated app views always run as the requesting user.
+        shared_execution_user = (
+            resource.effective_execution_user() if isinstance(resource, SharingConfiguration) else None
+        )
+
         context = {
             "view": self,
             "request": request,
@@ -932,6 +943,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             "get_team": lambda: resource.team,
             "insight_variables": InsightVariable.objects.filter(team=resource.team).all(),
             "export_cache_keys": export_cache_keys,
+            "shared_execution_user": shared_execution_user,
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 
@@ -1240,7 +1252,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             exported_data.update(
                 {
                     "inline_query_results": _compute_inline_query_results_for_shared_notebook(
-                        resource.notebook, resource.team
+                        resource.notebook, resource.team, shared_execution_user
                     )
                 }
             )

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1815,11 +1815,9 @@ class TestSharedWarehouseDenialMessage(APIBaseTest):
         response = self._refresh_via_token(config)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
-        assert f"The {kind} owner ({self.user.email}) doesn't have access to table `governed_view`." in str(
-            response.json()
-        )
+        assert f"The {kind} owner doesn't have access to table `governed_view`." in str(response.json())
 
-    def test_denial_without_creator_omits_email(self):
+    def test_denial_with_deleted_creator_worded_the_same(self):
         self.insight.created_by = None
         self.insight.save()
         config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -16,8 +16,6 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 
-from posthog.schema import CacheMissResponse
-
 from posthog.api.sharing import (
     SHARING_RESOURCE_EDIT_CHECKS,
     _assert_every_shareable_resource_is_gated,
@@ -1601,73 +1599,6 @@ class TestSharedCohortInlining(APIBaseTest):
         assert "created_by" not in widget_data
 
 
-class TestSharedExecutionPrincipal(APIBaseTest):
-    trends_query = {
-        "kind": "InsightVizNode",
-        "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
-    }
-
-    def setUp(self):
-        super().setUp()
-        self.creator = User.objects.create_and_join(self.organization, "creator@posthog.com", None)
-        self.client.logout()
-
-    def _shared_config(self, case: str) -> tuple[SharingConfiguration, User | None]:
-        if case == "insight runs as the insight creator":
-            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
-            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), self.creator
-        if case == "dashboard runs every tile as the dashboard creator":
-            dashboard = Dashboard.objects.create(team=self.team, created_by=self.creator)
-            tile_insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.user)
-            DashboardTile.objects.create(dashboard=dashboard, insight=tile_insight)
-            return SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True), self.creator
-        if case == "deleted creator falls back to userless execution":
-            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=None)
-            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
-        if case == "deactivated creator falls back to userless execution":
-            self.creator.is_active = False
-            self.creator.save()
-            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
-            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
-        raise AssertionError(f"Unknown case: {case}")
-
-    @parameterized.expand(
-        [
-            ("insight runs as the insight creator",),
-            ("dashboard runs every tile as the dashboard creator",),
-            ("deleted creator falls back to userless execution",),
-            ("deactivated creator falls back to userless execution",),
-        ]
-    )
-    def test_shared_render_executes_queries_as_artifact_creator(self, case: str):
-        config, expected_user = self._shared_config(case)
-
-        with patch(
-            "posthog.caching.calculate_results.process_query_dict",
-            return_value=CacheMissResponse(cache_key="irrelevant"),
-        ) as process_query_mock:
-            response = self.client.get(f"/shared/{config.access_token}.json")
-
-        assert response.status_code == status.HTTP_200_OK, response.content
-        assert process_query_mock.call_count >= 1
-        assert all(call.kwargs["user"] == expected_user for call in process_query_mock.call_args_list)
-
-    def test_sharing_token_api_refresh_executes_as_creator(self):
-        insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
-        config = SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True)
-
-        with patch(
-            "posthog.caching.calculate_results.process_query_dict",
-            return_value=CacheMissResponse(cache_key="irrelevant"),
-        ) as process_query_mock:
-            response = self.client.get(
-                f"/api/projects/{self.team.id}/insights/{insight.id}/?sharing_access_token={config.access_token}"
-            )
-
-        assert response.status_code == status.HTTP_200_OK, response.content
-        assert process_query_mock.call_args.kwargs["user"] == self.creator
-
-
 def _warehouse_access_control_flag(key: str, *args, **kwargs) -> bool:
     return key == "hogql-warehouse-access-control"
 
@@ -1797,6 +1728,16 @@ class TestSharedWarehouseDenialMessage(APIBaseTest):
             f"?sharing_access_token={config.access_token}&refresh=blocking"
         )
 
+    def test_shared_dashboard_renders_with_creator_access(self):
+        dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
+        DashboardTile.objects.create(dashboard=dashboard, insight=self.insight)
+        config = SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True)
+
+        response = self._refresh_via_token(config)
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert not response.json().get("result_error")
+
     @parameterized.expand(
         [
             ("insight",),
@@ -1808,6 +1749,11 @@ class TestSharedWarehouseDenialMessage(APIBaseTest):
         if kind == "insight":
             config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
         else:
+            # The tile is authored by a member who is NOT denied - the denial proves the
+            # dashboard creator's access governs the whole link, not the tile author's.
+            tile_author = User.objects.create_and_join(self.organization, "tile-author@posthog.com", None)
+            self.insight.created_by = tile_author
+            self.insight.save()
             dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
             DashboardTile.objects.create(dashboard=dashboard, insight=self.insight)
             config = SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True)
@@ -1817,9 +1763,21 @@ class TestSharedWarehouseDenialMessage(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert f"The {kind} owner doesn't have access to table `governed_view`." in str(response.json())
 
-    def test_denial_with_deleted_creator_worded_the_same(self):
-        self.insight.created_by = None
-        self.insight.save()
+    @parameterized.expand(
+        [
+            ("deleted",),
+            ("deactivated",),
+        ]
+    )
+    def test_denial_when_creator_is_gone_worded_the_same(self, case: str):
+        # No access-control rule needed: a gone creator falls back to userless execution,
+        # which fails closed on every warehouse table under the flag.
+        if case == "deleted":
+            self.insight.created_by = None
+            self.insight.save()
+        else:
+            self.user.is_active = False
+            self.user.save()
         config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
 
         response = self._refresh_via_token(config)

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1624,11 +1624,12 @@ class TestSharedExecutionPrincipal(APIBaseTest):
         if case == "deleted creator falls back to userless execution":
             insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=None)
             return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
-        # deactivated creator falls back to userless execution
-        self.creator.is_active = False
-        self.creator.save()
-        insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
-        return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
+        if case == "deactivated creator falls back to userless execution":
+            self.creator.is_active = False
+            self.creator.save()
+            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
+            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
+        raise AssertionError(f"Unknown case: {case}")
 
     @parameterized.expand(
         [

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1749,6 +1749,86 @@ class TestSharedNotebookWarehouseAccessControl(APIBaseTest):
         assert "warehouse-node" not in self._shared_inline_results()
 
 
+@patch("posthoganalytics.feature_enabled", new=Mock(side_effect=_warehouse_access_control_flag))
+class TestSharedWarehouseDenialMessage(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.membership.level = OrganizationMembership.Level.MEMBER
+        self.membership.save()
+
+        self.saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="governed_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1 AS id"},
+            columns={"id": "String"},
+        )
+        self.insight = Insight.objects.create(
+            team=self.team,
+            query={
+                "kind": "DataTableNode",
+                "source": {"kind": "HogQLQuery", "query": "SELECT id FROM governed_view"},
+            },
+            created_by=self.user,
+        )
+        self.client.logout()
+
+    def _deny_creator(self) -> None:
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_view",
+            resource_id=str(self.saved_query.id),
+            access_level="none",
+            organization_member=self.membership,
+        )
+
+    def _refresh_via_token(self, config: SharingConfiguration):
+        return self.client.get(
+            f"/api/projects/{self.team.id}/insights/{self.insight.id}/"
+            f"?sharing_access_token={config.access_token}&refresh=blocking"
+        )
+
+    @parameterized.expand(
+        [
+            ("insight",),
+            ("dashboard",),
+        ]
+    )
+    def test_denial_names_the_owner_for_anonymous_viewers(self, kind: str):
+        self._deny_creator()
+        if kind == "insight":
+            config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
+        else:
+            dashboard = Dashboard.objects.create(team=self.team, created_by=self.user)
+            DashboardTile.objects.create(dashboard=dashboard, insight=self.insight)
+            config = SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True)
+
+        response = self._refresh_via_token(config)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert f"The {kind} owner ({self.user.email}) doesn't have access to table `governed_view`." in str(
+            response.json()
+        )
+
+    def test_denial_without_creator_omits_email(self):
+        self.insight.created_by = None
+        self.insight.save()
+        config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
+
+        response = self._refresh_via_token(config)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "The insight owner doesn't have access to table `governed_view`." in str(response.json())
+
+
 class TestSharingResourceEditChecks(APIBaseTest):
     def test_every_shareable_resource_has_an_edit_check(self):
         assert set(SHARING_RESOURCE_EDIT_CHECKS) == SharingConfiguration.shareable_resource_fields()

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -16,6 +16,8 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 
+from posthog.schema import CacheMissResponse
+
 from posthog.api.sharing import (
     SHARING_RESOURCE_EDIT_CHECKS,
     _assert_every_shareable_resource_is_gated,
@@ -24,7 +26,7 @@ from posthog.api.sharing import (
     shared_url_as_png,
 )
 from posthog.constants import AvailableFeature
-from posthog.models import ActivityLog
+from posthog.models import ActivityLog, OrganizationMembership
 from posthog.models.filters.filter import Filter
 from posthog.models.share_password import SharePassword
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -33,7 +35,9 @@ from posthog.models.user import User
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
+from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.exports.backend.models.exported_asset import ExportedAsset, get_render_access_token
+from products.notebooks.backend.models import Notebook
 from products.product_analytics.backend.models.insight import Insight
 
 
@@ -1595,6 +1599,154 @@ class TestSharedCohortInlining(APIBaseTest):
         assert widget_data["widget_type"] == "error_tracking_list"
         assert widget_data["config"]["limit"] == 10
         assert "created_by" not in widget_data
+
+
+class TestSharedExecutionPrincipal(APIBaseTest):
+    trends_query = {
+        "kind": "InsightVizNode",
+        "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.creator = User.objects.create_and_join(self.organization, "creator@posthog.com", None)
+        self.client.logout()
+
+    def _shared_config(self, case: str) -> tuple[SharingConfiguration, User | None]:
+        if case == "insight runs as the insight creator":
+            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
+            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), self.creator
+        if case == "dashboard runs every tile as the dashboard creator":
+            dashboard = Dashboard.objects.create(team=self.team, created_by=self.creator)
+            tile_insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.user)
+            DashboardTile.objects.create(dashboard=dashboard, insight=tile_insight)
+            return SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True), self.creator
+        if case == "deleted creator falls back to userless execution":
+            insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=None)
+            return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
+        # deactivated creator falls back to userless execution
+        self.creator.is_active = False
+        self.creator.save()
+        insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
+        return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True), None
+
+    @parameterized.expand(
+        [
+            ("insight runs as the insight creator",),
+            ("dashboard runs every tile as the dashboard creator",),
+            ("deleted creator falls back to userless execution",),
+            ("deactivated creator falls back to userless execution",),
+        ]
+    )
+    def test_shared_render_executes_queries_as_artifact_creator(self, case: str):
+        config, expected_user = self._shared_config(case)
+
+        with patch(
+            "posthog.caching.calculate_results.process_query_dict",
+            return_value=CacheMissResponse(cache_key="irrelevant"),
+        ) as process_query_mock:
+            response = self.client.get(f"/shared/{config.access_token}.json")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert process_query_mock.call_count >= 1
+        assert all(call.kwargs["user"] == expected_user for call in process_query_mock.call_args_list)
+
+    def test_sharing_token_api_refresh_executes_as_creator(self):
+        insight = Insight.objects.create(team=self.team, query=self.trends_query, created_by=self.creator)
+        config = SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True)
+
+        with patch(
+            "posthog.caching.calculate_results.process_query_dict",
+            return_value=CacheMissResponse(cache_key="irrelevant"),
+        ) as process_query_mock:
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/insights/{insight.id}/?sharing_access_token={config.access_token}"
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert process_query_mock.call_args.kwargs["user"] == self.creator
+
+
+def _warehouse_access_control_flag(key: str, *args, **kwargs) -> bool:
+    return key == "hogql-warehouse-access-control"
+
+
+@patch("posthoganalytics.feature_enabled", new=Mock(side_effect=_warehouse_access_control_flag))
+class TestSharedNotebookWarehouseAccessControl(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.membership.level = OrganizationMembership.Level.MEMBER
+        self.membership.save()
+
+        self.saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="governed_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1 AS id"},
+            columns={"id": "String"},
+        )
+        self.notebook = Notebook.objects.create(
+            team=self.team,
+            title="Warehouse notebook",
+            created_by=self.user,
+            content={
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "ph-query",
+                        "attrs": {
+                            "nodeId": "warehouse-node",
+                            "query": {
+                                "kind": "DataTableNode",
+                                "source": {"kind": "HogQLQuery", "query": "SELECT id FROM governed_view"},
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        self.config = SharingConfiguration.objects.create(team=self.team, notebook=self.notebook, enabled=True)
+        self.client.logout()
+
+    def _shared_inline_results(self) -> dict:
+        response = self.client.get(f"/shared/{self.config.access_token}.json")
+        assert response.status_code == status.HTTP_200_OK, response.content
+        return response.json().get("inline_query_results", {})
+
+    def test_inline_warehouse_query_executes_with_creator_access(self):
+        results = self._shared_inline_results()
+        assert "warehouse-node" in results
+        assert "results" in results["warehouse-node"]
+        assert not results["warehouse-node"].get("error")
+
+    @parameterized.expand(
+        [
+            ("creator denied by access control",),
+            ("creator deleted",),
+        ]
+    )
+    def test_inline_warehouse_query_fails_closed(self, case: str):
+        if case == "creator denied by access control":
+            from ee.models.rbac.access_control import AccessControl
+
+            AccessControl.objects.create(
+                team=self.team,
+                resource="warehouse_view",
+                resource_id=str(self.saved_query.id),
+                access_level="none",
+                organization_member=self.membership,
+            )
+        else:
+            self.notebook.created_by = None
+            self.notebook.save()
+
+        assert "warehouse-node" not in self._shared_inline_results()
 
 
 class TestSharingResourceEditChecks(APIBaseTest):

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -748,9 +748,17 @@ class SharingAccessTokenAuthentication(authentication.BaseAuthentication):
             if request.method not in ["GET", "HEAD"]:
                 raise AuthenticationFailed(detail="Sharing access token can only be used for GET requests.")
             try:
-                sharing_configuration = SharingConfiguration.objects.filter(
-                    models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=timezone.now())
-                ).get(access_token=sharing_access_token, enabled=True)
+                sharing_configuration = (
+                    SharingConfiguration.objects.select_related(
+                        # The execution principal (artifact creator) is resolved on every
+                        # token-authenticated request; preload it to keep tile refreshes query-free.
+                        "insight__created_by",
+                        "dashboard__created_by",
+                        "notebook__created_by",
+                    )
+                    .filter(models.Q(expires_at__isnull=True) | models.Q(expires_at__gt=timezone.now()))
+                    .get(access_token=sharing_access_token, enabled=True)
+                )
 
                 # If password is required, don't authenticate via direct access_token
                 # Let the view handle showing the unlock page

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -750,8 +750,7 @@ class SharingAccessTokenAuthentication(authentication.BaseAuthentication):
             try:
                 sharing_configuration = (
                     SharingConfiguration.objects.select_related(
-                        # The execution principal (artifact creator) is resolved on every
-                        # token-authenticated request; preload it to keep tile refreshes query-free.
+                        # Preload the artifact creator, resolved on every token-authenticated request
                         "insight__created_by",
                         "dashboard__created_by",
                         "notebook__created_by",

--- a/posthog/models/sharing_configuration.py
+++ b/posthog/models/sharing_configuration.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from posthog.models.share_password import SharePassword
+    from posthog.models.user import User
 
 from django.conf import settings
 from django.db import models, transaction
@@ -255,6 +256,22 @@ class SharingConfiguration(models.Model):
             expiry_delta=timedelta(hours=24),  # 24-hour session duration
             audience=PosthogJwtAudience.SHARING_PASSWORD_PROTECTED,
         )
+
+    def effective_execution_user(self) -> "User | None":
+        """The principal that queries triggered by this share's public link execute as.
+
+        Anonymous viewers run the underlying queries with the access of the shared artifact's
+        creator (one uniform principal per artifact — a shared dashboard renders every tile as
+        the dashboard's creator). This way, revoking the creator's access to e.g. an
+        access-controlled warehouse table propagates to already-published links on their next
+        refresh. Fail-closed: returns None when the creator was deleted or deactivated, and for
+        recordings, which never execute HogQL through the shared context.
+        """
+        target = self.insight or self.dashboard or self.notebook
+        creator = target.created_by if target is not None else None
+        if creator is None or not creator.is_active:
+            return None
+        return creator
 
     def can_access_object(self, obj: models.Model):
         if obj.team_id != self.team_id:  # type: ignore

--- a/posthog/models/sharing_configuration.py
+++ b/posthog/models/sharing_configuration.py
@@ -273,6 +273,16 @@ class SharingConfiguration(models.Model):
             return None
         return creator
 
+    def shared_artifact_kind(self) -> str:
+        """Human-readable kind of the shared artifact, for viewer-facing copy on public pages."""
+        if self.dashboard_id:
+            return "dashboard"
+        if self.insight_id:
+            return "insight"
+        if self.notebook_id:
+            return "notebook"
+        return "resource"
+
     def can_access_object(self, obj: models.Model):
         if obj.team_id != self.team_id:  # type: ignore
             return False

--- a/posthog/models/sharing_configuration.py
+++ b/posthog/models/sharing_configuration.py
@@ -258,14 +258,10 @@ class SharingConfiguration(models.Model):
         )
 
     def effective_execution_user(self) -> "User | None":
-        """The principal that queries triggered by this share's public link execute as.
-
-        Anonymous viewers run the underlying queries with the access of the shared artifact's
-        creator (one uniform principal per artifact — a shared dashboard renders every tile as
-        the dashboard's creator). This way, revoking the creator's access to e.g. an
-        access-controlled warehouse table propagates to already-published links on their next
-        refresh. Fail-closed: returns None when the creator was deleted or deactivated, and for
-        recordings, which never execute HogQL through the shared context.
+        """
+        Public-link queries execute as the artifact's creator
+        (a shared dashboard renders every tile as the dashboard's creator).
+        Returns None when the creator is deleted or deactivated.
         """
         target = self.insight or self.dashboard or self.notebook
         creator = target.created_by if target is not None else None
@@ -274,7 +270,7 @@ class SharingConfiguration(models.Model):
         return creator
 
     def shared_artifact_kind(self) -> str:
-        """Human-readable kind of the shared artifact, for viewer-facing copy on public pages."""
+        """Human-readable kind of the shared artifact, for viewer-facing copy."""
         if self.dashboard_id:
             return "dashboard"
         if self.insight_id:

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -460,6 +460,26 @@ def _last_refresh_for_shared_gate(insight: Insight, dashboard_tile: DashboardTil
     return cs.last_refresh or cs.created_at
 
 
+# Must match the denial raised in posthog/hogql/database/database.py `get_table`.
+_TABLE_ACCESS_DENIED_PREFIX = "You don't have access"
+
+
+def _shared_denial_message(message: str, context: dict[str, Any]) -> str:
+    """Reword warehouse access denials for anonymous viewers of a shared artifact.
+
+    Shared queries execute as the artifact's creator, so "you" is wrong and unactionable for an
+    anonymous viewer — name the owner whose access governs the link so they know whom to ask.
+    """
+    if not message.startswith(_TABLE_ACCESS_DENIED_PREFIX):
+        return message
+    kind = context.get("shared_artifact_kind") or "resource"
+    owner = context.get("shared_execution_user")
+    rest = message.removeprefix(_TABLE_ACCESS_DENIED_PREFIX)
+    if owner is not None and owner.email:
+        return f"The {kind} owner ({owner.email}) doesn't have access{rest}"
+    return f"The {kind} owner doesn't have access{rest}"
+
+
 class InsightSerializer(InsightBasicSerializer):
     result = serializers.SerializerMethodField()
     hasMore = serializers.SerializerMethodField()
@@ -1139,7 +1159,10 @@ class InsightSerializer(InsightBasicSerializer):
                         analytics_props=get_request_analytics_properties(self.context["request"]),
                     )
             except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
-                raise ValidationError(str(e), getattr(e, "code_name", None))
+                message = str(e)
+                if self.context.get("is_shared"):
+                    message = _shared_denial_message(message, self.context)
+                raise ValidationError(message, getattr(e, "code_name", None))
             except ConcurrencyLimitExceeded as e:
                 logger.warn(
                     "concurrency_limit_exceeded_api", exception=e, insight_id=insight.id, team_id=insight.team_id
@@ -1469,6 +1492,7 @@ class InsightViewSet(
             # Sharing-token API refreshes are anonymous; queries execute as the shared
             # artifact's creator, mirroring the /shared/ page render.
             context["shared_execution_user"] = authenticator.sharing_configuration.effective_execution_user()
+            context["shared_artifact_kind"] = authenticator.sharing_configuration.shared_artifact_kind()
         context["insight_variables"] = InsightVariable.objects.filter(team=self.team).all()
 
         return context

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -467,16 +467,14 @@ _TABLE_ACCESS_DENIED_PREFIX = "You don't have access"
 def _shared_denial_message(message: str, context: dict[str, Any]) -> str:
     """Reword warehouse access denials for anonymous viewers of a shared artifact.
 
-    Shared queries execute as the artifact's creator, so "you" is wrong and unactionable for an
-    anonymous viewer — name the owner whose access governs the link so they know whom to ask.
+    Shared queries execute as the artifact's creator, so "you" is wrong for an anonymous viewer —
+    attribute the denial to the owner instead. Deliberately no name/email: this renders on a
+    public page.
     """
     if not message.startswith(_TABLE_ACCESS_DENIED_PREFIX):
         return message
     kind = context.get("shared_artifact_kind") or "resource"
-    owner = context.get("shared_execution_user")
     rest = message.removeprefix(_TABLE_ACCESS_DENIED_PREFIX)
-    if owner is not None and owner.email:
-        return f"The {kind} owner ({owner.email}) doesn't have access{rest}"
     return f"The {kind} owner doesn't have access{rest}"
 
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1119,6 +1119,12 @@ class InsightSerializer(InsightBasicSerializer):
                 # runners, so the cache fingerprint resolves access once per request, not per tile.
                 view = self.context.get("view")
                 request_user_access_control = getattr(view, "user_access_control", None) if request_user else None
+                if request_user is None and is_shared:
+                    # Anonymous shared views execute as the shared artifact's creator (resolved by
+                    # the sharing layer), so the creator's access control governs the public link.
+                    # The view's UserAccessControl is deliberately not reused here — it belongs to
+                    # the anonymous requester; downstream builds one for the creator when needed.
+                    request_user = self.context.get("shared_execution_user")
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(
                         insight,
@@ -1454,10 +1460,15 @@ class InsightViewSet(
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
 
+        authenticator = self.request.successful_authenticator
         context["is_shared"] = isinstance(
-            self.request.successful_authenticator,
+            authenticator,
             SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
         )
+        if isinstance(authenticator, SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication):
+            # Sharing-token API refreshes are anonymous; queries execute as the shared
+            # artifact's creator, mirroring the /shared/ page render.
+            context["shared_execution_user"] = authenticator.sharing_configuration.effective_execution_user()
         context["insight_variables"] = InsightVariable.objects.filter(team=self.team).all()
 
         return context

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1138,10 +1138,8 @@ class InsightSerializer(InsightBasicSerializer):
                 view = self.context.get("view")
                 request_user_access_control = getattr(view, "user_access_control", None) if request_user else None
                 if request_user is None and is_shared:
-                    # Anonymous shared views execute as the shared artifact's creator (resolved by
-                    # the sharing layer), so the creator's access control governs the public link.
-                    # The view's UserAccessControl is deliberately not reused here — it belongs to
-                    # the anonymous requester; downstream builds one for the creator when needed.
+                    # Anonymous shared views execute as the shared artifact's creator, so the
+                    # creator's access control governs the public link.
                     request_user = self.context.get("shared_execution_user")
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(


### PR DESCRIPTION
## Problem

Publicly shared dashboards, insights, and notebooks execute their queries with `user=None`, which fails closed for **every** warehouse table under `hogql-warehouse-access-control` (#61686) — warehouse-backed content can't be publicly shared at all. 

In this PR shared queries execute as the **artifact's creator**. if admins later restrict the creator's access to a warehouse table, already-published links stop exposing that data on the next refresh — access-control changes propagate to published content. 

Alternative approaches i've tried:
- #68130 - explicit anonymous principal, always-show, touches the whole query-runner stack, too complex for now
- #68181 - run-as-sharer, needs a new `enabled_by` field, and "whose access governs the link" becomes less obvious to viewers.

## Changes

**Execution principal** — the shared artifact's creator 
- `dashboard.created_by` for all tiles of a shared dashboard, 
- `insight.created_by` for a directly-shared insight, 
- `notebook.created_by` for notebooks
Deleted or deactivated creator → `None` → fail-closed behavior.

**Owner-facing error copy** — anonymous viewers can't act on "You don't have access to table X" (they aren't the "you"). Denials on shared contexts are reworded at the API error boundary, example:

> The dashboard owner doesn't have access to table `stripe_invoices`.

Deliberately no name or email, the message renders on an unauthenticated page.

**Known, accepted tradeoffs:**
- A member with edit access can enable sharing on an artifact created by a higher-access user, publishing data the enabler can't read themselves (flagged by review). Accepted for now; the planned follow-up is a **publish-time gate** — block enabling sharing when the enabler lacks access to the referenced tables — which kills the escalation without changing the execution principal.
- Dashboard tiles run as the dashboard creator even when tile insights were created by others

## Demo

Public shared dashboard, flag on, creator denied on the warehouse view — working tile alongside the owner denial (screenshot shows the earlier email variant; current copy is role-only):
<img width="1512" height="665" alt="image" src="https://github.com/user-attachments/assets/16143de3-1184-41e1-abde-ca29593ba6d1" />

## How did you test this code?

Tests.
- Insight/dashboard renders execute as the artifact creator (dashboard tiles as dashboard creator, not tile creators);
- Deleted and deactivated creators fall back to userless;
- Sharing-token API refresh uses the creator;
- Denial copy + deleted creator worded the same

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of three approaches (with #68130 and #68181), then finished interactively, the creator-ambiguity question (dashboard vs tile creator) was resolved to "dashboard creator governs the whole link," the owner-named error copy was added so anonymous viewers get an actionable message, and review feedback (query preloading, test-helper guard) was applied. The escalation concern raised by review is acknowledged above as a deliberate tradeoff with a planned publish-time gate as follow-up.

**Perf (review feedback)** — creators are `select_related` at both sharing-config fetch sites (viewer page queryset + `SharingAccessTokenAuthentication`), so principal resolution adds zero queries per request.

No migrations, no `database.py` changes — general userless execution stays fail-closed everywhere.
