### PR TITLE
feat(conversations): track support slack bot channel joins

### DIFF
--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -358,14 +358,15 @@ class TestSlackMemberAlerts(BaseTest):
 
         mock_get_client.return_value.chat_postMessage.assert_not_called()
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.get_slack_client")
-    def test_member_event_no_op_without_alert_channel(self, mock_get_client):
+    def test_member_event_no_alert_without_alert_channel(self, mock_get_client, _mock_bot_id):
         self.team.conversations_settings["slack_alert_channel_id"] = None
         self.team.save()
 
         handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
 
-        mock_get_client.assert_not_called()
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
 
     @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.get_slack_client")
@@ -409,3 +410,36 @@ class TestSlackMemberAlerts(BaseTest):
         mock_get_client.return_value.chat_postMessage.assert_called_once()
         kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
         assert kwargs["text"] == "<@U123> joined <#C_SUPPORT>"
+
+    @patch(f"{MODULE}.report_team_action")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_bot_join_fires_posthog_event(self, mock_get_client, _mock_bot_id, mock_report):
+        handle_member_joined_channel({"user": "U_OWN_BOT", "channel": "C_SUPPORT"}, self.team, "T123")
+
+        mock_report.assert_called_once_with(
+            self.team,
+            "support slack bot joined channel",
+            {"slack_team_id": "T123", "slack_channel_id": "C_SUPPORT", "is_configured_channel": False},
+        )
+        # It's analytics only — no Slack alert for the bot's own join.
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+
+    @patch(f"{MODULE}.report_team_action")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_bot_join_flags_configured_channel(self, _mock_get_client, _mock_bot_id, mock_report):
+        self.team.conversations_settings["slack_channel_ids"] = ["C_SUPPORT"]
+        self.team.save()
+
+        handle_member_joined_channel({"user": "U_OWN_BOT", "channel": "C_SUPPORT"}, self.team, "T123")
+
+        assert mock_report.call_args.args[2]["is_configured_channel"] is True
+
+    @patch(f"{MODULE}.report_team_action")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_non_bot_join_does_not_fire_posthog_event(self, _mock_get_client, _mock_bot_id, mock_report):
+        handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
+
+        mock_report.assert_not_called()

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -411,30 +411,30 @@ class TestSlackMemberAlerts(BaseTest):
         kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
         assert kwargs["text"] == "<@U123> joined <#C_SUPPORT>"
 
+    @parameterized.expand(
+        [
+            ("unconfigured_channel", [], False),
+            ("configured_channel", ["C_SUPPORT"], True),
+        ]
+    )
     @patch(f"{MODULE}.report_team_action")
     @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.get_slack_client")
-    def test_bot_join_fires_posthog_event(self, mock_get_client, _mock_bot_id, mock_report):
+    def test_bot_join_fires_posthog_event(
+        self, _name, channel_ids, expected_is_configured, mock_get_client, _mock_bot_id, mock_report
+    ):
+        self.team.conversations_settings["slack_channel_ids"] = channel_ids
+        self.team.save()
+
         handle_member_joined_channel({"user": "U_OWN_BOT", "channel": "C_SUPPORT"}, self.team, "T123")
 
         mock_report.assert_called_once_with(
             self.team,
             "support slack bot joined channel",
-            {"slack_team_id": "T123", "slack_channel_id": "C_SUPPORT", "is_configured_channel": False},
+            {"slack_team_id": "T123", "slack_channel_id": "C_SUPPORT", "is_configured_channel": expected_is_configured},
         )
         # It's analytics only — no Slack alert for the bot's own join.
         mock_get_client.return_value.chat_postMessage.assert_not_called()
-
-    @patch(f"{MODULE}.report_team_action")
-    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
-    @patch(f"{MODULE}.get_slack_client")
-    def test_bot_join_flags_configured_channel(self, _mock_get_client, _mock_bot_id, mock_report):
-        self.team.conversations_settings["slack_channel_ids"] = ["C_SUPPORT"]
-        self.team.save()
-
-        handle_member_joined_channel({"user": "U_OWN_BOT", "channel": "C_SUPPORT"}, self.team, "T123")
-
-        assert mock_report.call_args.args[2]["is_configured_channel"] is True
 
     @patch(f"{MODULE}.report_team_action")
     @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -20,6 +20,7 @@ from django.db.models import F
 import structlog
 from slack_sdk import WebClient
 
+from posthog.event_usage import report_team_action
 from posthog.models.comment import Comment
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
@@ -995,6 +996,41 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
         _backfill_thread_replies(client, team, ticket, channel, root_ts, after_ts=message_ts)
 
 
