### PR TITLE
fix(error-tracking): drop stale spike notifications

### DIFF
--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use tracing::warn;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::core::{
@@ -116,7 +116,7 @@ pub async fn handle_issue_spiking(
         event_properties,
     } = issue;
 
-    let issue_exists = persist_spike_event(
+    match persist_spike_event(
         context,
         meta.notification_id,
         meta.team_id,
@@ -124,15 +124,27 @@ pub async fn handle_issue_spiking(
         computed_baseline,
         current_bucket_value,
     )
-    .await?;
-    if !issue_exists {
-        warn!(
-            notification_id = %meta.notification_id,
-            team_id = meta.team_id,
-            issue_id = %issue_id,
-            "dropping spike notification for missing issue"
-        );
-        return Ok(());
+    .await?
+    {
+        PersistSpikeEventResult::Inserted => {}
+        PersistSpikeEventResult::AlreadyPersisted => {
+            debug!(
+                notification_id = %meta.notification_id,
+                team_id = meta.team_id,
+                issue_id = %issue_id,
+                "dropping duplicate spike notification"
+            );
+            return Ok(());
+        }
+        PersistSpikeEventResult::MissingIssue => {
+            warn!(
+                notification_id = %meta.notification_id,
+                team_id = meta.team_id,
+                issue_id = %issue_id,
+                "dropping spike notification for missing issue"
+            );
+            return Ok(());
+        }
     }
 
     let issue = issue_from_notification(meta.team_id, issue_id, issue_snapshot);
@@ -157,6 +169,12 @@ pub async fn handle_issue_spiking(
     Ok(())
 }
 
+enum PersistSpikeEventResult {
+    Inserted,
+    AlreadyPersisted,
+    MissingIssue,
+}
+
 fn issue_from_notification(
     team_id: i32,
     issue_id: Uuid,
@@ -179,7 +197,7 @@ async fn persist_spike_event(
     issue_id: Uuid,
     computed_baseline: f64,
     current_bucket_value: f64,
-) -> Result<bool, UnhandledError> {
+) -> Result<PersistSpikeEventResult, UnhandledError> {
     let now = Utc::now();
     let result = sqlx::query(
         r#"WITH existing_issue AS (
@@ -202,7 +220,7 @@ async fn persist_spike_event(
     .await?;
 
     if result.rows_affected() > 0 {
-        return Ok(true);
+        return Ok(PersistSpikeEventResult::Inserted);
     }
 
     let issue_exists: bool = sqlx::query_scalar(
@@ -215,7 +233,11 @@ async fn persist_spike_event(
     .fetch_one(&context.posthog_pool)
     .await?;
 
-    Ok(issue_exists)
+    if issue_exists {
+        return Ok(PersistSpikeEventResult::AlreadyPersisted);
+    }
+
+    Ok(PersistSpikeEventResult::MissingIssue)
 }
 
 fn parse_notification_timestamp(event_timestamp: &str, event_uuid: Uuid) -> DateTime<Utc> {

--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -115,9 +115,8 @@ pub async fn handle_issue_spiking(
         issue: issue_snapshot,
         event_properties,
     } = issue;
-    let issue = issue_from_notification(meta.team_id, issue_id, issue_snapshot);
 
-    persist_spike_event(
+    let issue_exists = persist_spike_event(
         context,
         meta.notification_id,
         meta.team_id,
@@ -126,6 +125,18 @@ pub async fn handle_issue_spiking(
         current_bucket_value,
     )
     .await?;
+    if !issue_exists {
+        warn!(
+            notification_id = %meta.notification_id,
+            team_id = meta.team_id,
+            issue_id = %issue_id,
+            "dropping spike notification for missing issue"
+        );
+        return Ok(());
+    }
+
+    let issue = issue_from_notification(meta.team_id, issue_id, issue_snapshot);
+
     send_issue_spiking_internal_event(
         &context.cyclotron_producer,
         &context.internal_events_topic,
@@ -168,12 +179,17 @@ async fn persist_spike_event(
     issue_id: Uuid,
     computed_baseline: f64,
     current_bucket_value: f64,
-) -> Result<(), UnhandledError> {
+) -> Result<bool, UnhandledError> {
     let now = Utc::now();
-    sqlx::query(
-        r#"INSERT INTO posthog_errortrackingspikeevent
+    let result = sqlx::query(
+        r#"WITH existing_issue AS (
+               SELECT 1 FROM posthog_errortrackingissue
+               WHERE team_id = $2 AND id = $3
+               FOR KEY SHARE
+           )
+           INSERT INTO posthog_errortrackingspikeevent
            (id, team_id, issue_id, detected_at, computed_baseline, current_bucket_value)
-           VALUES ($1, $2, $3, $4, $5, $6)
+           SELECT $1, $2, $3, $4, $5, $6 FROM existing_issue
            ON CONFLICT (id) DO NOTHING"#,
     )
     .bind(notification_id)
@@ -185,7 +201,21 @@ async fn persist_spike_event(
     .execute(&context.posthog_pool)
     .await?;
 
-    Ok(())
+    if result.rows_affected() > 0 {
+        return Ok(true);
+    }
+
+    let issue_exists: bool = sqlx::query_scalar(
+        r#"SELECT EXISTS(
+            SELECT 1 FROM posthog_errortrackingissue WHERE team_id = $1 AND id = $2
+        )"#,
+    )
+    .bind(team_id)
+    .bind(issue_id)
+    .fetch_one(&context.posthog_pool)
+    .await?;
+
+    Ok(issue_exists)
 }
 
 fn parse_notification_timestamp(event_timestamp: &str, event_uuid: Uuid) -> DateTime<Utc> {


### PR DESCRIPTION
## Problem

Spike notifications can reference an error tracking issue that no longer exists by the time the notifications worker handles the Kafka message. One known path is merging an issue, which deletes the source issue after moving its fingerprints. The stale spike notification then fails the `posthog_errortrackingspikeevent.issue_id` foreign key and crashes the consumer.

## Changes

- Only insert spike events when the referenced issue still exists.
- Lock the issue row during the insert so a concurrent delete cannot race the foreign key check.
- Drop the stale spike notification without sending the internal event or signal if the issue is gone.

## How did you test this code?

- `cd rust && cargo check -p cymbal --lib`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This is an internal ingestion reliability fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent to inspect the Cymbal notification flow and make the targeted Rust change. Skills invoked: `/error-tracking` and `/pr`.

We considered remapping spike notifications through the fingerprint carried in `event_properties`, but chose to drop the notification for now when the issue no longer exists.