### PR TITLE
feat(tasks): expose task automation MCP tools

### DIFF
--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -42,9 +42,9 @@ tools:
         title: Create task automation
         description: >
             Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`,
-            `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally
-            set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the
-            calling token's organization to have Tasks access enabled.
+            `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`.
+            Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`.
+            Requires the calling token's organization to have Tasks access enabled.
         feature_flag: tasks
     task-automations-destroy:
         operation: task_automations_destroy
@@ -87,9 +87,9 @@ tools:
             idempotent: false
         title: Update task automation
         description: >
-            Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`,
-            `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule
-            without deleting the automation.
+            Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`,
+            `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to
+            pause the schedule without deleting the automation.
         feature_flag: tasks
     task-automations-retrieve:
         operation: task_automations_retrieve

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -32,22 +32,93 @@ tools:
         enabled: false
     task-automations-create:
         operation: task_automations_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create task automation
+        description: >
+            Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`,
+            `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally
+            set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the
+            calling token's organization to have Tasks access enabled.
+        feature_flag: tasks
     task-automations-destroy:
         operation: task_automations_destroy
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete task automation
+        description: >
+            Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be
+            undone.
+        feature_flag: tasks
     task-automations-list:
         operation: task_automations_list
-        enabled: false
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List task automations
+        description: >
+            List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a
+            GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run.
+            Requires the calling token's organization to have Tasks access enabled.
+        feature_flag: tasks
     task-automations-partial-update:
         operation: task_automations_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Update task automation
+        description: >
+            Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`,
+            `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule
+            without deleting the automation.
+        feature_flag: tasks
     task-automations-retrieve:
         operation: task_automations_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get task automation
+        description: >
+            Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled
+            state, and the status, timestamp, and any error from its most recent run.
+        feature_flag: tasks
     task-automations-run-create:
         operation: task_automations_run_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run task automation
+        description: >
+            Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation
+            with its updated last-run status.
+        feature_flag: tasks
     tasks-create:
         operation: tasks_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -8841,5 +8841,95 @@
             "openWorldHint": true,
             "readOnlyHint": false
         }
+    },
+    "task-automations-list": {
+        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task automations",
+        "title": "List task automations",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-retrieve": {
+        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task automation",
+        "title": "Get task automation",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-create": {
+        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task automation",
+        "title": "Create task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-partial-update": {
+        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Update task automation",
+        "title": "Update task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-destroy": {
+        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Delete task automation",
+        "title": "Delete task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-run-create": {
+        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Run task automation",
+        "title": "Run task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
     }
 }

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -7518,6 +7518,96 @@
             "readOnlyHint": true
         }
     },
+    "task-automations-create": {
+        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task automation",
+        "title": "Create task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-destroy": {
+        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Delete task automation",
+        "title": "Delete task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-list": {
+        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task automations",
+        "title": "List task automations",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-partial-update": {
+        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Update task automation",
+        "title": "Update task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-retrieve": {
+        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task automation",
+        "title": "Get task automation",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-run-create": {
+        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Run task automation",
+        "title": "Run task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
     "tasks-list": {
         "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
@@ -8841,95 +8931,5 @@
             "openWorldHint": true,
             "readOnlyHint": false
         }
-    },
-    "task-automations-list": {
-        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "List task automations",
-        "title": "List task automations",
-        "required_scopes": ["task:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-retrieve": {
-        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Get task automation",
-        "title": "Get task automation",
-        "required_scopes": ["task:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-create": {
-        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Create task automation",
-        "title": "Create task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-partial-update": {
-        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Update task automation",
-        "title": "Update task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-destroy": {
-        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Delete task automation",
-        "title": "Delete task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-run-create": {
-        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Run task automation",
-        "title": "Run task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
     }
 }

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -9450,5 +9450,95 @@
             "openWorldHint": true,
             "readOnlyHint": false
         }
+    },
+    "task-automations-list": {
+        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task automations",
+        "title": "List task automations",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-retrieve": {
+        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task automation",
+        "title": "Get task automation",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-create": {
+        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task automation",
+        "title": "Create task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-partial-update": {
+        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Update task automation",
+        "title": "Update task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-destroy": {
+        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Delete task automation",
+        "title": "Delete task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-run-create": {
+        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Run task automation",
+        "title": "Run task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
     }
 }

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -8057,6 +8057,96 @@
             "readOnlyHint": false
         }
     },
+    "task-automations-create": {
+        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task automation",
+        "title": "Create task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-destroy": {
+        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Delete task automation",
+        "title": "Delete task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-list": {
+        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "List task automations",
+        "title": "List task automations",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-partial-update": {
+        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Update task automation",
+        "title": "Update task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-retrieve": {
+        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Get task automation",
+        "title": "Get task automation",
+        "required_scopes": ["task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "task-automations-run-create": {
+        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Run task automation",
+        "title": "Run task automation",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
     "tasks-list": {
         "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
@@ -9450,95 +9540,5 @@
             "openWorldHint": true,
             "readOnlyHint": false
         }
-    },
-    "task-automations-list": {
-        "description": "List task automations in the current project. Each automation is a cron-scheduled prompt that runs against a GitHub repository. Returns the schedule, target repository, enabled state, and the status of the last run. Requires the calling token's organization to have Tasks access enabled.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "List task automations",
-        "title": "List task automations",
-        "required_scopes": ["task:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-retrieve": {
-        "description": "Get a single task automation by ID, including its schedule, prompt, target repository, timezone, enabled state, and the status, timestamp, and any error from its most recent run.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Get task automation",
-        "title": "Get task automation",
-        "required_scopes": ["task:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-create": {
-        "description": "Create a task automation — a cron-scheduled prompt that runs against a GitHub repository. Requires `name`, `prompt`, `repository` (in `organization/repository` format), and a valid 5-field `cron_expression`. Optionally set `timezone` (IANA, defaults to UTC), `github_integration`, `template_id`, and `enabled`. Requires the calling token's organization to have Tasks access enabled.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Create task automation",
-        "title": "Create task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-partial-update": {
-        "description": "Update a task automation by ID. Any field can be changed — `name`, `prompt`, `repository`, `cron_expression`, `timezone`, `github_integration`, `template_id`, or `enabled`. Pass `enabled: false` to pause the schedule without deleting the automation.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Update task automation",
-        "title": "Update task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-destroy": {
-        "description": "Permanently delete a task automation by ID. This stops it from running on its schedule. This cannot be undone.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Delete task automation",
-        "title": "Delete task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
-    },
-    "task-automations-run-create": {
-        "description": "Trigger a task automation to run immediately, outside of its normal cron schedule. Returns the automation with its updated last-run status.",
-        "category": "Tasks",
-        "feature": "tasks",
-        "summary": "Run task automation",
-        "title": "Run task automation",
-        "required_scopes": ["task:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        },
-        "feature_flag": "tasks"
     }
 }

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -3,10 +3,180 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 5 enabled ops
+ * PostHog API - MCP 11 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const TaskAutomationsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const taskAutomationsCreateBodyNameMax = 255
+
+export const taskAutomationsCreateBodyRepositoryMax = 255
+
+export const taskAutomationsCreateBodyCronExpressionMax = 100
+
+export const taskAutomationsCreateBodyTimezoneDefault = `UTC`
+export const taskAutomationsCreateBodyTimezoneMax = 128
+
+export const taskAutomationsCreateBodyTemplateIdMax = 255
+
+export const taskAutomationsCreateBodyEnabledDefault = true
+
+export const TaskAutomationsCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(taskAutomationsCreateBodyNameMax)
+            .describe("Display name (stored as the backing task's title)."),
+        prompt: zod.string().describe("The automation prompt (stored as the backing task's description)."),
+        repository: zod
+            .string()
+            .max(taskAutomationsCreateBodyRepositoryMax)
+            .describe('Target repository in the format organization/repository.'),
+        github_integration: zod
+            .number()
+            .nullish()
+            .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
+        cron_expression: zod
+            .string()
+            .max(taskAutomationsCreateBodyCronExpressionMax)
+            .describe('Standard 5-field cron expression (minute hour day month weekday).'),
+        timezone: zod
+            .string()
+            .max(taskAutomationsCreateBodyTimezoneMax)
+            .default(taskAutomationsCreateBodyTimezoneDefault)
+            .describe('IANA timezone the schedule runs in.'),
+        template_id: zod
+            .string()
+            .max(taskAutomationsCreateBodyTemplateIdMax)
+            .nullish()
+            .describe('Optional template identifier this automation was created from.'),
+        enabled: zod
+            .boolean()
+            .default(taskAutomationsCreateBodyEnabledDefault)
+            .describe('Whether the schedule is active; paused when false.'),
+    })
+    .describe('Request body for creating or updating a task automation.')
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const taskAutomationsPartialUpdateBodyNameMax = 255
+
+export const taskAutomationsPartialUpdateBodyRepositoryMax = 255
+
+export const taskAutomationsPartialUpdateBodyCronExpressionMax = 100
+
+export const taskAutomationsPartialUpdateBodyTimezoneMax = 128
+
+export const taskAutomationsPartialUpdateBodyTemplateIdMax = 255
+
+export const TaskAutomationsPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(taskAutomationsPartialUpdateBodyNameMax)
+            .optional()
+            .describe("Display name (stored as the backing task's title)."),
+        prompt: zod.string().optional().describe("The automation prompt (stored as the backing task's description)."),
+        repository: zod
+            .string()
+            .max(taskAutomationsPartialUpdateBodyRepositoryMax)
+            .optional()
+            .describe('Target repository in the format organization/repository.'),
+        github_integration: zod
+            .number()
+            .nullish()
+            .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
+        cron_expression: zod
+            .string()
+            .max(taskAutomationsPartialUpdateBodyCronExpressionMax)
+            .optional()
+            .describe('Standard 5-field cron expression (minute hour day month weekday).'),
+        timezone: zod
+            .string()
+            .max(taskAutomationsPartialUpdateBodyTimezoneMax)
+            .optional()
+            .describe('IANA timezone the schedule runs in.'),
+        template_id: zod
+            .string()
+            .max(taskAutomationsPartialUpdateBodyTemplateIdMax)
+            .nullish()
+            .describe('Optional template identifier this automation was created from.'),
+        enabled: zod.boolean().optional().describe('Whether the schedule is active; paused when false.'),
+    })
+    .describe('Request body for creating or updating a task automation.')
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * API for managing scheduled task automations.
+ */
+export const TaskAutomationsRunCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 /**
  * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, repository, and created_by.
@@ -164,170 +334,4 @@ export const TasksRunsSessionLogsRetrieveQueryParams = /* @__PURE__ */ zod.objec
         .min(tasksRunsSessionLogsRetrieveQueryOffsetMin)
         .default(tasksRunsSessionLogsRetrieveQueryOffsetDefault)
         .describe('Zero-based offset into the filtered log entries'),
-})
-
-/**
- * List task automations for the current project.
- * @summary List task automations
- */
-export const TaskAutomationsListParams = /* @__PURE__ */ zod.object({
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const TaskAutomationsListQueryParams = /* @__PURE__ */ zod.object({
-    limit: zod.number().optional().describe('Number of results to return per page.'),
-    offset: zod.number().optional().describe('The initial index from which to return the results.'),
-})
-
-/**
- * Create a task automation.
- * @summary Create task automation
- */
-export const TaskAutomationsCreateParams = /* @__PURE__ */ zod.object({
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const taskAutomationsCreateBodyNameMax = 255
-
-export const taskAutomationsCreateBodyRepositoryMax = 255
-
-export const taskAutomationsCreateBodyCronExpressionMax = 100
-
-export const taskAutomationsCreateBodyTimezoneMax = 128
-
-export const taskAutomationsCreateBodyTemplateIdMax = 255
-
-export const TaskAutomationsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod
-        .string()
-        .max(taskAutomationsCreateBodyNameMax)
-        .describe("Display name (stored as the backing task's title)."),
-    prompt: zod.string().describe("The automation prompt (stored as the backing task's description)."),
-    repository: zod
-        .string()
-        .max(taskAutomationsCreateBodyRepositoryMax)
-        .describe('Target repository in the format organization/repository.'),
-    github_integration: zod
-        .number()
-        .nullish()
-        .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
-    cron_expression: zod
-        .string()
-        .max(taskAutomationsCreateBodyCronExpressionMax)
-        .describe('Standard 5-field cron expression (minute hour day month weekday).'),
-    timezone: zod
-        .string()
-        .max(taskAutomationsCreateBodyTimezoneMax)
-        .optional()
-        .describe('IANA timezone the schedule runs in.'),
-    template_id: zod
-        .string()
-        .max(taskAutomationsCreateBodyTemplateIdMax)
-        .nullish()
-        .describe('Optional template identifier this automation was created from.'),
-    enabled: zod.boolean().optional().describe('Whether the schedule is active; paused when false.'),
-})
-
-/**
- * Retrieve a single task automation by ID.
- * @summary Get task automation
- */
-export const TaskAutomationsRetrieveParams = /* @__PURE__ */ zod.object({
-    id: zod.string(),
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-/**
- * Update a task automation.
- * @summary Update task automation
- */
-export const TaskAutomationsPartialUpdateParams = /* @__PURE__ */ zod.object({
-    id: zod.string(),
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const taskAutomationsPartialUpdateBodyNameMax = 255
-
-export const taskAutomationsPartialUpdateBodyRepositoryMax = 255
-
-export const taskAutomationsPartialUpdateBodyCronExpressionMax = 100
-
-export const taskAutomationsPartialUpdateBodyTimezoneMax = 128
-
-export const taskAutomationsPartialUpdateBodyTemplateIdMax = 255
-
-export const TaskAutomationsPartialUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod
-        .string()
-        .max(taskAutomationsPartialUpdateBodyNameMax)
-        .optional()
-        .describe("Display name (stored as the backing task's title)."),
-    prompt: zod.string().optional().describe("The automation prompt (stored as the backing task's description)."),
-    repository: zod
-        .string()
-        .max(taskAutomationsPartialUpdateBodyRepositoryMax)
-        .optional()
-        .describe('Target repository in the format organization/repository.'),
-    github_integration: zod
-        .number()
-        .nullish()
-        .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
-    cron_expression: zod
-        .string()
-        .max(taskAutomationsPartialUpdateBodyCronExpressionMax)
-        .optional()
-        .describe('Standard 5-field cron expression (minute hour day month weekday).'),
-    timezone: zod
-        .string()
-        .max(taskAutomationsPartialUpdateBodyTimezoneMax)
-        .optional()
-        .describe('IANA timezone the schedule runs in.'),
-    template_id: zod
-        .string()
-        .max(taskAutomationsPartialUpdateBodyTemplateIdMax)
-        .nullish()
-        .describe('Optional template identifier this automation was created from.'),
-    enabled: zod.boolean().optional().describe('Whether the schedule is active; paused when false.'),
-})
-
-/**
- * Delete a task automation.
- * @summary Delete task automation
- */
-export const TaskAutomationsDestroyParams = /* @__PURE__ */ zod.object({
-    id: zod.string(),
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-/**
- * Trigger a task automation to run immediately.
- * @summary Run task automation
- */
-export const TaskAutomationsRunCreateParams = /* @__PURE__ */ zod.object({
-    id: zod.string(),
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
 })

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -165,3 +165,169 @@ export const TasksRunsSessionLogsRetrieveQueryParams = /* @__PURE__ */ zod.objec
         .default(tasksRunsSessionLogsRetrieveQueryOffsetDefault)
         .describe('Zero-based offset into the filtered log entries'),
 })
+
+/**
+ * List task automations for the current project.
+ * @summary List task automations
+ */
+export const TaskAutomationsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const TaskAutomationsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Create a task automation.
+ * @summary Create task automation
+ */
+export const TaskAutomationsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const taskAutomationsCreateBodyNameMax = 255
+
+export const taskAutomationsCreateBodyRepositoryMax = 255
+
+export const taskAutomationsCreateBodyCronExpressionMax = 100
+
+export const taskAutomationsCreateBodyTimezoneMax = 128
+
+export const taskAutomationsCreateBodyTemplateIdMax = 255
+
+export const TaskAutomationsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(taskAutomationsCreateBodyNameMax)
+        .describe("Display name (stored as the backing task's title)."),
+    prompt: zod.string().describe("The automation prompt (stored as the backing task's description)."),
+    repository: zod
+        .string()
+        .max(taskAutomationsCreateBodyRepositoryMax)
+        .describe('Target repository in the format organization/repository.'),
+    github_integration: zod
+        .number()
+        .nullish()
+        .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
+    cron_expression: zod
+        .string()
+        .max(taskAutomationsCreateBodyCronExpressionMax)
+        .describe('Standard 5-field cron expression (minute hour day month weekday).'),
+    timezone: zod
+        .string()
+        .max(taskAutomationsCreateBodyTimezoneMax)
+        .optional()
+        .describe('IANA timezone the schedule runs in.'),
+    template_id: zod
+        .string()
+        .max(taskAutomationsCreateBodyTemplateIdMax)
+        .nullish()
+        .describe('Optional template identifier this automation was created from.'),
+    enabled: zod.boolean().optional().describe('Whether the schedule is active; paused when false.'),
+})
+
+/**
+ * Retrieve a single task automation by ID.
+ * @summary Get task automation
+ */
+export const TaskAutomationsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Update a task automation.
+ * @summary Update task automation
+ */
+export const TaskAutomationsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const taskAutomationsPartialUpdateBodyNameMax = 255
+
+export const taskAutomationsPartialUpdateBodyRepositoryMax = 255
+
+export const taskAutomationsPartialUpdateBodyCronExpressionMax = 100
+
+export const taskAutomationsPartialUpdateBodyTimezoneMax = 128
+
+export const taskAutomationsPartialUpdateBodyTemplateIdMax = 255
+
+export const TaskAutomationsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(taskAutomationsPartialUpdateBodyNameMax)
+        .optional()
+        .describe("Display name (stored as the backing task's title)."),
+    prompt: zod.string().optional().describe("The automation prompt (stored as the backing task's description)."),
+    repository: zod
+        .string()
+        .max(taskAutomationsPartialUpdateBodyRepositoryMax)
+        .optional()
+        .describe('Target repository in the format organization/repository.'),
+    github_integration: zod
+        .number()
+        .nullish()
+        .describe("GitHub integration to run as. Defaults to the team's GitHub integration when omitted."),
+    cron_expression: zod
+        .string()
+        .max(taskAutomationsPartialUpdateBodyCronExpressionMax)
+        .optional()
+        .describe('Standard 5-field cron expression (minute hour day month weekday).'),
+    timezone: zod
+        .string()
+        .max(taskAutomationsPartialUpdateBodyTimezoneMax)
+        .optional()
+        .describe('IANA timezone the schedule runs in.'),
+    template_id: zod
+        .string()
+        .max(taskAutomationsPartialUpdateBodyTemplateIdMax)
+        .nullish()
+        .describe('Optional template identifier this automation was created from.'),
+    enabled: zod.boolean().optional().describe('Whether the schedule is active; paused when false.'),
+})
+
+/**
+ * Delete a task automation.
+ * @summary Delete task automation
+ */
+export const TaskAutomationsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Trigger a task automation to run immediately.
+ * @summary Run task automation
+ */
+export const TaskAutomationsRunCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -21,6 +21,160 @@ import {
 import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
+const TaskAutomationsCreateSchema = TaskAutomationsCreateBody
+
+const taskAutomationsCreate = (): ToolBase<typeof TaskAutomationsCreateSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-create',
+    schema: TaskAutomationsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.repository !== undefined) {
+            body['repository'] = params.repository
+        }
+        if (params.github_integration !== undefined) {
+            body['github_integration'] = params.github_integration
+        }
+        if (params.cron_expression !== undefined) {
+            body['cron_expression'] = params.cron_expression
+        }
+        if (params.timezone !== undefined) {
+            body['timezone'] = params.timezone
+        }
+        if (params.template_id !== undefined) {
+            body['template_id'] = params.template_id
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsDestroySchema = TaskAutomationsDestroyParams.omit({ project_id: true })
+
+const taskAutomationsDestroy = (): ToolBase<typeof TaskAutomationsDestroySchema, unknown> => ({
+    name: 'task-automations-destroy',
+    schema: TaskAutomationsDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsListSchema = TaskAutomationsListQueryParams
+
+const taskAutomationsList = (): ToolBase<
+    typeof TaskAutomationsListSchema,
+    WithPostHogUrl<Schemas.PaginatedTaskAutomationDTOList>
+> => ({
+    name: 'task-automations-list',
+    schema: TaskAutomationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedTaskAutomationDTOList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/tasks')
+    },
+})
+
+const TaskAutomationsPartialUpdateSchema = TaskAutomationsPartialUpdateParams.omit({ project_id: true }).extend(
+    TaskAutomationsPartialUpdateBody.shape
+)
+
+const taskAutomationsPartialUpdate = (): ToolBase<
+    typeof TaskAutomationsPartialUpdateSchema,
+    Schemas.TaskAutomationDTO
+> => ({
+    name: 'task-automations-partial-update',
+    schema: TaskAutomationsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.repository !== undefined) {
+            body['repository'] = params.repository
+        }
+        if (params.github_integration !== undefined) {
+            body['github_integration'] = params.github_integration
+        }
+        if (params.cron_expression !== undefined) {
+            body['cron_expression'] = params.cron_expression
+        }
+        if (params.timezone !== undefined) {
+            body['timezone'] = params.timezone
+        }
+        if (params.template_id !== undefined) {
+            body['template_id'] = params.template_id
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsRetrieveSchema = TaskAutomationsRetrieveParams.omit({ project_id: true })
+
+const taskAutomationsRetrieve = (): ToolBase<typeof TaskAutomationsRetrieveSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-retrieve',
+    schema: TaskAutomationsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsRunCreateSchema = TaskAutomationsRunCreateParams.omit({ project_id: true })
+
+const taskAutomationsRunCreate = (): ToolBase<typeof TaskAutomationsRunCreateSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-run-create',
+    schema: TaskAutomationsRunCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRunCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/run/`,
+        })
+        return result
+    },
+})
+
 const TasksListSchema = TasksListQueryParams
 
 const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.PaginatedTaskDetailDTOList>> => ({
@@ -183,170 +337,16 @@ const tasksRunsSessionLogsRetrieve = (): ToolBase<typeof TasksRunsSessionLogsRet
     },
 })
 