+def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str) -> None:
+    """Fire an internal PostHog event when our own bot is added to a channel.
+
+    Unlike the human join/leave alerts, this isn't gated on any team setting — it's usage
+    analytics for PostHog, not a customer-facing Slack message. Only the bot's own join is
+    tracked; every other user's join is ignored here.
+
+    There's deliberately no matching "bot left channel" event: Slack delivers
+    ``member_left_channel`` only to remaining channel members, so the bot doesn't reliably
+    receive its own removal.
+    """
+    user = event.get("user")
+    channel = event.get("channel")
+    if not user or not channel:
+        return
+    if not _SLACK_USER_ID_RE.match(user) or not _SLACK_CHANNEL_ID_RE.match(channel):
+        return
+
+    client = get_slack_client(team)
+    own_bot_user_id = get_bot_user_id_cached(team, client)
+    if not own_bot_user_id or user != own_bot_user_id:
+        return
+
+    settings_dict = team.conversations_settings or {}
+    report_team_action(
+        team,
+        "support slack bot joined channel",
+        {
+            "slack_team_id": slack_team_id,
+            "slack_channel_id": channel,
+            "is_configured_channel": channel in _configured_support_channels(settings_dict),
+        },
+    )
+
+
 def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
     """Post a join/leave alert to the configured alert channel.
 
@@ -1066,6 +1102,7 @@ def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
 
 def handle_member_joined_channel(event: dict, team: Team, slack_team_id: str) -> None:
     """Handle a Slack 'member_joined_channel' event by alerting the configured channel."""
+    _track_bot_joined_channel(event, team, slack_team_id)
     _handle_member_event(event, team, joined=True)
 
 

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -996,7 +996,7 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
         _backfill_thread_replies(client, team, ticket, channel, root_ts, after_ts=message_ts)
 
 
-def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str) -> None:
+def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str, *, own_bot_user_id: str | None) -> None:
     """Fire an internal PostHog event when our own bot is added to a channel.
 
     Unlike the human join/leave alerts, this isn't gated on any team setting — it's usage
@@ -1013,9 +1013,6 @@ def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str) -> No
         return
     if not _SLACK_USER_ID_RE.match(user) or not _SLACK_CHANNEL_ID_RE.match(channel):
         return
-
-    client = get_slack_client(team)
-    own_bot_user_id = get_bot_user_id_cached(team, client)
     if not own_bot_user_id or user != own_bot_user_id:
         return
 
@@ -1031,13 +1028,24 @@ def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str) -> No
     )
 
 
-def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
+def _handle_member_event(
+    event: dict,
+    team: Team,
+    *,
+    joined: bool,
+    client: WebClient | None = None,
+    own_bot_user_id: str | None = None,
+) -> None:
     """Post a join/leave alert to the configured alert channel.
 
     Fires for any channel the bot is in (Slack only delivers member_joined_channel /
     member_left_channel for channels the bot belongs to). Gated per-direction by the
     team's settings. Members of the team's own organization are skipped — the alert is
     meant to surface external participants, not internal teammates.
+
+    ``client``/``own_bot_user_id`` may be supplied by the caller so the join path resolves
+    the bot identity once for both tracking and alerting; when omitted (leave path) they're
+    resolved lazily here, after the gates, so a leave with alerts off does no Slack API work.
     """
     settings_dict = team.conversations_settings or {}
 
@@ -1057,12 +1065,13 @@ def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
         logger.warning("slack_member_event_malformed_ids", user=user, channel=channel)
         return
 
-    client = get_slack_client(team)
+    if client is None:
+        client = get_slack_client(team)
+        own_bot_user_id = get_bot_user_id_cached(team, client)
 
     # If we can't resolve the bot's own ID (auth.test failed), bail — without it we can't tell
     # the bot's own join apart from a real user's, and posting a self-referential alert is worse
     # than skipping one alert during a transient auth outage.
-    own_bot_user_id = get_bot_user_id_cached(team, client)
     if not own_bot_user_id:
         logger.warning("slack_member_event_bot_id_unresolved", team_id=_get_team_id(team))
         return
@@ -1102,8 +1111,12 @@ def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
 
 def handle_member_joined_channel(event: dict, team: Team, slack_team_id: str) -> None:
     """Handle a Slack 'member_joined_channel' event by alerting the configured channel."""
-    _track_bot_joined_channel(event, team, slack_team_id)
-    _handle_member_event(event, team, joined=True)
+    # Resolve the bot identity once and share it with both the analytics event and the alert,
+    # since a bot join always needs it for tracking regardless of the alert toggle.
+    client = get_slack_client(team)
+    own_bot_user_id = get_bot_user_id_cached(team, client)
+    _track_bot_joined_channel(event, team, slack_team_id, own_bot_user_id=own_bot_user_id)
+    _handle_member_event(event, team, joined=True, client=client, own_bot_user_id=own_bot_user_id)
 
 
 def handle_member_left_channel(event: dict, team: Team, slack_team_id: str) -> None:


### PR DESCRIPTION
## Problem

We had no visibility when a customer adds the SupportHog bot to a Slack channel. Human join/leave alerts exist, but the bot's own join was explicitly skipped and nothing was emitted to PostHog.

## Changes

- On `member_joined_channel`, detect when the joining user is SupportHog itself and fire an internal `report_team_action` event: `support slack bot joined channel`
- Event props: `slack_team_id`, `slack_channel_id`, `is_configured_channel` (whether the channel is in the team's configured support channels)
- No Slack UI message — analytics only, not gated on team settings
- No matching "bot left channel" event: Slack doesn't reliably deliver `member_left_channel` to a bot that's been removed from the channel
- Updated member-alert test to assert no Slack message is posted (bot-id resolution now runs before the alert-channel gate)

## How did you test this code?

- New regressions:
  - bot join fires `report_team_action` with expected props and no Slack alert
  - `is_configured_channel=True` when channel is in `slack_channel_ids`
  - non-bot joins do not fire the event