### PR TITLE
chore(clickhouse): model batch_exports goldens + drop endpoints placeholder

### DIFF
--- a/posthog/clickhouse/hcl/golden/prod-eu-batch_exports.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu-batch_exports.hcl
@@ -1,0 +1,830 @@
+database "posthog" {
+  table "query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    column "exception_name" {
+      type  = "String"
+      alias = "errorCodeToName(exception_code)"
+    }
+    column "ProfileEvents_RealTimeMicroseconds" {
+      type  = "Int64"
+      alias = "ProfileEvents['RealTimeMicroseconds']"
+    }
+    column "ProfileEvents_OSCPUVirtualTimeMicroseconds" {
+      type  = "Int64"
+      alias = "ProfileEvents['OSCPUVirtualTimeMicroseconds']"
+    }
+    column "ProfileEvents_S3Clients" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3Clients']"
+    }
+    column "ProfileEvents_S3DeleteObjects" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3DeleteObjects']"
+    }
+    column "ProfileEvents_S3CopyObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CopyObject']"
+    }
+    column "ProfileEvents_S3ListObjects" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3ListObjects']"
+    }
+    column "ProfileEvents_S3HeadObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3HeadObject']"
+    }
+    column "ProfileEvents_S3GetObjectAttributes" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3GetObjectAttributes']"
+    }
+    column "ProfileEvents_S3CreateMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CreateMultipartUpload']"
+    }
+    column "ProfileEvents_S3UploadPartCopy" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3UploadPartCopy']"
+    }
+    column "ProfileEvents_S3UploadPart" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3UploadPart']"
+    }
+    column "ProfileEvents_S3AbortMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3AbortMultipartUpload']"
+    }
+    column "ProfileEvents_S3CompleteMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CompleteMultipartUpload']"
+    }
+    column "ProfileEvents_S3PutObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3PutObject']"
+    }
+    column "ProfileEvents_S3GetObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3GetObject']"
+    }
+    column "ProfileEvents_ReadBufferFromS3Bytes" {
+      type  = "Int64"
+      alias = "ProfileEvents['ReadBufferFromS3Bytes']"
+    }
+    column "ProfileEvents_WriteBufferFromS3Bytes" {
+      type  = "Int64"
+      alias = "ProfileEvents['WriteBufferFromS3Bytes']"
+    }
+    column "lc_workflow" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.workflow"
+    }
+    column "lc_kind" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.kind"
+    }
+    column "lc_id" {
+      type  = "String"
+      alias = "CAST(log_comment.id, 'String')"
+    }
+    column "lc_route_id" {
+      type  = "String"
+      alias = "CAST(log_comment.route_id, 'String')"
+    }
+    column "lc_access_method" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.access_method"
+    }
+    column "lc_api_key_label" {
+      type  = "String"
+      alias = "CAST(log_comment.api_key_label, 'String')"
+    }
+    column "lc_api_key_mask" {
+      type  = "String"
+      alias = "CAST(log_comment.api_key_mask, 'String')"
+    }
+    column "lc_query_type" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.query_type"
+    }
+    column "lc_product" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.product"
+    }
+    column "lc_chargeable" {
+      type  = "Bool"
+      alias = "log_comment.chargeable"
+    }
+    column "lc_name" {
+      type  = "String"
+      alias = "CAST(log_comment.name, 'String')"
+    }
+    column "lc_request_name" {
+      type  = "String"
+      alias = "CAST(log_comment.request_name, 'String')"
+    }
+    column "lc_client_query_id" {
+      type  = "String"
+      alias = "CAST(log_comment.client_query_id, 'String')"
+    }
+    column "lc_org_id" {
+      type  = "String"
+      alias = "CAST(log_comment.org_id, 'String')"
+    }
+    column "lc_user_id" {
+      type  = "Int64"
+      alias = "log_comment.user_id"
+    }
+    column "lc_is_impersonated" {
+      type  = "Bool"
+      alias = "log_comment.is_impersonated"
+    }
+    column "lc_session_id" {
+      type  = "String"
+      alias = "CAST(log_comment.session_id, 'String')"
+    }
+    column "lc_dashboard_id" {
+      type  = "Int64"
+      alias = "log_comment.dashboard_id"
+    }
+    column "lc_insight_id" {
+      type  = "Int64"
+      alias = "log_comment.insight_id"
+    }
+    column "lc_cohort_id" {
+      type  = "Int64"
+      alias = "log_comment.cohort_id"
+    }
+    column "lc_batch_export_id" {
+      type  = "String"
+      alias = "CAST(log_comment.batch_export_id, 'String')"
+    }
+    column "lc_experiment_id" {
+      type  = "Int64"
+      alias = "log_comment.experiment_id"
+    }
+    column "lc_experiment_feature_flag_key" {
+      type  = "String"
+      alias = "CAST(log_comment.experiment_feature_flag_key, 'String')"
+    }
+    column "lc_alert_config_id" {
+      type  = "String"
+      alias = "CAST(log_comment.alert_config_id, 'String')"
+    }
+    column "lc_feature" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.feature"
+    }
+    column "lc_table_id" {
+      type  = "String"
+      alias = "CAST(log_comment.table_id, 'String')"
+    }
+    column "lc_warehouse_query" {
+      type  = "Bool"
+      alias = "log_comment.warehouse_query"
+    }
+    column "lc_person_on_events_mode" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.person_on_events_mode"
+    }
+    column "lc_service_name" {
+      type  = "String"
+      alias = "CAST(log_comment.service_name, 'String')"
+    }
+    column "lc_workload" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.workload"
+    }
+    column "lc_query__kind" {
+      type  = "LowCardinality(String)"
+      alias = "if(JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'kind'), JSONExtractString(toString(log_comment), 'query', 'kind'))"
+    }
+    column "lc_query__query" {
+      type  = "String"
+      alias = "multiIf(NOT is_initial_query, '', JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'query'), JSONExtractString(toString(log_comment), 'query', 'query'))"
+    }
+    column "lc_query" {
+      type  = "String"
+      alias = "if(is_initial_query, JSONExtractRaw(toString(log_comment), 'query'), '')"
+    }
+    column "lc_temporal__workflow_namespace" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_namespace`, 'String')"
+    }
+    column "lc_temporal__workflow_type" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_type`, 'String')"
+    }
+    column "lc_temporal__workflow_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_id`, 'String')"
+    }
+    column "lc_temporal__workflow_run_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_run_id`, 'String')"
+    }
+    column "lc_temporal__activity_type" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.activity_type`, 'String')"
+    }
+    column "lc_temporal__activity_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.activity_id`, 'String')"
+    }
+    column "lc_temporal__attempt" {
+      type  = "Int64"
+      alias = "log_comment.`temporal.attempt`"
+    }
+    column "lc_dagster__job_name" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.job_name`, 'String')"
+    }
+    column "lc_dagster__run_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.run_id`, 'String')"
+    }
+    column "lc_dagster__owner" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.tags.owner`, 'String')"
+    }
+    column "lc_modifiers" {
+      type  = "String"
+      alias = "if(is_initial_query, JSONExtractRaw(toString(log_comment), 'modifiers'), '')"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "sharded_query_log_archive"
+    }
+  }
+
+  table "sharded_events_recent" {
+    order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
+    partition_by = "toStartOfDay(inserted_at)"
+    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "uuid" {
+      type = "UUID"
+    }
+    column "event" {
+      type = "String"
+    }
+    column "properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "timestamp" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "elements_chain" {
+      type = "String"
+    }
+    column "created_at" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "person_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group0_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group1_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group2_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group3_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group4_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group0_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group1_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group2_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group3_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group4_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_mode" {
+      type = "Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2)"
+    }
+    column "historical_migration" {
+      type = "Bool"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "inserted_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent"
+      replica_name   = "{replica}"
+      version_column = "_timestamp"
+    }
+  }
+
+  table "writable_query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "query_log_archive_buffer"
+    }
+  }
+
+  materialized_view "ops_query_log_archive_mv" {
+    to_table = "posthog.writable_query_log_archive"
+    query    = <<SQL
+SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart'
+SQL
+
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "String"
+    }
+    column "ProfileEvents" {
+      type = "Map(LowCardinality(String), UInt64)"
+    }
+  }
+
+  view "custom_metrics_backups" {
+    query = <<SQL
+WITH
+  ['ClickHouseCustomMetric_BackupFailed', 'ClickHouseCustomMetric_BackupSuccess', 'ClickHouseCustomMetric_BackupCancelled', 'ClickHouseCustomMetric_BackupAttempts'] AS names,
+  [toInt64(countIf(status = 'BACKUP_FAILED')), toInt64(countIf(status = 'BACKUP_CREATED')), toInt64(countIf(status = 'BACKUP_CANCELLED')), toInt64(countIf(status = 'CREATING_BACKUP'))] AS values,
+  ['Number of failed backups', 'Number of successful backups', 'Number of cancelled backups', 'Number of backup attempts'] AS descriptions,
+  ['gauge', 'gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.backup_log
+WHERE event_date = today()
+GROUP BY
+  event_date
+SQL
+
+  }
+
+  view "custom_metrics_dictionaries" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_DictionariesFailed' AS name,
+  map(
+    'instance',
+    hostname(),
+    'database',
+    d.database,
+    'dictionary',
+    d.dict_name,
+    'uuid',
+    toString(d.uuid),
+    'status',
+    toString(d.status)
+  ) AS labels,
+  toUInt64(1) AS value,
+  'Dictionary is in FAILED or FAILED_AND_RELOADING status' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT name AS dict_name, database, uuid, status
+    FROM system.dictionaries
+    WHERE status IN ('FAILED', 'FAILED_AND_RELOADING')
+  ) AS d
+SQL
+
+  }
+
+  view "custom_metrics_part_counts" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_MaxPartCountPerPartition' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`, 'partition', partition) AS labels,
+  part_count AS value,
+  'Maximum number of active parts for any partition in a PostHog table' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT database, `table`, partition, count() AS part_count
+    FROM system.parts
+    WHERE
+      active
+    AND
+      (database = 'posthog')
+    GROUP BY
+      database, `table`, partition
+    ORDER BY database ASC, `table` ASC, part_count DESC, partition ASC
+    LIMIT 1 BY database, `table`
+  )
+SQL
+
+  }
+
+  view "custom_metrics_replication_queue" {
+    query = <<SQL
+WITH
+  ['ClickHouseCustomMetric_ReplicationQueueStuckEntries', 'ClickHouseCustomMetric_ReplicationQueueMaxPostponedEntrySeconds', 'ClickHouseCustomMetric_ReplicationQueueMaxErrorEntrySeconds'] AS names,
+  [toInt64(countIf(create_time < (now() - toIntervalDay(15)))), maxIf(dateDiff('seconds', create_time, last_postpone_time), last_postpone_time != '1970-01-01'), maxIf(dateDiff('seconds', create_time, last_exception_time), (last_exception_time != '1970-01-01') AND (last_exception_time > (now() - toIntervalMinute(5))))] AS values,
+  ['Number of entries that have been in the replication queue for more than 15 days', 'Maximum number of seconds that an entry has been postponed', 'Maximum number of seconds that an entry has been in error'] AS descriptions,
+  ['gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('table', `table`, 'instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.replication_queue
+GROUP BY
+  `table`
+HAVING
+  value > 0
+SQL
+
+  }
+
+  view "custom_metrics_server_crash" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_ServerCrash' AS name,
+  map('instance', hostname()) AS labels,
+  count() AS value,
+  'Number of server crashes for current date' AS help,
+  'gauge' AS type
+FROM system.crash_log
+WHERE event_date = today()
+GROUP BY
+  hostname()
+SQL
+
+  }
+
+  view "custom_metrics_table_sizes" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_TableTotalBytes' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`) AS labels,
+  CAST(total_bytes, 'Float64') AS value,
+  'Size of a database table on a given node (need a sum for sharded)' AS help,
+  'gauge' AS type
+FROM system.tables
+WHERE
+  (database NOT IN ('INFORMATION_SCHEMA', 'information_schema'))
+AND
+  (total_bytes IS NOT NULL)
+SQL
+
+  }
+
+  view "custom_metrics_test" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_Test' AS name,
+  map('instance', hostname()) AS labels,
+  1 AS value,
+  'Test to check that the metric endpoint is working' AS help,
+  'gauge' AS type
+SQL
+
+  }
+}

