### PR TITLE
feat: Add lane routing to ingestion acceptance tests

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -8,23 +8,26 @@ import posthoganalytics
 import temporalio.activity
 
 from posthog.temporal.ingestion_acceptance_test.client import PostHogClient
-from posthog.temporal.ingestion_acceptance_test.config import Config
+from posthog.temporal.ingestion_acceptance_test.config import load_config
 from posthog.temporal.ingestion_acceptance_test.results import TestSuiteResult
 from posthog.temporal.ingestion_acceptance_test.runner import RunningTests, run_tests
 from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification, send_slack_timeout_notification
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import discover_tests
+from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
 
 logger = structlog.get_logger(__name__)
 
 
 @temporalio.activity.defn
-async def run_ingestion_acceptance_tests() -> dict:
+async def run_ingestion_acceptance_tests(inputs: IngestionAcceptanceTestInput) -> dict:
     """Run ingestion acceptance tests and return results.
 
-    Configuration is loaded from environment variables:
-    - INGESTION_ACCEPTANCE_TEST_API_HOST
-    - INGESTION_ACCEPTANCE_TEST_PROJECT_API_KEY
-    - INGESTION_ACCEPTANCE_TEST_TEAM_ID
+    The lane on the input selects which ingestion routing to target. Config is
+    loaded from environment variables:
+    - With a lane: INGESTION_ACCEPTANCE_TEST_LANE_<LANE>_{API_HOST,TEAM_ID,PROJECT_API_KEY}
+    - Without a lane: the flat INGESTION_ACCEPTANCE_TEST_{API_HOST,PROJECT_API_KEY,TEAM_ID}
+
+    Shared settings come from the flat env vars regardless of lane:
     - INGESTION_ACCEPTANCE_TEST_EVENT_TIMEOUT_SECONDS (optional, default 3600)
     - INGESTION_ACCEPTANCE_TEST_POLL_INTERVAL_SECONDS (optional, default 10.0)
     - INGESTION_ACCEPTANCE_TEST_ACTIVITY_TIMEOUT_SECONDS (optional, default 3600)
@@ -34,14 +37,15 @@ async def run_ingestion_acceptance_tests() -> dict:
         Dict containing test results with summary, individual test outcomes,
         and environment information.
     """
-    logger.info("Starting ingestion acceptance tests")
+    logger.info("Starting ingestion acceptance tests", lane=inputs.lane)
 
