### PR TITLE
feat(scenes): show alpha/beta status tag in scene titles

### DIFF
--- a/frontend/src/layout/scenes/AGENTS.md
+++ b/frontend/src/layout/scenes/AGENTS.md
@@ -67,3 +67,12 @@ adding or moving menu items. This guide is the _when/why_; the skill is the _how
 `SceneMenuBar.tsx` captures `scene menu bar shown` / `menu opened` / `item clicked` centrally, so you
 don't wire analytics per scene. Just give items a stable `data-attr` (`${RESOURCE_TYPE}-menubar-<action>`)
 so the captured `item` is meaningful.
+
+## Alpha/beta status tags are automatic
+
+`SceneTitleSection` renders the same `ALPHA` / `BETA` tag next to the title that the product/tool shows
+in the navbar. The source of truth is the product manifest — a `tags: ['beta']` (or `['alpha']`) entry in
+`treeItemsProducts`, keyed to the scene via `sceneKey` / `sceneKeys` (see `sceneStatusTags.ts`). Don't
+hand-add a status tag via `nameSuffix`; tag the product in its manifest instead, so the navbar and the
+title stay in sync and graduating out of beta is a one-line change. (Special navbar entries not in the
+product tree, like Inbox, are listed explicitly in `sceneStatusTags.ts`.)

--- a/frontend/src/layout/scenes/components/SceneTitleSection.stories.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { sceneLogic } from 'scenes/sceneLogic'
+import { emptySceneParams } from 'scenes/scenes'
+
+import { SceneTitleSection } from './SceneTitleSection'
+
+// The alpha/beta tag beside a scene title is derived from the active scene (via `sceneLogic`),
+// not from a prop, so each story sets the scene before rendering.
+
+const meta: Meta = {
+    title: 'Scenes-App/Scene title section',
+    parameters: { layout: 'fullscreen', viewMode: 'story' },
+}
+export default meta
+
+type Story = StoryObj
+
+function renderForScene(sceneId: string, name: string): JSX.Element {
+    sceneLogic.mount()
+    sceneLogic.actions.setScene(sceneId, undefined, emptySceneParams, 'push')
+    return (
+        <div className="bg-primary p-4">
+            <SceneTitleSection name={name} resourceType={{ type: 'blank' }} />
+        </div>
+    )
+}
+
+export const AlphaProduct: Story = {
+    render: () => renderForScene('Links', 'Links'),
+}
+
+export const BetaProduct: Story = {
+    render: () => renderForScene('Inbox', 'Inbox'),
+}
+
+export const StableProduct: Story = {
+    render: () => renderForScene('FeatureFlags', 'Feature flags'),
+}

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -13,7 +13,7 @@ import {
     IconSparkles,
     IconWrench,
 } from '@posthog/icons'
-import { Tooltip } from '@posthog/lemon-ui'
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { ProductSetupButton } from 'lib/components/ProductSetup'
 import { RenderKeybind } from 'lib/components/Shortcuts/ShortcutMenu'
@@ -27,6 +27,7 @@ import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/Wrapping
 import { cn } from 'lib/utils/css-classes'
 import { AnimatedSparkles } from 'scenes/max/components/AnimatedSparkles'
 import { UseMaxToolOptions, useMaxTool } from 'scenes/max/useMaxTool'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -36,6 +37,7 @@ import { Breadcrumb, FileSystemIconColor, SidePanelTab } from '~/types'
 
 import { ProductIconWrapper, iconForType } from '../../panel-layout/ProjectTree/defaultTree'
 import { sceneLayoutLogic } from '../sceneLayoutLogic'
