### PR TITLE
feat(endpoints): rework playground with typed variable form

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2549,6 +2549,8 @@ export interface EndpointType extends WithAccessControl {
     columns?: { name: string; type: string }[]
     bucket_overrides?: Record<string, string> | null
     tags?: string[]
+    /** Breakdown property names that may be omitted on /run. Defaults to [] — every breakdown variable is required. */
+    optional_breakdown_properties?: string[]
 }
 
 /** Extends EndpointType with version-specific fields when fetching a specific version */

--- a/products/endpoints/backend/logic/strategies.py
+++ b/products/endpoints/backend/logic/strategies.py
@@ -285,7 +285,12 @@ def _emit_breakdown_limit_signal(team: Team, endpoint: Endpoint) -> None:
 # ---------------------------------------------------------------------------
 
 FILTERS_OVERRIDE_DEPRECATION_HEADERS = {
-    "X-PostHog-Warn": "filters_override is deprecated. Use variables instead: https://posthog.com/docs/api/endpoints"
+    "X-PostHog-Warn": (
+        "filters_override is deprecated. Use variables instead, "
+        "or mark the breakdown property as optional on the endpoint "
+        "if you want to call /run without supplying its value: "
+        "https://posthog.com/docs/api/endpoints"
+    )
 }
 
 

--- a/products/endpoints/backend/openapi.py
+++ b/products/endpoints/backend/openapi.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from rest_framework.request import Request
 
 from products.endpoints.backend.logic.strategies import InsightEndpointStrategy
