### PR TITLE
feat(endpoints): respect optional breakdown variables on materialized endpoints

### DIFF
--- a/products/endpoints/backend/logic/strategies.py
+++ b/products/endpoints/backend/logic/strategies.py
@@ -325,7 +325,10 @@ class EndpointQueryStrategy(abc.ABC):
         """Variables that MUST be provided when running against the materialized table.
 
         SECURITY: materialized tables contain rows for every variable value; omitting
-        a variable would return unfiltered data.
+        a variable would return unfiltered data. Endpoint owners can opt individual
+        breakdown properties out via ``EndpointVersion.optional_breakdown_properties``;
+        omitting an optional breakdown returns data aggregated across all values of
+        that dimension.
         """
 
     @abc.abstractmethod
@@ -611,8 +614,11 @@ class InsightEndpointStrategy(EndpointQueryStrategy):
         return allowed
 
     def required_materialized_variables(self) -> set[str]:
+        # Breakdown properties are required unless explicitly marked optional.
         if self.query_kind in self.BREAKDOWN_SUPPORTED_QUERY_TYPES:
-            return set(get_breakdown_properties(self._breakdown_filter))
+            all_breakdowns = set(get_breakdown_properties(self._breakdown_filter))
+            optional = set(self.version.optional_breakdown_properties or [])
+            return all_breakdowns - optional
         return set()
 
     def can_serve_variables_from_materialized(self, requested: set[str]) -> bool:
@@ -622,10 +628,12 @@ class InsightEndpointStrategy(EndpointQueryStrategy):
         return requested.issubset(allowed_props)
 
     def materialized_filters_override_satisfies_required(self, data: EndpointRunRequest) -> bool:
-        # apply_materialized_filters applies only the first property's value as a single breakdown
-        # filter, so filters_override can only satisfy a single-breakdown endpoint. A multi-breakdown
-        # endpoint would leave the other breakdowns unfiltered — require variables (one per breakdown).
-        if len(self.required_materialized_variables()) != 1:
+        # apply_materialized_filters applies only the first property's value as a single positionless
+        # breakdown filter, so filters_override can only satisfy an endpoint with exactly ONE breakdown
+        # overall. Gate on the total breakdown count, not the required count: with optional breakdowns
+        # subtracted, a multi-breakdown endpoint can have one required variable left, but a single
+        # has(breakdown_value, ...) predicate would leave the required dimension unconstrained.
+        if len(get_breakdown_properties(self._breakdown_filter)) != 1:
             return False
         fo = data.filters_override
         if not (fo and fo.properties):

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1216,6 +1216,28 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
         self.assertIn("Required variable", str(response.json()))
 
