### PR TITLE
feat(signals): error tracking backfill sort-order experiment

### DIFF
--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import structlog
 import posthoganalytics
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -12,6 +13,8 @@ from posthog.temporal.common.utils import close_db_connections
 
 if TYPE_CHECKING:
     from posthog.models import Team
+
+logger = structlog.get_logger(__name__)
 
 # Experiment gating which order the backfill fetches issues in.
 SIGNALS_ET_BACKFILL_SORT_FLAG = "signals-et-backfill-sort"
@@ -55,11 +58,17 @@ def _backfill_order_by(team: "Team") -> str:
     """
     from posthog.event_usage import groups
 
-    variant = posthoganalytics.get_feature_flag(
-        SIGNALS_ET_BACKFILL_SORT_FLAG,
-        str(team.uuid),
-        groups=groups(team=team),
-    )
+    try:
+        variant = posthoganalytics.get_feature_flag(
+            SIGNALS_ET_BACKFILL_SORT_FLAG,
+            str(team.uuid),
+            groups=groups(team=team),
+        )
+    except Exception as e:
+        # A flag-service failure must never fail the backfill — fall back to control.
+        logger.warning("signals_backfill_flag_eval_failed", team_id=team.id, error=str(e))
+        variant = None
+
     return ORDER_BY_USERS_IMPACTED if variant == "test" else ORDER_BY_RECENCY
 
 

--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -46,18 +46,19 @@ class EmitBackfillSignalInput:
 def _backfill_order_by(team: "Team") -> str:
     """Pick the backfill sort order for this team from the experiment variant.
 
-    Control (or flag service unavailable) keeps recency ordering; the test variant
-    ranks issues by the number of distinct users impacted.
+    The experiment is aggregated at the project (team) level, so the flag is
+    evaluated with the team's group — keyed the same way (`team.uuid`) as the
+    `pr_merged` events the experiment measures. Control (or an unavailable flag
+    service) keeps recency ordering; the test variant ranks issues by the number
+    of distinct users impacted. Evaluating the flag also records the team's
+    experiment exposure via `$feature_flag_called`.
     """
+    from posthog.event_usage import groups
+
     variant = posthoganalytics.get_feature_flag(
         SIGNALS_ET_BACKFILL_SORT_FLAG,
         str(team.uuid),
-        groups={"organization": str(team.organization_id), "project": str(team.id)},
-        group_properties={
-            "organization": {"id": str(team.organization_id)},
-            "project": {"id": str(team.id), "uuid": str(team.uuid)},
-        },
-        send_feature_flag_events=False,
+        groups=groups(team=team),
     )
     return ORDER_BY_USERS_IMPACTED if variant == "test" else ORDER_BY_RECENCY
 

--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -33,7 +33,7 @@ class EmitBackfillSignalInput:
 @scoped_temporal()
 @close_db_connections
 async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput) -> list[ErrorTrackingIssueData]:
-    """Fetch the 100 most recent error tracking issues ordered by first seen."""
+    """Fetch the 10 most recent error tracking issues ordered by first seen."""
     from posthog.schema import DateRange, ErrorTrackingQuery
 
     from posthog.models import Team
@@ -52,7 +52,7 @@ async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput
                 orderBy="first_seen",
                 orderDirection="DESC",
                 volumeResolution=1,
-                limit=100,
+                limit=10,
                 withFirstEvent=True,
                 withAggregations=False,
             ),

--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 import posthoganalytics
 from temporalio import activity, workflow
@@ -8,6 +9,19 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.scoped import scoped_temporal
 from posthog.temporal.common.utils import close_db_connections
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+# Experiment gating which order the backfill fetches issues in.
+SIGNALS_ET_BACKFILL_SORT_FLAG = "signals-et-backfill-sort"
+
+# Number of issues to seed the Signals inbox with on backfill.
+BACKFILL_ISSUE_LIMIT = 10
+
+# Issue sort orders (ErrorTrackingQuery.orderBy values), both applied DESC.
+ORDER_BY_RECENCY = "first_seen"  # control: most recently first-seen issues
+ORDER_BY_USERS_IMPACTED = "users"  # test: issues impacting the most distinct users
 
 
 @dataclass
@@ -29,37 +43,45 @@ class EmitBackfillSignalInput:
     issue: ErrorTrackingIssueData
 
 
-@activity.defn
-@scoped_temporal()
-@close_db_connections
-async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput) -> list[ErrorTrackingIssueData]:
-    """Fetch the 10 most recent error tracking issues ordered by first seen."""
-    from posthog.schema import DateRange, ErrorTrackingQuery
+def _backfill_order_by(team: "Team") -> str:
+    """Pick the backfill sort order for this team from the experiment variant.
 