-from products.endpoints.backend.models import Endpoint, EndpointVersion
+from products.endpoints.backend.models import Endpoint, EndpointVersion, _breakdown_property_names
 from products.product_analytics.backend.models.insight_variable import InsightVariable
 
 INSIGHT_VARIABLE_TYPE_TO_OPENAPI: dict[str, dict] = {
@@ -262,7 +262,7 @@ def _build_component_schemas(endpoint: Endpoint, version: EndpointVersion, team_
     }
 
     # Add variables schema based on query type and materialization state
-    variables_schema = _build_variables_schema(query, is_materialized, team_id)
+    variables_schema = _build_variables_schema(query, is_materialized, team_id, version)
     if variables_schema:
         schemas["EndpointRunRequest"]["properties"]["variables"] = {
             "$ref": "#/components/schemas/Variables",
@@ -272,22 +272,20 @@ def _build_component_schemas(endpoint: Endpoint, version: EndpointVersion, team_
     return schemas
 
 
-def _get_single_breakdown_property(breakdown_filter: dict) -> str | None:
-    """Extract breakdown property from either legacy or new format."""
-    breakdown = breakdown_filter.get("breakdown")
-    if breakdown:
-        return breakdown
-    breakdowns = breakdown_filter.get("breakdowns") or []
-    if len(breakdowns) == 1:
-        return breakdowns[0].get("property")
-    return None
+def _build_variables_schema(
+    query: dict, is_materialized: bool, team_id: int, version: EndpointVersion | None = None
+) -> dict | None:
+    """Build schema for variables based on query type and materialization state.
 
-
-def _build_variables_schema(query: dict, is_materialized: bool, team_id: int) -> dict | None:
-    """Build schema for variables based on query type and materialization state."""
+    Emits a top-level ``required`` array so generated SDKs and clients see which
+    variables they MUST send to /run. For insight endpoints this respects
+    ``EndpointVersion.optional_breakdown_properties`` — opted-out breakdowns are
+    listed as properties but kept out of ``required``, matching the runtime check.
+    """
     query_kind = query.get("kind")
     properties: dict = {}
     required: list[str] = []
+    optional_breakdowns: set[str] = set(version.optional_breakdown_properties or []) if version is not None else set()
 
     if query_kind == "HogQLQuery":
         variables = query.get("variables", {})
@@ -317,24 +315,28 @@ def _build_variables_schema(query: dict, is_materialized: bool, team_id: int) ->
                     properties[code_name]["example"] = default_value
                 else:
                     required.append(code_name)
+            # Materialized HogQL rejects ANY missing variable at run time, defaults included.
+            if is_materialized:
+                required = sorted(properties.keys())
     else:
         # Insight queries - only include breakdown for supported query types
         if query_kind in InsightEndpointStrategy.BREAKDOWN_SUPPORTED_QUERY_TYPES:
             breakdown_filter = query.get("breakdownFilter") or {}
-            breakdown = _get_single_breakdown_property(breakdown_filter)
-            if breakdown:
+            for breakdown in _breakdown_property_names(breakdown_filter):
+                if breakdown in properties:
+                    continue
                 properties[breakdown] = {
                     "type": "string",
                     "description": f"Filter by {breakdown} breakdown value",
                     "example": "Chrome",
                 }
-                # Materialized insights resolve the breakdown column at materialization
-                # time, so callers have to supply the value at execution; non-materialized
-                # insights can fall back to the saved filter.
-                if is_materialized:
+                # Breakdown variables are enforced at run time on both inline and
+                # materialized paths, unless the endpoint owner opted them out.
+                if breakdown not in optional_breakdowns:
                     required.append(breakdown)
 
         if not is_materialized:
+            # Non-materialized also supports date variables — never required.
             properties["date_from"] = {
                 "type": "string",
                 "description": "Filter results from this date (ISO format or relative like '-7d')",

--- a/products/endpoints/backend/tests/test_openapi_spec.py
+++ b/products/endpoints/backend/tests/test_openapi_spec.py
@@ -188,10 +188,9 @@ class TestEndpointOpenAPISpec(ClickhouseTestMixin, APIBaseTest):
         request_schema = spec["components"]["schemas"]["EndpointRunRequest"]
         self.assertNotIn("variables", request_schema.get("required", []))
 
-    def test_build_variables_schema_marks_breakdown_required_on_materialized_insight(self):
-        """Materialized insights resolve the breakdown column at materialization
-        time, so callers have to supply the value at execution. Non-materialized
-        insights fall back to the saved filter so the breakdown stays optional."""
+    def test_build_variables_schema_marks_breakdown_required_on_insight(self):
+        """Breakdown variables are enforced at run time on both inline and materialized
+        insight endpoints, so the spec marks them required on both paths."""
         from products.endpoints.backend.openapi import _build_variables_schema
 
         trends_query = {
@@ -208,7 +207,7 @@ class TestEndpointOpenAPISpec(ClickhouseTestMixin, APIBaseTest):
         schema_non_materialized = _build_variables_schema(trends_query, is_materialized=False, team_id=self.team.id)
         assert schema_non_materialized is not None
         self.assertIn("$browser", schema_non_materialized["properties"])
-        self.assertNotIn("required", schema_non_materialized)
+        self.assertEqual(schema_non_materialized.get("required"), ["$browser"])
 
     def test_openapi_spec_variable_types(self):
         from products.product_analytics.backend.models.insight_variable import InsightVariable
@@ -433,3 +432,205 @@ class TestEndpointOpenAPISpec(ClickhouseTestMixin, APIBaseTest):
 
         # Should not have Variables schema since no variables defined
         self.assertNotIn("Variables", spec["components"]["schemas"])
+
+
+class TestEndpointOpenAPIRequiredVariables(ClickhouseTestMixin, APIBaseTest):
+    """The Variables schema must surface which variables are required vs optional so
+    generated client SDKs reflect the real /run contract. Required breakdowns enforce; optional
+    breakdowns may be omitted."""
+
+    def _get(self, name: str) -> dict:
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/{name}/openapi.json/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        schemas = response.json()["components"]["schemas"]
+        self.assertIn("Variables", schemas, f"Variables schema missing for endpoint '{name}'")
+        return schemas["Variables"]
+
+    def _create_trends(self, name: str, breakdowns: list[dict], optional: list[str] | None = None):
+        endpoint = create_endpoint_with_version(
+            name=name,
+            team=self.team,
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode"}],
+                "breakdownFilter": {"breakdowns": breakdowns},
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+        if optional:
+            version = endpoint.versions.first()
+            version.optional_breakdown_properties = optional
+            version.save(update_fields=["optional_breakdown_properties"])
+        return endpoint
+
+    def test_single_breakdown_required_by_default(self):
+        self._create_trends("trends_one_breakdown", [{"property": "$browser", "type": "event"}])
+
+        schema = self._get("trends_one_breakdown")
+        self.assertIn("$browser", schema["properties"])
+        self.assertIn("$browser", schema.get("required", []))
+
+    def test_single_breakdown_omitted_from_required_when_optional(self):
+        self._create_trends("trends_one_optional", [{"property": "$browser", "type": "event"}], optional=["$browser"])
+
+        schema = self._get("trends_one_optional")
+        # Property is still surfaced so callers can pass it...
+        self.assertIn("$browser", schema["properties"])
+        # ...but it's NOT in the required list, so generated SDKs leave it optional.
+        # Either no `required` key at all, or `required` exists without $browser.
+        self.assertNotIn("$browser", schema.get("required", []))
+
+    def test_multi_breakdown_all_emitted_and_all_required_by_default(self):
+        """Every breakdown property must be surfaced and land in `required` until explicitly
+        marked optional — historically only the first breakdown was emitted."""
+        self._create_trends(
+            "trends_multi_breakdown",
+            [
+                {"property": "$browser", "type": "event"},
+                {"property": "$os", "type": "event"},
+                {"property": "$country", "type": "event"},
+            ],
+        )
+
+        schema = self._get("trends_multi_breakdown")
+        for prop in ("$browser", "$os", "$country"):
+            self.assertIn(prop, schema["properties"], f"property {prop} missing")
+            self.assertIn(prop, schema.get("required", []), f"property {prop} not marked required")
+
+    def test_multi_breakdown_required_minus_optional(self):
+        self._create_trends(
+            "trends_multi_one_optional",
+            [
+                {"property": "$browser", "type": "event"},
+                {"property": "$os", "type": "event"},
+            ],
+            optional=["$browser"],
+        )
+
+        schema = self._get("trends_multi_one_optional")
+        self.assertIn("$browser", schema["properties"])
+        self.assertIn("$os", schema["properties"])
+        self.assertIn("$os", schema.get("required", []))
+        self.assertNotIn("$browser", schema.get("required", []))
+
+    def test_all_breakdowns_optional_omits_required_array(self):
+        self._create_trends(
+            "trends_all_optional",
+            [
+                {"property": "$browser", "type": "event"},
+                {"property": "$os", "type": "event"},
+            ],
+            optional=["$browser", "$os"],
+        )
+
+        schema = self._get("trends_all_optional")
+        # No required entries — generated SDK treats every variable as optional.
+        self.assertNotIn("required", schema)
+
+    def test_date_variables_never_required(self):
+        """date_from / date_to are inline-only convenience variables; they always default at
+        runtime and must NOT appear in the required array, even when breakdowns are required."""
+        self._create_trends("trends_dates_not_required", [{"property": "$browser", "type": "event"}])
+
+        schema = self._get("trends_dates_not_required")
+        self.assertIn("date_from", schema["properties"])
+        self.assertIn("date_to", schema["properties"])
+        self.assertNotIn("date_from", schema.get("required", []))
+        self.assertNotIn("date_to", schema.get("required", []))
+
+    def test_hogql_inline_does_not_mark_variables_required(self):
+        """Inline HogQL substitutes defaults/NULLs for missing variables — that's a coherent
+        contract. The OpenAPI spec must not mark inline HogQL variables required, or generated
+        SDKs would reject calls that are legal at runtime."""
+        from products.product_analytics.backend.models.insight_variable import InsightVariable
+
+        InsightVariable.objects.create(
+            team=self.team,
+            id="00000000-0000-0000-0000-0000000000aa",
+            code_name="event_name",
+            type="String",
+        )
+        create_endpoint_with_version(
+            name="hogql_inline_no_required",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT count() FROM events WHERE event = {variables.event_name}",
+                "variables": {
+                    "00000000-0000-0000-0000-0000000000aa": {
+                        "variableId": "00000000-0000-0000-0000-0000000000aa",
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    },
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+
+        schema = self._get("hogql_inline_no_required")
+        self.assertIn("event_name", schema["properties"])
+        self.assertNotIn("required", schema)
+
+    def test_hogql_materialized_marks_all_variables_required(self):
+        """Materialized HogQL rejects ANY missing variable at run time, defaults included, so the
+        spec must mark every variable required — unlike the inline path, which substitutes
+        defaults/NULLs and stays optional."""
+        from products.endpoints.backend.openapi import _build_variables_schema
+        from products.product_analytics.backend.models.insight_variable import InsightVariable
+
+        with_default = InsightVariable.objects.create(
+            team=self.team,
+            id="00000000-0000-0000-0000-0000000000bb",
+            code_name="has_default",
+            type="String",
+            default_value="fallback",
+        )
+        no_default = InsightVariable.objects.create(
+            team=self.team,
+            id="00000000-0000-0000-0000-0000000000cc",
+            code_name="event_name",
+            type="String",
+        )
+        query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT count() FROM events WHERE event = {variables.event_name}",
+            "variables": {
+                str(with_default.id): {
+                    "variableId": str(with_default.id),
+                    "code_name": "has_default",
+                    "value": "fallback",
+                },
+                str(no_default.id): {"variableId": str(no_default.id), "code_name": "event_name"},
+            },
+        }
+
+        schema = _build_variables_schema(query, is_materialized=True, team_id=self.team.id)
+        assert schema is not None
+        self.assertEqual(schema.get("required"), ["event_name", "has_default"])
+
+    def test_deprecation_warning_mentions_marking_breakdown_optional(self):
+        """The X-PostHog-Warn deprecation message must mention the optional opt-in (not just
+        'use variables instead') — marking the breakdown optional is what callers actually want
+        if they were relying on permissive behavior."""
+        endpoint = create_endpoint_with_version(
+            name="hdr_check",
+            team=self.team,
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"kind": "EventsNode"}],
+                "breakdownFilter": {"breakdowns": [{"property": "$browser", "type": "event"}]},
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"filters_override": {"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        warn = response.headers.get("X-PostHog-Warn", "")
+        self.assertIn("filters_override is deprecated", warn)
+        self.assertIn("optional", warn)

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -15,7 +15,7 @@ import { isInsightVizNode } from '~/queries/utils'
 import { AccessControlLevel, AccessControlResourceType, EndpointType, EndpointVersionType } from '~/types'
 
 import { endpointLogic } from './endpointLogic'
-import { endpointSceneLogic } from './endpointSceneLogic'
+import { endpointSceneLogic, extractBreakdownPropertyNames } from './endpointSceneLogic'
 
 export const EndpointSceneHeader = (): JSX.Element => {
     const {
@@ -27,11 +27,18 @@ export const EndpointSceneHeader = (): JSX.Element => {
         bucketOverrides,
         debugInfoExpanded,
         dataFreshness,
+        optionalBreakdownProperties,
     } = useValues(endpointSceneLogic)
     const { endpointName, endpointDescription } = useValues(endpointLogic)
     const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic)
-    const { setLocalQuery, setDataFreshness, setIsMaterialized, resetBucketOverrides, setDebugInfoExpanded } =
-        useActions(endpointSceneLogic)
+    const {
+        setLocalQuery,
+        setDataFreshness,
+        setIsMaterialized,
+        resetBucketOverrides,
+        resetOptionalBreakdownProperties,
+        setDebugInfoExpanded,
+    } = useActions(endpointSceneLogic)
     const { superpowersEnabled } = useValues(superpowersLogic)
 
     // SceneTitleSection takes a boolean `canEdit` rather than disabled/disabledReason, so we can't
@@ -57,13 +64,20 @@ export const EndpointSceneHeader = (): JSX.Element => {
     const hasIsMaterializedChange = isMaterialized !== null && isMaterialized !== baseIsMaterialized
     const baseBucketOverrides = viewingVersion?.bucket_overrides ?? endpoint?.bucket_overrides ?? {}
     const hasBucketOverridesChange = !objectsEqual(bucketOverrides, baseBucketOverrides)
+    const baseOptionalBreakdowns =
+        viewingVersion?.optional_breakdown_properties ?? endpoint?.optional_breakdown_properties ?? []
+    const hasOptionalBreakdownChange = !objectsEqual(
+        [...optionalBreakdownProperties].sort(),
+        [...baseOptionalBreakdowns].sort()
+    )
     const hasChanges =
         hasNameChange ||
         hasDescriptionChange ||
         hasQueryChange ||
         hasDataFreshnessChange ||
         hasIsMaterializedChange ||
-        hasBucketOverridesChange
+        hasBucketOverridesChange ||
+        hasOptionalBreakdownChange
 
     const handleSave = (): void => {
         let queryToSave = (localQuery || endpoint?.query) as any
@@ -76,12 +90,20 @@ export const EndpointSceneHeader = (): JSX.Element => {
             return
         }
 
+        // Prune the optional list against the query actually being saved — a query edit can
+        // remove a breakdown after it was marked optional, and the backend rejects unknown names.
+        const savedQueryBreakdowns = extractBreakdownPropertyNames(
+            hasQueryChange ? queryToSave : (viewingVersion?.query ?? endpoint.query)
+        )
+        const prunedOptionalBreakdowns = optionalBreakdownProperties.filter((p) => savedQueryBreakdowns.includes(p))
+
         const updatePayload: Partial<EndpointRequest> = {
             description: hasDescriptionChange ? endpointDescription : undefined,
             data_freshness_seconds: hasDataFreshnessChange ? dataFreshness : undefined,
             query: hasQueryChange ? queryToSave : undefined,
             is_materialized: hasIsMaterializedChange ? isMaterialized : undefined,
             bucket_overrides: hasBucketOverridesChange ? bucketOverrides : undefined,
+            optional_breakdown_properties: hasOptionalBreakdownChange ? prunedOptionalBreakdowns : undefined,
         }
 
         updateEndpoint(endpoint.name, updatePayload, targetVersion ? { version: targetVersion } : undefined)
@@ -99,6 +121,9 @@ export const EndpointSceneHeader = (): JSX.Element => {
         setIsMaterialized(null)
         setLocalQuery(null)
         resetBucketOverrides(viewingVersion?.bucket_overrides ?? endpoint.bucket_overrides ?? {})
+        resetOptionalBreakdownProperties(
+            viewingVersion?.optional_breakdown_properties ?? endpoint.optional_breakdown_properties ?? []
+        )
     }
 
     return (

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -1,10 +1,11 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconClock, IconDatabase, IconInfo, IconList, IconRefresh } from '@posthog/icons'
+import { IconBrackets, IconClock, IconDatabase, IconInfo, IconList, IconRefresh } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
+    LemonCheckbox,
     LemonCollapse,
     LemonSelect,
     LemonSkeleton,
@@ -21,7 +22,18 @@ import { MaterializationStatusModal } from 'scenes/data-warehouse/saved_queries/
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { endpointLogic } from '../endpointLogic'
-import { endpointSceneLogic, MaterializationPreview } from '../endpointSceneLogic'
+import { endpointSceneLogic, extractBreakdownPropertyNames, MaterializationPreview } from '../endpointSceneLogic'
+
+// Names where flipping a breakdown to optional is most likely a customer-data leak — show
+// a soft warning when the user does so. Not a hard block; the author may have legitimate
+// reasons (e.g. an internal-only endpoint). Keep this list short and conservative; false
+// positives are cheap, false negatives cost data.
+const SENSITIVE_BREAKDOWN_NAME_PATTERNS = ['team', 'account', 'customer', 'tenant', 'user_id', 'org']
+
+function isSensitiveBreakdownName(name: string): boolean {
+    const lower = name.toLowerCase()
+    return SENSITIVE_BREAKDOWN_NAME_PATTERNS.some((p) => lower.includes(p))
+}
 
 const DATA_FRESHNESS_OPTIONS: { value: number; label: string }[] = [
     { value: 900, label: '15 minutes' },
@@ -65,13 +77,15 @@ function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'w
 
 export function EndpointConfiguration(): JSX.Element {
     const { endpoint } = useValues(endpointLogic)
-    const { setDataFreshness } = useActions(endpointSceneLogic)
+    const { setDataFreshness, toggleBreakdownOptional } = useActions(endpointSceneLogic)
     const {
         dataFreshness,
         viewingVersion,
         materializationPreview,
         materializationPreviewLoading,
         isMaterialized: localIsMaterialized,
+        currentQuery,
+        optionalBreakdownProperties,
     } = useValues(endpointSceneLogic)
     const { loadMaterializationPreview } = useActions(endpointSceneLogic)
     const [leftActiveKeys, setLeftActiveKeys] = useState<string[]>(['materialization'])
@@ -85,6 +99,8 @@ export function EndpointConfiguration(): JSX.Element {
     const baseIsMaterialized = viewingVersion?.is_materialized ?? endpoint.is_materialized
     const isMaterialized = localIsMaterialized ?? baseIsMaterialized
     const materializationExpanded = leftActiveKeys.includes('materialization')
+
+    const breakdownProperties = extractBreakdownPropertyNames(currentQuery)
 
     return (
         <div className="flex gap-6">
@@ -138,6 +154,29 @@ export function EndpointConfiguration(): JSX.Element {
                                 </div>
                             ),
                         },
+                        ...(breakdownProperties.length > 0
+                            ? [
+                                  {
+                                      key: 'variables',
+                                      header: (
+                                          <div className="flex items-center gap-2">
+                                              <IconBrackets className="text-lg" />
+                                              <span>Variables</span>
+                                              <Tooltip title="Required variables must be passed on every execution. Optional ones may be omitted; the response aggregates across every value.">
+                                                  <IconInfo className="text-lg text-secondary" />
+                                              </Tooltip>
+                                          </div>
+                                      ),
+                                      content: (
+                                          <BreakdownRequirementContent
+                                              breakdownProperties={breakdownProperties}
+                                              optionalBreakdownProperties={optionalBreakdownProperties}
+                                              onToggle={toggleBreakdownOptional}
+                                          />
+                                      ),
+                                  },
+                              ]
+                            : []),
                     ]}
                 />
             </div>
@@ -192,6 +231,61 @@ export function EndpointConfiguration(): JSX.Element {
                         ]}
                     />
                 </div>
+            )}
+        </div>
+    )
+}
+
+function BreakdownRequirementContent({
+    breakdownProperties,
+    optionalBreakdownProperties,
+    onToggle,
+}: {
+    breakdownProperties: string[]
+    optionalBreakdownProperties: string[]
+    onToggle: (property: string) => void
+}): JSX.Element {
+    const sensitiveMarkedOptional = optionalBreakdownProperties.filter(
+        (p) => breakdownProperties.includes(p) && isSensitiveBreakdownName(p)
+    )
+    return (
+        <div className="flex flex-col gap-3 p-1">
+            <p className="text-sm text-secondary m-0">
+                Uncheck <strong>Required</strong> to let callers omit a breakdown — the response then aggregates across
+                every value.
+            </p>
+            <div className="flex flex-col gap-2">
+                {breakdownProperties.map((property) => {
+                    const isOptional = optionalBreakdownProperties.includes(property)
+                    return (
+                        <div
+                            key={property}
+                            className="flex items-center justify-between gap-3 p-3 bg-accent-3000 border border-border rounded"
+                        >
+                            <div className="flex flex-col">
+                                <code className="text-sm">{property}</code>
+                                <span className="text-xs text-secondary">
+                                    {isOptional
+                                        ? 'May be omitted — aggregates across every value.'
+                                        : 'Must be passed on every execution.'}
+                                </span>
+                            </div>
+                            <LemonCheckbox
+                                checked={!isOptional}
+                                onChange={() => onToggle(property)}
+                                label="Required"
+                                bordered
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+            {sensitiveMarkedOptional.length > 0 && (
+                <LemonBanner type="warning">
+                    <strong>{sensitiveMarkedOptional.map((p) => `"${p}"`).join(', ')}</strong> looks like it identifies
+                    a tenant. Marking it optional lets callers execute this endpoint without that filter — double-check
+                    it isn't customer-facing.
+                </LemonBanner>
             )}
         </div>
     )

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
@@ -2,100 +2,59 @@ import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { IconExternal } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonLabel, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorInline } from 'lib/monaco/CodeEditorInline'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { EndpointVersionType } from '~/types'
+import { EndpointRunRequest } from '~/queries/schema/schema-general'
+import { EndpointType } from '~/types'
 
 import { CodeExampleTab, endpointLogic } from '../endpointLogic'
-import { endpointSceneLogic, generateEndpointPayload } from '../endpointSceneLogic'
-
-function formatPayloadForCodeExample(payload: Record<string, any>): string {
-    const entries = Object.entries(payload)
-    if (entries.length === 0) {
-        return ''
-    }
-
-    return entries
-        .map(([key, value], index) => {
-            const isLast = index === entries.length - 1
-            const comma = isLast ? '' : ','
-
-            // Format nested objects
-            if (typeof value === 'object' && value !== null && Object.keys(value).length === 0) {
-                return `    "${key}": {}${comma}  // Add ${key} here`
-            }
-
-            // Format variables specially
-            if (key === 'variables' && typeof value === 'object') {
-                const varEntries = Object.entries(value)
-                if (varEntries.length === 0) {
-                    return `    "${key}": {\n      // No variables defined\n    }${comma}`
-                }
-                const formattedVars = varEntries
-                    .map(([varKey, varValue], varIndex) => {
-                        const isLastVar = varIndex === varEntries.length - 1
-                        const varComma = isLastVar ? '' : ','
-                        return `      "${varKey}": ${JSON.stringify(varValue)}${varComma}`
-                    })
-                    .join('\n')
-                return `    "${key}": {\n${formattedVars}\n    }${comma}`
-            }
-
-            return `    "${key}": ${JSON.stringify(value, null, 2).replace(/\n/g, '\n    ')}${comma}`
-        })
-        .join('\n')
-}
+import { endpointSceneLogic } from '../endpointSceneLogic'
+import { EndpointPlaygroundForm } from './EndpointPlaygroundForm'
+import { EndpointPlaygroundJSONPreview } from './EndpointPlaygroundJSONPreview'
 
 function getEndpointUrl(endpointPath: string): string {
     return `${window.location.origin}${endpointPath}`
 }
 
-function generateTerminalExample(endpoint: EndpointVersionType, selectedVersion: number | null): string {
-    const payload = generateEndpointPayload(endpoint)
-    const hasPayload = Object.keys(payload).length > 0
-    const versionParam =
-        selectedVersion !== null && selectedVersion !== endpoint.current_version
-            ? `    "version": ${selectedVersion}`
-            : ''
-
-    // If no payload and no version, omit the -d flag entirely
-    if (!hasPayload && !versionParam) {
-        return `curl -X POST ${getEndpointUrl(endpoint.endpoint_path)} \\
-  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY"`
+/**
+ * Code example formatting. These render the *live* playground payload — so the snippet a
+ * user copies always matches what the form would POST. No silent reseeding from defaults.
+ */
+function formatBodyJson(payload: EndpointRunRequest, indent: number): string {
+    if (Object.keys(payload).length === 0) {
+        return ''
     }
-
-    const payloadBody = formatPayloadForCodeExample(payload)
-    const dataContent = [payloadBody, versionParam].filter(Boolean).join(',\n')
-
-    return `curl -X POST ${getEndpointUrl(endpoint.endpoint_path)} \\
-  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-${dataContent}
-  }'`
+    return JSON.stringify(payload, null, 2)
+        .split('\n')
+        .map((line, i) => (i === 0 ? line : ' '.repeat(indent) + line))
+        .join('\n')
 }
 
-function generatePythonExample(endpoint: EndpointVersionType, selectedVersion: number | null): string {
-    const payload = generateEndpointPayload(endpoint)
-    const hasPayload = Object.keys(payload).length > 0
-    const versionParam =
-        selectedVersion !== null && selectedVersion !== endpoint.current_version
-            ? `    "version": ${selectedVersion}`
-            : ''
+function generateTerminalExample(endpoint: EndpointType, payload: EndpointRunRequest): string {
+    const url = getEndpointUrl(endpoint.endpoint_path)
+    if (Object.keys(payload).length === 0) {
+        return `curl -X POST ${url} \\
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY"`
+    }
+    return `curl -X POST ${url} \\
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '${formatBodyJson(payload, 2)}'`
+}
 
-    // If no payload and no version, omit payload variable entirely
-    if (!hasPayload && !versionParam) {
+function generatePythonExample(endpoint: EndpointType, payload: EndpointRunRequest): string {
+    const url = getEndpointUrl(endpoint.endpoint_path)
+    if (Object.keys(payload).length === 0) {
         return `import requests
 
-url = "${getEndpointUrl(endpoint.endpoint_path)}"
+url = "${url}"
 
 headers = {
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'
@@ -104,111 +63,69 @@ headers = {
 response = requests.post(url, headers=headers)
 print(response.json())`
     }
-
-    const payloadBody = formatPayloadForCodeExample(payload)
-    const dataContent = [payloadBody, versionParam].filter(Boolean).join(',\n')
-
     return `import requests
-import json
 
-url = "${getEndpointUrl(endpoint.endpoint_path)}"
+url = "${url}"
 
 headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'
 }
 
-payload = {
-${dataContent}
-}
+payload = ${formatBodyJson(payload, 0)}
 
-response = requests.post(url, headers=headers, data=json.dumps(payload))
+response = requests.post(url, headers=headers, json=payload)
 print(response.json())`
 }
 
-function generateNodeExample(endpoint: EndpointVersionType, selectedVersion: number | null): string {
-    const payload = generateEndpointPayload(endpoint)
-    const hasPayload = Object.keys(payload).length > 0
-    const versionParam =
-        selectedVersion !== null && selectedVersion !== endpoint.current_version
-            ? `    "version": ${selectedVersion}`
-            : ''
-
-    // If no payload and no version, omit payload variable and body entirely
-    if (!hasPayload && !versionParam) {
+function generateNodeExample(endpoint: EndpointType, payload: EndpointRunRequest): string {
+    const url = getEndpointUrl(endpoint.endpoint_path)
+    if (Object.keys(payload).length === 0) {
         return `const fetch = require('node-fetch');
 
-const url = '${getEndpointUrl(endpoint.endpoint_path)}';
+const url = '${url}';
 
 const headers = {
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'
 };
 
-fetch(url, {
-    method: 'POST',
-    headers: headers
-})
-.then(response => response.json())
-.then(data => console.log(data))
-.catch(error => console.error('Error:', error));`
+fetch(url, { method: 'POST', headers })
+    .then((response) => response.json())
+    .then((data) => console.log(data))
+    .catch((error) => console.error('Error:', error));`
     }
-
-    const payloadBody = formatPayloadForCodeExample(payload)
-    const dataContent = [payloadBody, versionParam].filter(Boolean).join(',\n')
-
     return `const fetch = require('node-fetch');
 
-const url = '${getEndpointUrl(endpoint.endpoint_path)}';
+const url = '${url}';
 
 const headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'
 };
 
-const payload = {
-${dataContent}
-};
+const payload = ${formatBodyJson(payload, 0)};
 
-fetch(url, {
-    method: 'POST',
-    headers: headers,
-    body: JSON.stringify(payload)
-})
-.then(response => response.json())
-.then(data => console.log(data))
-.catch(error => console.error('Error:', error));`
+fetch(url, { method: 'POST', headers, body: JSON.stringify(payload) })
+    .then((response) => response.json())
+    .then((data) => console.log(data))
+    .catch((error) => console.error('Error:', error));`
 }
 
 export function EndpointPlayground(): JSX.Element {
     const { endpoint } = useValues(endpointLogic)
-    const { payloadJson, payloadJsonError, endpointResult, endpointResultLoading, viewingVersion, debugMode } =
-        useValues(endpointSceneLogic)
-    const { setPayloadJson, setPayloadJsonError, loadEndpointResult, setDebugMode } = useActions(endpointSceneLogic)
-    const { setActiveCodeExampleTab, setSelectedCodeExampleVersion } = useActions(endpointLogic)
-    const { activeCodeExampleTab, selectedCodeExampleVersion } = useValues(endpointLogic)
-    const { superpowersEnabled } = useValues(superpowersLogic)
-
-    // When viewing a specific version, use that version for code examples
-    const effectiveVersion = viewingVersion?.version ?? selectedCodeExampleVersion
+    const { endpointResult, endpointResultLoading, playgroundPayload } = useValues(endpointSceneLogic)
+    const { loadEndpointResult, setPlaygroundExecutionError } = useActions(endpointSceneLogic)
+    const { setActiveCodeExampleTab } = useActions(endpointLogic)
+    const { activeCodeExampleTab } = useValues(endpointLogic)
 
     const handleExecute = (): void => {
         if (!endpoint?.name) {
             return
         }
-
-        let data: any = {}
-        try {
-            data = payloadJson && payloadJson.trim() !== '' ? JSON.parse(payloadJson) : {}
-        } catch {
-            setPayloadJsonError('Invalid JSON in request payload')
-            return
-        }
-
-        if (debugMode) {
-            data = { ...data, debug: true }
-        }
-
-        loadEndpointResult({ name: endpoint.name, data })
+        // playgroundPayload already incorporates debug via the selector; no need to re-merge.
+        // Clear any prior per-variable error so a successful execution wipes the red border.
+        setPlaygroundExecutionError(null)
+        loadEndpointResult({ name: endpoint.name, data: playgroundPayload })
     }
 
     useEffect(() => {
@@ -222,7 +139,26 @@ export function EndpointPlayground(): JSX.Element {
 
         window.addEventListener('keydown', handleKeyDown, true)
         return () => window.removeEventListener('keydown', handleKeyDown, true)
-    }, [endpoint?.name, payloadJson, handleExecute])
+    }, [endpoint?.name, playgroundPayload, handleExecute])
+
+    // Detect Required-variable failures coming back from the server and route them to the
+    // matching variable input — the user gets a red border on the input that actually needs
+    // a value instead of a generic page-level banner.
+    useEffect(() => {
+        if (!endpointResult || endpointResultLoading) {
+            return
+        }
+        try {
+            const parsed = JSON.parse(endpointResult)
+            if (parsed?.error && typeof parsed.detail === 'string') {
+                if (parsed.detail.includes('Required variable')) {
+                    setPlaygroundExecutionError(parsed.detail)
+                }
+            }
+        } catch {
+            // Not JSON or no error — nothing to surface.
+        }
+    }, [endpointResult, endpointResultLoading, setPlaygroundExecutionError])
 
     if (!endpoint) {
         return <></>
@@ -231,13 +167,13 @@ export function EndpointPlayground(): JSX.Element {
     const getCodeExample = (tab: CodeExampleTab): string => {
         switch (tab) {
             case 'terminal':
-                return generateTerminalExample(endpoint, effectiveVersion)
+                return generateTerminalExample(endpoint, playgroundPayload)
             case 'python':
-                return generatePythonExample(endpoint, effectiveVersion)
+                return generatePythonExample(endpoint, playgroundPayload)
             case 'nodejs':
-                return generateNodeExample(endpoint, effectiveVersion)
+                return generateNodeExample(endpoint, playgroundPayload)
             default:
-                return generateTerminalExample(endpoint, effectiveVersion)
+                return generateTerminalExample(endpoint, playgroundPayload)
         }
     }
 
@@ -254,47 +190,20 @@ export function EndpointPlayground(): JSX.Element {
         }
     }
 
-    // Generate version options
-    const versionOptions = Array.from({ length: endpoint.current_version }, (_, i) => {
-        const version = i + 1
-        return {
-            value: version,
-            label: version === endpoint.current_version ? `v${version} (Current)` : `v${version}`,
-        }
-    })
-
     return (
         <SceneSection
             title="Playground"
             description={
                 <>
-                    Send API requests to your endpoints, play with setting different parameters in the request body and
-                    see what the resulting JSON response would look like. <br />
-                    Once you're done experimenting, find the code snippet for your use case below.
+                    Pick variable values and request options below, then execute against this endpoint to see what /run
+                    returns. The code snippet below mirrors the request the form would send.
                 </>
             }
         >
             <div className="flex gap-4" data-attr="endpoint-playground">
-                <div className="flex-1 flex flex-col gap-2">
-                    <LemonField.Pure
-                        label="Request payload"
-                        info={
-                            <>
-                                JSON payload sent with the request. Use <code className="text-xs">"variables"</code> to
-                                pass query parameters.
-                            </>
-                        }
-                    />
-
-                    <CodeEditorInline
-                        embedded
-                        language="json"
-                        value={payloadJson}
-                        onChange={(value) => setPayloadJson(value ?? '')}
-                        maxHeight={400}
-                    />
-                    {payloadJsonError && <LemonField.Pure error={payloadJsonError} />}
-
+                <div className="flex-1 flex flex-col gap-3 min-w-0">
+                    <EndpointPlaygroundForm />
+                    <EndpointPlaygroundJSONPreview />
                     <div className="flex items-center gap-2">
                         <LemonButton
                             type="primary"
@@ -311,9 +220,6 @@ export function EndpointPlayground(): JSX.Element {
                         >
                             Execute endpoint
                         </LemonButton>
-                        {superpowersEnabled && (
-                            <LemonSwitch checked={debugMode} onChange={setDebugMode} label="Debug" bordered />
-                        )}
                     </div>
                     {endpointResult &&
                         !endpointResultLoading &&
@@ -365,12 +271,6 @@ export function EndpointPlayground(): JSX.Element {
                     Example usage
                 </LemonLabel>
                 <div className="flex gap-2">
-                    <LemonSelect
-                        options={versionOptions}
-                        onChange={setSelectedCodeExampleVersion}
-                        value={effectiveVersion || endpoint.current_version}
-                        placeholder="Select version"
-                    />
                     <LemonSelect
                         options={[
                             { value: 'terminal', label: 'Terminal' },

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
@@ -391,7 +391,7 @@ export function EndpointPlayground(): JSX.Element {
                         icon={<IconExternal />}
                         targetBlank
                     >
-                        Personal API keys
+                        Create a Personal API Key
                     </LemonButton>
                 </div>
                 <div>

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundForm.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundForm.tsx
@@ -1,0 +1,173 @@
+import { useActions, useValues } from 'kea'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonInput, LemonSegmentedButton, LemonSelect, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+
+import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { EndpointRefreshMode, NodeKind } from '~/queries/schema/schema-general'
+
+import { endpointLogic } from '../endpointLogic'
+import { endpointSceneLogic } from '../endpointSceneLogic'
+import { EndpointPlaygroundVariableRow } from './EndpointPlaygroundVariableRow'
+
+const REFRESH_OPTIONS: { value: EndpointRefreshMode; label: string; tooltip: string }[] = [
+    {
+        value: 'cache',
+        label: 'cache',
+        tooltip: 'Return cached results if they are fresh enough; otherwise run the query. Default — fastest.',
+    },
+    {
+        value: 'force',
+        label: 'force',
+        tooltip: 'Bypass the cache and recompute. For materialized endpoints this still reads the materialized table.',
+    },
+    {
+        value: 'direct',
+        label: 'direct',
+        tooltip: 'Materialized endpoints only — bypass the materialized table and run the live query against raw data.',
+    },
+]
+
+function variableErrorFor(name: string, error: string | null): string | null {
+    // Server returns: "Required variable(s) '$browser', '$os' not provided"
+    // We surface the message under each specific variable input that's named in it.
+    if (!error) {
+        return null
+    }
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`['"]${escaped}['"]`)
+    return regex.test(error) ? error : null
+}
+
+export function EndpointPlaygroundForm(): JSX.Element {
+    const { endpoint } = useValues(endpointLogic)
+    const {
+        playgroundVariableSpecs,
+        playgroundVariableValues,
+        playgroundVariableSent,
+        playgroundRefresh,
+        playgroundLimit,
+        playgroundVersion,
+        playgroundExecutionError,
+        viewingVersion,
+        debugMode,
+    } = useValues(endpointSceneLogic)
+    const {
+        setPlaygroundVariableValue,
+        setPlaygroundVariableSent,
+        setPlaygroundRefresh,
+        setPlaygroundLimit,
+        setPlaygroundVersion,
+        setDebugMode,
+    } = useActions(endpointSceneLogic)
+    const { superpowersEnabled } = useValues(superpowersLogic)
+
+    if (!endpoint) {
+        return <></>
+    }
+
+    const isMaterialized = (viewingVersion?.is_materialized ?? endpoint.is_materialized) || false
+    const isHogQL = (viewingVersion?.query?.kind ?? endpoint.query?.kind) === NodeKind.HogQLQuery
+
+    const versionOptions = Array.from({ length: endpoint.current_version }, (_, i) => {
+        const v = i + 1
+        return { value: v, label: v === endpoint.current_version ? `v${v} (current)` : `v${v}` }
+    })
+
+    return (
+        <div className="flex flex-col gap-4">
+            {playgroundVariableSpecs.length > 0 ? (
+                <LemonField.Pure
+                    label="Variables"
+                    info="Unchecked variables are omitted from the request — the response aggregates across every value of that variable."
+                >
+                    <div className="flex flex-col gap-1.5">
+                        {playgroundVariableSpecs.map((spec) => {
+                            const variableError = variableErrorFor(spec.name, playgroundExecutionError)
+                            return (
+                                <EndpointPlaygroundVariableRow
+                                    key={spec.name}
+                                    spec={spec}
+                                    value={playgroundVariableValues[spec.name]}
+                                    sent={!!playgroundVariableSent[spec.name]}
+                                    errored={!!variableError}
+                                    errorMessage={variableError}
+                                    onValueChange={(value) => setPlaygroundVariableValue(spec.name, value)}
+                                    onSentChange={(sent) => setPlaygroundVariableSent(spec.name, sent)}
+                                />
+                            )
+                        })}
+                    </div>
+                </LemonField.Pure>
+            ) : (
+                <p className="text-sm text-secondary m-0">
+                    This endpoint has no configurable variables. Use the request options below to control execution.
+                </p>
+            )}
+
+            <LemonField.Pure
+                label="Request options"
+                info="Settings applied just to this execution. They don't change the saved endpoint."
+            >
+                <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                        <span className="text-xs text-secondary">Refresh</span>
+                        <LemonSegmentedButton
+                            value={playgroundRefresh}
+                            onChange={(v) => setPlaygroundRefresh(v as EndpointRefreshMode)}
+                            options={REFRESH_OPTIONS.map((opt) => ({
+                                ...opt,
+                                disabledReason:
+                                    opt.value === 'direct' && !isMaterialized
+                                        ? 'direct is only valid for materialized endpoints'
+                                        : undefined,
+                            }))}
+                            size="small"
+                        />
+                    </div>
+                    {isHogQL && (
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs text-secondary inline-flex items-center gap-1">
+                                Limit
+                                <Tooltip title="Cap on result rows (SQL-based endpoints).">
+                                    <IconInfo className="text-sm text-secondary" />
+                                </Tooltip>
+                            </span>
+                            <LemonInput
+                                type="number"
+                                min={1}
+                                value={playgroundLimit ?? undefined}
+                                onChange={(v) => setPlaygroundLimit(typeof v === 'number' ? v : null)}
+                                placeholder="default"
+                                size="small"
+                                className="w-32"
+                            />
+                        </div>
+                    )}
+                    <div className="flex flex-col gap-1 items-start">
+                        <span className="text-xs text-secondary">Version</span>
+                        <LemonSelect
+                            value={playgroundVersion ?? endpoint.current_version}
+                            onChange={(v) => setPlaygroundVersion(v === endpoint.current_version ? null : v)}
+                            options={versionOptions}
+                            size="small"
+                        />
+                    </div>
+                    {superpowersEnabled && (
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs text-secondary">Debug</span>
+                            <LemonSwitch
+                                checked={debugMode}
+                                onChange={setDebugMode}
+                                label="Include debug info in response"
+                                bordered
+                            />
+                        </div>
+                    )}
+                </div>
+            </LemonField.Pure>
+        </div>
+    )
+}

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundJSONPreview.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundJSONPreview.tsx
@@ -1,0 +1,34 @@
+import { useValues } from 'kea'
+
+import { LemonCollapse } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+import { endpointSceneLogic } from '../endpointSceneLogic'
+
+export function EndpointPlaygroundJSONPreview(): JSX.Element {
+    const { playgroundPayloadJsonPreview } = useValues(endpointSceneLogic)
+
+    return (
+        <LemonCollapse
+            multiple
+            defaultActiveKeys={['preview']}
+            panels={[
+                {
+                    key: 'preview',
+                    header: <span className="text-sm">Request payload (preview)</span>,
+                    content: (
+                        <div className="p-1">
+                            <p className="text-xs text-secondary mb-2">
+                                Read-only. This is the exact JSON body the playground will POST to /run.
+                            </p>
+                            <CodeSnippet language={Language.JSON} wrap>
+                                {playgroundPayloadJsonPreview}
+                            </CodeSnippet>
+                        </div>
+                    ),
+                },
+            ]}
+        />
+    )
+}

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundVariableRow.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlaygroundVariableRow.tsx
@@ -1,0 +1,82 @@
+import { LemonCheckbox, LemonInput, LemonTag } from '@posthog/lemon-ui'
+
+import { PlaygroundVariableSpec } from '../endpointSceneLogic'
+
+interface EndpointPlaygroundVariableRowProps {
+    spec: PlaygroundVariableSpec
+    value: unknown
+    sent: boolean
+    errored?: boolean
+    errorMessage?: string | null
+    onValueChange: (value: unknown) => void
+    onSentChange: (sent: boolean) => void
+}
+
+function formatValueForInput(value: unknown): string {
+    if (value === null || value === undefined) {
+        return ''
+    }
+    return String(value)
+}
+
+// Grid template shared by every variable row so the checkbox, name, tag and input columns
+// line up vertically regardless of how long each variable name is. Long names truncate
+// rather than push the input around (real tooltip on the `<code>` shows the full name).
+const VARIABLE_ROW_GRID = 'grid grid-cols-[auto_7rem_5rem_1fr] items-center gap-2'
+
+export function EndpointPlaygroundVariableRow({
+    spec,
+    value,
+    sent,
+    errored,
+    errorMessage,
+    onValueChange,
+    onSentChange,
+}: EndpointPlaygroundVariableRowProps): JSX.Element {
+    const placeholder =
+        spec.kind === 'date' ? "e.g. '-7d', '2024-01-01', 'now'" : spec.kind === 'breakdown' ? `e.g. "Chrome"` : ''
+
+    const offButRequired = !sent && spec.required
+    const showInlineError = errored && errorMessage
+    const inputDisabledReason = !sent ? `Tick "Send" to include ${spec.name} in the request.` : undefined
+
+    return (
+        <div
+            className={`flex flex-col gap-1 p-2 bg-accent-3000 border ${
+                errored || offButRequired ? 'border-danger' : 'border-border'
+            } rounded`}
+        >
+            <div className={`${VARIABLE_ROW_GRID} ${sent ? '' : 'opacity-60'}`}>
+                <LemonCheckbox
+                    checked={sent}
+                    onChange={onSentChange}
+                    disabledReason={
+                        spec.sendLocked
+                            ? `${spec.name} is required. Mark it optional in Configuration to allow omitting it.`
+                            : undefined
+                    }
+                />
+                <code className="text-sm truncate" title={spec.name}>
+                    {spec.name}
+                </code>
+                <LemonTag type={spec.required ? 'danger' : 'muted'} size="small" className="justify-self-start">
+                    {spec.required ? 'Required' : 'Optional'}
+                </LemonTag>
+                <LemonInput
+                    value={formatValueForInput(value)}
+                    onChange={(next) => onValueChange(next)}
+                    disabledReason={inputDisabledReason}
+                    placeholder={placeholder}
+                    size="small"
+                    status={errored ? 'danger' : 'default'}
+                    fullWidth
+                />
+            </div>
+            {showInlineError ? (
+                <span className="text-xs text-danger pl-7">{errorMessage}</span>
+            ) : offButRequired ? (
+                <span className="text-xs text-danger pl-7">Required — execution will 400 until you tick Send.</span>
+            ) : null}
+        </div>
+    )
+}

--- a/products/endpoints/frontend/endpointSceneLogic.test.ts
+++ b/products/endpoints/frontend/endpointSceneLogic.test.ts
@@ -161,4 +161,203 @@ describe('endpointSceneLogic', () => {
             expect(logic.values.optionalBreakdownProperties).toEqual(['$os'])
         })
     })
+
+    describe('playground typed form', () => {
+        beforeEach(() => {
+            // The outer beforeEach parks the URL on `version=2`, which makes
+            // loadEndpointSuccess run its version-loading path and bleed
+            // setPlaygroundVersion(2) into these tests. Drop the version param and reset
+            // the api mock so playground specs start from a clean state.
+            ;(api.endpoint.get as jest.Mock).mockReset()
+            ;(api.endpoint.get as jest.Mock).mockResolvedValue(undefined)
+            router.actions.push(urls.endpoint('test-endpoint'), { tab: EndpointTab.QUERY })
+        })
+
+        const trendsEndpoint: any = {
+            ...endpoint,
+            query: {
+                kind: 'TrendsQuery',
+                series: [{ kind: 'EventsNode' }],
+                breakdownFilter: {
+                    breakdowns: [
+                        { property: '$os', type: 'event' },
+                        { property: '$browser', type: 'event' },
+                    ],
+                },
+            },
+            is_materialized: true,
+        }
+
+        const inlineHogQLEndpoint: any = {
+            ...endpoint,
+            query: {
+                kind: 'HogQLQuery',
+                query: 'SELECT count() FROM events WHERE event = {variables.event_name}',
+                variables: {
+                    'var-evt-1': {
+                        variableId: 'var-evt-1',
+                        code_name: 'event_name',
+                        value: '$pageview',
+                    },
+                },
+            },
+            is_materialized: false,
+        }
+
+        it('derives required breakdown specs and seeds Send=on for each', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(trendsEndpoint)
+            }).toFinishAllListeners()
+
+            const specs = logic.values.playgroundVariableSpecs
+            expect(specs.map((s: any) => s.name)).toEqual(['$os', '$browser'])
+            specs.forEach((s: any) => {
+                expect(s.required).toBe(true)
+                expect(s.sendLocked).toBe(true)
+            })
+            expect(logic.values.playgroundVariableSent).toEqual({ $os: true, $browser: true })
+        })
+
+        it('respects optional_breakdown_properties: optional vars default to Send=off and unlocked', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess({
+                    ...trendsEndpoint,
+                    optional_breakdown_properties: ['$browser'],
+                })
+            }).toFinishAllListeners()
+
+            const specs = logic.values.playgroundVariableSpecs
+            const browser = specs.find((s: any) => s.name === '$browser')
+            const os = specs.find((s: any) => s.name === '$os')
+            expect(browser).toMatchObject({ required: false, sendLocked: false, defaultSent: false })
+            expect(os).toMatchObject({ required: true, sendLocked: true, defaultSent: true })
+            expect(logic.values.playgroundVariableSent).toEqual({ $os: true, $browser: false })
+        })
+
+        it('inline HogQL var with a default seeds Send=off (runtime substitutes the default)', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(inlineHogQLEndpoint)
+            }).toFinishAllListeners()
+
+            const specs = logic.values.playgroundVariableSpecs
+            expect(specs).toHaveLength(1)
+            expect(specs[0]).toMatchObject({
+                name: 'event_name',
+                required: false,
+                sendLocked: false,
+                defaultSent: false,
+                defaultValue: '$pageview',
+            })
+        })
+
+        it('materialized HogQL var is required and locked', async () => {
+            const matHogQL = { ...inlineHogQLEndpoint, is_materialized: true }
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(matHogQL)
+            }).toFinishAllListeners()
+
+            expect(logic.values.playgroundVariableSpecs[0]).toMatchObject({
+                required: true,
+                sendLocked: true,
+                defaultSent: true,
+            })
+        })
+
+        it('playgroundPayload drops sent=false variables entirely', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess({
+                    ...trendsEndpoint,
+                    optional_breakdown_properties: ['$browser'],
+                })
+                logic.actions.setPlaygroundVariableValue('$os', 'Mac OS X')
+                logic.actions.setPlaygroundVariableValue('$browser', 'Chrome')
+            }).toFinishAllListeners()
+
+            // $browser is sent=false (it's optional, default off). Even with a value typed in,
+            // it shouldn't appear in the payload.
+            expect(logic.values.playgroundPayload).toEqual({
+                variables: { $os: 'Mac OS X' },
+            })
+
+            // Flip Send on for $browser — it now joins the payload.
+            await expectLogic(logic, () => {
+                logic.actions.setPlaygroundVariableSent('$browser', true)
+            }).toFinishAllListeners()
+            expect(logic.values.playgroundPayload.variables).toEqual({
+                $os: 'Mac OS X',
+                $browser: 'Chrome',
+            })
+        })
+
+        it('playgroundPayload only emits non-default request options', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(trendsEndpoint)
+                logic.actions.setPlaygroundVariableValue('$os', 'Mac OS X')
+                logic.actions.setPlaygroundVariableValue('$browser', 'Chrome')
+            }).toFinishAllListeners()
+
+            // Default refresh=cache, no limit, no version → no extra fields in the payload.
+            expect(Object.keys(logic.values.playgroundPayload).sort()).toEqual(['variables'])
+
+            await expectLogic(logic, () => {
+                logic.actions.setPlaygroundRefresh('force')
+                logic.actions.setPlaygroundLimit(50)
+                logic.actions.setPlaygroundVersion(2)
+            }).toFinishAllListeners()
+
+            expect(logic.values.playgroundPayload).toMatchObject({
+                refresh: 'force',
+                limit: 50,
+                version: 2,
+            })
+        })
+
+        it('JSON preview reflects the live payload as the form changes', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(trendsEndpoint)
+                logic.actions.setPlaygroundVariableValue('$os', 'Linux')
+                logic.actions.setPlaygroundVariableValue('$browser', 'Firefox')
+            }).toFinishAllListeners()
+
+            const parsed = JSON.parse(logic.values.playgroundPayloadJsonPreview)
+            expect(parsed).toEqual({ variables: { $os: 'Linux', $browser: 'Firefox' } })
+        })
+
+        it('debug switch shows up as debug:true in the payload', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(trendsEndpoint)
+                logic.actions.setPlaygroundVariableValue('$os', 'Mac OS X')
+                logic.actions.setPlaygroundVariableValue('$browser', 'Chrome')
+                logic.actions.setDebugMode(true)
+            }).toFinishAllListeners()
+
+            expect(logic.values.playgroundPayload).toMatchObject({ debug: true })
+        })
+
+        it('re-seeds the form when switching versions', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(trendsEndpoint)
+            }).toFinishAllListeners()
+            await expectLogic(logic, () => {
+                logic.actions.setPlaygroundVariableValue('$os', 'Mac OS X')
+            }).toMatchValues({ playgroundVariableValues: expect.objectContaining({ $os: 'Mac OS X' }) })
+
+            // Switch to a viewing-version that has a different breakdown set entirely.
+            const versionWithDifferentBreakdowns = {
+                ...trendsEndpoint,
+                version: 2,
+                query: {
+                    ...trendsEndpoint.query,
+                    breakdownFilter: { breakdowns: [{ property: '$country', type: 'event' }] },
+                },
+            }
+            await expectLogic(logic, () => {
+                logic.actions.setViewingVersion(versionWithDifferentBreakdowns)
+            }).toFinishAllListeners()
+
+            expect(logic.values.playgroundVariableSpecs.map((s: any) => s.name)).toEqual(['$country'])
+            // Old values for vars that no longer exist are dropped from the seeded map.
+            expect(logic.values.playgroundVariableValues).toEqual({ $country: '' })
+        })
+    })
 })

