### PR TITLE
fix(sharing): run shared queries under an explicit anonymous viewer principal

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from typing import Optional, cast
+
+from django.contrib.auth.models import AnonymousUser
 
 import structlog
 import pydantic_core
@@ -34,6 +36,7 @@ from posthog.hogql_queries.query_runner import CacheMissResponse, ExecutionMode,
 from posthog.models import Team, User
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.schema_migrations.upgrade import upgrade
+from posthog.synthetic_user import SyntheticUser
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
 
@@ -50,7 +53,7 @@ def process_query_dict(
     variables_override_json: Optional[dict] = None,
     limit_context: Optional[LimitContext] = None,
     execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-    user: Optional[User] = None,
+    user: Optional[User | SyntheticUser | AnonymousUser] = None,
     user_access_control: Optional[UserAccessControl] = None,
     query_id: Optional[str] = None,
     insight_id: Optional[int] = None,
@@ -120,7 +123,7 @@ def process_query_model(
     variables_override: Optional[list[HogQLVariable]] = None,
     limit_context: Optional[LimitContext] = None,
     execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-    user: Optional[User] = None,
+    user: Optional[User | SyntheticUser | AnonymousUser] = None,
     user_access_control: Optional[UserAccessControl] = None,
     query_id: Optional[str] = None,
     insight_id: Optional[int] = None,
@@ -132,29 +135,33 @@ def process_query_model(
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
+    # Query internals are typed for real users but tolerate synthetic and shared-viewer
+    # principals at runtime (see QueryRunner.user); narrow pragmatically at this boundary.
+    runner_user = cast(Optional[User], user)
+
     if isinstance(query, HogQLAutocomplete):
         _, database = resolve_database_for_connection(
             team,
             query.connectionId,
-            user=user,
+            user=runner_user,
             error_factory=ValidationError,
             modifiers=create_default_modifiers_for_team(team),
         )
-        return get_hogql_autocomplete(query=query, team=team, database_arg=database, user=user)
+        return get_hogql_autocomplete(query=query, team=team, database_arg=database, user=runner_user)
 
     if isinstance(query, HogQLMetadata):
         metadata_query = HogQLMetadata.model_validate(query)
-        return get_hogql_metadata(query=metadata_query, team=team, user=user)
+        return get_hogql_metadata(query=metadata_query, team=team, user=runner_user)
 
     if isinstance(query, DatabaseSchemaQuery):
         _, database = resolve_database_for_connection(
             team,
             query.connectionId,
-            user=user,
+            user=runner_user,
             error_factory=ValidationError,
             modifiers=create_default_modifiers_for_team(team),
         )
-        context = HogQLContext(team_id=team.pk, team=team, database=database, user=user)
+        context = HogQLContext(team_id=team.pk, team=team, database=database, user=runner_user)
         serialized_tables = database.serialize(context, include_hidden_posthog_tables=True)
         table_names = set(serialized_tables.keys())
         joins = DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True)
@@ -182,7 +189,7 @@ def process_query_model(
         )
 
     query_runner = get_query_runner_or_none(
-        query, team, limit_context=limit_context, user=user, user_access_control=user_access_control
+        query, team, limit_context=limit_context, user=runner_user, user_access_control=user_access_control
     )
     if query_runner is None:  # This query doesn't run via query runner
         if hasattr(query, "source") and isinstance(query.source, BaseModel):
@@ -233,7 +240,7 @@ def process_query_model(
 
         result = query_runner.run(
             execution_mode=execution_mode,
-            user=user,
+            user=runner_user,
             query_id=query_id,
             insight_id=insight_id,
             dashboard_id=dashboard_id,

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -28,7 +28,11 @@ from posthog.api.data_color_theme import DataColorTheme, DataColorThemeSerialize
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_dict
 from posthog.api.shared import TeamPublicSerializer
-from posthog.auth import SharingAccessTokenAuthentication, SharingPasswordProtectedAuthentication
+from posthog.auth import (
+    SharedViewerAnonymousUser,
+    SharingAccessTokenAuthentication,
+    SharingPasswordProtectedAuthentication,
+)
 from posthog.clickhouse.client.async_task_chain import task_chain_context
 from posthog.constants import AvailableFeature
 from posthog.exceptions_capture import capture_exception
@@ -698,7 +702,9 @@ def custom_404_response(request):
     return render(request, "shared_resource_404.html", status=404)
 
 
-def _compute_inline_query_results_for_shared_notebook(notebook: Notebook, team: Team) -> dict[str, Any]:
+def _compute_inline_query_results_for_shared_notebook(
+    notebook: Notebook, team: Team, user: Optional[SharedViewerAnonymousUser]
+) -> dict[str, Any]:
     """Pre-compute results for every inline (non-saved-insight) ``ph-query`` node in a notebook.
 
     Mirrors the shared-insight path (`InsightSerializer.insight_result`) but for queries that
@@ -723,7 +729,7 @@ def _compute_inline_query_results_for_shared_notebook(notebook: Notebook, team: 
                 team,
                 query,
                 execution_mode=execution_mode,
-                user=None,
+                user=user,
             )
             if isinstance(result, BaseModel):
                 serialized = result.model_dump(mode="json")
@@ -924,6 +930,11 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                     message="Failed to parse cache_keys parameter - continuing without it",
                 )
 
+        # Sharing is an explicit publish act: run the shared queries under a shared-viewer
+        # principal (instead of userless, which fails closed on warehouse tables). Exported
+        # assets keep the userless behavior — they render from the creator-warmed cache.
+        shared_viewer = SharedViewerAnonymousUser(resource) if isinstance(resource, SharingConfiguration) else None
+
         context = {
             "view": self,
             "request": request,
@@ -932,6 +943,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             "get_team": lambda: resource.team,
             "insight_variables": InsightVariable.objects.filter(team=resource.team).all(),
             "export_cache_keys": export_cache_keys,
+            "shared_viewer_user": shared_viewer,
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 
@@ -1240,7 +1252,7 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             exported_data.update(
                 {
                     "inline_query_results": _compute_inline_query_results_for_shared_notebook(
-                        resource.notebook, resource.team
+                        resource.notebook, resource.team, shared_viewer
                     )
                 }
             )

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -23,6 +23,8 @@ from posthog.api.sharing import (
     check_can_edit_sharing_configuration,
     shared_url_as_png,
 )
+from posthog.auth import SharedViewerAnonymousUser
+from posthog.caching.fetch_from_cache import NothingInCacheResult
 from posthog.constants import AvailableFeature
 from posthog.models import ActivityLog
 from posthog.models.filters.filter import Filter
@@ -34,6 +36,7 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.exports.backend.models.exported_asset import ExportedAsset, get_render_access_token
+from products.notebooks.backend.models import Notebook
 from products.product_analytics.backend.models.insight import Insight
 
 
@@ -1634,3 +1637,84 @@ class TestSharingResourceEditChecks(APIBaseTest):
             check_can_edit_sharing_configuration(view, request, sharing)
 
         assert "cannot be shared through this endpoint" in str(caught.exception)
+
+
+class TestSharedViewerPrincipal(APIBaseTest):
+    def _shared_insight_config(self) -> SharingConfiguration:
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Shared trends",
+            query={
+                "kind": "InsightVizNode",
+                "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            },
+        )
+        return SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True)
+
+    def test_principal_requires_an_enabled_sharing_configuration(self):
+        with self.assertRaises(ValueError):
+            SharedViewerAnonymousUser(SharingConfiguration(team=self.team, enabled=False))
+
+    @mock_exporter_template
+    @patch("posthog.caching.calculate_results.calculate_for_query_based_insight")
+    def test_shared_insight_page_runs_queries_under_shared_viewer_principal(self, mock_calculate):
+        mock_calculate.return_value = NothingInCacheResult()
+        config = self._shared_insight_config()
+
+        response = self.client.get(f"/shared/{config.access_token}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_calculate.called
+        principal = mock_calculate.call_args.kwargs["user"]
+        assert isinstance(principal, SharedViewerAnonymousUser)
+        assert principal.sharing_configuration == config
+
+    @patch("posthog.caching.calculate_results.calculate_for_query_based_insight")
+    def test_sharing_token_api_refresh_runs_queries_under_shared_viewer_principal(self, mock_calculate):
+        mock_calculate.return_value = NothingInCacheResult()
+        config = self._shared_insight_config()
+        self.client.logout()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/?short_id={config.insight.short_id}"
+            f"&sharing_access_token={config.access_token}"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_calculate.called
+        principal = mock_calculate.call_args.kwargs["user"]
+        assert isinstance(principal, SharedViewerAnonymousUser)
+        assert principal.sharing_configuration == config
+
+    @patch("posthog.api.sharing.process_query_dict")
+    def test_shared_notebook_inline_queries_run_under_shared_viewer_principal(self, mock_process_query_dict):
+        mock_process_query_dict.return_value = {"results": []}
+        notebook = Notebook.objects.create(
+            team=self.team,
+            title="Shared notebook",
+            created_by=self.user,
+            content={
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "ph-query",
+                        "attrs": {
+                            "nodeId": "inline-node-1",
+                            "query": {
+                                "kind": "DataTableNode",
+                                "source": {"kind": "EventsQuery", "select": ["event"]},
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        config = SharingConfiguration.objects.create(team=self.team, notebook=notebook, enabled=True)
+
+        response = self.client.get(f"/shared/{config.access_token}.json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_process_query_dict.called
+        principal = mock_process_query_dict.call_args.kwargs["user"]
+        assert isinstance(principal, SharedViewerAnonymousUser)
+        assert principal.sharing_configuration == config

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -847,6 +847,35 @@ class SharingPasswordProtectedAuthentication(authentication.BaseAuthentication):
             return None
 
 
+class SharedViewerAnonymousUser(AnonymousUser):
+    """Principal for executing queries on behalf of a viewer of a publicly shared resource.
+
+    Enabling sharing is an explicit publish act: once a link is live, its query results are
+    shown to any anonymous viewer, so this principal declares
+    ``bypasses_warehouse_access_control`` instead of failing closed like a plain userless run.
+    RBAC-scoped system tables stay hidden (``readable_system_table_access_scopes`` is empty).
+
+    Pass it to query execution (``process_query_dict`` / ``Database.create_for``) only —
+    never assign it to ``request.user``.
+    """
+
+    # Shared pages always render their published results; see class docstring.
+    bypasses_warehouse_access_control: bool = True
+
+    email: Optional[str] = None
+
+    def __init__(self, sharing_configuration: SharingConfiguration) -> None:
+        super().__init__()
+        if not sharing_configuration.enabled:
+            raise ValueError("SharedViewerAnonymousUser requires an enabled sharing configuration")
+        self.sharing_configuration = sharing_configuration
+        self.current_team_id = sharing_configuration.team_id
+        self.distinct_id = f"shared-viewer-{sharing_configuration.team_id}"
+
+    def readable_system_table_access_scopes(self) -> set[str]:
+        return set()
+
+
 class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
     """
     OAuth 2.0 Bearer token authentication using access tokens

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Union
 
+from django.contrib.auth.models import AnonymousUser
+
 import structlog
 from pydantic import BaseModel
 
@@ -14,6 +16,7 @@ from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
 from posthog.models import Team, User
 from posthog.schema_migrations.upgrade_manager import upgrade_query
+from posthog.synthetic_user import SyntheticUser
 
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
@@ -53,7 +56,7 @@ def calculate_for_query_based_insight(
     team: Team,
     dashboard: Optional[Dashboard] = None,
     execution_mode: ExecutionMode,
-    user: Optional[User],
+    user: Optional[User | SyntheticUser | AnonymousUser],
     user_access_control: Optional["UserAccessControl"] = None,
     filters_override: Optional[dict] = None,
     variables_override: Optional[dict] = None,

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -169,6 +169,8 @@ from products.warehouse_sources.backend.facade.models import (
 # posthog.schema (the pydantic models) is runtime-imported inside serialize()/serialize_fields()
 # so it stays off django.setup(), where this module loads via the warehouse/data-modeling models.
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
     from posthog.schema import (
         DatabaseSchemaDataWarehouseTable,
         DatabaseSchemaEndpointTable,
@@ -205,7 +207,7 @@ class HogQLDatabaseSources:
     build phase runs without any queries."""
 
     team: "Team"
-    user: Optional["User | SyntheticUser"]
+    user: Optional["User | SyntheticUser | AnonymousUser"]
     connection_id: str | None
     modifiers: "HogQLQueryModifiers"
     is_managed_viewset_enabled: bool
@@ -438,7 +440,7 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
 
 def _compute_system_table_access_decision(
     team: "Team",
-    user: Optional["User | SyntheticUser"],
+    user: Optional["User | SyntheticUser | AnonymousUser"],
     user_access_control: Optional["UserAccessControl"] = None,
 ) -> tuple[Optional["UserAccessControl"], set[str]]:
     """Decide which scoped system tables to hide, doing the access-control I/O here so the build phase
@@ -448,9 +450,12 @@ def _compute_system_table_access_decision(
     Pass user_access_control when it's already preloaded to reuse the instance and avoid an extra query."""
     system_children = SystemTables().children
 
-    # Anonymous or synthetic principal: keep only access-controlled tables its scopes cover (none for anonymous / team token).
-    if user is None or isinstance(user, SyntheticUser):
-        readable_scopes = user.readable_system_table_access_scopes() if user is not None else set()
+    # Anonymous, synthetic, or unauthenticated principal (e.g. a shared-viewer): keep only
+    # access-controlled tables its scopes cover (none for anonymous / team token). Must return here —
+    # UserAccessControl below requires a real authenticated User.
+    if user is None or isinstance(user, SyntheticUser) or not user.is_authenticated:
+        scopes_getter = getattr(user, "readable_system_table_access_scopes", None)
+        readable_scopes = scopes_getter() if scopes_getter is not None else set()
         return None, {
             name
             for name, table_node in system_children.items()
@@ -459,7 +464,8 @@ def _compute_system_table_access_decision(
             and table_node.table.access_scope not in readable_scopes
         }
 
-    user_access_control = user_access_control or UserAccessControl(user=user, team=team)
+    # The guard above returned for every non-User principal; only a real authenticated User reaches here.
+    user_access_control = user_access_control or UserAccessControl(user=cast("User", user), team=team)
 
     org_membership = user_access_control._organization_membership
     if org_membership and org_membership.level >= OrganizationMembership.Level.ADMIN:
@@ -1049,7 +1055,7 @@ class Database(BaseModel):
         team_id: int | None = None,
         *,
         team: Optional["Team"] = None,
-        user: Optional["User | SyntheticUser"] = None,
+        user: Optional["User | SyntheticUser | AnonymousUser"] = None,
         user_access_control: Optional["UserAccessControl"] = None,
         modifiers: "HogQLQueryModifiers | None" = None,
         timings: HogQLTimings | None = None,
@@ -1076,7 +1082,7 @@ class Database(BaseModel):
         team_id: int | None = None,
         *,
         team: Optional["Team"] = None,
-        user: Optional["User | SyntheticUser"] = None,
+        user: Optional["User | SyntheticUser | AnonymousUser"] = None,
         user_access_control: Optional["UserAccessControl"] = None,
         modifiers: "HogQLQueryModifiers | None" = None,
         timings: HogQLTimings | None = None,
@@ -1305,11 +1311,13 @@ class Database(BaseModel):
             modifiers=modifiers,
             is_managed_viewset_enabled=is_managed_viewset_enabled,
             is_hogql_warehouse_access_control_enabled=is_hogql_warehouse_access_control_enabled,
-            # Synthetic principals (project secret API keys) are project-wide and bypass object-level
-            # RBAC by design, so they bypass warehouse access control too. System tables stay
+            # Principals declare their stance via `bypasses_warehouse_access_control`: synthetic
+            # principals (project secret API keys) are project-wide and bypass object-level RBAC by
+            # design; shared-viewer principals render published results. System tables stay
             # scope-gated for them via _compute_system_table_access_decision above. This field only
             # gates the warehouse checks in _build_from_sources.
-            bypass_warehouse_access_control=bypass_warehouse_access_control or isinstance(user, SyntheticUser),
+            bypass_warehouse_access_control=bypass_warehouse_access_control
+            or getattr(user, "bypasses_warehouse_access_control", False),
             direct_connection_metadata=direct_connection_metadata,
             user_access_control=user_access_control,
             denied_system_table_names=denied_system_table_names,

--- a/posthog/hogql/direct_connection.py
+++ b/posthog/hogql/direct_connection.py
@@ -44,8 +44,12 @@ def get_direct_connection_source(
     if source is None:
         return None
 
-    if user is not None and not UserAccessControl(user=user, team=team).check_access_level_for_object(
-        source, required_level="viewer"
+    # Unauthenticated principals (shared-viewer runs) have no RBAC identity to check;
+    # treat them like a userless call.
+    if (
+        user is not None
+        and user.is_authenticated
+        and not UserAccessControl(user=user, team=team).check_access_level_for_object(source, required_level="viewer")
     ):
         return None
 

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -1,6 +1,8 @@
 from posthog.test.base import BaseTest
 from unittest.mock import Mock, patch
 
+from parameterized import parameterized
+
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
@@ -8,7 +10,8 @@ from posthog.hogql.database.schema.system import SystemTables
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.printer.access_control import build_access_control_guard
 
-from posthog.models import OrganizationMembership
+from posthog.auth import SharedViewerAnonymousUser, TeamSecretTokenUser
+from posthog.models import OrganizationMembership, SharingConfiguration
 
 
 class TestAccessControlSystemTables(BaseTest):
@@ -497,6 +500,27 @@ class TestWarehouseTableAccessControl(BaseTest):
 
         assert "denied_table" not in database._denied_tables
         assert "allowed_table" not in database._denied_tables
+
+    @parameterized.expand(["shared_viewer", "team_secret_token"])
+    def test_bypassing_principals_skip_warehouse_acl_but_not_system_table_acl(self, principal_kind: str):
+        # Even a project-wide deny doesn't apply: these principals declare
+        # bypasses_warehouse_access_control instead of failing closed like a userless build.
+        self._create_ac(resource="warehouse_objects", access_level="none")
+        if principal_kind == "shared_viewer":
+            config = SharingConfiguration.objects.create(team=self.team, enabled=True)
+            principal: SharedViewerAnonymousUser | TeamSecretTokenUser = SharedViewerAnonymousUser(config)
+        else:
+            principal = TeamSecretTokenUser(self.team)
+
+        database = Database.create_for(team=self.team, user=principal)
+
+        assert "allowed_table" not in database._denied_tables
+        assert "denied_table" not in database._denied_tables
+        # RBAC-scoped system tables stay hidden - the bypass covers warehouse tables/views only.
+        system_node = database.tables.children.get("system")
+        assert system_node is not None
+        assert "dashboards" not in system_node.children
+        assert "system.dashboards" in database._denied_tables
 
     def test_to_printed_hogql_bypass_prints_warehouse_table_userless(self):
         # Guards the fail-closed fix: query runners print the response HogQL userless right after the

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -159,9 +159,12 @@ def prepare_ast_for_printing(
     # sources, which carry no restrictable event/person properties, so they need no enforcement here.
     if context.team_id is not None and context.restricted_properties is None:
         with context.timings.measure("load_restricted_properties"):
+            # Unauthenticated principals (shared-viewer runs) have no membership to resolve
+            # restrictions against; treat them as userless so only the default rules apply.
+            restrictions_user = context.user if context.user is not None and context.user.is_authenticated else None
             context.restricted_properties = get_restricted_properties_for_team(
                 team_id=context.team_id,
-                user=context.user,
+                user=restrictions_user,
             )
 
     if context.modifiers.inCohortVia == InCohortVia.LEFTJOIN_CONJOINED:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1639,9 +1639,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             ) as slo:
                 try:
                     # Abort early if the user doesn't have access to the query runner
-                    # We'll proceed as usual if there's no user connected to this request
+                    # We'll proceed as usual if there's no user connected to this request. Unauthenticated
+                    # principals (shared-viewer runs) have no RBAC identity to validate — the share link
+                    # itself is their authorization, matching the userless behavior.
                     # We're capturing the error for analytics purposes, but we reraise the same one
-                    if user is not None:
+                    if user is not None and user.is_authenticated:
                         try:
                             self.validate_query_runner_access(user)
                         except UserAccessControlError as error:
@@ -2013,7 +2015,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         """
         from products.access_control.backend.property_access_control import get_restricted_properties_for_team
 
-        restricted = get_restricted_properties_for_team(team_id=self.team.pk, user=self.user)
+        # Unauthenticated principals (shared-viewer runs) have no membership to resolve restrictions
+        # against; treat them as userless so only the default property rules apply.
+        user = self.user if self.user is not None and self.user.is_authenticated else None
+        restricted = get_restricted_properties_for_team(team_id=self.team.pk, user=user)
         if not restricted:
             return None
         return sorted(restricted)
@@ -2336,12 +2341,13 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
     @property
     def user_access_control(self) -> Optional[UserAccessControl]:
         """Access-control snapshot for the cache fingerprint. Built lazily - the fingerprint runs
-        before any database exists, which a cache hit never reaches. None for userless runs and for
-        synthetic principals (e.g. a project secret API key)."""
+        before any database exists, which a cache hit never reaches. None for userless runs, for
+        synthetic principals (e.g. a project secret API key), and for unauthenticated principals
+        (shared-viewer runs) — UserAccessControl requires a real authenticated User."""
         # user is typed Optional[User] but a project secret API key passes a SyntheticUser at runtime;
         # broaden for isinstance.
         user = cast("Optional[User | SyntheticUser]", self.user)
-        if user is None or isinstance(user, SyntheticUser):
+        if user is None or isinstance(user, SyntheticUser) or not user.is_authenticated:
             return None
         if self._user_access_control is None:
             self._user_access_control = UserAccessControl(user=user, team=self.team)
@@ -2351,10 +2357,12 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
         payload = super().get_cache_payload()
 
         # Don't include restricted resources/objects in cache_payload if the ACCESS_CONTROL
-        # feature is unavailable and a user is provided (i.e. not a userless query or a project token)
+        # feature is unavailable and a real user is provided (i.e. not a userless query, a project
+        # token, or an unauthenticated shared-viewer principal)
         user = cast("Optional[User | SyntheticUser]", self.user)
         if (
             user is not None
+            and user.is_authenticated
             and not isinstance(user, SyntheticUser)
             and not self.team.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL)
         ):
@@ -2397,12 +2405,15 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
         if user is None:
             return ["*"] if queried_resources is None else sorted(queried_resources) or None
 
-        # Synthetic principals (e.g. a project secret API key) are scope-gated; partition on the readable
-        # scopes so a narrower token can't be served a broader principal's cached result.
-        if isinstance(user, SyntheticUser):
+        # Synthetic principals (e.g. a project secret API key) and unauthenticated principals
+        # (shared-viewer runs) are scope-gated; partition on the readable scopes so a narrower
+        # token can't be served a broader principal's cached result.
+        if isinstance(user, SyntheticUser) or not user.is_authenticated:
             if queried_resources is None:
                 return ["*"]
-            return sorted(queried_resources - user.readable_system_table_access_scopes()) or None
+            scopes_getter = getattr(user, "readable_system_table_access_scopes", None)
+            readable_scopes = scopes_getter() if scopes_getter is not None else set()
+            return sorted(queried_resources - readable_scopes) or None
 
         user_access_control = self.user_access_control
         if user_access_control is None:

--- a/posthog/synthetic_user.py
+++ b/posthog/synthetic_user.py
@@ -20,6 +20,10 @@ class SyntheticUser:
     is_active: bool = True
     is_anonymous: bool = False
 
+    # Project-wide token principals bypass warehouse table/view access control by design;
+    # Database.create_for reads this declaratively.
+    bypasses_warehouse_access_control: bool = True
+
     def __init__(self, team, distinct_id: str):
         self.team = team
         self.current_team_id = team.id

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -52,7 +52,11 @@ from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import action, format_paginated_url
-from posthog.auth import SharingAccessTokenAuthentication, SharingPasswordProtectedAuthentication
+from posthog.auth import (
+    SharedViewerAnonymousUser,
+    SharingAccessTokenAuthentication,
+    SharingPasswordProtectedAuthentication,
+)
 from posthog.caching.fetch_from_cache import InsightResult, fetch_cached_response_by_key
 from posthog.clickhouse.cancel import cancel_query_on_cluster
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
@@ -1115,10 +1119,19 @@ class InsightSerializer(InsightBasicSerializer):
                 # tags here. No-op overwrite for authenticated paths (same values).
                 shared_tags = {"access_method": AccessMethod.SHARING_TOKEN} if is_shared else {}
                 request_user = None if self.context["request"].user.is_anonymous else self.context["request"].user
+                if request_user is None and is_shared:
+                    # Sharing is an explicit publish act: run under the shared-viewer principal so
+                    # warehouse-backed insights resolve instead of failing closed userless.
+                    request_user = self.context.get("shared_viewer_user")
                 # Reuse the request's single UserAccessControl across all of a dashboard's insight
                 # runners, so the cache fingerprint resolves access once per request, not per tile.
+                # Only for real users - UserAccessControl can't be built for a shared-viewer principal.
                 view = self.context.get("view")
-                request_user_access_control = getattr(view, "user_access_control", None) if request_user else None
+                request_user_access_control = (
+                    getattr(view, "user_access_control", None)
+                    if request_user is not None and request_user.is_authenticated
+                    else None
+                )
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(
                         insight,
@@ -1454,10 +1467,19 @@ class InsightViewSet(
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
 
-        context["is_shared"] = isinstance(
-            self.request.successful_authenticator,
+        authenticator = self.request.successful_authenticator
+        is_shared = isinstance(
+            authenticator,
             SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
         )
+        context["is_shared"] = is_shared
+        if is_shared:
+            # Refreshes from a shared page run under the shared-viewer principal, matching the
+            # server-side render in SharingViewerPageViewSet.
+            authenticator = cast(
+                SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication, authenticator
+            )
+            context["shared_viewer_user"] = SharedViewerAnonymousUser(authenticator.sharing_configuration)
         context["insight_variables"] = InsightVariable.objects.filter(team=self.team).all()
 
         return context


### PR DESCRIPTION
## Problem

With the `hogql-warehouse-access-control` flag enabled (#61686), the HogQL database build fails closed when there is no user: every warehouse table and view is stripped from the schema and queries error with "You don't have access to table `X`".

Publicly shared content executes queries with `user=None` today – the shared page render, the sharing-token API refresh, and the shared-notebook inline query builder. So under the flag, any shared dashboard, insight, or notebook backed by a warehouse table breaks for anonymous viewers, even though the person who enabled sharing deliberately published it.

## Changes

Semantics chosen here: enabling sharing is an explicit publish act, so a live public link always shows its query results at view time. This must not loosen anything for generic userless execution, so the fix is an explicit, unforgeable principal instead of a bypass flag:

- New `SharedViewerAnonymousUser(AnonymousUser)` in `posthog/auth.py`. It can only be constructed from an **enabled** `SharingConfiguration` (raises otherwise) and is passed to query execution only, never assigned to `request.user`.
- The warehouse bypass in `Database.create_for` becomes declarative: `getattr(user, "bypasses_warehouse_access_control", False)` replaces `isinstance(user, SyntheticUser)`, and `SyntheticUser` now declares the attribute. Project-secret-key and team-token behavior is preserved exactly, but each principal's stance is now greppable. Plain `AnonymousUser`, `None`, and real users default to `False`, so userless execution still fails closed.
- RBAC-scoped system tables stay hidden for unauthenticated principals – the anonymous guard in `_compute_system_table_access_decision` now covers any `is_authenticated == False` principal and resolves readable scopes by duck typing, returning before `UserAccessControl` is ever constructed.
- The principal is threaded at the sharing boundary only:
  - `SharingViewerPageViewSet.retrieve` puts it in the serializer context (`shared_viewer_user`), covering shared insights, dashboards (tiles inherit context), and notebook referenced insights.
  - the notebook inline query builder passes it to `process_query_dict`,
  - the insight viewset does the same for sharing-token authenticated refreshes, so a shared page's client-side refresh matches the server-side render.
- Every `UserAccessControl` construction site reachable from query execution now guards against unauthenticated principals (it requires a real `User` and its ORM lookups reject non-model principals): `validate_query_runner_access` in `run()`, the analytics cache-fingerprint snapshot, property-level access restrictions (runner and printer), and direct-connection resolution. In each case the unauthenticated principal gets exactly the pre-existing `user=None` behavior.
- Cache partitioning treats the shared-viewer principal like a scope-less synthetic principal (denied all RBAC-scoped resources), so a cached admin result over a system table can never be served to an anonymous viewer and vice versa.
- Type hints widened pragmatically where the principal flows (`process_query_dict`, `process_query_model`, `calculate_for_query_based_insight`, `Database.create_for`).

No migrations, no model changes.

### Tradeoffs (deliberate, please weigh in)

- **View-time trust**: a member who can enable sharing publishes warehouse data regardless of their own table access. The compensating control – gating the act of sharing (and edits to shared artifacts) on the actor's table access – is intentionally a follow-up, out of scope here.
- **Revocation**: restricting a table later does not hide it from already-shared pages. The sibling PR (creator-based execution) has the opposite tradeoff.
- **Declarative bypass**: `SyntheticUser`'s bypass moves from type-based to attribute-based. Behavior-preserving, but worth a careful look.
- **Async cache refresh gap**: async recalculation enqueues with `user_id=None` (the principal has no id), so a stale shared insight refreshed asynchronously still computes userless. Blocking/synchronous paths (the initial shared render) are covered.

This PR is one of two deliberately competing approaches to the same problem – a sibling PR implements the alternative (executing shared queries as a recorded creator-like principal). They are meant to be compared, not both merged.

## How did you test this code?

Automated tests were written but **not executed locally** – this was implemented in a restricted worktree where running the test suite is not allowed. Please rely on CI, and treat a green run as the verification gate. Static checks that did run locally: `ruff check`, `ruff format`, `py_compile` on every touched file, and the pre-commit hooks (`hogli lint:python:fix`, `format:python`, `uv run ty check`) passed.

New tests and the regression each catches:

- `test_bypassing_principals_skip_warehouse_acl_but_not_system_table_acl` (parameterized: shared viewer, team secret token) – catches dropping the attribute-based bypass (shared pages fail closed again), regressing `SyntheticUser`'s bypass during the type-to-attribute refactor, and the shared principal accidentally gaining RBAC system tables. The existing `test_no_user_fails_closed_for_warehouse_tables` already pins the userless fail-closed guarantee, so no duplicate was added.
- `test_principal_requires_an_enabled_sharing_configuration` – catches removal of the enabled-link guard, the unforgeability property.
- `test_shared_insight_page_runs_queries_under_shared_viewer_principal`, `test_sharing_token_api_refresh_runs_queries_under_shared_viewer_principal`, `test_shared_notebook_inline_queries_run_under_shared_viewer_principal` – each pins one of the three independent wirings at the sharing boundary; reverting any of them to `user=None` fails the corresponding test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this internal access-control path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by @a-lider.

Authored by Claude Code (Claude Fable 5), session: https://claude.ai/code/session_017RAzwb6gCsxideMX7QJj83. Skills invoked: /improving-drf-endpoints, /writing-tests.

Decisions along the way: chose an unforgeable principal class over a `bypass_warehouse_access_control=True` flag at the sharing call sites, so a forgotten `user=` elsewhere still fails closed. While tracing the principal through query execution, Claude found several sites that construct `UserAccessControl` (or ORM-filter by user) for any non-None user and would crash or mis-resolve on an anonymous principal – `validate_query_runner_access`, the cache fingerprint snapshot, property access restrictions, direct-connection checks – and guarded each to fall back to the pre-existing userless behavior. Cache partitioning for the principal deliberately mirrors the scope-less synthetic-principal branch to avoid serving RBAC-scoped cached results across principals with different visibility. This PR competes with a sibling PR that executes shared queries under a creator-based principal; the two are intended for side-by-side review.
