### PR TITLE
feat(experiments): filter slowest queries by exception code

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -47,6 +47,14 @@ const METRIC_TYPE_OPTIONS = [
     { value: 'retention', label: 'Retention' },
 ]
 
+const EXCEPTION_CODE_OPTIONS = [
+    { value: '', label: 'All exit codes' },
+    { value: '307', label: '307 (bytes)' },
+    { value: '159', label: '159 (timeout)' },
+    { value: '241', label: '241 (memory)' },
+    { value: '202', label: '202 (cluster busy)' },
+]
+
 // Group total = the read plus its precompute-build sub-queries (the user paid for all of them),
 // mirroring how the Duration column sums total_duration_ms over the group.
 const groupBytes = (item: SlowestQuery): number =>
@@ -142,6 +150,7 @@ export function QueryPerformance(): JSX.Element {
         teamIdFilter,
         experimentIdFilter,
         metricTypeFilter,
+        exceptionCodeFilter,
     } = useValues(queryPerformanceLogic)
     const {
         setSearch,
@@ -151,6 +160,7 @@ export function QueryPerformance(): JSX.Element {
         setTeamIdFilter,
         setExperimentIdFilter,
         setMetricTypeFilter,
+        setExceptionCodeFilter,
     } = useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
@@ -522,6 +532,13 @@ export function QueryPerformance(): JSX.Element {
                                         value={metricTypeFilter}
                                         onChange={(value) => setMetricTypeFilter(value ?? '')}
                                         options={METRIC_TYPE_OPTIONS}
+                                        className="w-44"
+                                    />
+                                    <LemonSelect
+                                        size="small"
+                                        value={exceptionCodeFilter}
+                                        onChange={(value) => setExceptionCodeFilter(value ?? '')}
+                                        options={EXCEPTION_CODE_OPTIONS}
                                         className="w-44"
                                     />
                                     <LemonButton

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -60,6 +60,7 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
         setTeamIdFilter: (teamId: string) => ({ teamId }),
         setExperimentIdFilter: (experimentId: string) => ({ experimentId }),
         setMetricTypeFilter: (metricType: string) => ({ metricType }),
+        setExceptionCodeFilter: (exceptionCode: string) => ({ exceptionCode }),
     }),
     reducers({
         search: [
@@ -90,6 +91,12 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             '',
             {
                 setMetricTypeFilter: (_, { metricType }) => metricType,
+            },
+        ],
+        exceptionCodeFilter: [
+            '',
+            {
+                setExceptionCodeFilter: (_, { exceptionCode }) => exceptionCode,
             },
         ],
     }),
@@ -138,6 +145,9 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
                             params.append('funnel_order_type', funnelOrderType)
                         }
                     }
+                    if (values.exceptionCodeFilter) {
+                        params.append('exception_code', values.exceptionCodeFilter)
+                    }
                     return await api.get(`api/debug_ch_queries/slowest_queries/?${params.toString()}`)
                 },
             },
@@ -160,6 +170,9 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             actions.loadSlowestQueries()
         },
         setMetricTypeFilter: () => {
+            actions.loadSlowestQueries()
+        },
+        setExceptionCodeFilter: () => {
             actions.loadSlowestQueries()
         },
     })),

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -443,6 +443,8 @@ class DebugCHQueries(viewsets.ViewSet):
                 exception_code_filter = int(request.query_params["exception_code"])
             except (TypeError, ValueError):
                 raise exceptions.ValidationError("exception_code must be an integer.")
+            if exception_code_filter <= 0:
+                raise exceptions.ValidationError("exception_code must be a positive integer.")
 
         params: dict = {
             "cluster": CLICKHOUSE_CLUSTER,

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -437,6 +437,13 @@ class DebugCHQueries(viewsets.ViewSet):
             if metric_type_filter != "funnel":
                 raise exceptions.ValidationError("funnel_order_type can only be used with metric_type=funnel.")
 
+        exception_code_filter: Optional[int] = None
+        if request.query_params.get("exception_code"):
+            try:
+                exception_code_filter = int(request.query_params["exception_code"])
+            except (TypeError, ValueError):
+                raise exceptions.ValidationError("exception_code must be an integer.")
+
         params: dict = {
             "cluster": CLICKHOUSE_CLUSTER,
             "hours": hours,
@@ -459,6 +466,13 @@ class DebugCHQueries(viewsets.ViewSet):
                 " AND JSONExtractString(log_comment, 'experiment_funnel_order_type') = %(funnel_order_type)s"
             )
             params["funnel_order_type"] = funnel_order_type_filter
+
+        # Filter at the group level (a group's terminal exception_code, resolved per query_id in per_query):
+        # keep groups where any query — read or precompute build — hit this code, so nesting stays intact.
+        having_exception_code = ""
+        if exception_code_filter is not None:
+            having_exception_code = "HAVING countIf(exception_code = %(exception_code)s) > 0"
+            params["exception_code"] = exception_code_filter
 
         # Each row is one ClickHouse query. A top-level read (surface != 'precompute_build') and the
         # precompute-build INSERTs it triggered share an experiment_query_group_id (set by the runner).
@@ -519,6 +533,7 @@ class DebugCHQueries(viewsets.ViewSet):
                 SELECT grp, sum(query_duration_ms) AS total_duration_ms
                 FROM grouped
                 GROUP BY grp
+                {having_exception_code}
                 ORDER BY total_duration_ms DESC
                 LIMIT 100
             )


### PR DESCRIPTION
Adds an optional `exception_code` filter to the staff-only "Slowest queries" table so staff can narrow the view to a specific ClickHouse failure code (e.g. only 307s) during an investigation. Applied at the group level via a `HAVING` on the ranked CTE, so a matched group still shows its parent read plus precompute-build sub-queries. Frontend adds a `LemonSelect` (All · 307 · 159 · 241 · 202) wired through the logic like the existing metric-type filter.

## 🤖 Agent context

Internal staff-only tooling. Backend param validated as int, bound via `%(exception_code)s`; frontend mirrors the existing `metricTypeFilter` pattern. No new tests per request.
