### PR TITLE
fix(billing): make billing limit saves per-product and non-blocking

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -317,6 +317,7 @@
         "concurrently": "catalog:",
         "esbuild-visualizer": "^0.6.0",
         "fake-indexeddb": "^6.0.1",
+        "fast-check": "^4.8.0",
         "fs-extra": "^10.0.0",
         "happy-dom": "^20.9.0",
         "history": "^5.0.1",

--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -14,9 +14,15 @@ import { billingProductLogic } from './billingProductLogic'
 
 export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const limitInputRef = useRef<HTMLInputElement | null>(null)
-    const { billing, billingLoading } = useValues(billingLogic)
-    const { isEditingBillingLimit, customLimitUsd, hasCustomLimitSet, currentAndUpgradePlans, billingLimitNextPeriod } =
-        useValues(billingProductLogic({ product, billingLimitInputRef: limitInputRef }))
+    const { billing } = useValues(billingLogic)
+    const {
+        isEditingBillingLimit,
+        isLimitUpdateInFlight,
+        customLimitUsd,
+        hasCustomLimitSet,
+        currentAndUpgradePlans,
+        billingLimitNextPeriod,
+    } = useValues(billingProductLogic({ product, billingLimitInputRef: limitInputRef }))
     const { setIsEditingBillingLimit, setBillingLimitInput, submitBillingLimitInput, removeBillingLimitNextPeriod } =
         useActions(billingProductLogic({ product }))
 
@@ -98,7 +104,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                             data-attr={`billing-limit-input-${product.type}`}
                                             onChange={onChange}
                                             prefix={<b>$</b>}
-                                            disabled={billingLoading}
+                                            disabled={isLimitUpdateInFlight}
                                             min={0}
                                             step={1}
                                             suffix={<>/ {billing?.billing_period?.interval}</>}
@@ -108,7 +114,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                 </LemonField>
 
                                 <LemonButton
-                                    loading={billingLoading}
+                                    loading={isLimitUpdateInFlight}
                                     type="primary"
                                     size="small"
                                     htmlType="submit"
@@ -120,7 +126,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                     onClick={() => {
                                         setIsEditingBillingLimit(false)
                                     }}
-                                    disabled={billingLoading}
+                                    disabled={isLimitUpdateInFlight}
                                     type="secondary"
                                     size="small"
                                 >
@@ -130,6 +136,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                     <LemonButton
                                         status="danger"
                                         size="small"
+                                        disabled={isLimitUpdateInFlight}
                                         data-attr={`remove-billing-limit-${product.type}`}
                                         tooltip="Remove billing limit"
                                         onClick={() => {
@@ -151,6 +158,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                             <LemonButton
                                 size="small"
                                 status="danger"
+                                loading={isLimitUpdateInFlight}
                                 onClick={() => removeBillingLimitNextPeriod(product.type)}
                                 data-attr={`remove-billing-limit-next-period-${product.type}`}
                             >

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check'
 import tk from 'timekeeper'
 
 import { OrganizationMembershipLevel } from 'lib/constants'
@@ -5,6 +6,7 @@ import { dayjs } from 'lib/dayjs'
 
 import { billingJson } from '~/mocks/fixtures/_billing'
 import billingJsonWithFlatFee from '~/mocks/fixtures/_billing_with_flat_fee.json'
+import { BillingType } from '~/types'
 
 import {
     buildUsageLimitApproachingMessage,
@@ -19,6 +21,7 @@ import {
     getMinimumBillingAccessLevel,
     getProration,
     getUsageLimitConsequence,
+    mergeLimitsForProduct,
     projectUsage,
     summarizeUsage,
 } from './billing-utils'
@@ -665,5 +668,70 @@ describe('canAccessBilling', () => {
         { level: null, ownerOnly: true, expected: false },
     ])('returns $expected for level=$level, ownerOnly=$ownerOnly', ({ level, ownerOnly, expected }) => {
         expect(canAccessBilling(level, ownerOnly)).toBe(expected)
+    })
+})
+
+describe('mergeLimitsForProduct', () => {
+    // The invariant the billing limits UI relies on: saves for different products can run
+    // concurrently and their responses can arrive in any order, yet folding the merges must
+    // reproduce the server's final state. Responses for the *same* product are applied in
+    // commit order — the UI guarantees this by disabling a product's editor while its save
+    // is in flight — so the generator only permutes across products.
+    const PRODUCTS = ['product_analytics', 'session_replay', 'surveys'] as const
+
+    // One committed server write: sets or removes (null) the product's key in each map.
+    const opArb = fc.record({
+        product: fc.constantFrom(...PRODUCTS),
+        custom: fc.option(fc.nat({ max: 1000 }), { nil: null }),
+        next: fc.option(fc.nat({ max: 1000 }), { nil: null }),
+    })
+
+    const applyOp = (map: Record<string, number>, key: string, value: number | null): void => {
+        if (value === null) {
+            delete map[key]
+        } else {
+            map[key] = value
+        }
+    }
+
+    it('folding responses in any per-product-ordered arrival order converges to server state', () => {
+        fc.assert(
+            fc.property(fc.array(opArb, { maxLength: 20 }), fc.array(fc.nat({ max: 1000 })), (ops, choices) => {
+                // Server model: ops commit in array order, each response echoes both full maps.
+                const serverCustom: Record<string, number> = { surveys: 50 }
+                const serverNext: Record<string, number> = {}
+                const responses = ops.map((op) => {
+                    applyOp(serverCustom, op.product, op.custom)
+                    applyOp(serverNext, op.product, op.next)
+                    return {
+                        product: op.product,
+                        limits: {
+                            custom_limits_usd: { ...serverCustom },
+                            next_period_custom_limits_usd: { ...serverNext },
+                        },
+                    }
+                })
+
+                // Arrival order: any interleaving that preserves per-product commit order.
+                const queues = PRODUCTS.map((p) => responses.filter((r) => r.product === p))
+                let billing = {
+                    custom_limits_usd: { surveys: 50 },
+                    next_period_custom_limits_usd: {},
+                } as BillingType
+                for (let i = 0; responses.length > 0 && queues.some((q) => q.length > 0); i++) {
+                    const nonEmpty = queues.filter((q) => q.length > 0)
+                    const queue = nonEmpty[(choices[i] ?? 0) % nonEmpty.length]
+                    const response = queue.shift()!
+                    billing = mergeLimitsForProduct(billing, response.product, response.limits)!
+                }
+
+                expect(billing.custom_limits_usd).toEqual(serverCustom)
+                expect(billing.next_period_custom_limits_usd).toEqual(serverNext)
+            })
+        )
+    })
+
+    it('returns null billing unchanged', () => {
+        expect(mergeLimitsForProduct(null, 'surveys', { custom_limits_usd: { surveys: 1 } })).toBeNull()
     })
 })

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -732,6 +732,22 @@ describe('mergeLimitsForProduct', () => {
         )
     })
 
