### PR TITLE
chore(exports): de-flake subscription reschedule test on Fridays

### DIFF
--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -4,6 +4,7 @@ from typing import Optional
 from uuid import uuid4
 
 import pytest
+from freezegun import freeze_time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.core.cache import cache
@@ -353,17 +354,21 @@ class TestSubscriptionTemporal(APILicensedTest):
         # A schedule edit must not fire a delivery but MUST still reschedule — the model
         # save() recomputes next_delivery_date; this guards that the no-fire short-circuit
         # doesn't accidentally skip the reschedule.
-        sub_id = self._create_subscription(invite_message=None, frequency="weekly").json()["id"]
-        before = Subscription.objects.get(id=sub_id).next_delivery_date
-        self.mock_temporal_client.start_workflow.reset_mock()
+        # Freeze to a Monday so the weekly cadence (which recurs on the start_date's Saturday)
+        # lands strictly later than the daily one — otherwise on a Friday "tomorrow" and "next
+        # Saturday" coincide and the strict-inequality assertion flakes.
+        with freeze_time("2024-01-01T12:00:00Z"):
+            sub_id = self._create_subscription(invite_message=None, frequency="weekly").json()["id"]
+            before = Subscription.objects.get(id=sub_id).next_delivery_date
+            self.mock_temporal_client.start_workflow.reset_mock()
 
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
-            {"frequency": "daily"},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_not_called()
-        after = Subscription.objects.get(id=sub_id).next_delivery_date
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+                {"frequency": "daily"},
+            )
+            assert response.status_code == status.HTTP_200_OK, response.content
+            self.mock_temporal_client.start_workflow.assert_not_called()
+            after = Subscription.objects.get(id=sub_id).next_delivery_date
         # Daily cadence brings the next delivery strictly earlier than the weekly one.
         assert before is not None
         assert after is not None


### PR DESCRIPTION
## Problem

`test_schedule_only_update_still_recomputes_next_delivery_date` in `ee/api/test/test_subscription.py` fails every Friday. It has flaked on master eight times in the last 30 days, always on a Friday.

The test creates a weekly subscription, records its next delivery date, patches it to daily, and asserts the daily next-delivery is strictly earlier than the weekly one. The subscription's `start_date` is `2022-01-01`, which is a Saturday, so a weekly rrule with no explicit weekday recurs on Saturdays. On any Friday, the daily "tomorrow" and the weekly "next Saturday" resolve to the same instant, so the two dates are equal and `after < before` fails. The reported run was Fri 2026-07-03: both dates came out as `2026-07-04`.

## Changes

Wrap the create and patch in `freeze_time` pinned to a Monday (`2024-01-01T12:00:00Z`). Weekly then lands on Sat Jan 6 and daily on Tue Jan 2, a strict inequality that holds on every run. The test's intent is unchanged: a schedule-only edit must still reschedule without firing a delivery.

## How did you test this code?

I (Claude) could not run the full Django `TestCase` in this sandbox since it has no Postgres or ClickHouse running. The pass/fail is decided entirely by the rrule date math in `_compute_next_delivery_date`, which is independent of the DB, so I reproduced that math in isolation with `dateutil.rrule` + `freezegun`. It confirmed the exact reported failure (Fri 2026-07-03 → both dates `2026-07-04`), that the flake is isolated to Fridays across a full-week sweep, and that the frozen-Monday fix yields `after < before` on every day. `ruff check` and `ruff format --check` are clean on the file.

This change fixes determinism only; it does not add coverage. It catches the same regression the original test did (a schedule-only edit skipping the reschedule) but without the Friday-only false failure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georges-Antoine directed this from a flaky-test report. I (Claude, via Claude Code) diagnosed the root cause, confirmed the Saturday/Friday calendar alignment, and applied the fix. I invoked the `/writing-tests` skill before editing the test per repo policy; it pointed to `/fixing-flaky-tests` for a determinism-only change, which this is.

I considered picking a different `start_date` to dodge the collision, but rejected it: weekly always recurs on the start date's weekday, so for any static start date there is exactly one weekday where daily and weekly coincide. Freezing the clock is the only fix that holds on all calendar days. Freezing to a Monday was chosen over a bare non-Friday because it keeps a comfortable margin from the Saturday recurrence.