--- a/posthog/clickhouse/hcl/golden/prod-us-batch_exports.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us-batch_exports.hcl
@@ -1,0 +1,822 @@
+database "posthog" {
+  table "query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    column "exception_name" {
+      type  = "String"
+      alias = "errorCodeToName(exception_code)"
+    }
+    column "ProfileEvents_RealTimeMicroseconds" {
+      type  = "Int64"
+      alias = "ProfileEvents['RealTimeMicroseconds']"
+    }
+    column "ProfileEvents_OSCPUVirtualTimeMicroseconds" {
+      type  = "Int64"
+      alias = "ProfileEvents['OSCPUVirtualTimeMicroseconds']"
+    }
+    column "ProfileEvents_S3Clients" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3Clients']"
+    }
+    column "ProfileEvents_S3DeleteObjects" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3DeleteObjects']"
+    }
+    column "ProfileEvents_S3CopyObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CopyObject']"
+    }
+    column "ProfileEvents_S3ListObjects" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3ListObjects']"
+    }
+    column "ProfileEvents_S3HeadObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3HeadObject']"
+    }
+    column "ProfileEvents_S3GetObjectAttributes" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3GetObjectAttributes']"
+    }
+    column "ProfileEvents_S3CreateMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CreateMultipartUpload']"
+    }
+    column "ProfileEvents_S3UploadPartCopy" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3UploadPartCopy']"
+    }
+    column "ProfileEvents_S3UploadPart" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3UploadPart']"
+    }
+    column "ProfileEvents_S3AbortMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3AbortMultipartUpload']"
+    }
+    column "ProfileEvents_S3CompleteMultipartUpload" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3CompleteMultipartUpload']"
+    }
+    column "ProfileEvents_S3PutObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3PutObject']"
+    }
+    column "ProfileEvents_S3GetObject" {
+      type  = "Int64"
+      alias = "ProfileEvents['S3GetObject']"
+    }
+    column "ProfileEvents_ReadBufferFromS3Bytes" {
+      type  = "Int64"
+      alias = "ProfileEvents['ReadBufferFromS3Bytes']"
+    }
+    column "ProfileEvents_WriteBufferFromS3Bytes" {
+      type  = "Int64"
+      alias = "ProfileEvents['WriteBufferFromS3Bytes']"
+    }
+    column "lc_workflow" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.workflow"
+    }
+    column "lc_kind" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.kind"
+    }
+    column "lc_id" {
+      type  = "String"
+      alias = "CAST(log_comment.id, 'String')"
+    }
+    column "lc_route_id" {
+      type  = "String"
+      alias = "CAST(log_comment.route_id, 'String')"
+    }
+    column "lc_access_method" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.access_method"
+    }
+    column "lc_api_key_label" {
+      type  = "String"
+      alias = "CAST(log_comment.api_key_label, 'String')"
+    }
+    column "lc_api_key_mask" {
+      type  = "String"
+      alias = "CAST(log_comment.api_key_mask, 'String')"
+    }
+    column "lc_query_type" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.query_type"
+    }
+    column "lc_product" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.product"
+    }
+    column "lc_chargeable" {
+      type  = "Bool"
+      alias = "log_comment.chargeable"
+    }
+    column "lc_name" {
+      type  = "String"
+      alias = "CAST(log_comment.name, 'String')"
+    }
+    column "lc_request_name" {
+      type  = "String"
+      alias = "CAST(log_comment.request_name, 'String')"
+    }
+    column "lc_client_query_id" {
+      type  = "String"
+      alias = "CAST(log_comment.client_query_id, 'String')"
+    }
+    column "lc_org_id" {
+      type  = "String"
+      alias = "CAST(log_comment.org_id, 'String')"
+    }
+    column "lc_user_id" {
+      type  = "Int64"
+      alias = "log_comment.user_id"
+    }
+    column "lc_is_impersonated" {
+      type  = "Bool"
+      alias = "log_comment.is_impersonated"
+    }
+    column "lc_session_id" {
+      type  = "String"
+      alias = "CAST(log_comment.session_id, 'String')"
+    }
+    column "lc_dashboard_id" {
+      type  = "Int64"
+      alias = "log_comment.dashboard_id"
+    }
+    column "lc_insight_id" {
+      type  = "Int64"
+      alias = "log_comment.insight_id"
+    }
+    column "lc_cohort_id" {
+      type  = "Int64"
+      alias = "log_comment.cohort_id"
+    }
+    column "lc_batch_export_id" {
+      type  = "String"
+      alias = "CAST(log_comment.batch_export_id, 'String')"
+    }
+    column "lc_experiment_id" {
+      type  = "Int64"
+      alias = "log_comment.experiment_id"
+    }
+    column "lc_experiment_feature_flag_key" {
+      type  = "String"
+      alias = "CAST(log_comment.experiment_feature_flag_key, 'String')"
+    }
+    column "lc_alert_config_id" {
+      type  = "String"
+      alias = "CAST(log_comment.alert_config_id, 'String')"
+    }
+    column "lc_feature" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.feature"
+    }
+    column "lc_table_id" {
+      type  = "String"
+      alias = "CAST(log_comment.table_id, 'String')"
+    }
+    column "lc_warehouse_query" {
+      type  = "Bool"
+      alias = "log_comment.warehouse_query"
+    }
+    column "lc_person_on_events_mode" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.person_on_events_mode"
+    }
+    column "lc_service_name" {
+      type  = "String"
+      alias = "CAST(log_comment.service_name, 'String')"
+    }
+    column "lc_workload" {
+      type  = "LowCardinality(String)"
+      alias = "log_comment.workload"
+    }
+    column "lc_query__kind" {
+      type  = "LowCardinality(String)"
+      alias = "if(JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'kind'), JSONExtractString(toString(log_comment), 'query', 'kind'))"
+    }
+    column "lc_query__query" {
+      type  = "String"
+      alias = "multiIf(NOT is_initial_query, '', JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'query'), JSONExtractString(toString(log_comment), 'query', 'query'))"
+    }
+    column "lc_query" {
+      type  = "String"
+      alias = "if(is_initial_query, JSONExtractRaw(toString(log_comment), 'query'), '')"
+    }
+    column "lc_temporal__workflow_namespace" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_namespace`, 'String')"
+    }
+    column "lc_temporal__workflow_type" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_type`, 'String')"
+    }
+    column "lc_temporal__workflow_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_id`, 'String')"
+    }
+    column "lc_temporal__workflow_run_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.workflow_run_id`, 'String')"
+    }
+    column "lc_temporal__activity_type" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.activity_type`, 'String')"
+    }
+    column "lc_temporal__activity_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`temporal.activity_id`, 'String')"
+    }
+    column "lc_temporal__attempt" {
+      type  = "Int64"
+      alias = "log_comment.`temporal.attempt`"
+    }
+    column "lc_dagster__job_name" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.job_name`, 'String')"
+    }
+    column "lc_dagster__run_id" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.run_id`, 'String')"
+    }
+    column "lc_dagster__owner" {
+      type  = "String"
+      alias = "CAST(log_comment.`dagster.tags.owner`, 'String')"
+    }
+    column "lc_modifiers" {
+      type  = "String"
+      alias = "if(is_initial_query, JSONExtractRaw(toString(log_comment), 'modifiers'), '')"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "sharded_query_log_archive"
+    }
+  }
+
+  table "sharded_events_recent" {
+    order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
+    partition_by = "toStartOfDay(inserted_at)"
+    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    settings = {
+      index_granularity     = "8192"
+      parts_to_delay_insert = "800"
+      parts_to_throw_insert = "1500"
+      ttl_only_drop_parts   = "1"
+    }
+    column "uuid" {
+      type = "UUID"
+    }
+    column "event" {
+      type = "String"
+    }
+    column "properties" {
+      type = "String"
+    }
+    column "timestamp" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "elements_chain" {
+      type = "String"
+    }
+    column "created_at" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "person_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_properties" {
+      type = "String"
+    }
+    column "group0_properties" {
+      type = "String"
+    }
+    column "group1_properties" {
+      type = "String"
+    }
+    column "group2_properties" {
+      type = "String"
+    }
+    column "group3_properties" {
+      type = "String"
+    }
+    column "group4_properties" {
+      type = "String"
+    }
+    column "group0_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group1_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group2_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group3_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group4_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_mode" {
+      type = "Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2)"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "inserted_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent"
+      replica_name   = "{replica}"
+      version_column = "_timestamp"
+    }
+  }
+
+  table "writable_query_log_archive" {
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email)"
+    }
+    column "ProfileEvents" {
+      type = "Map(String, UInt64)"
+    }
+    engine "distributed" {
+      cluster_name    = "ops"
+      remote_database = "posthog"
+      remote_table    = "query_log_archive_buffer"
+    }
+  }
+
+  materialized_view "ops_query_log_archive_mv" {
+    to_table = "posthog.writable_query_log_archive"
+    query    = <<SQL
+SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart'
+SQL
+
+    column "hostname" {
+      type = "LowCardinality(String)"
+    }
+    column "user" {
+      type = "LowCardinality(String)"
+    }
+    column "query_id" {
+      type = "String"
+    }
+    column "initial_query_id" {
+      type = "String"
+    }
+    column "is_initial_query" {
+      type = "UInt8"
+    }
+    column "type" {
+      type = "Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4)"
+    }
+    column "event_date" {
+      type = "Date"
+    }
+    column "event_time" {
+      type = "DateTime"
+    }
+    column "event_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_start_time" {
+      type = "DateTime"
+    }
+    column "query_start_time_microseconds" {
+      type = "DateTime64(6)"
+    }
+    column "query_duration_ms" {
+      type = "UInt64"
+    }
+    column "read_rows" {
+      type = "UInt64"
+    }
+    column "read_bytes" {
+      type = "UInt64"
+    }
+    column "written_rows" {
+      type = "UInt64"
+    }
+    column "written_bytes" {
+      type = "UInt64"
+    }
+    column "result_rows" {
+      type = "UInt64"
+    }
+    column "result_bytes" {
+      type = "UInt64"
+    }
+    column "memory_usage" {
+      type = "UInt64"
+    }
+    column "peak_threads_usage" {
+      type = "UInt64"
+    }
+    column "current_database" {
+      type = "LowCardinality(String)"
+    }
+    column "query" {
+      type = "String"
+    }
+    column "formatted_query" {
+      type = "String"
+    }
+    column "normalized_query_hash" {
+      type = "UInt64"
+    }
+    column "query_kind" {
+      type = "LowCardinality(String)"
+    }
+    column "exception_code" {
+      type = "Int32"
+    }
+    column "exception" {
+      type = "String"
+    }
+    column "stack_trace" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "log_comment" {
+      type = "String"
+    }
+    column "ProfileEvents" {
+      type = "Map(LowCardinality(String), UInt64)"
+    }
+  }
+
+  view "custom_metrics_backups" {
+    query = <<SQL
+WITH
+  ['ClickHouseCustomMetric_BackupFailed', 'ClickHouseCustomMetric_BackupSuccess', 'ClickHouseCustomMetric_BackupCancelled', 'ClickHouseCustomMetric_BackupAttempts'] AS names,
+  [toInt64(countIf(status = 'BACKUP_FAILED')), toInt64(countIf(status = 'BACKUP_CREATED')), toInt64(countIf(status = 'BACKUP_CANCELLED')), toInt64(countIf(status = 'CREATING_BACKUP'))] AS values,
+  ['Number of failed backups', 'Number of successful backups', 'Number of cancelled backups', 'Number of backup attempts'] AS descriptions,
+  ['gauge', 'gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.backup_log
+WHERE event_date = today()
+GROUP BY
+  event_date
+SQL
+
+  }
+
+  view "custom_metrics_dictionaries" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_DictionariesFailed' AS name,
+  map(
+    'instance',
+    hostname(),
+    'database',
+    d.database,
+    'dictionary',
+    d.dict_name,
+    'uuid',
+    toString(d.uuid),
+    'status',
+    toString(d.status)
+  ) AS labels,
+  toUInt64(1) AS value,
+  'Dictionary is in FAILED or FAILED_AND_RELOADING status' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT name AS dict_name, database, uuid, status
+    FROM system.dictionaries
+    WHERE status IN ('FAILED', 'FAILED_AND_RELOADING')
+  ) AS d
+SQL
+
+  }
+
+  view "custom_metrics_part_counts" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_MaxPartCountPerPartition' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`, 'partition', partition) AS labels,
+  part_count AS value,
+  'Maximum number of active parts for any partition in a PostHog table' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT database, `table`, partition, count() AS part_count
+    FROM system.parts
+    WHERE
+      active
+    AND
+      (database = 'posthog')
+    GROUP BY
+      database, `table`, partition
+    ORDER BY database ASC, `table` ASC, part_count DESC, partition ASC
+    LIMIT 1 BY database, `table`
+  )
+SQL
+
+  }
+
+  view "custom_metrics_replication_queue" {
+    query = <<SQL
+WITH
+  ['ClickHouseCustomMetric_ReplicationQueueStuckEntries', 'ClickHouseCustomMetric_ReplicationQueueMaxPostponedEntrySeconds', 'ClickHouseCustomMetric_ReplicationQueueMaxErrorEntrySeconds'] AS names,
+  [toInt64(countIf(create_time < (now() - toIntervalDay(15)))), maxIf(dateDiff('seconds', create_time, last_postpone_time), last_postpone_time != '1970-01-01'), maxIf(dateDiff('seconds', create_time, last_exception_time), (last_exception_time != '1970-01-01') AND (last_exception_time > (now() - toIntervalMinute(5))))] AS values,
+  ['Number of entries that have been in the replication queue for more than 15 days', 'Maximum number of seconds that an entry has been postponed', 'Maximum number of seconds that an entry has been in error'] AS descriptions,
+  ['gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('table', `table`, 'instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.replication_queue
+GROUP BY
+  `table`
+HAVING
+  value > 0
+SQL
+
+  }
+
+  view "custom_metrics_server_crash" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_ServerCrash' AS name,
+  map('instance', hostname()) AS labels,
+  count() AS value,
+  'Number of server crashes for current date' AS help,
+  'gauge' AS type
+FROM system.crash_log
+WHERE event_date = today()
+GROUP BY
+  hostname()
+SQL
+
+  }
+
+  view "custom_metrics_table_sizes" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_TableTotalBytes' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`) AS labels,
+  CAST(total_bytes, 'Float64') AS value,
+  'Size of a database table on a given node (need a sum for sharded)' AS help,
+  'gauge' AS type
+FROM system.tables
+WHERE
+  (database NOT IN ('INFORMATION_SCHEMA', 'information_schema'))
+AND
+  (total_bytes IS NOT NULL)
+SQL
+
+  }
+
+  view "custom_metrics_test" {
+    query = <<SQL
+SELECT
+  'ClickHouseCustomMetric_Test' AS name,
+  map('instance', hostname()) AS labels,
+  1 AS value,
+  'Test to check that the metric endpoint is working' AS help,
+  'gauge' AS type
+SQL
+
+  }
+}