+    it('a response that omits a limit map leaves that map untouched', () => {
+        const limitMapArb = fc.dictionary(fc.constantFrom<string>(...PRODUCTS), fc.nat({ max: 1000 }))
+        fc.assert(
+            fc.property(limitMapArb, limitMapArb, fc.constantFrom(...PRODUCTS), (custom, next, product) => {
+                const billing: BillingType = {
+                    ...billingJson,
+                    custom_limits_usd: custom,
+                    next_period_custom_limits_usd: next,
+                }
+                const merged = mergeLimitsForProduct(billing, product, {})!
+                expect(merged.custom_limits_usd).toEqual(custom)
+                expect(merged.next_period_custom_limits_usd).toEqual(next)
+            })
+        )
+    })
+
     it('returns null billing unchanged', () => {
         expect(mergeLimitsForProduct(null, 'surveys', { custom_limits_usd: { surveys: 1 } })).toBeNull()
     })

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -714,10 +714,11 @@ describe('mergeLimitsForProduct', () => {
 
                 // Arrival order: any interleaving that preserves per-product commit order.
                 const queues = PRODUCTS.map((p) => responses.filter((r) => r.product === p))
-                let billing = {
+                let billing: BillingType | null = {
+                    ...billingJson,
                     custom_limits_usd: { surveys: 50 },
                     next_period_custom_limits_usd: {},
-                } as BillingType
+                }
                 for (let i = 0; responses.length > 0 && queues.some((q) => q.length > 0); i++) {
                     const nonEmpty = queues.filter((q) => q.length > 0)
                     const queue = nonEmpty[(choices[i] ?? 0) % nonEmpty.length]

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -727,6 +727,16 @@ const withLimit = (
 }
 
 /**
+ * A response that omits a whole limit map carries no information about it — keep the current one.
+ * A present map is authoritative for the product's key (key absent from it = no limit).
+ */
+const mergeLimitMap = (
+    current: Record<string, number | null> | undefined,
+    key: string,
+    response: Record<string, number | null> | undefined
+): Record<string, number | null> => (response ? withLimit(current, key, response[key]) : (current ?? {}))
+
+/**
  * Pure per-key merge of a limits PATCH response for one product into billing state.
  * Merging only the saved product's key keeps concurrent saves for different products
  * commutative under any response arrival order — a response never overwrites another
@@ -742,15 +752,11 @@ export function mergeLimitsForProduct(
     return (
         billing && {
             ...billing,
-            custom_limits_usd: withLimit(
-                billing.custom_limits_usd,
-                productType,
-                limits.custom_limits_usd?.[productType]
-            ),
-            next_period_custom_limits_usd: withLimit(
+            custom_limits_usd: mergeLimitMap(billing.custom_limits_usd, productType, limits.custom_limits_usd),
+            next_period_custom_limits_usd: mergeLimitMap(
                 billing.next_period_custom_limits_usd,
                 productType,
-                limits.next_period_custom_limits_usd?.[productType]
+                limits.next_period_custom_limits_usd
             ),
         }
     )

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -713,3 +713,45 @@ export function buildUsageLimitApproachingMessage(
         message,
     }
 }
+
+export type BillingLimits = Pick<BillingType, 'custom_limits_usd' | 'next_period_custom_limits_usd'>
+
+/** Returns `map` with `key` set to `value`, or with `key` removed when `value` is null/undefined. */
+const withLimit = (
+    map: Record<string, number | null> | undefined,
+    key: string,
+    value: number | null | undefined
+): Record<string, number | null> => {
+    const { [key]: _discarded, ...rest } = map ?? {}
+    return value == null ? rest : { ...rest, [key]: value }
+}
+
+/**
+ * Pure per-key merge of a limits PATCH response for one product into billing state.
+ * Merging only the saved product's key keeps concurrent saves for different products
+ * commutative under any response arrival order — a response never overwrites another
+ * product's limit with a stale echo. Responses for the *same* product must be applied
+ * in commit order; the UI guarantees this by disabling a product's editor while its
+ * save is in flight.
+ */
+export function mergeLimitsForProduct(
+    billing: BillingType | null,
+    productType: string,
+    limits: BillingLimits
+): BillingType | null {
+    return (
+        billing && {
+            ...billing,
+            custom_limits_usd: withLimit(
+                billing.custom_limits_usd,
+                productType,
+                limits.custom_limits_usd?.[productType]
+            ),
+            next_period_custom_limits_usd: withLimit(
+                billing.next_period_custom_limits_usd,
+                productType,
+                limits.next_period_custom_limits_usd?.[productType]
+            ),
+        }
+    )
+}

--- a/frontend/src/scenes/billing/billingLimits.test.ts
+++ b/frontend/src/scenes/billing/billingLimits.test.ts
@@ -1,0 +1,154 @@
+/* oxlint-disable react-hooks/rules-of-hooks -- useMocks is a test helper, not a React hook */
+import { expectLogic } from 'kea-test-utils'
+
+import { billingLogic } from 'scenes/billing/billingLogic'
+import { billingProductLogic } from 'scenes/billing/billingProductLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { BillingProductV2Type } from '~/types'
+
+const productA = { type: 'product_analytics', name: 'Product analytics', subscribed: true } as BillingProductV2Type
+const productB = { type: 'session_replay', name: 'Session replay', subscribed: true } as BillingProductV2Type
+
+describe('billing limits', () => {
+    let logicA: ReturnType<typeof billingProductLogic.build>
+    let logicB: ReturnType<typeof billingProductLogic.build>
+    // Mock billing service state: PATCH merges per key and echoes the full maps, like the real one.
+    let serverLimits: Record<string, number>
+    let serverNextPeriodLimits: Record<string, number>
+
+    const billingPayload = (): Record<string, any> => ({
+        customer_id: 'cus_test',
+        products: [productA, productB],
+        custom_limits_usd: { ...serverLimits },
+        next_period_custom_limits_usd: { ...serverNextPeriodLimits },
+    })
+
+    const mergeIntoServerLimits = (limits: Record<string, number | null>): void => {
+        for (const [key, value] of Object.entries(limits)) {
+            if (value === null) {
+                delete serverLimits[key]
+            } else {
+                serverLimits[key] = value
+            }
+        }
+    }
+
+    beforeEach(async () => {
+        initKeaTests()
+        serverLimits = { session_replay: 200 }
+        serverNextPeriodLimits = { session_replay: 100 }
+        useMocks({
+            get: { '/api/billing': () => [200, billingPayload()] },
+            patch: {
+                '/api/billing': async ({ request }) => {
+                    const body: any = await request.json()
+                    mergeIntoServerLimits(body.custom_limits_usd ?? {})
+                    if (body.reset_limit_next_period) {
+                        delete serverNextPeriodLimits[body.reset_limit_next_period]
+                    }
+                    return [200, billingPayload()]
+                },
+            },
+        })
+        billingLogic.mount()
+        logicA = billingProductLogic({ product: productA })
+        logicA.mount()
+        logicB = billingProductLogic({ product: productB })
+        logicB.mount()
+        await expectLogic(billingLogic, () => billingLogic.actions.loadBilling()).toFinishAllListeners()
+    })
+
+    afterEach(() => {
+        logicB?.unmount()
+        logicA?.unmount()
+        billingLogic.unmount()
+    })
+
+    it("saving one product's limit does not touch another product's editing state", async () => {
+        logicA.actions.setIsEditingBillingLimit(true)
+        logicB.actions.setIsEditingBillingLimit(true)
+        logicB.actions.setBillingLimitInput(300)
+
+        await expectLogic(billingLogic, () =>
+            billingLogic.actions.updateBillingLimit(productA.type, 100)
+        ).toFinishAllListeners()
+
+        expect(billingLogic.values.billing?.custom_limits_usd).toEqual({
+            product_analytics: 100,
+            session_replay: 200,
+        })
+        expect(logicA.values.isEditingBillingLimit).toBe(false)
+        expect(logicB.values.isEditingBillingLimit).toBe(true)
+        expect(logicB.values.billingLimitInput).toEqual({ input: 300 })
+    })
+
+    it('tracks in-flight updates per product, not globally', async () => {
+        billingLogic.actions.updateBillingLimit(productA.type, 100)
+
+        expect(logicA.values.isLimitUpdateInFlight).toBe(true)
+        expect(logicB.values.isLimitUpdateInFlight).toBe(false)
+
+        await expectLogic(billingLogic).toFinishAllListeners()
+
+        expect(logicA.values.isLimitUpdateInFlight).toBe(false)
+    })
+
+    it('concurrent saves both land even when the first save responds last with stale data', async () => {
+        let releaseA: () => void = () => {}
+        const gateA = new Promise<void>((resolve) => (releaseA = resolve))
+        useMocks({
+            patch: {
+                '/api/billing': async ({ request }) => {
+                    const body: any = await request.json()
+                    mergeIntoServerLimits(body.custom_limits_usd)
+                    const response = billingPayload()
+                    if (productA.type in body.custom_limits_usd) {
+                        await gateA // A's response arrives after B has saved, so it lacks B's new limit
+                    }
+                    return [200, response]
+                },
+            },
+        })
+
+        billingLogic.actions.updateBillingLimit(productA.type, 100)
+        billingLogic.actions.updateBillingLimit(productB.type, 150)
+        await expectLogic(billingLogic).toDispatchActions(['updateBillingLimitSuccess', 'loadBillingSuccess'])
+
+        releaseA()
+        await expectLogic(billingLogic).toDispatchActions(['updateBillingLimitSuccess'])
+
+        expect(billingLogic.values.billing?.custom_limits_usd).toEqual({
+            product_analytics: 100,
+            session_replay: 150,
+        })
+
+        await expectLogic(billingLogic).toFinishAllListeners()
+    })
+
+    it('removing the next-period limit clears it for that product only', async () => {
+        expect(logicB.values.billingLimitNextPeriod).toBe(100)
+
+        await expectLogic(billingLogic, () =>
+            billingLogic.actions.removeBillingLimitNextPeriod(productB.type)
+        ).toFinishAllListeners()
+
+        expect(logicB.values.billingLimitNextPeriod).toBeNull()
+        expect(logicB.values.isLimitUpdateInFlight).toBe(false)
+        expect(billingLogic.values.billing?.custom_limits_usd).toEqual({ session_replay: 200 })
+    })
+
+    it('a failed save clears the in-flight flag and keeps the editor open for a retry', async () => {
+        useMocks({ patch: { '/api/billing': () => [500, {}] } })
+        logicA.actions.setIsEditingBillingLimit(true)
+
+        await expectLogic(billingLogic, () =>
+            billingLogic.actions.updateBillingLimit(productA.type, 100)
+        ).toFinishAllListeners()
+
+        expect(logicA.values.isLimitUpdateInFlight).toBe(false)
+        expect(logicA.values.isEditingBillingLimit).toBe(true)
+        expect(billingLogic.values.billing?.custom_limits_usd).toEqual({ session_replay: 200 })
+    })
+})

--- a/frontend/src/scenes/billing/billingLimits.test.ts
+++ b/frontend/src/scenes/billing/billingLimits.test.ts
@@ -127,6 +127,45 @@ describe('billing limits', () => {
         await expectLogic(billingLogic).toFinishAllListeners()
     })
 
+    it('a stale background refresh cannot clobber a newer save', async () => {
+        let releaseFirstRefresh: () => void = () => {}
+        const gate = new Promise<void>((resolve) => (releaseFirstRefresh = resolve))
+        let refreshes = 0
+        useMocks({
+            get: {
+                '/api/billing': async () => {
+                    refreshes += 1
+                    if (refreshes === 1) {
+                        await gate // the first refresh responds last, with data from before B's save
+                        return [
+                            200,
+                            {
+                                ...billingPayload(),
+                                custom_limits_usd: { product_analytics: 100, session_replay: 200 },
+                            },
+                        ]
+                    }
+                    return [200, billingPayload()]
+                },
+            },
+        })
+
+        await expectLogic(billingLogic, () =>
+            billingLogic.actions.updateBillingLimit(productA.type, 100)
+        ).toDispatchActions(['updateBillingLimitSuccess']) // refresh 1 starts, gated
+        await expectLogic(billingLogic, () =>
+            billingLogic.actions.updateBillingLimit(productB.type, 300)
+        ).toDispatchActions(['updateBillingLimitSuccess', 'loadBillingSuccess']) // refresh 2 lands
+
+        releaseFirstRefresh()
+        await expectLogic(billingLogic).toFinishAllListeners()
+
+        expect(billingLogic.values.billing?.custom_limits_usd).toEqual({
+            product_analytics: 100,
+            session_replay: 300,
+        })
+    })
+
     it('removing the next-period limit clears it for that product only', async () => {
         expect(logicB.values.billingLimitNextPeriod).toBe(100)
 

--- a/frontend/src/scenes/billing/billingLimits.test.ts
+++ b/frontend/src/scenes/billing/billingLimits.test.ts
@@ -102,7 +102,7 @@ describe('billing limits', () => {
             patch: {
                 '/api/billing': async ({ request }) => {
                     const body: any = await request.json()
-                    mergeIntoServerLimits(body.custom_limits_usd)
+                    mergeIntoServerLimits(body.custom_limits_usd ?? {})
                     const response = billingPayload()
                     if (productA.type in body.custom_limits_usd) {
                         await gateA // A's response arrives after B has saved, so it lacks B's new limit

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -80,6 +80,18 @@ export type SwitchPlanPayload = {
     to_plan_key: string
 }
 
+export type BillingLimits = Pick<BillingType, 'custom_limits_usd' | 'next_period_custom_limits_usd'>
+
+/** Returns `map` with `key` set to `value`, or with `key` removed when `value` is null/undefined. */
+const withLimit = (
+    map: Record<string, number | null> | undefined,
+    key: string,
+    value: number | null | undefined
+): Record<string, number | null> => {
+    const { [key]: _discarded, ...rest } = map ?? {}
+    return value == null ? rest : { ...rest, [key]: value }
+}
+
 const parseBillingResponse = (data: Partial<BillingType>): BillingType => {
     if (data.billing_period) {
         data.billing_period = {
@@ -177,6 +189,10 @@ export const billingLogic = kea<billingLogicType>([
         setCreditBrackets: (creditBrackets: any[]) => ({ creditBrackets }),
         scrollToProduct: (productType: string) => ({ productType }),
         setSwitchPlanLoading: (productKey: string | null) => ({ productKey }),
+        updateBillingLimit: (productType: string, amount: number | null) => ({ productType, amount }),
+        removeBillingLimitNextPeriod: (productType: string) => ({ productType }),
+        updateBillingLimitSuccess: (productType: string, limits: BillingLimits) => ({ productType, limits }),
+        updateBillingLimitFailure: (productType: string) => ({ productType }),
     }),
     connect(() => ({
         values: [
@@ -306,7 +322,7 @@ export const billingLogic = kea<billingLogicType>([
         billing: [
             null as BillingType | null,
             {
-                loadBilling: async () => {
+                loadBilling: async (_: void, breakpoint) => {
                     // Note: this is a temporary flag to skip forecasting in the billing page
                     // for customers running into performance issues until we have a more permanent fix
                     // of splitting the billing and forecasting data.
@@ -314,22 +330,11 @@ export const billingLogic = kea<billingLogicType>([
                     const response = await api.get(
                         'api/billing' + (skipForecasting ? '?include_forecasting=false' : '')
                     )
+                    // Concurrent limit saves each trigger a refresh; discard superseded responses so a
+                    // stale one can't overwrite newer state.
+                    breakpoint()
 
                     return parseBillingResponse(response)
-                },
-
-                updateBillingLimits: async (limits: { [key: string]: number | null }) => {
-                    try {
-                        const response = await api.update('api/billing', { custom_limits_usd: limits })
-                        lemonToast.success('Billing limits updated')
-                        actions.loadBilling()
-                        return parseBillingResponse(response)
-                    } catch (error: any) {
-                        lemonToast.error(
-                            'There was an error updating your billing limits. Please try again or contact support.'
-                        )
-                        throw error
-                    }
                 },
 
                 deactivateProduct: async (key: string, breakpoint) => {
@@ -516,6 +521,77 @@ export const billingLogic = kea<billingLogicType>([
             },
         ],
     })),
+    reducers({
+        // Limit writes are per product: merging only the saved key keeps concurrent saves commutative.
+        // `billingSource` is the reducer behind the lazy `billing` selector (kea-loaders lazy mode
+        // stores state in `<key>Source`), and is the only way to extend lazy loader state.
+        billingSource: {
+            // The state param is annotated because typegen sees lazy loader state as `any`.
+            updateBillingLimitSuccess: (state: BillingType | null, { productType, limits }) =>
+                state && {
+                    ...state,
+                    custom_limits_usd: withLimit(
+                        state.custom_limits_usd,
+                        productType,
+                        limits.custom_limits_usd?.[productType]
+                    ),
+                    next_period_custom_limits_usd: withLimit(
+                        state.next_period_custom_limits_usd,
+                        productType,
+                        limits.next_period_custom_limits_usd?.[productType]
+                    ),
+                },
+        },
+        limitUpdatesInFlight: [
+            {} as Record<string, true>,
+            {
+                updateBillingLimit: (state, { productType }) => ({ ...state, [productType]: true as const }),
+                removeBillingLimitNextPeriod: (state, { productType }) => ({
+                    ...state,
+                    [productType]: true as const,
+                }),
+                updateBillingLimitSuccess: (state, { productType }) => {
+                    const { [productType]: _discarded, ...rest } = state
+                    return rest
+                },
+                updateBillingLimitFailure: (state, { productType }) => {
+                    const { [productType]: _discarded, ...rest } = state
+                    return rest
+                },
+            },
+        ],
+    }),
+    listeners(({ actions }) => {
+        // Single write path for billing limits. The PATCH response echoes the server's decision for the
+        // saved product (a limit below current usage is clamped and deferred to next period), so the
+        // success payload carries both maps for the per-key merge above.
+        const patchLimits = async (
+            body: Record<string, unknown>,
+            productType: string,
+            successMessage: string
+        ): Promise<void> => {
+            try {
+                const limits: BillingLimits = await api.update('api/billing', body)
+                lemonToast.success(successMessage)
+                actions.updateBillingLimitSuccess(productType, limits)
+                actions.loadBilling() // background refresh of usage-derived fields; never gates the editors
+            } catch (error) {
+                posthog.captureException(error)
+                lemonToast.error('There was an error updating your billing limit. Please try again or contact support.')
+                actions.updateBillingLimitFailure(productType)
+            }
+        }
+        return {
+            updateBillingLimit: ({ productType, amount }) =>
+                patchLimits({ custom_limits_usd: { [productType]: amount } }, productType, 'Billing limit updated'),
+            removeBillingLimitNextPeriod: ({ productType }) =>
+                patchLimits(
+                    { reset_limit_next_period: productType },
+                    productType,
+                    'Billing limit for next period has been removed.'
+                ),
+        }
+    }),
     selectors({
         minimumBillingAccessLevel: [
             (s) => [s.featureFlags],

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -31,10 +31,12 @@ import {
 } from '~/types'
 
 import {
+    BillingLimits,
     buildUsageLimitApproachingMessage,
     buildUsageLimitExceededMessage,
     canAccessBilling as canAccessBillingUtil,
     getMinimumBillingAccessLevel,
+    mergeLimitsForProduct,
 } from './billing-utils'
 import type { billingLogicType } from './billingLogicType'
 import { DEFAULT_ESTIMATED_MONTHLY_CREDIT_AMOUNT_USD } from './CreditCTAHero'
@@ -78,18 +80,6 @@ export type SwitchPlanPayload = {
     from_plan_key: string
     to_product_key: string
     to_plan_key: string
-}
-
-export type BillingLimits = Pick<BillingType, 'custom_limits_usd' | 'next_period_custom_limits_usd'>
-
-/** Returns `map` with `key` set to `value`, or with `key` removed when `value` is null/undefined. */
-const withLimit = (
-    map: Record<string, number | null> | undefined,
-    key: string,
-    value: number | null | undefined
-): Record<string, number | null> => {
-    const { [key]: _discarded, ...rest } = map ?? {}
-    return value == null ? rest : { ...rest, [key]: value }
 }
 
 const parseBillingResponse = (data: Partial<BillingType>): BillingType => {
@@ -522,25 +512,12 @@ export const billingLogic = kea<billingLogicType>([
         ],
     })),
     reducers({
-        // Limit writes are per product: merging only the saved key keeps concurrent saves commutative.
         // `billingSource` is the reducer behind the lazy `billing` selector (kea-loaders lazy mode
         // stores state in `<key>Source`), and is the only way to extend lazy loader state.
         billingSource: {
             // The state param is annotated because typegen sees lazy loader state as `any`.
             updateBillingLimitSuccess: (state: BillingType | null, { productType, limits }) =>
-                state && {
-                    ...state,
-                    custom_limits_usd: withLimit(
-                        state.custom_limits_usd,
-                        productType,
-                        limits.custom_limits_usd?.[productType]
-                    ),
-                    next_period_custom_limits_usd: withLimit(
-                        state.next_period_custom_limits_usd,
-                        productType,
-                        limits.next_period_custom_limits_usd?.[productType]
-                    ),
-                },
+                mergeLimitsForProduct(state, productType, limits),
         },
         limitUpdatesInFlight: [
             {} as Record<string, true>,

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -312,7 +312,7 @@ export const billingLogic = kea<billingLogicType>([
         billing: [
             null as BillingType | null,
             {
-                loadBilling: async (_: void, breakpoint) => {
+                loadBilling: async (payload: { discardIfSuperseded: boolean } | void, breakpoint) => {
                     // Note: this is a temporary flag to skip forecasting in the billing page
                     // for customers running into performance issues until we have a more permanent fix
                     // of splitting the billing and forecasting data.
@@ -320,9 +320,12 @@ export const billingLogic = kea<billingLogicType>([
                     const response = await api.get(
                         'api/billing' + (skipForecasting ? '?include_forecasting=false' : '')
                     )
-                    // Concurrent limit saves each trigger a refresh; discard superseded responses so a
-                    // stale one can't overwrite newer state.
-                    breakpoint()
+                    // Concurrent limit saves each trigger a refresh; those opt in to discarding superseded
+                    // responses so a stale one can't overwrite newer state. Discarding stays opt-in because
+                    // `asyncActions.loadBilling()` awaiters rely on fresh state once the promise resolves.
+                    if (payload?.discardIfSuperseded) {
+                        breakpoint()
+                    }
 
                     return parseBillingResponse(response)
                 },
@@ -552,7 +555,8 @@ export const billingLogic = kea<billingLogicType>([
                 const limits: BillingLimits = await api.update('api/billing', body)
                 lemonToast.success(successMessage)
                 actions.updateBillingLimitSuccess(productType, limits)
-                actions.loadBilling() // background refresh of usage-derived fields; never gates the editors
+                // Background refresh of usage-derived fields; never gates the editors.
+                actions.loadBilling({ discardIfSuperseded: true })
             } catch (error) {
                 posthog.captureException(error)
                 lemonToast.error(`${errorMessage} Please try again or contact support.`)

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -545,7 +545,8 @@ export const billingLogic = kea<billingLogicType>([
         const patchLimits = async (
             body: Record<string, unknown>,
             productType: string,
-            successMessage: string
+            successMessage: string,
+            errorMessage: string
         ): Promise<void> => {
             try {
                 const limits: BillingLimits = await api.update('api/billing', body)
@@ -554,18 +555,24 @@ export const billingLogic = kea<billingLogicType>([
                 actions.loadBilling() // background refresh of usage-derived fields; never gates the editors
             } catch (error) {
                 posthog.captureException(error)
-                lemonToast.error('There was an error updating your billing limit. Please try again or contact support.')
+                lemonToast.error(`${errorMessage} Please try again or contact support.`)
                 actions.updateBillingLimitFailure(productType)
             }
         }
         return {
             updateBillingLimit: ({ productType, amount }) =>
-                patchLimits({ custom_limits_usd: { [productType]: amount } }, productType, 'Billing limit updated'),
+                patchLimits(
+                    { custom_limits_usd: { [productType]: amount } },
+                    productType,
+                    'Billing limit updated',
+                    'There was an error updating your billing limit.'
+                ),
             removeBillingLimitNextPeriod: ({ productType }) =>
                 patchLimits(
                     { reset_limit_next_period: productType },
                     productType,
-                    'Billing limit for next period has been removed.'
+                    'Billing limit for next period has been removed.',
+                    'There was an error removing your billing limit for next period.'
                 ),
         }
     }),

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -96,6 +96,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 'platformAddons',
                 'timeRemainingInSeconds',
                 'timeTotalInSeconds',
+                'limitUpdatesInFlight',
             ],
             featureFlagLogic,
             ['featureFlags'],
@@ -103,8 +104,9 @@ export const billingProductLogic = kea<billingProductLogicType>([
         actions: [
             billingLogic,
             [
-                'updateBillingLimits',
-                'updateBillingLimitsSuccess',
+                'updateBillingLimit',
+                'updateBillingLimitSuccess',
+                'removeBillingLimitNextPeriod',
                 'loadBilling',
                 'loadBillingSuccess',
                 'deactivateProduct',
@@ -154,7 +156,6 @@ export const billingProductLogic = kea<billingProductLogicType>([
         resetUnsubscribeModalStep: true,
         setHedgehogSatisfied: (satisfied: boolean) => ({ satisfied }),
         triggerMoreHedgehogs: true,
-        removeBillingLimitNextPeriod: (productType: string) => ({ productType }),
         showConfirmUpgradeModal: true,
         hideConfirmUpgradeModal: true,
         confirmProductUpgrade: true,
@@ -353,6 +354,10 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 const usageKeyLimit = product.usage_key ? billing?.custom_limits_usd?.[product.usage_key] : null
                 return usageKeyLimit ? Number(usageKeyLimit) : null
             },
+        ],
+        isLimitUpdateInFlight: [
+            (s, p) => [s.limitUpdatesInFlight, p.product],
+            (limitUpdatesInFlight, product): boolean => !!limitUpdatesInFlight[product.type],
         ],
         visibleAddons: [
             (s, p) => [s.featureFlags, p.product],
@@ -598,8 +603,10 @@ export const billingProductLogic = kea<billingProductLogicType>([
         ],
     })),
     listeners(({ actions, values, props }) => ({
-        updateBillingLimitsSuccess: () => {
-            actions.billingLoaded()
+        updateBillingLimitSuccess: ({ productType }) => {
+            if (productType === props.product.type) {
+                actions.billingLoaded()
+            }
         },
         billingLoaded: () => {
             function calculateDefaultBillingLimit(product: BillingProductV2Type | BillingProductV2AddonType): number {
@@ -771,19 +778,6 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 await breakpoint(200)
             }
         },
-        removeBillingLimitNextPeriod: async ({ productType }) => {
-            try {
-                await api.update('api/billing', { reset_limit_next_period: productType })
-                lemonToast.success('Billing limit for next period has been removed.')
-            } catch (e) {
-                console.error(e)
-                lemonToast.error(
-                    'There was an error removing your billing limit for next period. Please try again or contact support.'
-                )
-            } finally {
-                actions.loadBilling()
-            }
-        },
     })),
     forms(({ actions, props }) => ({
         billingLimitInput: {
@@ -805,10 +799,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                         primaryButton: {
                             status: 'danger',
                             children: 'Yes, I understand',
-                            onClick: () =>
-                                actions.updateBillingLimits({
-                                    [props.product.type]: input,
-                                }),
+                            onClick: () => actions.updateBillingLimit(props.product.type, input),
                         },
                         secondaryButton: {
                             children: 'No, I changed my mind',
@@ -826,10 +817,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                         primaryButton: {
                             status: 'danger',
                             children: 'Yes, I understand',
-                            onClick: () =>
-                                actions.updateBillingLimits({
-                                    [props.product.type]: input,
-                                }),
+                            onClick: () => actions.updateBillingLimit(props.product.type, input),
                         },
                         secondaryButton: {
                             children: 'No, I changed my mind',
@@ -837,9 +825,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     })
                     return
                 }
-                actions.updateBillingLimits({
-                    [props.product.type]: input,
-                })
+                actions.updateBillingLimit(props.product.type, input)
             },
             options: {
                 alwaysShowErrors: true,

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
@@ -39,7 +39,7 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
     path(['scenes', 'inbox', 'logics', 'inboxUsageLogic']),
     connect(() => ({
         values: [billingLogic, ['billing', 'billingLoading', 'canAccessBilling']],
-        actions: [billingLogic, ['loadBilling', 'updateBillingLimits']],
+        actions: [billingLogic, ['loadBilling', 'updateBillingLimit']],
     })),
     actions({
         openModal: true,
@@ -78,7 +78,7 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
                     return
                 }
                 const usd = Math.max(0, prs - freePrs) * pricePerPrUsd
-                actions.updateBillingLimits({ [product.type]: usd })
+                actions.updateBillingLimit(product.type, usd)
             },
         },
     })),

--- a/playwright/e2e/billing/billing-limits.spec.ts
+++ b/playwright/e2e/billing/billing-limits.spec.ts
@@ -6,7 +6,9 @@ import { PlaywrightWorkspaceSetupResult, expect, test } from '../../utils/worksp
 
 type BillingRouteHandlers = {
     getResponse: (billingContent: Record<string, any>) => Record<string, any>
-    patchResponse: (billingContent: Record<string, any>) => Record<string, any>
+    patchResponse: (billingContent: Record<string, any>, requestBody: Record<string, any>) => Record<string, any>
+    /** Awaited after a PATCH is applied but before its response is sent — lets a test hold a response in flight. */
+    beforePatchResponse?: (requestBody: Record<string, any>) => Promise<void> | void
 }
 
 async function setupBillingRoutes(page: Page, handlers: BillingRouteHandlers): Promise<void> {
@@ -33,10 +35,14 @@ async function setupBillingRoutes(page: Page, handlers: BillingRouteHandlers): P
                 },
             })
         } else if (method === 'PATCH') {
-            billingContent = handlers.patchResponse(billingContent)
+            const requestBody = route.request().postDataJSON() ?? {}
+            billingContent = handlers.patchResponse(billingContent, requestBody)
+            // Snapshot before the gate so a held response echoes the state at commit time, like a real slow server.
+            const responseBody = JSON.stringify(billingContent)
+            await handlers.beforePatchResponse?.(requestBody)
             await route.fulfill({
                 status: 200,
-                body: JSON.stringify(billingContent),
+                body: responseBody,
                 headers: {
                     'X-Mock-Response': 'true',
                 },
@@ -157,5 +163,125 @@ test.describe('Billing Limits', () => {
         await page.locator('[data-attr="remove-billing-limit-product_analytics"]').click()
 
         await expect(page.locator('[data-attr="billing-limit-not-set-product_analytics"]')).toBeVisible()
+    })
+
+    test("Saving one product's limit does not lock or clear another product's editor", async ({ page }) => {
+        let releaseAnalyticsResponse: () => void = () => {}
+        const analyticsResponseGate = new Promise<void>((resolve) => (releaseAnalyticsResponse = resolve))
+
+        await setupBillingRoutes(page, {
+            getResponse: (billingContent) => billingContent,
+            patchResponse: (billingContent, requestBody) => {
+                billingContent.custom_limits_usd = {
+                    ...billingContent.custom_limits_usd,
+                    ...requestBody.custom_limits_usd,
+                }
+                return billingContent
+            },
+            beforePatchResponse: (requestBody) =>
+                'product_analytics' in (requestBody.custom_limits_usd ?? {}) ? analyticsResponseGate : undefined,
+        })
+
+        await page.goto('/organization/billing')
+
+        const analytics = page.getByTestId('billing-limit-input-wrapper-product_analytics')
+        const replay = page.getByTestId('billing-limit-input-wrapper-session_replay')
+
+        await test.step('open both editors and type a value in each', async () => {
+            await analytics.scrollIntoViewIfNeeded()
+            await analytics.getByRole('button', { name: 'Set a billing limit' }).click()
+            await page.fill('[data-attr="billing-limit-input-product_analytics"]', '100')
+            await replay.scrollIntoViewIfNeeded()
+            await replay.getByRole('button', { name: 'Set a billing limit' }).click()
+            await page.fill('[data-attr="billing-limit-input-session_replay"]', '150')
+        })
+
+        await test.step("while one save is in flight, the other product's editor stays usable", async () => {
+            await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+            // The gated response holds this save in flight: its own input locks...
+            await expect(page.locator('[data-attr="billing-limit-input-product_analytics"]')).toBeDisabled()
+            // ...but the other product's editor must stay enabled with its typed value intact
+            await expect(page.locator('[data-attr="billing-limit-input-session_replay"]')).toBeEnabled()
+            await expect(page.locator('[data-attr="billing-limit-input-session_replay"]')).toHaveValue('150')
+        })
+
+        await test.step("completing the save closes only that product's editor", async () => {
+            releaseAnalyticsResponse()
+            await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
+                'You have a $100 billing limit set'
+            )
+            await expect(page.locator('[data-attr="billing-limit-input-session_replay"]')).toHaveValue('150')
+        })
+
+        await test.step('the untouched editor still saves normally', async () => {
+            await page.locator('[data-attr="save-billing-limit-session_replay"]').click()
+            await expect(page.locator('[data-attr="billing-limit-set-session_replay"]')).toContainText(
+                'You have a $150 billing limit set'
+            )
+            await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
+                'You have a $100 billing limit set'
+            )
+        })
+    })
+
+    test('Warns before saving a limit below current or projected usage', async ({ page }) => {
+        await setupBillingRoutes(page, {
+            getResponse: (billingContent) => {
+                const analytics = billingContent.products.find((p: any) => p.type === 'product_analytics')
+                analytics.current_amount_usd = '100.00'
+                analytics.projected_amount_usd = '150.00'
+                billingContent.next_period_custom_limits_usd = {}
+                return billingContent
+            },
+            patchResponse: (billingContent, requestBody) => {
+                // Model the real API: a limit below current spend is clamped to that spend
+                // for this period and the requested value is deferred to the next period.
+                for (const [key, value] of Object.entries<number>(requestBody.custom_limits_usd ?? {})) {
+                    if (value < 100) {
+                        billingContent.custom_limits_usd[key] = 100
+                        billingContent.next_period_custom_limits_usd[key] = value
+                    } else {
+                        billingContent.custom_limits_usd[key] = value
+                    }
+                }
+                return billingContent
+            },
+        })
+
+        await page.goto('/organization/billing')
+
+        const analytics = page.getByTestId('billing-limit-input-wrapper-product_analytics')
+        await analytics.scrollIntoViewIfNeeded()
+        await analytics.getByRole('button', { name: 'Set a billing limit' }).click()
+
+        await test.step('cancelling the below-usage warning saves nothing and keeps the editor open', async () => {
+            await page.fill('[data-attr="billing-limit-input-product_analytics"]', '50')
+            await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+            await expect(page.locator('.LemonModal')).toContainText('below your current usage')
+            await page.getByRole('button', { name: 'No, I changed my mind' }).click()
+            await expect(page.locator('.LemonModal')).not.toBeVisible()
+            await expect(page.locator('[data-attr="billing-limit-input-product_analytics"]')).toHaveValue('50')
+        })
+
+        await test.step('confirming clamps this period to usage and defers the limit to next period', async () => {
+            await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+            await page.getByRole('button', { name: 'Yes, I understand' }).click()
+            await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
+                'You have a $100 billing limit set'
+            )
+            await expect(analytics).toContainText('Your limit for next period: $50')
+            await expect(page.locator('[data-attr="remove-billing-limit-next-period-product_analytics"]')).toBeVisible()
+        })
+
+        await test.step('a limit below projected (but above current) usage warns about throttling', async () => {
+            await analytics.getByRole('button', { name: 'Edit limit' }).click()
+            await page.fill('[data-attr="billing-limit-input-product_analytics"]', '120')
+            await page.locator('[data-attr="save-billing-limit-product_analytics"]').click()
+            await expect(page.locator('.LemonModal')).toContainText('predicted usage is above your billing limit')
+            await page.getByRole('button', { name: 'Yes, I understand' }).click()
+            await expect(page.locator('[data-attr="billing-limit-set-product_analytics"]')).toContainText(
+                'You have a $120 billing limit set'
+            )
+        })
     })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -369,7 +369,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -397,7 +397,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
 
   common/storybook:
     dependencies:
@@ -418,7 +418,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: ^10.4.3
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/addon-links':
         specifier: ^10.4.3
         version: 10.4.6(@types/react@18.3.27)(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -430,10 +430,10 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -448,7 +448,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1288,6 +1288,9 @@ importers:
       fake-indexeddb:
         specifier: ^6.0.1
         version: 6.0.1
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -1827,7 +1830,7 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -1848,7 +1851,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1964,7 +1967,7 @@ importers:
         version: 5.2.0(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2595,7 +2598,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -2828,7 +2831,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -2954,7 +2957,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -3355,7 +3358,7 @@ importers:
         version: 2.1.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3538,7 +3541,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -4218,7 +4221,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -15432,6 +15435,10 @@ packages:
     resolution: {integrity: sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==}
     engines: {node: '>=18'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@3.0.1:
     resolution: {integrity: sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==}
 
@@ -19727,6 +19734,9 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  pure-rand@8.4.1:
+    resolution: {integrity: sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==}
 
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -26660,7 +26670,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -26674,7 +26684,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -26730,42 +26740,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))':
+  '@jest/core@30.0.5':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26780,7 +26755,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@22.18.8)
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -26837,7 +26812,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26852,7 +26827,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -31103,10 +31078,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -31141,9 +31116,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -31162,7 +31137,7 @@ snapshots:
       vite: 7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
@@ -31170,7 +31145,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.60.4
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -31225,11 +31200,11 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -31281,7 +31256,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -31291,14 +31266,14 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.39(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-circus: 30.0.5
       jest-environment-node: 30.0.5
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.0.5
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0))
       nyc: 15.1.0
       playwright: 1.60.0
       playwright-core: 1.60.0
@@ -34941,13 +34916,28 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  create-jest@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -34971,13 +34961,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.8.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36448,6 +36438,10 @@ snapshots:
   extsprintf@1.3.0: {}
 
   fake-indexeddb@6.0.1: {}
+
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.1
 
   fast-copy@3.0.1: {}
 
@@ -38026,16 +38020,35 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-cli@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      create-jest: 29.7.0
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-cli@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.18.8)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38064,16 +38077,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.8.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38102,15 +38115,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38121,15 +38134,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38174,7 +38187,35 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-config@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.18.8):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -38200,7 +38241,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38236,38 +38276,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -38293,12 +38302,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.0.5(@types/node@22.18.8):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38326,7 +38334,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38365,7 +38372,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38393,12 +38400,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38426,12 +38434,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38458,7 +38465,9 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
+      '@types/node': 25.8.0
       esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38661,7 +38670,7 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38672,9 +38681,9 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.8.0)
 
-  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38685,7 +38694,7 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -39240,11 +39249,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       ansi-escapes: 7.0.0
       chalk: 5.6.2
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-regex-util: 30.0.1
       jest-watcher: 30.0.5
       slash: 5.1.0
@@ -39316,12 +39325,24 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.18.8)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39340,12 +39361,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39365,12 +39386,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39378,12 +39399,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -42590,6 +42611,8 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  pure-rand@8.4.1: {}
+
   q@1.5.1: {}
 
   qrcode.react@4.2.0(react@18.3.1):
@@ -44758,6 +44781,20 @@ snapshots:
       esbuild: 0.28.0
       postcss: 8.5.15
 
+  terser-webpack-plugin@5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+    optionalDependencies:
+      cssnano: 7.0.6(postcss@8.5.15)
+      esbuild: 0.28.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optional: true
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
@@ -44985,27 +45022,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 6.0.3
-
-  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.18.8
-      acorn: 8.15.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.4
-    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3):
     dependencies:
@@ -46006,6 +46022,48 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.22.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
 
   webrtc-adapter@9.0.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -369,7 +369,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -397,7 +397,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   common/storybook:
     dependencies:
@@ -418,7 +418,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: ^10.4.3
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/addon-links':
         specifier: ^10.4.3
         version: 10.4.6(@types/react@18.3.27)(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -430,10 +430,10 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -448,7 +448,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1830,7 +1830,7 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -1851,7 +1851,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1967,7 +1967,7 @@ importers:
         version: 5.2.0(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2598,7 +2598,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -2831,7 +2831,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -2957,7 +2957,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -3358,7 +3358,7 @@ importers:
         version: 2.1.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3541,7 +3541,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -4221,7 +4221,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -26670,7 +26670,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -26684,7 +26684,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -26740,7 +26740,42 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5':
+  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26755,7 +26790,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -26812,7 +26847,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26827,7 +26862,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -31078,10 +31113,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -31116,9 +31151,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -31137,7 +31172,7 @@ snapshots:
       vite: 7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
@@ -31145,7 +31180,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.60.4
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -31200,11 +31235,11 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -31256,7 +31291,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -31266,14 +31301,14 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.39(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 30.0.5(@types/node@25.8.0)
+      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-circus: 30.0.5
       jest-environment-node: 30.0.5
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.0.5
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0))
+      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       nyc: 15.1.0
       playwright: 1.60.0
       playwright-core: 1.60.0
@@ -34916,28 +34951,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0:
+  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@22.18.8):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -34961,13 +34981,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.8.0):
+  create-jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.8.0)
+      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -38020,35 +38040,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0:
+  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@22.18.8):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38077,16 +38078,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.8.0):
+  jest-cli@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)
+      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)
+      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38115,15 +38116,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0):
+  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)
+      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38134,15 +38135,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38187,35 +38188,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@29.7.0:
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.18.8):
+  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -38241,6 +38214,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
+      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38276,7 +38250,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.8.0):
+  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -38302,11 +38307,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8):
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38334,6 +38340,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38372,7 +38379,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38400,13 +38407,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0):
+  jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38434,11 +38440,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38465,9 +38472,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.8.0
       esbuild-register: 3.6.0(esbuild@0.28.0)
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38670,7 +38675,7 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38681,9 +38686,9 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.8.0)
+      jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
-  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)):
+  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38694,7 +38699,7 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 30.0.5(@types/node@25.8.0)
+      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -39249,11 +39254,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)):
+  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
     dependencies:
       ansi-escapes: 7.0.0
       chalk: 5.6.2
-      jest: 30.0.5(@types/node@25.8.0)
+      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-regex-util: 30.0.1
       jest-watcher: 30.0.5
       slash: 5.1.0
@@ -39325,24 +39330,12 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0:
+  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.18.8):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)
+      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39361,12 +39354,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.8.0):
+  jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.8.0)
+      jest-cli: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39386,12 +39379,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0):
+  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)
+      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39399,12 +39392,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -44781,20 +44774,6 @@ snapshots:
       esbuild: 0.28.0
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
-    optionalDependencies:
-      cssnano: 7.0.6(postcss@8.5.15)
-      esbuild: 0.28.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-    optional: true
-
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
@@ -45022,6 +45001,27 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 6.0.3
+
+  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 22.18.8
+      acorn: 8.15.0
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.11.4
+    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3):
     dependencies:
@@ -46022,48 +46022,6 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
-
-  webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.22.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-    optional: true
 
   webrtc-adapter@9.0.5:
     dependencies:


### PR DESCRIPTION
## Problem

Setting a billing limit on the billing page is painful. Every save runs through the global `billing` loader in `billingLogic`, which causes two problems:

- One shared `billingLoading` flag disables every product's limit editor while any save is in flight, so you have to wait for each limit to save before touching the next one.
- The success handler broadcast `billingLoaded` to every mounted `billingProductLogic`, closing every open editor and wiping any limit you were mid-typing on another product.

On top of that, each save fired a redundant full `loadBilling()` even though the PATCH response already contains the fresh billing payload, adding a second multi-second round trip per save.

This is the first PR of a stack. Follow-ups move limit reads/writes to a dedicated lightweight endpoint on the billing service (`api/v2/limits/`) and a matching proxy here, removing the full-billing rebuild from the write path entirely.

## Changes

- `billingLogic` gets a dedicated write path for limits, with two entrypoints: `updateBillingLimit(productType, amount | null)` (set and remove) and `removeBillingLimitNextPeriod(productType)`. Both funnel through one `patchLimits` listener.
- On success, the response's `custom_limits_usd` and `next_period_custom_limits_usd` are merged into billing state per saved key only. Per-key merges are commutative, so concurrent saves for different products can't clobber each other even when responses arrive out of order. The merge extends `billingSource`, the reducer behind the lazy `billing` selector (kea-loaders lazy mode stores state in `<key>Source`, and the plain `billing` key is a selector that can't take reducer mutations).
- A `limitUpdatesInFlight` map replaces the global loading flag. `BillingLimit` keys its input and buttons off the new per-product `isLimitUpdateInFlight` selector.
- `billingProductLogic`'s success listener is scoped to its own product, so saving product A no longer closes product B's editor.
- The post-save `loadBilling()` becomes a background refresh of usage-derived fields (projected totals, gauges) that never gates the editors, and `loadBilling` now uses a `breakpoint()` so a superseded response can't overwrite newer state.
- Added the missing double-submission guards on the "Remove limit" and "Remove limit for next period" buttons.
- `inboxUsageLogic` (the only other caller) swaps to the new action.

No screenshots since the sandbox can't run the app. The UI is visually unchanged, only the disabled/loading wiring differs.

## How did you test this code?

Added `billingLimits.test.ts` (5 kea logic tests, all mocked via MSW). Each catches a regression nothing covered before, since the limits flow had no tests at all:

- Saving one product's limit doesn't touch another product's open editor or typed input (the main bug this PR fixes).
- In-flight state is tracked per product, not globally (guards against reintroducing a shared loading flag).
- Concurrent saves for two products both land even when the first save's response arrives last with stale maps, via a gated MSW handler that makes the race deterministic (guards against "simplifying" the per-key merge back to whole-map replacement).
- Removing the next-period limit clears it for that product only (locks the request/response contract before the follow-up PR swaps the endpoint).
- A failed save clears the in-flight flag and keeps the editor open for retry.

Two Playwright tests were added to the existing `billing-limits.spec.ts` (justifications per the e2e suite's value gate):

- **Concurrent saves**: one product's PATCH response is held in flight via a deterministic gate while asserting the other product's editor stays enabled with its typed value, and that completing the save closes only its own editor. This is the DOM-level version of the bug this PR fixes — the Jest tests assert logic values, not the rendered `disabled`/editor wiring, so a regression back to the global `billingLoading` flag would pass every layer below this one.
- **Usage warning dialogs**: cancel and confirm paths for the below-current-usage clamp warning (including rendering the clamped current limit + deferred next-period limit from one response) and the below-projected-usage throttle warning. These `LemonDialog` branches live in the form submit, which the Jest tests bypass entirely, and the fixture's zero usage made them unreachable by the existing e2e tests.

The merge itself is also property-tested (`billing-utils.spec.ts`, via a new `fast-check` dev dependency). The per-key merge now lives in `billing-utils.ts` as a pure `mergeLimitsForProduct`, and the property asserts that folding limit-save responses in any arrival order that preserves per-product commit order converges to the server's final state, across generated histories of sets and removals on three products and both limit maps. The gated-MSW logic test pins one adversarial interleaving through the real wiring; the property sweeps the ordering space at the pure level. I mutation-verified it: swapping the per-key merge for whole-map replacement fails the property within a few runs with a shrunk counterexample.

Also ran the neighboring `paymentEntryLogic.test.ts` suite (passes), kea typegen for the three touched logics, oxlint/oxfmt on changed files, and `hogli ci:preflight --fix` (zero failures). I was not able to run the full `typescript:check` in the sandbox because the repo-wide kea typegen pass OOMs there; CI runs both.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed, the billing limits workflow is unchanged from a user's perspective.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud session) directed by Marce. The work started as an investigation into why the limits page is slow and loses state, traced the cost of one save to three full billing-status rebuilds across the frontend, the Django proxy, and the billing service, and this PR fixes the frontend state layer first since it's independently shippable against the existing endpoint.

Skills invoked: `/writing-kea-logics`, `/writing-tests`, plus self-review with `rs-self-review`/`rs-adversarial-review`, which produced three of the changes here (the `loadBilling` breakpoint, the typed reducer param, and the next-period removal test).

Decisions worth knowing for review: extending `billingSource` was chosen over a sync setter loader handler after the obvious `reducers({ billing: ... })` extension threw at runtime ("can't add reducer, a selector with the same name exists"); the coupling to the kea-loaders internal name is one commented line and the new tests fail loudly if it changes. The per-key merge (rather than replacing both maps from the response) is deliberate, whole-map replacement loses concurrent writes when responses arrive out of order. A pre-existing quirk was found but intentionally left out of scope: removing a limit routes through the submit handler where `null` coerces to `0`, showing the misleading "limit below current usage" dialog.


