### PR TITLE
feat(data-modeling): add internal data_modeling_ops read API

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -547,13 +547,22 @@ WORKFLOWS_RESCHEDULE_JWT_SECRETS = get_list(
     get_from_env("WORKFLOWS_RESCHEDULE_JWT_SECRET", "local-dev-workflows-reschedule-jwt" if DEBUG or TEST else "")
 )
 
-# Dedicated signing key for the data_modeling_ops internal API (scoped JWTs minted by the
-# modeling-ops admin app). Per-purpose per .agents/security.md — never INTERNAL_API_SECRET,
-# SECRET_KEY, or JWT_SIGNING_KEY. Defaults to empty in every environment so requests fail closed
-# at request time (DataModelingOpsJWTAuthentication); set the env var explicitly, including local dev.
-DATA_MODELING_OPS_JWT_SECRET = get_from_env("DATA_MODELING_OPS_JWT_SECRET", "").strip()
-# Previous keys still accepted for verification during zero-downtime rotation, newest first.
-DATA_MODELING_OPS_JWT_SECRET_FALLBACKS = get_list(os.getenv("DATA_MODELING_OPS_JWT_SECRET_FALLBACKS", ""))
+# The data_modeling_ops internal API authenticates with OIDC ID tokens forwarded by the
+# modeling-ops admin app — no shared signing secret; verification runs against the issuer's
+# JWKS (see products/data_modeling/backend/presentation/internal_auth.py). Fail-closed: with
+# no audience configured, every request is rejected. In DEBUG/TEST the audience defaults to
+# the gcloud CLI's public OAuth client ID so `gcloud auth print-identity-token` works locally.
+LOCAL_DEV_DATA_MODELING_OPS_OIDC_AUDIENCE = "32555940559.apps.googleusercontent.com"
+DATA_MODELING_OPS_OIDC_ISSUER = get_from_env("DATA_MODELING_OPS_OIDC_ISSUER", "https://accounts.google.com")
+DATA_MODELING_OPS_OIDC_JWKS_URL = get_from_env(
+    "DATA_MODELING_OPS_OIDC_JWKS_URL", "https://www.googleapis.com/oauth2/v3/certs"
+)
+DATA_MODELING_OPS_OIDC_AUDIENCES = get_list(
+    os.getenv("DATA_MODELING_OPS_OIDC_AUDIENCES", LOCAL_DEV_DATA_MODELING_OPS_OIDC_AUDIENCE if DEBUG or TEST else "")
+)
+DATA_MODELING_OPS_OIDC_ALLOWED_DOMAINS = get_list(os.getenv("DATA_MODELING_OPS_OIDC_ALLOWED_DOMAINS", "posthog.com"))
+# Service (no-human) callers verified by the same issuer but exempt from the domain check.
+DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS = get_list(os.getenv("DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS", ""))
 
 EMBEDDING_API_URL = get_from_env("EMBEDDING_API_URL", "")
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -549,12 +549,9 @@ WORKFLOWS_RESCHEDULE_JWT_SECRETS = get_list(
 
 # Dedicated signing key for the data_modeling_ops internal API (scoped JWTs minted by the
 # modeling-ops admin app). Per-purpose per .agents/security.md — never INTERNAL_API_SECRET,
-# SECRET_KEY, or JWT_SIGNING_KEY. Defaults to a public dev value in DEBUG/TEST; elsewhere it
-# defaults to empty and requests fail closed at request time (DataModelingOpsJWTAuthentication).
-LOCAL_DEV_DATA_MODELING_OPS_JWT_SECRET = "posthog-data-modeling-ops-local"
-DATA_MODELING_OPS_JWT_SECRET = get_from_env(
-    "DATA_MODELING_OPS_JWT_SECRET", LOCAL_DEV_DATA_MODELING_OPS_JWT_SECRET if DEBUG or TEST else ""
-).strip()
+# SECRET_KEY, or JWT_SIGNING_KEY. Defaults to empty in every environment so requests fail closed
+# at request time (DataModelingOpsJWTAuthentication); set the env var explicitly, including local dev.
+DATA_MODELING_OPS_JWT_SECRET = get_from_env("DATA_MODELING_OPS_JWT_SECRET", "").strip()
 # Previous keys still accepted for verification during zero-downtime rotation, newest first.
 DATA_MODELING_OPS_JWT_SECRET_FALLBACKS = get_list(os.getenv("DATA_MODELING_OPS_JWT_SECRET_FALLBACKS", ""))
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -547,6 +547,17 @@ WORKFLOWS_RESCHEDULE_JWT_SECRETS = get_list(
     get_from_env("WORKFLOWS_RESCHEDULE_JWT_SECRET", "local-dev-workflows-reschedule-jwt" if DEBUG or TEST else "")
 )
 
+# Dedicated signing key for the data_modeling_ops internal API (scoped JWTs minted by the
+# modeling-ops admin app). Per-purpose per .agents/security.md — never INTERNAL_API_SECRET,
+# SECRET_KEY, or JWT_SIGNING_KEY. Defaults to a public dev value in DEBUG/TEST; elsewhere it
+# defaults to empty and requests fail closed at request time (DataModelingOpsJWTAuthentication).
+LOCAL_DEV_DATA_MODELING_OPS_JWT_SECRET = "posthog-data-modeling-ops-local"
+DATA_MODELING_OPS_JWT_SECRET = get_from_env(
+    "DATA_MODELING_OPS_JWT_SECRET", LOCAL_DEV_DATA_MODELING_OPS_JWT_SECRET if DEBUG or TEST else ""
+).strip()
+# Previous keys still accepted for verification during zero-downtime rotation, newest first.
+DATA_MODELING_OPS_JWT_SECRET_FALLBACKS = get_list(os.getenv("DATA_MODELING_OPS_JWT_SECRET_FALLBACKS", ""))
+
 EMBEDDING_API_URL = get_from_env("EMBEDDING_API_URL", "")
 
 # Used to generate embeddings on the fly, for use with the document embeddings table

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -47,9 +47,11 @@ from posthog.temporal.codec_server import decode_payloads
 
 from products.ai_observability.backend.api.personal_spend import PersonalSpendEUProxyViewSet
 from products.cdp.backend.api import hog_function_template
+from products.data_modeling.backend.facade.internal_ops import InternalDataModelingOpsViewSet
 from products.data_warehouse.backend.presentation.views.public_source_configs import PublicSourceConfigViewSet
 from products.demo.backend.facade.api import demo_route
 from products.early_access_features.backend.api import early_access_features
+from products.endpoints.backend.facade.internal_ops import InternalEndpointsOpsViewSet
 from products.legal_documents.backend.presentation.webhook import legal_document_pandadoc_webhook
 from products.messaging.backend.api.customerio_webhook import CustomerIOWebhookView
 from products.messaging.backend.api.push_subscriptions import push_subscriptions
@@ -500,6 +502,40 @@ urlpatterns = [
     path(
         "api/projects/<str:team_id>/internal/signals/emit",
         csrf_exempt(signals_views.InternalSignalViewSet.as_view({"post": "emit"})),
+    ),
+    # Internal read-only endpoints for the modeling-ops admin app (authenticated with
+    # scoped JWTs signed by DATA_MODELING_OPS_JWT_SECRET; not exposed to Contour ingress)
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/overview",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_overview"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_queries"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries/<str:saved_query_id>",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_detail"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries/<str:saved_query_id>/jobs",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_jobs"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/dags",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_dags"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/dags/<str:dag_id>",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_dag_detail"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/endpoints",
+        csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoints"})),
+    ),
+    path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/endpoints/<str:name>",
+        csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoint_detail"})),
     ),
     # Test setup endpoint (only available in TEST mode)
     path("api/setup_test/<str:test_name>/", csrf_exempt(playwright_setup.setup_test)),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -503,38 +503,41 @@ urlpatterns = [
         "api/projects/<str:team_id>/internal/signals/emit",
         csrf_exempt(signals_views.InternalSignalViewSet.as_view({"post": "emit"})),
     ),
-    # Internal read-only endpoints for the modeling-ops admin app (authenticated with
-    # OIDC ID tokens verified against the issuer JWKS; not exposed to Contour ingress)
+    # Read-only API for the modeling-ops admin app, which reads across every team.
+    # `?team_id=` narrows a list; entity routes take the entity's own id, since a team
+    # segment here would imply a scoping guarantee this API does not make (any verified
+    # operator may read any team). Authenticated with OIDC ID tokens verified against the
+    # issuer JWKS; Contour 403s the whole api/internal prefix at the edge.
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/overview",
-        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_overview"})),
+        "api/internal/data_modeling_ops/teams/<str:team_id>",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_team_detail"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries",
+        "api/internal/data_modeling_ops/saved_queries",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_queries"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries/<str:saved_query_id>",
+        "api/internal/data_modeling_ops/saved_queries/<str:saved_query_id>",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_detail"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/saved_queries/<str:saved_query_id>/jobs",
+        "api/internal/data_modeling_ops/saved_queries/<str:saved_query_id>/jobs",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_jobs"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/dags",
+        "api/internal/data_modeling_ops/dags",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_dags"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/dags/<str:dag_id>",
+        "api/internal/data_modeling_ops/dags/<str:dag_id>",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_dag_detail"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/endpoints",
+        "api/internal/data_modeling_ops/endpoints",
         csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoints"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/endpoints/<str:name>",
+        "api/internal/data_modeling_ops/endpoints/<str:endpoint_id>",
         csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoint_detail"})),
     ),
     # Test setup endpoint (only available in TEST mode)

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -504,7 +504,7 @@ urlpatterns = [
         csrf_exempt(signals_views.InternalSignalViewSet.as_view({"post": "emit"})),
     ),
     # Internal read-only endpoints for the modeling-ops admin app (authenticated with
