### PR TITLE
feat(data-warehouse): send default_team_id when provisioning duckgres

### DIFF
--- a/products/data_warehouse/backend/presentation/views/managed_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/managed_warehouse.py
@@ -208,6 +208,12 @@ def provision(
         "/provision",
         json_body={
             "database_name": database_name,
+            # The provisioning team is the warehouse's default team: duckgres pins it so
+            # queries without an explicit team resolve to this environment's tables. It's
+            # required — duckgres denies a provision without it. In-product this is the
+            # calling (currently active) team; in the Django admin it's the mandatory team
+            # field on the provision form.
+            "default_team_id": team_id,
             "ducklake": {"enabled": True},
             "metadata_store": {"type": "cnpg-shard"},
             "data_store": {"type": "s3bucket"},

--- a/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
@@ -59,6 +59,25 @@ def test_provision_persists_duckgres_server_on_success(mock_request: MagicMock) 
 @pytest.mark.django_db
 @override_settings(CLOUD_DEPLOYMENT="US", DUCKGRES_PG_PORT=5432)
 @patch("products.data_warehouse.backend.presentation.views.managed_warehouse._request")
+def test_provision_sends_default_team_id_to_control_plane(mock_request: MagicMock) -> None:
+    # duckgres denies a provision without a default team, so the provisioning team must be
+    # forwarded as default_team_id in the outbound body.
+    org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
+    mock_request.return_value = Response(
+        {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
+        status=202,
+    )
+
+    managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
+
+    json_body = mock_request.call_args.kwargs["json_body"]
+    assert json_body["default_team_id"] == team.id
+
+
+@pytest.mark.django_db
+@override_settings(CLOUD_DEPLOYMENT="US", DUCKGRES_PG_PORT=5432)
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse._request")
 def test_provision_persists_bucket_returned_by_control_plane(mock_request: MagicMock) -> None:
     # When the control plane returns the authoritative bucket name, persist it
     # verbatim instead of re-deriving — the CP owns the naming rule (it pins the


### PR DESCRIPTION
## Problem

When a managed warehouse (duckgres) is provisioned, the control plane needs a default team pinned to the environment so queries without an explicit team resolve to the right tables. We weren't sending it, and duckgres denies a provision without it.

## Changes

Forward the provisioning team to the duckgres `/provision` call as `default_team_id`.

Both entry points already thread a team through `managed_warehouse.provision`, so this is a single field added to the outbound request body:

- **In-product `/data-ops` provision action** (behind the `data-warehouse-scene` flag) uses the currently active team.
- **Django admin provision form** already has a mandatory team field, enforced both client-side (`required`) and server-side (`_resolve_team`). That satisfies the "team must be filled out or duckgres denies" requirement.

## How did you test this code?

Added `test_provision_sends_default_team_id_to_control_plane`, which asserts the outbound provision body includes `default_team_id` set to the provisioning team. It guards against the field being dropped or renamed, which would make duckgres reject every provision. No existing test inspected the outbound payload.

I (the PostHog Slack app) could not run the suite locally in this environment (no test runner available); CI will run it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread. The change funnels through the single `managed_warehouse.provision` adapter that both the DRF viewset action and the Django admin view already call, so no changes were needed at either call site. I invoked the `/writing-tests` skill to gate the new test against the value bar before adding it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A1M678WCV/p1783077106335789)*
