### PR TITLE
feat(flags): block new legacy secret token creation

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -41,6 +41,7 @@ from posthog.api.team import (
     get_or_mint_live_events_token,
     handle_conversations_token_on_update,
     handle_logs_config,
+    validate_secret_token_generation,
     validate_team_attrs,
 )
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
@@ -1531,6 +1532,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     )
     def rotate_secret_token(self, request: request.Request, id: str, **kwargs) -> response.Response:
         project = self.get_object()
+        validate_secret_token_generation(project.passthrough_team, cast(User, request.user))
         project.passthrough_team.rotate_secret_token_and_save(
             user=request.user, is_impersonated_session=is_impersonated(request)
         )

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -12,6 +12,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field, extend_schema_view
 from opentelemetry import trace
@@ -274,6 +275,25 @@ def handle_evaluation_context_suggestions(request: request.Request, team: Team) 
             )
 
     return response.Response({"success": True, "name": context_name, "hidden_from_suggestions": hidden})
+
+
+def validate_secret_token_generation(team: Team, user: User) -> None:
+    """Rotating an existing legacy secret token stays allowed for safe migration, but minting a
+    first one is blocked once the team has access to project secret API keys."""
+    if team.secret_api_token or team.secret_api_token_backup:
+        return
+    if posthoganalytics.feature_enabled(
+        "project-secret-api-keys",
+        str(user.distinct_id),
+        groups={"organization": str(team.organization_id), "project": str(team.id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    ):
+        raise exceptions.ValidationError(
+            "The feature flags secure API key is deprecated. Create a project secret API key with the "
+            "feature_flag:read scope instead."
+        )
 
 
 def _format_serializer_errors(serializer_errors: dict) -> str:
@@ -1981,6 +2001,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     )
     def rotate_secret_token(self, request: request.Request, id: str, **kwargs) -> response.Response:
         team = self.get_object()
+        validate_secret_token_generation(team, cast(User, request.user))
         team.rotate_secret_token_and_save(user=request.user, is_impersonated_session=is_impersonated(request))
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data)
 

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -685,6 +685,39 @@ def team_api_test_factory():
                 ]
             )
 
+        @patch("posthog.api.team.posthoganalytics.feature_enabled", return_value=True)
+        def test_generate_first_secret_token_blocked_when_psak_enabled(self, _mock_flag):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+
+            self.team.secret_api_token = None
+            self.team.secret_api_token_backup = None
+            self.team.save()
+
+            response = self.client.patch(f"/api/environments/{self.team.id}/rotate_secret_token/")
+
+            self.team.refresh_from_db()
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn("project secret API key", response.json()["detail"])
+            self.assertIsNone(self.team.secret_api_token)
+
+        @patch("posthog.api.team.posthoganalytics.feature_enabled", return_value=True)
+        def test_rotate_existing_secret_token_allowed_when_psak_enabled(self, _mock_flag):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+
+            secret_api_token = "phs_JVRb8fNi0XyIKGgUCyi29ZJUOXEr6NF2dKBy5Ws8XVeF11C"
+            self.team.secret_api_token = secret_api_token
+            self.team.secret_api_token_backup = None
+            self.team.save()
+
+            response = self.client.patch(f"/api/environments/{self.team.id}/rotate_secret_token/")
+
+            self.team.refresh_from_db()
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertNotEqual(self.team.secret_api_token, secret_api_token)
+            self.assertEqual(self.team.secret_api_token_backup, secret_api_token)
+
         @freeze_time("2022-02-08")
         def test_delete_secret_backup_token(self):
             self.organization_membership.level = OrganizationMembership.Level.ADMIN


### PR DESCRIPTION
## Problem

The feature flags secure API key (`Team.secret_api_token`) is a plaintext credential being replaced by project secret API keys (PSAKs), tracked in #63111. #67215 hid the "Generate key" button for teams that never set one up, but that was UI-only. The `rotate_secret_token` endpoint would still mint a first legacy token for any team that called it directly, creating new deprecated credentials we'd later have to migrate away.

## Changes

- `PATCH /rotate_secret_token` (both the `/api/environments/` and `/api/projects/` paths) now rejects the request with a 400 when the team has no existing secret token and the `project-secret-api-keys` flag is enabled for it. The error points at creating a PSAK with the `feature_flag:read` scope instead.
- Rotation of an existing token is unchanged. Customers still need the active/backup overlap to swap credentials safely during the migration.
- Teams without PSAK access are unaffected, first-time generation keeps working for them. This matches the feature flag gating of the UI.

## How did you test this code?

Added two tests in `test_team.py`, which run against both URL paths via the shared test factory:

- Flag on + no existing token asserts the 400 and that no token was persisted. Catches the guard being removed or its condition inverted.
- Flag on + existing token asserts rotation still succeeds. Catches over-blocking, which would break the safe rotation path existing customers rely on.

The pre-existing `test_generate_secret_token` (flag off) covers that first-time generation still works for teams without PSAK access. All secret token tests pass locally on both paths.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed. The settings UI deprecation notice shipped in #67215, and the SDK docs updates are tracked in #66177.
