### PR TITLE
feat(weekly-digest): add usage trends (WoW) and new error issues

### DIFF
--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -2,11 +2,13 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
+from posthog.test.base import _create_event, flush_persons_and_events
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest_asyncio
 
 from posthog.temporal.weekly_digest.activities import (
+    _query_team_usage_trends,
     _usage_trend_metric,
     count_organizations,
     count_teams,
@@ -910,3 +912,42 @@ def test_usage_trend_metric(current, previous, expected_direction, expected_chan
     assert metric.direction == expected_direction
     assert metric.change_pct == expected_change_pct
     assert metric.has_baseline is expected_has_baseline
+
+
+@pytest.mark.django_db
+def test_query_team_usage_trends_windows_persons_and_test_accounts(team):
+    # Guards the previously-unvalidated usage query: window boundaries, distinct-person
+    # "active users" (matching DAU/WAU), and that filterTestAccounts drops test traffic.
+    period_end = datetime(2024, 1, 8, tzinfo=UTC)
+    period_start = period_end - timedelta(days=7)  # current window [period_start, period_end)
+
+    p1, p2 = str(uuid4()), str(uuid4())
+    # Current window: 3 events across 2 distinct persons.
+    _create_event(team=team, event="$pageview", distinct_id="a", person_id=p1, timestamp="2024-01-03T00:00:00Z")
+    _create_event(team=team, event="$pageview", distinct_id="a", person_id=p1, timestamp="2024-01-04T00:00:00Z")
+    _create_event(team=team, event="$pageview", distinct_id="b", person_id=p2, timestamp="2024-01-05T00:00:00Z")
+    # Previous window: 1 event, 1 person.
+    _create_event(team=team, event="$pageview", distinct_id="a", person_id=p1, timestamp="2023-12-31T00:00:00Z")
+    # Exactly at period_end is excluded (window is half-open: timestamp < cur_end).
+    _create_event(team=team, event="$pageview", distinct_id="b", person_id=p2, timestamp="2024-01-08T00:00:00Z")
+
+    # test_account_filters are phrased to KEEP real accounts, so "is_not localhost" drops the test event below.
+    team.test_account_filters = [{"key": "$host", "type": "event", "value": "localhost", "operator": "is_not"}]
+    team.save()
+    # Test-account traffic in the current window must not inflate the numbers.
+    _create_event(
+        team=team,
+        event="$pageview",
+        distinct_id="t",
+        person_id=str(uuid4()),
+        timestamp="2024-01-06T00:00:00Z",
+        properties={"$host": "localhost"},
+    )
+    flush_persons_and_events()
+
+    result = _query_team_usage_trends(team.id, period_start, period_end)
+
+    assert result is not None
+    events, users = result.metrics
+    assert (events.label, events.current, events.previous) == ("Events", 3, 1)
+    assert (users.label, users.current, users.previous) == ("Active users", 2, 1)

--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -23,6 +23,7 @@ from posthog.temporal.weekly_digest.activities import (
     generate_product_suggestion_lookup,
     generate_recording_lookup,
     generate_survey_lookup,
+    generate_usage_trends_lookup,
     generate_user_notification_lookup,
     send_weekly_digest_batch,
 )
@@ -32,6 +33,7 @@ from posthog.temporal.weekly_digest.types import (
     GenerateDigestDataBatchInput,
     GenerateOrganizationDigestInput,
     SendWeeklyDigestBatchInput,
+    UsageTrends,
 )
 
 
@@ -951,3 +953,32 @@ def test_query_team_usage_trends_windows_persons_and_test_accounts(team):
     events, users = result.metrics
     assert (events.label, events.current, events.previous) == ("Events", 3, 1)
     assert (users.label, users.current, users.previous) == ("Active users", 2, 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "side_effects,should_raise",
+    [
+        # Systemic failure (broken query / offline outage): every team errors -> fail the run loudly.
+        ([Exception("boom"), Exception("boom")], True),
+        # Isolated failure: one team errors, another succeeds -> tolerate and keep going.
+        ([Exception("boom"), UsageTrends(metrics=[])], False),
+    ],
+)
+async def test_generate_usage_trends_lookup_raises_only_when_every_team_fails(
+    side_effects, should_raise, mock_redis, common_input, digest
+):
+    input_data = GenerateDigestDataBatchInput(batch=(0, 2), digest=digest, common=common_input)
+    team_1, team_2 = MagicMock(), MagicMock()
+    team_1.id, team_2.id = 1, 2
+    mock_team_queryset = MockAsyncQuerySet([team_1, team_2])
+
+    with patch("posthog.temporal.weekly_digest.activities.query_teams_for_digest", return_value=mock_team_queryset):
+        with patch("posthog.temporal.weekly_digest.activities.database_sync_to_async") as mock_sync:
+            mock_sync.return_value = AsyncMock(side_effect=side_effects)
+            with patch("posthog.temporal.weekly_digest.activities.redis.from_url", return_value=mock_redis):
+                if should_raise:
+                    with pytest.raises(RuntimeError):
+                        await generate_usage_trends_lookup(input_data)
+                else:
+                    await generate_usage_trends_lookup(input_data)

--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest_asyncio
 
 from posthog.temporal.weekly_digest.activities import (
+    _usage_trend_metric,
     count_organizations,
     count_teams,
     generate_dashboard_lookup,
@@ -888,3 +889,24 @@ async def test_send_weekly_digest_batch_with_product_suggestion(mock_redis, comm
     suggestion = team_report["new_product_suggestion"]
     assert suggestion["product_path"] == "Error tracking"
     assert suggestion["reason_text"] == "This product is recommended for you by our team."
+
+
+@pytest.mark.parametrize(
+    "current,previous,expected_direction,expected_change_pct,expected_has_baseline",
+    [
+        (150, 100, "up", 50, True),
+        (50, 100, "down", 50, True),
+        (100, 100, "flat", 0, True),
+        # No previous-week baseline: growth from 0 must not be reported as "no change"
+        (10_000, 0, "flat", 0, False),
+        (0, 0, "flat", 0, False),
+    ],
+)
+def test_usage_trend_metric(current, previous, expected_direction, expected_change_pct, expected_has_baseline):
+    metric = _usage_trend_metric("Events", current, previous)
+
+    assert metric.current == current
+    assert metric.previous == previous
+    assert metric.direction == expected_direction
+    assert metric.change_pct == expected_change_pct
+    assert metric.has_baseline is expected_has_baseline

--- a/posthog/temporal/tests/weekly_digest/test_queries.py
+++ b/posthog/temporal/tests/weekly_digest/test_queries.py
@@ -1,0 +1,45 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from posthog.temporal.weekly_digest.queries import query_new_error_issues
+
+from products.error_tracking.backend.models import ErrorTrackingIssue
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_issue(
+    team,
+    name: str,
+    created_at: datetime,
+    status: ErrorTrackingIssue.Status = ErrorTrackingIssue.Status.ACTIVE,
+) -> ErrorTrackingIssue:
+    issue = ErrorTrackingIssue.objects.create(team=team, name=name, status=status)
+    # created_at is auto_now_add, so it has to be set after creation
+    ErrorTrackingIssue.objects.filter(id=issue.id).update(created_at=created_at)
+    return issue
+
+
+def test_query_new_error_issues_window_boundaries_and_status(team):
+    period_end = datetime(2024, 1, 8, tzinfo=UTC)
+    period_start = period_end - timedelta(days=7)
+
+    in_window = _create_issue(team, "in window", period_start + timedelta(days=1))
+    at_period_end = _create_issue(team, "at period end", period_end)
+    _create_issue(team, "at period start", period_start)  # excluded: window is exclusive at the start
+    _create_issue(team, "before window", period_start - timedelta(seconds=1))
+    _create_issue(team, "after window", period_end + timedelta(seconds=1))
+    for status in (
+        ErrorTrackingIssue.Status.ARCHIVED,
+        ErrorTrackingIssue.Status.RESOLVED,
+        ErrorTrackingIssue.Status.SUPPRESSED,
+        ErrorTrackingIssue.Status.PENDING_RELEASE,
+    ):
+        _create_issue(team, f"{status} in window", period_start + timedelta(days=1), status=status)
+
+    results = list(query_new_error_issues(period_start, period_end))
+
+    # Only active issues created within the window, newest first
+    assert [r["id"] for r in results] == [at_period_end.id, in_window.id]
+    assert all(r["team_id"] == team.id for r in results)

--- a/posthog/temporal/tests/weekly_digest/test_types.py
+++ b/posthog/temporal/tests/weekly_digest/test_types.py
@@ -1,10 +1,12 @@
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from posthog.temporal.weekly_digest.activities import DIGEST_ITEM_COUNT_THRESHOLD
 from posthog.temporal.weekly_digest.types import (
     DashboardList,
     Digest,
     DigestDashboard,
+    DigestErrorIssue,
     DigestEventDefinition,
     DigestExperiment,
     DigestExternalDataSource,
@@ -12,6 +14,7 @@ from posthog.temporal.weekly_digest.types import (
     DigestFilter,
     DigestProductSuggestion,
     DigestSurvey,
+    ErrorIssueList,
     EventDefinitionList,
     ExperimentList,
     ExternalDataSourceList,
@@ -21,6 +24,8 @@ from posthog.temporal.weekly_digest.types import (
     RecordingCount,
     SurveyList,
     TeamDigest,
+    UsageTrendMetric,
+    UsageTrends,
     UserDigestContext,
     UserSpecificDigest,
 )
@@ -132,6 +137,36 @@ def test_team_digest_count_items():
     )
 
     assert digest.count_items() == 3  # dashboards, event_definitions, feature_flags
+
+
+def test_error_issues_count_toward_digest_threshold_but_usage_trends_do_not():
+    # An org whose only activity is new error issues must cross DIGEST_ITEM_COUNT_THRESHOLD;
+    # usage trends are ambient context and must not count.
+    team = TeamDigest(
+        id=1,
+        name="Test Team",
+        dashboards=DashboardList(root=[]),
+        event_definitions=EventDefinitionList(root=[]),
+        experiments_launched=ExperimentList(root=[]),
+        experiments_completed=ExperimentList(root=[]),
+        external_data_sources=ExternalDataSourceList(root=[]),
+        feature_flags=FeatureFlagList(root=[]),
+        filters=FilterList(root=[]),
+        expiring_recordings=RecordingCount(recording_count=0),
+        surveys_launched=SurveyList(root=[]),
+        usage_trends=UsageTrends(metrics=[UsageTrendMetric(label="Events", current=100)]),
+    )
+    org = OrganizationDigest(id=uuid4(), name="Test Org", created_at=datetime.now(UTC), team_digests=[team])
+
+    assert org.count_items() == 0
+    assert org.is_empty() is True
+
+    team.error_issues = ErrorIssueList(
+        root=[DigestErrorIssue(name=f"Error {i}", id=uuid4()) for i in range(DIGEST_ITEM_COUNT_THRESHOLD)]
+    )
+
+    assert org.is_empty() is False
+    assert org.count_items() >= DIGEST_ITEM_COUNT_THRESHOLD
 
 
 def test_team_digest_render_payload():

--- a/posthog/temporal/tests/weekly_digest/test_workflows.py
+++ b/posthog/temporal/tests/weekly_digest/test_workflows.py
@@ -120,6 +120,8 @@ async def test_generate_digest_data_workflow():
         "filter": 0,
         "recording": 0,
         "product_suggestion": 0,
+        "error_issue": 0,
+        "usage_trends": 0,
         "org_digest": 0,
     }
 
@@ -177,6 +179,14 @@ async def test_generate_digest_data_workflow():
     async def generate_product_suggestion_lookup_mocked(input) -> None:
         activity_calls["product_suggestion"] += 1
 
+    @activity.defn(name="generate-error-issue-lookup")
+    async def generate_error_issue_lookup_mocked(input) -> None:
+        activity_calls["error_issue"] += 1
+
+    @activity.defn(name="generate-usage-trends-lookup")
+    async def generate_usage_trends_lookup_mocked(input) -> None:
+        activity_calls["usage_trends"] += 1
+
     @activity.defn(name="generate-organization-digest-batch")
     async def generate_organization_digest_batch_mocked(input) -> None:
         activity_calls["org_digest"] += 1
@@ -201,6 +211,8 @@ async def test_generate_digest_data_workflow():
                 generate_filter_lookup_mocked,
                 generate_recording_lookup_mocked,
                 generate_product_suggestion_lookup_mocked,
+                generate_error_issue_lookup_mocked,
+                generate_usage_trends_lookup_mocked,
                 generate_organization_digest_batch_mocked,
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
@@ -237,6 +249,8 @@ async def test_generate_digest_data_workflow():
     assert activity_calls["filter"] == expected_team_batches
     assert activity_calls["recording"] == expected_team_batches
     assert activity_calls["product_suggestion"] == expected_team_batches
+    assert activity_calls["error_issue"] == expected_team_batches
+    assert activity_calls["usage_trends"] == expected_team_batches
 
     # Calculate expected batches for organizations
     expected_org_batches = (TEST_ORG_COUNT + TEST_BATCH_SIZE - 1) // TEST_BATCH_SIZE

--- a/posthog/temporal/weekly_digest/README.md
+++ b/posthog/temporal/weekly_digest/README.md
@@ -30,6 +30,8 @@ Generated via `team_data_key(digest_key, TeamDataKey.*, team_id)`:
 | `SAVED_FILTERS`         | `{digest_key}-saved-filters-{team_id}`         | Interesting replay filters         |
 | `EXPIRING_RECORDINGS`   | `{digest_key}-expiring-recordings-{team_id}`   | Count of soon-to-expire recordings |
 | `SURVEYS_LAUNCHED`      | `{digest_key}-surveys-launched-{team_id}`      | Surveys launched                   |
+| `USAGE_TRENDS`          | `{digest_key}-usage-trends-{team_id}`          | Event volume + active users, WoW   |
+| `ERROR_ISSUES`          | `{digest_key}-error-issues-{team_id}`          | New error-tracking issues          |
 
 ### Organization-level data
 

--- a/posthog/temporal/weekly_digest/__init__.py
+++ b/posthog/temporal/weekly_digest/__init__.py
@@ -2,6 +2,7 @@ from posthog.temporal.weekly_digest.activities import (
     count_organizations,
     count_teams,
     generate_dashboard_lookup,
+    generate_error_issue_lookup,
     generate_event_definition_lookup,
     generate_experiment_completed_lookup,
     generate_experiment_launched_lookup,
@@ -12,6 +13,7 @@ from posthog.temporal.weekly_digest.activities import (
     generate_product_suggestion_lookup,
     generate_recording_lookup,
     generate_survey_lookup,
+    generate_usage_trends_lookup,
     generate_user_notification_lookup,
     send_weekly_digest_batch,
 )
@@ -43,4 +45,6 @@ ACTIVITIES = [
     generate_filter_lookup,
     generate_recording_lookup,
     generate_product_suggestion_lookup,
+    generate_error_issue_lookup,
+    generate_usage_trends_lookup,
 ]

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -346,14 +346,15 @@ async def generate_error_issue_lookup(input: GenerateDigestDataBatchInput) -> No
 
 
 # NOTE: This ClickHouse query is written to match the recording-lookup pattern but has
-# NOT been executed against a live cluster — review the table/column names and confirm
-# `uniq(distinct_id)` is the desired "active users" definition before enabling in prod.
+# NOT been executed against a live cluster — review the table/column names before enabling
+# in prod. "Active users" counts persons (`uniq(person_id)`), matching lifecycle/DAU/WAU
+# elsewhere in PostHog — counting distinct_ids would overcount (one person, many devices).
 USAGE_TRENDS_QUERY = """
 SELECT
     countIf(timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS events_current,
     countIf(timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS events_previous,
-    uniqIf(distinct_id, timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS users_current,
-    uniqIf(distinct_id, timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS users_previous
+    uniqIf(person_id, timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS users_current,
+    uniqIf(person_id, timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS users_previous
 FROM events
 WHERE team_id = %(team_id)s
     AND timestamp >= %(prev_start)s
@@ -363,15 +364,17 @@ FORMAT JSON
 
 
 def _usage_trend_metric(label: str, current: int, previous: int) -> UsageTrendMetric:
-    change = compute_week_over_week_change(current, previous or None, higher_is_better=True)
+    has_baseline = previous > 0
+    change = compute_week_over_week_change(current, previous if has_baseline else None, higher_is_better=True)
     if change is None:
-        return UsageTrendMetric(label=label, current=current, previous=previous, change_pct=0, direction="flat")
+        return UsageTrendMetric(label=label, current=current, previous=previous, has_baseline=has_baseline)
     return UsageTrendMetric(
         label=label,
         current=current,
         previous=previous,
         change_pct=change["percent"],
         direction="up" if change["direction"] == "Up" else "down",
+        has_baseline=True,
     )
 
 
@@ -411,6 +414,9 @@ async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> N
                         raw_response = await ch_response.content.read()
 
                     response = ClickHouseResponse.model_validate_json(raw_response)
+                    if not response.data:
+                        logger.warning(f"Usage trends query returned no rows for team {team.id}, skipping...")
+                        continue
                     row = response.data[0]
 
                     events_current = int(row.get("events_current", 0) or 0)

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -107,6 +107,7 @@ async def generate_digest_data_lookup(
     key_kind: TeamDataKey,
     query_func: Callable[[datetime, datetime], QuerySet],
     resource_type: DigestResourceType,
+    per_team_limit: int | None = None,
 ) -> None:
     async with Heartbeater():
         bind_contextvars(
@@ -128,7 +129,10 @@ async def generate_digest_data_lookup(
             batch_start, batch_end = input.batch
             async for team in query_teams_for_digest()[batch_start:batch_end]:
                 try:
-                    digest_data = resource_type(await queryset_to_list(db_query.filter(team_id=team.id)))
+                    team_query = db_query.filter(team_id=team.id)
+                    if per_team_limit is not None:
+                        team_query = team_query[:per_team_limit]
+                    digest_data = resource_type(await queryset_to_list(team_query))
 
                     key = team_data_key(input.digest.key, key_kind, team.id)
                     await r.setex(key, input.common.redis_ttl, digest_data.model_dump_json())
@@ -340,6 +344,12 @@ async def generate_recording_lookup(input: GenerateDigestDataBatchInput) -> None
         )
 
 
+# Issue names come from exception ingestion, so a noisy (or malicious) client can create
+# hundreds of new issues in a week. Cap at the 5 newest per team, mirroring the error
+# tracking weekly digest, which also shows at most 5 new issues.
+NEW_ERROR_ISSUES_PER_TEAM_LIMIT = 5
+
+
 @activity.defn(name="generate-error-issue-lookup")
 async def generate_error_issue_lookup(input: GenerateDigestDataBatchInput) -> None:
     # New error-tracking issues follow the standard "created within window" lookup,
@@ -349,6 +359,7 @@ async def generate_error_issue_lookup(input: GenerateDigestDataBatchInput) -> No
         key_kind=TeamDataKey.ERROR_ISSUES,
         query_func=query_new_error_issues,
         resource_type=ErrorIssueList,
+        per_team_limit=NEW_ERROR_ISSUES_PER_TEAM_LIMIT,
     )
 
 

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -13,7 +13,14 @@ from pydantic import ValidationError
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
+from posthog.schema import HogQLFilters
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
 from posthog.models.messaging import MessagingRecord
+from posthog.models.team import Team
 from posthog.ph_client import get_client as get_ph_client
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.session_recording_playlist_api import PLAYLIST_COUNT_REDIS_PREFIX
@@ -345,21 +352,20 @@ async def generate_error_issue_lookup(input: GenerateDigestDataBatchInput) -> No
     )
 
 
-# NOTE: This ClickHouse query is written to match the recording-lookup pattern but has
-# NOT been executed against a live cluster — review the table/column names before enabling
-# in prod. "Active users" counts persons (`uniq(person_id)`), matching lifecycle/DAU/WAU
-# elsewhere in PostHog — counting distinct_ids would overcount (one person, many devices).
+# Weekly usage snapshot per team. Written in HogQL so it inherits the team's test-account
+# filtering (the numbers match what the team sees in product analytics) and column translation.
+# "Active users" mirrors the DAU/WAU trends definition — distinct persons, `uniqExactIf(person_id)`,
+# which is the conditional form of the `count(DISTINCT person_id)` those insights print. Counting
+# distinct_ids would overcount (one person, many devices). Two windows are compared in one pass;
+# the query runs on the offline cluster since it scans two weeks of events for every active team.
 USAGE_TRENDS_QUERY = """
 SELECT
-    countIf(timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS events_current,
-    countIf(timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS events_previous,
-    uniqIf(person_id, timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS users_current,
-    uniqIf(person_id, timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS users_previous
+    countIf(timestamp >= {cur_start} AND timestamp < {cur_end}) AS events_current,
+    countIf(timestamp >= {prev_start} AND timestamp < {cur_start}) AS events_previous,
+    uniqExactIf(person_id, timestamp >= {cur_start} AND timestamp < {cur_end}) AS users_current,
+    uniqExactIf(person_id, timestamp >= {prev_start} AND timestamp < {cur_start}) AS users_previous
 FROM events
-WHERE team_id = %(team_id)s
-    AND timestamp >= %(prev_start)s
-    AND timestamp < %(cur_end)s
-FORMAT JSON
+WHERE timestamp >= {prev_start} AND timestamp < {cur_end} AND {filters}
 """
 
 
@@ -378,6 +384,44 @@ def _usage_trend_metric(label: str, current: int, previous: int) -> UsageTrendMe
     )
 
 
+def _query_team_usage_trends(team_id: int, period_start: datetime, period_end: datetime) -> UsageTrends | None:
+    """Run the per-team usage snapshot on the offline cluster. Returns None for inactive teams.
+
+    Synchronous (HogQL execution is sync); callers wrap it with ``database_sync_to_async``.
+    """
+    team = Team.objects.get(pk=team_id)
+    window = period_end - period_start
+    response = execute_hogql_query(
+        query=USAGE_TRENDS_QUERY,
+        team=team,
+        placeholders={
+            "cur_start": ast.Constant(value=period_start),
+            "cur_end": ast.Constant(value=period_end),
+            "prev_start": ast.Constant(value=period_start - window),
+        },
+        filters=HogQLFilters(filterTestAccounts=True),
+        workload=Workload.OFFLINE,
+    )
+
+    if not response.results or not response.results[0]:
+        return None
+
+    events_current, events_previous, users_current, users_previous = response.results[0]
+    events_current = int(events_current or 0)
+    users_current = int(users_current or 0)
+
+    # Skip inactive teams entirely — no numbers worth showing.
+    if events_current == 0:
+        return None
+
+    return UsageTrends(
+        metrics=[
+            _usage_trend_metric("Events", events_current, int(events_previous or 0)),
+            _usage_trend_metric("Active users", users_current, int(users_previous or 0)),
+        ]
+    )
+
+
 @activity.defn(name="generate-usage-trends-lookup")
 async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> None:
     async with Heartbeater():
@@ -391,51 +435,15 @@ async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> N
         logger = LOGGER.bind()
         logger.info("Generating usage trends batch")
 
-        window = input.digest.period_end - input.digest.period_start
-        parameters_base = {
-            "cur_start": input.digest.period_start,
-            "cur_end": input.digest.period_end,
-            "prev_start": input.digest.period_start - window,
-            "prev_end": input.digest.period_start,
-        }
-
         team_count = 0
 
-        async with redis.from_url(_redis_url(input.common)) as r, get_ch_client() as ch_client:
+        async with redis.from_url(_redis_url(input.common)) as r:
             batch_start, batch_end = input.batch
             async for team in query_teams_for_digest()[batch_start:batch_end]:
                 try:
-                    raw_response: bytes = b""
-                    async with ch_client.aget_query(
-                        query=USAGE_TRENDS_QUERY,
-                        query_parameters={**parameters_base, "team_id": team.id},
-                        query_id=str(uuid4()),
-                    ) as ch_response:
-                        raw_response = await ch_response.content.read()
-
-                    response = ClickHouseResponse.model_validate_json(raw_response)
-                    if not response.data:
-                        logger.warning(f"Usage trends query returned no rows for team {team.id}, skipping...")
-                        continue
-                    row = response.data[0]
-
-                    events_current = int(row.get("events_current", 0) or 0)
-                    users_current = int(row.get("users_current", 0) or 0)
-
-                    # Skip inactive teams entirely — no numbers worth showing.
-                    if events_current == 0:
-                        continue
-
-                    usage_trends = UsageTrends(
-                        metrics=[
-                            _usage_trend_metric("Events", events_current, int(row.get("events_previous", 0) or 0)),
-                            _usage_trend_metric("Active users", users_current, int(row.get("users_previous", 0) or 0)),
-                        ]
+                    usage_trends = await database_sync_to_async(_query_team_usage_trends)(
+                        team.id, input.digest.period_start, input.digest.period_end
                     )
-
-                    key = team_data_key(input.digest.key, TeamDataKey.USAGE_TRENDS, team.id)
-                    await r.setex(key, input.common.redis_ttl, usage_trends.model_dump_json())
-                    team_count += 1
                 except Exception as e:
                     logger.warning(
                         f"Failed to generate usage trends for team {team.id}, skipping...",
@@ -443,6 +451,13 @@ async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> N
                         team_id=team.id,
                     )
                     continue
+
+                if usage_trends is None:
+                    continue
+
+                key = team_data_key(input.digest.key, TeamDataKey.USAGE_TRENDS, team.id)
+                await r.setex(key, input.common.redis_ttl, usage_trends.model_dump_json())
+                team_count += 1
 
         logger.info("Finished generating usage trends batch", team_count=team_count)
 

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -436,15 +436,19 @@ async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> N
         logger.info("Generating usage trends batch")
 
         team_count = 0
+        attempted = 0
+        error_count = 0
 
         async with redis.from_url(_redis_url(input.common)) as r:
             batch_start, batch_end = input.batch
             async for team in query_teams_for_digest()[batch_start:batch_end]:
+                attempted += 1
                 try:
                     usage_trends = await database_sync_to_async(_query_team_usage_trends)(
                         team.id, input.digest.period_start, input.digest.period_end
                     )
                 except Exception as e:
+                    error_count += 1
                     logger.warning(
                         f"Failed to generate usage trends for team {team.id}, skipping...",
                         error=str(e),
@@ -459,7 +463,13 @@ async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> N
                 await r.setex(key, input.common.redis_ttl, usage_trends.model_dump_json())
                 team_count += 1
 
-        logger.info("Finished generating usage trends batch", team_count=team_count)
+        # A malformed query (or an offline-cluster outage) fails for every team, which would
+        # otherwise look identical to "no active teams" and silently ship an empty section for
+        # the whole batch. Surface it so the activity retries and then fails the run loudly.
+        if attempted > 0 and error_count == attempted:
+            raise RuntimeError(f"Usage trends query failed for all {attempted} teams in batch")
+
+        logger.info("Finished generating usage trends batch", team_count=team_count, error_count=error_count)
 
 
 @activity.defn(name="generate-user-notification-lookup")

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -19,6 +19,7 @@ from posthog.session_recordings.queries.session_replay_events import SessionRepl
 from posthog.session_recordings.session_recording_playlist_api import PLAYLIST_COUNT_REDIS_PREFIX
 from posthog.sync import database_sync_to_async
 from posthog.tasks.email import NotificationSetting, should_send_notification
+from posthog.tasks.email_utils import compute_week_over_week_change
 from posthog.temporal.common.clickhouse import get_client as get_ch_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -27,6 +28,7 @@ from posthog.temporal.weekly_digest.queries import (
     query_experiments_completed,
     query_experiments_launched,
     query_new_dashboards,
+    query_new_error_issues,
     query_new_event_definitions,
     query_new_external_data_sources,
     query_new_feature_flags,
@@ -45,6 +47,7 @@ from posthog.temporal.weekly_digest.types import (
     DashboardList,
     DigestProductSuggestion,
     DigestResourceType,
+    ErrorIssueList,
     EventDefinitionList,
     ExperimentList,
     ExternalDataSourceList,
@@ -58,6 +61,8 @@ from posthog.temporal.weekly_digest.types import (
     SendWeeklyDigestBatchInput,
     SurveyList,
     TeamDigest,
+    UsageTrendMetric,
+    UsageTrends,
     UserDigestContext,
 )
 
@@ -328,6 +333,114 @@ async def generate_recording_lookup(input: GenerateDigestDataBatchInput) -> None
         )
 
 
+@activity.defn(name="generate-error-issue-lookup")
+async def generate_error_issue_lookup(input: GenerateDigestDataBatchInput) -> None:
+    # New error-tracking issues follow the standard "created within window" lookup,
+    # exactly like dashboards / feature flags.
+    return await generate_digest_data_lookup(
+        input,
+        key_kind=TeamDataKey.ERROR_ISSUES,
+        query_func=query_new_error_issues,
+        resource_type=ErrorIssueList,
+    )
+
+
+# NOTE: This ClickHouse query is written to match the recording-lookup pattern but has
+# NOT been executed against a live cluster — review the table/column names and confirm
+# `uniq(distinct_id)` is the desired "active users" definition before enabling in prod.
+USAGE_TRENDS_QUERY = """
+SELECT
+    countIf(timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS events_current,
+    countIf(timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS events_previous,
+    uniqIf(distinct_id, timestamp >= %(cur_start)s AND timestamp < %(cur_end)s) AS users_current,
+    uniqIf(distinct_id, timestamp >= %(prev_start)s AND timestamp < %(prev_end)s) AS users_previous
+FROM events
+WHERE team_id = %(team_id)s
+    AND timestamp >= %(prev_start)s
+    AND timestamp < %(cur_end)s
+FORMAT JSON
+"""
+
+
+def _usage_trend_metric(label: str, current: int, previous: int) -> UsageTrendMetric:
+    change = compute_week_over_week_change(current, previous or None, higher_is_better=True)
+    if change is None:
+        return UsageTrendMetric(label=label, current=current, previous=previous, change_pct=0, direction="flat")
+    return UsageTrendMetric(
+        label=label,
+        current=current,
+        previous=previous,
+        change_pct=change["percent"],
+        direction="up" if change["direction"] == "Up" else "down",
+    )
+
+
+@activity.defn(name="generate-usage-trends-lookup")
+async def generate_usage_trends_lookup(input: GenerateDigestDataBatchInput) -> None:
+    async with Heartbeater():
+        bind_contextvars(
+            digest_key=input.digest.key,
+            period_start=input.digest.period_start,
+            period_end=input.digest.period_end,
+            batch_start=input.batch[0],
+            batch_end=input.batch[1],
+        )
+        logger = LOGGER.bind()
+        logger.info("Generating usage trends batch")
+
+        window = input.digest.period_end - input.digest.period_start
+        parameters_base = {
+            "cur_start": input.digest.period_start,
+            "cur_end": input.digest.period_end,
+            "prev_start": input.digest.period_start - window,
+            "prev_end": input.digest.period_start,
+        }
+
+        team_count = 0
+
+        async with redis.from_url(_redis_url(input.common)) as r, get_ch_client() as ch_client:
+            batch_start, batch_end = input.batch
+            async for team in query_teams_for_digest()[batch_start:batch_end]:
+                try:
+                    raw_response: bytes = b""
+                    async with ch_client.aget_query(
+                        query=USAGE_TRENDS_QUERY,
+                        query_parameters={**parameters_base, "team_id": team.id},
+                        query_id=str(uuid4()),
+                    ) as ch_response:
+                        raw_response = await ch_response.content.read()
+
+                    response = ClickHouseResponse.model_validate_json(raw_response)
+                    row = response.data[0]
+
+                    events_current = int(row.get("events_current", 0) or 0)
+                    users_current = int(row.get("users_current", 0) or 0)
+
+                    # Skip inactive teams entirely — no numbers worth showing.
+                    if events_current == 0:
+                        continue
+
+                    usage_trends = UsageTrends(
+                        metrics=[
+                            _usage_trend_metric("Events", events_current, int(row.get("events_previous", 0) or 0)),
+                            _usage_trend_metric("Active users", users_current, int(row.get("users_previous", 0) or 0)),
+                        ]
+                    )
+
+                    key = team_data_key(input.digest.key, TeamDataKey.USAGE_TRENDS, team.id)
+                    await r.setex(key, input.common.redis_ttl, usage_trends.model_dump_json())
+                    team_count += 1
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to generate usage trends for team {team.id}, skipping...",
+                        error=str(e),
+                        team_id=team.id,
+                    )
+                    continue
+
+        logger.info("Finished generating usage trends batch", team_count=team_count)
+
+
 @activity.defn(name="generate-user-notification-lookup")
 async def generate_user_notification_lookup(input: GenerateDigestDataBatchInput) -> None:
     async with Heartbeater():
@@ -463,6 +576,8 @@ async def generate_organization_digest_batch(input: GenerateOrganizationDigestIn
                                 team_data_key(input.digest.key, TeamDataKey.SAVED_FILTERS, team.id),
                                 team_data_key(input.digest.key, TeamDataKey.EXPIRING_RECORDINGS, team.id),
                                 team_data_key(input.digest.key, TeamDataKey.SURVEYS_LAUNCHED, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.USAGE_TRENDS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.ERROR_ISSUES, team.id),
                             ]
                         )
 
@@ -476,6 +591,8 @@ async def generate_organization_digest_batch(input: GenerateOrganizationDigestIn
                             FilterList(root=[]),
                             RecordingCount(recording_count=0),
                             SurveyList(root=[]),
+                            UsageTrends(),
+                            ErrorIssueList(root=[]),
                         ]
 
                         digest_data = [
@@ -496,6 +613,8 @@ async def generate_organization_digest_batch(input: GenerateOrganizationDigestIn
                                 filters=digest_data[6],
                                 expiring_recordings=digest_data[7],
                                 surveys_launched=digest_data[8],
+                                usage_trends=digest_data[9],
+                                error_issues=digest_data[10],
                             )
                         )
                         team_count += 1

--- a/posthog/temporal/weekly_digest/keys.py
+++ b/posthog/temporal/weekly_digest/keys.py
@@ -12,6 +12,8 @@ class TeamDataKey(StrEnum):
     SAVED_FILTERS = "saved-filters"
     EXPIRING_RECORDINGS = "expiring-recordings"
     SURVEYS_LAUNCHED = "surveys-launched"
+    USAGE_TRENDS = "usage-trends"
+    ERROR_ISSUES = "error-issues"
 
 
 class UserDataKey(StrEnum):

--- a/posthog/temporal/weekly_digest/queries.py
+++ b/posthog/temporal/weekly_digest/queries.py
@@ -11,7 +11,7 @@ from posthog.session_recordings.models.session_recording_playlist import Session
 from posthog.sync import database_sync_to_async
 
 from products.dashboards.backend.models.dashboard import Dashboard
-from products.error_tracking.backend.models import ErrorTrackingIssue
+from products.error_tracking.backend.facade.api import query_new_error_issues as query_new_error_issues
 from products.event_definitions.backend.models.event_definition import EventDefinition
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -149,20 +149,6 @@ def query_user_product_suggestions(
         created_at__gt=period_start,
         created_at__lte=period_end,
     ).values("product_path", "reason", "reason_text")
-
-
-def query_new_error_issues(period_start: datetime, period_end: datetime) -> QuerySet:
-    # "New this week" = issue first created within the digest window. Only active issues
-    # (not archived/resolved/suppressed) are worth surfacing as a new production error.
-    return (
-        ErrorTrackingIssue.objects.filter(
-            created_at__gt=period_start,
-            created_at__lte=period_end,
-            status=ErrorTrackingIssue.Status.ACTIVE,
-        )
-        .order_by("-created_at")
-        .values("team_id", "name", "id")
-    )
 
 
 @database_sync_to_async

--- a/posthog/temporal/weekly_digest/queries.py
+++ b/posthog/temporal/weekly_digest/queries.py
@@ -11,6 +11,7 @@ from posthog.session_recordings.models.session_recording_playlist import Session
 from posthog.sync import database_sync_to_async
 
 from products.dashboards.backend.models.dashboard import Dashboard
+from products.error_tracking.backend.models import ErrorTrackingIssue
 from products.event_definitions.backend.models.event_definition import EventDefinition
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -148,6 +149,20 @@ def query_user_product_suggestions(
         created_at__gt=period_start,
         created_at__lte=period_end,
     ).values("product_path", "reason", "reason_text")
+
+
+def query_new_error_issues(period_start: datetime, period_end: datetime) -> QuerySet:
+    # "New this week" = issue first created within the digest window. Only active issues
+    # (not archived/resolved/suppressed) are worth surfacing as a new production error.
+    return (
+        ErrorTrackingIssue.objects.filter(
+            created_at__gt=period_start,
+            created_at__lte=period_end,
+            status=ErrorTrackingIssue.Status.ACTIVE,
+        )
+        .order_by("-created_at")
+        .values("team_id", "name", "id")
+    )
 
 
 @database_sync_to_async

--- a/posthog/temporal/weekly_digest/types.py
+++ b/posthog/temporal/weekly_digest/types.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, TypeAlias
 from uuid import UUID
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, RootModel, field_validator
 
 from posthog.utils import get_instance_region
 
@@ -119,6 +119,28 @@ class DigestSurvey(BaseModel):
     start_date: datetime
 
 
+class DigestErrorIssue(BaseModel):
+    name: str = "Untitled issue"
+    id: UUID
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _default_name(cls, value: str | None) -> str:
+        return value or "Untitled issue"
+
+
+class UsageTrendMetric(BaseModel):
+    label: str  # e.g. "Events", "Active users"
+    current: int
+    previous: Optional[int] = None
+    change_pct: int = 0  # absolute rounded percentage; 0 when no meaningful comparison
+    direction: str = "flat"  # "up" | "down" | "flat"
+
+
+class UsageTrends(BaseModel):
+    metrics: list[UsageTrendMetric] = []
+
+
 class DashboardList(RootModel):
     root: list[DigestDashboard]
 
@@ -154,6 +176,10 @@ class SurveyList(RootModel):
     root: list[DigestSurvey]
 
 
+class ErrorIssueList(RootModel):
+    root: list[DigestErrorIssue]
+
+
 PRODUCT_SUGGESTION_REASON_DEFAULTS: dict[str, str] = {
     "new_product": "This is a brand new product. Give it a try!",
     "sales_led": "This product is recommended for you by our team.",
@@ -186,6 +212,7 @@ DigestResourceType: TypeAlias = (
     | type[FeatureFlagList]
     | type[FilterList]
     | type[SurveyList]
+    | type[ErrorIssueList]
 )
 
 
@@ -201,8 +228,15 @@ class TeamDigest(BaseModel):
     filters: FilterList
     expiring_recordings: RecordingCount
     surveys_launched: SurveyList
+    # New signals. Defaults keep older callers/tests constructing TeamDigest working.
+    usage_trends: UsageTrends = UsageTrends()
+    error_issues: ErrorIssueList = ErrorIssueList(root=[])
 
     def _fields(self) -> list[RootModel]:
+        # NOTE: usage_trends is intentionally excluded — it is ambient context (present
+        # for nearly every active team), so counting it would make almost every org
+        # cross DIGEST_ITEM_COUNT_THRESHOLD and receive an email. error_issues IS counted:
+        # a new production error is worth an email on its own.
         return [
             self.dashboards,
             self.event_definitions,
@@ -212,6 +246,7 @@ class TeamDigest(BaseModel):
             self.feature_flags,
             self.filters,
             self.surveys_launched,
+            self.error_issues,
         ]
 
     def is_empty(self) -> bool:
@@ -233,6 +268,8 @@ class TeamDigest(BaseModel):
             "interesting_saved_filters": [f.render_payload() for f in self.filters.root],
             "expiring_recordings": self.expiring_recordings.model_dump(),
             "new_surveys_launched": self.surveys_launched.model_dump(),
+            "usage_trends": self.usage_trends.model_dump(),
+            "new_error_issues": self.error_issues.model_dump(),
         }
 
         if product_suggestion:

--- a/posthog/temporal/weekly_digest/types.py
+++ b/posthog/temporal/weekly_digest/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, TypeAlias
+from typing import Literal, Optional, TypeAlias
 from uuid import UUID
 
 from pydantic import BaseModel, RootModel, field_validator
@@ -134,7 +134,10 @@ class UsageTrendMetric(BaseModel):
     current: int
     previous: Optional[int] = None
     change_pct: int = 0  # absolute rounded percentage; 0 when no meaningful comparison
-    direction: str = "flat"  # "up" | "down" | "flat"
+    direction: Literal["up", "down", "flat"] = "flat"
+    # False when there was no previous-week activity to compare against, so the template
+    # can render "new" instead of conflating 0 -> N growth with "no change".
+    has_baseline: bool = True
 
 
 class UsageTrends(BaseModel):

--- a/posthog/temporal/weekly_digest/workflows.py
+++ b/posthog/temporal/weekly_digest/workflows.py
@@ -12,6 +12,7 @@ from posthog.temporal.weekly_digest.activities import (
     count_organizations,
     count_teams,
     generate_dashboard_lookup,
+    generate_error_issue_lookup,
     generate_event_definition_lookup,
     generate_experiment_completed_lookup,
     generate_experiment_launched_lookup,
@@ -22,6 +23,7 @@ from posthog.temporal.weekly_digest.activities import (
     generate_product_suggestion_lookup,
     generate_recording_lookup,
     generate_survey_lookup,
+    generate_usage_trends_lookup,
     generate_user_notification_lookup,
     send_weekly_digest_batch,
 )
@@ -133,6 +135,8 @@ class GenerateDigestDataWorkflow(PostHogWorkflow):
             generate_filter_lookup,
             generate_recording_lookup,
             generate_product_suggestion_lookup,
+            generate_error_issue_lookup,
+            generate_usage_trends_lookup,
         ]
 
         await asyncio.gather(

--- a/products/error_tracking/backend/facade/api.py
+++ b/products/error_tracking/backend/facade/api.py
@@ -131,6 +131,8 @@ def query_new_error_issues(period_start: datetime, period_end: datetime) -> Quer
     # "New this week" = issue first created within the digest window. Only active issues
     # (not archived/resolved/suppressed) are worth surfacing as a new production error.
     # Cross-team batch query for the weekly digest — callers execute it off the request path.
+    # Issue names are attacker-controlled (created from exception ingestion), so callers must
+    # cap how many they surface per team; newest-first ordering makes a per-team slice safe.
     return (
         ErrorTrackingIssue.objects.filter(
             created_at__gt=period_start,

--- a/products/error_tracking/backend/facade/api.py
+++ b/products/error_tracking/backend/facade/api.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
+from django.db.models import QuerySet
+
 import posthoganalytics
 
 from posthog.event_usage import groups
@@ -123,6 +125,21 @@ def list_issues(team_id: int) -> list[contracts.ErrorTrackingIssuePreview]:
 def list_issues_created_since(team_id: int, since: datetime, limit: int) -> list[contracts.ErrorTrackingIssuePreview]:
     issues = logic.list_issues_created_since(team_id=team_id, since=since, limit=limit)
     return [_to_issue_preview(issue) for issue in issues]
+
+
+def query_new_error_issues(period_start: datetime, period_end: datetime) -> QuerySet:
+    # "New this week" = issue first created within the digest window. Only active issues
+    # (not archived/resolved/suppressed) are worth surfacing as a new production error.
+    # Cross-team batch query for the weekly digest — callers execute it off the request path.
+    return (
+        ErrorTrackingIssue.objects.filter(
+            created_at__gt=period_start,
+            created_at__lte=period_end,
+            status=ErrorTrackingIssue.Status.ACTIVE,
+        )
+        .order_by("-created_at")
+        .values("team_id", "name", "id")
+    )
 
 
 def get_issue(issue_id: UUID, team_id: int) -> contracts.ErrorTrackingIssue:


### PR DESCRIPTION
## Summary

Adds two new team-level signals to the weekly digest so it reports **how the product is doing**, not just **what was created**. Both follow the existing "add a team-level field" recipe in `posthog/temporal/weekly_digest/README.md`.

- **`new_error_issues`** — error-tracking issues first created within the digest window (active only). Clean Postgres query on `ErrorTrackingIssue.created_at`, slots into the generic `generate_digest_data_lookup` pattern (same as dashboards/flags).
- **`usage_trends`** — event volume + active users this week vs. last, week-over-week, via ClickHouse. Reuses `compute_week_over_week_change` from `email_utils`.

## New payload properties

Both are nested under each `teams[].report` in the `transactional email` event (`template_name = weekly_digest_report`):

```
report.usage_trends      { metrics: [ { label, current, previous, change_pct, direction } ] }
report.new_error_issues  [ { id, name } ]
```

The Customer.io CDP destination already forwards `teams` as a whole object, so these nested fields flow through automatically — no destination mapping change required (verify with a test send).

## Behaviour notes

- **`new_error_issues` counts toward the send gate** (`DIGEST_ITEM_COUNT_THRESHOLD = 4`), so orgs with several new errors and little else now qualify for a digest. Intentional — a new production error is worth an email. Easy to flip in `TeamDigest._fields()`.
- **`usage_trends` is excluded from the send gate** — it's present for nearly every active team and would otherwise email everyone.

## ⚠️ Needs review before enabling

The `usage_trends` ClickHouse query (`USAGE_TRENDS_QUERY` in `activities.py`) was written to match the recording-lookup pattern but **has not been run against a live cluster**. Please confirm the `events` table/column names and that `uniq(distinct_id)` is the desired "active users" definition. It fails safe (per-team try/except → team simply omits usage_trends), but should be validated.

## Companion work (not in this repo)

The Customer.io digest template (campaign #164) has matching guarded `{% if %}` blocks ready to render these two sections once the data lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)