### PR TITLE
feat(tasks): per-org agent log/artifact retention

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1527,20 +1527,16 @@ def _build_artifact_storage_path(run: TaskRun, artifact_id: str, name: str) -> t
 
 
 def _tag_artifact_object(run: TaskRun, storage_path: str) -> None:
-    from posthog.storage import object_storage  # noqa: PLC0415 — keep storage deps off the api import path
-
     from products.tasks.backend.logic.services.staged_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
         RUN_ARTIFACT_TTL_DAYS,
+        tag_task_artifact,
     )
 
-    ttl_days = run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))
-    try:
-        object_storage.tag(storage_path, {"ttl_days": str(ttl_days), "team_id": str(run.team_id)})
-    except Exception as exc:
-        logger.warning(
-            "task_run.artifact_tag_failed",
-            extra={"task_run_id": str(run.id), "storage_path": storage_path, "error": str(exc)},
-        )
+    tag_task_artifact(
+        storage_path,
+        ttl_days=str(run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))),
+        team_id=run.team_id,
+    )
 
 
 def _build_artifact_manifest_entry(
@@ -3454,13 +3450,10 @@ def run_task(
 
     if pending_user_artifact_ids:
         run_artifacts: list[dict] = []
+        run_ttl_days = str(task_run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS)))
         for staged_artifact in staged_artifacts:
             storage_path = str(staged_artifact["storage_path"])
-            tag_task_artifact(
-                storage_path,
-                ttl_days=str(task_run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))),
-                team_id=task.team_id,
-            )
+            tag_task_artifact(storage_path, ttl_days=run_ttl_days, team_id=task.team_id)
             run_artifacts.append(dict(staged_artifact))
 
         task_run.artifacts = run_artifacts

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -36,6 +36,7 @@ from posthog.models.integration import Integration
 from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, is_blocked_sandbox_env_key
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
+from products.tasks.backend.logic.services.staged_artifacts import RUN_ARTIFACT_TTL_DAYS, tag_task_artifact
 from products.tasks.backend.models import (
     CodeInvite,
     CodeInviteRedemption,
@@ -1527,11 +1528,6 @@ def _build_artifact_storage_path(run: TaskRun, artifact_id: str, name: str) -> t
 
 
 def _tag_artifact_object(run: TaskRun, storage_path: str) -> None:
-    from products.tasks.backend.logic.services.staged_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
-        RUN_ARTIFACT_TTL_DAYS,
-        tag_task_artifact,
-    )
-
     tag_task_artifact(
         storage_path,
         ttl_days=str(run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))),
