### PR TITLE
feat(mcp-analytics): expose sessions-tool-calls as an MCP tool

### DIFF
--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -83,7 +83,23 @@ tools:
         feature_flag: mcp-analytics
     mcp-analytics-sessions-tool-calls:
         operation: mcp_analytics_sessions_tool_calls
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List session tool calls
+        description: >
+            List a single session's $mcp_tool_call events in chronological order — the drill-down for a session found
+            via mcp-analytics-sessions-list. Pass the session's session_id (the {id} path param); for sessions older
+            than the default 7-day lookback, also pass its session_start as date_from so the event scan reaches them.
+            Each call has tool_name, intent, timestamp, duration_ms, and is_error / error_message. Pages with limit
+            (defaults to 500 — the whole page, since sessions rarely have more — max 500) and offset; the response's
+            has_next flag indicates whether more calls remain.
+        feature_flag: mcp-analytics
     mcp-feedback-list:
         operation: mcp_analytics_feedback_list
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5610,6 +5610,21 @@
         },
         "feature_flag": "mcp-analytics"
     },
+    "mcp-analytics-sessions-tool-calls": {
+        "description": "List a single session's $mcp_tool_call events in chronological order — the drill-down for a session found via mcp-analytics-sessions-list. Pass the session's session_id (the {id} path param); for sessions older than the default 7-day lookback, also pass its session_start as date_from so the event scan reaches them. Each call has tool_name, intent, timestamp, duration_ms, and is_error / error_message. Pages with limit (defaults to 500 — the whole page, since sessions rarely have more — max 500) and offset; the response's has_next flag indicates whether more calls remain.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List session tool calls",
+        "title": "List session tool calls",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
     "mcp-connection-tools-list": {
         "description": "Load a connected MCP server's live tool catalog by connection `id` (from mcp-connections-list). Returns each tool's `tool_name`, `description`, `input_schema`, and `approval_state`. ALWAYS call this to load a connection's REAL tool names before curating per-agent MCP tool permissions (an agent's `spec.mcps[].tools[]` with `level` / `default_tool_approval`) — never invent or guess tool names from past sessions or skill prose.",
         "category": "MCP Store",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6046,6 +6046,21 @@
         },
         "feature_flag": "mcp-analytics"
     },
+    "mcp-analytics-sessions-tool-calls": {
+        "description": "List a single session's $mcp_tool_call events in chronological order — the drill-down for a session found via mcp-analytics-sessions-list. Pass the session's session_id (the {id} path param); for sessions older than the default 7-day lookback, also pass its session_start as date_from so the event scan reaches them. Each call has tool_name, intent, timestamp, duration_ms, and is_error / error_message. Pages with limit (defaults to 500 — the whole page, since sessions rarely have more — max 500) and offset; the response's has_next flag indicates whether more calls remain.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List session tool calls",
+        "title": "List session tool calls",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
     "mcp-connection-tools-list": {
         "description": "Load a connected MCP server's live tool catalog by connection `id` (from mcp-connections-list). Returns each tool's `tool_name`, `description`, `input_schema`, and `approval_state`. ALWAYS call this to load a connection's REAL tool names before curating per-agent MCP tool permissions (an agent's `spec.mcps[].tools[]` with `level` / `default_tool_approval`) — never invent or guess tool names from past sessions or skill prose.",
         "category": "MCP Store",

--- a/services/mcp/src/generated/mcp_analytics/api.ts
+++ b/services/mcp/src/generated/mcp_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 6 enabled ops
+ * PostHog API - MCP 7 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -285,5 +285,47 @@ export const McpAnalyticsSessionsGenerateIntentQueryParams = /* @__PURE__ */ zod
         .optional()
         .describe(
             "Absolute ISO timestamp lower bound for the intent scan — pass the session's start so older sessions resolve. Defaults to a 7-day lookback when omitted."
+        ),
+})
+
+/**
+ * List a page of the $mcp_tool_call events that belong to a given $session_id, in chronological order.
+ */
+export const McpAnalyticsSessionsToolCallsParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this mcp analytics submission.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const mcpAnalyticsSessionsToolCallsQueryLimitDefault = 500
+export const mcpAnalyticsSessionsToolCallsQueryLimitMax = 500
+
+export const mcpAnalyticsSessionsToolCallsQueryOffsetDefault = 0
+export const mcpAnalyticsSessionsToolCallsQueryOffsetMin = 0
+
+export const McpAnalyticsSessionsToolCallsQueryParams = /* @__PURE__ */ zod.object({
+    date_from: zod.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe(
+            "Absolute ISO timestamp lower bound for the event scan — pass the session's start so older sessions resolve. Defaults to a 7-day lookback when omitted or unparseable."
+        ),
+    limit: zod
+        .number()
+        .min(1)
+        .max(mcpAnalyticsSessionsToolCallsQueryLimitMax)
+        .default(mcpAnalyticsSessionsToolCallsQueryLimitDefault)
+        .describe(
+            "Maximum tool calls to return per page (1–500). Defaults to 500 — the whole page — so a session's calls come back in one request; pass a smaller value for a lighter response. Values above the cap are rejected."
+        ),
+    offset: zod
+        .number()
+        .min(mcpAnalyticsSessionsToolCallsQueryOffsetMin)
+        .default(mcpAnalyticsSessionsToolCallsQueryOffsetDefault)
+        .describe(
+            "Number of tool calls to skip before returning results. Combine with limit to page through a session's calls; the response's has_next flag indicates whether more remain."
         ),
 })

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -8,6 +8,8 @@ import {
     McpAnalyticsSessionsGenerateIntentParams,
     McpAnalyticsSessionsGenerateIntentQueryParams,
     McpAnalyticsSessionsListQueryParams,
+    McpAnalyticsSessionsToolCallsParams,
+    McpAnalyticsSessionsToolCallsQueryParams,
 } from '@/generated/mcp_analytics/api'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