+    def test_materialized_multi_breakdown_one_optional_filters_override_does_not_bypass_required(self):
+        # SECURITY: with one of two breakdowns optional, exactly one REQUIRED variable remains — but
+        # filters_override still applies a single positionless filter, so it must not satisfy the
+        # required check on a multi-breakdown endpoint (the required dimension would go unconstrained).
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_multi_optional_fo",
+            breakdowns=[
+                {"property": "$os", "type": "event"},
+                {"property": "$browser", "type": "event"},
+            ],
+            optional=["$browser"],
+        )
+
+        with mock.patch.object(EndpointExecutionService, "_execute_query_and_respond", return_value=Response({})):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+                {"filters_override": {"properties": [{"key": "$os", "type": "event", "value": "Mac OS X"}]}},
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertIn("Required variable", str(response.json()))
+
     def test_materialized_hogql_endpoint_with_variable_executes_correctly(self):
         """Test that HogQL endpoints with variables work when materialized.
 
@@ -1644,6 +1666,168 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
             observed.get("link_committed"),
             "EndpointVersion must be linked to the saved query before materialization is scheduled",
         )
+
+    def _create_materialized_trends_endpoint(self, name: str, breakdowns: list[dict], optional: list[str]):
+        """Shared helper for the optional-breakdown tests. Stands up a materialized TrendsQuery
+        endpoint whose saved_query is in COMPLETED status with a backing DataWarehouseTable —
+        the same minimal setup `test_materialized_insight_endpoint_with_breakdown_executes_correctly`
+        uses to drive the materialized read path."""
+        trends_query = {
+            "kind": "TrendsQuery",
+            "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+            "dateRange": {"date_from": "-7d"},
+            "interval": "day",
+            "breakdownFilter": {"breakdowns": breakdowns, "breakdown_limit": 5},
+        }
+
+        _create_event(team=self.team, event="$pageview", distinct_id="user1")
+        flush_persons_and_events()
+
+        endpoint = create_endpoint_with_version(
+            name=name,
+            team=self.team,
+            query=trends_query,
+            created_by=self.user,
+            is_active=True,
+        )
+        # Persist the optional list on the live version.
+        version = endpoint.versions.first()
+        version.optional_breakdown_properties = optional
+        version.save(update_fields=["optional_breakdown_properties"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "data_freshness_seconds": 43200},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        version.refresh_from_db()
+        saved_query = version.saved_query
+        assert saved_query is not None
+        saved_query.status = DataWarehouseSavedQuery.Status.COMPLETED
+        saved_query.last_run_at = timezone.now()
+        saved_query.table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name=name,
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern=f"s3://test-bucket/{name}",
+        )
+        saved_query.save()
+        return endpoint
+
+    def test_optional_breakdown_materialized_allows_missing_variable(self):
+        """Materialized endpoint with $browser marked optional should accept /run with no variables — and
+        the resulting HogQL should NOT include a $browser WHERE filter (aggregate across all values)."""
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_browser_optional",
+            breakdowns=[{"property": "$browser", "type": "event"}],
+            optional=["$browser"],
+        )
+
+        with mock.patch.object(
+            EndpointExecutionService, "_execute_query_and_respond", return_value=Response({})
+        ) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+                {},
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        mock_exec.assert_called()
+        query_payload = mock_exec.call_args[0][0]["query"]
+        self.assertEqual(query_payload["kind"], "HogQLQuery")
+        # No breakdown_value WHERE filter when the dimension is optional and absent.
+        self.assertNotIn("has(breakdown_value", query_payload["query"].lower())
+
+    def test_optional_breakdown_materialized_still_allows_explicit_value(self):
+        """Even though $browser is optional, callers can still pass it and get a filtered result."""
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_browser_opt_explicit",
+            breakdowns=[{"property": "$browser", "type": "event"}],
+            optional=["$browser"],
+        )
+
+        with mock.patch.object(
+            EndpointExecutionService, "_execute_query_and_respond", return_value=Response({})
+        ) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+                {"variables": {"$browser": "Chrome"}},
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        mock_exec.assert_called()
+        query_sql = mock_exec.call_args[0][0]["query"]["query"].lower()
+        self.assertIn("has(breakdown_value", query_sql)
+        self.assertIn("chrome", query_sql)
+
+    def test_required_breakdown_still_400s_when_missing(self):
+        """Without the flag, behavior is unchanged — missing breakdown var on a materialized endpoint
+        is still rejected. This is the regression check on the security wall."""
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_browser_required",
+            breakdowns=[{"property": "$browser", "type": "event"}],
+            optional=[],
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertIn("$browser", response.json().get("detail", ""))
+
+    def test_multi_breakdown_one_required_one_optional_only_required_provided(self):
+        """The headline path: 2 breakdowns, $os required and $browser optional. Caller passes only
+        $os. Expect 200, $os filter applied, no $browser filter — aggregate across all browsers."""
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_multi_one_optional",
+            breakdowns=[
+                {"property": "$os", "type": "event"},
+                {"property": "$browser", "type": "event"},
+            ],
+            optional=["$browser"],
+        )
+
+        with mock.patch.object(
+            EndpointExecutionService, "_execute_query_and_respond", return_value=Response({})
+        ) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+                {"variables": {"$os": "Mac OS X"}},
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        mock_exec.assert_called()
+        query_sql = mock_exec.call_args[0][0]["query"]["query"].lower()
+        # The $os filter lands on breakdown_value[N]; the $browser filter does NOT appear at all
+        # — there's only one positional breakdown_value index referenced.
+        self.assertEqual(query_sql.count("breakdown_value["), 1)
+        self.assertIn("mac os x", query_sql)
+
+    def test_multi_breakdown_one_required_one_optional_missing_required_rejected(self):
+        """Inverse of the above: optional $browser is fine, but missing required $os 400s."""
+        endpoint = self._create_materialized_trends_endpoint(
+            name="trends_multi_missing_required",
+            breakdowns=[
+                {"property": "$os", "type": "event"},
+                {"property": "$browser", "type": "event"},
+            ],
+            optional=["$browser"],
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run",
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        # Required missing list should mention $os, not $browser.
+        detail = response.json().get("detail", "")
+        self.assertIn("$os", detail)
+        self.assertNotIn("$browser", detail)
 
     def test_build_endpoint_hogql_performs_no_db_writes(self):
         _create_event(team=self.team, event="$pageview", distinct_id="u1")

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -700,3 +700,65 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
                 endpoint.get_version().query,
                 self.team,
             )
+
+    def test_materialized_trends_optional_breakdown_returns_all_values(self):
+        """PR 2 verification: with `$browser` marked optional and the caller passing no variables,
+        the materialized read skips the WHERE filter and returns rows for every browser value.
+        The insight transformer must group those rows into per-breakdown-value series without
+        tripping MaterializedSeriesMismatchError.
+
+        This is the "all values back from API" path the plan flags as unverified — the materialized
+        rows look identical to a filtered read, but no variable filter has narrowed the set first.
+        """
+        endpoint = create_endpoint_with_version(
+            name="trends_optional_breakdown_all_values",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser", type=BreakdownType.EVENT)]),
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        self._materialize_endpoint(endpoint)
+        version = endpoint.versions.first()
+        version.optional_breakdown_properties = ["$browser"]
+        version.save(update_fields=["optional_breakdown_properties"])
+
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        # The materialized table emits one row per (series_index, breakdown_value).
+        # No variable filter ⇒ rows for every breakdown value flow back unfiltered.
+        flat_response = HogQLQueryResponse(
+            results=[
+                (dates, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], ["Chrome"]),
+                (dates, [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0], ["Safari"]),
+                (dates, [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0], ["Firefox"]),
+            ],
+            columns=["date", "total", "breakdown_value"],
+            types=["Array(Date)", "Array(Float64)", "Array(String)"],
+            hasMore=False,
+        )
+
+        # Caller passes no variables — relies on $browser being optional.
+        with mock.patch(
+            "products.endpoints.backend.logic.execution.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        # Must NOT 400 (optional was respected) and must NOT raise MaterializedSeriesMismatchError.
+        assert mat_resp.status_code == status.HTTP_200_OK, mat_resp.json()
+        mat_results = mat_resp.json()["results"]
+
+        # One result entry per breakdown value the table emitted.
+        assert len(mat_results) == 3, f"Expected one series per browser value, got {len(mat_results)}"
+        # breakdown_value is a list (multi-breakdown shape, single element here).
+        browsers = {(bv[0] if isinstance(bv := r.get("breakdown_value"), list) else bv) for r in mat_results}
+        assert browsers == {"Chrome", "Safari", "Firefox"}, browsers
+
+        # Shape parity with the inline path.
+        for r in mat_results:
+            for field in TRENDS_REQUIRED_FIELDS:
+                assert field in r, f"Materialized response missing '{field}': {r}"


### PR DESCRIPTION
## Problem

Materialized insight endpoints 400 when any breakdown variable is omitted — even when the endpoint owner explicitly wants callers to be able to skip one and get data aggregated across all values of that dimension. The previous PR added the `optional_breakdown_properties` declaration; this PR makes the materialized run path honor it.

## Changes

- `InsightEndpointStrategy.required_materialized_variables()` subtracts the version's `optional_breakdown_properties` from the all-breakdowns set, so the `/run` required-variables check passes when only optional ones are missing.
- When an optional breakdown is omitted, the materialized read emits no WHERE filter for that dimension, and the insight transformer groups the all-values rows into one series per breakdown value.

Behavior delta: an owner sets `optional_breakdown_properties=["$browser"]` on a materialized endpoint → `/run` with no variables returns 200 with per-browser series. Endpoints without the flag are unchanged — missing required breakdowns still 400 (regression-tested).

## How did you test this code?

- `test_endpoint_materialization.py` optional-breakdown tests: missing-optional accepted with no WHERE filter, explicit value still filters, required-still-400s regression, multi-breakdown one-required-one-optional permutations.
- `test_insight_response_parity.py::test_materialized_trends_optional_breakdown_returns_all_values` — the previously-unverified transformer path: all-values rows come back as one series per breakdown value with full insight shape, no `MaterializedSeriesMismatchError`.
- Full endpoints backend suite at the stack tip: 671 passed.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs land with the UI PR at the top of this stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Restacked from a pre-existing local branch; the required-variables change was ported from the retired viewset helper into `logic/strategies.py`, and test mocks re-pointed at `EndpointExecutionService`. Design doc: `products/endpoints/dev/plan-optional-breakdown-variables.dev.md`.
