### PR TITLE
chore(billing): run usage reports v2 every 30 minutes

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -617,10 +617,14 @@ async def create_finalize_usage_reports_schedule(client: Client):
     Reports *yesterday* (`day_offset=1`) once the day is complete — its
     pointer carries `report_completeness="complete"`, billing's signal that
     the numbers are final for that date.
-    02:45 leaves ~2.75 hours for ingestion lag after midnight, gives the
-    01:45 intraday slot a full hour to finish (the two schedules' SKIP
-    policies don't see each other, so spacing is the only concurrency
-    control), and stays ahead of the legacy Celery run at 03:45 UTC. Unlike
+    02:45 leaves ~2.75 hours for ingestion lag after midnight and stays ahead
+    of the legacy Celery run at 03:45 UTC. The intraday schedule now runs
+    every 30 minutes, so this slot sits between the 02:30 and 03:00 intraday
+    runs rather than clearing them by an hour, and the two schedules' SKIP
+    policies don't see each other. A brief overlap is harmless: every run
+    writes under its own `{date}/{run_id}` S3 prefix, and the finalizer
+    reports yesterday while the intraday runs report today, so overlapping
+    runs touch distinct data and at worst add concurrent query load. Unlike
     the intraday schedule this run has no later slot to supersede it, so the
     retry policy keeps re-running it across the day (5m, 10m, ... capped at
     2h) until it succeeds. Anything longer than that is a manual backfill:

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -577,11 +577,11 @@ async def cleanup_legacy_session_summarization_schedules(client: Client):
 
 
 async def create_run_usage_reports_schedule(client: Client):
-    """Intraday usage report run every 3 hours at minute 45 (8 times a day).
+    """Intraday usage report run every 30 minutes.
 
     Reports *today's* usage so far (`day_offset=0`) so billing gets fresh
     numbers throughout the day. A failed slot is superseded by the next one
-    3 hours later, so no retries. The complete-day capture is handled by the
+    30 minutes later, so no retries. The complete-day capture is handled by the
     daily finalizer schedule (`create_finalize_usage_reports_schedule`). The
     workflow writes per-org usage data to S3 and sends a single SQS pointer
     to the billing service.
@@ -596,15 +596,7 @@ async def create_run_usage_reports_schedule(client: Client):
             task_queue=settings.BILLING_TASK_QUEUE,
             retry_policy=common.RetryPolicy(maximum_attempts=1),
         ),
-        spec=ScheduleSpec(
-            calendars=[
-                ScheduleCalendarSpec(
-                    comment="Every 3 hours at minute 45 (01:45, 04:45, ..., 22:45 UTC)",
-                    hour=[ScheduleRange(start=1, end=22, step=3)],
-                    minute=[ScheduleRange(start=45, end=45)],
-                )
-            ]
-        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=30))]),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 


### PR DESCRIPTION
## Problem

The usage reports v2 flow (the `run-usage-reports` Temporal schedule) reports today's usage so far so billing gets fresh intraday numbers. It runs every 3 hours (8 times a day), so billing can be up to 3 hours stale between runs. We want fresher data.

## Changes

Change the `run-usage-reports` schedule cadence from every 3 hours to every 30 minutes in `create_run_usage_reports_schedule` (`posthog/temporal/schedule.py`).

Concretely, I swapped the calendar spec (`hour` range with `step=3` at minute 45, 8 runs/day) for a plain interval spec:

```python
spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=30))]),
```

It now fires at :00 and :30 UTC every hour, 48 runs/day. The `overlap=SKIP` and `maximum_attempts=1` (no retries, a failed slot is superseded by the next) policies are unchanged and still make sense at the tighter cadence. Docstring updated to match.

Worth calling out for the reviewer: this is roughly a 6x increase in run frequency. Each run scans per-org usage, writes to S3, and sends an SQS pointer to the billing service, so downstream load on that workflow and billing ingestion scales up proportionally. Flagging in case there's a cost or capacity concern I'm not aware of.

## How did you test this code?

No manual run against a live Temporal cluster. This is a one-line spec change. The existing schedule-builder tests in `posthog/temporal/tests/usage_report/test_schedule.py` still cover it — they assert the builder doesn't raise, hands Temporal a JSON-serializable input, and carries the right `day_offset`. None assert on the run-usage-reports cadence, so they're unaffected. I did not add a new test: pinning the exact interval would be a change-detector assertion with no realistic regression to catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Marcelino) directed this; Claude Code made the edit. The ask was simply to bump the cadence from 3h to 30m. Claude chose the interval spec over a calendar spec with a minute step because it's cleaner and matches the pattern other schedules in the same file already use (both `ScheduleIntervalSpec` and `timedelta` were already imported). No skills were needed for a change this small.