@@ -94,6 +96,31 @@ const mcpAnalyticsSessionsList = (): ToolBase<
                 offset: params.offset,
                 order_by: params.order_by,
                 search: params.search,
+            },
+        })
+        return await withPostHogUrl(context, result, '/mcp-analytics')
+    },
+})
+
+const McpAnalyticsSessionsToolCallsSchema = McpAnalyticsSessionsToolCallsParams.omit({ project_id: true }).extend(
+    McpAnalyticsSessionsToolCallsQueryParams.shape
+)
+
+const mcpAnalyticsSessionsToolCalls = (): ToolBase<
+    typeof McpAnalyticsSessionsToolCallsSchema,
+    WithPostHogUrl<Schemas.PaginatedMCPToolCallList>
+> => ({
+    name: 'mcp-analytics-sessions-tool-calls',
+    schema: McpAnalyticsSessionsToolCallsSchema,
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsToolCallsSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedMCPToolCallList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/tool_calls/`,
+            query: {
+                date_from: params.date_from,
+                limit: params.limit,
+                offset: params.offset,
             },
         })
         return await withPostHogUrl(context, result, '/mcp-analytics')
@@ -524,6 +551,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'mcp-analytics-intent-clusters-retrieve': mcpAnalyticsIntentClustersRetrieve,
     'mcp-analytics-sessions-generate-intent': mcpAnalyticsSessionsGenerateIntent,
     'mcp-analytics-sessions-list': mcpAnalyticsSessionsList,
+    'mcp-analytics-sessions-tool-calls': mcpAnalyticsSessionsToolCalls,
     'mcp-feedback-submit': mcpFeedbackSubmit,
     'mcp-missing-capability-report': mcpMissingCapabilityReport,
     'query-mcp-harness-breakdown': createQueryWrapper({


### PR DESCRIPTION
## Problem

The per-session tool-calls endpoint is built and (in #68154) paginated, but it isn't exposed as an MCP tool — agents can list sessions (`sessions-list`) but can't drill into one session's calls.

## Changes

Enable `mcp-analytics-sessions-tool-calls` (read scope, `mcp-analytics` flag) and regenerate the tool artifacts: handler, Orval Zod params, and the tool registries. The generated schema takes the session id (path) plus `date_from` (kept as a `date-time`), `limit` (max 500), and `offset` — all inherited straight from the endpoint's OpenAPI spec, so no constants are duplicated in the YAML.

No backend change — purely the tool config plus generated output.

> **Stacked on #68154** (the pagination backend, which the tool's Zod schema depends on). Review/merge that first.

## How did you test this code?

Agent (Claude Code), no manual testing. Ran locally: `lint-tool-names` and `tsc --noEmit` on the MCP package (no errors in the generated `mcp_analytics` files). Regenerated from the spec so the diff is scoped to this tool.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @gesh. Skill: `/implementing-mcp-tools`. Sibling of the load-more UI PR (#68162) — both stack on the backend PR independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