--- a/posthog/clickhouse/hcl/nodes
+++ b/posthog/clickhouse/hcl/nodes
@@ -70,5 +70,11 @@ prod-eu  sessions   roles/shared roles/sessions/shared roles/sessions/prod-eu
 # raw_sessions_v3) plus the query_log_archive path. Dump-baselined.
 prod-us  sessionsv3 roles/shared roles/sessionsv3/prod-us
 
+# BATCH_EXPORTS satellite: hosts the sharded_events_recent data table (the recent-events
+# store the export workers read; data/ops reach it via Distributed proxies) plus the
+# query_log_archive path. Env-specific — prod-eu carries an extra historical_migration
+# column. Dump-baselined (no local batch-exports node).
+prod-us  batch_exports roles/shared roles/batch_exports/prod-us
+prod-eu  batch_exports roles/shared roles/batch_exports/prod-eu
+
 # prod-us  data       roles/shared roles/data/shared roles/data/prod-us
-# prod-us  endpoints  roles/shared

--- a/posthog/clickhouse/hcl/roles/batch_exports/prod-eu/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/batch_exports/prod-eu/tables.hcl
@@ -1,0 +1,102 @@
+database "posthog" {
+  table "sharded_events_recent" {
+    order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
+    partition_by = "toStartOfDay(inserted_at)"
+    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "uuid" {
+      type = "UUID"
+    }
+    column "event" {
+      type = "String"
+    }
+    column "properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "timestamp" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "elements_chain" {
+      type = "String"
+    }
+    column "created_at" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "person_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group0_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group1_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group2_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group3_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group4_properties" {
+      type  = "String"
+      codec = "ZSTD(3)"
+    }
+    column "group0_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group1_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group2_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group3_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group4_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_mode" {
+      type = "Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2)"
+    }
+    column "historical_migration" {
+      type = "Bool"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "inserted_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent"
+      replica_name   = "{replica}"
+      version_column = "_timestamp"
+    }
+  }
+}