-    config = Config()
+    config = load_config(inputs.lane)
 
     logger.info(
         "Loaded config",
         api_host=config.api_host,
         team_id=config.team_id,
+        lane=config.lane,
     )
 
     posthog_sdk = posthoganalytics.Posthog(

--- a/posthog/temporal/ingestion_acceptance_test/config.py
+++ b/posthog/temporal/ingestion_acceptance_test/config.py
@@ -1,7 +1,12 @@
 """Configuration loading from environment variables using pydantic-settings."""
 
+import os
+
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ENV_PREFIX = "INGESTION_ACCEPTANCE_TEST_"
+DEFAULT_LANE = "main"
 
 
 class Config(BaseSettings):
@@ -11,13 +16,14 @@ class Config(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="INGESTION_ACCEPTANCE_TEST_",
+        env_prefix=ENV_PREFIX,
         frozen=True,
     )
 
     api_host: str
     project_api_key: str
     team_id: int
+    lane: str = Field(default=DEFAULT_LANE)
     event_timeout_seconds: int = Field(default=3600)
     poll_interval_seconds: float = Field(default=10.0)
     activity_timeout_seconds: int = Field(default=3600)
@@ -33,7 +39,57 @@ class Config(BaseSettings):
         return {
             "api_host": self.api_host,
             "team_id": str(self.team_id),
+            "lane": self.lane,
             "event_timeout_seconds": str(self.event_timeout_seconds),
             "poll_interval_seconds": str(self.poll_interval_seconds),
             "activity_timeout_seconds": str(self.activity_timeout_seconds),
         }
+
+
+def _lane_env_segment(lane: str) -> str:
+    """Normalize a lane name into its env var segment (e.g. "turbo" -> "TURBO")."""
+    return lane.strip().upper().replace("-", "_")
+
+
+def configured_lanes() -> list[str]:
+    """Lane names to schedule, parsed from INGESTION_ACCEPTANCE_TEST_LANES.
+
+    The value is a comma-separated list (e.g. "main,turbo") and is set per
+    environment, so each region schedules only the lanes it declares. Returns an
+    empty list when unset, in which case callers fall back to the single
+    flat-config schedule (the pre-lane behavior).
+    """
+    raw = os.environ.get(f"{ENV_PREFIX}LANES", "")
+    return [name.strip() for name in raw.split(",") if name.strip()]
+
+
+def load_config(lane: str | None = None) -> Config:
+    """Build a Config for the given lane.
+
+    When lane is None, config is read from the flat INGESTION_ACCEPTANCE_TEST_*
+    env vars (the pre-lane behavior).
+
+    When a lane is given, api_host, team_id and project_api_key are read from the
+    per-lane env vars INGESTION_ACCEPTANCE_TEST_LANE_<LANE>_{API_HOST,TEAM_ID,PROJECT_API_KEY}.
+    Shared settings (timeouts, Slack webhook) still come from the flat env vars.
+
+    Raises:
+        ValueError: if the lane's required per-lane env vars are not set.
+    """
+    if lane is None:
+        return Config()
+
+    prefix = f"{ENV_PREFIX}LANE_{_lane_env_segment(lane)}_"
+    try:
+        api_host = os.environ[f"{prefix}API_HOST"]
+        project_api_key = os.environ[f"{prefix}PROJECT_API_KEY"]
+        team_id = int(os.environ[f"{prefix}TEAM_ID"])
+    except KeyError as e:
+        raise ValueError(f"Lane {lane!r} is misconfigured: missing env var {e.args[0]}") from e
+
+    return Config(
+        lane=lane,
+        api_host=api_host,
+        project_api_key=project_api_key,
+        team_id=team_id,
+    )

--- a/posthog/temporal/ingestion_acceptance_test/config.py
+++ b/posthog/temporal/ingestion_acceptance_test/config.py
@@ -83,9 +83,16 @@ def load_config(lane: str | None = None) -> Config:
     try:
         api_host = os.environ[f"{prefix}API_HOST"]
         project_api_key = os.environ[f"{prefix}PROJECT_API_KEY"]
-        team_id = int(os.environ[f"{prefix}TEAM_ID"])
+        team_id_raw = os.environ[f"{prefix}TEAM_ID"]
     except KeyError as e:
         raise ValueError(f"Lane {lane!r} is misconfigured: missing env var {e.args[0]}") from e
+
+    try:
+        team_id = int(team_id_raw)
+    except ValueError as e:
+        raise ValueError(
+            f"Lane {lane!r} is misconfigured: {prefix}TEAM_ID must be an integer, got {team_id_raw!r}"
+        ) from e
 
     return Config(
         lane=lane,

--- a/posthog/temporal/ingestion_acceptance_test/schedule.py
+++ b/posthog/temporal/ingestion_acceptance_test/schedule.py
@@ -8,22 +8,46 @@ from django.conf import settings
 from temporalio import common
 from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
 
-from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.ingestion_acceptance_test.config import configured_lanes
 from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
 
 SCHEDULE_ID = "ingestion-acceptance-test-schedule"
 WORKFLOW_NAME = "ingestion-acceptance-test"
 
 
-async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
-    """Create or update the schedule for the ingestion acceptance test workflow.
+def _lane_schedule_id(lane: str) -> str:
+    return f"ingestion-acceptance-test-{lane}-schedule"
 
-    This schedule runs every 10 minutes to verify the ingestion pipeline is healthy.
+
+async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
+    """Create or update the ingestion acceptance test schedules.
+
+    Each schedule runs every 15 minutes to verify the ingestion pipeline is healthy.
+
+    When INGESTION_ACCEPTANCE_TEST_LANES is set (e.g. "main,turbo"), one schedule
+    is created per lane, each targeting that lane's ingestion routing. Lanes are
+    declared per environment, so a region only schedules the lanes it lists.
+    When unset, a single schedule using the flat env config is created (the
+    pre-lane behavior).
     """
-    schedule = Schedule(
+    lanes = configured_lanes()
+    if lanes:
+        # Retire the pre-lane schedule so "main" isn't tested by both it and the
+        # main lane schedule after the lane cutover deploys.
+        if await a_schedule_exists(client, SCHEDULE_ID):
+            await a_delete_schedule(client, SCHEDULE_ID)
+        for lane in lanes:
+            await _upsert_schedule(client, _lane_schedule_id(lane), IngestionAcceptanceTestInput(lane=lane))
+    else:
+        await _upsert_schedule(client, SCHEDULE_ID, IngestionAcceptanceTestInput())
+
+
+def _build_schedule(inputs: IngestionAcceptanceTestInput) -> Schedule:
+    return Schedule(
         action=ScheduleActionStartWorkflow(
             WORKFLOW_NAME,
-            IngestionAcceptanceTestInput(),
+            inputs,
             id=str(uuid.uuid4()),
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
             retry_policy=common.RetryPolicy(
@@ -33,7 +57,11 @@ async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=15))]),
     )
 
-    if await a_schedule_exists(client, SCHEDULE_ID):
-        await a_update_schedule(client, SCHEDULE_ID, schedule)
+
+async def _upsert_schedule(client: Client, schedule_id: str, inputs: IngestionAcceptanceTestInput) -> None:
+    schedule = _build_schedule(inputs)
+
+    if await a_schedule_exists(client, schedule_id):
+        await a_update_schedule(client, schedule_id, schedule)
     else:
-        await a_create_schedule(client, SCHEDULE_ID, schedule, trigger_immediately=False)
+        await a_create_schedule(client, schedule_id, schedule, trigger_immediately=False)

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -53,7 +53,7 @@ def send_slack_notification(config: Config, result: TestSuiteResult) -> bool:
 def _build_slack_blocks(config: Config, result: TestSuiteResult) -> list[dict[str, Any]]:
     """Build Slack blocks for the test result notification."""
     blocks: list[dict[str, Any]] = [
-        _build_header_block(result),
+        _build_header_block(config),
         _build_summary_block(result),
         {"type": "divider"},
     ]
@@ -63,14 +63,13 @@ def _build_slack_blocks(config: Config, result: TestSuiteResult) -> list[dict[st
     return blocks
 
 
-def _build_header_block(result: TestSuiteResult) -> dict[str, Any]:
+def _build_header_block(config: Config) -> dict[str, Any]:
     # Only called when there are failures (send_slack_notification returns early on success)
-    _ = result  # Unused but kept for API consistency
     return {
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": ":bomb: *Unsuccessful run for Ingestion Acceptance Tests*",
+            "text": f":bomb: *Unsuccessful run in {config.lane} lane for Ingestion Acceptance Tests*",
         },
     }
 
@@ -101,6 +100,7 @@ def _build_summary_block(result: TestSuiteResult) -> dict[str, Any]:
 
 def _build_context_block(config: Config, result: TestSuiteResult) -> dict[str, Any]:
     text = (
+        f":traffic_light: Lane: {config.lane} | "
         f":globe_with_meridians: Env: {config.api_host} | "
         f":file_folder: Team: {config.team_id} | "
         f":hourglass: Duration: {result.total_duration_seconds:.2f}s"
@@ -136,7 +136,7 @@ def send_slack_timeout_notification(config: Config, running_tests: list[RunningT
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":hourglass: *Ingestion Acceptance Tests Timed Out*",
+                "text": f":hourglass: *Ingestion Acceptance Tests Timed Out in {config.lane} lane*",
             },
         },
         {
@@ -145,6 +145,7 @@ def send_slack_timeout_notification(config: Config, running_tests: list[RunningT
                 {
                     "type": "mrkdwn",
                     "text": (
+                        f":traffic_light: Lane: {config.lane} | "
                         f":globe_with_meridians: Env: {config.api_host} | "
                         f":file_folder: Team: {config.team_id} | "
                         f":stopwatch: Timeout: {config.activity_timeout_seconds}s | "

--- a/posthog/temporal/ingestion_acceptance_test/terminal_report.py
+++ b/posthog/temporal/ingestion_acceptance_test/terminal_report.py
@@ -18,11 +18,13 @@ def format_terminal_report(result: TestSuiteResult) -> str:
 def _format_header(result: TestSuiteResult) -> str:
     status_emoji = "✅" if result.success else "❌"
     status_text = "PASSED" if result.success else "FAILED"
-    return f"{status_emoji} Ingestion Acceptance Tests: {status_text}\n"
+    lane = result.environment.get("lane", "unknown")
+    return f"{status_emoji} Ingestion Acceptance Tests ({lane} lane): {status_text}\n"
 
 
 def _format_environment(result: TestSuiteResult) -> str:
     return (
+        f"Lane:        {result.environment.get('lane', 'unknown')}\n"
         f"Environment: {result.environment.get('api_host', 'unknown')}\n"
         f"Team ID:     {result.environment.get('team_id', 'unknown')}\n"
         f"Timestamp:   {result.timestamp}\n"

--- a/posthog/temporal/ingestion_acceptance_test/types.py
+++ b/posthog/temporal/ingestion_acceptance_test/types.py
@@ -6,8 +6,10 @@ from pydantic import BaseModel
 class IngestionAcceptanceTestInput(BaseModel):
     """Input for the ingestion acceptance test workflow.
 
-    Currently empty as no configuration is needed, but follows the standard
-    pattern for Temporal workflows to allow future extensibility.
+    The lane selects which ingestion routing the run targets (e.g. "main",
+    "turbo"). Each lane resolves its own api_host, team_id and project_api_key
+    from the worker environment. When lane is None the run falls back to the
+    flat INGESTION_ACCEPTANCE_TEST_* env vars (the pre-lane behavior).
     """
 
-    pass
+    lane: str | None = None

--- a/posthog/temporal/ingestion_acceptance_test/workflows.py
+++ b/posthog/temporal/ingestion_acceptance_test/workflows.py
@@ -33,6 +33,7 @@ class IngestionAcceptanceTestWorkflow(PostHogWorkflow):
         """
         result = await temporalio.workflow.execute_activity(
             run_ingestion_acceptance_tests,
+            inputs,
             start_to_close_timeout=timedelta(hours=1, minutes=5),
             retry_policy=RetryPolicy(
                 maximum_attempts=1,

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ingestion_acceptance_test.config import Config
+from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
 
 
 @pytest.fixture
@@ -24,13 +25,13 @@ class TestRunIngestionAcceptanceTestsTimeout:
     @patch("posthog.temporal.ingestion_acceptance_test.activities.PostHogClient")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.posthoganalytics.Posthog")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.discover_tests", return_value=[])
-    @patch("posthog.temporal.ingestion_acceptance_test.activities.Config")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.load_config")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.run_tests")
     @pytest.mark.asyncio
     async def test_sends_slack_timeout_notification_on_timeout(
         self,
         mock_run_tests: MagicMock,
-        mock_config_cls: MagicMock,
+        mock_load_config: MagicMock,
         mock_discover: MagicMock,
         mock_posthog: MagicMock,
         mock_client_cls: MagicMock,
@@ -38,7 +39,7 @@ class TestRunIngestionAcceptanceTestsTimeout:
         mock_send_timeout: MagicMock,
         config: Config,
     ) -> None:
-        mock_config_cls.return_value = config
+        mock_load_config.return_value = config
 
         def slow_run_tests(*args, **kwargs):
             time.sleep(5)
@@ -48,7 +49,7 @@ class TestRunIngestionAcceptanceTestsTimeout:
         from posthog.temporal.ingestion_acceptance_test.activities import run_ingestion_acceptance_tests
 
         with pytest.raises(asyncio.TimeoutError):
-            await run_ingestion_acceptance_tests()
+            await run_ingestion_acceptance_tests(IngestionAcceptanceTestInput())
 
         mock_send_timeout.assert_called_once_with(config, running_tests=[])
         mock_send_slack.assert_not_called()
@@ -58,13 +59,13 @@ class TestRunIngestionAcceptanceTestsTimeout:
     @patch("posthog.temporal.ingestion_acceptance_test.activities.PostHogClient")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.posthoganalytics.Posthog")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.discover_tests", return_value=[])
-    @patch("posthog.temporal.ingestion_acceptance_test.activities.Config")
+    @patch("posthog.temporal.ingestion_acceptance_test.activities.load_config")
     @patch("posthog.temporal.ingestion_acceptance_test.activities.run_tests")
     @pytest.mark.asyncio
     async def test_does_not_send_timeout_notification_when_tests_complete(
         self,
         mock_run_tests: MagicMock,
-        mock_config_cls: MagicMock,
+        mock_load_config: MagicMock,
         mock_discover: MagicMock,
         mock_posthog: MagicMock,
         mock_client_cls: MagicMock,
@@ -72,7 +73,7 @@ class TestRunIngestionAcceptanceTestsTimeout:
         mock_send_timeout: MagicMock,
         config: Config,
     ) -> None:
-        mock_config_cls.return_value = config
+        mock_load_config.return_value = config
 
         mock_result = MagicMock()
         mock_result.to_dict.return_value = {"success": True}
@@ -80,7 +81,7 @@ class TestRunIngestionAcceptanceTestsTimeout:
 
         from posthog.temporal.ingestion_acceptance_test.activities import run_ingestion_acceptance_tests
 
-        result = await run_ingestion_acceptance_tests()
+        result = await run_ingestion_acceptance_tests(IngestionAcceptanceTestInput())
 
         assert result == {"success": True}
         mock_send_timeout.assert_not_called()

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_config.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_config.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from posthog.temporal.ingestion_acceptance_test.config import DEFAULT_LANE, configured_lanes, load_config
+
+FLAT_ENV = {
+    "INGESTION_ACCEPTANCE_TEST_API_HOST": "https://flat.example.com",
+    "INGESTION_ACCEPTANCE_TEST_PROJECT_API_KEY": "phc_flat",
+    "INGESTION_ACCEPTANCE_TEST_TEAM_ID": "111",
+}
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """Strip ambient INGESTION_ACCEPTANCE_TEST_* vars so each test is hermetic."""
+    for key in list(os.environ):
+        if key.startswith("INGESTION_ACCEPTANCE_TEST_"):
+            monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+class TestLoadConfig:
+    def test_flat_config_when_no_lane(self, clean_env: pytest.MonkeyPatch) -> None:
+        for key, value in FLAT_ENV.items():
+            clean_env.setenv(key, value)
+
+        config = load_config()
+
+        assert config.api_host == "https://flat.example.com"
+        assert config.project_api_key == "phc_flat"
+        assert config.team_id == 111
+        assert config.lane == DEFAULT_LANE  # flat runs report as the "main" lane
+
+    def test_lane_config_reads_per_lane_env(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_API_HOST", "https://turbo.example.com/")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_PROJECT_API_KEY", "phc_turbo")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_TEAM_ID", "222")
+
+        config = load_config("turbo")
+
+        assert config.lane == "turbo"
+        assert config.api_host == "https://turbo.example.com"  # trailing slash stripped
+        assert config.project_api_key == "phc_turbo"
+        assert config.team_id == 222
+
+    def test_lane_name_normalized_to_env_segment(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_FAST_LANE_API_HOST", "https://fast.example.com")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_FAST_LANE_PROJECT_API_KEY", "phc_fast")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_FAST_LANE_TEAM_ID", "333")
+
+        config = load_config("fast-lane")
+
+        assert config.lane == "fast-lane"
+        assert config.team_id == 333
+
+    def test_missing_lane_env_raises_descriptive_error(self, clean_env: pytest.MonkeyPatch) -> None:
+        with pytest.raises(ValueError, match="Lane 'turbo' is misconfigured"):
+            load_config("turbo")
+
+    def test_shared_settings_come_from_flat_env_for_lane(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_MAIN_API_HOST", "https://main.example.com")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_MAIN_PROJECT_API_KEY", "phc_main")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_MAIN_TEAM_ID", "444")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_POLL_INTERVAL_SECONDS", "2.5")
+
+        config = load_config("main")
+
+        assert config.poll_interval_seconds == 2.5
+
+
+class TestConfiguredLanes:
+    def test_empty_when_unset(self, clean_env: pytest.MonkeyPatch) -> None:
+        assert configured_lanes() == []
+
+    def test_parses_comma_separated(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANES", "main,turbo")
+        assert configured_lanes() == ["main", "turbo"]
+
+    def test_strips_whitespace_and_blanks(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANES", " main , , turbo ,")
+        assert configured_lanes() == ["main", "turbo"]

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_config.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_config.py
@@ -60,6 +60,14 @@ class TestLoadConfig:
         with pytest.raises(ValueError, match="Lane 'turbo' is misconfigured"):
             load_config("turbo")
 
+    def test_non_integer_team_id_raises_descriptive_error(self, clean_env: pytest.MonkeyPatch) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_API_HOST", "https://turbo.example.com")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_PROJECT_API_KEY", "phc_turbo")
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_TURBO_TEAM_ID", "not-a-number")
+
+        with pytest.raises(ValueError, match="TEAM_ID must be an integer"):
+            load_config("turbo")
+
     def test_shared_settings_come_from_flat_env_for_lane(self, clean_env: pytest.MonkeyPatch) -> None:
         clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_MAIN_API_HOST", "https://main.example.com")
         clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANE_MAIN_PROJECT_API_KEY", "phc_main")
@@ -75,10 +83,13 @@ class TestConfiguredLanes:
     def test_empty_when_unset(self, clean_env: pytest.MonkeyPatch) -> None:
         assert configured_lanes() == []
 
-    def test_parses_comma_separated(self, clean_env: pytest.MonkeyPatch) -> None:
-        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANES", "main,turbo")
-        assert configured_lanes() == ["main", "turbo"]
-
-    def test_strips_whitespace_and_blanks(self, clean_env: pytest.MonkeyPatch) -> None:
-        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANES", " main , , turbo ,")
-        assert configured_lanes() == ["main", "turbo"]
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("main,turbo", ["main", "turbo"]),
+            (" main , , turbo ,", ["main", "turbo"]),
+        ],
+    )
+    def test_parses_lanes(self, clean_env: pytest.MonkeyPatch, raw: str, expected: list[str]) -> None:
+        clean_env.setenv("INGESTION_ACCEPTANCE_TEST_LANES", raw)
+        assert configured_lanes() == expected

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_schedule.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_schedule.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.conf import settings
+
+from temporalio.client import ScheduleActionStartWorkflow
+
+from posthog.temporal.ingestion_acceptance_test.schedule import WORKFLOW_NAME, _build_schedule, _lane_schedule_id
+from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
+
+
+def _action(inputs: IngestionAcceptanceTestInput) -> ScheduleActionStartWorkflow:
+    action = _build_schedule(inputs).action
+    assert isinstance(action, ScheduleActionStartWorkflow)
+    return action
+
+
+class TestBuildSchedule:
+    def test_targets_general_purpose_queue(self) -> None:
+        assert _action(IngestionAcceptanceTestInput()).task_queue == settings.GENERAL_PURPOSE_TASK_QUEUE
+
+    def test_starts_ingestion_acceptance_workflow(self) -> None:
+        assert _action(IngestionAcceptanceTestInput()).workflow == WORKFLOW_NAME
+
+    def test_passes_lane_to_workflow(self) -> None:
+        action = _action(IngestionAcceptanceTestInput(lane="turbo"))
+        assert list(action.args) == [IngestionAcceptanceTestInput(lane="turbo")]
+
+    def test_interval_is_15_minutes(self) -> None:
+        schedule = _build_schedule(IngestionAcceptanceTestInput())
+        assert schedule.spec.intervals[0].every == timedelta(minutes=15)
+
+
+class TestLaneScheduleId:
+    def test_lane_schedule_id_format(self) -> None:
+        assert _lane_schedule_id("turbo") == "ingestion-acceptance-test-turbo-schedule"
+
+
+class TestDeployRegistry:
+    def test_schedule_is_wired_into_deploy_registry(self) -> None:
+        # Without this entry the schedule is never upserted on deploy and the
+        # workflow never fires. Guards that exact regression.
+        from posthog.temporal.ingestion_acceptance_test.schedule import (  # noqa: PLC0415
+            create_ingestion_acceptance_test_schedule,
+        )
+        from posthog.temporal.schedule import schedules  # noqa: PLC0415 — heavy registry import, kept off module load
+
+        assert create_ingestion_acceptance_test_schedule in schedules

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
@@ -115,6 +115,7 @@ class TestSendSlackNotification:
         assert header_block["type"] == "section"
         header_text = header_block["text"]["text"]
         assert "Unsuccessful" in header_text
+        assert "main lane" in header_text
 
     @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")
     def test_payload_contains_summary_with_counts(
@@ -204,6 +205,7 @@ class TestSendSlackTimeoutNotification:
         payload = mock_post.call_args[1]["json"]
         header_text = payload["blocks"][0]["text"]["text"]
         assert "Timed Out" in header_text
+        assert "main lane" in header_text
 
     @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")
     def test_payload_contains_environment_timeout_and_token_info(self, mock_post: MagicMock, config: Config) -> None:


### PR DESCRIPTION
## Problem

The ingestion acceptance test workflow reads a single flat configuration from the environment, so a worker can only exercise one ingestion routing and the reports cannot tell which routing failed.

## Changes

Add a lane field to the workflow input that selects the ingestion routing for a run.
Resolve per lane api_host, team_id and project_api_key from prefixed environment variables and fall back to the flat configuration when no lane is set.
Create one schedule per lane declared in INGESTION_ACCEPTANCE_TEST_LANES and retire the legacy schedule once lanes are configured.
Include the lane name in the Slack and terminal reports so a failure identifies the affected lane.
Add unit tests for the lane config loading, lane parsing and schedule construction, and update the activity and Slack tests for the new signatures.

## Rollout

Merge the companion charts change first so the environment exposes the lane variables while the flat variables still work.
Merge this change second to switch the schedules onto lanes.

Companion charts PR: PostHog/charts#12834