--- a/products/endpoints/frontend/endpointSceneLogic.test.ts
+++ b/products/endpoints/frontend/endpointSceneLogic.test.ts
@@ -112,4 +112,53 @@ describe('endpointSceneLogic', () => {
             version: 2,
         })
     })
+
+    describe('optionalBreakdownProperties reducer', () => {
+        it('seeds from the loaded endpoint', async () => {
+            const endpointWithOptional = { ...endpoint, optional_breakdown_properties: ['$browser'] }
+            await expectLogic(logic, () => {
+                logic.actions.loadEndpointSuccess(endpointWithOptional)
+            }).toFinishAllListeners()
+
+            expect(logic.values.optionalBreakdownProperties).toEqual(['$browser'])
+        })
+
+        it('toggleBreakdownOptional flips a single property both ways', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.toggleBreakdownOptional('$browser')
+            }).toMatchValues({ optionalBreakdownProperties: ['$browser'] })
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleBreakdownOptional('$browser')
+            }).toMatchValues({ optionalBreakdownProperties: [] })
+        })
+
+        it('toggleBreakdownOptional preserves order across independent properties', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.toggleBreakdownOptional('$browser')
+                logic.actions.toggleBreakdownOptional('$os')
+            }).toMatchValues({ optionalBreakdownProperties: ['$browser', '$os'] })
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleBreakdownOptional('$browser')
+            }).toMatchValues({ optionalBreakdownProperties: ['$os'] })
+        })
+
+        it('resetOptionalBreakdownProperties wins on version switch', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.toggleBreakdownOptional('$browser')
+            }).toMatchValues({ optionalBreakdownProperties: ['$browser'] })
+
+            const versionData = {
+                ...endpoint,
+                version: 2,
+                optional_breakdown_properties: ['$os'],
+            }
+            await expectLogic(logic, () => {
+                logic.actions.setViewingVersion(versionData)
+            }).toFinishAllListeners()
+
+            expect(logic.values.optionalBreakdownProperties).toEqual(['$os'])
+        })
+    })
 })

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -22,15 +22,28 @@ const DEFAULT_DATA_FRESHNESS_SECONDS = 86400
 // Query types that support user-configurable breakdown filtering
 const BREAKDOWN_SUPPORTED_QUERY_TYPES = new Set([NodeKind.TrendsQuery, NodeKind.RetentionQuery])
 