--- a/posthog/clickhouse/hcl/roles/batch_exports/prod-us/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/batch_exports/prod-us/tables.hcl
@@ -1,0 +1,94 @@
+database "posthog" {
+  table "sharded_events_recent" {
+    order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
+    partition_by = "toStartOfDay(inserted_at)"
+    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    settings = {
+      index_granularity     = "8192"
+      parts_to_delay_insert = "800"
+      parts_to_throw_insert = "1500"
+      ttl_only_drop_parts   = "1"
+    }
+    column "uuid" {
+      type = "UUID"
+    }
+    column "event" {
+      type = "String"
+    }
+    column "properties" {
+      type = "String"
+    }
+    column "timestamp" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "elements_chain" {
+      type = "String"
+    }
+    column "created_at" {
+      type = "DateTime64(6, 'UTC')"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "person_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_properties" {
+      type = "String"
+    }
+    column "group0_properties" {
+      type = "String"
+    }
+    column "group1_properties" {
+      type = "String"
+    }
+    column "group2_properties" {
+      type = "String"
+    }
+    column "group3_properties" {
+      type = "String"
+    }
+    column "group4_properties" {
+      type = "String"
+    }
+    column "group0_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group1_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group2_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group3_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "group4_created_at" {
+      type = "DateTime64(3)"
+    }
+    column "person_mode" {
+      type = "Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2)"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "inserted_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent"
+      replica_name   = "{replica}"
+      version_column = "_timestamp"
+    }
+  }
+}

