### PR TITLE
chore(ci): make semgrep PR scans diff-aware

### DIFF
--- a/.github/actions/semgrep-scan-mode/action.yml
+++ b/.github/actions/semgrep-scan-mode/action.yml
@@ -1,0 +1,24 @@
+name: 'Semgrep scan mode'
+description: >
+    Decide whether a semgrep job can scan diff-aware. On pull requests the checkout is
+    GitHub's PR merge commit, so HEAD^ is the base branch tip and a diff against it covers
+    exactly the PR's changes — the calling job must check out with fetch-depth 2 for HEAD^
+    to be available. Any other event (or an unresolvable HEAD^) falls back to a full scan.
+outputs:
+    baseline-commit:
+        description: 'Commit for semgrep --baseline-commit; empty means run a full scan'
+        value: ${{ steps.scan-mode.outputs.baseline_commit }}
+runs:
+    using: 'composite'
+    steps:
+        - name: Determine scan mode
+          id: scan-mode
+          shell: bash
+          run: |
+              if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
+                  echo "Diff-aware scan against baseline $baseline"
+                  echo "baseline_commit=$baseline" >> "$GITHUB_OUTPUT"
+              else
+                  echo "Full scan"
+                  echo "baseline_commit=" >> "$GITHUB_OUTPUT"
+              fi

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -33,6 +33,23 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Depth 2 so pull request scans can diff against the base tip (HEAD^).
+                  fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
+
+            # On pull requests, scan only files changed since the base branch — the
+            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # scans still run on every push to master as the backstop.
+            - name: Determine scan mode
+              id: scan-mode
+              run: |
+                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
+                      echo "Diff-aware scan against baseline $baseline"
+                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "Full scan"
+                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Run Semgrep
               run: |
@@ -40,6 +57,7 @@ jobs:
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
+                      ${{ steps.scan-mode.outputs.baseline_args }} \
                       --config "p/python" \
                       --config "p/owasp-top-ten" \
                       --config "p/security-audit" \
@@ -149,6 +167,23 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Depth 2 so pull request scans can diff against the base tip (HEAD^).
+                  fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
+
+            # On pull requests, scan only files changed since the base branch — the
+            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # scans still run on every push to master as the backstop.
+            - name: Determine scan mode
+              id: scan-mode
+              run: |
+                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
+                      echo "Diff-aware scan against baseline $baseline"
+                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "Full scan"
+                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Run Semgrep
               run: |
@@ -156,6 +191,7 @@ jobs:
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
+                      ${{ steps.scan-mode.outputs.baseline_args }} \
                       --config ".semgrep/rules/" \
                       --config "p/javascript" \
                       --config "p/owasp-top-ten" \
@@ -222,6 +258,23 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Depth 2 so pull request scans can diff against the base tip (HEAD^).
+                  fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
+
+            # On pull requests, scan only files changed since the base branch — the
+            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # scans still run on every push to master as the backstop.
+            - name: Determine scan mode
+              id: scan-mode
+              run: |
+                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
+                      echo "Diff-aware scan against baseline $baseline"
+                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "Full scan"
+                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
+                  fi
 
             # exclude all directories already scanned by other jobs
             - name: Run Semgrep
@@ -230,6 +283,7 @@ jobs:
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
+                      ${{ steps.scan-mode.outputs.baseline_args }} \
                       --config "p/owasp-top-ten" \
                       --config "p/security-audit" \
                       --config "p/trailofbits" \

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -37,27 +37,21 @@ jobs:
                   # Depth 2 so pull request scans can diff against the base tip (HEAD^).
                   fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
 
-            # On pull requests, scan only files changed since the base branch — the
-            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # On pull requests, scan only files changed since the base branch. Full
             # scans still run on every push to master as the backstop.
             - name: Determine scan mode
               id: scan-mode
-              run: |
-                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
-                      echo "Diff-aware scan against baseline $baseline"
-                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "Full scan"
-                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
-                  fi
+              uses: ./.github/actions/semgrep-scan-mode
 
             - name: Run Semgrep
+              env:
+                  BASELINE_COMMIT: ${{ steps.scan-mode.outputs.baseline-commit }}
               run: |
                   docker run --rm -v "${{ github.workspace }}:/src" -w /src \
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
-                      ${{ steps.scan-mode.outputs.baseline_args }} \
+                      ${BASELINE_COMMIT:+--baseline-commit "$BASELINE_COMMIT"} \
                       --config "p/python" \
                       --config "p/owasp-top-ten" \
                       --config "p/security-audit" \
@@ -171,27 +165,21 @@ jobs:
                   # Depth 2 so pull request scans can diff against the base tip (HEAD^).
                   fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
 
-            # On pull requests, scan only files changed since the base branch — the
-            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # On pull requests, scan only files changed since the base branch. Full
             # scans still run on every push to master as the backstop.
             - name: Determine scan mode
               id: scan-mode
-              run: |
-                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
-                      echo "Diff-aware scan against baseline $baseline"
-                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "Full scan"
-                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
-                  fi
+              uses: ./.github/actions/semgrep-scan-mode
 
             - name: Run Semgrep
+              env:
+                  BASELINE_COMMIT: ${{ steps.scan-mode.outputs.baseline-commit }}
               run: |
                   docker run --rm -v "${{ github.workspace }}:/src" -w /src \
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
-                      ${{ steps.scan-mode.outputs.baseline_args }} \
+                      ${BASELINE_COMMIT:+--baseline-commit "$BASELINE_COMMIT"} \
                       --config ".semgrep/rules/" \
                       --config "p/javascript" \
                       --config "p/owasp-top-ten" \