+import { getSceneStatusTag } from '../sceneStatusTags'
 import { SceneBreadcrumbBackButton } from './SceneBreadcrumbs'
 
 export function SceneTitlePanelButton({
@@ -246,7 +248,10 @@ export function SceneTitleSection({
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const { zenMode } = useValues(navigation3000Logic)
     const { showDescription } = useValues(sceneLayoutLogic)
+    const { activeSceneId } = useValues(sceneLogic)
     const { toggleShowDescription } = useActions(sceneLayoutLogic)
+    // Mirror the alpha/beta status the current product/tool shows in the navbar, next to the title.
+    const statusTag = getSceneStatusTag(activeSceneId)
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
     const sentinelRef = useRef<HTMLDivElement>(null)
@@ -351,6 +356,15 @@ export function SceneTitleSection({
                                     isGeneratingMetadata={isGeneratingMetadata}
                                     suffix={
                                         <>
+                                            {statusTag && (
+                                                <LemonTag
+                                                    type={statusTag === 'alpha' ? 'completion' : 'warning'}
+                                                    size="small"
+                                                    className="relative top-[-1px] shrink-0"
+                                                >
+                                                    {statusTag.toUpperCase()}
+                                                </LemonTag>
+                                            )}
                                             {nameSuffix}
                                             {hasDescription ? (
                                                 <ButtonPrimitive

--- a/frontend/src/layout/scenes/sceneStatusTags.test.ts
+++ b/frontend/src/layout/scenes/sceneStatusTags.test.ts
@@ -1,0 +1,27 @@
+import { getSceneStatusTag } from './sceneStatusTags'
+
+jest.mock('~/products', () => ({
+    getTreeItemsProducts: () => [
+        // Multi-scene product: every scene key in the list inherits the tag
+        { tags: ['beta'], sceneKey: 'Alpha', sceneKeys: ['Alpha', 'AlphaChild'] },
+        // Falls back to the single sceneKey when sceneKeys is absent
+        { tags: ['alpha'], sceneKey: 'Solo' },
+        // Untagged product contributes nothing
+        { sceneKey: 'Stable', sceneKeys: ['Stable'] },
+    ],
+}))
+
+describe('getSceneStatusTag', () => {
+    it.each([
+        ['Alpha', 'beta'],
+        ['AlphaChild', 'beta'],
+        ['Solo', 'alpha'],
+        ['Inbox', 'beta'], // special navbar entry not in the product tree
+    ])('maps %s to %s', (sceneId, expected) => {
+        expect(getSceneStatusTag(sceneId)).toBe(expected)
+    })
+
+    it.each([['Stable'], ['UnknownScene'], [null], [undefined]])('returns undefined for %s', (sceneId) => {
+        expect(getSceneStatusTag(sceneId)).toBeUndefined()
+    })
+})

--- a/frontend/src/layout/scenes/sceneStatusTags.test.ts
+++ b/frontend/src/layout/scenes/sceneStatusTags.test.ts
@@ -21,7 +21,7 @@ describe('getSceneStatusTag', () => {
         expect(getSceneStatusTag(sceneId)).toBe(expected)
     })
 
-    it.each([['Stable'], ['UnknownScene'], [null], [undefined]])('returns undefined for %s', (sceneId) => {
-        expect(getSceneStatusTag(sceneId)).toBeUndefined()
+    it.each([['Stable'], ['UnknownScene'], [null], [undefined]])('returns null for %s', (sceneId) => {
+        expect(getSceneStatusTag(sceneId)).toBeNull()
     })
 })

--- a/frontend/src/layout/scenes/sceneStatusTags.ts
+++ b/frontend/src/layout/scenes/sceneStatusTags.ts
@@ -8,8 +8,6 @@ const EXTRA_SCENE_STATUS_TAGS: Record<string, ProductStatusTag> = {
     Inbox: 'beta',
 }
 
-let sceneStatusTagMap: Record<string, ProductStatusTag> | null = null
-
 function buildSceneStatusTagMap(): Record<string, ProductStatusTag> {
     const map: Record<string, ProductStatusTag> = { ...EXTRA_SCENE_STATUS_TAGS }
     for (const item of getTreeItemsProducts()) {
@@ -28,16 +26,15 @@ function buildSceneStatusTagMap(): Record<string, ProductStatusTag> {
     return map
 }
 
+const sceneStatusTagMap = buildSceneStatusTagMap()
+
 /**
  * The status tag ('alpha' | 'beta') a scene should show next to its title, mirroring how the same
- * product/tool is tagged in the navbar. Returns undefined for stable products and unknown scenes.
+ * product/tool is tagged in the navbar. Returns null for stable products and unknown scenes.
  */
-export function getSceneStatusTag(sceneId: string | null | undefined): ProductStatusTag | undefined {
+export function getSceneStatusTag(sceneId: string | null | undefined): ProductStatusTag | null {
     if (!sceneId) {
-        return undefined
+        return null
     }
-    if (!sceneStatusTagMap) {
-        sceneStatusTagMap = buildSceneStatusTagMap()
-    }
-    return sceneStatusTagMap[sceneId]
+    return sceneStatusTagMap[sceneId] ?? null
 }

--- a/frontend/src/layout/scenes/sceneStatusTags.ts
+++ b/frontend/src/layout/scenes/sceneStatusTags.ts
@@ -1,0 +1,43 @@
+import { getTreeItemsProducts } from '~/products'
+
+export type ProductStatusTag = 'alpha' | 'beta'
+
+// Special navbar entries that carry a status tag but aren't part of the product tree
+// (getTreeItemsProducts), so they can't be derived from a manifest.
+const EXTRA_SCENE_STATUS_TAGS: Record<string, ProductStatusTag> = {
+    Inbox: 'beta',
+}
+
+let sceneStatusTagMap: Record<string, ProductStatusTag> | null = null
+
+function buildSceneStatusTagMap(): Record<string, ProductStatusTag> {
+    const map: Record<string, ProductStatusTag> = { ...EXTRA_SCENE_STATUS_TAGS }
+    for (const item of getTreeItemsProducts()) {
+        const tag = item.tags?.[0]
+        if (!tag) {
+            continue
+        }
+        const sceneKeys = item.sceneKeys ?? (item.sceneKey ? [item.sceneKey] : [])
+        for (const sceneKey of sceneKeys) {
+            // First registration wins, so an explicit override above isn't clobbered by a manifest.
+            if (!(sceneKey in map)) {
+                map[sceneKey] = tag
+            }
+        }
+    }
+    return map
+}
+
+/**
+ * The status tag ('alpha' | 'beta') a scene should show next to its title, mirroring how the same
+ * product/tool is tagged in the navbar. Returns undefined for stable products and unknown scenes.
+ */
+export function getSceneStatusTag(sceneId: string | null | undefined): ProductStatusTag | undefined {
+    if (!sceneId) {
+        return undefined
+    }
+    if (!sceneStatusTagMap) {
+        sceneStatusTagMap = buildSceneStatusTagMap()
+    }
+    return sceneStatusTagMap[sceneId]
+}


### PR DESCRIPTION
## Problem

Beta and alpha products/tools are tagged in the navbar, but once you're inside the product the scene title says nothing about its status. This came out of a discussion where a one-off "Beta" label was added to the inbox header - the better fix is to do it consistently for every product/tool we already mark as alpha/beta, rather than per-scene. As raised in [this Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783072179376899?thread_ts=1783072179.376899&cid=C09SK2PAGKF), we under-communicate product status and it's a PostHog-wide gap.

## Changes

`SceneTitleSection` now renders the same `ALPHA` / `BETA` tag next to the title that the product shows in the navbar. There's one source of truth: the product manifest's `treeItemsProducts` entry (`tags: ['beta']` / `['alpha']`), keyed to scenes via `sceneKey` / `sceneKeys`. A small helper (`sceneStatusTags.ts`) builds a scene-to-tag map from those manifests and the current scene is looked up via `sceneLogic`. Special navbar entries that aren't in the product tree (Inbox) are listed explicitly in the helper.

Because it's manifest-driven, graduating a product out of beta stays a one-line change that updates both the navbar and the title, and no scene needs to hand-add a status tag.

I went with mirroring both alpha and beta (not beta-only) since the navbar already shows both and consistency is the whole point - easy to restrict to beta-only if we'd rather.

### Screenshots

Rendered from the new `Scenes-App/Scene title section` stories.

| Alpha product (Links) | Beta product (Inbox) | Stable product (Feature flags) |
| --- | --- | --- |
| ![alpha](https://raw.githubusercontent.com/PostHog/pr-assets/ee54ba9c75831a3b6bc9fec769a9fa3ddbdb7d55/2026/07/43a5cbfc-f396-4010-9cfc-62b9f2a83d0d.png) | ![beta](https://raw.githubusercontent.com/PostHog/pr-assets/90a853c7f44dc1bfb1caf709f5c34b5fdfb000e7/2026/07/fb1b19d5-05fe-4191-a812-33dcc17b4261.png) | ![stable](https://raw.githubusercontent.com/PostHog/pr-assets/3fc8f566cd02e3006721cb49a4b69dc9dccc2099/2026/07/9b982ae8-967a-4f8a-9ff2-317b2ee8522d.png) |

## How did you test this code?

- `sceneStatusTags.test.ts` locks in the mapping logic: `sceneKeys` expansion, the single-`sceneKey` fallback, untagged products contributing nothing, the Inbox special case, and unknown/null scenes returning undefined. That regression - a broken map silently dropping every status label - isn't covered anywhere else.
- Added `SceneTitleSection.stories.tsx` with the three states above, which is where this PR's visual-regression coverage comes from. The tag is derived from `sceneLogic`'s active scene rather than a prop, so each story sets the scene before rendering. The stable case is there to pin the negative: a stable product must render no tag at all.
- Rendered all three stories against a local Storybook, which is where the screenshots come from.
- `oxlint` + `oxfmt` clean on the touched files. `tsgo --noEmit` reports no errors in them (the errors it does report are pre-existing in `products/workflows`).

I did not run the full app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `frontend/src/layout/scenes/AGENTS.md` to note the tags are automatic and manifest-driven.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread, directed by Michael. Invoked `/writing-tests` to gate both the unit test and the stories.

Key decision: rather than editing each beta product's scene to add a `nameSuffix` tag (scattered, easy to drift from the navbar), I centralized it in `SceneTitleSection` and derived status from the existing manifest tags. This keeps one source of truth and covers every current and future beta/alpha product automatically. Matched the existing `LemonTag` styling used by `NavLink` and `ProjectTree` for the same tags.

The stories landed in a later pass. `SceneTitleSection` had no stories at all, so this adds the first ones; they're deliberately scoped to the status tag rather than trying to cover the whole title section.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783072179376899?thread_ts=1783072179.376899&cid=C09SK2PAGKF)*