--- a/posthog/clickhouse/hcl/sql/prod-eu-batch_exports.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu-batch_exports.sql
@@ -1,0 +1,295 @@
+-- AUTO-GENERATED from the declarative HCL by ops/gen-sql.sh — do not edit.
+-- Full CREATE schema for the prod-eu/batch_exports node. Apply to a fresh ClickHouse to build it.
+
+CREATE TABLE posthog.query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64),
+  exception_name String ALIAS errorCodeToName(exception_code),
+  ProfileEvents_RealTimeMicroseconds Int64 ALIAS ProfileEvents['RealTimeMicroseconds'],
+  ProfileEvents_OSCPUVirtualTimeMicroseconds Int64 ALIAS ProfileEvents['OSCPUVirtualTimeMicroseconds'],
+  ProfileEvents_S3Clients Int64 ALIAS ProfileEvents['S3Clients'],
+  ProfileEvents_S3DeleteObjects Int64 ALIAS ProfileEvents['S3DeleteObjects'],
+  ProfileEvents_S3CopyObject Int64 ALIAS ProfileEvents['S3CopyObject'],
+  ProfileEvents_S3ListObjects Int64 ALIAS ProfileEvents['S3ListObjects'],
+  ProfileEvents_S3HeadObject Int64 ALIAS ProfileEvents['S3HeadObject'],
+  ProfileEvents_S3GetObjectAttributes Int64 ALIAS ProfileEvents['S3GetObjectAttributes'],
+  ProfileEvents_S3CreateMultipartUpload Int64 ALIAS ProfileEvents['S3CreateMultipartUpload'],
+  ProfileEvents_S3UploadPartCopy Int64 ALIAS ProfileEvents['S3UploadPartCopy'],
+  ProfileEvents_S3UploadPart Int64 ALIAS ProfileEvents['S3UploadPart'],
+  ProfileEvents_S3AbortMultipartUpload Int64 ALIAS ProfileEvents['S3AbortMultipartUpload'],
+  ProfileEvents_S3CompleteMultipartUpload Int64 ALIAS ProfileEvents['S3CompleteMultipartUpload'],
+  ProfileEvents_S3PutObject Int64 ALIAS ProfileEvents['S3PutObject'],
+  ProfileEvents_S3GetObject Int64 ALIAS ProfileEvents['S3GetObject'],
+  ProfileEvents_ReadBufferFromS3Bytes Int64 ALIAS ProfileEvents['ReadBufferFromS3Bytes'],
+  ProfileEvents_WriteBufferFromS3Bytes Int64 ALIAS ProfileEvents['WriteBufferFromS3Bytes'],
+  lc_workflow LowCardinality(String) ALIAS log_comment.workflow,
+  lc_kind LowCardinality(String) ALIAS log_comment.kind,
+  lc_id String ALIAS CAST(log_comment.id, 'String'),
+  lc_route_id String ALIAS CAST(log_comment.route_id, 'String'),
+  lc_access_method LowCardinality(String) ALIAS log_comment.access_method,
+  lc_api_key_label String ALIAS CAST(log_comment.api_key_label, 'String'),
+  lc_api_key_mask String ALIAS CAST(log_comment.api_key_mask, 'String'),
+  lc_query_type LowCardinality(String) ALIAS log_comment.query_type,
+  lc_product LowCardinality(String) ALIAS log_comment.product,
+  lc_chargeable Bool ALIAS log_comment.chargeable,
+  lc_name String ALIAS CAST(log_comment.name, 'String'),
+  lc_request_name String ALIAS CAST(log_comment.request_name, 'String'),
+  lc_client_query_id String ALIAS CAST(log_comment.client_query_id, 'String'),
+  lc_org_id String ALIAS CAST(log_comment.org_id, 'String'),
+  lc_user_id Int64 ALIAS log_comment.user_id,
+  lc_is_impersonated Bool ALIAS log_comment.is_impersonated,
+  lc_session_id String ALIAS CAST(log_comment.session_id, 'String'),
+  lc_dashboard_id Int64 ALIAS log_comment.dashboard_id,
+  lc_insight_id Int64 ALIAS log_comment.insight_id,
+  lc_cohort_id Int64 ALIAS log_comment.cohort_id,
+  lc_batch_export_id String ALIAS CAST(log_comment.batch_export_id, 'String'),
+  lc_experiment_id Int64 ALIAS log_comment.experiment_id,
+  lc_experiment_feature_flag_key String ALIAS CAST(log_comment.experiment_feature_flag_key, 'String'),
+  lc_alert_config_id String ALIAS CAST(log_comment.alert_config_id, 'String'),
+  lc_feature LowCardinality(String) ALIAS log_comment.feature,
+  lc_table_id String ALIAS CAST(log_comment.table_id, 'String'),
+  lc_warehouse_query Bool ALIAS log_comment.warehouse_query,
+  lc_person_on_events_mode LowCardinality(String) ALIAS log_comment.person_on_events_mode,
+  lc_service_name String ALIAS CAST(log_comment.service_name, 'String'),
+  lc_workload LowCardinality(String) ALIAS log_comment.workload,
+  lc_query__kind LowCardinality(String) ALIAS if(JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'kind'), JSONExtractString(toString(log_comment), 'query', 'kind')),
+  lc_query__query String ALIAS multiIf(NOT is_initial_query, '', JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'query'), JSONExtractString(toString(log_comment), 'query', 'query')),
+  lc_query String ALIAS if(is_initial_query, JSONExtractRaw(toString(log_comment), 'query'), ''),
+  lc_temporal__workflow_namespace String ALIAS CAST(log_comment.`temporal.workflow_namespace`, 'String'),
+  lc_temporal__workflow_type String ALIAS CAST(log_comment.`temporal.workflow_type`, 'String'),
+  lc_temporal__workflow_id String ALIAS CAST(log_comment.`temporal.workflow_id`, 'String'),
+  lc_temporal__workflow_run_id String ALIAS CAST(log_comment.`temporal.workflow_run_id`, 'String'),
+  lc_temporal__activity_type String ALIAS CAST(log_comment.`temporal.activity_type`, 'String'),
+  lc_temporal__activity_id String ALIAS CAST(log_comment.`temporal.activity_id`, 'String'),
+  lc_temporal__attempt Int64 ALIAS log_comment.`temporal.attempt`,
+  lc_dagster__job_name String ALIAS CAST(log_comment.`dagster.job_name`, 'String'),
+  lc_dagster__run_id String ALIAS CAST(log_comment.`dagster.run_id`, 'String'),
+  lc_dagster__owner String ALIAS CAST(log_comment.`dagster.tags.owner`, 'String'),
+  lc_modifiers String ALIAS if(is_initial_query, JSONExtractRaw(toString(log_comment), 'modifiers'), '')
+) ENGINE = Distributed('ops', 'posthog', 'sharded_query_log_archive');
+CREATE TABLE posthog.sharded_events_recent (
+  uuid UUID,
+  event String,
+  properties String CODEC(ZSTD(3)),
+  timestamp DateTime64(6, 'UTC'),
+  team_id Int64,
+  distinct_id String,
+  elements_chain String,
+  created_at DateTime64(6, 'UTC'),
+  person_id UUID,
+  person_created_at DateTime64(3),
+  person_properties String CODEC(ZSTD(3)),
+  group0_properties String CODEC(ZSTD(3)),
+  group1_properties String CODEC(ZSTD(3)),
+  group2_properties String CODEC(ZSTD(3)),
+  group3_properties String CODEC(ZSTD(3)),
+  group4_properties String CODEC(ZSTD(3)),
+  group0_created_at DateTime64(3),
+  group1_created_at DateTime64(3),
+  group2_created_at DateTime64(3),
+  group3_created_at DateTime64(3),
+  group4_created_at DateTime64(3),
+  person_mode Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2),
+  historical_migration Bool,
+  _timestamp DateTime,
+  _offset UInt64,
+  inserted_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.writable_query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64)
+) ENGINE = Distributed('ops', 'posthog', 'query_log_archive_buffer');
+CREATE MATERIALIZED VIEW posthog.ops_query_log_archive_mv TO posthog.writable_query_log_archive (hostname LowCardinality(String), user LowCardinality(String), query_id String, initial_query_id String, is_initial_query UInt8, type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4), event_date Date, event_time DateTime, event_time_microseconds DateTime64(6), query_start_time DateTime, query_start_time_microseconds DateTime64(6), query_duration_ms UInt64, read_rows UInt64, read_bytes UInt64, written_rows UInt64, written_bytes UInt64, result_rows UInt64, result_bytes UInt64, memory_usage UInt64, peak_threads_usage UInt64, current_database LowCardinality(String), query String, formatted_query String, normalized_query_hash UInt64, query_kind LowCardinality(String), exception_code Int32, exception String, stack_trace String, team_id Int64, log_comment String, ProfileEvents Map(LowCardinality(String), UInt64)) AS SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart';
+CREATE VIEW posthog.custom_metrics_backups AS WITH
+  ['ClickHouseCustomMetric_BackupFailed', 'ClickHouseCustomMetric_BackupSuccess', 'ClickHouseCustomMetric_BackupCancelled', 'ClickHouseCustomMetric_BackupAttempts'] AS names,
+  [toInt64(countIf(status = 'BACKUP_FAILED')), toInt64(countIf(status = 'BACKUP_CREATED')), toInt64(countIf(status = 'BACKUP_CANCELLED')), toInt64(countIf(status = 'CREATING_BACKUP'))] AS values,
+  ['Number of failed backups', 'Number of successful backups', 'Number of cancelled backups', 'Number of backup attempts'] AS descriptions,
+  ['gauge', 'gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.backup_log
+WHERE event_date = today()
+GROUP BY
+  event_date;
+CREATE VIEW posthog.custom_metrics_dictionaries AS SELECT
+  'ClickHouseCustomMetric_DictionariesFailed' AS name,
+  map(
+    'instance',
+    hostname(),
+    'database',
+    d.database,
+    'dictionary',
+    d.dict_name,
+    'uuid',
+    toString(d.uuid),
+    'status',
+    toString(d.status)
+  ) AS labels,
+  toUInt64(1) AS value,
+  'Dictionary is in FAILED or FAILED_AND_RELOADING status' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT name AS dict_name, database, uuid, status
+    FROM system.dictionaries
+    WHERE status IN ('FAILED', 'FAILED_AND_RELOADING')
+  ) AS d;
+CREATE VIEW posthog.custom_metrics_part_counts AS SELECT
+  'ClickHouseCustomMetric_MaxPartCountPerPartition' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`, 'partition', partition) AS labels,
+  part_count AS value,
+  'Maximum number of active parts for any partition in a PostHog table' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT database, `table`, partition, count() AS part_count
+    FROM system.parts
+    WHERE
+      active
+    AND
+      (database = 'posthog')
+    GROUP BY
+      database, `table`, partition
+    ORDER BY database ASC, `table` ASC, part_count DESC, partition ASC
+    LIMIT 1 BY database, `table`
+  );
+CREATE VIEW posthog.custom_metrics_replication_queue AS WITH
+  ['ClickHouseCustomMetric_ReplicationQueueStuckEntries', 'ClickHouseCustomMetric_ReplicationQueueMaxPostponedEntrySeconds', 'ClickHouseCustomMetric_ReplicationQueueMaxErrorEntrySeconds'] AS names,
+  [toInt64(countIf(create_time < (now() - toIntervalDay(15)))), maxIf(dateDiff('seconds', create_time, last_postpone_time), last_postpone_time != '1970-01-01'), maxIf(dateDiff('seconds', create_time, last_exception_time), (last_exception_time != '1970-01-01') AND (last_exception_time > (now() - toIntervalMinute(5))))] AS values,
+  ['Number of entries that have been in the replication queue for more than 15 days', 'Maximum number of seconds that an entry has been postponed', 'Maximum number of seconds that an entry has been in error'] AS descriptions,
+  ['gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('table', `table`, 'instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.replication_queue
+GROUP BY
+  `table`
+HAVING
+  value > 0;
+CREATE VIEW posthog.custom_metrics_server_crash AS SELECT
+  'ClickHouseCustomMetric_ServerCrash' AS name,
+  map('instance', hostname()) AS labels,
+  count() AS value,
+  'Number of server crashes for current date' AS help,
+  'gauge' AS type
+FROM system.crash_log
+WHERE event_date = today()
+GROUP BY
+  hostname();
+CREATE VIEW posthog.custom_metrics_table_sizes AS SELECT
+  'ClickHouseCustomMetric_TableTotalBytes' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`) AS labels,
+  CAST(total_bytes, 'Float64') AS value,
+  'Size of a database table on a given node (need a sum for sharded)' AS help,
+  'gauge' AS type
+FROM system.tables
+WHERE
+  (database NOT IN ('INFORMATION_SCHEMA', 'information_schema'))
+AND
+  (total_bytes IS NOT NULL);
+CREATE VIEW posthog.custom_metrics_test AS SELECT
+  'ClickHouseCustomMetric_Test' AS name,
+  map('instance', hostname()) AS labels,
+  1 AS value,
+  'Test to check that the metric endpoint is working' AS help,
+  'gauge' AS type;

