### PR TITLE
feat(authentication): pin test@posthog.com to top of dev login list

### DIFF
--- a/frontend/src/scenes/authentication/shared/devLoginLogic.ts
+++ b/frontend/src/scenes/authentication/shared/devLoginLogic.ts
@@ -13,6 +13,8 @@ export interface DevUser {
 
 export const DEV_LOGIN_SECONDS_SAVED_PER_CLICK = 5
 
+export const DEV_LOGIN_DEFAULT_EMAIL = 'test@posthog.com'
+
 export const devLoginLogic = kea<devLoginLogicType>([
     path(['scenes', 'authentication', 'shared', 'devLoginLogic']),
     actions({
@@ -36,7 +38,13 @@ export const devLoginLogic = kea<devLoginLogicType>([
                     breakpoint()
                     try {
                         const response = await api.get<{ users: DevUser[] }>('api/login/dev')
-                        return response.users
+                        // Pin the default seeded user to the top; the rest keep the backend's alphabetical order.
+                        const users = [...response.users]
+                        const defaultIndex = users.findIndex((u) => u.email === DEV_LOGIN_DEFAULT_EMAIL)
+                        if (defaultIndex > 0) {
+                            users.unshift(...users.splice(defaultIndex, 1))
+                        }
+                        return users
                     } catch {
                         // Endpoint is unavailable unless allow_dev_login is set in preflight.
                         return []


### PR DESCRIPTION
## Problem

The dev-only "Login tools" panel on the sign in page lists users alphabetically, so the default seeded `test@posthog.com` user sits buried mid-list among the ~50 demo users. It's the user you want almost every time, and you have to scan for it on every login.

## Changes

Pins `test@posthog.com` to the top of the dev login list, client-side only.

- `devLoginLogic.ts` reorders the loader result: the default user moves to the front, everyone else keeps the backend's alphabetical order.
- Adds an exported `DEV_LOGIN_DEFAULT_EMAIL` constant.
- No backend changes. `DevLoginPanel.tsx` already renders in loader order, so it's untouched.

Known trade-off of staying client-side: the backend returns the first 50 users alphabetically, so in a dev DB where `test@posthog.com` sorts past position 50 it wouldn't be in the payload to pin. Not realistic for dev environments.

## How did you test this code?

- Ran the exact reorder logic against a real local `GET /api/login/dev` payload: `test@posthog.com` moved from index 31 to first, and the remaining users' relative order was byte-identical to the backend's.
- oxlint and oxfmt clean on the changed file, kea typegen regenerated for it, and typescript check reports zero errors for the touched files.
- No screenshot: the agent's worktree wasn't the checkout served by the running dev stack, so it couldn't capture the panel rendering this change live.
- No tests added: this is a dev-only convenience panel and the change is a three-line reorder with no branching logic worth a mocked kea test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, the dev login panel isn't documented under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code). Skills invoked: `/adopting-generated-api-types` (concluded the manual `api.get` call stays, since `api/login/dev` has no generated function because the backend `list` lacks `@extend_schema`, and the backend was explicitly out of scope).
- The first plan ordered the list on the backend with a `Case`/`When` expression so the default user could never fall outside the 50-user cap. I asked for it in the UI layer instead, so the reorder lives in the kea loader and the backend is untouched.
- A whole-repo `pnpm format` run corrupted two unrelated files via `oxlint --fix-dangerously` (syntax error in `useMaxTool.ts`, dep-array change in `DashboardItems.tsx`). Claude reverted both, scoped lint/format to the changed file, and reported the tooling bug via `hogli devex:feedback`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
