### PR TITLE
fix(customer-analytics): Paginate accounts list past 100 rows

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
@@ -335,6 +335,29 @@ describe('dataNodeLogic', () => {
         })
     })
 
+    it('can load next data for AccountsQuery', async () => {
+        logic = dataNodeLogic({
+            key: testUniqueKey,
+            query: setLatestVersionsOnQuery({ kind: NodeKind.AccountsQuery }),
+        })
+        const results = [[{}], [{}], [{}]]
+        mockedQuery.mockResolvedValueOnce({ results, hasMore: true })
+        logic.mount()
+        await expectLogic(logic)
+            .toMatchValues({ responseLoading: true, canLoadNextData: false, nextQuery: null, response: null })
+            .delay(0)
+        await expectLogic(logic).toMatchValues({
+            responseLoading: false,
+            canLoadNextData: true,
+            nextQuery: setLatestVersionsOnQuery({
+                kind: NodeKind.AccountsQuery,
+                limit: 100,
+                offset: 3,
+            }),
+            response: partial({ results }),
+        })
+    })
+
     it('can autoload new data for EventsQuery', async () => {
         const results = [
             [

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -37,6 +37,8 @@ import {
     ActorsQueryResponse,
     AnyResponseType,
     DashboardFilter,
+    AccountsQuery,
+    AccountsQueryResponse,
     DataNode,
     DataVisualizationNode,
     ErrorTrackingQuery,
@@ -63,6 +65,7 @@ import {
     TracesQueryResponse,
 } from '~/queries/schema/schema-general'
 import {
+    isAccountsQuery,
     isActorsQuery,
     isErrorTrackingQuery,
     isEventsQuery,
@@ -456,7 +459,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         isTracesQuery(props.query) ||
                         isErrorTrackingQuery(props.query) ||
                         isSessionsQuery(props.query) ||
-                        isMarketingAnalyticsTableQuery(props.query)
+                        isMarketingAnalyticsTableQuery(props.query) ||
+                        isAccountsQuery(props.query)
                     ) {
                         const newResponse =
                             (await performQuery(
@@ -479,6 +483,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                             | TracesQueryResponse
                             | SessionsQueryResponse
                             | MarketingAnalyticsTableQueryResponse
+                            | AccountsQueryResponse
 
                         let results = [...(queryResponse?.results ?? []), ...(newResponse?.results ?? [])]
 
@@ -825,7 +830,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         isErrorTrackingQuery(query) ||
                         isTracesQuery(query) ||
                         isSessionsQuery(query) ||
-                        isMarketingAnalyticsTableQuery(query)) &&
+                        isMarketingAnalyticsTableQuery(query) ||
+                        isAccountsQuery(query)) &&
                     !responseError &&
                     !dataLoading
                 ) {
@@ -839,6 +845,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                 | TracesQueryResponse
                                 | SessionsQueryResponse
                                 | MarketingAnalyticsTableQueryResponse
+                                | AccountsQueryResponse
                         )?.hasMore
                     ) {
                         const sortKey = isTracesQuery(query) ? null : (query.orderBy?.[0] ?? 'timestamp DESC')
@@ -871,6 +878,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                     | TracesQueryResponse
                                     | SessionsQueryResponse
                                     | MarketingAnalyticsTableQueryResponse
+                                    | AccountsQueryResponse
                             )?.results
                             return {
                                 ...query,
@@ -887,6 +895,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                 | TracesQuery
                                 | SessionsQuery
                                 | MarketingAnalyticsTableQuery
+                                | AccountsQuery
                         }
                     }
                 }


### PR DESCRIPTION
## Problem
The customer analytics accounts list stops at 100 rows and shows "reached the end of results" even when more accounts exist — "load more" does nothing.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add `AccountsQuery` to `dataNodeLogic`'s `nextQuery` selector so pagination builds a follow-up query with an incremented `offset`
- Add `AccountsQuery` to the `loadNextData` listener so subsequent pages fetch and append
- Result: `canLoadNextData` becomes true when the backend reports `hasMore`, unblocking pagination past 100
- Add a `dataNodeLogic` test asserting `AccountsQuery` produces a next query with the right offset
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests
<!-- Please describe how you tested this code. e.g. unit tests, manual testing, etc. -->

## Publish to changelog?
No
<!-- Only publish to changelog if the change is user-facing and notable -->

## Docs update
No
<!-- Did you update the docs? Link the PR here. If not, why not? -->

## 🤖 Agent context
Authored by PostHog Code.

The backend `AccountsQueryRunner` already honored `limit`/`offset` (via `HogQLHasMorePaginator`); the bug was purely that the frontend never built a follow-up query for `AccountsQuery`, mirroring the seven other paginated query types.
<!-- Add any context that would help a reviewer or future agent understand the decisions made here -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
