### PR TITLE
fix(gitlab): give an actionable message when the instance URL redirects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
@@ -215,7 +215,14 @@ def validate_credentials(
         return False, str(e)
 
     if response.is_redirect or response.is_permanent_redirect:
-        return False, HOST_NOT_ALLOWED_ERROR
+        # A redirect on the API request usually means the instance URL doesn't point directly at
+        # GitLab (a project/web page, a login/SSO gateway, or a proxy). We can't follow it — the
+        # target could be an internal address (SSRF) — so guide the user to the right URL.
+        return False, (
+            "The GitLab instance URL returned an unexpected redirect. Enter just your instance URL "
+            "(for example https://gitlab.com or https://gitlab.example.com) with no project path, and make sure "
+            "it points directly at GitLab rather than a login, SSO, or proxy page."
+        )
 
     if response.status_code == 200:
         return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
@@ -275,7 +275,7 @@ class TestValidateCredentials:
         with self._patch_session(_response(status_code=302)) as patched:
             valid, msg = validate_credentials("https://gitlab.com", "tok", "group/project")
             assert valid is False
-            assert msg == gitlab_module.HOST_NOT_ALLOWED_ERROR
+            assert "unexpected redirect" in (msg or "")
             assert patched.return_value.get.call_args.kwargs["allow_redirects"] is False
 
     def test_blocks_unsafe_host(self):


### PR DESCRIPTION
## Problem

Creating a GitLab warehouse source whose instance URL responds with a redirect failed with an internal marker string that gives the user nothing to act on (redacted shape: a bare "host is not allowed" token). That marker exists so the sync pipeline can classify the failure as non-retryable, but on the interactive create path it just leaks to the user. A redirect on the API probe almost always means the instance URL points at a project/web page, a login or SSO gateway, or a proxy rather than the GitLab API itself.

## Changes

In `validate_credentials`, the redirect branch now returns an actionable message telling the user to enter their bare instance URL (for example `https://gitlab.com` or `https://gitlab.example.com`) with no project path, and to make sure it points directly at GitLab rather than a login/SSO/proxy page. Behavior is unchanged otherwise: we still pass `allow_redirects=False` so we never follow a redirect to a potentially internal address (SSRF).

## How did you test this code?

Updated the existing redirect test to assert the new actionable message and kept its `allow_redirects=False` assertion, which is the real regression guard (we must never follow the redirect). Ran the `TestValidateCredentials` suite locally:

```
pytest .../gitlab/tests/test_gitlab.py::TestValidateCredentials
```

Ran `ruff check` and `ruff format` over the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged real GitLab source-creation failures. Traced the failing string and found `_is_host_safe` always returns its own specific message, so the only path that emitted the bare marker was the redirect branch in `validate_credentials`. That branch reused the sync pipeline's non-retryable marker verbatim, which is meaningless to a user on the create path. Kept the SSRF protection intact and only changed the user-facing text plus the corresponding test assertion. Invoked the `/writing-tests` skill before touching the test.
