### PR TITLE
fix: attribute delivery export assets to the subscription owner

### DIFF
--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -914,6 +914,9 @@ async def test_create_export_assets_creates_exported_assets(
     assert asset.team_id == team.id
     assert asset.insight_id == insight.id
     assert asset.export_format == "image/png"
+    # The exporter renders the insight as the asset's creator — without it the render is userless
+    # and warehouse access control fails closed, breaking deliveries of warehouse-backed insights.
+    assert asset.created_by_id == user.id
 
     # SLO started is emitted by the interceptor, not this activity. Internal QueryRunner.run()
     # calls during snapshot build emit query_service SLO events — those are unrelated.

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -233,6 +233,9 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
             insight=insight,
             dashboard=dashboard,
             expires_after=expiry,
+            # The exporter runs the insight query as the asset's creator; without it the render is
+            # userless and warehouse access control fails closed, breaking subscription deliveries.
+            created_by=subscription.created_by,
         )
         for _tile, insight in export_pairs
     ]


### PR DESCRIPTION
## Problem

Subscription deliveries of insights over warehouse tables/views fail under the `hogql-warehouse-access-control` flag (#61686):

```
QueryError: You don't have access to table `<warehouse view>`.
```

Seen on scheduled deliveries (internal, flag at 100%):
- [Unknown table `dbt_billing_upcoming_invoices_latest`](https://us.posthog.com/project/2/error_tracking/019f26fa-9f7b-77f3-a640-c88f69720ae2)
- [Unknown table `iwa_summary_customer_month`](https://us.posthog.com/project/2/error_tracking/019f26fa-9f7c-72d3-a2ba-1b25001908f9)
- [Unknown table `activity_logs`](https://us.posthog.com/project/2/error_tracking/019f2730-a886-7420-9c81-8be9674c57dd)

Root cause: the delivery activity creates its `ExportedAsset`s **without `created_by`**. The image exporter then does the right thing — renders as `user=exported_asset.created_by` — but that's `None`, so the render is userless and warehouse access control fails closed. The same function already builds delivery snapshots with `user=subscription.created_by` ten lines below; the asset creation just never set it.

User-initiated exports are unaffected (their assets carry the requesting user).

## Changes

- Set `created_by=subscription.created_by` on the delivery `ExportedAsset`s — the subscription is already `select_related("created_by", ...)` in this activity, so no extra query and no lazy FK load in async code.

> Same owner-attribution pattern as exports, alerts, and cache warming: background reads run as the artifact's owner. If the owner later loses access to a table, their subscription deliveries fail closed — intended.

## How did you test this code?

Existing tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?