### PR TITLE
feat(scenes): show beta label on beta product scene titles

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -469,6 +469,27 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
 export const getDefaultTreeGames = (): FileSystemImport[] =>
     [...getTreeItemsGames()].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))
 
+// Maturity tag ('beta' / 'alpha') a product's root scene is labeled with in the navbar, keyed by scene.
+// Lets scene titles mirror the navbar's labeling without every scene repeating it. Cached because the
+// product tree is static for the session.
+let productTagBySceneKey: Map<string, 'alpha' | 'beta'> | null = null
+
+export const getProductTagForScene = (sceneId?: string | null): 'alpha' | 'beta' | undefined => {
+    if (!sceneId) {
+        return undefined
+    }
+    if (!productTagBySceneKey) {
+        productTagBySceneKey = new Map()
+        for (const item of getTreeItemsProducts()) {
+            const tag = item.tags?.[0]
+            if (item.sceneKey && tag) {
+                productTagBySceneKey.set(item.sceneKey, tag)
+            }
+        }
+    }
+    return productTagBySceneKey.get(sceneId)
+}
+
 export const getDefaultTreeDataAndPeople = (): FileSystemImport[] =>
     [...getDefaultTreeData(), ...getDefaultTreePersons()].sort((a, b) =>
         a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' })

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -13,7 +13,7 @@ import {
     IconSparkles,
     IconWrench,
 } from '@posthog/icons'
-import { Tooltip } from '@posthog/lemon-ui'
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { ProductSetupButton } from 'lib/components/ProductSetup'
 import { RenderKeybind } from 'lib/components/Shortcuts/ShortcutMenu'
@@ -27,6 +27,7 @@ import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/Wrapping
 import { cn } from 'lib/utils/css-classes'
 import { AnimatedSparkles } from 'scenes/max/components/AnimatedSparkles'
 import { UseMaxToolOptions, useMaxTool } from 'scenes/max/useMaxTool'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -34,7 +35,7 @@ import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLog
 import { FileSystemIconType } from '~/queries/schema/schema-general'
 import { Breadcrumb, FileSystemIconColor, SidePanelTab } from '~/types'
 
-import { ProductIconWrapper, iconForType } from '../../panel-layout/ProjectTree/defaultTree'
+import { ProductIconWrapper, getProductTagForScene, iconForType } from '../../panel-layout/ProjectTree/defaultTree'
 import { sceneLayoutLogic } from '../sceneLayoutLogic'
 import { SceneBreadcrumbBackButton } from './SceneBreadcrumbs'
 
@@ -246,7 +247,16 @@ export function SceneTitleSection({
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const { zenMode } = useValues(navigation3000Logic)
     const { showDescription } = useValues(sceneLayoutLogic)
+    const { activeSceneId } = useValues(sceneLogic)
     const { toggleShowDescription } = useActions(sceneLayoutLogic)
+    // Mirror the navbar's "Beta" label on the product's scene title, unless the scene sets its own suffix.
+    const effectiveNameSuffix =
+        nameSuffix ??
+        (getProductTagForScene(activeSceneId) === 'beta' ? (
+            <LemonTag type="completion" className="ml-2 shrink-0">
+                Beta
+            </LemonTag>
+        ) : undefined)
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
     const sentinelRef = useRef<HTMLDivElement>(null)
@@ -351,7 +361,7 @@ export function SceneTitleSection({
                                     isGeneratingMetadata={isGeneratingMetadata}
                                     suffix={
                                         <>
-                                            {nameSuffix}
+                                            {effectiveNameSuffix}
                                             {hasDescription ? (
                                                 <ButtonPrimitive
                                                     className={cn(

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -188,7 +188,11 @@ export function InboxScene(): JSX.Element {
             <div className={showDetail ? 'hidden' : 'flex flex-col gap-y-4 flex-1 min-h-0'}>
                 <SceneTitleSection
                     name="Inbox"
-                    nameSuffix={<LemonTag type="warning">Beta</LemonTag>}
+                    nameSuffix={
+                        <LemonTag type="completion" className="ml-2 shrink-0">
+                            Beta
+                        </LemonTag>
+                    }
                     // The description explains the active tab so new users can orient themselves.
                     // In the onboarding takeover the tabs are locked, so keep the overall pitch.
                     description={

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconArrowLeft, IconBug } from '@posthog/icons'
-import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -188,6 +188,7 @@ export function InboxScene(): JSX.Element {
             <div className={showDetail ? 'hidden' : 'flex flex-col gap-y-4 flex-1 min-h-0'}>
                 <SceneTitleSection
                     name="Inbox"
+                    nameSuffix={<LemonTag type="warning">Beta</LemonTag>}
                     // The description explains the active tab so new users can orient themselves.
                     // In the onboarding takeover the tabs are locked, so keep the overall pitch.
                     description={


### PR DESCRIPTION
## Problem

We undercommunicate product status. Beta products and tools are tagged "Beta" in the navbar, but that status disappears once you're inside the scene. The word "beta" shows up nowhere on the scene itself, so users can't tell they're using an early-stage product from the page they're actually on.

This started as a one-off "Beta" tag on the Inbox header, then we decided to make it consistent across every beta product/tool rather than sprinkle it scene by scene.

## Changes

`SceneTitleSection` now derives a "Beta" label from the same product tree that drives the navbar. Any product whose tree item is tagged `beta` gets the label next to its scene title automatically — no per-scene wiring, and it stays in sync as products graduate out of beta (drop the tag in the manifest and both the navbar and the title update together).

- `getProductTagForScene(sceneId)` in `defaultTree.tsx` maps a product's root scene to its maturity tag, built lazily from `getTreeItemsProducts()` and cached.
- `SceneTitleSection` renders the label unless the scene passes its own `nameSuffix`, so scenes keep the ability to override.
- Inbox keeps its explicit tag (it's a top-level nav item, not a product-tree entry); the shared label matches its `completion` styling.

Currently surfaces on: Customer analytics, Marketing analytics, MCP analytics, Heatmaps, Replay vision, Support, and the AI evals Datasets and LLM Prompts scenes.

## How did you test this code?

Not manually tested — I (Claude) couldn't run the dev server or the frontend toolchain in this environment (no `node_modules`), so lint/typecheck run in CI. The change is scoped to reading a static field off the existing product tree and rendering a `LemonTag`. No tests added: the mapping is derived from generated product data, so a unit test would mostly restate the implementation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Oliver drove this; I (the PostHog Slack app, Claude) implemented it from the Slack thread. The initial ask was a Beta tag on the Inbox header; the thread then landed on making it consistent for all beta products/tools rather than editing each scene.

I chose a central derivation over hand-editing ~8 scene files because it stays in sync with the navbar and avoids drift when a product leaves beta. I read the tag from the product manifest tree (the generated, canonical source), keying on each beta item's `sceneKey`, rather than unioning the older `navigationLogic` tags — those disagree with the manifests in a couple of places (e.g. Logs), and I didn't want to unilaterally assert a beta status the manifest doesn't. Scoped to `beta` only per the thread; extending to `alpha` later is a one-line change. Verified none of the affected beta scenes already pass a `nameSuffix` (so nothing gets double-tagged) and that each has a single, static product-name title.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783072179376899?thread_ts=1783072179.376899&cid=C09SK2PAGKF)*