@@ -2986,7 +2982,6 @@ def finalize_task_staged_artifacts(
         build_task_artifact_entry,
         cache_task_staged_artifact,
         get_safe_artifact_name,
-        tag_task_artifact,
     )
     from products.tasks.backend.presentation.serializers import (  # noqa: PLC0415
         build_task_run_artifact_size_error,
@@ -3243,10 +3238,8 @@ def run_task(
     gate (429) is applied by the view before calling this.
     """
     from products.tasks.backend.logic.services.staged_artifacts import (  # noqa: PLC0415
-        RUN_ARTIFACT_TTL_DAYS,
         build_task_staged_artifact_cache_key,
         get_task_staged_artifacts,
-        tag_task_artifact,
     )
     from products.tasks.backend.redis import get_tasks_cache  # noqa: PLC0415
     from products.tasks.backend.temporal.process_task.utils import (  # noqa: PLC0415 — keep temporalio off the api import path

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1529,8 +1529,13 @@ def _build_artifact_storage_path(run: TaskRun, artifact_id: str, name: str) -> t
 def _tag_artifact_object(run: TaskRun, storage_path: str) -> None:
     from posthog.storage import object_storage  # noqa: PLC0415 — keep storage deps off the api import path
 
+    from products.tasks.backend.logic.services.staged_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
+        RUN_ARTIFACT_TTL_DAYS,
+    )
+
+    ttl_days = run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))
     try:
-        object_storage.tag(storage_path, {"ttl_days": "30", "team_id": str(run.team_id)})
+        object_storage.tag(storage_path, {"ttl_days": str(ttl_days), "team_id": str(run.team_id)})
     except Exception as exc:
         logger.warning(
             "task_run.artifact_tag_failed",
@@ -3451,7 +3456,11 @@ def run_task(
         run_artifacts: list[dict] = []
         for staged_artifact in staged_artifacts:
             storage_path = str(staged_artifact["storage_path"])
-            tag_task_artifact(storage_path, ttl_days=RUN_ARTIFACT_TTL_DAYS, team_id=task.team_id)
+            tag_task_artifact(
+                storage_path,
+                ttl_days=str(task_run.resolve_ttl_days(int(RUN_ARTIFACT_TTL_DAYS))),
+                team_id=task.team_id,
+            )
             run_artifacts.append(dict(staged_artifact))
 
         task_run.artifacts = run_artifacts

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1116,23 +1116,26 @@ class TaskRun(models.Model):
 
         object_storage.write(self.log_url, content)
 
-        effective_ttl_days = self.resolve_ttl_days(self.DEFAULT_LOG_TTL_DAYS) if ttl_days == "auto" else ttl_days
-        if is_new_file and effective_ttl_days is not None:
-            try:
-                object_storage.tag(
-                    self.log_url,
-                    {
-                        "ttl_days": str(effective_ttl_days),
-                        "team_id": str(self.team_id),
-                    },
-                )
-            except Exception as e:
-                logger.warning(
-                    "task_run.failed_to_tag_logs",
-                    task_run_id=str(self.id),
-                    log_url=self.log_url,
-                    error=str(e),
-                )
+        if is_new_file:
+            # Resolve inside the guard so appends after the first don't pay for it (a potential
+            # DB hit to lazy-load the org off self.team).
+            effective_ttl_days = self.resolve_ttl_days(self.DEFAULT_LOG_TTL_DAYS) if ttl_days == "auto" else ttl_days
+            if effective_ttl_days is not None:
+                try:
+                    object_storage.tag(
+                        self.log_url,
+                        {
+                            "ttl_days": str(effective_ttl_days),
+                            "team_id": str(self.team_id),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "task_run.failed_to_tag_logs",
+                        task_run_id=str(self.id),
+                        log_url=self.log_url,
+                        error=str(e),
+                    )
 
     def capture_event(self, event: str, properties: dict | None = None, event_uuid: str | None = None) -> None:
         try:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1084,12 +1084,25 @@ class TaskRun(models.Model):
     # expiry — user history must not silently vanish after 30 days.
     DEFAULT_LOG_TTL_DAYS = 30
 
-    def append_log(self, entries: list[dict], *, ttl_days: int | None = DEFAULT_LOG_TTL_DAYS):
+    # Organizations granted extended agent log/artifact retention (e.g. compliance requirements),
+    # keyed by organization UUID → retention in days. Orgs not listed here fall back to the caller's
+    # default. NB: the S3 lifecycle rule honoring the `ttl_days` tag must define a matching tier for
+    # the value to take effect — see the app-assets bucket lifecycle config in cloud-infra.
+    EXTENDED_RETENTION_ORG_IDS: dict[str, int] = {
+        "019bc0eb-5005-0000-e43c-e03292a94627": 365,
+    }
+
+    def resolve_ttl_days(self, default_ttl_days: int) -> int:
+        """Retention (in days) for this run's stored objects, extended for allowlisted organizations."""
+        return self.EXTENDED_RETENTION_ORG_IDS.get(str(self.team.organization_id), default_ttl_days)
+
+    def append_log(self, entries: list[dict], *, ttl_days: int | None | Literal["auto"] = "auto"):
         """Append log entries to S3 storage.
 
-        `ttl_days` tags a newly-created log file for expiry; pass `None` to write a log that is
-        never auto-expired. The tag is only applied on
-        first write — re-tagging an existing log would not change a TTL already in flight.
+        `ttl_days` tags a newly-created log file for expiry. The default `"auto"` resolves the TTL
+        from the run's organization (see `resolve_ttl_days`); pass an explicit int to override,
+        or `None` to write a log that is never auto-expired. The tag is only applied on first
+        write — re-tagging an existing log would not change a TTL already in flight.
         """
         entries = [e for e in entries if not self._is_agent_message_chunk(e)]
         if not entries:
@@ -1103,12 +1116,13 @@ class TaskRun(models.Model):
 
         object_storage.write(self.log_url, content)
 
-        if is_new_file and ttl_days is not None:
+        effective_ttl_days = self.resolve_ttl_days(self.DEFAULT_LOG_TTL_DAYS) if ttl_days == "auto" else ttl_days
+        if is_new_file and effective_ttl_days is not None:
             try:
                 object_storage.tag(
                     self.log_url,
                     {
-                        "ttl_days": str(ttl_days),
+                        "ttl_days": str(effective_ttl_days),
                         "team_id": str(self.team_id),
                     },
                 )

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -714,6 +714,26 @@ class TestTaskRun(TestCase):
             # Tagging might not be available in test environment
             pass
 
+    def test_ttl_default_for_regular_org(self):
+        run = TaskRun.objects.create(task=self.task, team=self.team)
+        self.assertEqual(run.resolve_ttl_days(30), 30)
+        self.assertEqual(run.resolve_ttl_days(1), 1)
+
+    def test_ttl_extended_for_allowlisted_org(self):
+        # Explicit UUID + 365 rather than reading the allowlist back, so removing/changing the
+        # compliance entry fails this test instead of silently reverting the org to 30-day retention.
+        org = Organization.objects.create(id="019bc0eb-5005-0000-e43c-e03292a94627", name="Compliance Org")
+        team = Team.objects.create(organization=org, name="Compliance Team")
+        task = Task.objects.create(
+            team=team,
+            title="Compliance Task",
+            description="Test Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        run = TaskRun.objects.create(task=task, team=team)
+        # Both the log default (30) and the run-artifact default (30) are lifted to the extended value.
+        self.assertEqual(run.resolve_ttl_days(30), 365)
+
     def test_mark_completed(self):
         run = TaskRun.objects.create(
             task=self.task,


### PR DESCRIPTION
## Problem

Agent run logs (the JSONL stream of the agent's messages, "thinking", console and sandbox output) and run artifacts are stored in S3 and tagged with a `ttl_days` value that an S3 lifecycle rule uses to expire them. The default is 30 days, uniform across every org.

Some customers have compliance requirements that mandate longer retention of logs describing how artifacts were produced. There was no way to grant a specific org a longer window.

## Changes

Adds a small org allowlist on `TaskRun` that lifts the retention window for listed organizations (currently one, for a compliance requirement) from the 30-day default to 365 days. Everyone else is unchanged.

- `TaskRun.EXTENDED_RETENTION_ORG_IDS` maps org UUID to retention days. Adding a future org is a one-line entry.
- `TaskRun.resolve_ttl_days(default)` returns the extended value for allowlisted orgs, else the caller's default.
- `append_log` now defaults `ttl_days="auto"`, resolving per-org. Explicit int / `None` overrides still work.
- Run artifact tagging (both the direct-upload and staged-promotion paths) routes through the same resolver.
- Staged / ephemeral artifacts (1-day TTL) are deliberately untouched.

Important: the `ttl_days` tag only has an effect once the destination bucket's lifecycle config honors it. Today the app-assets bucket (where task logs live) has no rule acting on this tag at all, so the tag is currently inert and logs persist indefinitely regardless of value. A companion cloud-infra change adds the lifecycle rules (tag-based tiers scoped to the `tasks/` prefix, including a 365 tier). This PR is the code half; it is safe to merge independently but does not change real-world retention until the infra half lands.

## How did you test this code?

Automated (all run locally, green):
- `test_ttl_extended_for_allowlisted_org` — a run whose org is on the allowlist resolves to 365. The UUID and 365 are asserted literally rather than read back from the allowlist, so removing or changing the compliance entry fails this test instead of silently reverting the org to 30 days. This is the regression that matters for the compliance guarantee.
- `test_ttl_default_for_regular_org` — a normal org still resolves to the caller's default (30, and 1 for the ephemeral case).
- Existing `test_log_file_tagged_with_ttl` and the artifact tag/finalize tests still pass, confirming the default path is unchanged for non-allowlisted orgs.

I (Claude) did not do manual end-to-end testing against real S3.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael directed this while investigating a customer compliance question about agent-log retention. I (Claude) traced the existing tagging path and found two things: the 30-day TTL was uniform with no per-org override, and separately the tag is currently inert on the app-assets bucket because no lifecycle rule acts on it (a pre-existing gap from the S3-migration PR, tracked separately with the infra owner).

Decisions along the way: chose a hardcoded allowlist dict over a DB field or setting, since the need is "one org now, maybe more later" and a config-driven system would be premature. Generalized the original log-only resolver to cover run artifacts too after confirming the compliance framing covers produced artifacts, while leaving the deliberately-ephemeral staged artifacts (1-day) alone. No skills were required (no migration, serializer, or endpoint-contract changes).
