### PR TITLE
fix(data-modeling): report real backfill status in dry-run

### DIFF
--- a/products/data_modeling/backend/management/commands/backfill_dag_schedule_type.py
+++ b/products/data_modeling/backend/management/commands/backfill_dag_schedule_type.py
@@ -26,10 +26,21 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        found, updated, failed = _backfill_schedule_type(dry_run)
+        found, already_stamped, updated, failed = _backfill_schedule_type(dry_run)
         verb = "would stamp" if dry_run else "stamped"
-        logger.info("Backfill complete", execute_dag_schedules=found, updated=updated, failed=failed, dry_run=dry_run)
-        self.stdout.write(f"execute-dag schedules found: {found}; {verb}: {updated}; failed: {failed}")
+        stamped = found - already_stamped if dry_run else updated
+        logger.info(
+            "Backfill complete",
+            execute_dag_schedules=found,
+            already_stamped=already_stamped,
+            updated=updated,
+            failed=failed,
+            dry_run=dry_run,
+        )
+        self.stdout.write(
+            f"execute-dag schedules found: {found}; already stamped: {already_stamped}; "
+            f"{verb}: {stamped}; failed: {failed}"
+        )
 
 
 async def _updater(input: ScheduleUpdateInput) -> ScheduleUpdate:
@@ -40,9 +51,10 @@ async def _updater(input: ScheduleUpdateInput) -> ScheduleUpdate:
 
 
 @async_to_sync
-async def _backfill_schedule_type(dry_run: bool) -> tuple[int, int, int]:
+async def _backfill_schedule_type(dry_run: bool) -> tuple[int, int, int, int]:
     temporal = await async_connect()
     found = 0
+    already_stamped = 0
     updated = 0
     failed = 0
     async for listing in await temporal.list_schedules():
@@ -53,6 +65,9 @@ async def _backfill_schedule_type(dry_run: bool) -> tuple[int, int, int]:
         ):
             continue
         found += 1
+        if listing.typed_search_attributes.get(POSTHOG_SCHEDULE_TYPE_KEY) == DATA_MODELING_EXECUTE_DAG_WORKFLOW:
+            already_stamped += 1
+            continue
         if dry_run:
             continue
         try:
@@ -61,4 +76,4 @@ async def _backfill_schedule_type(dry_run: bool) -> tuple[int, int, int]:
         except Exception:
             failed += 1
             logger.exception("Error stamping schedule", schedule_id=listing.id)
-    return found, updated, failed
+    return found, already_stamped, updated, failed

--- a/products/data_modeling/backend/test/test_backfill_dag_schedule_type.py
+++ b/products/data_modeling/backend/test/test_backfill_dag_schedule_type.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from parameterized import parameterized
+from temporalio.client import ScheduleListActionStartWorkflow
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
+
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_TYPE_KEY
+
+from products.data_modeling.backend.management.commands.backfill_dag_schedule_type import _backfill_schedule_type
+from products.data_modeling.backend.schedule import DATA_MODELING_EXECUTE_DAG_WORKFLOW
+
+
+class TestBackfillScheduleType:
+    def _listing(self, schedule_id: str, workflow: str, schedule_type: str | None = None):
+        action = mock.Mock(spec=ScheduleListActionStartWorkflow, workflow=workflow)
+        attrs = TypedSearchAttributes(
+            [SearchAttributePair(POSTHOG_SCHEDULE_TYPE_KEY, schedule_type)] if schedule_type else []
+        )
+        return mock.Mock(id=schedule_id, schedule=mock.Mock(action=action), typed_search_attributes=attrs)
+
+    def _temporal(self, listings):
+        async def fake_list_schedules(*args, **kwargs):
+            async def gen():
+                for listing in listings:
+                    yield listing
+
+            return gen()
+
+        temporal = mock.Mock()
+        temporal.list_schedules = fake_list_schedules
+        temporal.get_schedule_handle = mock.Mock(return_value=mock.Mock(update=mock.AsyncMock()))
+        return temporal
+
+    @parameterized.expand(
+        [
+            ("dry_run", True, 0, []),
+            ("real_run", False, 2, ["missing-1", "missing-2"]),
+        ]
+    )
+    def test_counts_stamped_vs_missing_and_updates_only_missing(self, _name, dry_run, expected_updated, updated_ids):
+        listings = [
+            self._listing("already-stamped", DATA_MODELING_EXECUTE_DAG_WORKFLOW, DATA_MODELING_EXECUTE_DAG_WORKFLOW),
+            self._listing("missing-1", DATA_MODELING_EXECUTE_DAG_WORKFLOW),
+            self._listing("missing-2", DATA_MODELING_EXECUTE_DAG_WORKFLOW),
+            self._listing("v1-schedule", "data-modeling-run"),
+        ]
+        temporal = self._temporal(listings)
+        with mock.patch(
+            "products.data_modeling.backend.management.commands.backfill_dag_schedule_type.async_connect",
+            new=mock.AsyncMock(return_value=temporal),
+        ):
+            found, already_stamped, updated, failed = _backfill_schedule_type(dry_run)
+
+        assert (found, already_stamped, updated, failed) == (3, 1, expected_updated, 0)
+        assert [call.args[0] for call in temporal.get_schedule_handle.call_args_list] == updated_ids


### PR DESCRIPTION
## Problem

`backfill_dag_schedule_type --dry-run` always reports `would stamp: 0` because the dry-run branch `continue`s before the update counter is ever incremented.
Against a real fleet it printed `execute-dag schedules found: 9989; would stamp: 0`, which gives the operator no signal about how many schedules actually still need the `PostHogScheduleType` attribute.
The real run had a related gap: it re-issued an update for every matching schedule on each invocation, so a backfill interrupted midway had to redo thousands of no-op updates on resume.

## Changes

- Classify each execute-dag schedule by reading `PostHogScheduleType` from the listing's search attributes (already in the list payload, so no extra RPCs).
- Dry-run now reports `already stamped` and a real `would stamp` count.
- Real runs skip already-stamped schedules, making an interrupted backfill cheap to resume.

## How did you test this code?

Added `test_backfill_dag_schedule_type.py` (parameterized dry-run/real-run) with the Temporal client mocked at the connection boundary, following the existing pattern in `test_schedule.py`.
It catches the shipped regression: with the previous code, dry-run reports 0 stampable schedules regardless of fleet state, and real runs update already-stamped schedules.
The command had no tests before.
`pytest products/data_modeling/backend/test/test_backfill_dag_schedule_type.py` passes locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal operational management command, no docs to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote the fix and test after I hit the misleading dry-run output while running the backfill.
Skills invoked: /writing-tests, /quick-fix-pr.
Design choice: exact-value comparison on the attribute (not key presence), so a schedule tagged with a wrong value gets re-stamped rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcSposWEDNNeFsTLn7VFYr
