### PR TITLE
feat(heatmaps): instrument heatmap mode usage and load failures

### DIFF
--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -390,11 +390,8 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         setIframeBanner: ({ banner }) => {
             // the load-failure timer also runs on scenes that never mount an iframe
             // (screenshot detail, the new-heatmap form), so only capture when one exists
-            if (banner && document.getElementById('heatmap-iframe')) {
-                posthog.capture('in-app iFrame banner set', {
-                    level: banner.level,
-                    message: typeof banner.message === 'string' ? banner.message : undefined,
-                })
+            if (banner?.level === 'error' && document.getElementById('heatmap-iframe')) {
+                posthog.capture('in-app heatmap load failed')
             }
         },
 

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -319,6 +319,8 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         },
 
         onIframeLoad: () => {
+            actions.stopTrackingLoading()
+
             // it should be impossible to load an iframe without a dataUrl
             // right?!
             const url = values.dataUrl ?? ''
@@ -383,6 +385,17 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 }, 7500)
                 return () => clearTimeout(timerId)
             }, 'errorTimeout')
+        },
+
+        setIframeBanner: ({ banner }) => {
+            // the load-failure timer also runs on scenes that never mount an iframe
+            // (screenshot detail, the new-heatmap form), so only capture when one exists
+            if (banner && document.getElementById('heatmap-iframe')) {
+                posthog.capture('in-app iFrame banner set', {
+                    level: banner.level,
+                    message: typeof banner.message === 'string' ? banner.message : undefined,
+                })
+            }
         },
 
         stopTrackingLoading: () => {

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -378,6 +378,11 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
 
             cache.disposables.add(() => {
                 const timerId = setTimeout(() => {
+                    // this timer also runs on scenes that never mount an iframe
+                    // (screenshot detail, the new-heatmap form), so only capture when one exists
+                    if (document.getElementById('heatmap-iframe')) {
+                        posthog.capture('in-app heatmap load failed')
+                    }
                     actions.setIframeBanner({
                         level: 'error',
                         message: 'The heatmap failed to load (or is very slow).',
@@ -385,14 +390,6 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 }, 7500)
                 return () => clearTimeout(timerId)
             }, 'errorTimeout')
-        },
-
-        setIframeBanner: ({ banner }) => {
-            // the load-failure timer also runs on scenes that never mount an iframe
-            // (screenshot detail, the new-heatmap form), so only capture when one exists
-            if (banner?.level === 'error' && document.getElementById('heatmap-iframe')) {
-                posthog.capture('in-app heatmap load failed')
-            }
         },
 
         stopTrackingLoading: () => {

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -45,6 +45,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
         updateHeatmap,
         onIframeLoad,
         setScreenshotLoaded,
+        setScreenshotError,
         exportHeatmap,
         setContainerWidth,
     } = useActions(logic)
@@ -195,7 +196,8 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                             }}
                                             className="rounded-b-lg border-l border-r border-b"
                                             onError={() => {
-                                                console.error('Failed to load screenshot')
+                                                setScreenshotLoaded(false)
+                                                setScreenshotError('The screenshot failed to load.')
                                             }}
                                         />
                                     </>

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -193,6 +193,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                                             }}
                                             onLoad={() => {
                                                 setScreenshotLoaded(true)
+                                                setScreenshotError(null)
                                             }}
                                             className="rounded-b-lg border-l border-r border-b"
                                             onError={() => {

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -329,7 +329,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
         },
         setScreenshotError: ({ error }) => {
             if (error) {
-                posthog.capture('in-app heatmap screenshot failed to display', { error })
+                posthog.capture('in-app heatmap screenshot failed', { error })
             }
         },
         exportHeatmap: () => {

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
@@ -150,6 +151,10 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 actions.setBlockConsentModals(item.block_consent_modals ?? false)
                 actions.snapshotSavedBlockConsentModals(item.block_consent_modals ?? false)
                 actions.setType(item.type)
+                posthog.capture('in-app heatmap viewed', {
+                    heatmap_type: item.type,
+                    heatmap_status: item.status,
+                })
                 if (item.type === 'screenshot') {
                     const desiredWidth = values.widthOverride
                     if (item.status === 'completed' && item.has_content) {
@@ -255,6 +260,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     block_consent_modals: values.blockConsentModals,
                 }
                 const created = await api.savedHeatmaps.create(data)
+                posthog.capture('in-app heatmap created', { heatmap_type: values.type })
                 actions.loadSavedHeatmaps()
                 // Navigate to the created heatmap detail page
                 router.actions.push(`/heatmaps/${created.short_id}`)
@@ -314,6 +320,16 @@ export const heatmapLogic = kea<heatmapLogicType>([
             }
             if (values.type === 'screenshot') {
                 actions.regenerateScreenshot()
+            }
+        },
+        setScreenshotLoaded: ({ screenshotLoaded }) => {
+            if (screenshotLoaded) {
+                posthog.capture('in-app heatmap screenshot loaded', { width: values.widthOverride })
+            }
+        },
+        setScreenshotError: ({ error }) => {
+            if (error) {
+                posthog.capture('in-app heatmap screenshot failed to display', { error })
             }
         },
         exportHeatmap: () => {


### PR DESCRIPTION
## Problem

We recently dug into how the in-app heatmaps product is used and couldn't answer basic questions from telemetry: which capture method (screenshot vs iframe) customers actually use, how often loads fail, or whether screenshots are ever viewed after generation. Iframe load-failure banners were set in state but never captured, saved-heatmap views carried no type, and iframe-type creations fired no event at all (the backend `heatmap screenshot generated` event only covers screenshot generation).

## Changes

New client-side captures:

- `in-app heatmap viewed` with `heatmap_type` / `heatmap_status` when a saved heatmap loads
- `in-app heatmap created` with `heatmap_type` (closes the iframe-type creation blindspot)
- `in-app heatmap screenshot loaded` and `in-app heatmap screenshot failed` (generation, polling, and display failures, distinguished by the `error` property — the img error path now dispatches `setScreenshotError`, so display failures get the error banner and retry instead of a bare console line)
- `in-app heatmap load failed`, captured at the failure-timer site (originally reused the toolbar's `in-app iFrame banner set` name; review flagged the semantics collision, so it's a fresh outcome-named event)

Two correctness fixes so the failure event means something:

- `onIframeLoad` now cancels the 7.5s load-failure timer. Nothing ever dispatched `stopTrackingLoading`, so the "failed to load" banner state fired after every load, healthy or not (it was also never rendered, so nobody noticed).
- The banner capture is gated on a heatmap iframe actually being mounted, because the timer also runs on scenes that never load one (screenshot detail, the new-heatmap form).

## How did you test this code?

Existing `heatmapLogic` tests pass. No new tests: the changes are `posthog.capture` calls and a timer cancellation, and a test asserting "capture was called" would be change-detector noise per our testing conventions. The known limitation is that an iframe blocked by X-Frame-Options still fires `load`, so blocked embeds don't produce a failure event, only genuine timeouts do.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal telemetry only.

## 🤖 Agent context


Authored with PostHog Code (Claude). This is PR 1 of a stack of 3 (telemetry, then a recording-mode clickmap, then a recording fallback for failed heatmaps), motivated by a usage/satisfaction analysis of the heatmaps product that found these instrumentation gaps. While adding the banner capture I found the dead `stopTrackingLoading` path and fixed it here so the new event isn't emitted spuriously; the alternative (restructuring the timer to only start when an iframe is expected) touches three scenes and was rejected as out of scope. `/writing-tests` was invoked and concluded no new tests were warranted for capture calls.

---