--- a/posthog/clickhouse/hcl/sql/prod-us-batch_exports.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us-batch_exports.sql
@@ -1,0 +1,294 @@
+-- AUTO-GENERATED from the declarative HCL by ops/gen-sql.sh — do not edit.
+-- Full CREATE schema for the prod-us/batch_exports node. Apply to a fresh ClickHouse to build it.
+
+CREATE TABLE posthog.query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64),
+  exception_name String ALIAS errorCodeToName(exception_code),
+  ProfileEvents_RealTimeMicroseconds Int64 ALIAS ProfileEvents['RealTimeMicroseconds'],
+  ProfileEvents_OSCPUVirtualTimeMicroseconds Int64 ALIAS ProfileEvents['OSCPUVirtualTimeMicroseconds'],
+  ProfileEvents_S3Clients Int64 ALIAS ProfileEvents['S3Clients'],
+  ProfileEvents_S3DeleteObjects Int64 ALIAS ProfileEvents['S3DeleteObjects'],
+  ProfileEvents_S3CopyObject Int64 ALIAS ProfileEvents['S3CopyObject'],
+  ProfileEvents_S3ListObjects Int64 ALIAS ProfileEvents['S3ListObjects'],
+  ProfileEvents_S3HeadObject Int64 ALIAS ProfileEvents['S3HeadObject'],
+  ProfileEvents_S3GetObjectAttributes Int64 ALIAS ProfileEvents['S3GetObjectAttributes'],
+  ProfileEvents_S3CreateMultipartUpload Int64 ALIAS ProfileEvents['S3CreateMultipartUpload'],
+  ProfileEvents_S3UploadPartCopy Int64 ALIAS ProfileEvents['S3UploadPartCopy'],
+  ProfileEvents_S3UploadPart Int64 ALIAS ProfileEvents['S3UploadPart'],
+  ProfileEvents_S3AbortMultipartUpload Int64 ALIAS ProfileEvents['S3AbortMultipartUpload'],
+  ProfileEvents_S3CompleteMultipartUpload Int64 ALIAS ProfileEvents['S3CompleteMultipartUpload'],
+  ProfileEvents_S3PutObject Int64 ALIAS ProfileEvents['S3PutObject'],
+  ProfileEvents_S3GetObject Int64 ALIAS ProfileEvents['S3GetObject'],
+  ProfileEvents_ReadBufferFromS3Bytes Int64 ALIAS ProfileEvents['ReadBufferFromS3Bytes'],
+  ProfileEvents_WriteBufferFromS3Bytes Int64 ALIAS ProfileEvents['WriteBufferFromS3Bytes'],
+  lc_workflow LowCardinality(String) ALIAS log_comment.workflow,
+  lc_kind LowCardinality(String) ALIAS log_comment.kind,
+  lc_id String ALIAS CAST(log_comment.id, 'String'),
+  lc_route_id String ALIAS CAST(log_comment.route_id, 'String'),
+  lc_access_method LowCardinality(String) ALIAS log_comment.access_method,
+  lc_api_key_label String ALIAS CAST(log_comment.api_key_label, 'String'),
+  lc_api_key_mask String ALIAS CAST(log_comment.api_key_mask, 'String'),
+  lc_query_type LowCardinality(String) ALIAS log_comment.query_type,
+  lc_product LowCardinality(String) ALIAS log_comment.product,
+  lc_chargeable Bool ALIAS log_comment.chargeable,
+  lc_name String ALIAS CAST(log_comment.name, 'String'),
+  lc_request_name String ALIAS CAST(log_comment.request_name, 'String'),
+  lc_client_query_id String ALIAS CAST(log_comment.client_query_id, 'String'),
+  lc_org_id String ALIAS CAST(log_comment.org_id, 'String'),
+  lc_user_id Int64 ALIAS log_comment.user_id,
+  lc_is_impersonated Bool ALIAS log_comment.is_impersonated,
+  lc_session_id String ALIAS CAST(log_comment.session_id, 'String'),
+  lc_dashboard_id Int64 ALIAS log_comment.dashboard_id,
+  lc_insight_id Int64 ALIAS log_comment.insight_id,
+  lc_cohort_id Int64 ALIAS log_comment.cohort_id,
+  lc_batch_export_id String ALIAS CAST(log_comment.batch_export_id, 'String'),
+  lc_experiment_id Int64 ALIAS log_comment.experiment_id,
+  lc_experiment_feature_flag_key String ALIAS CAST(log_comment.experiment_feature_flag_key, 'String'),
+  lc_alert_config_id String ALIAS CAST(log_comment.alert_config_id, 'String'),
+  lc_feature LowCardinality(String) ALIAS log_comment.feature,
+  lc_table_id String ALIAS CAST(log_comment.table_id, 'String'),
+  lc_warehouse_query Bool ALIAS log_comment.warehouse_query,
+  lc_person_on_events_mode LowCardinality(String) ALIAS log_comment.person_on_events_mode,
+  lc_service_name String ALIAS CAST(log_comment.service_name, 'String'),
+  lc_workload LowCardinality(String) ALIAS log_comment.workload,
+  lc_query__kind LowCardinality(String) ALIAS if(JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'kind'), JSONExtractString(toString(log_comment), 'query', 'kind')),
+  lc_query__query String ALIAS multiIf(NOT is_initial_query, '', JSONHas(toString(log_comment), 'query', 'source'), JSONExtractString(toString(log_comment), 'query', 'source', 'query'), JSONExtractString(toString(log_comment), 'query', 'query')),
+  lc_query String ALIAS if(is_initial_query, JSONExtractRaw(toString(log_comment), 'query'), ''),
+  lc_temporal__workflow_namespace String ALIAS CAST(log_comment.`temporal.workflow_namespace`, 'String'),
+  lc_temporal__workflow_type String ALIAS CAST(log_comment.`temporal.workflow_type`, 'String'),
+  lc_temporal__workflow_id String ALIAS CAST(log_comment.`temporal.workflow_id`, 'String'),
+  lc_temporal__workflow_run_id String ALIAS CAST(log_comment.`temporal.workflow_run_id`, 'String'),
+  lc_temporal__activity_type String ALIAS CAST(log_comment.`temporal.activity_type`, 'String'),
+  lc_temporal__activity_id String ALIAS CAST(log_comment.`temporal.activity_id`, 'String'),
+  lc_temporal__attempt Int64 ALIAS log_comment.`temporal.attempt`,
+  lc_dagster__job_name String ALIAS CAST(log_comment.`dagster.job_name`, 'String'),
+  lc_dagster__run_id String ALIAS CAST(log_comment.`dagster.run_id`, 'String'),
+  lc_dagster__owner String ALIAS CAST(log_comment.`dagster.tags.owner`, 'String'),
+  lc_modifiers String ALIAS if(is_initial_query, JSONExtractRaw(toString(log_comment), 'modifiers'), '')
+) ENGINE = Distributed('ops', 'posthog', 'sharded_query_log_archive');
+CREATE TABLE posthog.sharded_events_recent (
+  uuid UUID,
+  event String,
+  properties String,
+  timestamp DateTime64(6, 'UTC'),
+  team_id Int64,
+  distinct_id String,
+  elements_chain String,
+  created_at DateTime64(6, 'UTC'),
+  person_id UUID,
+  person_created_at DateTime64(3),
+  person_properties String,
+  group0_properties String,
+  group1_properties String,
+  group2_properties String,
+  group3_properties String,
+  group4_properties String,
+  group0_created_at DateTime64(3),
+  group1_created_at DateTime64(3),
+  group2_created_at DateTime64(3),
+  group3_created_at DateTime64(3),
+  group4_created_at DateTime64(3),
+  person_mode Enum8('full'=0, 'propertyless'=1, 'force_upgrade'=2),
+  _timestamp DateTime,
+  _offset UInt64,
+  inserted_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, parts_to_delay_insert = 800, parts_to_throw_insert = 1500, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.writable_query_log_archive (
+  hostname LowCardinality(String),
+  user LowCardinality(String),
+  query_id String,
+  initial_query_id String,
+  is_initial_query UInt8,
+  type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4),
+  event_date Date,
+  event_time DateTime,
+  event_time_microseconds DateTime64(6),
+  query_start_time DateTime,
+  query_start_time_microseconds DateTime64(6),
+  query_duration_ms UInt64,
+  read_rows UInt64,
+  read_bytes UInt64,
+  written_rows UInt64,
+  written_bytes UInt64,
+  result_rows UInt64,
+  result_bytes UInt64,
+  memory_usage UInt64,
+  peak_threads_usage UInt64,
+  current_database LowCardinality(String),
+  query String,
+  formatted_query String,
+  normalized_query_hash UInt64,
+  query_kind LowCardinality(String),
+  exception_code Int32,
+  exception String,
+  stack_trace String,
+  team_id Int64,
+  log_comment JSON(max_dynamic_paths=256, access_method LowCardinality(String), alert_config_id String, api_key_label String, api_key_mask String, batch_export_id String, chargeable Bool, client_query_id String, cohort_id Int64, `dagster.job_name` String, `dagster.run_id` String, `dagster.tags.owner` String, dashboard_id Int64, experiment_feature_flag_key String, experiment_id Int64, feature LowCardinality(String), id String, insight_id Int64, is_impersonated Bool, kind LowCardinality(String), name String, org_id String, person_on_events_mode LowCardinality(String), product LowCardinality(String), query_type LowCardinality(String), request_name String, route_id String, service_name String, session_id String, table_id String, team_id Int64, `temporal.activity_id` String, `temporal.activity_type` String, `temporal.attempt` Int64, `temporal.workflow_id` String, `temporal.workflow_namespace` String, `temporal.workflow_run_id` String, `temporal.workflow_type` String, user_id Int64, warehouse_query Bool, workflow LowCardinality(String), workload LowCardinality(String), SKIP cache_key, SKIP filter, SKIP hogql_features, SKIP http_referer, SKIP http_request_id, SKIP http_user_agent, SKIP query_settings, SKIP timings, SKIP user_email),
+  ProfileEvents Map(String, UInt64)
+) ENGINE = Distributed('ops', 'posthog', 'query_log_archive_buffer');
+CREATE MATERIALIZED VIEW posthog.ops_query_log_archive_mv TO posthog.writable_query_log_archive (hostname LowCardinality(String), user LowCardinality(String), query_id String, initial_query_id String, is_initial_query UInt8, type Enum8('QueryStart'=1, 'QueryFinish'=2, 'ExceptionBeforeStart'=3, 'ExceptionWhileProcessing'=4), event_date Date, event_time DateTime, event_time_microseconds DateTime64(6), query_start_time DateTime, query_start_time_microseconds DateTime64(6), query_duration_ms UInt64, read_rows UInt64, read_bytes UInt64, written_rows UInt64, written_bytes UInt64, result_rows UInt64, result_bytes UInt64, memory_usage UInt64, peak_threads_usage UInt64, current_database LowCardinality(String), query String, formatted_query String, normalized_query_hash UInt64, query_kind LowCardinality(String), exception_code Int32, exception String, stack_trace String, team_id Int64, log_comment String, ProfileEvents Map(LowCardinality(String), UInt64)) AS SELECT
+  hostname,
+  user,
+  query_id,
+  initial_query_id,
+  is_initial_query,
+  type,
+  event_date,
+  event_time,
+  event_time_microseconds,
+  query_start_time,
+  query_start_time_microseconds,
+  query_duration_ms,
+  read_rows,
+  read_bytes,
+  written_rows,
+  written_bytes,
+  result_rows,
+  result_bytes,
+  memory_usage,
+  peak_threads_usage,
+  current_database,
+  query,
+  formatted_query,
+  normalized_query_hash,
+  query_kind,
+  exception_code,
+  exception,
+  stack_trace,
+  JSONExtractInt(log_comment, 'team_id') AS team_id,
+  if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
+  ProfileEvents
+FROM system.query_log
+WHERE type != 'QueryStart';
+CREATE VIEW posthog.custom_metrics_backups AS WITH
+  ['ClickHouseCustomMetric_BackupFailed', 'ClickHouseCustomMetric_BackupSuccess', 'ClickHouseCustomMetric_BackupCancelled', 'ClickHouseCustomMetric_BackupAttempts'] AS names,
+  [toInt64(countIf(status = 'BACKUP_FAILED')), toInt64(countIf(status = 'BACKUP_CREATED')), toInt64(countIf(status = 'BACKUP_CANCELLED')), toInt64(countIf(status = 'CREATING_BACKUP'))] AS values,
+  ['Number of failed backups', 'Number of successful backups', 'Number of cancelled backups', 'Number of backup attempts'] AS descriptions,
+  ['gauge', 'gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.backup_log
+WHERE event_date = today()
+GROUP BY
+  event_date;
+CREATE VIEW posthog.custom_metrics_dictionaries AS SELECT
+  'ClickHouseCustomMetric_DictionariesFailed' AS name,
+  map(
+    'instance',
+    hostname(),
+    'database',
+    d.database,
+    'dictionary',
+    d.dict_name,
+    'uuid',
+    toString(d.uuid),
+    'status',
+    toString(d.status)
+  ) AS labels,
+  toUInt64(1) AS value,
+  'Dictionary is in FAILED or FAILED_AND_RELOADING status' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT name AS dict_name, database, uuid, status
+    FROM system.dictionaries
+    WHERE status IN ('FAILED', 'FAILED_AND_RELOADING')
+  ) AS d;
+CREATE VIEW posthog.custom_metrics_part_counts AS SELECT
+  'ClickHouseCustomMetric_MaxPartCountPerPartition' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`, 'partition', partition) AS labels,
+  part_count AS value,
+  'Maximum number of active parts for any partition in a PostHog table' AS help,
+  'gauge' AS type
+FROM
+  (
+    SELECT database, `table`, partition, count() AS part_count
+    FROM system.parts
+    WHERE
+      active
+    AND
+      (database = 'posthog')
+    GROUP BY
+      database, `table`, partition
+    ORDER BY database ASC, `table` ASC, part_count DESC, partition ASC
+    LIMIT 1 BY database, `table`
+  );
+CREATE VIEW posthog.custom_metrics_replication_queue AS WITH
+  ['ClickHouseCustomMetric_ReplicationQueueStuckEntries', 'ClickHouseCustomMetric_ReplicationQueueMaxPostponedEntrySeconds', 'ClickHouseCustomMetric_ReplicationQueueMaxErrorEntrySeconds'] AS names,
+  [toInt64(countIf(create_time < (now() - toIntervalDay(15)))), maxIf(dateDiff('seconds', create_time, last_postpone_time), last_postpone_time != '1970-01-01'), maxIf(dateDiff('seconds', create_time, last_exception_time), (last_exception_time != '1970-01-01') AND (last_exception_time > (now() - toIntervalMinute(5))))] AS values,
+  ['Number of entries that have been in the replication queue for more than 15 days', 'Maximum number of seconds that an entry has been postponed', 'Maximum number of seconds that an entry has been in error'] AS descriptions,
+  ['gauge', 'gauge', 'gauge'] AS types,
+  arrayJoin(arrayZip(names, values, descriptions, types)) AS tpl
+SELECT
+  tpl.1 AS name,
+  map('table', `table`, 'instance', hostname()) AS labels,
+  tpl.2 AS value,
+  tpl.3 AS help,
+  tpl.4 AS type
+FROM system.replication_queue
+GROUP BY
+  `table`
+HAVING
+  value > 0;
+CREATE VIEW posthog.custom_metrics_server_crash AS SELECT
+  'ClickHouseCustomMetric_ServerCrash' AS name,
+  map('instance', hostname()) AS labels,
+  count() AS value,
+  'Number of server crashes for current date' AS help,
+  'gauge' AS type
+FROM system.crash_log
+WHERE event_date = today()
+GROUP BY
+  hostname();
+CREATE VIEW posthog.custom_metrics_table_sizes AS SELECT
+  'ClickHouseCustomMetric_TableTotalBytes' AS name,
+  map('instance', hostname(), 'database', database, 'table', `table`) AS labels,
+  CAST(total_bytes, 'Float64') AS value,
+  'Size of a database table on a given node (need a sum for sharded)' AS help,
+  'gauge' AS type
+FROM system.tables
+WHERE
+  (database NOT IN ('INFORMATION_SCHEMA', 'information_schema'))
+AND
+  (total_bytes IS NOT NULL);
+CREATE VIEW posthog.custom_metrics_test AS SELECT
+  'ClickHouseCustomMetric_Test' AS name,
+  map('instance', hostname()) AS labels,
+  1 AS value,
+  'Test to check that the metric endpoint is working' AS help,
+  'gauge' AS type;


### PR DESCRIPTION
## Changes

- **`batch_exports`** — model the batch-exports cluster, dump-baselined from the prod node dumps. It hosts a single role-specific table, **`sharded_events_recent`** (the recent-events store the export workers read; data/ops reach it via Distributed proxies), plus the shared `query_log_archive` path. Per-env: prod-eu carries an extra `historical_migration` column.
- **Drop the dead `endpoints` placeholder** — there's no endpoints node schema in the prod dumps (it's a query-routing role with no tables of its own).

## How did you test this code?

I'm an agent. Each `prod-us`/`prod-eu` batch_exports golden `hclexp diff`s clean against its node dump (modulo gate-ignored `custom_metrics`). `check.sh` green (21 goldens); validate clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Reference-only role — there's no local batch-exports node in the multinode stack, so it's dump-baselined (not live-gate-verifiable), same as `sessionsv3`. This closes out the remaining real prod node roles: `ingestion-*` live in another repo, `offline` is a replica type (not a distinct schema), and `endpoints` has no schema. Only `data` (the main sharded cluster) remains.