### PR TITLE
fix(ci): shard jest 4 ways and use all runner cores

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -625,7 +625,7 @@ jobs:
             # or skip jest entirely (should_run=false) when selection can't be
             # trusted. On ready PRs, master push, and merge_group it's skipped, so
             # we fall back to the full FOSS×EE × chunk fanout (the merge gate).
-            matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2]}') }}
+            matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2,3,4]}') }}
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -643,7 +643,10 @@ jobs:
               env:
                   NODE_OPTIONS: --max-old-space-size=16384
                   SHARD_INDEX: ${{ matrix.chunk }}
-                  SHARD_COUNT: 2
+                  # Keep shard runtime well under timeout-minutes: the EE suite at 2
+                  # shards ran 13-15 min on the 2-worker config and regularly died at
+                  # the 15-min timeout, failing the whole run.
+                  SHARD_COUNT: 4
                   MODE: ${{ needs.select-jest-tests.outputs.mode }}
                   CHANGED_FILES: ${{ needs.select-jest-tests.outputs.changed_files }}
               run: |
@@ -665,7 +668,9 @@ jobs:
                           --passWithNoTests \
                           --findRelatedTests $CHANGED_FILES
                   else
-                      bin/turbo run test --filter=@posthog/frontend -- --maxWorkers=2
+                      # 100% = one worker per available core. Public-repo ubuntu-latest
+                      # runners have 4 vCPUs; a hardcoded 2 left half the machine idle.
+                      bin/turbo run test --filter=@posthog/frontend -- --maxWorkers=100%
                   fi
 
     calculate-running-time:


### PR DESCRIPTION
## Problem

Frontend CI's jest jobs have outgrown their configuration, and they're now the biggest self-inflicted merge bottleneck on the repo:

- The full matrix is FOSS/EE × 2 shards, each pinned to `--maxWorkers=2`. That worker count was sized for the old 2-vCPU GitHub-hosted runners, but public-repo `ubuntu-latest` runners have had 4 vCPUs since early 2025, so half of each machine sits idle.
- The EE shard now runs 13-15 min of pure jest against the job's `timeout-minutes: 15`. In one recent ~11 hour window, 32 of 500 frontend CI runs on PRs had `Jest test (EE - 1)` killed at exactly the 15-minute timeout, failing the whole run. Every one of those costs the author a full extra CI cycle, and the failure rate keeps climbing as the suite grows.

## Changes

Three knobs in the jest job of `ci-frontend.yml`, everything else untouched:

- Full-run matrix goes from 2 to 4 chunks per segment (the `test` script already takes native `jest --shard`, so this is just the fallback matrix literal)
- `SHARD_COUNT` env goes 2 → 4 to match
- `--maxWorkers=2` → `--maxWorkers=100%`, one worker per available core, which degrades gracefully if a runner ever has fewer cores

Expected effect: each jest job drops from ~13-15 min to ~4-6 min, frontend CI wall time drops from ~15 min to ~7 min, and the timeout deaths stop with ~3x headroom. This stays on free GitHub-hosted runners, and total core-minutes stay roughly flat since the same work is split finer. Average org-level runner concurrency doesn't grow because the jobs are proportionally shorter.

Safety notes: merge gating flows through the `Frontend Tests Pass` aggregator (not per-shard check names), nothing outside this file references the shard count, and the draft-PR selective jest path is unaffected. The change is self-contained in the workflow file, so open PRs that haven't rebased are unaffected.

## How did you test this code?

I validated the YAML parses and that the matrix/env/CLI changes are consistent with how `frontend/package.json`'s `test` script consumes `SHARD_INDEX`/`SHARD_COUNT`. This PR is opened ready (not draft) deliberately, so its own CI run exercises the full 4-shard matrix - the per-job and wall-clock timings on this PR are the verification, compared against the 2-shard baseline measured from recent runs on master's config. I could not run jest locally in the sandbox.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-internal change with no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) directed by @thmsobrmlr, who asked for the highest-leverage quick win for CI merge latency and then for this PR.
- Analysis used the GitHub Actions API (`gh api`) over recent workflow runs, jobs, and steps: ~62% of recently merged PRs merged within 3 minutes of their last check finishing, i.e. CI runtime is the merge gate. Backend, storybook, and e2e suites are already heavily sharded with lean per-shard setup, while jest was the outlier: 2 shards, 2 workers, brushing its own timeout. The `diagnosing-ci-and-merge-bottlenecks` skill was invoked at the start for methodology.
- Alternatives considered and deferred: moving jest to paid depot runners (works, but the free 4-vCPU runners get ~3x with this change at zero cost), fixing the 10-minute full-history migration replay in `Validate migrations` (real waste, but co-tied with the django test long pole so it doesn't move backend wall time alone), and sharding the monolithic e2e playwright job (duplicates ~6.5 min of environment setup per shard).