-    # scoped JWTs signed by DATA_MODELING_OPS_JWT_SECRET; not exposed to Contour ingress)
+    # OIDC ID tokens verified against the issuer JWKS; not exposed to Contour ingress)
     path(
         "api/projects/<str:team_id>/internal/data_modeling_ops/overview",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_overview"})),

--- a/products/data_modeling/backend/facade/internal_ops.py
+++ b/products/data_modeling/backend/facade/internal_ops.py
@@ -1,0 +1,21 @@
+"""Wiring for the data_modeling_ops internal (service-to-service) API.
+
+Core URL routing and sibling products import the viewset and auth primitives from
+here rather than reaching into presentation modules. Only imported by posthog/urls.py
+(request time) and the endpoints product, so the DRF dependencies stay off the
+``django.setup()`` path.
+"""
+
+from products.data_modeling.backend.presentation.internal_auth import (
+    DATA_MODELING_OPS_AUDIENCE,
+    DataModelingOpsJWTAuthentication,
+    mint_data_modeling_ops_token,
+)
+from products.data_modeling.backend.presentation.internal_views import InternalDataModelingOpsViewSet
+
+__all__ = [
+    "DATA_MODELING_OPS_AUDIENCE",
+    "DataModelingOpsJWTAuthentication",
+    "InternalDataModelingOpsViewSet",
+    "mint_data_modeling_ops_token",
+]

--- a/products/data_modeling/backend/facade/internal_ops.py
+++ b/products/data_modeling/backend/facade/internal_ops.py
@@ -7,15 +7,13 @@ here rather than reaching into presentation modules. Only imported by posthog/ur
 """
 
 from products.data_modeling.backend.presentation.internal_auth import (
-    DATA_MODELING_OPS_AUDIENCE,
-    DataModelingOpsJWTAuthentication,
-    mint_data_modeling_ops_token,
+    DataModelingOpsAuthenticationMixin,
+    DataModelingOpsOIDCAuthentication,
 )
 from products.data_modeling.backend.presentation.internal_views import InternalDataModelingOpsViewSet
 
 __all__ = [
-    "DATA_MODELING_OPS_AUDIENCE",
-    "DataModelingOpsJWTAuthentication",
+    "DataModelingOpsAuthenticationMixin",
+    "DataModelingOpsOIDCAuthentication",
     "InternalDataModelingOpsViewSet",
-    "mint_data_modeling_ops_token",
 ]

--- a/products/data_modeling/backend/facade/internal_ops.py
+++ b/products/data_modeling/backend/facade/internal_ops.py
@@ -10,10 +10,16 @@ from products.data_modeling.backend.presentation.internal_auth import (
     DataModelingOpsAuthenticationMixin,
     DataModelingOpsOIDCAuthentication,
 )
-from products.data_modeling.backend.presentation.internal_views import InternalDataModelingOpsViewSet
+from products.data_modeling.backend.presentation.internal_views import (
+    InternalDataModelingOpsViewSet,
+    scoped_to_team,
+    team_id_filter,
+)
 
 __all__ = [
     "DataModelingOpsAuthenticationMixin",
     "DataModelingOpsOIDCAuthentication",
     "InternalDataModelingOpsViewSet",
+    "scoped_to_team",
+    "team_id_filter",
 ]

--- a/products/data_modeling/backend/presentation/internal_auth.py
+++ b/products/data_modeling/backend/presentation/internal_auth.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 from django.apps import apps
 from django.conf import settings
+from django.http import HttpRequest
 
 import jwt
 import structlog
@@ -133,5 +134,5 @@ class DataModelingOpsJWTAuthentication(InternalAPIAuthentication):
         )
         return (InternalAPIUser(current_organization_id=team.organization_id, current_team_id=team.id), claims)
 
-    def authenticate_header(self, request: Request) -> str:
+    def authenticate_header(self, request: HttpRequest) -> str:
         return self.keyword

--- a/products/data_modeling/backend/presentation/internal_auth.py
+++ b/products/data_modeling/backend/presentation/internal_auth.py
@@ -1,0 +1,137 @@
+"""Authentication for the data_modeling_ops internal (service-to-service) API.
+
+Scoped JWTs signed with a dedicated per-audience key (DATA_MODELING_OPS_JWT_SECRET),
+short-lived and pinned to a team, so a leaked token is useless outside its team and
+expiry window. See .agents/security.md (secrets & service-to-service auth).
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional
+
+from django.apps import apps
+from django.conf import settings
+
+import jwt
+import structlog
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+
+from posthog.auth import InternalAPIAuthentication, InternalAPIUser
+
+logger = structlog.get_logger(__name__)
+
+DATA_MODELING_OPS_AUDIENCE = "posthog:data_modeling_ops"
+JWT_ALGORITHM = "HS256"
+DEFAULT_TOKEN_EXPIRY = timedelta(minutes=5)
+
+
+def _verification_keys() -> list[str]:
+    return [
+        key for key in [settings.DATA_MODELING_OPS_JWT_SECRET, *settings.DATA_MODELING_OPS_JWT_SECRET_FALLBACKS] if key
+    ]
+
+
+def mint_data_modeling_ops_token(
+    team_id: int,
+    acting_user: str,
+    expiry_delta: timedelta = DEFAULT_TOKEN_EXPIRY,
+) -> str:
+    """Mint a token accepted by DataModelingOpsJWTAuthentication.
+
+    Used by tests and local tooling; the modeling-ops app mints its own tokens with the
+    shared signing key. ``acting_user`` identifies the human behind the service call for
+    audit logging.
+    """
+    if not settings.DATA_MODELING_OPS_JWT_SECRET:
+        raise ValueError("DATA_MODELING_OPS_JWT_SECRET is not configured")
+    return jwt.encode(
+        {
+            "aud": DATA_MODELING_OPS_AUDIENCE,
+            "exp": datetime.now(tz=UTC) + expiry_delta,
+            "team_id": team_id,
+            "acting_user": acting_user,
+        },
+        settings.DATA_MODELING_OPS_JWT_SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+
+
+class DataModelingOpsJWTAuthentication(InternalAPIAuthentication):
+    """DRF authentication for data_modeling_ops internal API requests.
+
+    Requires ``Authorization: Bearer <jwt>`` where the token carries the
+    data_modeling_ops audience, an expiry, and a ``team_id`` claim matching the
+    team in the requested URL. Subclasses InternalAPIAuthentication so the router's
+    internal-service permission short-circuit applies, but replaces the shared-secret
+    credential with a scoped JWT (see .agents/security.md).
+    """
+
+    keyword = "Bearer"
+
+    def _requested_team_id(self, request: Request) -> Optional[str]:
+        parser_context = getattr(request, "parser_context", None)
+        if isinstance(parser_context, dict):
+            kwargs = parser_context.get("kwargs")
+            if isinstance(kwargs, dict) and kwargs.get("team_id") is not None:
+                return str(kwargs["team_id"])
+
+        django_request = getattr(request, "_request", request)
+        resolver_match = getattr(django_request, "resolver_match", None)
+        if resolver_match and getattr(resolver_match, "kwargs", None):
+            team_id = resolver_match.kwargs.get("team_id")
+            if team_id is not None:
+                return str(team_id)
+
+        return None
+
+    def _decode(self, token: str) -> dict[str, Any]:
+        keys = _verification_keys()
+        if not keys:
+            logger.error("data_modeling_ops_auth_not_configured")
+            raise AuthenticationFailed("Internal API authentication is not configured.")
+
+        last_error: jwt.InvalidTokenError | None = None
+        for key in keys:
+            try:
+                return jwt.decode(
+                    token,
+                    key,
+                    audience=DATA_MODELING_OPS_AUDIENCE,
+                    algorithms=[JWT_ALGORITHM],
+                    options={"require": ["exp", "aud"]},
+                )
+            except jwt.InvalidSignatureError as error:
+                last_error = error
+            except jwt.InvalidTokenError as error:
+                raise AuthenticationFailed("Invalid internal API token.") from error
+
+        raise AuthenticationFailed("Invalid internal API token.") from last_error
+
+    def authenticate(self, request: Request) -> tuple[InternalAPIUser, dict[str, Any]]:
+        header = request.headers.get("Authorization", "")
+        if not header.startswith(f"{self.keyword} "):
+            raise AuthenticationFailed("Missing internal API token.")
+
+        claims = self._decode(header[len(self.keyword) + 1 :].strip())
+
+        requested_team_id = self._requested_team_id(request)
+        token_team_id = claims.get("team_id")
+        if requested_team_id is None or token_team_id is None or str(token_team_id) != requested_team_id:
+            raise AuthenticationFailed("Token is not valid for this team.")
+
+        Team = apps.get_model(app_label="posthog", model_name="Team")
+        try:
+            team = Team.objects.only("id", "organization_id").get(id=requested_team_id)
+        except (Team.DoesNotExist, ValueError):
+            raise AuthenticationFailed("Invalid internal API team.")
+
+        logger.info(
+            "data_modeling_ops_internal_request",
+            team_id=team.id,
+            acting_user=claims.get("acting_user"),
+            path=request.path,
+        )
+        return (InternalAPIUser(current_organization_id=team.organization_id, current_team_id=team.id), claims)
+
+    def authenticate_header(self, request: Request) -> str:
+        return self.keyword

--- a/products/data_modeling/backend/presentation/internal_auth.py
+++ b/products/data_modeling/backend/presentation/internal_auth.py
@@ -1,19 +1,29 @@
-"""Authentication for the data_modeling_ops internal (service-to-service) API.
+"""OIDC authentication for the data_modeling_ops internal API.
 
-Scoped JWTs signed with a dedicated per-audience key (DATA_MODELING_OPS_JWT_SECRET),
-short-lived and pinned to a team, so a leaked token is useless outside its team and
-expiry window. See .agents/security.md (secrets & service-to-service auth).
+The modeling-ops admin app sits behind SSO and forwards the operator's OIDC ID token;
+Django verifies it against the issuer's JWKS — signature, issuer, audience, expiry, and
+the email domain. There is no shared signing secret to provision or rotate, a compromised
+caller cannot mint credentials, and ``acting_user`` in the audit log is the verified email
+claim rather than a self-asserted string.
+
+Service (no-human) callers present ID tokens from the same issuer (e.g. a service
+account's identity token); their emails are allow-listed via
+DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS and exempt from the domain check.
+
+Local dev: DATA_MODELING_OPS_OIDC_AUDIENCES defaults (DEBUG/TEST) to the gcloud CLI's
+public OAuth client ID, so ``gcloud auth print-identity-token`` yields a working token
+against ./bin/start with no extra setup.
 """
 
-from datetime import UTC, datetime, timedelta
-from typing import Any, Optional
+from functools import cache
+from typing import Any
 
-from django.apps import apps
 from django.conf import settings
 from django.http import HttpRequest
 
 import jwt
 import structlog
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
@@ -21,92 +31,60 @@ from posthog.auth import InternalAPIAuthentication, InternalAPIUser
 
 logger = structlog.get_logger(__name__)
 
-DATA_MODELING_OPS_AUDIENCE = "posthog:data_modeling_ops"
-JWT_ALGORITHM = "HS256"
-DEFAULT_TOKEN_EXPIRY = timedelta(minutes=5)
+JWT_ALGORITHM = "RS256"
 
 
-def _verification_keys() -> list[str]:
-    return [
-        key for key in [settings.DATA_MODELING_OPS_JWT_SECRET, *settings.DATA_MODELING_OPS_JWT_SECRET_FALLBACKS] if key
-    ]
+@cache
+def _jwks_client(jwks_url: str) -> jwt.PyJWKClient:
+    return jwt.PyJWKClient(jwks_url, cache_keys=True)
 
 
-def mint_data_modeling_ops_token(
-    team_id: int,
-    acting_user: str,
-    expiry_delta: timedelta = DEFAULT_TOKEN_EXPIRY,
-) -> str:
-    """Mint a token accepted by DataModelingOpsJWTAuthentication.
-
-    Used by tests and local tooling; the modeling-ops app mints its own tokens with the
-    shared signing key. ``acting_user`` identifies the human behind the service call for
-    audit logging.
-    """
-    if not settings.DATA_MODELING_OPS_JWT_SECRET:
-        raise ValueError("DATA_MODELING_OPS_JWT_SECRET is not configured")
-    return jwt.encode(
-        {
-            "aud": DATA_MODELING_OPS_AUDIENCE,
-            "exp": datetime.now(tz=UTC) + expiry_delta,
-            "team_id": team_id,
-            "acting_user": acting_user,
-        },
-        settings.DATA_MODELING_OPS_JWT_SECRET,
-        algorithm=JWT_ALGORITHM,
-    )
-
-
-class DataModelingOpsJWTAuthentication(InternalAPIAuthentication):
+class DataModelingOpsOIDCAuthentication(InternalAPIAuthentication):
     """DRF authentication for data_modeling_ops internal API requests.
 
-    Requires ``Authorization: Bearer <jwt>`` where the token carries the
-    data_modeling_ops audience, an expiry, and a ``team_id`` claim matching the
-    team in the requested URL. Subclasses InternalAPIAuthentication so the router's
-    internal-service permission short-circuit applies, but replaces the shared-secret
-    credential with a scoped JWT (see .agents/security.md).
+    Requires ``Authorization: Bearer <oidc-id-token>`` verified against the configured
+    issuer's JWKS. Team scoping comes from the requested URL, not the token: any verified
+    operator identity may call both the team-scoped and the fleet route families, which is
+    the intended semantics for a read-only staff tool. Subclasses InternalAPIAuthentication
+    so the router's internal-service permission short-circuit applies.
     """
 
     keyword = "Bearer"
 
-    def _requested_team_id(self, request: Request) -> Optional[str]:
-        parser_context = getattr(request, "parser_context", None)
-        if isinstance(parser_context, dict):
-            kwargs = parser_context.get("kwargs")
-            if isinstance(kwargs, dict) and kwargs.get("team_id") is not None:
-                return str(kwargs["team_id"])
-
-        django_request = getattr(request, "_request", request)
-        resolver_match = getattr(django_request, "resolver_match", None)
-        if resolver_match and getattr(resolver_match, "kwargs", None):
-            team_id = resolver_match.kwargs.get("team_id")
-            if team_id is not None:
-                return str(team_id)
-
-        return None
-
     def _decode(self, token: str) -> dict[str, Any]:
-        keys = _verification_keys()
-        if not keys:
+        audiences = settings.DATA_MODELING_OPS_OIDC_AUDIENCES
+        if not audiences:
             logger.error("data_modeling_ops_auth_not_configured")
             raise AuthenticationFailed("Internal API authentication is not configured.")
 
-        last_error: jwt.InvalidTokenError | None = None
-        for key in keys:
-            try:
-                return jwt.decode(
-                    token,
-                    key,
-                    audience=DATA_MODELING_OPS_AUDIENCE,
-                    algorithms=[JWT_ALGORITHM],
-                    options={"require": ["exp", "aud"]},
-                )
-            except jwt.InvalidSignatureError as error:
-                last_error = error
-            except jwt.InvalidTokenError as error:
-                raise AuthenticationFailed("Invalid internal API token.") from error
+        try:
+            signing_key = _jwks_client(settings.DATA_MODELING_OPS_OIDC_JWKS_URL).get_signing_key_from_jwt(token)
+            return jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=[JWT_ALGORITHM],
+                audience=audiences,
+                issuer=settings.DATA_MODELING_OPS_OIDC_ISSUER,
+                options={"require": ["exp", "aud", "iss"]},
+            )
+        except (jwt.PyJWKClientError, jwt.InvalidTokenError) as error:
+            raise AuthenticationFailed("Invalid internal API token.") from error
 
-        raise AuthenticationFailed("Invalid internal API token.") from last_error
+    def _verified_identity(self, claims: dict[str, Any]) -> str:
+        email = str(claims.get("email") or "").lower()
+        if not email:
+            raise AuthenticationFailed("Token carries no identity.")
+
+        service_accounts = {value.lower() for value in settings.DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS}
+        if email in service_accounts:
+            return email
+
+        if not claims.get("email_verified"):
+            raise AuthenticationFailed("Token identity is not verified.")
+        domain = email.rsplit("@", 1)[-1]
+        if domain not in settings.DATA_MODELING_OPS_OIDC_ALLOWED_DOMAINS:
+            raise AuthenticationFailed("Token identity is not allowed.")
+        return email
 
     def authenticate(self, request: Request) -> tuple[InternalAPIUser, dict[str, Any]]:
         header = request.headers.get("Authorization", "")
@@ -114,25 +92,30 @@ class DataModelingOpsJWTAuthentication(InternalAPIAuthentication):
             raise AuthenticationFailed("Missing internal API token.")
 
         claims = self._decode(header[len(self.keyword) + 1 :].strip())
-
-        requested_team_id = self._requested_team_id(request)
-        token_team_id = claims.get("team_id")
-        if requested_team_id is None or token_team_id is None or str(token_team_id) != requested_team_id:
-            raise AuthenticationFailed("Token is not valid for this team.")
-
-        Team = apps.get_model(app_label="posthog", model_name="Team")
-        try:
-            team = Team.objects.only("id", "organization_id").get(id=requested_team_id)
-        except (Team.DoesNotExist, ValueError):
-            raise AuthenticationFailed("Invalid internal API team.")
+        acting_user = self._verified_identity(claims)
+        user = self._get_internal_api_user(request)
 
         logger.info(
             "data_modeling_ops_internal_request",
-            team_id=team.id,
-            acting_user=claims.get("acting_user"),
+            team_id=user.current_team_id,
+            acting_user=acting_user,
             path=request.path,
         )
-        return (InternalAPIUser(current_organization_id=team.organization_id, current_team_id=team.id), claims)
+        return (user, claims)
 
     def authenticate_header(self, request: HttpRequest) -> str:
         return self.keyword
+
+
+class DataModelingOpsAuthenticationMixin:
+    """Pins a viewset to the OIDC authenticator only.
+
+    TeamAndOrgViewSetMixin.get_authenticators always appends the session/PAT/OAuth
+    authenticators after the custom ones, which on these internal routes would let any
+    logged-in user through. Must precede TeamAndOrgViewSetMixin in the bases.
+    """
+
+    authentication_classes = [DataModelingOpsOIDCAuthentication]
+
+    def get_authenticators(self) -> list[BaseAuthentication]:
+        return [DataModelingOpsOIDCAuthentication()]

--- a/products/data_modeling/backend/presentation/internal_auth.py
+++ b/products/data_modeling/backend/presentation/internal_auth.py
@@ -121,9 +121,11 @@ class DataModelingOpsAuthenticationMixin:
     TeamAndOrgViewSetMixin.get_authenticators always appends the session/PAT/OAuth
     authenticators after the custom ones, which on these internal routes would let any
     logged-in user through. Must precede TeamAndOrgViewSetMixin in the bases.
-    """
 
-    authentication_classes = [DataModelingOpsOIDCAuthentication]
+    Overriding get_authenticators rather than setting authentication_classes is what
+    makes the pinning stick, since both mixins' get_authenticators ignore the attribute
+    once this one wins the MRO. The session-only rejection test guards it.
+    """
 
     def get_authenticators(self) -> list[BaseAuthentication]:
         return [DataModelingOpsOIDCAuthentication()]

--- a/products/data_modeling/backend/presentation/internal_auth.py
+++ b/products/data_modeling/backend/presentation/internal_auth.py
@@ -1,14 +1,15 @@
 """OIDC authentication for the data_modeling_ops internal API.
 
 The modeling-ops admin app sits behind SSO and forwards the operator's OIDC ID token;
-Django verifies it against the issuer's JWKS — signature, issuer, audience, expiry, and
-the email domain. There is no shared signing secret to provision or rotate, a compromised
+Django verifies it against the issuer's JWKS — signature, issuer, audience, expiry, and the
+hosted domain. There is no shared signing secret to provision or rotate, a compromised
 caller cannot mint credentials, and ``acting_user`` in the audit log is the verified email
 claim rather than a self-asserted string.
 
 Service (no-human) callers present ID tokens from the same issuer (e.g. a service
 account's identity token); their emails are allow-listed via
-DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS and exempt from the domain check.
+DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS and exempt from the domain check, which
+service-account tokens could not satisfy — they carry no hosted-domain claim.
 
 Local dev: DATA_MODELING_OPS_OIDC_AUDIENCES defaults (DEBUG/TEST) to the gcloud CLI's
 public OAuth client ID, so ``gcloud auth print-identity-token`` yields a working token
@@ -81,8 +82,15 @@ class DataModelingOpsOIDCAuthentication(InternalAPIAuthentication):
 
         if not claims.get("email_verified"):
             raise AuthenticationFailed("Token identity is not verified.")
-        domain = email.rsplit("@", 1)[-1]
-        if domain not in settings.DATA_MODELING_OPS_OIDC_ALLOWED_DOMAINS:
+        # Trust the issuer-controlled hosted-domain claim, not the email string: a consumer
+        # Google account can hold a verified address on an allowed domain while sitting outside
+        # the managed Workspace, so suspending the employee would not revoke it. Same check as
+        # the Django admin OIDC gate in ee/middleware.py.
+        allowed_domains = settings.DATA_MODELING_OPS_OIDC_ALLOWED_DOMAINS
+        hosted_domain = claims.get("hd")
+        if not hosted_domain or hosted_domain not in allowed_domains:
+            raise AuthenticationFailed("Token identity is not allowed.")
+        if email.rsplit("@", 1)[-1] not in allowed_domains:
             raise AuthenticationFailed("Token identity is not allowed.")
         return email
 

--- a/products/data_modeling/backend/presentation/internal_serializers.py
+++ b/products/data_modeling/backend/presentation/internal_serializers.py
@@ -1,0 +1,239 @@
+"""Read-only serializers for the data_modeling_ops internal API.
+
+These back service-to-service responses consumed by the modeling-ops admin app; they
+intentionally expose operational fields (engine, storage deltas, full errors) that the
+customer-facing serializers hide.
+"""
+
+from rest_framework import serializers
+
+from products.data_modeling.backend.facade.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+
+
+class InternalBackingTableSerializer(serializers.ModelSerializer):
+    is_linked = serializers.SerializerMethodField(
+        help_text="Whether this table is the one the saved query's table FK currently points at. "
+        "Unlinked rows with the same name are orphaned duplicate backing tables."
+    )
+
+    class Meta:
+        model = DataWarehouseTable
+        fields = [
+            "id",
+            "name",
+            "format",
+            "url_pattern",
+            "queryable_folder",
+            "row_count",
+            "size_in_s3_mib",
+            "created_at",
+            "is_linked",
+        ]
+        read_only_fields = fields
+
+    def get_is_linked(self, table: DataWarehouseTable) -> bool:
+        return str(table.id) == str(self.context.get("linked_table_id"))
+
+
+class InternalSavedQuerySummarySerializer(serializers.ModelSerializer):
+    table_id = serializers.UUIDField(
+        read_only=True, allow_null=True, help_text="Backing DataWarehouseTable id, when materialized."
+    )
+
+    class Meta:
+        model = DataWarehouseSavedQuery
+        fields = [
+            "id",
+            "name",
+            "status",
+            "last_run_at",
+            "latest_error",
+            "is_materialized",
+            "sync_frequency_interval",
+            "origin",
+            "table_id",
+            "created_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "latest_error": {"help_text": "Full latest error text, untruncated."},
+            "sync_frequency_interval": {
+                "help_text": "v1 per-query materialization cadence; null once a team is on v2 DAG scheduling."
+            },
+        }
+
+
+class InternalSavedQueryNodeContextSerializer(serializers.Serializer):
+    node_id = serializers.UUIDField(help_text="Node id representing this saved query in a DAG.")
+    dag_id = serializers.UUIDField(help_text="DAG the node belongs to.")
+    dag_name = serializers.CharField(help_text="Name of the DAG the node belongs to.")
+    node_type = serializers.CharField(help_text="Node type: table, view, matview, or endpoint.")
+    upstream = serializers.ListField(
+        child=serializers.CharField(), help_text="Names of immediate upstream nodes in this DAG."
+    )
+    downstream = serializers.ListField(
+        child=serializers.CharField(), help_text="Names of immediate downstream nodes in this DAG."
+    )
+
+
+class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
+    query = serializers.JSONField(read_only=True, help_text="Stored HogQL query payload (JSON with a 'query' key).")
+    columns = serializers.JSONField(
+        read_only=True, allow_null=True, help_text="Dict of all columns with ClickHouse type."
+    )
+    created_by_email = serializers.SerializerMethodField(help_text="Email of the user who created the saved query.")
+    last_successful_job_at = serializers.SerializerMethodField(
+        help_text="Completion time of the most recent COMPLETED materialization job. More trustworthy than "
+        "last_run_at, which the v2 DAG success path does not write."
+    )
+    nodes = serializers.SerializerMethodField(
+        help_text="DAG context: one entry per DAG this saved query has a node in, with immediate lineage."
+    )
+    double_materialized = serializers.SerializerMethodField(
+        help_text="True when the saved query has nodes in more than one DAG (duplicate materialization)."
+    )
+    backing_tables = serializers.SerializerMethodField(
+        help_text="All DataWarehouseTable rows sharing this saved query's name, linked or not. "
+        "More than one entry means duplicate backing tables."
+    )
+
+    class Meta(InternalSavedQuerySummarySerializer.Meta):
+        fields = [
+            *InternalSavedQuerySummarySerializer.Meta.fields,
+            "query",
+            "columns",
+            "created_by_email",
+            "last_successful_job_at",
+            "nodes",
+            "double_materialized",
+            "backing_tables",
+        ]
+        read_only_fields = fields
+
+    def get_created_by_email(self, saved_query: DataWarehouseSavedQuery) -> str | None:
+        return saved_query.created_by.email if saved_query.created_by else None
+
+    def get_last_successful_job_at(self, saved_query: DataWarehouseSavedQuery) -> str | None:
+        last_successful_job_at = self.context.get("last_successful_job_at")
+        return last_successful_job_at.isoformat() if last_successful_job_at else None
+
+    def get_nodes(self, saved_query: DataWarehouseSavedQuery) -> list[dict]:
+        return list(InternalSavedQueryNodeContextSerializer(self.context.get("nodes", []), many=True).data)
+
+    def get_double_materialized(self, saved_query: DataWarehouseSavedQuery) -> bool:
+        return len(self.context.get("nodes", [])) > 1
+
+    def get_backing_tables(self, saved_query: DataWarehouseSavedQuery) -> list[dict]:
+        return list(
+            InternalBackingTableSerializer(self.context.get("backing_tables", []), many=True, context=self.context).data
+        )
+
+
+class InternalDataModelingJobSerializer(serializers.ModelSerializer):
+    saved_query_id = serializers.UUIDField(
+        read_only=True, allow_null=True, help_text="Saved query this job materialized."
+    )
+
+    class Meta:
+        model = DataModelingJob
+        fields = [
+            "id",
+            "saved_query_id",
+            "status",
+            "engine",
+            "rows_materialized",
+            "rows_expected",
+            "error",
+            "workflow_id",
+            "workflow_run_id",
+            "parent_workflow_id",
+            "storage_delta_mib",
+            "created_at",
+            "updated_at",
+            "last_run_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "engine": {"help_text": "Materialization engine: clickhouse or duckgres."},
+            "error": {"help_text": "Full error text, untruncated."},
+            "storage_delta_mib": {"help_text": "Storage growth caused by this job, in MiB."},
+        }
+
+
+class InternalDAGSummarySerializer(serializers.ModelSerializer):
+    node_count = serializers.IntegerField(read_only=True, default=0, help_text="Number of nodes in the DAG.")
+
+    class Meta:
+        model = DAG
+        fields = [
+            "id",
+            "name",
+            "sync_frequency_interval",
+            "node_count",
+            "created_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "sync_frequency_interval": {"help_text": "DAG-level materialization cadence for v2 scheduling."},
+        }
+
+
+class InternalNodeSerializer(serializers.ModelSerializer):
+    saved_query_id = serializers.UUIDField(
+        read_only=True, allow_null=True, help_text="Saved query backing this node; null for source tables."
+    )
+    last_run_at = serializers.SerializerMethodField(
+        help_text="Last run time recorded in node system properties, if any."
+    )
+    last_run_status = serializers.SerializerMethodField(
+        help_text="Last run status recorded in node system properties, if any."
+    )
+
+    class Meta:
+        model = Node
+        fields = [
+            "id",
+            "name",
+            "type",
+            "saved_query_id",
+            "last_run_at",
+            "last_run_status",
+        ]
+        read_only_fields = fields
+
+    def get_last_run_at(self, node: Node) -> str | None:
+        return (node.properties or {}).get("system", {}).get("last_run_at")
+
+    def get_last_run_status(self, node: Node) -> str | None:
+        return (node.properties or {}).get("system", {}).get("last_run_status")
+
+
+class InternalEdgeSerializer(serializers.ModelSerializer):
+    source_id = serializers.UUIDField(read_only=True, help_text="Upstream node id.")
+    target_id = serializers.UUIDField(read_only=True, help_text="Downstream node id.")
+
+    class Meta:
+        model = Edge
+        fields = ["id", "source_id", "target_id"]
+        read_only_fields = fields
+
+
+class InternalTeamOverviewSerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team the overview describes.")
+    v2_backend_enabled = serializers.BooleanField(
+        help_text="Whether the data-modeling-backend-v2 flag is on for this team. The flag is an exclusion "
+        "list, so false means the team is excluded from the v2 backend."
+    )
+    dag_count = serializers.IntegerField(help_text="Number of DAGs.")
+    node_count = serializers.IntegerField(help_text="Number of nodes across all DAGs.")
+    saved_query_count = serializers.IntegerField(help_text="Number of non-deleted saved queries.")
+    materialized_saved_query_count = serializers.IntegerField(help_text="Saved queries that are materialized.")
+    failing_saved_query_count = serializers.IntegerField(help_text="Saved queries whose last run failed.")
+    saved_queries_with_sync_frequency_count = serializers.IntegerField(
+        help_text="Saved queries still carrying a v1 sync_frequency_interval — nonzero on a v2 team means "
+        "the v1-to-v2 migration never finished cleanup."
+    )
+    endpoint_origin_saved_query_count = serializers.IntegerField(
+        help_text="Saved queries created by endpoint materialization."
+    )

--- a/products/data_modeling/backend/presentation/internal_serializers.py
+++ b/products/data_modeling/backend/presentation/internal_serializers.py
@@ -95,7 +95,8 @@ class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
     )
     backing_tables = serializers.SerializerMethodField(
         help_text="All DataWarehouseTable rows sharing this saved query's name, linked or not. "
-        "More than one entry means duplicate backing tables."
+        "More than one entry means duplicate backing tables — treat as a lead, not proof: the match "
+        "is by name, so an unrelated table of the same name also shows up here."
     )
 
     class Meta(InternalSavedQuerySummarySerializer.Meta):

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -188,10 +188,13 @@ class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
 
     @extend_schema(exclude=True)
     def internal_saved_query_jobs(self, request: Request, team_id: str, saved_query_id: str) -> Response:
-        queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
-            "-created_at"
-        )
-        return self._paginate(request, queryset, InternalDataModelingJobSerializer)
+        try:
+            queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
+                "-created_at"
+            )
+            return self._paginate(request, queryset, InternalDataModelingJobSerializer)
+        except (DjangoValidationError, ValueError):
+            return Response({"error": "Saved query not found"}, status=404)
 
     @extend_schema(exclude=True)
     def internal_dags(self, request: Request, team_id: str) -> Response:

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -3,7 +3,7 @@
 Routes are wired manually in posthog/urls.py under
 ``api/projects/<team_id>/internal/data_modeling_ops/`` — Contour 403s the ``internal``
 prefix at the edge, so these are unreachable from the internet and authenticated with
-scoped JWTs (see internal_auth.py).
+OIDC ID tokens (see internal_auth.py).
 """
 
 import uuid
@@ -29,7 +29,7 @@ from products.data_modeling.backend.facade.models import (
     Edge,
     Node,
 )
-from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsJWTAuthentication
+from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsAuthenticationMixin
 from products.data_modeling.backend.presentation.internal_serializers import (
     InternalDAGSummarySerializer,
     InternalDataModelingJobSerializer,
@@ -65,16 +65,17 @@ class InternalDataModelingOpsPagination(pagination.LimitOffsetPagination):
     max_limit = 500
 
 
-class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+class InternalDataModelingOpsViewSet(
+    DataModelingOpsAuthenticationMixin, TeamAndOrgViewSetMixin, viewsets.GenericViewSet
+):
     """Internal read-only endpoints for the modeling-ops admin app.
 
-    Authenticated with scoped JWTs (DATA_MODELING_OPS_JWT_SECRET); not exposed through
-    Contour ingress.
+    Authenticated with OIDC ID tokens only (no session/PAT/OAuth fallback); not exposed
+    through Contour ingress.
     """
 
     scope_object = "INTERNAL"
     serializer_class = _FallbackSerializer
-    authentication_classes = [DataModelingOpsJWTAuthentication]
 
     def _paginate(
         self, request: Request, queryset: QuerySet, serializer_class: type[serializers.Serializer]

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -1,0 +1,206 @@
+"""Read-only internal (service-to-service) API for the modeling-ops admin app.
+
+Routes are wired manually in posthog/urls.py under
+``api/projects/<team_id>/internal/data_modeling_ops/`` — Contour 403s the ``internal``
+prefix at the edge, so these are unreachable from the internet and authenticated with
+scoped JWTs (see internal_auth.py).
+"""
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Count, Q, QuerySet
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import pagination, serializers, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.documentation import _FallbackSerializer
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models import Team
+from posthog.ph_client import feature_enabled_or_false
+
+from products.data_modeling.backend.facade.models import (
+    DAG,
+    DataModelingJob,
+    DataModelingJobStatus,
+    DataWarehouseSavedQuery,
+    Edge,
+    Node,
+)
+from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsJWTAuthentication
+from products.data_modeling.backend.presentation.internal_serializers import (
+    InternalDAGSummarySerializer,
+    InternalDataModelingJobSerializer,
+    InternalEdgeSerializer,
+    InternalNodeSerializer,
+    InternalSavedQueryDetailSerializer,
+    InternalSavedQuerySummarySerializer,
+    InternalTeamOverviewSerializer,
+)
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+
+# Flag evaluation is project-group based, so any stable distinct_id gives the same answer.
+DATA_MODELING_OPS_DISTINCT_ID = "data_modeling_ops_internal"
+
+
+def _is_v2_backend_enabled_for_team(team: Team) -> bool:
+    return feature_enabled_or_false(
+        "data-modeling-backend-v2",
+        DATA_MODELING_OPS_DISTINCT_ID,
+        groups={
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        group_properties={
+            "organization": {"id": str(team.organization_id)},
+            "project": {"id": str(team.id)},
+        },
+    )
+
+
+class InternalDataModelingOpsPagination(pagination.LimitOffsetPagination):
+    default_limit = 100
+    max_limit = 500
+
+
+class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+    """Internal read-only endpoints for the modeling-ops admin app.
+
+    Authenticated with scoped JWTs (DATA_MODELING_OPS_JWT_SECRET); not exposed through
+    Contour ingress.
+    """
+
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+    authentication_classes = [DataModelingOpsJWTAuthentication]
+
+    def _paginate(
+        self, request: Request, queryset: QuerySet, serializer_class: type[serializers.Serializer]
+    ) -> Response:
+        paginator = InternalDataModelingOpsPagination()
+        page = paginator.paginate_queryset(queryset, request, view=self)
+        serializer = serializer_class(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    @extend_schema(exclude=True)
+    def internal_overview(self, request: Request, team_id: str) -> Response:
+        # Manual (non-router) paths don't populate the mixin's parents_query_dict, so the
+        # team comes from the URL arg — the auth class already pinned the token to it.
+        team = Team.objects.get(id=int(team_id))
+        saved_queries = DataWarehouseSavedQuery.objects.filter(team_id=team.id).exclude(deleted=True)
+        saved_query_counts = saved_queries.aggregate(
+            total=Count("id"),
+            materialized=Count("id", filter=Q(is_materialized=True)),
+            failing=Count("id", filter=Q(status=DataWarehouseSavedQuery.Status.FAILED)),
+            with_sync_frequency=Count("id", filter=Q(sync_frequency_interval__isnull=False)),
+            endpoint_origin=Count("id", filter=Q(origin=DataWarehouseSavedQuery.Origin.ENDPOINT)),
+        )
+        serializer = InternalTeamOverviewSerializer(
+            {
+                "team_id": team.id,
+                "v2_backend_enabled": _is_v2_backend_enabled_for_team(team),
+                "dag_count": DAG.objects.filter(team_id=team.id).count(),
+                "node_count": Node.objects.filter(team_id=team.id).count(),
+                "saved_query_count": saved_query_counts["total"],
+                "materialized_saved_query_count": saved_query_counts["materialized"],
+                "failing_saved_query_count": saved_query_counts["failing"],
+                "saved_queries_with_sync_frequency_count": saved_query_counts["with_sync_frequency"],
+                "endpoint_origin_saved_query_count": saved_query_counts["endpoint_origin"],
+            }
+        )
+        return Response(serializer.data)
+
+    @extend_schema(exclude=True)
+    def internal_saved_queries(self, request: Request, team_id: str) -> Response:
+        queryset = (
+            DataWarehouseSavedQuery.objects.filter(team_id=int(team_id)).exclude(deleted=True).order_by("-created_at")
+        )
+        status_filter = request.query_params.get("status")
+        if status_filter:
+            queryset = queryset.filter(status=status_filter)
+        return self._paginate(request, queryset, InternalSavedQuerySummarySerializer)
+
+    @extend_schema(exclude=True)
+    def internal_saved_query_detail(self, request: Request, team_id: str, saved_query_id: str) -> Response:
+        try:
+            saved_query = DataWarehouseSavedQuery.objects.select_related("table", "created_by").get(
+                team_id=int(team_id), id=saved_query_id
+            )
+        except (DataWarehouseSavedQuery.DoesNotExist, DjangoValidationError, ValueError):
+            return Response({"error": "Saved query not found"}, status=404)
+
+        nodes = []
+        for node in Node.objects.filter(team_id=int(team_id), saved_query=saved_query).select_related("dag"):
+            upstream = list(
+                Edge.objects.filter(team_id=int(team_id), dag_id=node.dag_id, target=node).values_list(
+                    "source__name", flat=True
+                )
+            )
+            downstream = list(
+                Edge.objects.filter(team_id=int(team_id), dag_id=node.dag_id, source=node).values_list(
+                    "target__name", flat=True
+                )
+            )
+            nodes.append(
+                {
+                    "node_id": node.id,
+                    "dag_id": node.dag_id,
+                    "dag_name": node.dag.name,
+                    "node_type": node.type,
+                    "upstream": upstream,
+                    "downstream": downstream,
+                }
+            )
+
+        backing_tables = list(
+            DataWarehouseTable.objects.filter(team_id=int(team_id), name=saved_query.name).exclude(deleted=True)
+        )
+        last_successful_job_at = (
+            DataModelingJob.objects.filter(
+                team_id=int(team_id), saved_query=saved_query, status=DataModelingJobStatus.COMPLETED
+            )
+            .order_by("-updated_at")
+            .values_list("updated_at", flat=True)
+            .first()
+        )
+
+        serializer = InternalSavedQueryDetailSerializer(
+            saved_query,
+            context={
+                "nodes": nodes,
+                "backing_tables": backing_tables,
+                "linked_table_id": saved_query.table_id,
+                "last_successful_job_at": last_successful_job_at,
+            },
+        )
+        return Response(serializer.data)
+
+    @extend_schema(exclude=True)
+    def internal_saved_query_jobs(self, request: Request, team_id: str, saved_query_id: str) -> Response:
+        queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
+            "-created_at"
+        )
+        return self._paginate(request, queryset, InternalDataModelingJobSerializer)
+
+    @extend_schema(exclude=True)
+    def internal_dags(self, request: Request, team_id: str) -> Response:
+        queryset = DAG.objects.filter(team_id=int(team_id)).annotate(node_count=Count("node")).order_by("name")
+        serializer = InternalDAGSummarySerializer(queryset, many=True)
+        return Response({"results": serializer.data})
+
+    @extend_schema(exclude=True)
+    def internal_dag_detail(self, request: Request, team_id: str, dag_id: str) -> Response:
+        try:
+            dag = DAG.objects.annotate(node_count=Count("node")).get(team_id=int(team_id), id=dag_id)
+        except (DAG.DoesNotExist, DjangoValidationError, ValueError):
+            return Response({"error": "DAG not found"}, status=404)
+
+        nodes = Node.objects.filter(team_id=int(team_id), dag=dag).order_by("name")
+        edges = Edge.objects.filter(team_id=int(team_id), dag=dag)
+        return Response(
+            {
+                "dag": InternalDAGSummarySerializer(dag).data,
+                "nodes": InternalNodeSerializer(nodes, many=True).data,
+                "edges": InternalEdgeSerializer(edges, many=True).data,
+            }
+        )

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -6,6 +6,8 @@ prefix at the edge, so these are unreachable from the internet and authenticated
 scoped JWTs (see internal_auth.py).
 """
 
+import uuid
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Count, Q, QuerySet
 
@@ -63,7 +65,7 @@ class InternalDataModelingOpsPagination(pagination.LimitOffsetPagination):
     max_limit = 500
 
 
-class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """Internal read-only endpoints for the modeling-ops admin app.
 
     Authenticated with scoped JWTs (DATA_MODELING_OPS_JWT_SECRET); not exposed through
@@ -117,6 +119,11 @@ class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
         )
         status_filter = request.query_params.get("status")
         if status_filter:
+            valid_statuses = set(DataWarehouseSavedQuery.Status.values)
+            if status_filter not in valid_statuses:
+                return Response(
+                    {"error": f"Unknown status; expected one of {', '.join(sorted(valid_statuses))}"}, status=400
+                )
             queryset = queryset.filter(status=status_filter)
         return self._paginate(request, queryset, InternalSavedQuerySummarySerializer)
 
@@ -129,28 +136,32 @@ class InternalDataModelingOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
         except (DataWarehouseSavedQuery.DoesNotExist, DjangoValidationError, ValueError):
             return Response({"error": "Saved query not found"}, status=404)
 
-        nodes = []
-        for node in Node.objects.filter(team_id=int(team_id), saved_query=saved_query).select_related("dag"):
-            upstream = list(
-                Edge.objects.filter(team_id=int(team_id), dag_id=node.dag_id, target=node).values_list(
-                    "source__name", flat=True
-                )
-            )
-            downstream = list(
-                Edge.objects.filter(team_id=int(team_id), dag_id=node.dag_id, source=node).values_list(
-                    "target__name", flat=True
-                )
-            )
-            nodes.append(
-                {
-                    "node_id": node.id,
-                    "dag_id": node.dag_id,
-                    "dag_name": node.dag.name,
-                    "node_type": node.type,
-                    "upstream": upstream,
-                    "downstream": downstream,
-                }
-            )
+        saved_query_nodes = list(
+            Node.objects.filter(team_id=int(team_id), saved_query=saved_query).select_related("dag")
+        )
+        node_ids = [node.id for node in saved_query_nodes]
+        upstream_by_node: dict[uuid.UUID, list[str]] = {}
+        for target_id, source_name in Edge.objects.filter(team_id=int(team_id), target_id__in=node_ids).values_list(
+            "target_id", "source__name"
+        ):
+            upstream_by_node.setdefault(target_id, []).append(source_name)
+        downstream_by_node: dict[uuid.UUID, list[str]] = {}
+        for source_id, target_name in Edge.objects.filter(team_id=int(team_id), source_id__in=node_ids).values_list(
+            "source_id", "target__name"
+        ):
+            downstream_by_node.setdefault(source_id, []).append(target_name)
+
+        nodes = [
+            {
+                "node_id": node.id,
+                "dag_id": node.dag_id,
+                "dag_name": node.dag.name,
+                "node_type": node.type,
+                "upstream": upstream_by_node.get(node.id, []),
+                "downstream": downstream_by_node.get(node.id, []),
+            }
+            for node in saved_query_nodes
+        ]
 
         backing_tables = list(
             DataWarehouseTable.objects.filter(team_id=int(team_id), name=saved_query.name).exclude(deleted=True)

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -1,19 +1,24 @@
 """Read-only internal (service-to-service) API for the modeling-ops admin app.
 
-Routes are wired manually in posthog/urls.py under
-``api/projects/<team_id>/internal/data_modeling_ops/`` — Contour 403s the ``internal``
-prefix at the edge, so these are unreachable from the internet and authenticated with
-OIDC ID tokens (see internal_auth.py).
+Routes are wired manually in posthog/urls.py under ``api/internal/data_modeling_ops/`` —
+Contour 403s that whole prefix at the edge, so these are unreachable from the internet,
+and they are authenticated with OIDC ID tokens (see internal_auth.py).
+
+The app reads across every team, so team is a ``?team_id=`` filter on lists rather than a
+URL segment, and entities are fetched by their own globally unique id. A team-nested path
+would read as a tenancy boundary, which this API deliberately does not have: any verified
+operator may read any team.
 """
 
 import uuid
-from typing import cast
+from typing import Any, cast
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Count, Q, QuerySet
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import pagination, serializers, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -61,6 +66,26 @@ def _is_v2_backend_enabled(team_id: int, organization_id: str) -> bool:
     )
 
 
+def team_id_filter(request: Request) -> int | None:
+    """``?team_id=`` narrows a list to one team; absent means every team.
+
+    The filter is deliberately not a URL segment: any verified operator may read any
+    team here, so a team-nested path would imply a scoping guarantee this API does not
+    make. Entities are found by their own (globally unique) id instead.
+    """
+    raw = request.query_params.get("team_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValidationError({"team_id": "Must be an integer."})
+
+
+def scoped_to_team(queryset: QuerySet, team_id: int | None) -> QuerySet:
+    return queryset if team_id is None else queryset.filter(team_id=team_id)
+
+
 class InternalDataModelingOpsPagination(pagination.LimitOffsetPagination):
     default_limit = 100
     max_limit = 500
@@ -87,9 +112,9 @@ class InternalDataModelingOpsViewSet(
         return paginator.get_paginated_response(serializer.data)
 
     @extend_schema(exclude=True)
-    def internal_overview(self, request: Request, team_id: str) -> Response:
+    def internal_team_detail(self, request: Request, team_id: str, **kwargs: Any) -> Response:
         # Manual (non-router) paths don't populate the mixin's parents_query_dict. The
-        # authenticator already resolved the URL's team, so reuse it instead of re-querying.
+        # authenticator resolves this route's team_id kwarg, so reuse it here.
         user = cast(InternalAPIUser, request.user)
         team_pk = int(team_id)
         saved_queries = DataWarehouseSavedQuery.objects.filter(team_id=team_pk).exclude(deleted=True)
@@ -116,10 +141,10 @@ class InternalDataModelingOpsViewSet(
         return Response(serializer.data)
 
     @extend_schema(exclude=True)
-    def internal_saved_queries(self, request: Request, team_id: str) -> Response:
-        queryset = (
-            DataWarehouseSavedQuery.objects.filter(team_id=int(team_id)).exclude(deleted=True).order_by("-created_at")
-        )
+    def internal_saved_queries(self, request: Request, **kwargs: Any) -> Response:
+        queryset = scoped_to_team(
+            DataWarehouseSavedQuery.objects.exclude(deleted=True), team_id_filter(request)
+        ).order_by("-created_at")
         status_filter = request.query_params.get("status")
         if status_filter:
             valid_statuses = set(DataWarehouseSavedQuery.Status.values)
@@ -131,27 +156,28 @@ class InternalDataModelingOpsViewSet(
         return self._paginate(request, queryset, InternalSavedQuerySummarySerializer)
 
     @extend_schema(exclude=True)
-    def internal_saved_query_detail(self, request: Request, team_id: str, saved_query_id: str) -> Response:
+    def internal_saved_query_detail(self, request: Request, saved_query_id: str, **kwargs: Any) -> Response:
         try:
             saved_query = (
                 DataWarehouseSavedQuery.objects.select_related("table", "created_by")
                 .exclude(deleted=True)
-                .get(team_id=int(team_id), id=saved_query_id)
+                .get(id=saved_query_id)
             )
         except (DataWarehouseSavedQuery.DoesNotExist, DjangoValidationError, ValueError):
             return Response({"error": "Saved query not found"}, status=404)
 
-        saved_query_nodes = list(
-            Node.objects.filter(team_id=int(team_id), saved_query=saved_query).select_related("dag")
-        )
+        # The saved query's own team scopes everything below it; the caller does not
+        # supply one, since the id already identifies the row across every team.
+        team_pk = saved_query.team_id
+        saved_query_nodes = list(Node.objects.filter(team_id=team_pk, saved_query=saved_query).select_related("dag"))
         node_ids = [node.id for node in saved_query_nodes]
         upstream_by_node: dict[uuid.UUID, list[str]] = {}
-        for target_id, source_name in Edge.objects.filter(team_id=int(team_id), target_id__in=node_ids).values_list(
+        for target_id, source_name in Edge.objects.filter(team_id=team_pk, target_id__in=node_ids).values_list(
             "target_id", "source__name"
         ):
             upstream_by_node.setdefault(target_id, []).append(source_name)
         downstream_by_node: dict[uuid.UUID, list[str]] = {}
-        for source_id, target_name in Edge.objects.filter(team_id=int(team_id), source_id__in=node_ids).values_list(
+        for source_id, target_name in Edge.objects.filter(team_id=team_pk, source_id__in=node_ids).values_list(
             "source_id", "target__name"
         ):
             downstream_by_node.setdefault(source_id, []).append(target_name)
@@ -169,11 +195,11 @@ class InternalDataModelingOpsViewSet(
         ]
 
         backing_tables = list(
-            DataWarehouseTable.objects.filter(team_id=int(team_id), name=saved_query.name).exclude(deleted=True)
+            DataWarehouseTable.objects.filter(team_id=team_pk, name=saved_query.name).exclude(deleted=True)
         )
         last_successful_job_at = (
             DataModelingJob.objects.filter(
-                team_id=int(team_id), saved_query=saved_query, status=DataModelingJobStatus.COMPLETED
+                team_id=team_pk, saved_query=saved_query, status=DataModelingJobStatus.COMPLETED
             )
             .order_by("-updated_at")
             .values_list("updated_at", flat=True)
@@ -192,37 +218,40 @@ class InternalDataModelingOpsViewSet(
         return Response(serializer.data)
 
     @extend_schema(exclude=True)
-    def internal_saved_query_jobs(self, request: Request, team_id: str, saved_query_id: str) -> Response:
+    def internal_saved_query_jobs(self, request: Request, saved_query_id: str, **kwargs: Any) -> Response:
         try:
-            parent_exists = (
-                DataWarehouseSavedQuery.objects.filter(team_id=int(team_id), id=saved_query_id)
+            parent = (
+                DataWarehouseSavedQuery.objects.filter(id=saved_query_id)
                 .exclude(deleted=True)
-                .exists()
+                .values_list("team_id", flat=True)
+                .first()
             )
         except (DjangoValidationError, ValueError):
             return Response({"error": "Saved query not found"}, status=404)
-        if not parent_exists:
+        if parent is None:
             return Response({"error": "Saved query not found"}, status=404)
 
-        queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
-            "-created_at"
-        )
+        queryset = DataModelingJob.objects.filter(team_id=parent, saved_query_id=saved_query_id).order_by("-created_at")
         return self._paginate(request, queryset, InternalDataModelingJobSerializer)
 
     @extend_schema(exclude=True)
-    def internal_dags(self, request: Request, team_id: str) -> Response:
-        queryset = DAG.objects.filter(team_id=int(team_id)).annotate(node_count=Count("node")).order_by("name")
+    def internal_dags(self, request: Request, **kwargs: Any) -> Response:
+        queryset = (
+            scoped_to_team(DAG.objects.all(), team_id_filter(request))
+            .annotate(node_count=Count("node"))
+            .order_by("name")
+        )
         return self._paginate(request, queryset, InternalDAGSummarySerializer)
 
     @extend_schema(exclude=True)
-    def internal_dag_detail(self, request: Request, team_id: str, dag_id: str) -> Response:
+    def internal_dag_detail(self, request: Request, dag_id: str, **kwargs: Any) -> Response:
         try:
-            dag = DAG.objects.annotate(node_count=Count("node")).get(team_id=int(team_id), id=dag_id)
+            dag = DAG.objects.annotate(node_count=Count("node")).get(id=dag_id)
         except (DAG.DoesNotExist, DjangoValidationError, ValueError):
             return Response({"error": "DAG not found"}, status=404)
 
-        nodes = Node.objects.filter(team_id=int(team_id), dag=dag).order_by("name")
-        edges = Edge.objects.filter(team_id=int(team_id), dag=dag)
+        nodes = Node.objects.filter(team_id=dag.team_id, dag=dag).order_by("name")
+        edges = Edge.objects.filter(team_id=dag.team_id, dag=dag)
         return Response(
             {
                 "dag": InternalDAGSummarySerializer(dag).data,

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -133,8 +133,10 @@ class InternalDataModelingOpsViewSet(
     @extend_schema(exclude=True)
     def internal_saved_query_detail(self, request: Request, team_id: str, saved_query_id: str) -> Response:
         try:
-            saved_query = DataWarehouseSavedQuery.objects.select_related("table", "created_by").get(
-                team_id=int(team_id), id=saved_query_id
+            saved_query = (
+                DataWarehouseSavedQuery.objects.select_related("table", "created_by")
+                .exclude(deleted=True)
+                .get(team_id=int(team_id), id=saved_query_id)
             )
         except (DataWarehouseSavedQuery.DoesNotExist, DjangoValidationError, ValueError):
             return Response({"error": "Saved query not found"}, status=404)
@@ -192,12 +194,20 @@ class InternalDataModelingOpsViewSet(
     @extend_schema(exclude=True)
     def internal_saved_query_jobs(self, request: Request, team_id: str, saved_query_id: str) -> Response:
         try:
-            queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
-                "-created_at"
+            parent_exists = (
+                DataWarehouseSavedQuery.objects.filter(team_id=int(team_id), id=saved_query_id)
+                .exclude(deleted=True)
+                .exists()
             )
-            return self._paginate(request, queryset, InternalDataModelingJobSerializer)
         except (DjangoValidationError, ValueError):
             return Response({"error": "Saved query not found"}, status=404)
+        if not parent_exists:
+            return Response({"error": "Saved query not found"}, status=404)
+
+        queryset = DataModelingJob.objects.filter(team_id=int(team_id), saved_query_id=saved_query_id).order_by(
+            "-created_at"
+        )
+        return self._paginate(request, queryset, InternalDataModelingJobSerializer)
 
     @extend_schema(exclude=True)
     def internal_dags(self, request: Request, team_id: str) -> Response:

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -7,6 +7,7 @@ OIDC ID tokens (see internal_auth.py).
 """
 
 import uuid
+from typing import cast
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Count, Q, QuerySet
@@ -18,7 +19,7 @@ from rest_framework.response import Response
 
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.models import Team
+from posthog.auth import InternalAPIUser
 from posthog.ph_client import feature_enabled_or_false
 
 from products.data_modeling.backend.facade.models import (
@@ -45,17 +46,17 @@ from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 DATA_MODELING_OPS_DISTINCT_ID = "data_modeling_ops_internal"
 
 
-def _is_v2_backend_enabled_for_team(team: Team) -> bool:
+def _is_v2_backend_enabled(team_id: int, organization_id: str) -> bool:
     return feature_enabled_or_false(
         "data-modeling-backend-v2",
         DATA_MODELING_OPS_DISTINCT_ID,
         groups={
-            "organization": str(team.organization_id),
-            "project": str(team.id),
+            "organization": organization_id,
+            "project": str(team_id),
         },
         group_properties={
-            "organization": {"id": str(team.organization_id)},
-            "project": {"id": str(team.id)},
+            "organization": {"id": organization_id},
+            "project": {"id": str(team_id)},
         },
     )
 
@@ -87,10 +88,11 @@ class InternalDataModelingOpsViewSet(
 
     @extend_schema(exclude=True)
     def internal_overview(self, request: Request, team_id: str) -> Response:
-        # Manual (non-router) paths don't populate the mixin's parents_query_dict, so the
-        # team comes from the URL arg — the auth class already pinned the token to it.
-        team = Team.objects.get(id=int(team_id))
-        saved_queries = DataWarehouseSavedQuery.objects.filter(team_id=team.id).exclude(deleted=True)
+        # Manual (non-router) paths don't populate the mixin's parents_query_dict. The
+        # authenticator already resolved the URL's team, so reuse it instead of re-querying.
+        user = cast(InternalAPIUser, request.user)
+        team_pk = int(team_id)
+        saved_queries = DataWarehouseSavedQuery.objects.filter(team_id=team_pk).exclude(deleted=True)
         saved_query_counts = saved_queries.aggregate(
             total=Count("id"),
             materialized=Count("id", filter=Q(is_materialized=True)),
@@ -100,10 +102,10 @@ class InternalDataModelingOpsViewSet(
         )
         serializer = InternalTeamOverviewSerializer(
             {
-                "team_id": team.id,
-                "v2_backend_enabled": _is_v2_backend_enabled_for_team(team),
-                "dag_count": DAG.objects.filter(team_id=team.id).count(),
-                "node_count": Node.objects.filter(team_id=team.id).count(),
+                "team_id": team_pk,
+                "v2_backend_enabled": _is_v2_backend_enabled(team_pk, str(user.current_organization_id)),
+                "dag_count": DAG.objects.filter(team_id=team_pk).count(),
+                "node_count": Node.objects.filter(team_id=team_pk).count(),
                 "saved_query_count": saved_query_counts["total"],
                 "materialized_saved_query_count": saved_query_counts["materialized"],
                 "failing_saved_query_count": saved_query_counts["failing"],
@@ -200,8 +202,7 @@ class InternalDataModelingOpsViewSet(
     @extend_schema(exclude=True)
     def internal_dags(self, request: Request, team_id: str) -> Response:
         queryset = DAG.objects.filter(team_id=int(team_id)).annotate(node_count=Count("node")).order_by("name")
-        serializer = InternalDAGSummarySerializer(queryset, many=True)
-        return Response({"results": serializer.data})
+        return self._paginate(request, queryset, InternalDAGSummarySerializer)
 
     @extend_schema(exclude=True)
     def internal_dag_detail(self, request: Request, team_id: str, dag_id: str) -> Response:

--- a/products/data_modeling/backend/tests/api/oidc.py
+++ b/products/data_modeling/backend/tests/api/oidc.py
@@ -1,0 +1,54 @@
+"""Offline OIDC token minting for internal ops API tests.
+
+Tokens are signed with a module-level RSA keypair; ``OidcAuthTestMixin`` patches the
+JWKS lookup in internal_auth so they verify without any network access.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from unittest.mock import patch
+
+from django.conf import settings
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def mint_oidc_token(
+    email: str = "ops@posthog.com",
+    *,
+    audience: str | None = None,
+    issuer: str | None = None,
+    expiry_delta: timedelta = timedelta(minutes=5),
+    email_verified: bool = True,
+    **extra_claims: Any,
+) -> str:
+    return jwt.encode(
+        {
+            "aud": audience or settings.DATA_MODELING_OPS_OIDC_AUDIENCES[0],
+            "iss": issuer or settings.DATA_MODELING_OPS_OIDC_ISSUER,
+            "exp": datetime.now(tz=UTC) + expiry_delta,
+            "email": email,
+            "email_verified": email_verified,
+            **extra_claims,
+        },
+        _PRIVATE_KEY,
+        algorithm="RS256",
+    )
+
+
+class OidcAuthTestMixin:
+    def setUp(self) -> None:
+        super().setUp()  # type: ignore[misc]
+        patcher = patch(
+            "products.data_modeling.backend.presentation.internal_auth._jwks_client",
+            return_value=SimpleNamespace(
+                get_signing_key_from_jwt=lambda token: SimpleNamespace(key=_PRIVATE_KEY.public_key())
+            ),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)  # type: ignore[attr-defined]

--- a/products/data_modeling/backend/tests/api/oidc.py
+++ b/products/data_modeling/backend/tests/api/oidc.py
@@ -25,20 +25,20 @@ def mint_oidc_token(
     issuer: str | None = None,
     expiry_delta: timedelta = timedelta(minutes=5),
     email_verified: bool = True,
+    hosted_domain: str | None = "posthog.com",
     **extra_claims: Any,
 ) -> str:
-    return jwt.encode(
-        {
-            "aud": audience or settings.DATA_MODELING_OPS_OIDC_AUDIENCES[0],
-            "iss": issuer or settings.DATA_MODELING_OPS_OIDC_ISSUER,
-            "exp": datetime.now(tz=UTC) + expiry_delta,
-            "email": email,
-            "email_verified": email_verified,
-            **extra_claims,
-        },
-        _PRIVATE_KEY,
-        algorithm="RS256",
-    )
+    claims: dict[str, Any] = {
+        "aud": audience or settings.DATA_MODELING_OPS_OIDC_AUDIENCES[0],
+        "iss": issuer or settings.DATA_MODELING_OPS_OIDC_ISSUER,
+        "exp": datetime.now(tz=UTC) + expiry_delta,
+        "email": email,
+        "email_verified": email_verified,
+        **extra_claims,
+    }
+    if hosted_domain is not None:
+        claims["hd"] = hosted_domain
+    return jwt.encode(claims, _PRIVATE_KEY, algorithm="RS256")
 
 
 class OidcAuthTestMixin:

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -139,6 +139,10 @@ class TestInternalDataModelingOpsAPI(APIBaseTest):
         self.assertEqual(results[0]["engine"], "duckgres")
         self.assertEqual(results[0]["storage_delta_mib"], 12.5)
 
+    def test_jobs_returns_404_for_malformed_saved_query_id(self):
+        response = self._get("/saved_queries/not-a-uuid/jobs", self._token())
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_dag_detail_returns_nodes_and_edges(self):
         dag = DAG.objects.create(team=self.team, name="Default")
         saved_query = DataWarehouseSavedQuery.objects.create(

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -30,10 +30,9 @@ def _wrong_audience_token(team_id: int) -> str:
 class TestInternalDataModelingOpsAPI(APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
-        kwargs = {}
         if token is not None:
-            kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
-        return self.client.get(f"{base}{path}", **kwargs)
+            return self.client.get(f"{base}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
+        return self.client.get(f"{base}{path}")
 
     def _token(self, team_id: int | None = None) -> str:
         return mint_data_modeling_ops_token(team_id=team_id or self.team.id, acting_user="test@posthog.com")

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -1,0 +1,156 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import APIBaseTest
+
+from django.conf import settings
+
+import jwt
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Team
+
+from products.data_modeling.backend.facade.internal_ops import mint_data_modeling_ops_token
+from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node, NodeType
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+
+
+def _wrong_audience_token(team_id: int) -> str:
+    return jwt.encode(
+        {
+            "aud": "posthog:something_else",
+            "exp": datetime.now(tz=UTC) + timedelta(minutes=5),
+            "team_id": team_id,
+        },
+        settings.DATA_MODELING_OPS_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+class TestInternalDataModelingOpsAPI(APIBaseTest):
+    def _get(self, path: str, token: str | None = None):
+        base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
+        kwargs = {}
+        if token is not None:
+            kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+        return self.client.get(f"{base}{path}", **kwargs)
+
+    def _token(self, team_id: int | None = None) -> str:
+        return mint_data_modeling_ops_token(team_id=team_id or self.team.id, acting_user="test@posthog.com")
+
+    @parameterized.expand(
+        [
+            ("no_token", lambda self: None),
+            ("expired_token", lambda self: mint_data_modeling_ops_token(self.team.id, "x", timedelta(minutes=-1))),
+            ("wrong_audience", lambda self: _wrong_audience_token(self.team.id)),
+            (
+                "other_teams_token",
+                lambda self: mint_data_modeling_ops_token(Team.objects.create(organization=self.organization).id, "x"),
+            ),
+        ]
+    )
+    def test_rejects_invalid_tokens(self, _name, token_factory):
+        response = self._get("/overview", token_factory(self))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_overview_counts(self):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        materialized = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="materialized_view",
+            query={"query": "select 1"},
+            is_materialized=True,
+            sync_frequency_interval=timedelta(hours=24),
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="failing_view",
+            query={"query": "select 1"},
+            status=DataWarehouseSavedQuery.Status.FAILED,
+        )
+        Node.objects.create(team=self.team, dag=dag, saved_query=materialized, type=NodeType.MAT_VIEW)
+
+        response = self._get("/overview", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["team_id"], self.team.id)
+        self.assertEqual(data["dag_count"], 1)
+        self.assertEqual(data["node_count"], 1)
+        self.assertEqual(data["saved_query_count"], 2)
+        self.assertEqual(data["materialized_saved_query_count"], 1)
+        self.assertEqual(data["failing_saved_query_count"], 1)
+        self.assertEqual(data["saved_queries_with_sync_frequency_count"], 1)
+
+    def test_saved_query_detail_surfaces_duplicate_backing_tables_and_dag_context(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select * from events"}
+        )
+        linked = DataWarehouseTable.objects.create(
+            team=self.team, name="my_view", format="Parquet", url_pattern="s3://bucket/linked"
+        )
+        orphan = DataWarehouseTable.objects.create(
+            team=self.team, name="my_view", format="Parquet", url_pattern="s3://bucket/orphan"
+        )
+        saved_query.table = linked
+        saved_query.save()
+
+        dag = DAG.objects.create(team=self.team, name="Default")
+        node = Node.objects.create(team=self.team, dag=dag, saved_query=saved_query, type=NodeType.MAT_VIEW)
+        events_table = Node.objects.create(team=self.team, dag=dag, name="events", type=NodeType.TABLE)
+        Edge.objects.create(team=self.team, dag=dag, source=events_table, target=node)
+
+        response = self._get(f"/saved_queries/{saved_query.id}", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["query"], {"query": "select * from events"})
+        backing_by_url = {t["url_pattern"]: t for t in data["backing_tables"]}
+        self.assertEqual(len(backing_by_url), 2)
+        self.assertTrue(backing_by_url["s3://bucket/linked"]["is_linked"])
+        self.assertFalse(backing_by_url["s3://bucket/orphan"]["is_linked"])
+        self.assertEqual(str(orphan.id), backing_by_url["s3://bucket/orphan"]["id"])
+        self.assertEqual(len(data["nodes"]), 1)
+        self.assertEqual(data["nodes"][0]["dag_name"], "Default")
+        self.assertEqual(data["nodes"][0]["upstream"], ["events"])
+        self.assertFalse(data["double_materialized"])
+
+    def test_jobs_expose_engine_and_storage_including_duckgres(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.COMPLETED,
+            engine=DataModelingJob.Engine.DUCKGRES,
+            storage_delta_mib=12.5,
+            rows_materialized=100,
+        )
+
+        response = self._get(f"/saved_queries/{saved_query.id}/jobs", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["engine"], "duckgres")
+        self.assertEqual(results[0]["storage_delta_mib"], 12.5)
+
+    def test_dag_detail_returns_nodes_and_edges(self):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}
+        )
+        node = Node.objects.create(team=self.team, dag=dag, saved_query=saved_query, type=NodeType.VIEW)
+        events_table = Node.objects.create(team=self.team, dag=dag, name="events", type=NodeType.TABLE)
+        Edge.objects.create(team=self.team, dag=dag, source=events_table, target=node)
+
+        response = self._get(f"/dags/{dag.id}", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["dag"]["name"], "Default")
+        self.assertEqual(data["dag"]["node_count"], 2)
+        self.assertEqual({n["name"] for n in data["nodes"]}, {"events", "my_view"})
+        self.assertEqual(len(data["edges"]), 1)
+        self.assertEqual(data["edges"][0]["source_id"], str(events_table.id))

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -114,6 +114,10 @@ class TestInternalDataModelingOpsAPI(APIBaseTest):
         self.assertEqual(data["nodes"][0]["upstream"], ["events"])
         self.assertFalse(data["double_materialized"])
 
+    def test_saved_queries_rejects_unknown_status_filter(self):
+        response = self._get("/saved_queries?status=Failing", self._token())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_jobs_expose_engine_and_storage_including_duckgres(self):
         saved_query = DataWarehouseSavedQuery.objects.create(
             team=self.team, name="my_view", query={"query": "select 1"}

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -1,58 +1,48 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
 
-from django.conf import settings
 from django.test import override_settings
 
-import jwt
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.models import Team
-
-from products.data_modeling.backend.facade.internal_ops import mint_data_modeling_ops_token
 from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node, NodeType
+from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
-def _wrong_audience_token(team_id: int) -> str:
-    return jwt.encode(
-        {
-            "aud": "posthog:something_else",
-            "exp": datetime.now(tz=UTC) + timedelta(minutes=5),
-            "team_id": team_id,
-        },
-        settings.DATA_MODELING_OPS_JWT_SECRET,
-        algorithm="HS256",
-    )
-
-
-@override_settings(DATA_MODELING_OPS_JWT_SECRET="test-modeling-ops-secret")
-class TestInternalDataModelingOpsAPI(APIBaseTest):
+class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
         if token is not None:
             return self.client.get(f"{base}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
         return self.client.get(f"{base}{path}")
 
-    def _token(self, team_id: int | None = None) -> str:
-        return mint_data_modeling_ops_token(team_id=team_id or self.team.id, acting_user="test@posthog.com")
+    def _token(self) -> str:
+        return mint_oidc_token()
 
+    # The client is session-logged-in (APIBaseTest), so the no-bearer row also proves
+    # session auth cannot reach these routes.
     @parameterized.expand(
         [
-            ("no_token", lambda self: None),
-            ("expired_token", lambda self: mint_data_modeling_ops_token(self.team.id, "x", timedelta(minutes=-1))),
-            ("wrong_audience", lambda self: _wrong_audience_token(self.team.id)),
-            (
-                "other_teams_token",
-                lambda self: mint_data_modeling_ops_token(Team.objects.create(organization=self.organization).id, "x"),
-            ),
+            ("session_only_no_bearer", lambda: None),
+            ("expired_token", lambda: mint_oidc_token(expiry_delta=timedelta(minutes=-1))),
+            ("wrong_audience", lambda: mint_oidc_token(audience="some-other-client-id")),
+            ("wrong_issuer", lambda: mint_oidc_token(issuer="https://evil.example.com")),
+            ("unverified_email", lambda: mint_oidc_token(email_verified=False)),
+            ("wrong_domain", lambda: mint_oidc_token(email="ops@example.com")),
         ]
     )
     def test_rejects_invalid_tokens(self, _name, token_factory):
-        response = self._get("/overview", token_factory(self))
+        response = self._get("/overview", token_factory())
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS=["ops-bot@proj.iam.gserviceaccount.com"])
+    def test_allow_listed_service_account_bypasses_domain_check(self):
+        token = mint_oidc_token(email="ops-bot@proj.iam.gserviceaccount.com", email_verified=False)
+        response = self._get("/overview", token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_overview_counts(self):
         dag = DAG.objects.create(team=self.team, name="Default")

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from posthog.test.base import APIBaseTest
 
 from django.conf import settings
+from django.test import override_settings
 
 import jwt
 from parameterized import parameterized
@@ -27,6 +28,7 @@ def _wrong_audience_token(team_id: int) -> str:
     )
 
 
+@override_settings(DATA_MODELING_OPS_JWT_SECRET="test-modeling-ops-secret")
 class TestInternalDataModelingOpsAPI(APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -139,6 +139,14 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
         response = self._get("/saved_queries/not-a-uuid/jobs", self._token())
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @parameterized.expand([("detail", ""), ("jobs", "/jobs")])
+    def test_soft_deleted_saved_query_is_not_readable_by_id(self, _name, suffix):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="deleted_view", query={"query": "select 1"}, deleted=True
+        )
+        response = self._get(f"/saved_queries/{saved_query.id}{suffix}", self._token())
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_dag_detail_returns_nodes_and_edges(self):
         dag = DAG.objects.create(team=self.team, name="Default")
         saved_query = DataWarehouseSavedQuery.objects.create(

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -31,7 +31,11 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
             ("wrong_audience", lambda: mint_oidc_token(audience="some-other-client-id")),
             ("wrong_issuer", lambda: mint_oidc_token(issuer="https://evil.example.com")),
             ("unverified_email", lambda: mint_oidc_token(email_verified=False)),
-            ("wrong_domain", lambda: mint_oidc_token(email="ops@example.com")),
+            ("wrong_email_domain", lambda: mint_oidc_token(email="ops@example.com")),
+            # A consumer Google account can verify an address on our domain but carries no
+            # hosted-domain claim, so Workspace offboarding would never revoke it.
+            ("missing_hosted_domain", lambda: mint_oidc_token(hosted_domain=None)),
+            ("wrong_hosted_domain", lambda: mint_oidc_token(hosted_domain="example.com")),
         ]
     )
     def test_rejects_invalid_tokens(self, _name, token_factory):
@@ -40,7 +44,7 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
 
     @override_settings(DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS=["ops-bot@proj.iam.gserviceaccount.com"])
     def test_allow_listed_service_account_bypasses_domain_check(self):
-        token = mint_oidc_token(email="ops-bot@proj.iam.gserviceaccount.com", email_verified=False)
+        token = mint_oidc_token(email="ops-bot@proj.iam.gserviceaccount.com", email_verified=False, hosted_domain=None)
         response = self._get("/overview", token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -7,6 +7,8 @@ from django.test import override_settings
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.models import Team
+
 from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node, NodeType
 from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
@@ -14,7 +16,7 @@ from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def _get(self, path: str, token: str | None = None):
-        base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
+        base = "/api/internal/data_modeling_ops"
         if token is not None:
             return self.client.get(f"{base}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
         return self.client.get(f"{base}{path}")
@@ -39,13 +41,13 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
         ]
     )
     def test_rejects_invalid_tokens(self, _name, token_factory):
-        response = self._get("/overview", token_factory())
+        response = self._get(f"/teams/{self.team.id}", token_factory())
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @override_settings(DATA_MODELING_OPS_OIDC_SERVICE_ACCOUNT_EMAILS=["ops-bot@proj.iam.gserviceaccount.com"])
     def test_allow_listed_service_account_bypasses_domain_check(self):
         token = mint_oidc_token(email="ops-bot@proj.iam.gserviceaccount.com", email_verified=False, hosted_domain=None)
-        response = self._get("/overview", token)
+        response = self._get(f"/teams/{self.team.id}", token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_overview_counts(self):
@@ -65,7 +67,7 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
         )
         Node.objects.create(team=self.team, dag=dag, saved_query=materialized, type=NodeType.MAT_VIEW)
 
-        response = self._get("/overview", self._token())
+        response = self._get(f"/teams/{self.team.id}", self._token())
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -113,6 +115,23 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def test_saved_queries_rejects_unknown_status_filter(self):
         response = self._get("/saved_queries?status=Failing", self._token())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_rejects_non_integer_team_id_filter(self):
+        response = self._get("/saved_queries?team_id=abc", self._token())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand([("saved_queries", "saved_queries", "view"), ("dags", "dags", "dag")])
+    def test_team_id_filter_narrows_otherwise_fleet_wide_list(self, _name, resource, prefix):
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        for team in (self.team, other_team):
+            DataWarehouseSavedQuery.objects.create(team=team, name=f"view_{team.id}", query={"query": "select 1"})
+            DAG.objects.create(team=team, name=f"dag_{team.id}")
+
+        unfiltered = self._get(f"/{resource}", self._token()).json()["results"]
+        filtered = self._get(f"/{resource}?team_id={self.team.id}", self._token()).json()["results"]
+
+        self.assertEqual(len(unfiltered), 2)
+        self.assertEqual([row["name"] for row in filtered], [f"{prefix}_{self.team.id}"])
 
     def test_jobs_expose_engine_and_storage_including_duckgres(self):
         saved_query = DataWarehouseSavedQuery.objects.create(

--- a/products/endpoints/backend/facade/internal_ops.py
+++ b/products/endpoints/backend/facade/internal_ops.py
@@ -1,0 +1,10 @@
+"""Wiring for the endpoints side of the data_modeling_ops internal API.
+
+Core URL routing imports the viewset from here rather than reaching into presentation
+modules. Only imported by posthog/urls.py (request time), so the DRF dependencies stay
+off the ``django.setup()`` path.
+"""
+
+from products.endpoints.backend.presentation.views.internal_ops import InternalEndpointsOpsViewSet
+
+__all__ = ["InternalEndpointsOpsViewSet"]

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -1,8 +1,8 @@
 """Read-only internal (service-to-service) endpoints API for the modeling-ops admin app.
 
 Lives in the endpoints product (data_modeling cannot depend on endpoints), but shares
-the ``api/projects/<team_id>/internal/data_modeling_ops/`` URL prefix and the scoped-JWT
-auth from the data_modeling facade. Wired manually in posthog/urls.py.
+the ``api/projects/<team_id>/internal/data_modeling_ops/`` URL prefix and the OIDC auth
+from the data_modeling facade. Wired manually in posthog/urls.py.
 """
 
 from drf_spectacular.utils import extend_schema
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.facade.internal_ops import DataModelingOpsJWTAuthentication
+from products.data_modeling.backend.facade.internal_ops import DataModelingOpsAuthenticationMixin
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
 from products.endpoints.backend.facade.models import Endpoint, EndpointVersion
 
@@ -95,12 +95,11 @@ class InternalEndpointSummarySerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class InternalEndpointsOpsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+class InternalEndpointsOpsViewSet(DataModelingOpsAuthenticationMixin, TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """Internal read-only endpoint data for the modeling-ops admin app."""
 
     scope_object = "INTERNAL"
     serializer_class = _FallbackSerializer
-    authentication_classes = [DataModelingOpsJWTAuthentication]
 
     @extend_schema(exclude=True)
     def internal_endpoints(self, request: Request, team_id: str) -> Response:

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -15,7 +15,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from products.data_modeling.backend.facade.internal_ops import DataModelingOpsJWTAuthentication
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
-from products.endpoints.backend.models import Endpoint, EndpointVersion
+from products.endpoints.backend.facade.models import Endpoint, EndpointVersion
 
 
 class InternalEndpointVersionSerializer(serializers.ModelSerializer):

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -1,0 +1,142 @@
+"""Read-only internal (service-to-service) endpoints API for the modeling-ops admin app.
+
+Lives in the endpoints product (data_modeling cannot depend on endpoints), but shares
+the ``api/projects/<team_id>/internal/data_modeling_ops/`` URL prefix and the scoped-JWT
+auth from the data_modeling facade. Wired manually in posthog/urls.py.
+"""
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.documentation import _FallbackSerializer
+from posthog.api.routing import TeamAndOrgViewSetMixin
+
+from products.data_modeling.backend.facade.internal_ops import DataModelingOpsJWTAuthentication
+from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
+from products.endpoints.backend.models import Endpoint, EndpointVersion
+
+
+class InternalEndpointVersionSerializer(serializers.ModelSerializer):
+    is_materialized = serializers.BooleanField(
+        read_only=True, help_text="Derived from the saved query's table FK: true when a backing table exists."
+    )
+    saved_query_id = serializers.UUIDField(
+        read_only=True, allow_null=True, help_text="Saved query materializing this version, if any."
+    )
+    saved_query_status = serializers.SerializerMethodField(help_text="Status of the materializing saved query, if any.")
+    saved_query_last_run_at = serializers.SerializerMethodField(
+        help_text="saved_query.last_run_at — unreliable on v2 teams (the v2 success path does not write it); "
+        "compare with last_successful_job_at."
+    )
+    saved_query_latest_error = serializers.SerializerMethodField(
+        help_text="Latest error of the materializing saved query, untruncated."
+    )
+    last_successful_job_at = serializers.SerializerMethodField(
+        help_text="Completion time of the most recent COMPLETED materialization job for the saved query — "
+        "the trustworthy freshness signal."
+    )
+
+    class Meta:
+        model = EndpointVersion
+        fields = [
+            "id",
+            "version",
+            "query",
+            "description",
+            "is_active",
+            "is_materialized",
+            "data_freshness_seconds",
+            "created_at",
+            "last_executed_at",
+            "saved_query_id",
+            "saved_query_status",
+            "saved_query_last_run_at",
+            "saved_query_latest_error",
+            "last_successful_job_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "query": {"help_text": "Immutable query snapshot for this version."},
+            "data_freshness_seconds": {"help_text": "Freshness target controlling cache TTL and sync cadence."},
+        }
+
+    def get_saved_query_status(self, version: EndpointVersion) -> str | None:
+        return version.saved_query.status if version.saved_query else None
+
+    def get_saved_query_last_run_at(self, version: EndpointVersion) -> str | None:
+        if version.saved_query and version.saved_query.last_run_at:
+            return version.saved_query.last_run_at.isoformat()
+        return None
+
+    def get_saved_query_latest_error(self, version: EndpointVersion) -> str | None:
+        return version.saved_query.latest_error if version.saved_query else None
+
+    def get_last_successful_job_at(self, version: EndpointVersion) -> str | None:
+        last_successful_job_at = self.context.get("last_successful_job_at_by_saved_query", {}).get(
+            version.saved_query_id
+        )
+        return last_successful_job_at.isoformat() if last_successful_job_at else None
+
+
+class InternalEndpointSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Endpoint
+        fields = [
+            "id",
+            "name",
+            "is_active",
+            "current_version",
+            "derived_from_insight",
+            "created_at",
+            "last_executed_at",
+        ]
+        read_only_fields = fields
+
+
+class InternalEndpointsOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+    """Internal read-only endpoint data for the modeling-ops admin app."""
+
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+    authentication_classes = [DataModelingOpsJWTAuthentication]
+
+    @extend_schema(exclude=True)
+    def internal_endpoints(self, request: Request, team_id: str) -> Response:
+        queryset = Endpoint.objects.filter(team_id=int(team_id)).exclude(deleted=True).order_by("name")
+        serializer = InternalEndpointSummarySerializer(queryset, many=True)
+        return Response({"results": serializer.data})
+
+    @extend_schema(exclude=True)
+    def internal_endpoint_detail(self, request: Request, team_id: str, name: str) -> Response:
+        endpoint = Endpoint.objects.filter(team_id=int(team_id), name=name).exclude(deleted=True).first()
+        if endpoint is None:
+            return Response({"error": "Endpoint not found"}, status=404)
+
+        versions = list(endpoint.versions.select_related("saved_query").all())
+        saved_query_ids = [v.saved_query_id for v in versions if v.saved_query_id]
+        last_successful_job_at_by_saved_query = {}
+        if saved_query_ids:
+            successful_jobs = (
+                DataModelingJob.objects.filter(
+                    team_id=int(team_id),
+                    saved_query_id__in=saved_query_ids,
+                    status=DataModelingJobStatus.COMPLETED,
+                )
+                .order_by("saved_query_id", "-updated_at")
+                .distinct("saved_query_id")
+                .values_list("saved_query_id", "updated_at")
+            )
+            last_successful_job_at_by_saved_query = dict(successful_jobs)
+
+        return Response(
+            {
+                **InternalEndpointSummarySerializer(endpoint).data,
+                "versions": InternalEndpointVersionSerializer(
+                    versions,
+                    many=True,
+                    context={"last_successful_job_at_by_saved_query": last_successful_job_at_by_saved_query},
+                ).data,
+            }
+        )

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -95,7 +95,7 @@ class InternalEndpointSummarySerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class InternalEndpointsOpsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+class InternalEndpointsOpsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """Internal read-only endpoint data for the modeling-ops admin app."""
 
     scope_object = "INTERNAL"

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -1,9 +1,13 @@
 """Read-only internal (service-to-service) endpoints API for the modeling-ops admin app.
 
 Lives in the endpoints product (data_modeling cannot depend on endpoints), but shares
-the ``api/projects/<team_id>/internal/data_modeling_ops/`` URL prefix and the OIDC auth
-from the data_modeling facade. Wired manually in posthog/urls.py.
+the ``api/internal/data_modeling_ops/`` URL prefix and the OIDC auth from the
+data_modeling facade. Wired manually in posthog/urls.py.
 """
+
+from typing import Any
+
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import pagination, serializers, viewsets
@@ -13,7 +17,11 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.facade.internal_ops import DataModelingOpsAuthenticationMixin
+from products.data_modeling.backend.facade.internal_ops import (
+    DataModelingOpsAuthenticationMixin,
+    scoped_to_team,
+    team_id_filter,
+)
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
 from products.endpoints.backend.facade.models import Endpoint, EndpointVersion
 
@@ -115,18 +123,26 @@ class InternalEndpointsOpsViewSet(DataModelingOpsAuthenticationMixin, TeamAndOrg
     pagination_class = InternalEndpointsOpsPagination
 
     @extend_schema(exclude=True)
-    def internal_endpoints(self, request: Request, team_id: str) -> Response:
-        queryset = Endpoint.objects.filter(team_id=int(team_id)).exclude(deleted=True).order_by("name")
+    def internal_endpoints(self, request: Request, **kwargs: Any) -> Response:
+        queryset = scoped_to_team(Endpoint.objects.exclude(deleted=True), team_id_filter(request)).order_by(
+            "team_id", "name"
+        )
         page = self.paginate_queryset(queryset)
         serializer = InternalEndpointSummarySerializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
     @extend_schema(exclude=True)
-    def internal_endpoint_detail(self, request: Request, team_id: str, name: str) -> Response:
-        endpoint = Endpoint.objects.filter(team_id=int(team_id), name=name).exclude(deleted=True).first()
+    def internal_endpoint_detail(self, request: Request, endpoint_id: str, **kwargs: Any) -> Response:
+        # Looked up by id rather than name: names are unique per team, ids are unique
+        # everywhere, so the caller does not have to know the team to fetch one.
+        try:
+            endpoint = Endpoint.objects.filter(id=endpoint_id).exclude(deleted=True).first()
+        except (DjangoValidationError, ValueError):
+            return Response({"error": "Endpoint not found"}, status=404)
         if endpoint is None:
             return Response({"error": "Endpoint not found"}, status=404)
 
+        team_id = endpoint.team_id
         versions = list(endpoint.versions.select_related("saved_query").all())
         saved_query_ids = [v.saved_query_id for v in versions if v.saved_query_id]
         last_successful_job_at_by_saved_query = {}

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -6,7 +6,7 @@ from the data_modeling facade. Wired manually in posthog/urls.py.
 """
 
 from drf_spectacular.utils import extend_schema
-from rest_framework import serializers, viewsets
+from rest_framework import pagination, serializers, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -93,6 +93,18 @@ class InternalEndpointSummarySerializer(serializers.ModelSerializer):
             "last_executed_at",
         ]
         read_only_fields = fields
+        extra_kwargs = {
+            "name": {"help_text": "Endpoint name, unique per team and used in its run path."},
+            "is_active": {"help_text": "False when the endpoint is disabled and rejects runs."},
+            "current_version": {"help_text": "Version number served by the run path."},
+            "derived_from_insight": {"help_text": "Insight this endpoint was created from, if any."},
+            "last_executed_at": {"help_text": "Last time any version of this endpoint was run."},
+        }
+
+
+class InternalEndpointsOpsPagination(pagination.LimitOffsetPagination):
+    default_limit = 100
+    max_limit = 500
 
 
 class InternalEndpointsOpsViewSet(DataModelingOpsAuthenticationMixin, TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
@@ -100,12 +112,14 @@ class InternalEndpointsOpsViewSet(DataModelingOpsAuthenticationMixin, TeamAndOrg
 
     scope_object = "INTERNAL"
     serializer_class = _FallbackSerializer
+    pagination_class = InternalEndpointsOpsPagination
 
     @extend_schema(exclude=True)
     def internal_endpoints(self, request: Request, team_id: str) -> Response:
         queryset = Endpoint.objects.filter(team_id=int(team_id)).exclude(deleted=True).order_by("name")
-        serializer = InternalEndpointSummarySerializer(queryset, many=True)
-        return Response({"results": serializer.data})
+        page = self.paginate_queryset(queryset)
+        serializer = InternalEndpointSummarySerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 
     @extend_schema(exclude=True)
     def internal_endpoint_detail(self, request: Request, team_id: str, name: str) -> Response:

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -1,5 +1,7 @@
 from posthog.test.base import APIBaseTest
 
+from django.test import override_settings
+
 from rest_framework import status
 
 from products.data_modeling.backend.facade.internal_ops import mint_data_modeling_ops_token
@@ -7,6 +9,7 @@ from products.data_modeling.backend.facade.models import DataModelingJob, DataWa
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 
 
+@override_settings(DATA_MODELING_OPS_JWT_SECRET="test-modeling-ops-secret")
 class TestInternalEndpointsOpsAPI(APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -1,0 +1,67 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from products.data_modeling.backend.facade.internal_ops import mint_data_modeling_ops_token
+from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
+from products.endpoints.backend.models import Endpoint, EndpointVersion
+
+
+class TestInternalEndpointsOpsAPI(APIBaseTest):
+    def _get(self, path: str, token: str | None = None):
+        base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
+        kwargs = {}
+        if token is not None:
+            kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+        return self.client.get(f"{base}{path}", **kwargs)
+
+    def _token(self) -> str:
+        return mint_data_modeling_ops_token(team_id=self.team.id, acting_user="test@posthog.com")
+
+    def test_rejects_missing_token(self):
+        response = self._get("/endpoints")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_endpoint_detail_reports_job_derived_freshness_when_last_run_at_is_unwritten(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="my_endpoint_v1",
+            query={"query": "select 1"},
+            is_materialized=True,
+            last_run_at=None,
+        )
+        endpoint = Endpoint.objects.create(team=self.team, name="my_endpoint", created_by=self.user)
+        EndpointVersion.objects.create(
+            endpoint=endpoint,
+            team=self.team,
+            version=1,
+            query={"kind": "HogQLQuery", "query": "select 1"},
+            saved_query=saved_query,
+        )
+        job = DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.COMPLETED,
+        )
+
+        response = self._get("/endpoints/my_endpoint", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["name"], "my_endpoint")
+        self.assertEqual(len(data["versions"]), 1)
+        version = data["versions"][0]
+        self.assertEqual(version["saved_query_id"], str(saved_query.id))
+        self.assertIsNone(version["saved_query_last_run_at"])
+        self.assertEqual(version["last_successful_job_at"], job.updated_at.isoformat())
+
+    def test_endpoints_list(self):
+        Endpoint.objects.create(team=self.team, name="a_endpoint", created_by=self.user)
+        Endpoint.objects.create(team=self.team, name="b_endpoint", created_by=self.user, is_active=False)
+
+        response = self._get("/endpoints", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual([e["name"] for e in results], ["a_endpoint", "b_endpoint"])
+        self.assertFalse(results[1]["is_active"])

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -1,16 +1,13 @@
 from posthog.test.base import APIBaseTest
 
-from django.test import override_settings
-
 from rest_framework import status
 
-from products.data_modeling.backend.facade.internal_ops import mint_data_modeling_ops_token
 from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
+from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 
 
-@override_settings(DATA_MODELING_OPS_JWT_SECRET="test-modeling-ops-secret")
-class TestInternalEndpointsOpsAPI(APIBaseTest):
+class TestInternalEndpointsOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
         if token is not None:
@@ -18,7 +15,7 @@ class TestInternalEndpointsOpsAPI(APIBaseTest):
         return self.client.get(f"{base}{path}")
 
     def _token(self) -> str:
-        return mint_data_modeling_ops_token(team_id=self.team.id, acting_user="test@posthog.com")
+        return mint_oidc_token()
 
     def test_rejects_missing_token(self):
         response = self._get("/endpoints")

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -10,10 +10,9 @@ from products.endpoints.backend.models import Endpoint, EndpointVersion
 class TestInternalEndpointsOpsAPI(APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
-        kwargs = {}
         if token is not None:
-            kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
-        return self.client.get(f"{base}{path}", **kwargs)
+            return self.client.get(f"{base}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
+        return self.client.get(f"{base}{path}")
 
     def _token(self) -> str:
         return mint_data_modeling_ops_token(team_id=self.team.id, acting_user="test@posthog.com")
@@ -53,6 +52,7 @@ class TestInternalEndpointsOpsAPI(APIBaseTest):
         version = data["versions"][0]
         self.assertEqual(version["saved_query_id"], str(saved_query.id))
         self.assertIsNone(version["saved_query_last_run_at"])
+        assert job.updated_at is not None
         self.assertEqual(version["last_successful_job_at"], job.updated_at.isoformat())
 
     def test_endpoints_list(self):

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -9,7 +9,7 @@ from products.endpoints.backend.models import Endpoint, EndpointVersion
 
 class TestInternalEndpointsOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def _get(self, path: str, token: str | None = None):
-        base = f"/api/projects/{self.team.id}/internal/data_modeling_ops"
+        base = "/api/internal/data_modeling_ops"
         if token is not None:
             return self.client.get(f"{base}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
         return self.client.get(f"{base}{path}")
@@ -43,7 +43,7 @@ class TestInternalEndpointsOpsAPI(OidcAuthTestMixin, APIBaseTest):
             status=DataModelingJob.Status.COMPLETED,
         )
 
-        response = self._get("/endpoints/my_endpoint", self._token())
+        response = self._get(f"/endpoints/{endpoint.id}", self._token())
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()


### PR DESCRIPTION
## Problem

Debugging a team's data-modeling state means hopping between psql, the Temporal UI and Grafana. There's no Django admin for saved queries, DAGs, nodes or jobs, and the customer-facing serializers hide operational fields like `engine` and `storage_delta_mib`.

This is the read-only backend for an internal ops app. The app lives in its own repo and runs in-cluster.

## Changes

Read-only routes under `api/internal/data_modeling_ops/`, a prefix Contour 403s at the edge:

| Route | Returns |
|---|---|
| `teams/<team_id>` | per-team counts plus `data-modeling-backend-v2` flag state |
| `saved_queries`, `saved_queries/<id>` | status, query, DAG lineage, duplicate backing tables, job-derived freshness |
| `saved_queries/<id>/jobs` | job history including `engine` and `storage_delta_mib` |
| `dags`, `dags/<id>` | nodes, edges, per-node last run |
| `endpoints`, `endpoints/<id>` | versions with staleness inputs |

The app reads across every team, so team is a `?team_id=` filter on lists, not a URL segment, and entities are fetched by their own id. A team-nested path would read as a tenancy boundary this API deliberately doesn't have: any verified operator may read any team. Entity ids are unique across teams, so the segment identified nothing the id didn't.

Auth is an OIDC ID token verified against the issuer JWKS: signature, `iss`, `aud`, `exp`, `email_verified`, and the issuer-controlled `hd` hosted-domain claim, matching the Django admin gate in `ee/middleware.py`. No shared secret, and `acting_user` is the verified email. The viewsets pin `get_authenticators`, because `TeamAndOrgViewSetMixin` otherwise appends session, PAT and OAuth authenticators after the custom one.

The endpoints viewset lives in `products/endpoints/` because tach forbids data_modeling importing endpoints. Everything is excluded from the public OpenAPI schema.

## How did you test this code?

80 automated tests. The ones carrying weight:

- token rejection table against an offline mocked JWKS: expired, wrong audience, wrong issuer, unverified email, wrong email domain, missing `hd`, mismatched `hd`. The no-bearer row runs on a session-logged-in client, so it also locks out session auth.
- `?team_id=` actually narrows: rows in two teams, unfiltered returns both, filtered returns one. Catches a list route ignoring the filter and leaking another team's rows into a team view.
- soft-deleted saved queries 404 on both detail and jobs.
- jobs expose `engine` and `storage_delta_mib`; detail surfaces unlinked duplicate backing tables; endpoint detail reports `last_successful_job_at` while `last_run_at` is null.

I also ran this branch against the local dev stack and probed every credential type. A non-staff personal API key and a real session cookie both return 200 on a normal route and 401 here. Route introspection confirms these viewsets bind only the OIDC authenticator, where a normal viewset binds five including OAuth, PAT and session.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/verifying-posthog-local`.

Two things changed shape during review. Auth began as a shared HS256 secret and became OIDC, so no secret is ever provisioned or rotated. Routes began team-nested under `api/projects/<team_id>/internal/...` and moved here once it was clear the segment wasn't an authorization boundary. That also collapses the API onto one edge rule instead of two: the team-nested Contour rule matches `\d+`, but the path converter accepted any string, so a non-numeric team id reached Django instead of being 403'd (OIDC still rejected it).
