### PR TITLE
fix(data-warehouse): give actionable copy for Meta Ads permission errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -69,8 +69,23 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
             # access tokens, checkpoint-required, invalidated sessions, permission denials).
             # `meta_ads._raise_meta_api_error` prefixes these with this exact message.
             META_AUTH_ERROR_MESSAGE: META_AUTH_ERROR_MESSAGE,
-            "Ad account owner has NOT": None,
-            "cannot be loaded due to missing permissions": None,
+            # Graph API code 200: "Ad account owner has NOT granted ads_management or ads_read
+            # permission." The connected Meta user can't read this ad account's data. Retrying
+            # can't grant the permission — the account owner has to. Without a message here the
+            # raw Graph API JSON blob surfaces to the user, so give actionable guidance instead.
+            "Ad account owner has NOT": (
+                "Meta denied access to this ad account — the connected Meta account is missing the "
+                "ads_read permission needed to sync its data. Ask the ad account owner to grant that "
+                "access, then reconnect the Meta Ads integration."
+            ),
+            # Graph API code 100: "This endpoint cannot be loaded due to missing permissions." A
+            # specific endpoint can't be read with the permissions the user granted. Same as above:
+            # not fixable by retrying, and the raw JSON would otherwise reach the user.
+            "cannot be loaded due to missing permissions": (
+                "Meta blocked this request because the connected account is missing a permission "
+                "required to read your ads data. Please reconnect the Meta Ads integration and grant "
+                "all requested permissions."
+            ),
             # Meta returns this 500 when the requested query is too large for their backend to
             # service. Both pagination paths adapt to it (stats chunks shrink 30 → 7 → 1 day, and
             # both paths shrink the per-page limit 500 → 100 → 50); if it still escapes after those


### PR DESCRIPTION
## Problem

Replay Vision watched real users try to onboard a Meta Ads data warehouse source, and permission failures were a recurring dead end. When Meta's Graph API rejects a request for a missing permission, two of those errors were already classified as non-retryable but had no friendly message attached, so the raw Graph API JSON blob leaked straight to the user, for example:

```
Meta API request failed: 400 - {"error":{"message":"(#200) Ad account owner has NOT granted ads_management or ads_read permission.","type":"OAuthException","code":200}}
```

That tells a user nothing about what to actually do.

## Changes

Replace the two `None` values in `MetaAdsSource.get_non_retryable_errors()` with clear, actionable copy:

- **Code 200** ("Ad account owner has NOT granted ads_read") now explains the connected account is missing `ads_read` and the account owner has to grant it, then reconnect.
- **Code 100** ("cannot be loaded due to missing permissions") now tells the user to reconnect and grant all requested permissions.

This follows the exact pattern the team already uses for BigQuery job-creation permissions and Google Ads permission errors. No logic or classification changes. The error keys (match patterns) are untouched, so retry behavior is identical.

## How did you test this code?

The change is a pure copy swap of dict values. The existing `TestNonRetryableErrors::test_errors_match_pattern` iterates over the dict keys (unchanged), so it still passes. I (Claude) could not run pytest in this environment (no pytest in the available venv), so I verified by inspection that no test asserts these values are `None` and that the keys are unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) authored this while synthesizing friction themes from a batch of Replay Vision session summaries of the data warehouse new-source onboarding flow. Meta Ads permission failures recurred across many sessions. Investigating where those errors surface led to `get_non_retryable_errors`, where two permission errors were correctly marked non-retryable but fell back to dumping the raw Graph API JSON at the user. The fix mirrors the recently merged BigQuery job-creation guidance and the existing Google Ads permission copy, so it stays consistent with how the team handles this class of error. No skills were required for a copy-only backend change.
