### PR TITLE
fix(devex): stop required-check gates going green on cancelled builds

### DIFF
--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -101,17 +101,21 @@ jobs:
         name: Agent Proxy CI Pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !cancelled() }}
+        # always(), not !cancelled(): a skipped required check is treated as a pass by
+        # branch protection, so on cancellation the gate must run and emit an explicit
+        # result rather than skip into a green. A cancelled or timed-out job is caught
+        # by the != success && != skipped checks below; a legitimate no-change skip passes.
+        if: always()
         steps:
             - name: Check outcomes
               run: |
-                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
-                    echo "Change detection job failed."
+                  if [[ "${{ needs.changes.result }}" != "success" && "${{ needs.changes.result }}" != "skipped" ]]; then
+                    echo "Change detection did not succeed (result: ${{ needs.changes.result }})."
                     exit 1
                   fi
 
-                  if [[ "${{ needs.agent-proxy.result }}" == "failure" ]]; then
-                    echo "Agent Proxy checks failed."
+                  if [[ "${{ needs.agent-proxy.result }}" != "success" && "${{ needs.agent-proxy.result }}" != "skipped" ]]; then
+                    echo "Agent Proxy checks did not succeed (result: ${{ needs.agent-proxy.result }})."
                     exit 1
                   fi
 

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -101,17 +101,21 @@ jobs:
         name: LLM Services Tests Pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !cancelled() }}
+        # always(), not !cancelled(): a skipped required check is treated as a pass by
+        # branch protection, so on cancellation the gate must run and emit an explicit
+        # result rather than skip into a green. A cancelled or timed-out job is caught
+        # by the != success && != skipped checks below; a legitimate no-change skip passes.
+        if: always()
         steps:
             - name: Check outcomes
               run: |
-                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
-                    echo "Change detection job failed."
+                  if [[ "${{ needs.changes.result }}" != "success" && "${{ needs.changes.result }}" != "skipped" ]]; then
+                    echo "Change detection did not succeed (result: ${{ needs.changes.result }})."
                     exit 1
                   fi
 
-                  if [[ "${{ needs.llm-gateway.result }}" == "failure" ]]; then
-                    echo "LLM Gateway tests failed."
+                  if [[ "${{ needs.llm-gateway.result }}" != "success" && "${{ needs.llm-gateway.result }}" != "skipped" ]]; then
+                    echo "LLM Gateway tests did not succeed (result: ${{ needs.llm-gateway.result }})."
                     exit 1
                   fi
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -590,7 +590,7 @@ jobs:
 
     # Collate matrix + VR completion status for the required check
     visual_regression_tests:
-        needs: [visual-regression, vr-setup, vr-complete]
+        needs: [build-storybook, visual-regression, vr-setup, vr-complete]
         name: Visual regression tests pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -598,13 +598,23 @@ jobs:
         steps:
             - name: Check matrix outcome
               run: |
+                  # A failed, timed-out or cancelled Storybook build skips the VR jobs
+                  # below rather than failing them, and this gate would read those skips
+                  # as a pass — a green required check with zero visual coverage. Naming
+                  # the build here makes its failure hit the gate directly. A legitimate
+                  # "no frontend changes" run leaves the build skipped, which still passes.
+                  if [[ "${{ needs.build-storybook.result }}" != "success" && "${{ needs.build-storybook.result }}" != "skipped" ]]; then
+                    echo "Storybook build did not succeed (result: ${{ needs.build-storybook.result }}) — visual regression is uncovered."
+                    exit 1
+                  fi
+
                   if [[ "${{ needs.visual-regression.result }}" != "success" && "${{ needs.visual-regression.result }}" != "skipped" ]]; then
                     echo "One or more jobs in the visual-regression test matrix failed."
                     exit 1
                   fi
 
-                  if [[ "${{ needs.vr-setup.result }}" == "failure" ]]; then
-                    echo "Visual Review setup failed — VR CLI or API error."
+                  if [[ "${{ needs.vr-setup.result }}" != "success" && "${{ needs.vr-setup.result }}" != "skipped" ]]; then
+                    echo "Visual Review setup failed or was cancelled (result: ${{ needs.vr-setup.result }})."
                     exit 1
                   fi
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -590,7 +590,7 @@ jobs:
 
     # Collate matrix + VR completion status for the required check
     visual_regression_tests:
