### PR TITLE
fix(llma): use team active key when eval config has no pinned key

### DIFF
--- a/posthog/temporal/ai_observability/model_resolution.py
+++ b/posthog/temporal/ai_observability/model_resolution.py
@@ -54,6 +54,11 @@ class ExplicitModelSpec:
         if self.provider_key_id:
             return ResolvedModel(self.provider, self.model, _resolve_key_by_id(team_id, self.provider_key_id))
 
+        config = _eval_config(team_id)
+        fallback = active_key_fallback(config, self.provider)
+        if fallback is not None:
+            return ResolvedModel(self.provider, self.model, _ensure_usable(fallback))
+
         if self.model not in TRIAL_MODEL_IDS:
             raise ApplicationError(
                 f"Model '{self.model}' is not available on the trial plan. "
@@ -61,7 +66,7 @@ class ExplicitModelSpec:
                 {"error_type": "model_not_allowed", "model": self.model},
                 non_retryable=True,
             )
-        _assert_trial_quota(_eval_config(team_id))
+        _assert_trial_quota(config)
         return ResolvedModel(self.provider, self.model, None)
 
 
@@ -94,6 +99,12 @@ def model_spec(model_configuration: dict[str, Any] | None) -> ModelSpec:
             provider_key_id=model_configuration.get("provider_key_id"),
         )
     return DefaultModelSpec()
+
+
+def active_key_fallback(config: EvaluationConfig, provider: str) -> LLMProviderKey | None:
+    """The BYOK key a config with no pinned key resolves to, or None for the trial path."""
+    key = config.active_provider_key
+    return key if key is not None and key.provider == provider else None
 
 
 def _eval_config(team_id: int) -> EvaluationConfig:

--- a/posthog/temporal/ai_observability/test_model_resolution.py
+++ b/posthog/temporal/ai_observability/test_model_resolution.py
@@ -81,6 +81,26 @@ class TestExplicitModelSpec:
             ExplicitModelSpec("openai", "gpt-5-mini", None).resolve(team.id)
         assert _error_type(exc_info) == "trial_limit_reached"
 
+    def test_null_key_falls_back_to_matching_active_key_despite_exhausted_quota(self, team):
+        # Regression: an eval whose model config pinned a model but no key was blocked with
+        # trial_limit_reached even though the team had a healthy active key for that provider.
+        key = _key(team, "openai")
+        EvaluationConfig.objects.create(team=team, active_provider_key=key, trial_eval_limit=100, trial_evals_used=100)
+
+        resolved = ExplicitModelSpec("openai", "gpt-5-mini", None).resolve(team.id)
+
+        assert resolved.provider_key == key
+        assert resolved.is_byok
+
+    def test_null_key_ignores_active_key_of_a_different_provider(self, team):
+        key = _key(team, "anthropic")
+        EvaluationConfig.objects.create(team=team, active_provider_key=key)
+
+        resolved = ExplicitModelSpec("openai", "gpt-5-mini", None).resolve(team.id)
+
+        assert resolved.provider_key is None
+        assert not resolved.is_byok
+
 
 @pytest.mark.django_db
 class TestDefaultModelSpec:

--- a/products/ai_observability/backend/api/evaluations.py
+++ b/products/ai_observability/backend/api/evaluations.py
@@ -23,6 +23,7 @@ from posthog.models import User
 from posthog.permissions import AccessControlPermission
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.temporal.ai_observability.message_utils import extract_text_from_messages
+from posthog.temporal.ai_observability.model_resolution import active_key_fallback
 from posthog.temporal.ai_observability.run_evaluation import extract_event_io, run_hog_eval
 
 from ..feature_flags import is_sentiment_evaluations_enabled
@@ -463,18 +464,21 @@ class EvaluationSerializer(serializers.ModelSerializer):
 
     def _effective_provider_key(self, data: dict) -> LLMProviderKey | None:
         """Return the provider key the evaluation will use after this update."""
+        team = self.context["get_team"]()
         model_config_data = data.get("model_configuration")
         if model_config_data is not None:
             provider_key_id = model_config_data.get("provider_key_id")
-            if not provider_key_id:
-                return None
-            return LLMProviderKey.objects.filter(
-                id=provider_key_id,
-                team=self.context["get_team"](),
-            ).first()
-        if self.instance and self.instance.model_configuration:
-            return self.instance.model_configuration.provider_key
-        return None
+            provider = model_config_data.get("provider")
+        elif self.instance and self.instance.model_configuration:
+            provider_key_id = self.instance.model_configuration.provider_key_id
+            provider = self.instance.model_configuration.provider
+        else:
+            return None
+
+        if provider_key_id:
+            return LLMProviderKey.objects.filter(id=provider_key_id, team=team).first()
+        config = EvaluationConfig.objects.filter(team=team).first()
+        return active_key_fallback(config, provider) if config and provider else None
 
     def _create_or_update_model_configuration(
         self, model_config_data: dict[str, Any] | None, team_id: int


### PR DESCRIPTION
## Problem

A team with a healthy provider key set up for evals could not re-enable an evaluation once their trial credits ran out, hitting `Trial evaluation limit reached. Add a provider API key to re-enable this evaluation` even though they clearly had a usable key. 

## Changes

Fix a bug in the specific path they hit that prevented re-enabling the eval.

## How did you test this code?

Automated only. I (Claude) did not perform manual UI testing. I extended `posthog/temporal/ai_observability/test_model_resolution.py` with two cases and ran the suite (16 passed):

- `test_null_key_falls_back_to_matching_active_key_despite_exhausted_quota` — the reported state: explicit config, null key, matching active key, trial exhausted → resolves BYOK instead of raising `trial_limit_reached`. No existing test covered an explicit config falling back to the active key.
- `test_null_key_ignores_active_key_of_a_different_provider` — guards the provider-match condition so an Anthropic active key can't hijack an OpenAI model. No existing test covered a mismatched-provider active key on the explicit path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Carlos) drove this with Claude via PostHog Code. We started from the support ticket and traced it empirically rather than guessing: the `query-clickhouse-via-metabase` skill was used to read the reporting team's rows straight from the EU app Postgres (EvaluationConfig, the evaluation, its model configuration, and provider keys), which confirmed the exact broken state (trial 100/100, healthy active OpenAI key, eval model config with a null `provider_key_id`).

Decisions along the way: an API-gate-only fix was rejected because execution resolves independently, so the eval would re-enable and then immediately re-disable on the next run. We chose to put the fallback in the centralised `model_resolution` module (the source of truth used by judge and tagger) and extract a small pure helper so the API gate delegates rather than duplicates, closing the drift that caused the divergence in the first place. We deliberately kept the fallback provider-matched and left the fuller "make the validator call `resolve()` directly" refactor out of scope since `resolve()` has side effects and raises Temporal errors.