-    from posthog.models import Team
-    from posthog.sync import database_sync_to_async
+    Control (or flag service unavailable) keeps recency ordering; the test variant
+    ranks issues by the number of distinct users impacted.
+    """
+    variant = posthoganalytics.get_feature_flag(
+        SIGNALS_ET_BACKFILL_SORT_FLAG,
+        str(team.uuid),
+        groups={"organization": str(team.organization_id), "project": str(team.id)},
+        group_properties={
+            "organization": {"id": str(team.organization_id)},
+            "project": {"id": str(team.id), "uuid": str(team.uuid)},
+        },
+        send_feature_flag_events=False,
+    )
+    return ORDER_BY_USERS_IMPACTED if variant == "test" else ORDER_BY_RECENCY
+
+
+def _fetch_issues_ordered_by(team: "Team", order_by: str) -> list[ErrorTrackingIssueData]:
+    """Fetch the top BACKFILL_ISSUE_LIMIT issues for a team, ordered by `order_by` DESC."""
+    from posthog.schema import DateRange, ErrorTrackingQuery
 
     from products.error_tracking.backend.facade.queries import ErrorTrackingQueryRunner
 
-    team = await Team.objects.aget(id=input.team_id)
-
-    def _run_query():
-        runner = ErrorTrackingQueryRunner(
-            team=team,
-            query=ErrorTrackingQuery(
-                kind="ErrorTrackingQuery",
-                dateRange=DateRange(),
-                orderBy="first_seen",
-                orderDirection="DESC",
-                volumeResolution=1,
-                limit=10,
-                withFirstEvent=True,
-                withAggregations=False,
-            ),
-        )
-        return runner.calculate()
-
-    response = await database_sync_to_async(_run_query)()
+    runner = ErrorTrackingQueryRunner(
+        team=team,
+        query=ErrorTrackingQuery(
+            kind="ErrorTrackingQuery",
+            dateRange=DateRange(),
+            orderBy=order_by,
+            orderDirection="DESC",
+            volumeResolution=1,
+            limit=BACKFILL_ISSUE_LIMIT,
+            withFirstEvent=True,
+            withAggregations=False,
+        ),
+    )
+    response = runner.calculate()
 
     issues: list[ErrorTrackingIssueData] = []
     for result in response.results:
@@ -86,6 +108,19 @@ async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput
         )
 
     return issues
+
+
+@activity.defn
+@scoped_temporal()
+@close_db_connections
+async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput) -> list[ErrorTrackingIssueData]:
+    """Fetch the issues to backfill, ordered per the team's experiment variant."""
+    from posthog.models import Team
+    from posthog.sync import database_sync_to_async
+
+    team = await Team.objects.aget(id=input.team_id)
+    order_by = await database_sync_to_async(_backfill_order_by)(team)
+    return await database_sync_to_async(_fetch_issues_ordered_by)(team, order_by)
 
 
 @activity.defn


### PR DESCRIPTION
## Problem

The Signals error tracking backfill seeds a team's inbox with their top issues. It fetched the 100 most recent issues, ordered purely by recency. We want to (a) seed fewer, higher-signal issues, and (b) test whether ranking by user impact produces more useful first reports than recency — especially for projects where an unidentified, noisy client-side error would otherwise dominate.

## Changes

- Lower the backfill fetch limit from 100 to 10.
- Gate the fetch order behind a new **team-level** experiment (`signals-et-backfill-sort`):
  - **control** — recency (`first_seen` DESC), the existing behaviour.
  - **test** — number of distinct users impacted (`users` DESC).
- The flag is evaluated with the team's **project group** (keyed by `team.uuid`, via the shared `groups()` helper), so assignment and analysis are per team — matching how `pr_merged` events are grouped. Evaluating the flag also records the team's exposure. If the flag service is unavailable it falls back to recency.
- Extract the issue query into a helper parameterized by sort order so both paths share the same parsing.

The experiment is configured to aggregate on the project group type, with a primary metric counting merged PRs whose `origin_product` is `signal_report` — i.e. only signals-originated PRs, measured per team.

Experiment (draft): https://us.posthog.com/project/2/experiments/380778

## How did you test this code?

No automated tests run — this product has no existing test for the backfill workflow, and the change is a query-ordering + flag-evaluation refactor. `ruff check` / `ruff format` pass on the changed file. The activity's input/output signature is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack. Loaded the `creating-experiments` and `configuring-experiment-analytics` skills; created the draft experiment and metric over MCP. Consulted the error tracking query backend to confirm `orderBy: "users"` maps to distinct-users-impacted. Made the experiment team-level by aggregating the flag on the project group type and evaluating it with the team's group, keyed by `team.uuid` to match the group key on the PR-merge events (`groups()` helper). Primary metric counts `pr_merged` filtered to `origin_product = signal_report`.

Note: the flag's group aggregation was set on the flag directly (MCP has no experiment-level group-type setter); a future draft re-sync of flag params could reset it, so it's worth confirming the group type sticks before launch.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783069408510309)*
