### PR TITLE
fix(conversations): reclaim orphaned mailgun domains on email reconnect

### DIFF
--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -359,14 +359,14 @@ class TestEmailMultiConfig(BaseTest):
 
     @patch(
         "products.conversations.backend.api.email_settings.mailgun_add_domain",
-        side_effect=MailgunDomainConflict("Domain example.com already exists"),
+        side_effect=MailgunDomainConflict("Domain example.com is already registered by another Mailgun account"),
     )
     @patch("products.conversations.backend.api.email_settings.mailgun_delete_domain")
     @patch(
         "products.conversations.backend.api.email_settings.get_instance_setting",
         return_value="mg.posthog.com",
     )
-    def test_connect_rejects_preexisting_mailgun_domain(
+    def test_connect_rejects_domain_taken_by_another_account(
         self,
         _mock_setting: MagicMock,
         mock_mailgun_delete: MagicMock,

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -25,12 +25,13 @@ def _mailgun_response(status_code: int, body: dict | None = None) -> MagicMock:
 @patch("products.conversations.backend.mailgun.get_instance_setting", return_value="fake-api-key")
 @patch("products.conversations.backend.mailgun.requests.post")
 class TestAddDomain:
+    @patch("products.conversations.backend.mailgun.requests.get")
     @patch("products.conversations.backend.mailgun.requests.delete")
-    def test_already_exists_reclaims_by_delete_and_recreate(
-        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+    def test_already_exists_unverified_reclaims_by_delete_and_recreate(
+        self, mock_delete: MagicMock, mock_get: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
     ):
-        # Orphan re-add: domain still in our Mailgun account (prior delete failed/skipped).
-        # add_domain must delete then recreate it so it comes back fresh/unverified.
+        # Orphan re-add: domain still in our Mailgun account (prior delete failed/skipped)
+        # and unverified. add_domain deletes then recreates it so it comes back fresh.
         mock_post.side_effect = [
             _mailgun_response(400, {"message": "domain example.com already exists"}),
             _mailgun_response(
@@ -43,6 +44,7 @@ class TestAddDomain:
                 },
             ),
         ]
+        mock_get.return_value = _mailgun_response(200, {"domain": {"state": "unverified"}})
         mock_delete.return_value = _mailgun_response(200)
 
         result = add_domain("example.com")
@@ -51,12 +53,30 @@ class TestAddDomain:
         mock_delete.assert_called_once()
         assert mock_post.call_count == 2
 
+    @patch("products.conversations.backend.mailgun.requests.get")
+    @patch("products.conversations.backend.mailgun.requests.delete")
+    def test_already_exists_verified_refuses_to_reclaim(
+        self, mock_delete: MagicMock, mock_get: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+    ):
+        # A verified/active domain means someone proved DNS control. Absence of a local
+        # row is not proof the requester owns it, so we must not delete it.
+        mock_post.return_value = _mailgun_response(400, {"message": "domain example.com already exists"})
+        mock_get.return_value = _mailgun_response(200, {"domain": {"state": "active"}})
+
+        with pytest.raises(MailgunDomainConflict, match="verified in Mailgun"):
+            add_domain("example.com")
+
+        mock_delete.assert_not_called()
+        assert mock_post.call_count == 1
+
+    @patch("products.conversations.backend.mailgun.requests.get")
     @patch("products.conversations.backend.mailgun.requests.delete")
     def test_already_exists_still_present_after_delete_raises(
-        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+        self, mock_delete: MagicMock, mock_get: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
     ):
         # If the recreate still reports "already exists" we must not loop forever.
         mock_post.return_value = _mailgun_response(400, {"message": "domain example.com already exists"})
+        mock_get.return_value = _mailgun_response(200, {"domain": {"state": "unverified"}})
         mock_delete.return_value = _mailgun_response(200)
 
         with pytest.raises(MailgunDomainConflict, match="could not be reclaimed"):
@@ -87,14 +107,16 @@ class TestAddDomain:
 
         assert [r["record_type"] for r in result["sending_dns_records"]] == ["TXT"]
 
+    @patch("products.conversations.backend.mailgun.requests.get")
     @patch("products.conversations.backend.mailgun.requests.delete")
     def test_case_insensitive_already_exists_match(
-        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+        self, mock_delete: MagicMock, mock_get: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
     ):
         mock_post.side_effect = [
             _mailgun_response(400, {"message": "Domain Already EXISTS"}),
             _mailgun_response(201, {"sending_dns_records": []}),
         ]
+        mock_get.return_value = _mailgun_response(200, {"domain": {"state": "unverified"}})
         mock_delete.return_value = _mailgun_response(200)
 
         result = add_domain("example.com")

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -25,11 +25,44 @@ def _mailgun_response(status_code: int, body: dict | None = None) -> MagicMock:
 @patch("products.conversations.backend.mailgun.get_instance_setting", return_value="fake-api-key")
 @patch("products.conversations.backend.mailgun.requests.post")
 class TestAddDomain:
-    def test_already_exists_raises_instead_of_adopting(self, mock_post: MagicMock, _mock_key: MagicMock):
-        mock_post.return_value = _mailgun_response(400, {"message": "domain example.com already exists"})
+    @patch("products.conversations.backend.mailgun.requests.delete")
+    def test_already_exists_reclaims_by_delete_and_recreate(
+        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+    ):
+        # Orphan re-add: domain still in our Mailgun account (prior delete failed/skipped).
+        # add_domain must delete then recreate it so it comes back fresh/unverified.
+        mock_post.side_effect = [
+            _mailgun_response(400, {"message": "domain example.com already exists"}),
+            _mailgun_response(
+                201,
+                {
+                    "sending_dns_records": [
+                        {"record_type": "TXT", "name": "example.com", "value": "v=spf1"},
+                        {"record_type": "CNAME", "name": "track.example.com", "value": "m.mg"},
+                    ]
+                },
+            ),
+        ]
+        mock_delete.return_value = _mailgun_response(200)
 
-        with pytest.raises(MailgunDomainConflict, match="already exists"):
+        result = add_domain("example.com")
+
+        assert [r["record_type"] for r in result["sending_dns_records"]] == ["TXT"]
+        mock_delete.assert_called_once()
+        assert mock_post.call_count == 2
+
+    @patch("products.conversations.backend.mailgun.requests.delete")
+    def test_already_exists_still_present_after_delete_raises(
+        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+    ):
+        # If the recreate still reports "already exists" we must not loop forever.
+        mock_post.return_value = _mailgun_response(400, {"message": "domain example.com already exists"})
+        mock_delete.return_value = _mailgun_response(200)
+
+        with pytest.raises(MailgunDomainConflict, match="could not be reclaimed"):
             add_domain("example.com")
+
+        assert mock_post.call_count == 2
 
     def test_already_taken_still_raises(self, mock_post: MagicMock, _mock_key: MagicMock):
         mock_post.return_value = _mailgun_response(
@@ -54,11 +87,20 @@ class TestAddDomain:
 
         assert [r["record_type"] for r in result["sending_dns_records"]] == ["TXT"]
 
-    def test_case_insensitive_already_exists_match(self, mock_post: MagicMock, _mock_key: MagicMock):
-        mock_post.return_value = _mailgun_response(400, {"message": "Domain Already EXISTS"})
+    @patch("products.conversations.backend.mailgun.requests.delete")
+    def test_case_insensitive_already_exists_match(
+        self, mock_delete: MagicMock, mock_post: MagicMock, _mock_key: MagicMock
+    ):
+        mock_post.side_effect = [
+            _mailgun_response(400, {"message": "Domain Already EXISTS"}),
+            _mailgun_response(201, {"sending_dns_records": []}),
+        ]
+        mock_delete.return_value = _mailgun_response(200)
 
-        with pytest.raises(MailgunDomainConflict, match="already exists"):
-            add_domain("example.com")
+        result = add_domain("example.com")
+
+        assert result == {"sending_dns_records": []}
+        mock_delete.assert_called_once()
 
     def test_unrecognised_400_falls_through_to_raise_for_status(self, mock_post: MagicMock, _mock_key: MagicMock):
         resp = _mailgun_response(400, {"message": "some other error"})

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -98,12 +98,16 @@ def add_domain(domain: str, *, _reclaim_orphan: bool = True) -> dict[str, Any]:
     """Register a sending domain with Mailgun. Returns DNS records to configure.
 
     Our Mailgun account is shared across all tenants, so a domain can already exist
-    in the account as an *orphan* — a prior disconnect removed the PostHog row but
-    the Mailgun delete failed or was skipped. In that case we reclaim it by deleting
-    and recreating so it comes back **unverified**, forcing fresh DNS proof. We never
-    adopt a pre-existing (possibly still-active) domain as-is: that would let a
-    different tenant inherit another org's verified sending domain without ever
-    controlling its DNS. Cross-org ownership is guarded in PostHog before we get here.
+    in the account with no PostHog owner — an *orphan* left when a prior disconnect
+    removed the EmailChannel row but the Mailgun delete failed or was skipped.
+
+    We reclaim such a domain (delete + recreate, so it comes back unverified and forces
+    fresh DNS proof) ONLY when it is not verified in Mailgun. We never touch a verified
+    domain: an active domain means someone proved DNS control over it, and "no local row"
+    is not proof that the current requester owns it. Deleting it would break that party's
+    sending, and recreating it and letting the requester through would hand them a domain
+    they don't control. Verified conflicts fail loud for manual reconciliation instead.
+    Cross-org and same-org sibling ownership is guarded in PostHog before we get here.
     """
     resp = requests.post(
         f"{MAILGUN_API_BASE}/domains",
@@ -123,21 +127,43 @@ def add_domain(domain: str, *, _reclaim_orphan: bool = True) -> dict[str, Any]:
             error_msg = resp.json().get("message", "").lower()
         except Exception:
             error_msg = ""
-        # Orphan in our own account — delete and recreate once so re-add works but the
-        # domain starts unverified. _reclaim_orphan guards against an infinite loop if
-        # the delete didn't actually clear it.
         if "already exists" in error_msg:
-            if _reclaim_orphan:
-                logger.info("mailgun_domain_already_exists_reclaiming", domain=domain)
-                delete_domain(domain)
-                return add_domain(domain, _reclaim_orphan=False)
-            raise MailgunDomainConflict(f"Domain {domain} already exists and could not be reclaimed")
+            # _reclaim_orphan is False only on the post-delete recreate; if the domain
+            # still reports "already exists" then the delete didn't clear it — stop
+            # instead of looping.
+            if not _reclaim_orphan:
+                raise MailgunDomainConflict(f"Domain {domain} already exists and could not be reclaimed")
+            state = _get_domain_state(domain)
+            if state == "active":
+                raise MailgunDomainConflict(
+                    f"Domain {domain} already exists and is verified in Mailgun; refusing to reclaim"
+                )
+            logger.info("mailgun_domain_orphan_reclaiming", domain=domain, state=state)
+            delete_domain(domain)
+            return add_domain(domain, _reclaim_orphan=False)
         # Registered under a *different* Mailgun account — we genuinely can't use it.
         if "already taken" in error_msg:
             raise MailgunDomainConflict(f"Domain {domain} is already registered by another Mailgun account")
 
     resp.raise_for_status()
     return {}
+
+
+def _get_domain_state(domain: str) -> str:
+    """Return Mailgun's verification state for a domain (e.g. "active", "unverified").
+
+    Returns "unknown" if the domain can't be fetched (e.g. it vanished between calls),
+    which callers treat as not-active — i.e. safe to recreate.
+    """
+    resp = requests.get(
+        f"{MAILGUN_API_BASE}/domains/{domain}",
+        auth=("api", _get_api_key()),
+        timeout=15,
+    )
+    if resp.status_code == 404:
+        return "unknown"
+    resp.raise_for_status()
+    return resp.json().get("domain", {}).get("state", "unknown")
 
 
 def get_domain_dns_records(domain: str) -> dict[str, Any]:

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -94,8 +94,17 @@ def _filter_sending_records(records: list[dict[str, Any]]) -> list[dict[str, Any
     return [r for r in records if r.get("record_type", "").upper() != "CNAME"]
 
 
-def add_domain(domain: str) -> dict[str, Any]:
-    """Register a sending domain with Mailgun. Returns DNS records to configure."""
+def add_domain(domain: str, *, _reclaim_orphan: bool = True) -> dict[str, Any]:
+    """Register a sending domain with Mailgun. Returns DNS records to configure.
+
+    Our Mailgun account is shared across all tenants, so a domain can already exist
+    in the account as an *orphan* — a prior disconnect removed the PostHog row but
+    the Mailgun delete failed or was skipped. In that case we reclaim it by deleting
+    and recreating so it comes back **unverified**, forcing fresh DNS proof. We never
+    adopt a pre-existing (possibly still-active) domain as-is: that would let a
+    different tenant inherit another org's verified sending domain without ever
+    controlling its DNS. Cross-org ownership is guarded in PostHog before we get here.
+    """
     resp = requests.post(
         f"{MAILGUN_API_BASE}/domains",
         auth=("api", _get_api_key()),
@@ -114,11 +123,16 @@ def add_domain(domain: str) -> dict[str, Any]:
             error_msg = resp.json().get("message", "").lower()
         except Exception:
             error_msg = ""
-        # Never silently adopt a pre-existing Mailgun domain — the shared
-        # account may hold domains we don't own. Fail loud so operators
-        # can reconcile manually.
+        # Orphan in our own account — delete and recreate once so re-add works but the
+        # domain starts unverified. _reclaim_orphan guards against an infinite loop if
+        # the delete didn't actually clear it.
         if "already exists" in error_msg:
-            raise MailgunDomainConflict(f"Domain {domain} already exists")
+            if _reclaim_orphan:
+                logger.info("mailgun_domain_already_exists_reclaiming", domain=domain)
+                delete_domain(domain)
+                return add_domain(domain, _reclaim_orphan=False)
+            raise MailgunDomainConflict(f"Domain {domain} already exists and could not be reclaimed")
+        # Registered under a *different* Mailgun account — we genuinely can't use it.
         if "already taken" in error_msg:
             raise MailgunDomainConflict(f"Domain {domain} is already registered by another Mailgun account")
 


### PR DESCRIPTION
## Problem

Disconnecting an email channel in Conversations removes the PostHog `EmailChannel` row, but the Mailgun domain delete can fail or be skipped (Mailgun outage, missing API key, sibling config still on the domain). The domain stays in our shared Mailgun account as an orphan with no local owner. Re-adding the same domain then fails with Mailgun "already exists", so users can't reconnect.

## Changes

- On `add_domain`, when Mailgun returns "already exists", check the domain's Mailgun verification state before doing anything destructive
- If the orphan is **not verified**, reclaim it by deleting and recreating so it comes back unverified with fresh DNS records. It sends for nobody, so this resets nothing of value
- If the domain is **verified/active**, refuse and raise a conflict. An active domain means someone proved DNS control, and "no local row" is not proof the requester owns it. We don't delete it (would break their sending) and don't hand it over (would let the requester inherit a domain they don't control). These fail loud for manual reconciliation
- Guard against infinite retry: if delete+recreate still hits "already exists", raise `MailgunDomainConflict`
- Update unit tests for the state-gated reclaim and rename the endpoint conflict test to reflect the "another Mailgun account" case only

## How did you test this code?

- `hogli test products/conversations/backend/api/tests/test_mailgun.py` covers: unverified orphan reclaims (delete+recreate), verified domain refuses reclaim (no delete), post-delete still-exists raises instead of looping, and case-insensitive match