@@ -262,28 +250,22 @@ jobs:
                   # Depth 2 so pull request scans can diff against the base tip (HEAD^).
                   fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 1 }}
 
-            # On pull requests, scan only files changed since the base branch — the
-            # checkout is GitHub's PR merge commit, so HEAD^ is the base tip. Full
+            # On pull requests, scan only files changed since the base branch. Full
             # scans still run on every push to master as the backstop.
             - name: Determine scan mode
               id: scan-mode
-              run: |
-                  if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && baseline=$(git rev-parse --verify --quiet HEAD^); then
-                      echo "Diff-aware scan against baseline $baseline"
-                      echo "baseline_args=--baseline-commit $baseline" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "Full scan"
-                      echo "baseline_args=" >> "$GITHUB_OUTPUT"
-                  fi
+              uses: ./.github/actions/semgrep-scan-mode
 
             # exclude all directories already scanned by other jobs
             - name: Run Semgrep
+              env:
+                  BASELINE_COMMIT: ${{ steps.scan-mode.outputs.baseline-commit }}
               run: |
                   docker run --rm -v "${{ github.workspace }}:/src" -w /src \
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \
                     ${{ env.SEMGREP_IMAGE }} \
                     semgrep \
-                      ${{ steps.scan-mode.outputs.baseline_args }} \
+                      ${BASELINE_COMMIT:+--baseline-commit "$BASELINE_COMMIT"} \
                       --config "p/owasp-top-ten" \
                       --config "p/security-audit" \
                       --config "p/trailofbits" \


### PR DESCRIPTION
## Problem

"Semgrep Checks Pass" is a required check, and its three slow jobs run a full-repo scan on every PR no matter what changed:

| Job | Typical PR runtime | Scope |
| --- | --- | --- |
| semgrep-general | ~11.5-12 min | everything not covered by the language jobs |
| semgrep-python | ~10.5 min | `bin/ common/ ee/ posthog/ products/ ...` (~17k files) |
| semgrep-js | ~5 min | `frontend/ nodejs/ ...` (~8k files) |

That makes ~12-13 minutes the floor for merging any PR. On docs-only or small PRs the rest of CI finishes in 1-6 minutes and semgrep is the sole long pole. On code PRs it ties the biggest test suites, so it gates a large share of merges too (checked the last 15 merged PRs, semgrep was a top-3 finisher on nearly all of them).

## Changes

Make the three slow jobs diff-aware on `pull_request` events using semgrep's `--baseline-commit`:

- checkout with `fetch-depth: 2` so the base tip is available. The PR checkout is GitHub's merge commit, so `HEAD^` is exactly the base branch tip and the diff against it is exactly the PR's changes
- a `Determine scan mode` step emits `--baseline-commit <sha>` on PRs and nothing otherwise, falling back to a full scan if `HEAD^` can't be resolved
- pushes to master (and `merge_group`) keep the full-repo scan as the backstop, so anything a diff scan could theoretically miss still fails on master immediately after merge

With the baseline, semgrep only scans files changed in the PR and filters findings that already existed at the base. Expected job time drops from 10-12 min to roughly 1-2 min (rule download/compile becomes the dominant cost). This also saves ~25 runner-minutes per push event across the three jobs.

No docker changes needed. The pinned `semgrep/semgrep` image sets `SEMGREP_IN_DOCKER=1` and semgrep then auto-configures `git config --global --add safe.directory '*'` on startup, so its internal git calls (diff, temp worktree for the baseline pass) work against the mounted checkout. I verified this in the image config for the pinned digest.

The other five jobs (go, rust, products-frontend, devex, test-rules) already finish in under 2 minutes and keep full scans.

## How did you test this code?

I could not run the docker-based jobs themselves, so the container path gets its first real exercise from this PR's own CI run (this PR should itself show the speedup). Everything else was validated locally with semgrep 1.167.0 (same version as the pinned image) in a `--depth 2` clone of a real PR merge ref (`pull/68165/merge`), matching the CI checkout:

- clean PR diff: exits 0, scan limited to changed files, ~10-20s instead of 10+ min
- injected `subprocess.run(cmd, shell=True)` in a changed file: caught by `python.lang.security.audit.subprocess-shell-true` with exit 1
- `HEAD^` resolves and `git merge-base` works in the shallow depth-2 clone
- confirmed semgrep's `BaselineHandler` requirements from source: clean tree, baseline commit present, temp `git worktree` in container `/tmp` (not the mounted workspace)
- `hogli lint:workflows` and `hogli ci:preflight --fix` pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-internal behavior. Local semgrep usage documented in `.agents/security.md` is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (PostHog Code cloud task) directed by @thmsobrmlr, who asked for one quick win to cut CI merge wait.
- Skills invoked: `diagnosing-ci-and-merge-bottlenecks`, `depot-github-runners` (read for the alternative below).
- Found the target by pulling check-run timings for the last 15 merged PRs via `gh api`: semgrep jobs were the most universal long pole because they run unfiltered on every PR while test suites are path-gated.
- Considered and rejected: per-job path filtering (still full 10 min scan when any Python file changes), bigger depot runners with more `--jobs` (cuts time ~3x but costs money and keeps rescanning unchanged code). Diff-aware scanning gives the largest cut with full scans retained on master.
- Profiled the scans locally with `--time` while investigating (YAML generic rules dominate semgrep-general at ~330s CPU), and validated the baseline behavior end-to-end as described above.
