### PR TITLE
fix(cdp): validate To field liquid template in native_email inputs

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
@@ -228,14 +228,18 @@ describe('CyclotronJobInputsValidation', () => {
             })
             const schema: CyclotronJobInputSchemaType[] = [{ key: 'email', type: 'native_email', label: 'Email' }]
 
-            it('errors on a malformed Liquid template in to.email', () => {
-                // Dot notation on a $-prefixed, hyphenated survey key is invalid Liquid — the natural first attempt.
-                const result = CyclotronJobInputsValidation.validate(
-                    nativeEmailInput({ name: '', email: '{{ event.properties.$survey_response_1c0454ff-1138 }}' }),
-                    schema
-                )
+            // Dot notation on a $-prefixed, hyphenated survey key is invalid Liquid — the natural first attempt.
+            it.each([
+                [
+                    'a malformed Liquid template',
+                    '{{ event.properties.$survey_response_1c0454ff-1138 }}',
+                    'Liquid template error',
+                ],
+                ['an empty address', '', 'To is required'],
+            ])('errors when to.email is %s', (_desc, email, expectedError) => {
+                const result = CyclotronJobInputsValidation.validate(nativeEmailInput({ name: '', email }), schema)
                 expect(result.valid).toBe(false)
-                expect(result.errors.email).toContain('Liquid template error')
+                expect(result.errors.email).toContain(expectedError)
             })
 
             it('passes a valid bracket-notation Liquid template in to.email', () => {
@@ -245,12 +249,6 @@ describe('CyclotronJobInputsValidation', () => {
                 )
                 expect(result.valid).toBe(true)
                 expect(result.errors).toEqual({})
-            })
-
-            it('requires the To address when to.email is empty', () => {
-                const result = CyclotronJobInputsValidation.validate(nativeEmailInput({ name: '', email: '' }), schema)
-                expect(result.valid).toBe(false)
-                expect(result.errors.email).toContain('To is required')
             })
         })
 

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
@@ -1,4 +1,4 @@
-import { CyclotronJobInputSchemaType } from '~/types'
+import { CyclotronJobInputSchemaType, CyclotronJobInputType } from '~/types'
 
 import { CyclotronJobInputsValidation, TEMPLATING_MISMATCH_WARNINGS } from './CyclotronJobInputsValidation'
 
@@ -212,6 +212,45 @@ describe('CyclotronJobInputsValidation', () => {
 
                 expect(result.valid).toBe(true)
                 expect(result.errors).toEqual({})
+            })
+        })
+
+        describe('native_email To field (object form)', () => {
+            // native_email stores `to` as { name, email }, unlike the legacy `email` type which stores a bare string.
+            const nativeEmailInput = (
+                to: unknown,
+                templating: 'hog' | 'liquid' = 'liquid'
+            ): Record<string, CyclotronJobInputType> => ({
+                email: {
+                    templating,
+                    value: { html: '<p>Hi</p>', subject: 'Subject', from: { integrationId: 1 }, to },
+                },
+            })
+            const schema: CyclotronJobInputSchemaType[] = [{ key: 'email', type: 'native_email', label: 'Email' }]
+
+            it('errors on a malformed Liquid template in to.email', () => {
+                // Dot notation on a $-prefixed, hyphenated survey key is invalid Liquid — the natural first attempt.
+                const result = CyclotronJobInputsValidation.validate(
+                    nativeEmailInput({ name: '', email: '{{ event.properties.$survey_response_1c0454ff-1138 }}' }),
+                    schema
+                )
+                expect(result.valid).toBe(false)
+                expect(result.errors.email).toContain('Liquid template error')
+            })
+
+            it('passes a valid bracket-notation Liquid template in to.email', () => {
+                const result = CyclotronJobInputsValidation.validate(
+                    nativeEmailInput({ name: '', email: "{{ event.properties['$survey_response_1c0454ff-1138'] }}" }),
+                    schema
+                )
+                expect(result.valid).toBe(true)
+                expect(result.errors).toEqual({})
+            })
+
+            it('requires the To address when to.email is empty', () => {
+                const result = CyclotronJobInputsValidation.validate(nativeEmailInput({ name: '', email: '' }), schema)
+                expect(result.valid).toBe(false)
+                expect(result.errors.email).toContain('To is required')
             })
         })
 

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.ts
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.ts
@@ -145,6 +145,10 @@ const validateInput = (input: CyclotronJobInputType, inputSchema: CyclotronJobIn
     }
 
     if (['email', 'native_email'].includes(inputSchema.type) && value) {
+        // `native_email` stores `to` as { name, email }; the legacy `email` type stores a bare address string.
+        // Pull out the address so it gets the same required + templating validation as every other field —
+        // otherwise a malformed Liquid template in the To field (or an empty address) saves with no error.
+        const toEmail = value.to && typeof value.to === 'object' ? value.to.email : value.to
         const emailTemplateErrors: Partial<EmailTemplate> = {
             html:
                 !value.html && !value.text
@@ -155,7 +159,7 @@ const validateInput = (input: CyclotronJobInputType, inputSchema: CyclotronJobIn
             text: value.text ? getTemplatingError(value.text) : undefined,
             subject: !value.subject ? 'Subject is required' : getTemplatingError(value.subject),
             from: !value.from ? 'From is required' : getTemplatingError(value.from),
-            to: !value.to ? 'To is required' : getTemplatingError(value.to),
+            to: !toEmail ? 'To is required' : getTemplatingError(toEmail),
         }
 
         const combinedErrors = Object.values(emailTemplateErrors)


### PR DESCRIPTION
## Problem

When building a workflow email, the recipient (**To**) field accepts a Liquid template — e.g. pulling the address from a survey response. But unlike every other email field (subject, from, html, text), the To field's template was **never validated**, so a mistake there saved silently with no error and only failed at send time. This came up when a teammate tried to send a sponsorship-intake confirmation to the email a survey respondent entered, and got no feedback on why it "didn't work".

Root cause: the `native_email` input stores `to` as a `{ name, email }` object (the legacy `email` type stores a bare string). The validation code read the whole object instead of the `email` string, so `getTemplatingError` (which only runs on strings) skipped it, and the "To is required" check saw a truthy object even when the address was empty.

Notably, the underlying Liquid evaluator handles these survey keys fine — `{{ event.properties['$survey_response_<uuid>'] }}` (bracket notation) renders correctly. The trap is that Liquid **dot** notation on a `$`-prefixed, hyphenated key is invalid, and nothing surfaced that error on the To field.

## Changes

Extract the address string from the `to` object before running the required-field and Liquid templating checks, so the To field validates like all the others. The legacy `email` type (bare string `to`) is unaffected.

## How did you test this code?

Added 3 cases to `CyclotronJobInputsValidation.test.ts` for the `native_email` object-form `to` — no existing test exercised it (the existing email tests use a bare string `to`):

- malformed Liquid in `to.email` (dot-notation on a survey key) now surfaces a `Liquid template error` — previously returned valid with no error
- a valid bracket-notation Liquid template still passes (guards against over-eager rejection)
- an empty `to.email` now triggers "To is required" — previously an empty object slipped through

Ran the full file locally: 45/45 pass (2 of the new cases fail without the fix, confirming the regression they catch). Lint/format clean on both files. No manual UI testing performed by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Slack report that a survey-response email couldn't be sent from a workflow. Started from the hypothesis that PostHog's Liquid evaluator couldn't reference `$survey_response_<uuid>` keys, but reproduced against the real `LiquidRenderer` (liquidjs) and found bracket notation renders correctly — so the runtime was never the gap. Traced the actual rough edge to the frontend: the To field's template is silently unvalidated for `native_email` because `to` is an object. Fix + TDD tests scoped to that.

Skills invoked: `/writing-tests` (to gate the added cases).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1783076459242879?thread_ts=1783076459.242879&cid=C06GG249PR6)*
