### PR TITLE
fix(proxy): pin create-proxy retry to the record's provisioning path

### DIFF
--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -44,9 +44,9 @@ from posthog.temporal.proxy_service.common import (
     activity_send_proxy_created_email,
     activity_update_proxy_record,
     get_grpc_client,
+    is_cloudflare_proxy_by_cname,
     record_exists,
     update_record,
-    use_cloudflare_proxy,
     use_gateway_api,
 )
 from posthog.temporal.proxy_service.monitor import MonitorManagedProxyInputs
@@ -526,8 +526,12 @@ class CreateManagedProxyWorkflow(PostHogWorkflow):
                 ),
             )
 
-            # Branch based on whether to use Cloudflare or the legacy proxy provisioner
-            if use_cloudflare_proxy():
+            # Branch on the path this proxy was provisioned on, read from its target_cname,
+            # not the global CLOUDFLARE_PROXY_ENABLED flag. The target_cname was fixed to a
+            # Cloudflare or legacy base when the record was created, so this keeps a retry (or
+            # any re-run) on the proxy's original path — a legacy proxy is never migrated onto
+            # Cloudflare just because the global flag flipped on after it was created.
+            if is_cloudflare_proxy_by_cname(inputs.target_cname):
                 # Cloudflare for SaaS path: Create Custom Hostname and Worker Route
                 cloudflare_inputs = CreateCloudflareProxyInputs(
                     organization_id=inputs.organization_id,

--- a/posthog/temporal/proxy_service/test/test_create_workflow.py
+++ b/posthog/temporal/proxy_service/test/test_create_workflow.py
@@ -16,6 +16,7 @@ from posthog.temporal.proxy_service.create import (
     CreateManagedProxyInputs,
     CreateManagedProxyWorkflow,
     ScheduleMonitorJobInputs,
+    WaitForCertificateInputs,
     WaitForDNSRecordsInputs,
 )
 
@@ -28,6 +29,7 @@ def _make_mock_activities(failing_activity: str | None = None, error_type: str =
         error_type: The exception type string for the ApplicationError.
     """
     status_updates: list[str] = []
+    called: list[str] = []
 
     def _maybe_raise(activity_name: str):
         if activity_name == failing_activity:
@@ -47,11 +49,23 @@ def _make_mock_activities(failing_activity: str | None = None, error_type: str =
 
     @activity.defn(name="create_cloudflare_custom_hostname")
     async def mock_create_hostname(inputs: CreateCloudflareProxyInputs):
+        called.append("create_cloudflare_custom_hostname")
         _maybe_raise("create_cloudflare_custom_hostname")
 
     @activity.defn(name="wait_for_cloudflare_certificate")
     async def mock_wait_cert(inputs: CreateCloudflareProxyInputs):
+        called.append("wait_for_cloudflare_certificate")
         _maybe_raise("wait_for_cloudflare_certificate")
+
+    @activity.defn(name="create_managed_proxy")
+    async def mock_create_managed_proxy(inputs: CreateManagedProxyInputs):
+        called.append("create_managed_proxy")
+        _maybe_raise("create_managed_proxy")
+
+    @activity.defn(name="wait_for_certificate")
+    async def mock_wait_for_certificate(inputs: WaitForCertificateInputs):
+        called.append("wait_for_certificate")
+        _maybe_raise("wait_for_certificate")
 
     @activity.defn(name="activity_send_proxy_created_email")
     async def mock_send_email(inputs: SendProxyCreatedEmailInputs):
@@ -66,24 +80,26 @@ def _make_mock_activities(failing_activity: str | None = None, error_type: str =
         mock_update_record,
         mock_create_hostname,
         mock_wait_cert,
+        mock_create_managed_proxy,
+        mock_wait_for_certificate,
         mock_send_email,
         mock_schedule_monitor,
     ]
 
-    return activities, status_updates
+    return activities, status_updates, called
 
 
-def _make_workflow_inputs():
+def _make_workflow_inputs(target_cname: str = "target.example.com"):
     return CreateManagedProxyInputs(
         organization_id=uuid.uuid4(),
         proxy_record_id=uuid.uuid4(),
         domain="test.example.com",
-        target_cname="target.example.com",
+        target_cname=target_cname,
     )
 
 
 @pytest.mark.django_db(transaction=True)
-@patch("posthog.temporal.proxy_service.create.use_cloudflare_proxy", return_value=True)
+@patch("posthog.temporal.proxy_service.create.is_cloudflare_proxy_by_cname", return_value=True)
 class TestCreateManagedProxyWorkflowErrorHandling:
     @pytest.mark.parametrize(
         "failing_activity",
@@ -93,7 +109,7 @@ class TestCreateManagedProxyWorkflowErrorHandling:
         ],
     )
     async def test_activity_error_sets_erroring_status(self, _mock_cloudflare, failing_activity):
-        activities, status_updates = _make_mock_activities(failing_activity=failing_activity)
+        activities, status_updates, _called = _make_mock_activities(failing_activity=failing_activity)
         task_queue = str(uuid.uuid4())
 
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -115,7 +131,7 @@ class TestCreateManagedProxyWorkflowErrorHandling:
         assert "erroring" in status_updates
 
     async def test_record_deleted_exception_returns_without_error(self, _mock_cloudflare):
-        activities, status_updates = _make_mock_activities(
+        activities, status_updates, _called = _make_mock_activities(
             failing_activity="create_cloudflare_custom_hostname",
             error_type="RecordDeletedException",
         )
@@ -139,7 +155,7 @@ class TestCreateManagedProxyWorkflowErrorHandling:
         assert "erroring" not in status_updates
 
     async def test_happy_path_sets_valid_status(self, _mock_cloudflare):
-        activities, status_updates = _make_mock_activities()
+        activities, status_updates, _called = _make_mock_activities()
         task_queue = str(uuid.uuid4())
 
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -161,7 +177,9 @@ class TestCreateManagedProxyWorkflowErrorHandling:
         assert "erroring" not in status_updates
 
     async def test_email_failure_does_not_fail_workflow(self, _mock_cloudflare):
-        activities, status_updates = _make_mock_activities(failing_activity="activity_send_proxy_created_email")
+        activities, status_updates, _called = _make_mock_activities(
+            failing_activity="activity_send_proxy_created_email"
+        )
         task_queue = str(uuid.uuid4())
 
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -181,3 +199,41 @@ class TestCreateManagedProxyWorkflowErrorHandling:
 
         assert "valid" in status_updates
         assert "erroring" not in status_updates
+
+
+@pytest.mark.django_db(transaction=True)
+class TestCreateManagedProxyWorkflowPathSelection:
+    """The provisioning path must follow the record's target_cname, not the global flag, so a
+    retry never migrates a legacy proxy onto Cloudflare after the flag is enabled globally."""
+
+    @pytest.mark.parametrize(
+        "target_cname,expected,forbidden",
+        [
+            ("digest.cf-base.example.com", "create_cloudflare_custom_hostname", "create_managed_proxy"),
+            # Legacy target while the global flag is ON — must still take the legacy path.
+            ("digest.legacy-base.example.com", "create_managed_proxy", "create_cloudflare_custom_hostname"),
+        ],
+    )
+    async def test_path_follows_target_cname_not_global_flag(self, settings, target_cname, expected, forbidden):
+        settings.CLOUDFLARE_PROXY_BASE_CNAME = "cf-base.example.com"
+        settings.CLOUDFLARE_PROXY_ENABLED = True  # flag on — but the target_cname must decide the path
+        activities, _status_updates, called = _make_mock_activities()
+        task_queue = str(uuid.uuid4())
+
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[CreateManagedProxyWorkflow],
+                activities=activities,
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    CreateManagedProxyWorkflow.run,
+                    _make_workflow_inputs(target_cname=target_cname),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+        assert expected in called
+        assert forbidden not in called


### PR DESCRIPTION
## Problem

The create-proxy workflow chose the Cloudflare vs legacy path from the global `CLOUDFLARE_PROXY_ENABLED` flag at runtime. Retrying a proxy created on the legacy path after that flag was enabled re-provisioned it onto Cloudflare, where it can never validate — a live proxy was migrated into a stuck state this way.

## Changes

- Select the provisioning path from the proxy's own `target_cname`, not the global flag, so a retry always stays on the proxy's original path
- New proxies are unaffected — their `target_cname` already reflects the flag's value at creation time

> [!IMPORTANT]
> Stacked on #68175 (path-aware diagnostics); review/merge that first. Third companion — cancellation/`issuing` recovery — is a separate PR.

## How did you test this code?

- 2 workflow tests added proving the path follows `target_cname` even with the flag on; existing create-workflow suite still green.
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Second of three fixes from a client case where a healthy legacy managed proxy was pushed into a broken Cloudflare migration. This addresses the mechanism: `create-proxy` read the path from a global flag rather than the record, so a retry migrated the proxy. The monitor and deletion paths already detect the path per-record via `is_cloudflare_proxy_by_cname`; this aligns provisioning with them.

Skills invoked: /writing-tests, and this description via the creating-pull-requests skill.