-const TaskAutomationsListSchema = TaskAutomationsListQueryParams
-
-const taskAutomationsList = (): ToolBase<
-    typeof TaskAutomationsListSchema,
-    Schemas.PaginatedTaskAutomationDTOList
-> => ({
-    name: 'task-automations-list',
-    schema: TaskAutomationsListSchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsListSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.PaginatedTaskAutomationDTOList>({
-            method: 'GET',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
-            query: {
-                limit: params.limit,
-                offset: params.offset,
-            },
-        })
-        return result
-    },
-})
-
-const TaskAutomationsCreateSchema = TaskAutomationsCreateBody
-
-const taskAutomationsCreate = (): ToolBase<typeof TaskAutomationsCreateSchema, Schemas.TaskAutomationDTO> => ({
-    name: 'task-automations-create',
-    schema: TaskAutomationsCreateSchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsCreateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.name !== undefined) {
-            body['name'] = params.name
-        }
-        if (params.prompt !== undefined) {
-            body['prompt'] = params.prompt
-        }
-        if (params.repository !== undefined) {
-            body['repository'] = params.repository
-        }
-        if (params.github_integration !== undefined) {
-            body['github_integration'] = params.github_integration
-        }
-        if (params.cron_expression !== undefined) {
-            body['cron_expression'] = params.cron_expression
-        }
-        if (params.timezone !== undefined) {
-            body['timezone'] = params.timezone
-        }
-        if (params.template_id !== undefined) {
-            body['template_id'] = params.template_id
-        }
-        if (params.enabled !== undefined) {
-            body['enabled'] = params.enabled
-        }
-        const result = await context.api.request<Schemas.TaskAutomationDTO>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
-            body,
-        })
-        return result
-    },
-})
-
-const TaskAutomationsRetrieveSchema = TaskAutomationsRetrieveParams.omit({ project_id: true })
-
-const taskAutomationsRetrieve = (): ToolBase<typeof TaskAutomationsRetrieveSchema, Schemas.TaskAutomationDTO> => ({
-    name: 'task-automations-retrieve',
-    schema: TaskAutomationsRetrieveSchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRetrieveSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.TaskAutomationDTO>({
-            method: 'GET',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
-        })
-        return result
-    },
-})
-
-const TaskAutomationsPartialUpdateSchema = TaskAutomationsPartialUpdateParams.omit({ project_id: true }).extend(
-    TaskAutomationsPartialUpdateBody.shape
-)
-
-const taskAutomationsPartialUpdate = (): ToolBase<
-    typeof TaskAutomationsPartialUpdateSchema,
-    Schemas.TaskAutomationDTO
-> => ({
-    name: 'task-automations-partial-update',
-    schema: TaskAutomationsPartialUpdateSchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsPartialUpdateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.name !== undefined) {
-            body['name'] = params.name
-        }
-        if (params.prompt !== undefined) {
-            body['prompt'] = params.prompt
-        }
-        if (params.repository !== undefined) {
-            body['repository'] = params.repository
-        }
-        if (params.github_integration !== undefined) {
-            body['github_integration'] = params.github_integration
-        }
-        if (params.cron_expression !== undefined) {
-            body['cron_expression'] = params.cron_expression
-        }
-        if (params.timezone !== undefined) {
-            body['timezone'] = params.timezone
-        }
-        if (params.template_id !== undefined) {
-            body['template_id'] = params.template_id
-        }
-        if (params.enabled !== undefined) {
-            body['enabled'] = params.enabled
-        }
-        const result = await context.api.request<Schemas.TaskAutomationDTO>({
-            method: 'PATCH',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
-            body,
-        })
-        return result
-    },
-})
-
-const TaskAutomationsDestroySchema = TaskAutomationsDestroyParams.omit({ project_id: true })
-
-const taskAutomationsDestroy = (): ToolBase<typeof TaskAutomationsDestroySchema, unknown> => ({
-    name: 'task-automations-destroy',
-    schema: TaskAutomationsDestroySchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsDestroySchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<unknown>({
-            method: 'DELETE',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
-        })
-        return result
-    },
-})
-
-const TaskAutomationsRunCreateSchema = TaskAutomationsRunCreateParams.omit({ project_id: true })
-
-const taskAutomationsRunCreate = (): ToolBase<typeof TaskAutomationsRunCreateSchema, Schemas.TaskAutomationDTO> => ({
-    name: 'task-automations-run-create',
-    schema: TaskAutomationsRunCreateSchema,
-    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRunCreateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.TaskAutomationDTO>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/run/`,
-        })
-        return result
-    },
-})
-
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'task-automations-create': taskAutomationsCreate,
+    'task-automations-destroy': taskAutomationsDestroy,
+    'task-automations-list': taskAutomationsList,
+    'task-automations-partial-update': taskAutomationsPartialUpdate,
+    'task-automations-retrieve': taskAutomationsRetrieve,
+    'task-automations-run-create': taskAutomationsRunCreate,
     'tasks-list': tasksList,
     'tasks-retrieve': tasksRetrieve,
     'tasks-runs-list': tasksRunsList,
     'tasks-runs-retrieve': tasksRunsRetrieve,
     'tasks-runs-session-logs-retrieve': tasksRunsSessionLogsRetrieve,
-    'task-automations-list': taskAutomationsList,
-    'task-automations-create': taskAutomationsCreate,
-    'task-automations-retrieve': taskAutomationsRetrieve,
-    'task-automations-partial-update': taskAutomationsPartialUpdate,
-    'task-automations-destroy': taskAutomationsDestroy,
-    'task-automations-run-create': taskAutomationsRunCreate,
 }

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -3,6 +3,13 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    TaskAutomationsCreateBody,
+    TaskAutomationsDestroyParams,
+    TaskAutomationsListQueryParams,
+    TaskAutomationsPartialUpdateBody,
+    TaskAutomationsPartialUpdateParams,
+    TaskAutomationsRetrieveParams,
+    TaskAutomationsRunCreateParams,
     TasksListQueryParams,
     TasksRetrieveParams,
     TasksRunsListParams,
@@ -176,10 +183,170 @@ const tasksRunsSessionLogsRetrieve = (): ToolBase<typeof TasksRunsSessionLogsRet
     },
 })
 
+const TaskAutomationsListSchema = TaskAutomationsListQueryParams
+
+const taskAutomationsList = (): ToolBase<
+    typeof TaskAutomationsListSchema,
+    Schemas.PaginatedTaskAutomationDTOList
+> => ({
+    name: 'task-automations-list',
+    schema: TaskAutomationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedTaskAutomationDTOList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return result
+    },
+})
+
+const TaskAutomationsCreateSchema = TaskAutomationsCreateBody
+
+const taskAutomationsCreate = (): ToolBase<typeof TaskAutomationsCreateSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-create',
+    schema: TaskAutomationsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.repository !== undefined) {
+            body['repository'] = params.repository
+        }
+        if (params.github_integration !== undefined) {
+            body['github_integration'] = params.github_integration
+        }
+        if (params.cron_expression !== undefined) {
+            body['cron_expression'] = params.cron_expression
+        }
+        if (params.timezone !== undefined) {
+            body['timezone'] = params.timezone
+        }
+        if (params.template_id !== undefined) {
+            body['template_id'] = params.template_id
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsRetrieveSchema = TaskAutomationsRetrieveParams.omit({ project_id: true })
+
+const taskAutomationsRetrieve = (): ToolBase<typeof TaskAutomationsRetrieveSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-retrieve',
+    schema: TaskAutomationsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsPartialUpdateSchema = TaskAutomationsPartialUpdateParams.omit({ project_id: true }).extend(
+    TaskAutomationsPartialUpdateBody.shape
+)
+
+const taskAutomationsPartialUpdate = (): ToolBase<
+    typeof TaskAutomationsPartialUpdateSchema,
+    Schemas.TaskAutomationDTO
+> => ({
+    name: 'task-automations-partial-update',
+    schema: TaskAutomationsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.repository !== undefined) {
+            body['repository'] = params.repository
+        }
+        if (params.github_integration !== undefined) {
+            body['github_integration'] = params.github_integration
+        }
+        if (params.cron_expression !== undefined) {
+            body['cron_expression'] = params.cron_expression
+        }
+        if (params.timezone !== undefined) {
+            body['timezone'] = params.timezone
+        }
+        if (params.template_id !== undefined) {
+            body['template_id'] = params.template_id
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsDestroySchema = TaskAutomationsDestroyParams.omit({ project_id: true })
+
+const taskAutomationsDestroy = (): ToolBase<typeof TaskAutomationsDestroySchema, unknown> => ({
+    name: 'task-automations-destroy',
+    schema: TaskAutomationsDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const TaskAutomationsRunCreateSchema = TaskAutomationsRunCreateParams.omit({ project_id: true })
+
+const taskAutomationsRunCreate = (): ToolBase<typeof TaskAutomationsRunCreateSchema, Schemas.TaskAutomationDTO> => ({
+    name: 'task-automations-run-create',
+    schema: TaskAutomationsRunCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TaskAutomationsRunCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TaskAutomationDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/task_automations/${encodeURIComponent(String(params.id))}/run/`,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'tasks-list': tasksList,
     'tasks-retrieve': tasksRetrieve,
     'tasks-runs-list': tasksRunsList,
     'tasks-runs-retrieve': tasksRunsRetrieve,
     'tasks-runs-session-logs-retrieve': tasksRunsSessionLogsRetrieve,
+    'task-automations-list': taskAutomationsList,
+    'task-automations-create': taskAutomationsCreate,
+    'task-automations-retrieve': taskAutomationsRetrieve,
+    'task-automations-partial-update': taskAutomationsPartialUpdate,
+    'task-automations-destroy': taskAutomationsDestroy,
+    'task-automations-run-create': taskAutomationsRunCreate,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-create.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Request body for creating or updating a task automation.",
     "properties": {
         "cron_expression": {
             "description": "Standard 5-field cron expression (minute hour day month weekday).",
@@ -7,6 +8,7 @@
             "type": "string"
         },
         "enabled": {
+            "default": true,
             "description": "Whether the schedule is active; paused when false.",
             "type": "boolean"
         },
@@ -48,6 +50,7 @@
             "description": "Optional template identifier this automation was created from."
         },
         "timezone": {
+            "default": "UTC",
             "description": "IANA timezone the schedule runs in.",
             "maxLength": 128,
             "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-create.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "cron_expression": {
+            "description": "Standard 5-field cron expression (minute hour day month weekday).",
+            "maxLength": 100,
+            "type": "string"
+        },
+        "enabled": {
+            "description": "Whether the schedule is active; paused when false.",
+            "type": "boolean"
+        },
+        "github_integration": {
+            "anyOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "GitHub integration to run as. Defaults to the team's GitHub integration when omitted."
+        },
+        "name": {
+            "description": "Display name (stored as the backing task's title).",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "prompt": {
+            "description": "The automation prompt (stored as the backing task's description).",
+            "type": "string"
+        },
+        "repository": {
+            "description": "Target repository in the format organization/repository.",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "template_id": {
+            "anyOf": [
+                {
+                    "maxLength": 255,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional template identifier this automation was created from."
+        },
+        "timezone": {
+            "description": "IANA timezone the schedule runs in.",
+            "maxLength": 128,
+            "type": "string"
+        }
+    },
+    "required": ["name", "prompt", "repository", "cron_expression"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-destroy.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-destroy.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-partial-update.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "cron_expression": {
+            "description": "Standard 5-field cron expression (minute hour day month weekday).",
+            "maxLength": 100,
+            "type": "string"
+        },
+        "enabled": {
+            "description": "Whether the schedule is active; paused when false.",
+            "type": "boolean"
+        },
+        "github_integration": {
+            "anyOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "GitHub integration to run as. Defaults to the team's GitHub integration when omitted."
+        },
+        "id": {
+            "type": "string"
+        },
+        "name": {
+            "description": "Display name (stored as the backing task's title).",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "prompt": {
+            "description": "The automation prompt (stored as the backing task's description).",
+            "type": "string"
+        },
+        "repository": {
+            "description": "Target repository in the format organization/repository.",
+            "maxLength": 255,
+            "type": "string"
+        },
+        "template_id": {
+            "anyOf": [
+                {
+                    "maxLength": 255,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional template identifier this automation was created from."
+        },
+        "timezone": {
+            "description": "IANA timezone the schedule runs in.",
+            "maxLength": 128,
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-retrieve.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-run-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/task-automations-run-create.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

The Tasks product exposes task automations (cron-scheduled prompts that run against a GitHub repo) over the REST API, but there was no way to manage them from the MCP server. Agents could list and read tasks and task runs, but not create, inspect, edit, delete, or trigger the automations that schedule them.

## Changes

Enabled the six `task_automations` operations that were already scaffolded (disabled) in the Tasks MCP config, and committed the artifacts the codegen produces from them:

- `products/tasks/mcp/tools.yaml` — flipped the six stubs to `enabled: true` with scopes, annotations, titles and descriptions. Reads (`list`, `retrieve`) use `task:read`; writes (`create`, `partial-update`, `destroy`, `run-create`) use `task:write`. All six carry `feature_flag: tasks`, matching the existing tasks tools.
- `services/mcp/src/generated/tasks/api.ts` and `services/mcp/src/tools/generated/tasks.ts` — the Orval Zod schemas and tool handlers.
- `services/mcp/schema/generated-tool-definitions.json` and `tool-definitions-all.json` — tool metadata.
- Six new tool-schema snapshots.

Write tools take `name`, `prompt`, `repository` (in `organization/repository` format) and a 5-field `cron_expression`, plus optional `timezone`, `github_integration`, `template_id` and `enabled`. Delete is a hard delete (matching the backend's `DELETE`), and run is a no-body `POST .../{id}/run/` that returns the automation with its updated last-run status.

## How did you test this code?

The generated files here were hand-produced to mirror what `hogli build:openapi` emits, because that pipeline needs a running Django backend to produce `frontend/tmp/openapi.json`, which I (the agent) could not run in this environment. To be safe, they should be regenerated with `hogli build:openapi` and diffed before merge to confirm byte-parity with the live OpenAPI schema. The schemas were reconstructed from the committed `TaskAutomationDTO` / `TaskAutomationWrite` / `PatchedTaskAutomationWrite` types in `src/api/generated.ts`, so they track the real API shape.

Automated tests I (the agent) actually ran in `services/mcp`, all passing:

- `tests/unit/tool-schema-snapshots.test.ts` (regenerated with `-u`, then re-run clean) — imports the generated handlers at runtime and snapshots each tool's input schema. This is the load-bearing check that the new handlers and Zod schemas are valid and the six tools are exposed. The `create` snapshot confirms `name`/`prompt`/`repository`/`cron_expression` are required with correct `maxLength`s and that `github_integration`/`template_id` are nullable.
- `tests/unit/tool-catalog.test.ts`, `tool-references.test.ts`, `tool-name-validation.test.ts`, `tool-filtering.test.ts` — 762 tests, validating every registered tool has a definition, references resolve, and names are valid.
- `tests/unit/generate-tools.test.ts` — 83 tests, validating the YAML config parses.
- `pnpm run lint-tool-names` — passes.

A full `tsgo --noEmit` was not clean, but only because this was a sparse monorepo checkout missing unrelated deps (`@posthog/quill`, frontend fixtures); there are no type errors in the two files I touched.

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @vdekrijger from a Slack thread; authored by Claude (the PostHog Slack app agent). The original ask was to add task-automation CRUD + run tools to the (now archived) `posthog/mcp` repo; when that repo turned out to be archived, the work was retargeted here to `services/mcp` in the monorepo.

The monorepo MCP uses a YAML + OpenAPI codegen pipeline rather than hand-written tools, so the real change is the six-tool config in `products/tasks/mcp/tools.yaml`; the `src/generated/**` and `schema/*.json` files are normally produced by `hogli build:openapi`. Since that generator needs a live backend, I reproduced its output by hand, following the exact patterns of the existing `tasks` and `annotations` tools, and verified via the snapshot and catalog tests above. Reviewers should re-run `hogli build:openapi` to confirm the generated files match.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783079422391249)*
