### PR TITLE
fix(llma): route heavy AI property filters to ai_events on list views

### DIFF
--- a/posthog/hogql_queries/ai/ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/ai_table_resolver.py
@@ -153,3 +153,14 @@ AI_EVENT_NAMES = frozenset(
         "$ai_evaluation",
     }
 )
+
+# Event types that make up a trace's shape. Ordered for deterministic query output;
+# excludes $ai_evaluation, which is scored metadata rather than a trace-structure event.
+TRACE_EVENT_NAMES: tuple[str, ...] = (
+    "$ai_span",
+    "$ai_generation",
+    "$ai_embedding",
+    "$ai_metric",
+    "$ai_feedback",
+    "$ai_trace",
+)

--- a/posthog/hogql_queries/ai/heavy_property_filters.py
+++ b/posthog/hogql_queries/ai/heavy_property_filters.py
@@ -1,0 +1,120 @@
+"""Route property filters on heavy AI properties to the dedicated ai_events table.
+
+Ingestion strips the heavy AI content properties ($ai_input, $ai_output_choices, ...)
+from the events-table copy of AI events and stores them as dedicated columns on
+`posthog.ai_events` (see nodejs/src/ingestion/common/steps/event-processing/
+split-ai-events-step.ts). A property filter like `$ai_output_choices icontains "x"`
+evaluated against `events.properties` can therefore never match.
+
+The helpers here rewrite such filters into an IN subquery against ai_events, anchored
+on `uuid` (per-event lists, e.g. the generations tab) or `trace_id` (trace-level
+lists). All heavy filters land in a single subquery so they must match on the same
+ai_events row, mirroring how ANDed property filters behave against a single events row.
+
+ai_events rows expire after their retention TTL, so content filters only match events
+still inside that window — older events are excluded from filtered results entirely.
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import TypeVar
+
+from posthog.schema import EventPropertyFilter, PropertyOperator
+
+from posthog.hogql import ast
+from posthog.hogql.property import property_to_expr
+
+from posthog.hogql_queries.ai.ai_property_rewriter import AI_PROPERTY_TO_COLUMN, rewrite_expr_for_ai_events_table
+from posthog.hogql_queries.ai.utils import HEAVY_COLUMN_TO_PROPERTY
+from posthog.models.team.team import Team
+
+HEAVY_AI_PROPERTY_KEYS: frozenset[str] = frozenset(HEAVY_COLUMN_TO_PROPERTY.values())
+
+_PropertyFilterT = TypeVar("_PropertyFilterT")
+
+
+def split_heavy_ai_property_filters(
+    properties: Sequence[_PropertyFilterT] | None,
+) -> tuple[list[EventPropertyFilter], list[_PropertyFilterT]]:
+    """Split property filters into (heavy AI content filters, everything else)."""
+    heavy: list[EventPropertyFilter] = []
+    regular: list[_PropertyFilterT] = []
+    for prop in properties or []:
+        if isinstance(prop, EventPropertyFilter) and prop.key in HEAVY_AI_PROPERTY_KEYS:
+            heavy.append(prop)
+        else:
+            regular.append(prop)
+    return heavy, regular
+
+
+def _heavy_property_condition(prop: EventPropertyFilter, team: Team) -> ast.Expr:
+    # Heavy columns are Nullable(String); absent content is NULL. property_to_expr compiles
+    # is_set/is_not_set to `!= NULL` / `= NULL`, which never matches once rewritten onto the
+    # column, so map those to notEmpty()/empty() over the NULL-normalized column instead.
+    if prop.operator in (PropertyOperator.IS_SET, PropertyOperator.IS_NOT_SET):
+        normalized = ast.Call(
+            name="ifNull",
+            args=[ast.Field(chain=[AI_PROPERTY_TO_COLUMN[prop.key]]), ast.Constant(value="")],
+        )
+        return ast.Call(name="notEmpty" if prop.operator == PropertyOperator.IS_SET else "empty", args=[normalized])
+    return rewrite_expr_for_ai_events_table(property_to_expr(prop, team))
+
+
+def heavy_ai_properties_in_expr(
+    *,
+    anchor: ast.Expr,
+    select_column: str,
+    heavy_properties: Sequence[EventPropertyFilter],
+    team: Team,
+    event_names: Sequence[str] | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    distinct: bool = False,
+) -> ast.Expr:
+    """Build `<anchor> IN (SELECT <select_column> FROM posthog.ai_events WHERE ...)`.
+
+    `event_names` and the date bounds should mirror the outer query's filters so the
+    ai_events scan is pruned to the same window.
+    """
+    conditions: list[ast.Expr] = [_heavy_property_condition(prop, team) for prop in heavy_properties]
+    if event_names:
+        if len(event_names) == 1:
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["event"]),
+                    right=ast.Constant(value=event_names[0]),
+                )
+            )
+        else:
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.In,
+                    left=ast.Field(chain=["event"]),
+                    right=ast.Tuple(exprs=[ast.Constant(value=name) for name in event_names]),
+                )
+            )
+    if date_from is not None:
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=date_from),
+            )
+        )
+    if date_to is not None:
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=date_to),
+            )
+        )
+
+    subquery = ast.SelectQuery(
+        distinct=distinct or None,
+        select=[ast.Field(chain=[select_column])],
+        select_from=ast.JoinExpr(table=ast.Field(chain=["posthog", "ai_events"])),
+        where=ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0],
+    )
+    return ast.CompareOperation(op=ast.CompareOperationOp.In, left=anchor, right=subquery)

--- a/posthog/hogql_queries/ai/heavy_property_filters.py
+++ b/posthog/hogql_queries/ai/heavy_property_filters.py
@@ -1,18 +1,9 @@
-"""Route property filters on heavy AI properties to the dedicated ai_events table.
+"""Route filters on heavy AI content properties to the dedicated ai_events table.
 
-Ingestion strips the heavy AI content properties ($ai_input, $ai_output_choices, ...)
-from the events-table copy of AI events and stores them as dedicated columns on
-`posthog.ai_events` (see nodejs/src/ingestion/common/steps/event-processing/
-split-ai-events-step.ts). A property filter like `$ai_output_choices icontains "x"`
-evaluated against `events.properties` can therefore never match.
-
-The helpers here rewrite such filters into an IN subquery against ai_events, anchored
-on `uuid` (per-event lists, e.g. the generations tab) or `trace_id` (trace-level
-lists). All heavy filters land in a single subquery so they must match on the same
-ai_events row, mirroring how ANDed property filters behave against a single events row.
-
-ai_events rows expire after their retention TTL, so content filters only match events
-still inside that window — older events are excluded from filtered results entirely.
+Ingestion strips the heavy AI properties ($ai_input, $ai_output_choices, ...) from the
+events-table copy of AI events into dedicated columns on `posthog.ai_events`, so a filter
+on them against `events.properties` never matches. These helpers rewrite such filters into
+subqueries against ai_events, anchored on `uuid` (per-event) or `trace_id` (per-trace).
 """
 
 from collections.abc import Sequence
