### PR TITLE
chore(llma): add Juraj for prompt management paths

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -220,6 +220,11 @@ services/mcp/src/tools/generated/ai_observability.ts @PostHog/team-ai-observabil
 services/mcp/src/tools/aiObservability/ @PostHog/team-ai-observability
 services/mcp/src/ui-apps/apps/generated/llm-costs.tsx @PostHog/team-ai-observability
 
+# Prompt management - owned by @PostHog/team-ai-observability plus @jurajmajerik as individual owner
+products/ai_observability/frontend/prompts/ @PostHog/team-ai-observability @jurajmajerik
+products/ai_observability/backend/models/llm_prompt.py @PostHog/team-ai-observability @jurajmajerik
+posthog/**/*llm_prompt*.py @PostHog/team-ai-observability @jurajmajerik
+
 # LLM Gateway - owned by @PostHog/team-ai-gateway
 nodejs/src/ingestion/pipelines/ai/costs/ @PostHog/team-ai-observability @PostHog/team-ai-gateway
 nodejs/src/ingestion/pipelines/ai/costs/scripts/ @PostHog/team-ai-gateway


### PR DESCRIPTION
## Problem

Prompt management files are owned only at the product level (`products/ai_observability/**` → team-ai-observability), and the shared-code pieces outside `products/` — the API viewset/serializers/service, the HyperCache storage layer, sanitization, and the cache task — had **no CODEOWNERS entry at all**.

## Changes

Add a three-line prompt management block to `CODEOWNERS-soft` listing @PostHog/team-ai-observability plus @jurajmajerik as individual owner (same pattern as `products/user_interviews/**`):

- `products/ai_observability/frontend/prompts/` — the prompts UI
- `products/ai_observability/backend/models/llm_prompt.py` — the model
- `posthog/**/*llm_prompt*.py` — every shared-code prompt file (API, storage, sanitization, tasks, tests, migrations), present and future

The glob also closes the unowned gap on the shared-code paths for the team.

## How did you test this code?

Verified resolution with the vendored CODEOWNERS matcher (`ownership.js --all`) and with the approval agent's own parser (`tools/pr-approval-agent/gates.py`): all listed paths resolve to team + individual, and `products/ai_observability/frontend/playground/` correctly still resolves to team-ai-gateway.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code; skills invoked: /establishing-code-ownership. One known limitation surfaced while verifying: the PR approval agent's ownership summary (`_summarize_ownership` in `tools/pr-approval-agent/review_pr.py`) only performs GitHub *team* membership checks, so an individual `@user` owner is listed among owners but not recognized as "author is on an owning team" — this affects the existing user_interviews individual owners too. That tool is team-security-owned (blocking CODEOWNERS), so it's deliberately not touched here; a small follow-up there would treat an owner entry equal to `@{author}` as authored-owned.