-function getSingleBreakdownProperty(breakdownFilter: any): string | null {
-    if (breakdownFilter?.breakdown) {
-        return breakdownFilter.breakdown
+export function extractBreakdownPropertyNames(query: unknown): string[] {
+    // Single source of truth for reading breakdown property names out of a query on the
+    // frontend — mirrors the backend's canonical extractor, including the legacy list form.
+    if (!query || typeof query !== 'object') {
+        return []
     }
-    const breakdowns = breakdownFilter?.breakdowns || []
-    if (breakdowns.length === 1) {
-        return breakdowns[0]?.property
+    const breakdownFilter = (
+        query as { breakdownFilter?: { breakdown?: unknown; breakdowns?: { property?: unknown }[] } | null }
+    ).breakdownFilter
+    if (!breakdownFilter) {
+        return []
     }
-    return null
+    const legacy = breakdownFilter.breakdown
+    if (Array.isArray(legacy)) {
+        return legacy.filter((b): b is string => typeof b === 'string' && !!b)
+    }
+    if (typeof legacy === 'string' && legacy) {
+        return [legacy]
+    }
+    return (breakdownFilter.breakdowns ?? [])
+        .map((b) => (typeof b?.property === 'string' ? b.property : null))
+        .filter((p): p is string => !!p)
 }
 
 export function generateEndpointPayload(endpoint: EndpointVersionType | null): Record<string, any> {
@@ -65,10 +78,10 @@ export function generateEndpointPayload(endpoint: EndpointVersionType | null): R
 
         // Only include breakdown for query types that support it
         if (queryKind && BREAKDOWN_SUPPORTED_QUERY_TYPES.has(queryKind as NodeKind)) {
-            const breakdownFilter = (query as any).breakdownFilter || {}
-            const breakdown = getSingleBreakdownProperty(breakdownFilter)
-            if (breakdown) {
-                variablesValues[breakdown] = ''
+            const breakdownNames = extractBreakdownPropertyNames(query)
+            // The legacy playground payload only supports a single breakdown variable.
+            if (breakdownNames.length === 1) {
+                variablesValues[breakdownNames[0]] = ''
             }
         }
 
@@ -136,6 +149,8 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setViewingVersion: (version: EndpointVersionType | null) => ({ version }),
         setBucketOverride: (column: string, bucketFn: string) => ({ column, bucketFn }),
         resetBucketOverrides: (overrides: Record<string, string>) => ({ overrides }),
+        toggleBreakdownOptional: (property: string) => ({ property }),
+        resetOptionalBreakdownProperties: (props: string[]) => ({ props }),
         setDebugMode: (debugMode: boolean) => ({ debugMode }),
         setDebugInfoExpanded: (debugInfoExpanded: boolean) => ({ debugInfoExpanded }),
         loadMaterializationPreview: true,
@@ -223,6 +238,15 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                 setBucketOverride: (state, { column, bucketFn }) => ({ ...state, [column]: bucketFn }),
                 resetBucketOverrides: (_, { overrides }) => overrides,
                 loadEndpointSuccess: (_, { endpoint }) => endpoint?.bucket_overrides ?? {},
+            },
+        ],
+        optionalBreakdownProperties: [
+            [] as string[],
+            {
+                toggleBreakdownOptional: (state, { property }) =>
+                    state.includes(property) ? state.filter((p) => p !== property) : [...state, property],
+                resetOptionalBreakdownProperties: (_, { props }) => props,
+                loadEndpointSuccess: (_, { endpoint }) => endpoint?.optional_breakdown_properties ?? [],
             },
         ],
         // Clear stale playground results when switching endpoints
@@ -346,6 +370,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             const initialPayload = generateInitialPayloadJson(endpoint)
             actions.setPayloadJson(initialPayload)
             actions.setDataFreshness(endpoint?.data_freshness_seconds ?? DEFAULT_DATA_FRESHNESS_SECONDS)
+            actions.resetOptionalBreakdownProperties(endpoint?.optional_breakdown_properties ?? [])
 
             const { searchParams, hashParams } = router.values
 
@@ -415,6 +440,11 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
 
             // Reset bucket overrides to viewed version's values
             actions.resetBucketOverrides(version?.bucket_overrides ?? values.endpoint?.bucket_overrides ?? {})
+
+            // Reset optional breakdowns to viewed version's value (or endpoint's if going back to current)
+            actions.resetOptionalBreakdownProperties(
+                version?.optional_breakdown_properties ?? values.endpoint?.optional_breakdown_properties ?? []
+            )
 
             // Reset data freshness to viewed version's value (or endpoint's if going back to current)
             actions.setDataFreshness(

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -9,7 +9,14 @@ import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { DataTableNode, EndpointRunRequest, InsightVizNode, Node, NodeKind } from '~/queries/schema/schema-general'
+import {
+    DataTableNode,
+    EndpointRefreshMode,
+    EndpointRunRequest,
+    InsightVizNode,
+    Node,
+    NodeKind,
+} from '~/queries/schema/schema-general'
 import { isHogQLQuery, isInsightQueryNode } from '~/queries/utils'
 import { Breadcrumb, EndpointType, EndpointVersionType } from '~/types'
 
@@ -46,61 +53,125 @@ export function extractBreakdownPropertyNames(query: unknown): string[] {
         .filter((p): p is string => !!p)
 }
 
-export function generateEndpointPayload(endpoint: EndpointVersionType | null): Record<string, any> {
+/**
+ * Playground variable contract — drives the typed form, the Send checkbox state, and the
+ * code-example snippets. Stays in lockstep with the runtime contract enforced by
+ * `_get_required_variables` / `_get_allowed_variables` on the backend.
+ */
+export type PlaygroundVariableKind = 'hogql' | 'breakdown' | 'date'
+export type PlaygroundVariableInputType = 'text' | 'number' | 'boolean' | 'date' | 'list'
+
+export interface PlaygroundVariableSpec {
+    /** code_name (HogQL) or property name (insight breakdown / date_from / date_to). */
+    name: string
+    kind: PlaygroundVariableKind
+    inputType: PlaygroundVariableInputType
+    /** Server will 400 if this variable is omitted at /run time. */
+    required: boolean
+    /** Seed value for the input. */
+    defaultValue: unknown
+    /** Initial state of the Send checkbox. */
+    defaultSent: boolean
+    /** When true, the Send checkbox is disabled — used for required vars that can't be sensibly unsent. */
+    sendLocked: boolean
+}
+
+/**
+ * Derive the playground form's per-variable contract from an endpoint version. The form
+ * uses this to render the right widget per variable and to set Send-checkbox state /
+ * lock state in a way that matches what the server will accept at /run time.
+ */
+export function derivePlaygroundVariableSpecs(
+    endpoint: EndpointVersionType | null,
+    viewingVersion: EndpointVersionType | null
+): PlaygroundVariableSpec[] {
     if (!endpoint) {
-        return {}
+        return []
     }
 
-    const query = endpoint.query
-    const isMaterialized = endpoint.is_materialized
-    const queryKind = query?.kind
+    const effective = viewingVersion ?? endpoint
+    const query = effective.query
+    const isMaterialized = effective.is_materialized
+    const optionalBreakdowns = new Set(effective.optional_breakdown_properties ?? [])
+    const specs: PlaygroundVariableSpec[] = []
 
-    if (queryKind === NodeKind.HogQLQuery) {
-        // HogQL: include variables with default values
-        const variables = query.variables || {}
-        const entries = Object.entries(variables)
-
-        if (entries.length === 0) {
-            return {}
-        }
-
-        const variablesValues: Record<string, any> = {}
-        entries.forEach(([_, value]: [string, any]) => {
-            variablesValues[value.code_name] = value.value
+    if (query?.kind === NodeKind.HogQLQuery) {
+        const variables = (query as any).variables ?? {}
+        Object.values(variables).forEach((value: any) => {
+            const codeName = value?.code_name
+            if (!codeName) {
+                return
+            }
+            const defaultValue = value?.value ?? ''
+            const hasDefault = defaultValue !== '' && defaultValue !== null && defaultValue !== undefined
+            specs.push({
+                name: codeName,
+                kind: 'hogql',
+                inputType: 'text',
+                // Materialized HogQL endpoints require every materialized variable; inline HogQL
+                // substitutes the default or NULL, so it's effectively optional.
+                required: isMaterialized,
+                defaultValue,
+                defaultSent: isMaterialized || !hasDefault,
+                sendLocked: isMaterialized,
+            })
         })
-
-        return { variables: variablesValues }
+        return specs
     }
 
     if (isInsightQueryNode(query)) {
-        // Insight query - build variables based on what's available
-        const variablesValues: Record<string, any> = {}
-
-        // Only include breakdown for query types that support it
-        if (queryKind && BREAKDOWN_SUPPORTED_QUERY_TYPES.has(queryKind as NodeKind)) {
-            const breakdownNames = extractBreakdownPropertyNames(query)
-            // The legacy playground payload only supports a single breakdown variable.
-            if (breakdownNames.length === 1) {
-                variablesValues[breakdownNames[0]] = ''
-            }
+        if (query?.kind && BREAKDOWN_SUPPORTED_QUERY_TYPES.has(query.kind as NodeKind)) {
+            extractBreakdownPropertyNames(query).forEach((name) => {
+                const isOptional = optionalBreakdowns.has(name)
+                specs.push({
+                    name,
+                    kind: 'breakdown',
+                    inputType: 'text',
+                    required: !isOptional,
+                    defaultValue: '',
+                    defaultSent: !isOptional,
+                    sendLocked: !isOptional,
+                })
+            })
         }
-
-        // Non-materialized also supports date filtering
         if (!isMaterialized) {
-            variablesValues['date_from'] = '-7d'
-            variablesValues['date_to'] = ''
-        }
-
-        if (Object.keys(variablesValues).length > 0) {
-            return { variables: variablesValues }
+            specs.push(
+                {
+                    name: 'date_from',
+                    kind: 'date',
+                    inputType: 'text',
+                    required: false,
+                    defaultValue: '-7d',
+                    defaultSent: false,
+                    sendLocked: false,
+                },
+                {
+                    name: 'date_to',
+                    kind: 'date',
+                    inputType: 'text',
+                    required: false,
+                    defaultValue: '',
+                    defaultSent: false,
+                    sendLocked: false,
+                }
+            )
         }
     }
 
-    return {}
+    return specs
 }
 
-function generateInitialPayloadJson(endpoint: EndpointVersionType | null): string {
-    return JSON.stringify(generateEndpointPayload(endpoint), null, 2)
+function seedPlaygroundFormFromSpecs(specs: PlaygroundVariableSpec[]): {
+    values: Record<string, unknown>
+    sent: Record<string, boolean>
+} {
+    const values: Record<string, unknown> = {}
+    const sent: Record<string, boolean> = {}
+    specs.forEach((spec) => {
+        values[spec.name] = spec.defaultValue
+        sent[spec.name] = spec.defaultSent
+    })
+    return { values, sent }
 }
 
 export enum EndpointTab {
@@ -131,18 +202,24 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                 'loadEndpoint',
                 'loadEndpointSuccess',
                 'loadVersions',
+                'loadVersionsSuccess',
                 'setEndpointDescription',
                 'clearMaterializationStatus',
                 'updateEndpointSuccess',
             ],
         ],
-        values: [endpointLogic(), ['endpoint', 'endpointLoading']],
+        values: [endpointLogic(), ['endpoint', 'endpointLoading', 'versions']],
     })),
     actions({
         setLocalQuery: (query: Node | null) => ({ query }),
         setActiveTab: (tab: EndpointTab) => ({ tab }),
-        setPayloadJson: (value: string) => ({ value }),
-        setPayloadJsonError: (error: string | null) => ({ error }),
+        setPlaygroundVariableValue: (name: string, value: unknown) => ({ name, value }),
+        setPlaygroundVariableSent: (name: string, sent: boolean) => ({ name, sent }),
+        resetPlaygroundForm: (specs: PlaygroundVariableSpec[]) => ({ specs }),
+        setPlaygroundRefresh: (refresh: EndpointRefreshMode) => ({ refresh }),
+        setPlaygroundLimit: (limit: number | null) => ({ limit }),
+        setPlaygroundVersion: (version: number | null) => ({ version }),
+        setPlaygroundExecutionError: (error: string | null) => ({ error }),
         setDataFreshness: (dataFreshness: number) => ({ dataFreshness }),
         setIsMaterialized: (isMaterialized: boolean | null) => ({ isMaterialized }),
         setEndpointName: (name: string | null) => ({ name }),
@@ -172,20 +249,50 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                 loadEndpoint: () => EndpointTab.QUERY,
             },
         ],
-        payloadJson: [
-            '' as string,
+        playgroundVariableValues: [
+            {} as Record<string, unknown>,
             {
-                setPayloadJson: (_, { value }) => value,
-                loadEndpoint: () => '',
+                setPlaygroundVariableValue: (state, { name, value }) => ({ ...state, [name]: value }),
+                resetPlaygroundForm: (_, { specs }) => seedPlaygroundFormFromSpecs(specs).values,
+                loadEndpoint: () => ({}),
             },
         ],
-        payloadJsonError: [
+        playgroundVariableSent: [
+            {} as Record<string, boolean>,
+            {
+                setPlaygroundVariableSent: (state, { name, sent }) => ({ ...state, [name]: sent }),
+                resetPlaygroundForm: (_, { specs }) => seedPlaygroundFormFromSpecs(specs).sent,
+                loadEndpoint: () => ({}),
+            },
+        ],
+        playgroundRefresh: [
+            'cache' as EndpointRefreshMode,
+            {
+                setPlaygroundRefresh: (_, { refresh }) => refresh,
+                loadEndpoint: () => 'cache' as EndpointRefreshMode,
+            },
+        ],
+        playgroundLimit: [
+            null as number | null,
+            {
+                setPlaygroundLimit: (_, { limit }) => limit,
+                loadEndpoint: () => null,
+            },
+        ],
+        playgroundVersion: [
+            null as number | null,
+            {
+                setPlaygroundVersion: (_, { version }) => version,
+                loadEndpoint: () => null,
+            },
+        ],
+        playgroundExecutionError: [
             null as string | null,
             {
-                setPayloadJsonError: (_, { error }) => error,
-                setPayloadJson: () => null,
+                setPlaygroundExecutionError: (_, { error }) => error,
+                loadEndpointResult: () => null,
+                resetPlaygroundForm: () => null,
                 loadEndpoint: () => null,
-                updateEndpointSuccess: () => null,
             },
         ],
         dataFreshness: [
@@ -309,6 +416,80 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                 viewingVersion: EndpointVersionType | null
             ): Node | null => localQuery || viewingVersion?.query || endpoint?.query || null,
         ],
+        playgroundVariableSpecs: [
+            (s) => [s.endpoint, s.viewingVersion, s.playgroundVersion, s.versions],
+            (
+                endpoint: EndpointType | null,
+                viewingVersion: EndpointVersionType | null,
+                playgroundVersion: number | null,
+                versions: EndpointVersionType[] | null
+            ): PlaygroundVariableSpec[] => {
+                // The playground can pin a version independently of the editor's viewing version —
+                // the variable contract must follow the version the request will actually run against.
+                const playgroundTarget =
+                    playgroundVersion !== null
+                        ? ((versions ?? []).find((v) => v.version === playgroundVersion) ?? null)
+                        : null
+                if (playgroundTarget) {
+                    return derivePlaygroundVariableSpecs(endpoint as EndpointVersionType | null, playgroundTarget)
+                }
+                // The endpoint payload also includes the bucket overrides, but the playground
+                // form only knows about the variable contract — bucket settings live in
+                // Configuration. Cast through EndpointVersionType because the runtime shape
+                // includes the version-detail fields when viewingVersion is set; for the base
+                // current-version case we have all the fields we need on EndpointType too.
+                return derivePlaygroundVariableSpecs(endpoint as EndpointVersionType | null, viewingVersion)
+            },
+        ],
+        playgroundPayload: [
+            (s) => [
+                s.playgroundVariableSpecs,
+                s.playgroundVariableValues,
+                s.playgroundVariableSent,
+                s.playgroundRefresh,
+                s.playgroundLimit,
+                s.playgroundVersion,
+                s.debugMode,
+            ],
+            (
+                specs: PlaygroundVariableSpec[],
+                values: Record<string, unknown>,
+                sent: Record<string, boolean>,
+                refresh: EndpointRefreshMode,
+                limit: number | null,
+                version: number | null,
+                debugMode: boolean
+            ): EndpointRunRequest => {
+                const variables: Record<string, unknown> = {}
+                specs.forEach((spec) => {
+                    if (sent[spec.name]) {
+                        variables[spec.name] = values[spec.name] ?? spec.defaultValue
+                    }
+                })
+                const payload: EndpointRunRequest = {}
+                if (Object.keys(variables).length > 0) {
+                    payload.variables = variables as Record<string, string>
+                }
+                // Only emit fields that diverge from defaults — keeps the JSON preview tight.
+                if (refresh && refresh !== 'cache') {
+                    payload.refresh = refresh
+                }
+                if (limit !== null && limit !== undefined) {
+                    ;(payload as any).limit = limit
+                }
+                if (version !== null && version !== undefined) {
+                    ;(payload as any).version = version
+                }
+                if (debugMode) {
+                    ;(payload as any).debug = true
+                }
+                return payload
+            },
+        ],
+        playgroundPayloadJsonPreview: [
+            (s) => [s.playgroundPayload],
+            (payload: EndpointRunRequest): string => JSON.stringify(payload, null, 2),
+        ],
         queryToRender: [
             (s) => [s.currentQuery],
             (currentQuery: Node | null): Node | null => {
@@ -352,6 +533,22 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         ],
     }),
     listeners(({ actions, values, cache }) => ({
+        setPlaygroundVersion: ({ version }: { version: number | null }) => {
+            // Keep the variable form in lockstep with the version the request will run against.
+            if (version !== null && !(values.versions ?? []).some((v: EndpointVersionType) => v.version === version)) {
+                if (values.endpoint?.name) {
+                    actions.loadVersions(values.endpoint.name)
+                }
+                return // reseed happens in loadVersionsSuccess once the version is resolvable
+            }
+            actions.resetPlaygroundForm(values.playgroundVariableSpecs)
+        },
+        loadVersionsSuccess: () => {
+            // Finish a playground reseed that was waiting on the versions list.
+            if (values.playgroundVersion !== null) {
+                actions.resetPlaygroundForm(values.playgroundVariableSpecs)
+            }
+        },
         keepSqlEditorMounted: ({ editorTabId }) => {
             // Already holding a mount for this editor
             if (cache.sqlEditorTabId === editorTabId) {
@@ -367,8 +564,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             cache.sqlEditorTabId = null
         },
         loadEndpointSuccess: async ({ endpoint }: { endpoint: EndpointVersionType | null; payload?: string }) => {
-            const initialPayload = generateInitialPayloadJson(endpoint)
-            actions.setPayloadJson(initialPayload)
+            actions.resetPlaygroundForm(derivePlaygroundVariableSpecs(endpoint, null))
             actions.setDataFreshness(endpoint?.data_freshness_seconds ?? DEFAULT_DATA_FRESHNESS_SECONDS)
             actions.resetOptionalBreakdownProperties(endpoint?.optional_breakdown_properties ?? [])
 
@@ -460,15 +656,13 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
                 actions.setEndpointDescription(values.endpoint.description || '')
             }
 
-            // Update payload with version field if viewing a specific version
-            if (values.endpoint) {
-                const basePayload = generateEndpointPayload(values.endpoint)
-                if (version && version.version !== values.endpoint.current_version) {
-                    const payloadWithVersion = { ...basePayload, version: version.version }
-                    actions.setPayloadJson(JSON.stringify(payloadWithVersion, null, 2))
-                } else {
-                    actions.setPayloadJson(JSON.stringify(basePayload, null, 2))
-                }
+            // Re-seed the playground form against the version the user is viewing.
+            actions.resetPlaygroundForm(derivePlaygroundVariableSpecs(values.endpoint, version))
+            // Pin the version field on the playground request if the user is viewing a non-current version.
+            if (version && version.version !== values.endpoint?.current_version) {
+                actions.setPlaygroundVersion(version.version)
+            } else {
+                actions.setPlaygroundVersion(null)
             }
 
             // Update URL when viewing version changes


### PR DESCRIPTION
## Problem

The endpoint playground asks users to hand-edit a raw JSON payload to try their endpoint. With required vs optional variables now a real contract, the playground should present a typed form that reflects it.

## Changes

- Reworks the playground into a typed variable form: one row per variable with type-appropriate inputs, required/optional indicated, plus a live JSON payload preview.
- New components: `EndpointPlaygroundForm`, `EndpointPlaygroundVariableRow`, `EndpointPlaygroundJSONPreview`; `endpointSceneLogic` gains the form state, payload generation, and validation logic (kea-first, no local hook state).

## How did you test this code?

- `endpointSceneLogic.test.ts` jest coverage for form state, payload generation, and variable handling (part of 15 passing endpoints frontend tests).
- `pnpm --filter=@posthog/frontend typescript:check` passes.
- No manual browser testing was performed by the agent — worth a screenshot pass before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change; playground behavior is self-describing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Top of the stack and deliberately not on the critical path — the API/SDK value ships with the four backend PRs below even if this UI iteration stalls.