@@ -29,6 +20,19 @@ from posthog.hogql_queries.ai.utils import HEAVY_COLUMN_TO_PROPERTY
 from posthog.models.team.team import Team
 
 HEAVY_AI_PROPERTY_KEYS: frozenset[str] = frozenset(HEAVY_COLUMN_TO_PROPERTY.values())
+
+# Negated operators resolve as an anti-join against their positive counterpart
+# (`anchor NOT IN <events matching the positive>`) instead of a semi-join on the negated
+# predicate. ai_events has no row-level dedup, so one event can have several rows with the
+# heavy column populated on some and empty on others; a semi-join on e.g. `NOT ILIKE` would
+# match the empty duplicate of every event, whereas the anti-join excludes only events that
+# have a matching row — the correct "does not contain" / "is not set" semantics.
+_POSITIVE_COUNTERPART: dict[PropertyOperator, PropertyOperator] = {
+    PropertyOperator.IS_NOT_SET: PropertyOperator.IS_SET,
+    PropertyOperator.NOT_ICONTAINS: PropertyOperator.ICONTAINS,
+    PropertyOperator.IS_NOT: PropertyOperator.EXACT,
+    PropertyOperator.NOT_REGEX: PropertyOperator.REGEX,
+}
 
 _PropertyFilterT = TypeVar("_PropertyFilterT")
 