-        needs: [build-storybook, visual-regression, vr-setup, vr-complete]
+        needs: [changes, build-storybook, visual-regression, vr-setup, vr-complete]
         name: Visual regression tests pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -598,6 +598,15 @@ jobs:
         steps:
             - name: Check matrix outcome
               run: |
+                  # Change detection is the root of the graph: if it fails, build-storybook
+                  # (and everything after) is skipped, which the checks below would read as
+                  # a pass. Fail here so a broken paths-filter/checkout can't launder into a
+                  # green required check. A legitimate skip (e.g. merge_group) still passes.
+                  if [[ "${{ needs.changes.result }}" != "success" && "${{ needs.changes.result }}" != "skipped" ]]; then
+                    echo "Change detection did not succeed (result: ${{ needs.changes.result }}) — cannot certify visual regression."
+                    exit 1
+                  fi
+
                   # A failed, timed-out or cancelled Storybook build skips the VR jobs
                   # below rather than failing them, and this gate would read those skips
                   # as a pass — a green required check with zero visual coverage. Naming


### PR DESCRIPTION
## Problem

A "collate" gate job that only inspects downstream test jobs can report a green required check even when nothing ran. Spotted on a real Storybook run: the build got cancelled (concurrency supersede), every VR job downstream skipped, and `Visual regression tests pass` still went green.

The mechanism: when the build is a **separate** job, its failure/cancellation makes the test jobs **skip** (they gate on `build.result == 'success'`). If the collate gate treats skipped deps as a pass and never checks the build itself, a cancelled or timed-out build launders into a green required check with zero coverage. Switching the gate to `!cancelled()` doesn't help — a *skipped* required check is itself treated as a pass by branch protection, so the gate has to actually run and emit an explicit result.

With auto-merge on, this means a build that hits a problem or times out can let a PR merge without the check ever really running.

## Changes

Keep `if: always()` on the gates (so they always emit a real pass/fail) and do the work in bash:

- **ci-storybook** — the visual regression gate never looked at `build-storybook`. Add it to the gate's `needs` and fail on any non-success/skip result; also tighten the `vr-setup` check from `== 'failure'` to `!= success && != skipped` so a cancellation is caught too.
- **ci-agent-proxy / ci-llm-gateway** — single-job gates used `!cancelled()` and only failed on `'failure'`, so a cancel or timeout slipped through green. Move them to `always()` + `!= success && != skipped`, matching the backend/rust/mcp/nodejs gates.

Legit skips (no frontend changes, no relevant service changes) still pass — those show up as `skipped`, which the checks allow.

The backend `Django Tests Pass` gate had the same class of hole via `build_django_matrix`; it was already fixed in #68003. This PR closes the remaining instances.

## How did you test this code?

No automated tests — these are branch-protection collate jobs whose behavior only manifests against GitHub's real job-result semantics, which isn't reproducible in unit tests. Verified by:

- `actionlint` on all three files — no new findings (pre-existing `info`/`style` shellcheck notes on untouched lines only).
- Truth-table review of each gate against the possible upstream results: `success` → pass, legit `skipped` → pass, `failure`/`cancelled`/timeout → exit 1. Cross-checked the fix shape against the already-merged backend gate (#68003) and the rust/mcp gates that were already correct.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from a "why did a cancelled Storybook run go green?" question and traced it to the collate-gate pattern. Swept all 15 required-check gates across `.github/workflows/` for the same shape; found the launder-via-skip hole only where a separate build job feeds skip-gated test jobs (storybook; backend was already fixed in #68003), plus a weaker cancel/timeout gap in the two `!cancelled()` + `== 'failure'`-only single-job gates. Rust, mcp, nodejs, oauth-proxy, sandbox already guard their build deps correctly; e2e-playwright builds in-job so a build failure fails the job directly (safe).

Key decision: rejected `!cancelled()` as the fix — a skipped required check reads as a pass to branch protection, so the gate must stay `always()` and assert results explicitly in bash. No new files or dependencies, so unrebased in-flight PRs degrade fine.