@@ -47,36 +51,24 @@ def split_heavy_ai_property_filters(
     return heavy, regular
 
 
-def _heavy_property_condition(prop: EventPropertyFilter, team: Team) -> ast.Expr:
-    # Heavy columns are Nullable(String); absent content is NULL. property_to_expr compiles
-    # is_set/is_not_set to `!= NULL` / `= NULL`, which never matches once rewritten onto the
-    # column, so map those to notEmpty()/empty() over the NULL-normalized column instead.
-    if prop.operator in (PropertyOperator.IS_SET, PropertyOperator.IS_NOT_SET):
+def _positive_predicate(prop: EventPropertyFilter, team: Team) -> ast.Expr:
+    # Heavy columns are Nullable; property_to_expr compiles is_set to `!= NULL`, which never
+    # matches a Nullable column, so use notEmpty() over the NULL-normalized column instead.
+    if prop.operator == PropertyOperator.IS_SET:
         normalized = ast.Call(
             name="ifNull",
             args=[ast.Field(chain=[AI_PROPERTY_TO_COLUMN[prop.key]]), ast.Constant(value="")],
         )
-        return ast.Call(name="notEmpty" if prop.operator == PropertyOperator.IS_SET else "empty", args=[normalized])
+        return ast.Call(name="notEmpty", args=[normalized])
     return rewrite_expr_for_ai_events_table(property_to_expr(prop, team))
 
 
-def heavy_ai_properties_in_expr(
-    *,
-    anchor: ast.Expr,
-    select_column: str,
-    heavy_properties: Sequence[EventPropertyFilter],
-    team: Team,
-    event_names: Sequence[str] | None = None,
-    date_from: datetime | None = None,
-    date_to: datetime | None = None,
-    distinct: bool = False,
-) -> ast.Expr:
-    """Build `<anchor> IN (SELECT <select_column> FROM posthog.ai_events WHERE ...)`.
-
-    `event_names` and the date bounds should mirror the outer query's filters so the
-    ai_events scan is pruned to the same window.
-    """
-    conditions: list[ast.Expr] = [_heavy_property_condition(prop, team) for prop in heavy_properties]
+def _scope_conditions(
+    event_names: Sequence[str] | None,
+    date_from: datetime | None,
+    date_to: datetime | None,
+) -> list[ast.Expr]:
+    conditions: list[ast.Expr] = []
     if event_names:
         if len(event_names) == 1:
             conditions.append(
@@ -110,11 +102,60 @@ def heavy_ai_properties_in_expr(
                 right=ast.Constant(value=date_to),
             )
         )
+    return conditions
 
-    subquery = ast.SelectQuery(
+
+def _ai_events_subquery(select_column: str, conditions: list[ast.Expr], distinct: bool) -> ast.SelectQuery:
+    return ast.SelectQuery(
         distinct=distinct or None,
         select=[ast.Field(chain=[select_column])],
         select_from=ast.JoinExpr(table=ast.Field(chain=["posthog", "ai_events"])),
         where=ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0],
     )
-    return ast.CompareOperation(op=ast.CompareOperationOp.In, left=anchor, right=subquery)
+
+
+def heavy_ai_properties_in_expr(
+    *,
+    anchor: ast.Expr,
+    select_column: str,
+    heavy_properties: Sequence[EventPropertyFilter],
+    team: Team,
+    event_names: Sequence[str] | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    distinct: bool = False,
+) -> ast.Expr:
+    """Resolve heavy AI content filters against ai_events, returning a single expr.
+
+    Positive filters become one semi-join `<anchor> IN (SELECT <select_column> ... WHERE ...)`
+    (all positives must match the same ai_events row). Each negated filter becomes its own
+    anti-join `<anchor> NOT IN (SELECT ... WHERE <positive counterpart>)`. `event_names` and
+    the date bounds mirror the outer query's filters so each ai_events scan is pruned.
+    """
+    scope = _scope_conditions(event_names, date_from, date_to)
+
+    positive = [prop for prop in heavy_properties if prop.operator not in _POSITIVE_COUNTERPART]
+    negative = [prop for prop in heavy_properties if prop.operator in _POSITIVE_COUNTERPART]
+
+    exprs: list[ast.Expr] = []
+    if positive:
+        conditions = [_positive_predicate(prop, team) for prop in positive] + scope
+        exprs.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.In,
+                left=anchor,
+                right=_ai_events_subquery(select_column, conditions, distinct),
+            )
+        )
+    for prop in negative:
+        counterpart = prop.model_copy(update={"operator": _POSITIVE_COUNTERPART[prop.operator]})
+        conditions = [_positive_predicate(counterpart, team), *scope]
+        exprs.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.NotIn,
+                left=anchor,
+                right=_ai_events_subquery(select_column, conditions, distinct),
+            )
+        )
+
+    return ast.And(exprs=exprs) if len(exprs) > 1 else exprs[0]

--- a/posthog/hogql_queries/ai/test/test_heavy_ai_property_filters.py
+++ b/posthog/hogql_queries/ai/test/test_heavy_ai_property_filters.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, _create_person
+
+from parameterized import parameterized
+
+from posthog.schema import DateRange, EventPropertyFilter, EventsQuery, PropertyOperator, TracesQuery
+
+from posthog.hogql_queries.ai.traces_query_runner import TracesQueryRunner
+from posthog.hogql_queries.events_query_runner import EventsQueryRunner
+from posthog.models.ai_events.test_util import bulk_create_ai_events
+
+
+class TestHeavyAiPropertyFilters(ClickhouseTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        _create_person(distinct_ids=["person1"], team=self.team)
+        self.generation_uuids: dict[str, str] = {}
+        # Mimic the ingestion split: the events-table copy has the heavy properties
+        # stripped; the full content only exists on the ai_events table.
+        self._create_generation(
+            key="gen1",
+            trace_id="trace1",
+            timestamp=datetime(2024, 12, 1, 0, 5),
+            output_content="the needle result",
+        )
+        self._create_generation(
+            key="gen2",
+            trace_id="trace2",
+            timestamp=datetime(2024, 12, 1, 0, 10),
+            output_content="plain result",
+            extra_properties={"foo": "bar"},
+        )
+        self._create_generation(
+            key="gen3",
+            trace_id="trace3",
+            timestamp=datetime(2024, 12, 1, 0, 15),
+            output_content=None,
+        )
+
+    def _create_generation(
+        self,
+        *,
+        key: str,
+        trace_id: str,
+        timestamp: datetime,
+        output_content: str | None,
+        extra_properties: dict[str, Any] | None = None,
+    ) -> None:
+        event_uuid = str(uuid4())
+        self.generation_uuids[key] = event_uuid
+        stripped_props: dict[str, Any] = {
+            "$ai_trace_id": trace_id,
+            "$ai_model": "gpt-4o",
+            **(extra_properties or {}),
+        }
+        _create_event(
+            event="$ai_generation",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=timestamp,
+            event_uuid=event_uuid,
+            properties=stripped_props,
+        )
+        ai_events_props = dict(stripped_props)
+        if output_content is not None:
+            ai_events_props["$ai_output_choices"] = [{"role": "assistant", "content": output_content}]
+        bulk_create_ai_events(
+            [
+                {
+                    "event": "$ai_generation",
+                    "team": self.team,
+                    "distinct_id": "person1",
+                    "timestamp": timestamp,
+                    "event_uuid": event_uuid,
+                    "properties": ai_events_props,
+                }
+            ]
+        )
+
+    @parameterized.expand(
+        [
+            ("icontains", PropertyOperator.ICONTAINS, "needle", {"gen1"}),
+            ("not_icontains", PropertyOperator.NOT_ICONTAINS, "needle", {"gen2"}),
+            ("is_set", PropertyOperator.IS_SET, None, {"gen1", "gen2"}),
+            ("is_not_set", PropertyOperator.IS_NOT_SET, None, {"gen3"}),
+        ]
+    )
+    def test_events_query_filters_on_heavy_content(self, _name, operator, value, expected_keys):
+        with freeze_time("2024-12-02T00:00:00Z"):
+            response = EventsQueryRunner(
+                team=self.team,
+                query=EventsQuery(
+                    kind="EventsQuery",
+                    select=["uuid"],
+                    event="$ai_generation",
+                    after="-7d",
+                    orderBy=["timestamp ASC"],
+                    properties=[
+                        EventPropertyFilter(key="$ai_output_choices", value=value, operator=operator, type="event")
+                    ],
+                ),
+            ).calculate()
+
+        self.assertEqual(
+            {str(row[0]) for row in response.results},
+            {self.generation_uuids[key] for key in expected_keys},
+        )
+
+    def test_traces_query_filters_on_heavy_content(self):
+        response = TracesQueryRunner(
+            team=self.team,
+            query=TracesQuery(
+                dateRange=DateRange(date_from="2024-12-01T00:00:00Z", date_to="2024-12-01T01:00:00Z"),
+                properties=[
+                    EventPropertyFilter(
+                        key="$ai_output_choices",
+                        value="needle",
+                        operator=PropertyOperator.ICONTAINS,
+                        type="event",
+                    )
+                ],
+            ),
+        ).calculate()
+
+        self.assertEqual([trace.id for trace in response.results], ["trace1"])
+
+    def test_traces_query_combines_heavy_and_regular_filters(self):
+        response = TracesQueryRunner(
+            team=self.team,
+            query=TracesQuery(
+                dateRange=DateRange(date_from="2024-12-01T00:00:00Z", date_to="2024-12-01T01:00:00Z"),
+                properties=[
+                    EventPropertyFilter(
+                        key="$ai_output_choices",
+                        value="result",
+                        operator=PropertyOperator.ICONTAINS,
+                        type="event",
+                    ),
+                    EventPropertyFilter(key="foo", value="bar", operator=PropertyOperator.EXACT, type="event"),
+                ],
+            ),
+        ).calculate()
+
+        self.assertEqual([trace.id for trace in response.results], ["trace2"])

--- a/posthog/hogql_queries/ai/test/test_heavy_ai_property_filters.py
+++ b/posthog/hogql_queries/ai/test/test_heavy_ai_property_filters.py
@@ -84,7 +84,7 @@ class TestHeavyAiPropertyFilters(ClickhouseTestMixin, BaseTest):
     @parameterized.expand(
         [
             ("icontains", PropertyOperator.ICONTAINS, "needle", {"gen1"}),
-            ("not_icontains", PropertyOperator.NOT_ICONTAINS, "needle", {"gen2"}),
+            ("not_icontains", PropertyOperator.NOT_ICONTAINS, "needle", {"gen2", "gen3"}),
             ("is_set", PropertyOperator.IS_SET, None, {"gen1", "gen2"}),
             ("is_not_set", PropertyOperator.IS_NOT_SET, None, {"gen3"}),
         ]

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -24,6 +24,7 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.hogql_queries.ai.ai_table_resolver import TRACE_EVENT_NAMES
 from posthog.hogql_queries.ai.heavy_property_filters import heavy_ai_properties_in_expr, split_heavy_ai_property_filters
 from posthog.hogql_queries.ai.sentiment_evaluations import (
     EMPTY_SENTIMENT_EVALUATION_LOOKUP,
@@ -38,16 +39,9 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 logger = structlog.get_logger(__name__)
 
-# Event types that participate in trace selection, aggregation, and filtering.
-TRACE_EVENT_NAMES: tuple[str, ...] = (
-    "$ai_span",
-    "$ai_generation",
-    "$ai_embedding",
-    "$ai_metric",
-    "$ai_feedback",
-    "$ai_trace",
-)
-_TRACE_EVENT_NAMES_SQL = ", ".join(f"'{name}'" for name in TRACE_EVENT_NAMES)
+
+def _trace_event_names_expr() -> ast.Tuple:
+    return ast.Tuple(exprs=[ast.Constant(value=name) for name in TRACE_EVENT_NAMES])
 
 
 class TracesQueryDateRange(QueryDateRange):
@@ -137,7 +131,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                         min(timestamp) as first_ts,
                         max(timestamp) as last_ts
                     FROM events
-                    WHERE event IN ({_TRACE_EVENT_NAMES_SQL})
+                    WHERE event IN {{trace_event_names}}
                       AND {{conditions}}
                     GROUP BY trace_id
                     HAVING min(timestamp) <= {{unbuffered_date_to}}
@@ -152,6 +146,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                 query_type="TracesQuery_TraceIds",
                 query=trace_ids_query,
                 placeholders={
+                    "trace_event_names": _trace_event_names_expr(),
                     "conditions": self._get_subquery_filter(),
                     "limit": ast.Constant(value=pagination_limit),
                     "unbuffered_date_from": self._date_range.date_from_for_filtering_as_hogql(),
@@ -200,6 +195,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
             query_result = self.paginator.execute_hogql_query(
                 query=self._to_query_with_trace_ids(trace_ids),
                 placeholders={
+                    "trace_event_names": _trace_event_names_expr(),
                     "filter_conditions": self._get_where_clause(date_range=narrowed_date_range),
                 },
                 team=self.team,
@@ -254,7 +250,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids])
 
         query = parse_select(
-            f"""
+            """
             SELECT
                 properties.$ai_trace_id AS id,
                 any(properties.$ai_session_id) AS ai_session_id,
@@ -356,8 +352,8 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                     )
                 ) AS tools
             FROM events
-            WHERE event IN ({_TRACE_EVENT_NAMES_SQL})
-              AND {{filter_conditions}}
+            WHERE event IN {trace_event_names}
+              AND {filter_conditions}
             GROUP BY properties.$ai_trace_id
             ORDER BY first_timestamp DESC
             """,
@@ -547,9 +543,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                 for prop in regular_props:
                     property_filters.append(property_to_expr(prop, self.team))
                 if heavy_ai_props:
-                    # Heavy AI content is stripped from events.properties at ingestion, so
-                    # match trace IDs against the ai_events content columns instead. A trace
-                    # matches when any of its events in the window carries matching content.
+                    # A trace matches when any of its events in the window carries the content.
                     property_filters.append(
                         heavy_ai_properties_in_expr(
                             anchor=ast.Field(chain=["properties", "$ai_trace_id"]),

--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -24,6 +24,7 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.hogql_queries.ai.heavy_property_filters import heavy_ai_properties_in_expr, split_heavy_ai_property_filters
 from posthog.hogql_queries.ai.sentiment_evaluations import (
     EMPTY_SENTIMENT_EVALUATION_LOOKUP,
     SentimentEvaluationLookup,
@@ -36,6 +37,17 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 logger = structlog.get_logger(__name__)
+
+# Event types that participate in trace selection, aggregation, and filtering.
+TRACE_EVENT_NAMES: tuple[str, ...] = (
+    "$ai_span",
+    "$ai_generation",
+    "$ai_embedding",
+    "$ai_metric",
+    "$ai_feedback",
+    "$ai_trace",
+)
+_TRACE_EVENT_NAMES_SQL = ", ".join(f"'{name}'" for name in TRACE_EVENT_NAMES)
 
 
 class TracesQueryDateRange(QueryDateRange):
@@ -125,7 +137,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                         min(timestamp) as first_ts,
                         max(timestamp) as last_ts
                     FROM events
-                    WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
+                    WHERE event IN ({_TRACE_EVENT_NAMES_SQL})
                       AND {{conditions}}
                     GROUP BY trace_id
                     HAVING min(timestamp) <= {{unbuffered_date_to}}
@@ -242,7 +254,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_ids])
 
         query = parse_select(
-            """
+            f"""
             SELECT
                 properties.$ai_trace_id AS id,
                 any(properties.$ai_session_id) AS ai_session_id,
@@ -344,10 +356,8 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                     )
                 ) AS tools
             FROM events
-            WHERE event IN (
-                '$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace'
-            )
-              AND {filter_conditions}
+            WHERE event IN ({_TRACE_EVENT_NAMES_SQL})
+              AND {{filter_conditions}}
             GROUP BY properties.$ai_trace_id
             ORDER BY first_timestamp DESC
             """,
@@ -533,8 +543,25 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         property_filters: list[ast.Expr] = []
         if self.query.properties:
             with self.timings.measure("property_filters"):
-                for prop in self.query.properties:
+                heavy_ai_props, regular_props = split_heavy_ai_property_filters(self.query.properties)
+                for prop in regular_props:
                     property_filters.append(property_to_expr(prop, self.team))
+                if heavy_ai_props:
+                    # Heavy AI content is stripped from events.properties at ingestion, so
+                    # match trace IDs against the ai_events content columns instead. A trace
+                    # matches when any of its events in the window carries matching content.
+                    property_filters.append(
+                        heavy_ai_properties_in_expr(
+                            anchor=ast.Field(chain=["properties", "$ai_trace_id"]),
+                            select_column="trace_id",
+                            heavy_properties=heavy_ai_props,
+                            team=self.team,
+                            event_names=TRACE_EVENT_NAMES,
+                            date_from=self._date_range.date_from(),
+                            date_to=self._date_range.date_to(),
+                            distinct=True,
+                        )
+                    )
 
         if not property_filters:
             return None

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -209,10 +209,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
             checker.visit(expr)
 
     def _heavy_ai_properties_expr(self, heavy_props: list[EventPropertyFilter]) -> ast.Expr:
-        # Heavy AI content ($ai_input, $ai_output_choices, ...) is stripped from
-        # events.properties at ingestion and lives on posthog.ai_events, so filters on it
-        # match event UUIDs against that table instead. The bounds mirror the outer query's
-        # timestamp window (see the "timestamps" section of to_query) to prune the scan.
+        # Bounds mirror the "timestamps" window in to_query so the ai_events scan is pruned.
         before = self.query.before or (now() + timedelta(seconds=5)).isoformat()
         date_to = relative_date_parse(before, self.team.timezone_info)
         after = self.query.after or "-24h"

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -8,7 +8,13 @@ from django.utils.timezone import now
 import orjson
 import structlog
 
-from posthog.schema import CachedEventsQueryResponse, DashboardFilter, EventsQuery, EventsQueryResponse
+from posthog.schema import (
+    CachedEventsQueryResponse,
+    DashboardFilter,
+    EventPropertyFilter,
+    EventsQuery,
+    EventsQueryResponse,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.ast import Alias
@@ -25,6 +31,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.element import ElementSerializer
 from posthog.api.person import PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
+from posthog.hogql_queries.ai.heavy_property_filters import heavy_ai_properties_in_expr, split_heavy_ai_property_filters
 from posthog.hogql_queries.insights.insight_actors_query_runner import InsightActorsQueryRunner
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, get_query_runner
@@ -201,6 +208,26 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
         for expr in select:
             checker.visit(expr)
 
+    def _heavy_ai_properties_expr(self, heavy_props: list[EventPropertyFilter]) -> ast.Expr:
+        # Heavy AI content ($ai_input, $ai_output_choices, ...) is stripped from
+        # events.properties at ingestion and lives on posthog.ai_events, so filters on it
+        # match event UUIDs against that table instead. The bounds mirror the outer query's
+        # timestamp window (see the "timestamps" section of to_query) to prune the scan.
+        before = self.query.before or (now() + timedelta(seconds=5)).isoformat()
+        date_to = relative_date_parse(before, self.team.timezone_info)
+        after = self.query.after or "-24h"
+        date_from = relative_date_parse(after, self.team.timezone_info) if after != "all" else None
+        event_names = [e for e in [self.query.event, *(self.query.events or [])] if e]
+        return heavy_ai_properties_in_expr(
+            anchor=ast.Call(name="toString", args=[ast.Field(chain=["uuid"])]),
+            select_column="uuid",
+            heavy_properties=heavy_props,
+            team=self.team,
+            event_names=event_names or None,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
     def to_query(self) -> ast.SelectQuery:
         # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.
         with self.timings.measure("build_ast"):
@@ -221,7 +248,10 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                     where_exprs = [parse_expr(expr, timings=self.timings) for expr in where_input]
                 if self.query.properties:
                     with self.timings.measure("properties"):
-                        where_exprs.extend(property_to_expr(property, self.team) for property in self.query.properties)
+                        heavy_ai_props, regular_props = split_heavy_ai_property_filters(self.query.properties)
+                        where_exprs.extend(property_to_expr(property, self.team) for property in regular_props)
+                        if heavy_ai_props:
+                            where_exprs.append(self._heavy_ai_properties_expr(heavy_ai_props))
                 if self.query.fixedProperties:
                     with self.timings.measure("fixed_properties"):
                         where_exprs.extend(


### PR DESCRIPTION
## Problem

Filtering the AI observability Traces or Generations list by AI content properties (AI output `$ai_output_choices`, AI input `$ai_input`, and the other heavy properties) returns zero results, even when the content visibly matches on the single-trace page. Reported by a customer via a support ticket.

Since the ai_events ingestion split, the heavy content properties are stripped from the events-table copy of AI events and stored as dedicated columns on `posthog.ai_events`. The single-trace and neighbors runners read through `query_ai_events()`, which rewrites `properties.$ai_*` filters onto those columns, so content filtering already works there. The two list paths do not go through that layer and compile these filters against the now-empty `events.properties`:

- Traces tab: `TracesQueryRunner` runs `property_to_expr` against `FROM events`
- Generations tab: a generic `EventsQuery`, where `EventsQueryRunner` does the same

The filter UI still offers these properties, so users get silent empty states. This is the unimplemented half of the rule in `products/ai_observability/AGENTS.md` that single-trace and list runners must not diverge on `ai_events` vs `events` routing.

## Changes

- New `posthog/hogql_queries/ai/heavy_property_filters.py` splits heavy AI content filters from regular ones and resolves them against `posthog.ai_events`, reusing `AiPropertyRewriter` to map `properties.$ai_*` onto the dedicated columns:
  - Positive operators (icontains, is_set, exact, regex) become one semi-join `anchor IN (SELECT ... FROM posthog.ai_events WHERE ...)`, so all positive filters must match the same ai_events row.
  - Negated operators (not_icontains, is_not_set, is_not, not_regex) become an anti-join against their positive counterpart, `anchor NOT IN (SELECT ... WHERE <positive>)`. `ai_events` is a sharded MergeTree with no row-level dedup, so one event can have several rows with the heavy column populated on some and empty on others. A semi-join on the negated predicate (for example `NOT ILIKE`) would match the empty duplicate of every event and return everything; the anti-join excludes only events that actually have a matching row. This is the same result filtering gave when the content still lived on `events.properties` (absent content read as an empty string).
  - `is_set` is special-cased to `notEmpty()` over the NULL-normalized column, because the columns are `Nullable(String)` and `property_to_expr` compiles `is_set` to `!= NULL`, which never matches a Nullable column.
- `TracesQueryRunner`: heavy filters resolve as `properties.$ai_trace_id [NOT] IN (SELECT DISTINCT trace_id FROM posthog.ai_events ...)`, bounded by the buffered date range and the trace event types (a trace matches when any of its events carries matching content). The trace event-name list is now the shared `TRACE_EVENT_NAMES` constant next to the canonical `AI_EVENT_NAMES` in `ai_table_resolver`, passed into the SQL as an `ast.Tuple` HogQL placeholder rather than string-interpolated.
- `EventsQueryRunner`: heavy filters resolve as `toString(uuid) [NOT] IN (SELECT uuid FROM posthog.ai_events ...)`, bounded by the query's `after`/`before` window and event names. Non-AI queries are unaffected; the split only triggers on the six heavy `$ai_*` keys.

Known limits:
- `ai_events` has a retention TTL (about 30 days), so content filters only reflect events still in that window. For positive filters, older events cannot match (their content is gone). For negated filters, older events are included, since we cannot verify they contain the term, which mirrors the empty-string default.
- Filters written as raw HogQL expressions are not rewritten.
- `fixedProperties` are not routed the same way yet.

## How did you test this code?

Added `posthog/hogql_queries/ai/test/test_heavy_ai_property_filters.py`, with fixtures that mimic production stripping (events rows without heavy properties, content only in `ai_events`):

- generations list `icontains` / `not_icontains` / `is_set` / `is_not_set` on `$ai_output_choices` return the correct events, and the traces list returns the matching trace. `not_icontains` returns both the non-matching generation and the one with no output, which catches the regression where negated filters were compiled as a semi-join on the negated predicate (matching the empty duplicate rows and dropping null-content events).
- combined heavy + regular filter on the traces list, which catches the splitter dropping regular filters.

The ClickHouse-backed suite passes locally against the dev stack: `test_heavy_ai_property_filters` (6 passed), `test_traces_query_runner` (43 passed, 27 snapshots, no SQL drift from the placeholder change), and `test_events_query_runner` (37 passed, confirming non-AI queries are unaffected). `ruff` and the `ty` type check pass. No manual browser testing was done.

To reproduce manually: on the Generations tab, add a property filter such as `$ai_output_choices contains <term>` over a recent date range. On master it returns nothing; on this branch it returns the matching generations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Christiaan asked PostHog Code (Claude) to investigate a customer bug report and fix it, then to review and harden the fix. Investigation confirmed with production and local data that the heavy properties are absent from recent events rows while the same filters match against `ai_events` content, and traced both list paths to `property_to_expr` on `events.properties`.

Key decisions: anchor the events subquery on `uuid` (per-event semantics for the generations list) and the traces subquery on `trace_id` (any event in the trace matches); resolve negated operators as anti-joins so results are robust to `ai_events` un-deduped rows and match native `events.properties` semantics; pass the trace event names through a HogQL placeholder (`ast.Tuple`) instead of an f-string, which also clears the `hogql-fstring-audit` semgrep check; centralize the trace event names in `ai_table_resolver`. Read the repo `writing-tests` skill before changing tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
