### PR TITLE
feat(tasks): channels, task channel ownership, and task threads

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -246,6 +246,8 @@ rules:
                               |TaskAutomation
                               |TaskPresence
                               |TaskRun
+                              |TaskThreadMessage
+                              |Channel
                               |EmailChannel
                               |EvaluationReport
                               |Text
@@ -515,6 +517,8 @@ rules:
                         |TaskAutomation
                         |TaskPresence
                         |TaskRun
+                        |TaskThreadMessage
+                        |Channel
                         |EmailChannel
                         |EvaluationReport
                         |Text

--- a/posthog/api/file_system/registrations.py
+++ b/posthog/api/file_system/registrations.py
@@ -286,21 +286,22 @@ def _action_post_restore(context: RestoreContext, action: Any) -> None:
     )
 
 
-def _ensure_task_visible_to_user(task: Any, user: Any | None) -> None:
-    # Mirror TaskViewSet.task_visibility_q: tasks belong to their creator (plus team-wide
-    # signal-pipeline tasks and legacy unowned tasks). Without this, anyone with file system
-    # write access could delete or restore another user's filed task via the generic flow.
+def _ensure_task_controllable_by_user(task: Any, user: Any | None) -> None:
+    # Mirror the tasks control rules (task_control_q): tasks belong to their creator (plus
+    # team-wide signal-pipeline tasks and legacy unowned tasks); public-channel read visibility
+    # does not grant mutation. Without this, anyone with file system write access could delete
+    # or restore another user's filed task via the generic flow.
     user_id = getattr(user, "id", None)
-    if not tasks_facade.is_task_visible_to_user(task.id, user_id):
+    if not tasks_facade.is_task_controllable_by_user(task.id, user_id):
         raise PermissionDenied("You do not have permission to modify this task.")
 
 
 def _task_pre_delete(context: DeletionContext, task: Any) -> None:
-    _ensure_task_visible_to_user(task, context.user)
+    _ensure_task_controllable_by_user(task, context.user)
 
 
 def _task_pre_restore(context: RestoreContext, task: Any) -> None:
-    _ensure_task_visible_to_user(task, context.user)
+    _ensure_task_controllable_by_user(task, context.user)
 
 
 def _task_post_delete(context: DeletionContext, task: Any) -> None:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3970,8 +3970,9 @@ def _channel_to_dto(channel: Channel) -> contracts.ChannelDTO:
 
 
 def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
+    # select_related so _channel_to_dto doesn't lazy-load created_by per call.
     try:
-        channel, _ = Channel.objects.get_or_create(
+        channel, _ = Channel.objects.select_related("created_by").get_or_create(
             team_id=team_id,
             created_by_id=user_id,
             channel_type=Channel.ChannelType.PERSONAL,
@@ -3979,7 +3980,7 @@ def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
             defaults={"name": Channel.PERSONAL_CHANNEL_NAME},
         )
     except IntegrityError:
-        channel = Channel.objects.get(
+        channel = Channel.objects.select_related("created_by").get(
             team_id=team_id,
             created_by_id=user_id,
             channel_type=Channel.ChannelType.PERSONAL,
@@ -4008,7 +4009,7 @@ def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contract
     if not normalized:
         return None
     try:
-        channel, _ = Channel.objects.get_or_create(
+        channel, _ = Channel.objects.select_related("created_by").get_or_create(
             team_id=team_id,
             name=normalized,
             channel_type=Channel.ChannelType.PUBLIC,
@@ -4016,7 +4017,7 @@ def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contract
             defaults={"created_by_id": user_id},
         )
     except IntegrityError:
-        channel = Channel.objects.get(
+        channel = Channel.objects.select_related("created_by").get(
             team_id=team_id, name=normalized, channel_type=Channel.ChannelType.PUBLIC, deleted=False
         )
     return _channel_to_dto(channel)
@@ -4090,7 +4091,8 @@ def create_thread_message(
     if _visible_task(task_id, team_id, user_id) is None:
         return None
     message = TaskThreadMessage.objects.create(team_id=team_id, task_id=task_id, author_id=user_id, content=content)
-    return _thread_message_to_dto(TaskThreadMessage.objects.select_related("author", "forwarded_by").get(pk=message.pk))
+    # Fresh message: forwarded_by is None (no query) and author lazy-loads once.
+    return _thread_message_to_dto(message)
 
 
 def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:
@@ -4129,7 +4131,7 @@ def forward_thread_message(
         return "no_run", None
 
     author = message.author
-    author_name = (f"{author.first_name} {author.last_name}".strip() or author.email) if author else "A teammate"
+    author_name = (author.get_full_name() or author.email) if author else "A teammate"
     content = f"[Thread comment from {author_name}] {message.content}"
     signal_result = signal_task_run_user_message(run.id, task.id, team_id, content=content, artifact_ids=[])
     if not signal_result:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -15,8 +15,8 @@ config-only importer never drags docker/temporalio onto the ``django.setup()`` p
 Functions that bridge to those heavy surfaces import them lazily inside the function body.
 """
 
-import logging
 import re
+import logging
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Literal
@@ -2531,10 +2531,13 @@ def signal_report_queryset():
 def channel_queryset():
     """Live ``Channel`` queryset for the task write serializer's channel FK field.
 
-    Kept here so presentation never imports tasks models directly; team scoping comes from
-    the serializer's team-scoped field, ownership of personal channels from ``validate_channel``.
+    Kept here so presentation never imports tasks models directly. Deliberately
+    ``unscoped()``: the serializer is also instantiated without team context (e.g.
+    drf-spectacular schema generation), where the fail-closed manager would raise.
+    Team scoping comes from the serializer's team-scoped field, ownership of
+    personal channels from ``validate_channel``.
     """
-    return Channel.objects.filter(deleted=False)
+    return Channel.objects.unscoped().filter(deleted=False)
 
 
 def is_internal_debug_team(team_id: int | None) -> bool:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -141,7 +141,7 @@ __all__ = [
     "get_task_run_stream_info",
     "get_task_summaries",
     "is_internal_debug_team",
-    "is_task_visible_to_user",
+    "is_task_controllable_by_user",
     "is_valid_sandbox_env_var_key",
     "latest_task_run_pr_url_subquery",
     "leave_task_presence",
@@ -455,13 +455,14 @@ def task_exists(task_id: str | UUID, team_id: int) -> bool:
     return Task.objects.filter(id=task_id, team_id=team_id).exists()
 
 
-def is_task_visible_to_user(task_id: str | UUID, user_id: int | None) -> bool:
-    """Whether the task is visible to the user under the task visibility rules.
+def is_task_controllable_by_user(task_id: str | UUID, user_id: int | None) -> bool:
+    """Whether the user may mutate the task under the task control rules.
 
     Tasks belong to their creator, plus team-wide signal-pipeline tasks and legacy unowned
-    tasks. Used by core's file-system flow to gate delete/restore on a filed task.
+    tasks. Used by core's file-system flow to gate delete/restore on a filed task; public-channel
+    read visibility deliberately does not qualify.
     """
-    return Task.objects.filter(task_visibility_q(user_id), pk=task_id).exists()
+    return Task.objects.filter(task_control_q(user_id), pk=task_id).exists()
 
 
 def get_sandbox_snapshot(snapshot_id: str | UUID) -> contracts.SandboxSnapshotDTO | None:
@@ -1248,8 +1249,9 @@ def _task_run_queryset():
     )
 
 
-def _get_task_for_run_visibility(task_id: str | UUID, team_id: int, user_id: int | None) -> Task | None:
-    return Task.objects.filter(id=task_id, team_id=team_id).filter(task_visibility_q(user_id)).first()
+def _get_task_for_run_control(task_id: str | UUID, team_id: int, user_id: int | None) -> Task | None:
+    """The task, only if the user may drive runs on it (``task_control_q``, not mere visibility)."""
+    return Task.objects.filter(id=task_id, team_id=team_id).filter(task_control_q(user_id)).first()
 
 
 def _get_visible_run(run_id: str | UUID, task_id: str | UUID, team_id: int) -> TaskRun | None:
@@ -2218,7 +2220,7 @@ def bootstrap_task_run(
         get_reasoning_effort_error,
     )
 
-    task = _get_task_for_run_visibility(task_id, team_id, user_id)
+    task = _get_task_for_run_control(task_id, team_id, user_id)
     if task is None:
         return None
 
@@ -4134,8 +4136,10 @@ def forward_thread_message(
     # Lock the message row so concurrent forwards of the same message can't
     # both pass the forwarded_to_agent_at check and double-signal the agent.
     with transaction.atomic():
+        # of=("self",) locks only the message row: FOR UPDATE cannot span the nullable
+        # outer joins that select_related on author/forwarded_by introduces.
         message = (
-            TaskThreadMessage.objects.select_for_update()
+            TaskThreadMessage.objects.select_for_update(of=("self",))
             .select_related("author", "forwarded_by")
             .filter(id=message_id, task_id=task_id, team_id=team_id)
             .first()

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -51,7 +51,7 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
 )
 from products.tasks.backend.prompts import WIZARD_PR_AGENT_PROMPT
-from products.tasks.backend.visibility import task_run_visibility_q, task_visibility_q
+from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
 from . import contracts
 
@@ -1258,17 +1258,24 @@ def _get_visible_run(run_id: str | UUID, task_id: str | UUID, team_id: int) -> T
 
 
 def task_accessible_for_run_view(
-    task_id: str | UUID, team_id: int, user_id: int | None, *, bypass_visibility: bool = False
+    task_id: str | UUID,
+    team_id: int,
+    user_id: int | None,
+    *,
+    bypass_visibility: bool = False,
+    for_control: bool = False,
 ) -> bool:
     """Whether the parent task exists and (unless bypassed) is visible to the user.
 
     Mirrors the parent-task gate in ``TaskRunViewSet.safely_get_queryset``: runs are always scoped
     to a task, and access to that task is gated by ``task_visibility_q`` except for internal-debug
-    read actions, which the caller signals via ``bypass_visibility``.
+    read actions, which the caller signals via ``bypass_visibility``. Run-mutating actions pass
+    ``for_control`` to use the narrower ``task_control_q`` — public-channel visibility lets
+    teammates watch a run, not drive it.
     """
     task_filter = Task.objects.filter(id=task_id, team_id=team_id)
     if not bypass_visibility:
-        task_filter = task_filter.filter(task_visibility_q(user_id))
+        task_filter = task_filter.filter(task_control_q(user_id) if for_control else task_visibility_q(user_id))
     return task_filter.exists()
 
 
@@ -2555,10 +2562,12 @@ def _task_detail_queryset():
     ).prefetch_related("runs")
 
 
-def _visible_task_qs(team_id: int, user_id: int | None, *, bypass_visibility: bool = False):
+def _visible_task_qs(team_id: int, user_id: int | None, *, bypass_visibility: bool = False, for_control: bool = False):
+    """Team-scoped live tasks, gated by read visibility — or by the narrower
+    control predicate when ``for_control`` (mutations, runs, agent commands)."""
     qs = Task.objects.filter(team_id=team_id, deleted=False)
     if not bypass_visibility:
-        qs = qs.filter(task_visibility_q(user_id))
+        qs = qs.filter(task_control_q(user_id) if for_control else task_visibility_q(user_id))
     return qs
 
 
@@ -2606,14 +2615,15 @@ def get_conversation_task_dtos(task_ids: Sequence[str | UUID], team_id: int) -> 
     return {task.id: _task_detail_to_dto(task, include_latest_run=False) for task in tasks}
 
 
-def task_visible(task_id: str | UUID, team_id: int, user_id: int | None) -> bool:
+def task_visible(task_id: str | UUID, team_id: int, user_id: int | None, *, for_control: bool = False) -> bool:
     """Whether a non-deleted task exists for the team and is visible to the user.
 
     Mirrors the existence gate ``TaskViewSet.get_object()`` applied (team + ``deleted=False`` +
     ``task_visibility_q``). Used by the ``run`` action to 404 before the usage gate, preserving
-    the original ordering.
+    the original ordering; the ``run`` action passes ``for_control`` since starting a run drives
+    the task.
     """
-    return _visible_task_qs(team_id, user_id).filter(id=task_id).exists()
+    return _visible_task_qs(team_id, user_id, for_control=for_control).filter(id=task_id).exists()
 
 
 async def select_repository_for_message(team_id: int, user_id: int, message: str, *, origin_product: str) -> str | None:
@@ -2918,8 +2928,8 @@ def set_task_title(task_id: str | UUID, team_id: int, title: str) -> bool:
 def update_task(
     task_id: str | UUID, team_id: int, user_id: int | None, *, validated_data: dict
 ) -> contracts.TaskDetailDTO | None:
-    """Update a task, mirroring ``TaskSerializer.update``. ``None`` if not found/visible."""
-    task = _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+    """Update a task, mirroring ``TaskSerializer.update``. ``None`` if not found/controllable."""
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
 
@@ -2944,8 +2954,8 @@ def update_task(
 
 
 def soft_delete_task(task_id: str | UUID, team_id: int, user_id: int | None) -> bool:
-    """Soft-delete a task. Returns whether a task was found/visible and deleted."""
-    task = _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+    """Soft-delete a task. Returns whether a task was found/controllable and deleted."""
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return False
     logger.info("Soft deleting task %s", task.id)
@@ -2975,7 +2985,8 @@ def prepare_task_staged_artifacts(
         get_safe_artifact_name,
     )
 
-    task = _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+    # Staged artifacts feed the task's next run, so this is control, not viewing.
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
 
@@ -3036,7 +3047,7 @@ def finalize_task_staged_artifacts(
         get_task_run_artifact_max_size_bytes,
     )
 
-    task = _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
 
@@ -3301,7 +3312,7 @@ def run_task(
         parse_run_state,
     )
 
-    task = _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+    task = _visible_task_qs(team_id, user_id, for_control=True).filter(id=task_id).first()
     if task is None:
         return None
 
@@ -4115,30 +4126,37 @@ def forward_thread_message(
     ``already_forwarded`` / ``no_run`` / ``signal_failed``.
     """
     task = _visible_task(task_id, team_id, user_id)
-    message = (
-        TaskThreadMessage.objects.select_related("author", "forwarded_by")
-        .filter(id=message_id, task_id=task_id, team_id=team_id)
-        .first()
-    )
-    if task is None or message is None:
+    if task is None:
         return "not_found", None
     if task.created_by_id != user_id:
         return "forbidden", None
-    if message.forwarded_to_agent_at is not None:
-        return "already_forwarded", _thread_message_to_dto(message)
-    run = task.latest_run
-    if run is None or run.status in (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED):
-        return "no_run", None
 
-    author = message.author
-    author_name = (author.get_full_name() or author.email) if author else "A teammate"
-    content = f"[Thread comment from {author_name}] {message.content}"
-    signal_result = signal_task_run_user_message(run.id, task.id, team_id, content=content, artifact_ids=[])
-    if not signal_result:
-        return "signal_failed", None
+    # Lock the message row so concurrent forwards of the same message can't
+    # both pass the forwarded_to_agent_at check and double-signal the agent.
+    with transaction.atomic():
+        message = (
+            TaskThreadMessage.objects.select_for_update()
+            .select_related("author", "forwarded_by")
+            .filter(id=message_id, task_id=task_id, team_id=team_id)
+            .first()
+        )
+        if message is None:
+            return "not_found", None
+        if message.forwarded_to_agent_at is not None:
+            return "already_forwarded", _thread_message_to_dto(message)
+        run = task.latest_run
+        if run is None or run.status in (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED):
+            return "no_run", None
 
-    message.forwarded_to_agent_at = django_timezone.now()
-    message.forwarded_by_id = user_id
-    message.forwarded_run = run
-    message.save(update_fields=["forwarded_to_agent_at", "forwarded_by", "forwarded_run"])
+        author = message.author
+        author_name = (author.get_full_name() or author.email) if author else "A teammate"
+        content = f"[Thread comment from {author_name}] {message.content}"
+        signal_result = signal_task_run_user_message(run.id, task.id, team_id, content=content, artifact_ids=[])
+        if not signal_result:
+            return "signal_failed", None
+
+        message.forwarded_to_agent_at = django_timezone.now()
+        message.forwarded_by_id = user_id
+        message.forwarded_run = run
+        message.save(update_fields=["forwarded_to_agent_at", "forwarded_by", "forwarded_run"])
     return "ok", _thread_message_to_dto(message)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -16,13 +16,14 @@ Functions that bridge to those heavy surfaces import them lazily inside the func
 """
 
 import logging
+import re
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import CharField, Count, Exists, F, Min, OuterRef, Q, QuerySet, Subquery
 from django.db.models.fields.json import KeyTextTransform
 from django.utils import timezone as django_timezone
@@ -37,6 +38,7 @@ from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIAB
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
 from products.tasks.backend.models import (
+    Channel,
     CodeInvite,
     CodeInviteRedemption,
     CodeWorkflowConfig,
@@ -46,6 +48,7 @@ from products.tasks.backend.models import (
     Task,
     TaskAutomation,
     TaskRun,
+    TaskThreadMessage,
 )
 from products.tasks.backend.prompts import WIZARD_PR_AGENT_PROMPT
 from products.tasks.backend.visibility import task_run_visibility_q, task_visibility_q
@@ -382,6 +385,7 @@ def _task_detail_to_dto(
         updated_at=task.updated_at,
         created_by=_user_basic_info(task.created_by if task.created_by_id else None),
         latest_run_id=latest_run_id,
+        channel=task.channel_id,
     )
 
 
@@ -2524,6 +2528,15 @@ def signal_report_queryset():
     return SignalReport.objects.all()
 
 
+def channel_queryset():
+    """Live ``Channel`` queryset for the task write serializer's channel FK field.
+
+    Kept here so presentation never imports tasks models directly; team scoping comes from
+    the serializer's team-scoped field, ownership of personal channels from ``validate_channel``.
+    """
+    return Channel.objects.filter(deleted=False)
+
+
 def is_internal_debug_team(team_id: int | None) -> bool:
     """Whether the team is the PostHog-internal debugging team. Mirrors the original view helper."""
     from django.conf import settings  # noqa: PLC0415
@@ -2647,6 +2660,10 @@ def _list_tasks_queryset(team_id: int, user_id: int | None, *, filters: dict) ->
 
     if created_by:
         qs = qs.filter(created_by_id=created_by)
+
+    channel = filters.get("channel")
+    if channel:
+        qs = qs.filter(channel_id=channel)
 
     if search:
         search_term = search.strip()
@@ -2832,6 +2849,10 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
                 warm_task.title = generate_task_title(message)
                 warm_task.title_manually_set = False
                 warm_task.save(update_fields=["title", "title_manually_set", "updated_at"])
+            channel = validated_data.get("channel")
+            if channel is not None and warm_task.channel_id != channel.id:
+                warm_task.channel = channel
+                warm_task.save(update_fields=["channel", "updated_at"])
             _activate_warm_run(warm_run, warm_task, team_id, message=message or None, artifact_ids=[])
             return _task_detail_to_dto(_task_detail_queryset().get(pk=warm_task.pk))
 
@@ -3921,3 +3942,198 @@ def send_cancel(run_id: str | UUID, *, auth_token: str | None = None):
 
     run = TaskRun.objects.select_related("task").get(id=run_id)
     return _send_cancel(run, auth_token=auth_token)
+
+
+# --- Channels & task threads ---
+
+
+def normalize_channel_name(name: str) -> str:
+    """Slack-style channel key: lowercase, whitespace collapsed to dashes.
+
+    Channels are resolved by name from client-side surfaces (folder names), so the
+    stored key must be canonical for the (team, name) uniqueness to mean anything.
+    """
+    return re.sub(r"\s+", "-", name.strip().lower())[:128]
+
+
+def _channel_to_dto(channel: Channel) -> contracts.ChannelDTO:
+    return contracts.ChannelDTO(
+        id=channel.id,
+        name=channel.name,
+        channel_type=channel.channel_type,
+        created_at=channel.created_at,
+        created_by=_user_basic_info(channel.created_by if channel.created_by_id else None),
+    )
+
+
+def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
+    try:
+        channel, _ = Channel.objects.get_or_create(
+            team_id=team_id,
+            created_by_id=user_id,
+            channel_type=Channel.ChannelType.PERSONAL,
+            deleted=False,
+            defaults={"name": Channel.PERSONAL_CHANNEL_NAME},
+        )
+    except IntegrityError:
+        channel = Channel.objects.get(
+            team_id=team_id,
+            created_by_id=user_id,
+            channel_type=Channel.ChannelType.PERSONAL,
+            deleted=False,
+        )
+    return channel
+
+
+def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDTO]:
+    """All live public channels plus the requester's personal channel (provisioned lazily),
+    personal first, then by name."""
+    channels: list[Channel] = []
+    if user_id is not None:
+        channels.append(_ensure_personal_channel(team_id, user_id))
+    channels.extend(
+        Channel.objects.filter(team_id=team_id, channel_type=Channel.ChannelType.PUBLIC, deleted=False)
+        .select_related("created_by")
+        .order_by("name")
+    )
+    return [_channel_to_dto(channel) for channel in channels]
+
+
+def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contracts.ChannelDTO | None:
+    """Resolve-or-create a public channel by (normalized) name. ``None`` for empty names."""
+    normalized = normalize_channel_name(name)
+    if not normalized:
+        return None
+    try:
+        channel, _ = Channel.objects.get_or_create(
+            team_id=team_id,
+            name=normalized,
+            channel_type=Channel.ChannelType.PUBLIC,
+            deleted=False,
+            defaults={"created_by_id": user_id},
+        )
+    except IntegrityError:
+        channel = Channel.objects.get(
+            team_id=team_id, name=normalized, channel_type=Channel.ChannelType.PUBLIC, deleted=False
+        )
+    return _channel_to_dto(channel)
+
+
+def rename_channel(channel_id: str | UUID, team_id: int, *, name: str) -> contracts.ChannelDTO | str:
+    """Rename a public channel. Returns the DTO, or an error kind: ``not_found`` /
+    ``invalid_name`` / ``personal`` / ``name_taken``."""
+    channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
+    if channel is None:
+        return "not_found"
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        return "personal"
+    normalized = normalize_channel_name(name)
+    if not normalized:
+        return "invalid_name"
+    channel.name = normalized
+    try:
+        channel.save(update_fields=["name", "updated_at"])
+    except IntegrityError:
+        return "name_taken"
+    return _channel_to_dto(channel)
+
+
+def delete_channel(channel_id: str | UUID, team_id: int) -> str:
+    """Soft-delete a public channel. Returns ``ok`` / ``not_found`` / ``personal``."""
+    channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
+    if channel is None:
+        return "not_found"
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        return "personal"
+    channel.deleted = True
+    channel.save(update_fields=["deleted", "updated_at"])
+    return "ok"
+
+
+def _thread_message_to_dto(message: TaskThreadMessage) -> contracts.TaskThreadMessageDTO:
+    return contracts.TaskThreadMessageDTO(
+        id=message.id,
+        task=message.task_id,
+        content=message.content,
+        created_at=message.created_at,
+        author=_user_basic_info(message.author if message.author_id else None),
+        forwarded_to_agent_at=message.forwarded_to_agent_at,
+        forwarded_by=_user_basic_info(message.forwarded_by if message.forwarded_by_id else None),
+    )
+
+
+def _visible_task(task_id: str | UUID, team_id: int, user_id: int | None) -> Task | None:
+    return _visible_task_qs(team_id, user_id).filter(id=task_id).first()
+
+
+def list_thread_messages(
+    task_id: str | UUID, team_id: int, user_id: int | None
+) -> list[contracts.TaskThreadMessageDTO] | None:
+    """A task's thread, ascending. ``None`` when the task isn't visible to the user."""
+    if _visible_task(task_id, team_id, user_id) is None:
+        return None
+    messages = (
+        TaskThreadMessage.objects.filter(task_id=task_id, team_id=team_id)
+        .select_related("author", "forwarded_by")
+        .order_by("created_at", "id")
+    )
+    return [_thread_message_to_dto(message) for message in messages]
+
+
+def create_thread_message(
+    task_id: str | UUID, team_id: int, user_id: int | None, *, content: str
+) -> contracts.TaskThreadMessageDTO | None:
+    """Add a thread message as the requester. ``None`` when the task isn't visible."""
+    if _visible_task(task_id, team_id, user_id) is None:
+        return None
+    message = TaskThreadMessage.objects.create(team_id=team_id, task_id=task_id, author_id=user_id, content=content)
+    return _thread_message_to_dto(TaskThreadMessage.objects.select_related("author", "forwarded_by").get(pk=message.pk))
+
+
+def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:
+    """Delete own thread message. Returns ``ok`` / ``not_found`` / ``forbidden``."""
+    message = TaskThreadMessage.objects.filter(id=message_id, task_id=task_id, team_id=team_id).first()
+    if message is None or _visible_task(task_id, team_id, user_id) is None:
+        return "not_found"
+    if message.author_id != user_id:
+        return "forbidden"
+    message.delete()
+    return "ok"
+
+
+def forward_thread_message(
+    message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None
+) -> tuple[str, contracts.TaskThreadMessageDTO | None]:
+    """Send a thread message to the task's agent. Task-author only.
+
+    Returns ``(kind, dto)`` where kind is ``ok`` / ``not_found`` / ``forbidden`` /
+    ``already_forwarded`` / ``no_run`` / ``signal_failed``.
+    """
+    task = _visible_task(task_id, team_id, user_id)
+    message = (
+        TaskThreadMessage.objects.select_related("author", "forwarded_by")
+        .filter(id=message_id, task_id=task_id, team_id=team_id)
+        .first()
+    )
+    if task is None or message is None:
+        return "not_found", None
+    if task.created_by_id != user_id:
+        return "forbidden", None
+    if message.forwarded_to_agent_at is not None:
+        return "already_forwarded", _thread_message_to_dto(message)
+    run = task.latest_run
+    if run is None or run.status in (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED):
+        return "no_run", None
+
+    author = message.author
+    author_name = (f"{author.first_name} {author.last_name}".strip() or author.email) if author else "A teammate"
+    content = f"[Thread comment from {author_name}] {message.content}"
+    signal_result = signal_task_run_user_message(run.id, task.id, team_id, content=content, artifact_ids=[])
+    if not signal_result:
+        return "signal_failed", None
+
+    message.forwarded_to_agent_at = django_timezone.now()
+    message.forwarded_by_id = user_id
+    message.forwarded_run = run
+    message.save(update_fields=["forwarded_to_agent_at", "forwarded_by", "forwarded_run"])
+    return "ok", _thread_message_to_dto(message)

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -118,6 +118,31 @@ class TaskDetailDTO:
     updated_at: datetime | None = None
     created_by: "TaskUserBasicInfo | None" = None
     latest_run_id: UUID | None = None
+    channel: UUID | None = None
+
+
+@dataclass(frozen=True)
+class ChannelDTO:
+    """The HTTP representation of a task channel."""
+
+    id: UUID
+    name: str
+    channel_type: str
+    created_at: datetime
+    created_by: "TaskUserBasicInfo | None" = None
+
+
+@dataclass(frozen=True)
+class TaskThreadMessageDTO:
+    """The HTTP representation of one message in a task's thread."""
+
+    id: UUID
+    task: UUID
+    content: str
+    created_at: datetime
+    author: "TaskUserBasicInfo | None" = None
+    forwarded_to_agent_at: datetime | None = None
+    forwarded_by: "TaskUserBasicInfo | None" = None
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
+++ b/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
@@ -36,6 +36,7 @@ class Migration(migrations.Migration):
                     "created_by",
                     models.ForeignKey(
                         blank=True,
+                        db_constraint=False,
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="+",
@@ -101,6 +102,7 @@ class Migration(migrations.Migration):
                     "author",
                     models.ForeignKey(
                         blank=True,
+                        db_constraint=False,
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="+",
@@ -111,6 +113,7 @@ class Migration(migrations.Migration):
                     "forwarded_by",
                     models.ForeignKey(
                         blank=True,
+                        db_constraint=False,
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="+",

--- a/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
+++ b/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
@@ -46,6 +46,7 @@ class Migration(migrations.Migration):
                 (
                     "team",
                     models.ForeignKey(
+                        db_constraint=False,
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="+",
                         to="posthog.team",
@@ -83,10 +84,6 @@ class Migration(migrations.Migration):
                 related_name="tasks",
                 to="tasks.channel",
             ),
-        ),
-        migrations.AddIndex(
-            model_name="task",
-            index=models.Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx"),
         ),
         migrations.CreateModel(
             name="TaskThreadMessage",
@@ -142,6 +139,7 @@ class Migration(migrations.Migration):
                 (
                     "team",
                     models.ForeignKey(
+                        db_constraint=False,
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="+",
                         to="posthog.team",

--- a/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
+++ b/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
@@ -1,0 +1,156 @@
+import uuid
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1166_oauth_impersonated_by"),
+        ("tasks", "0044_alter_task_origin_product"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Channel",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                ("name", models.CharField(max_length=128)),
+                (
+                    "channel_type",
+                    models.CharField(
+                        choices=[("public", "Public"), ("personal", "Personal")],
+                        default="public",
+                        max_length=16,
+                    ),
+                ),
+                ("deleted", models.BooleanField(default=False)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_channel",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="channel",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("channel_type", "public"), ("deleted", False)),
+                fields=("team", "name"),
+                name="task_channel_team_name_public_unique",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="channel",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("channel_type", "personal"), ("deleted", False)),
+                fields=("team", "created_by"),
+                name="task_channel_team_user_personal_unique",
+            ),
+        ),
+        migrations.AddField(
+            model_name="task",
+            name="channel",
+            field=models.ForeignKey(
+                blank=True,
+                db_index=False,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="tasks",
+                to="tasks.channel",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="task",
+            index=models.Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx"),
+        ),
+        migrations.CreateModel(
+            name="TaskThreadMessage",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                ("content", models.TextField()),
+                ("forwarded_to_agent_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "author",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "forwarded_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "forwarded_run",
+                    models.ForeignKey(
+                        blank=True,
+                        db_index=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="tasks.taskrun",
+                    ),
+                ),
+                (
+                    "task",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="thread_messages",
+                        to="tasks.task",
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_thread_message",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="taskthreadmessage",
+            index=models.Index(fields=["task", "created_at"], name="task_thread_msg_task_created"),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
+++ b/products/tasks/backend/migrations/0045_channel_task_channel_taskthreadmessage.py
@@ -1,7 +1,7 @@
 import uuid
 
-import django.db.models.deletion
 import django.utils.timezone
+import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 

--- a/products/tasks/backend/migrations/0046_task_channel_feed_index.py
+++ b/products/tasks/backend/migrations/0046_task_channel_feed_index.py
@@ -1,0 +1,17 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for AddIndexConcurrently
+
+    dependencies = [
+        ("tasks", "0045_channel_task_channel_taskthreadmessage"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="task",
+            index=models.Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx"),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0046_task_channel_feed_index.py
+++ b/products/tasks/backend/migrations/0046_task_channel_feed_index.py
@@ -1,16 +1,17 @@
-from django.contrib.postgres.operations import AddIndexConcurrently
 from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
 
 
 class Migration(migrations.Migration):
-    atomic = False  # Required for AddIndexConcurrently
+    atomic = False  # Required for concurrent index creation
 
     dependencies = [
         ("tasks", "0045_channel_task_channel_taskthreadmessage"),
     ]
 
     operations = [
-        AddIndexConcurrently(
+        SafeAddIndexConcurrently(
             model_name="task",
             index=models.Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx"),
         ),

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0044_alter_task_origin_product
+0045_channel_task_channel_taskthreadmessage

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0045_channel_task_channel_taskthreadmessage
+0046_task_channel_feed_index

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -56,6 +56,46 @@ def resolve_schema(schema: type[BaseModel] | dict) -> dict:
     return schema.model_json_schema()
 
 
+class Channel(models.Model):
+    """A shared feed of tasks (rendered as "#<name>" in PostHog Code). Every task is
+    owned by the channel it was kicked off in. Each user gets one private "personal"
+    channel ("#me") per team, provisioned lazily on first channel list."""
+
+    class ChannelType(models.TextChoices):
+        PUBLIC = "public", "Public"
+        PERSONAL = "personal", "Personal"
+
+    PERSONAL_CHANNEL_NAME = "me"
+
+    # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    name = models.CharField(max_length=128)
+    channel_type = models.CharField(max_length=16, choices=ChannelType, default=ChannelType.PUBLIC)
+    created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    deleted = models.BooleanField(default=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "posthog_task_channel"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team", "name"],
+                condition=models.Q(channel_type="public", deleted=False),
+                name="task_channel_team_name_public_unique",
+            ),
+            models.UniqueConstraint(
+                fields=["team", "created_by"],
+                condition=models.Q(channel_type="personal", deleted=False),
+                name="task_channel_team_user_personal_unique",
+            ),
+        ]
+
+    def __str__(self):
+        return f"#{self.name}"
+
+
 class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
     class OriginProduct(models.TextChoices):
         ONBOARDING = "onboarding", "Onboarding"
@@ -115,6 +155,17 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         max_length=255, null=True, blank=True
     )  # Format is organization/repo, for example posthog/posthog-js
 
+    # Channel this task was kicked off in. Legacy tasks (and tasks from non-channel
+    # surfaces) stay NULL. SET_NULL so deleting a channel never deletes its tasks.
+    channel = models.ForeignKey(
+        "tasks.Channel",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="tasks",
+        db_index=False,
+    )
+
     # DEPRECATED - do not use
     signal_report = models.ForeignKey(
         "signals.SignalReport",
@@ -162,6 +213,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             models.Index(fields=["archived"], name="posthog_task_archived_idx"),
             models.Index(fields=["team", "-created_at", "-id"], name="posthog_task_team_created_idx"),
             models.Index(fields=["team", "created_by", "-created_at", "-id"], name="posthog_task_team_creator_idx"),
+            models.Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx"),
         ]
 
     def __str__(self):
@@ -659,6 +711,32 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             transaction.on_commit(_dispatch)
 
         return task
+
+
+class TaskThreadMessage(models.Model):
+    """One human message in a task's thread — the side conversation channel members
+    have around a task. Messages never reach the agent unless the task author
+    forwards one (send_to_agent), which stamps the forwarded_* fields."""
+
+    # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name="thread_messages")
+    author = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    content = models.TextField()
+    forwarded_to_agent_at = models.DateTimeField(null=True, blank=True)
+    forwarded_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    forwarded_run = models.ForeignKey(
+        "tasks.TaskRun", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_index=False
+    )
+    created_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_thread_message"
+        indexes = [models.Index(fields=["task", "created_at"], name="task_thread_msg_task_created")]
+
+    def __str__(self):
+        return f"Thread message {self.id} on task {self.task_id}"
 
 
 class TaskAutomationManager(models.Manager):

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -69,12 +69,13 @@ class Channel(TeamScopedRootMixin):
 
     # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    # db_constraint=False on the team/user FKs: posthog_team and posthog_user are written on
+    # virtually every request, and adding an FK constraint takes a SHARE ROW EXCLUSIVE lock on
+    # them that stalls deploys. Django still enforces the relation and on_delete at the app
+    # level (see safe-django-migrations.md).
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+", db_constraint=False)
     name = models.CharField(max_length=128)
     channel_type = models.CharField(max_length=16, choices=ChannelType, default=ChannelType.PUBLIC)
-    # db_constraint=False: posthog_user is written on virtually every request, and adding an FK
-    # constraint takes a SHARE ROW EXCLUSIVE lock on it that stalls deploys. SET_NULL is enforced
-    # by Django regardless, so we skip the DB-level constraint (see safe-django-migrations.md).
     created_by = models.ForeignKey(
         "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
     )
@@ -725,10 +726,11 @@ class TaskThreadMessage(TeamScopedRootMixin):
 
     # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    # db_constraint=False on the team/user FKs: adding an FK constraint to those hot tables
+    # locks them and stalls deploys; Django still enforces the relation and on_delete at the
+    # app level (see safe-django-migrations.md).
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+", db_constraint=False)
     task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name="thread_messages")
-    # db_constraint=False on the user FKs: adding an FK constraint to the hot posthog_user table
-    # locks it and stalls deploys; Django still enforces SET_NULL (see safe-django-migrations.md).
     author = models.ForeignKey(
         "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
     )

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -56,7 +56,7 @@ def resolve_schema(schema: type[BaseModel] | dict) -> dict:
     return schema.model_json_schema()
 
 
-class Channel(models.Model):
+class Channel(TeamScopedRootMixin):
     """A shared feed of tasks (rendered as "#<name>" in PostHog Code). Every task is
     owned by the channel it was kicked off in. Each user gets one private "personal"
     channel ("#me") per team, provisioned lazily on first channel list."""
@@ -713,7 +713,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         return task
 
 
-class TaskThreadMessage(models.Model):
+class TaskThreadMessage(TeamScopedRootMixin):
     """One human message in a task's thread — the side conversation channel members
     have around a task. Messages never reach the agent unless the task author
     forwards one (send_to_agent), which stamps the forwarded_* fields."""

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -72,7 +72,12 @@ class Channel(TeamScopedRootMixin):
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
     name = models.CharField(max_length=128)
     channel_type = models.CharField(max_length=16, choices=ChannelType, default=ChannelType.PUBLIC)
-    created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    # db_constraint=False: posthog_user is written on virtually every request, and adding an FK
+    # constraint takes a SHARE ROW EXCLUSIVE lock on it that stalls deploys. SET_NULL is enforced
+    # by Django regardless, so we skip the DB-level constraint (see safe-django-migrations.md).
+    created_by = models.ForeignKey(
+        "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
+    )
     deleted = models.BooleanField(default=False)
     created_at = models.DateTimeField(default=django_timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
@@ -722,10 +727,16 @@ class TaskThreadMessage(TeamScopedRootMixin):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
     task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name="thread_messages")
-    author = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    # db_constraint=False on the user FKs: adding an FK constraint to the hot posthog_user table
+    # locks it and stalls deploys; Django still enforces SET_NULL (see safe-django-migrations.md).
+    author = models.ForeignKey(
+        "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
+    )
     content = models.TextField()
     forwarded_to_agent_at = models.DateTimeField(null=True, blank=True)
-    forwarded_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    forwarded_by = models.ForeignKey(
+        "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
+    )
     forwarded_run = models.ForeignKey(
         "tasks.TaskRun", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_index=False
     )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -17,11 +17,13 @@ from posthog.models.user_integration import UserIntegration
 
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.contracts import (
+    ChannelDTO,
     SandboxEnvironmentDTO,
     TaskAutomationDTO,
     TaskDetailDTO,
     TaskRunDetailDTO,
     TaskSummaryDTO,
+    TaskThreadMessageDTO,
     TaskUserBasicInfo,
 )
 from products.tasks.backend.facade.run_config import (
@@ -333,6 +335,7 @@ class TaskSerializer(DataclassSerializer):
             "updated_at",
             "created_by",
             "ci_prompt",
+            "channel",
         ]
 
 
@@ -463,6 +466,12 @@ class TaskWriteSerializer(serializers.Serializer):
         write_only=True,
         help_text="Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.",
     )
+    channel = TeamScopedPrimaryKeyRelatedField(  # nosemgrep: unscoped-primary-key-related-field
+        queryset=Integration.objects.none(),
+        required=False,
+        allow_null=True,
+        help_text="Channel this task is owned by (the channel it was kicked off in).",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -471,6 +480,16 @@ class TaskWriteSerializer(serializers.Serializer):
         cast(
             serializers.PrimaryKeyRelatedField, self.fields["signal_report"]
         ).queryset = tasks_facade.signal_report_queryset()
+        # Channel queryset comes from the facade so presentation stays off tasks models.
+        cast(serializers.PrimaryKeyRelatedField, self.fields["channel"]).queryset = tasks_facade.channel_queryset()
+
+    def validate_channel(self, value):
+        """Personal channels are private: only their owner may file tasks into them."""
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        if value is not None and value.channel_type == "personal" and value.created_by_id != getattr(user, "id", None):
+            raise serializers.ValidationError("Personal channels can only be used by their owner")
+        return value
 
     def validate_github_integration(self, value):
         """Validate that the GitHub integration belongs to the same team"""
@@ -988,6 +1007,42 @@ class TaskListQuerySerializer(serializers.Serializer):
             "archived tasks, 'false' for the default, or 'all' to include both."
         ),
     )
+    channel = serializers.UUIDField(required=False, help_text="Filter tasks to a channel's feed.")
+
+
+class ChannelSerializer(DataclassSerializer):
+    """Response shape for a task channel, read from a frozen ``ChannelDTO``."""
+
+    created_by = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+
+    class Meta:
+        dataclass = ChannelDTO
+        fields = ["id", "name", "channel_type", "created_at", "created_by"]
+
+
+class ChannelWriteSerializer(serializers.Serializer):
+    """Request body for creating (resolve-or-create) or renaming a public channel."""
+
+    name = serializers.CharField(
+        max_length=128, help_text="Channel name, rendered as #<name>. Normalized to lowercase-dashed."
+    )
+
+
+class TaskThreadMessageSerializer(DataclassSerializer):
+    """Response shape for one message in a task's thread."""
+
+    author = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+    forwarded_by = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+
+    class Meta:
+        dataclass = TaskThreadMessageDTO
+        fields = ["id", "task", "content", "created_at", "author", "forwarded_to_agent_at", "forwarded_by"]
+
+
+class TaskThreadMessageWriteSerializer(serializers.Serializer):
+    """Request body for posting a thread message."""
+
+    content = serializers.CharField(help_text="Message text.")
 
 
 class TaskRepositoriesResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -224,6 +224,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         filters = {key: request.query_params.get(key) for key in request.query_params}
         filters["internal"] = getattr(request, "validated_query_data", {}).get("internal")
         filters["archived"] = getattr(request, "validated_query_data", {}).get("archived")
+        filters["channel"] = getattr(request, "validated_query_data", {}).get("channel")
         tasks = tasks_facade._list_tasks_queryset(self.team_id, self._user_id(), filters=filters)
         page = self.paginate_queryset(tasks)
         assert page is not None, "TaskViewSet list requires an active paginator"

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -517,7 +517,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["post"], url_path="run", required_scopes=["task:write"])
     def run(self, request, pk=None, **kwargs):
         # Original order: 404 if the task isn't visible, then gate (always cloud) before the run.
-        if not tasks_facade.task_visible(pk, self.team_id, self._user_id()):
+        if not tasks_facade.task_visible(pk, self.team_id, self._user_id(), for_control=True):
             raise NotFound()
 
         if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
@@ -755,20 +755,40 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _user_id(self) -> int | None:
         return getattr(self.request.user, "id", None)
 
+    # Actions that only read run state. Everything else mutates or drives the
+    # run, so it requires task control (not just visibility): public-channel
+    # visibility lets teammates watch a run, never command it. connection_token
+    # is a GET but mints a write-capable token, so it is deliberately absent.
+    _READ_ONLY_ACTIONS = (
+        "list",
+        "retrieve",
+        "logs",
+        "session_logs",
+        "stream",
+        "stream_token",
+        "artifacts_presign",
+        "artifacts_download",
+    )
+
     def _ensure_task_accessible(self) -> str:
         """Gate access to the parent task, mirroring the old ``safely_get_queryset``.
 
         ``?ph_debug=true`` lets internal-debug teams read other members' runs through read-only
-        actions; connection_token is a GET but mints a write-capable token, so it stays gated.
+        actions.
         """
         task_id = self._task_id()
+        is_read_only = self.action in self._READ_ONLY_ACTIONS
         is_internal_debug_read = (
             _is_internal_debug_team(self.team_id)
             and self.action in ("list", "retrieve", "logs", "session_logs", "stream", "stream_token")
             and self.request.query_params.get("ph_debug") == "true"
         )
         if not tasks_facade.task_accessible_for_run_view(
-            task_id, self.team_id, self._user_id(), bypass_visibility=is_internal_debug_read
+            task_id,
+            self.team_id,
+            self._user_id(),
+            bypass_visibility=is_internal_debug_read,
+            for_control=not is_read_only,
         ):
             raise NotFound("Task not found")
         return task_id

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -1,4 +1,3 @@
-import logging
 from uuid import UUID
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -20,8 +19,6 @@ from products.tasks.backend.presentation.serializers import (
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -1,0 +1,187 @@
+import logging
+from uuid import UUID
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.permissions import APIScopePermission
+
+from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.presentation.serializers import (
+    ChannelSerializer,
+    ChannelWriteSerializer,
+    TaskThreadMessageSerializer,
+    TaskThreadMessageWriteSerializer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    API for task channels — the shared feeds tasks are kicked off in. Listing lazily
+    provisions the requester's personal "#me" channel; creation is resolve-or-create
+    by normalized name so clients can map channel-like surfaces onto backend channels.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    serializer_class = ChannelSerializer
+
+    def _user_id(self) -> int | None:
+        return getattr(self.request.user, "id", None)
+
+    @extend_schema(
+        responses={200: OpenApiResponse(response=ChannelSerializer(many=True), description="List of channels")},
+        summary="List channels",
+        description="All live public channels plus the requester's personal #me channel (created on first list).",
+    )
+    def list(self, request, *args, **kwargs):
+        channels = tasks_facade.list_channels(self.team_id, self._user_id())
+        return Response(ChannelSerializer(channels, many=True).data)
+
+    @extend_schema(
+        request=ChannelWriteSerializer,
+        responses={200: ChannelSerializer},
+        summary="Resolve or create a public channel",
+        description="Returns the existing public channel with the (normalized) name, creating it if needed.",
+    )
+    def create(self, request, **kwargs):
+        serializer = ChannelWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        channel = tasks_facade.resolve_channel(self.team_id, self._user_id(), name=serializer.validated_data["name"])
+        if channel is None:
+            return Response({"detail": "Invalid channel name"}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(ChannelSerializer(channel).data)
+
+    @extend_schema(
+        request=ChannelWriteSerializer,
+        responses={200: ChannelSerializer},
+        summary="Rename a public channel",
+    )
+    def partial_update(self, request, pk=None, **kwargs):
+        serializer = ChannelWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        result = tasks_facade.rename_channel(pk, self.team_id, name=serializer.validated_data["name"])
+        if result == "not_found":
+            raise NotFound()
+        if result == "personal":
+            raise PermissionDenied("Personal channels cannot be renamed")
+        if result == "invalid_name":
+            return Response({"detail": "Invalid channel name"}, status=status.HTTP_400_BAD_REQUEST)
+        if result == "name_taken":
+            return Response({"detail": "A channel with this name already exists"}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(ChannelSerializer(result).data)
+
+    @extend_schema(responses={204: None}, summary="Delete a public channel")
+    def destroy(self, request, pk=None, **kwargs):
+        result = tasks_facade.delete_channel(pk, self.team_id)
+        if result == "not_found":
+            raise NotFound()
+        if result == "personal":
+            raise PermissionDenied("Personal channels cannot be deleted")
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class TaskThreadMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    API for a task's thread — the human-only side conversation around a task. Messages
+    reach the agent only via the explicit send_to_agent action, gated to the task author.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    http_method_names = ["get", "post", "delete", "head", "options"]
+    serializer_class = TaskThreadMessageSerializer
+
+    def _task_id(self) -> str:
+        task_id = self.kwargs.get("parent_lookup_task_id")
+        if not task_id:
+            raise NotFound("Task ID is required")
+        try:
+            UUID(task_id)
+        except (ValueError, TypeError):
+            raise NotFound("Task not found")
+        return task_id
+
+    def _user_id(self) -> int | None:
+        return getattr(self.request.user, "id", None)
+
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(response=TaskThreadMessageSerializer(many=True), description="Thread messages")
+        },
+        summary="List thread messages",
+        description="The task's thread in chronological order.",
+    )
+    def list(self, request, *args, **kwargs):
+        messages = tasks_facade.list_thread_messages(self._task_id(), self.team_id, self._user_id())
+        if messages is None:
+            raise NotFound("Task not found")
+        return Response(TaskThreadMessageSerializer(messages, many=True).data)
+
+    @extend_schema(
+        request=TaskThreadMessageWriteSerializer,
+        responses={201: TaskThreadMessageSerializer},
+        summary="Post a thread message",
+    )
+    def create(self, request, **kwargs):
+        serializer = TaskThreadMessageWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        message = tasks_facade.create_thread_message(
+            self._task_id(), self.team_id, self._user_id(), content=serializer.validated_data["content"]
+        )
+        if message is None:
+            raise NotFound("Task not found")
+        return Response(TaskThreadMessageSerializer(message).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(responses={204: None}, summary="Delete own thread message")
+    def destroy(self, request, pk=None, **kwargs):
+        result = tasks_facade.delete_thread_message(pk, self._task_id(), self.team_id, self._user_id())
+        if result == "not_found":
+            raise NotFound()
+        if result == "forbidden":
+            raise PermissionDenied("Only the author can delete a thread message")
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        responses={
+            200: TaskThreadMessageSerializer,
+            400: OpenApiResponse(description="No signalable run, or message already forwarded"),
+        },
+        summary="Send a thread message to the agent",
+        description="Task author only: forwards the message into the task's latest live run.",
+    )
+    @action(detail=True, methods=["post"], url_path="send_to_agent", required_scopes=["task:write"])
+    def send_to_agent(self, request, pk=None, **kwargs):
+        kind, message = tasks_facade.forward_thread_message(pk, self._task_id(), self.team_id, self._user_id())
+        if kind == "not_found":
+            raise NotFound()
+        if kind == "forbidden":
+            raise PermissionDenied("Only the task author can send thread messages to the agent")
+        if kind == "already_forwarded":
+            return Response({"detail": "Message was already sent to the agent"}, status=status.HTTP_400_BAD_REQUEST)
+        if kind == "no_run":
+            return Response(
+                {"detail": "Task has no active run to receive the message"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        if kind == "signal_failed":
+            return Response({"detail": "Failed to queue message for the agent"}, status=status.HTTP_502_BAD_GATEWAY)
+        return Response(TaskThreadMessageSerializer(message).data)

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -2,12 +2,17 @@ from posthog.api.routing import RouterRegistry
 
 import products.tasks.backend.presentation.views.api as tasks
 import products.tasks.backend.presentation.views.seat_api as seats
+import products.tasks.backend.presentation.views.channels_api as channels
 import products.tasks.backend.presentation.views.code_home_api as code_home
 
 
 def register_routes(routers: RouterRegistry) -> None:
     project_tasks_router = routers.projects.register(r"tasks", tasks.TaskViewSet, "project_tasks", ["team_id"])
     project_tasks_router.register(r"runs", tasks.TaskRunViewSet, "project_task_runs", ["team_id", "task_id"])
+    project_tasks_router.register(
+        r"thread_messages", channels.TaskThreadMessageViewSet, "project_task_thread_messages", ["team_id", "task_id"]
+    )
+    routers.projects.register(r"task_channels", channels.ChannelViewSet, "project_task_channels", ["team_id"])
     routers.projects.register(r"task_automations", tasks.TaskAutomationViewSet, "project_task_automations", ["team_id"])
     routers.projects.register(
         r"sandbox_environments", tasks.SandboxEnvironmentViewSet, "project_sandbox_environments", ["team_id"]

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -1,0 +1,202 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from posthog.models import Organization, OrganizationMembership, Team, User
+
+from products.tasks.backend.models import Channel, Task, TaskRun, TaskThreadMessage
+
+
+class ChannelsAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Growth Team")
+        self.user = User.objects.create_user(email="author@example.com", first_name="Ann", password="password")
+        self.other_user = User.objects.create_user(email="peer@example.com", first_name="Bob", password="password")
+        for user in (self.user, self.other_user):
+            self.organization.members.add(user)
+            OrganizationMembership.objects.filter(user=user, organization=self.organization).update(
+                level=OrganizationMembership.Level.ADMIN
+            )
+
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def _channels_url(self) -> str:
+        return f"/api/projects/{self.team.id}/task_channels/"
+
+    def _tasks_url(self) -> str:
+        return f"/api/projects/{self.team.id}/tasks/"
+
+    def _thread_url(self, task_id) -> str:
+        return f"/api/projects/{self.team.id}/tasks/{task_id}/thread_messages/"
+
+    def test_list_provisions_personal_channel(self):
+        response = self.client.get(self._channels_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        personal = [c for c in response.json() if c["channel_type"] == "personal"]
+        self.assertEqual(len(personal), 1)
+        self.assertEqual(personal[0]["name"], "me")
+        self.assertEqual(personal[0]["created_by"]["id"], self.user.id)
+
+        # Listing again reuses the same personal channel
+        again = self.client.get(self._channels_url()).json()
+        self.assertEqual(
+            [c["id"] for c in again if c["channel_type"] == "personal"],
+            [personal[0]["id"]],
+        )
+
+    def test_personal_channels_are_per_user(self):
+        mine = self.client.get(self._channels_url()).json()
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        theirs = other_client.get(self._channels_url()).json()
+
+        my_personal = [c["id"] for c in mine if c["channel_type"] == "personal"]
+        their_personal = [c["id"] for c in theirs if c["channel_type"] == "personal"]
+        self.assertNotEqual(my_personal, their_personal)
+        self.assertNotIn(my_personal[0], [c["id"] for c in theirs])
+
+    def test_resolve_or_create_public_channel(self):
+        first = self.client.post(self._channels_url(), {"name": "Growth Ideas"})
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(first.json()["name"], "growth-ideas")
+        second = self.client.post(self._channels_url(), {"name": "growth ideas"})
+        self.assertEqual(second.json()["id"], first.json()["id"])
+
+    def test_personal_channel_cannot_be_renamed_or_deleted(self):
+        self.client.get(self._channels_url())
+        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        rename = self.client.patch(f"{self._channels_url()}{personal.id}/", {"name": "not-me"})
+        self.assertEqual(rename.status_code, status.HTTP_403_FORBIDDEN)
+        delete = self.client.delete(f"{self._channels_url()}{personal.id}/")
+        self.assertEqual(delete.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_task_created_in_public_channel_is_team_visible(self):
+        channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        created = self.client.post(
+            self._tasks_url(),
+            {"title": "Ship it", "description": "Do the thing", "channel": channel_id},
+        )
+        self.assertEqual(created.status_code, status.HTTP_201_CREATED, created.content)
+        self.assertEqual(created.json()["channel"], channel_id)
+
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        listed = other_client.get(self._tasks_url(), {"channel": channel_id}).json()["results"]
+        self.assertEqual([t["id"] for t in listed], [created.json()["id"]])
+
+    def test_task_in_personal_channel_stays_private(self):
+        self.client.get(self._channels_url())
+        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        created = self.client.post(
+            self._tasks_url(),
+            {"title": "Secret", "description": "mine", "channel": str(personal.id)},
+        )
+        self.assertEqual(created.status_code, status.HTTP_201_CREATED, created.content)
+
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        listed = other_client.get(self._tasks_url(), {"channel": str(personal.id)}).json()["results"]
+        self.assertEqual(listed, [])
+
+    def test_cannot_file_task_into_someone_elses_personal_channel(self):
+        self.client.get(self._channels_url())
+        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        response = other_client.post(
+            self._tasks_url(),
+            {"title": "Sneaky", "description": "nope", "channel": str(personal.id)},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class ThreadMessagesAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Growth Team")
+        self.author = User.objects.create_user(email="author@example.com", first_name="Ann", password="password")
+        self.peer = User.objects.create_user(email="peer@example.com", first_name="Bob", password="password")
+        for user in (self.author, self.peer):
+            self.organization.members.add(user)
+            OrganizationMembership.objects.filter(user=user, organization=self.organization).update(
+                level=OrganizationMembership.Level.ADMIN
+            )
+
+        self.channel = Channel.objects.create(team=self.team, name="growth", created_by=self.author)
+        self.task = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="A Task",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+        self.author_client = APIClient()
+        self.author_client.force_authenticate(self.author)
+        self.peer_client = APIClient()
+        self.peer_client.force_authenticate(self.peer)
+
+    def _thread_url(self) -> str:
+        return f"/api/projects/{self.team.id}/tasks/{self.task.id}/thread_messages/"
+
+    def test_post_and_list_thread_messages(self):
+        posted = self.peer_client.post(self._thread_url(), {"content": "What about mobile?"})
+        self.assertEqual(posted.status_code, status.HTTP_201_CREATED, posted.content)
+        self.assertEqual(posted.json()["author"]["id"], self.peer.id)
+        self.assertIsNone(posted.json()["forwarded_to_agent_at"])
+
+        listed = self.author_client.get(self._thread_url()).json()
+        self.assertEqual([m["content"] for m in listed], ["What about mobile?"])
+
+    def test_delete_is_author_only(self):
+        message_id = self.peer_client.post(self._thread_url(), {"content": "mine"}).json()["id"]
+        forbidden = self.author_client.delete(f"{self._thread_url()}{message_id}/")
+        self.assertEqual(forbidden.status_code, status.HTTP_403_FORBIDDEN)
+        allowed = self.peer_client.delete(f"{self._thread_url()}{message_id}/")
+        self.assertEqual(allowed.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_send_to_agent_is_task_author_only(self):
+        message_id = self.peer_client.post(self._thread_url(), {"content": "try X"}).json()["id"]
+        response = self.peer_client.post(f"{self._thread_url()}{message_id}/send_to_agent/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_send_to_agent_requires_live_run(self):
+        message_id = self.peer_client.post(self._thread_url(), {"content": "try X"}).json()["id"]
+        response = self.author_client.post(f"{self._thread_url()}{message_id}/send_to_agent/")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_send_to_agent_forwards_and_stamps(self):
+        run = TaskRun.objects.create(task=self.task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+        message_id = self.peer_client.post(self._thread_url(), {"content": "try X"}).json()["id"]
+
+        with patch("products.tasks.backend.facade.api.signal_task_run_user_message", return_value=True) as signal:
+            response = self.author_client.post(f"{self._thread_url()}{message_id}/send_to_agent/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertIsNotNone(response.json()["forwarded_to_agent_at"])
+        self.assertEqual(response.json()["forwarded_by"]["id"], self.author.id)
+        signal.assert_called_once()
+        self.assertIn("Bob", signal.call_args.kwargs["content"])
+        self.assertIn("try X", signal.call_args.kwargs["content"])
+        self.assertEqual(TaskThreadMessage.objects.get(id=message_id).forwarded_run_id, run.id)
+
+        again = self.author_client.post(f"{self._thread_url()}{message_id}/send_to_agent/")
+        self.assertEqual(again.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_thread_hidden_when_task_not_visible(self):
+        private_task = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            title="Private",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        url = f"/api/projects/{self.team.id}/tasks/{private_task.id}/thread_messages/"
+        response = self.peer_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -69,7 +69,9 @@ class ChannelsAPITestCase(TestCase):
 
     def test_personal_channel_cannot_be_renamed_or_deleted(self):
         self.client.get(self._channels_url())
-        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        # Direct ORM reads in tests bypass the DRF-set team context, so opt out
+        # of the fail-closed scoping explicitly (see test_presence.py).
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
         rename = self.client.patch(f"{self._channels_url()}{personal.id}/", {"name": "not-me"})
         self.assertEqual(rename.status_code, status.HTTP_403_FORBIDDEN)
         delete = self.client.delete(f"{self._channels_url()}{personal.id}/")
@@ -91,7 +93,7 @@ class ChannelsAPITestCase(TestCase):
 
     def test_task_in_personal_channel_stays_private(self):
         self.client.get(self._channels_url())
-        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
         created = self.client.post(
             self._tasks_url(),
             {"title": "Secret", "description": "mine", "channel": str(personal.id)},
@@ -105,7 +107,7 @@ class ChannelsAPITestCase(TestCase):
 
     def test_cannot_file_task_into_someone_elses_personal_channel(self):
         self.client.get(self._channels_url())
-        personal = Channel.objects.get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
         other_client = APIClient()
         other_client.force_authenticate(self.other_user)
         response = other_client.post(
@@ -127,7 +129,10 @@ class ThreadMessagesAPITestCase(TestCase):
                 level=OrganizationMembership.Level.ADMIN
             )
 
-        self.channel = Channel.objects.create(team=self.team, name="growth", created_by=self.author)
+        # Direct instantiation sidesteps the fail-closed TeamScopedManager so
+        # setUp doesn't need a team_scope wrapper (see test_presence.py).
+        self.channel = Channel(team=self.team, name="growth", created_by=self.author)
+        self.channel.save()
         self.task = Task.objects.create(
             team=self.team,
             created_by=self.author,
@@ -184,7 +189,10 @@ class ThreadMessagesAPITestCase(TestCase):
         signal.assert_called_once()
         self.assertIn("Bob", signal.call_args.kwargs["content"])
         self.assertIn("try X", signal.call_args.kwargs["content"])
-        self.assertEqual(TaskThreadMessage.objects.get(id=message_id).forwarded_run_id, run.id)
+        self.assertEqual(
+            TaskThreadMessage.objects.unscoped().get(id=message_id).forwarded_run_id,
+            run.id,
+        )
 
         again = self.author_client.post(f"{self._thread_url()}{message_id}/send_to_agent/")
         self.assertEqual(again.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -31,9 +31,6 @@ class ChannelsAPITestCase(TestCase):
     def _tasks_url(self) -> str:
         return f"/api/projects/{self.team.id}/tasks/"
 
-    def _thread_url(self, task_id) -> str:
-        return f"/api/projects/{self.team.id}/tasks/{task_id}/thread_messages/"
-
     def test_list_provisions_personal_channel(self):
         response = self.client.get(self._channels_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -88,6 +88,33 @@ class ChannelsAPITestCase(TestCase):
         listed = other_client.get(self._tasks_url(), {"channel": channel_id}).json()["results"]
         self.assertEqual([t["id"] for t in listed], [created.json()["id"]])
 
+    def test_public_channel_task_is_readable_but_not_controllable_by_teammates(self):
+        channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        created = self.client.post(
+            self._tasks_url(),
+            {"title": "Ship it", "description": "d", "channel": channel_id},
+        )
+        task_id = created.json()["id"]
+
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        # Channel visibility grants reads: detail and the runs list.
+        self.assertEqual(other_client.get(f"{self._tasks_url()}{task_id}/").status_code, status.HTTP_200_OK)
+        self.assertEqual(other_client.get(f"{self._tasks_url()}{task_id}/runs/").status_code, status.HTTP_200_OK)
+        # But never control: edits, deletes, and run creation stay author-only.
+        self.assertEqual(
+            other_client.patch(f"{self._tasks_url()}{task_id}/", {"title": "hijack"}).status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            other_client.delete(f"{self._tasks_url()}{task_id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            other_client.post(f"{self._tasks_url()}{task_id}/runs/", {}).status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
     def test_task_in_personal_channel_stays_private(self):
         self.client.get(self._channels_url())
         personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -110,10 +110,10 @@ class TestFacadeReadsAndMappers(TestCase):
         task = self._make_task()
         self.assertTrue(facade.task_exists(task.id, self.team.id))
         self.assertFalse(facade.task_exists(task.id, self.team.id + 999))
-        # Creator can see it; an unrelated user cannot.
-        self.assertTrue(facade.is_task_visible_to_user(task.id, self.user.id))
+        # Creator can control it; an unrelated user cannot.
+        self.assertTrue(facade.is_task_controllable_by_user(task.id, self.user.id))
         other_user = User.objects.create(email="other@test.com", distinct_id="other")
-        self.assertFalse(facade.is_task_visible_to_user(task.id, other_user.id))
+        self.assertFalse(facade.is_task_controllable_by_user(task.id, other_user.id))
 
     def test_get_latest_pr_url_and_run_by_task(self):
         task = self._make_task()

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -7,7 +7,7 @@ tasks API surface — its module-scope imports reach jsonschema and the modal SD
 
 from django.db.models import Q
 
-from products.tasks.backend.models import Task
+from products.tasks.backend.models import Channel, Task
 
 # Origin products whose tasks are team-scoped rather than personal: every team member
 # can view them regardless of who created them.
@@ -36,9 +36,17 @@ def task_visibility_q(user_id: int | None) -> Q:
       team member — they cannot be executed in any case because oauth.py
       requires `task.created_by` to mint OAuth tokens), or
     - its `origin_product` is one of `TEAM_VISIBLE_ORIGIN_PRODUCTS`, i.e. a
-      team-scoped artifact (signals, onboarding) that any team member should see.
+      team-scoped artifact (signals, onboarding) that any team member should see, or
+    - it lives in a public channel: channel feeds are multiplayer, so every team
+      member sees every task filed there. Personal-channel ("#me") tasks stay
+      creator-only via the first rule.
     """
-    return Q(created_by_id=user_id) | Q(created_by__isnull=True) | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+    return (
+        Q(created_by_id=user_id)
+        | Q(created_by__isnull=True)
+        | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+        | Q(channel__channel_type=Channel.ChannelType.PUBLIC, channel__deleted=False)
+    )
 
 
 def task_run_visibility_q(user_id: int | None) -> Q:
@@ -47,4 +55,5 @@ def task_run_visibility_q(user_id: int | None) -> Q:
         Q(task__created_by_id=user_id)
         | Q(task__created_by__isnull=True)
         | Q(task__origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+        | Q(task__channel__channel_type=Channel.ChannelType.PUBLIC, task__channel__deleted=False)
     )

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -27,26 +27,34 @@ TEAM_VISIBLE_ORIGIN_PRODUCTS = [
 ]
 
 
-def task_visibility_q(user_id: int | None) -> Q:
-    """Filter for tasks visible to the given user.
+def task_control_q(user_id: int | None) -> Q:
+    """Filter for tasks the given user may mutate or drive (edits, runs, agent commands).
 
-    A task is visible if:
+    A task is controllable if:
     - its creator matches `user_id`, or
     - it has no creator at all (legacy unowned tasks remain visible to any
       team member — they cannot be executed in any case because oauth.py
       requires `task.created_by` to mint OAuth tokens), or
     - its `origin_product` is one of `TEAM_VISIBLE_ORIGIN_PRODUCTS`, i.e. a
-      team-scoped artifact (signals, onboarding) that any team member should see, or
-    - it lives in a public channel: channel feeds are multiplayer, so every team
-      member sees every task filed there. Personal-channel ("#me") tasks stay
-      creator-only via the first rule.
+      team-scoped artifact (signals, onboarding) any team member may pick up.
+
+    Deliberately narrower than ``task_visibility_q``: public-channel tasks are
+    team-readable but stay creator-driven — seeing a teammate's task in a feed
+    must not allow editing it, starting runs, or messaging its agent (thread
+    forwarding is the explicit, author-only path for that).
     """
-    return (
-        Q(created_by_id=user_id)
-        | Q(created_by__isnull=True)
-        | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
-        | Q(channel__channel_type=Channel.ChannelType.PUBLIC, channel__deleted=False)
-    )
+    return Q(created_by_id=user_id) | Q(created_by__isnull=True) | Q(origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+
+
+def task_visibility_q(user_id: int | None) -> Q:
+    """Filter for tasks visible (readable) to the given user.
+
+    Everything controllable per ``task_control_q``, plus tasks in a public
+    channel: channel feeds are multiplayer, so every team member sees every
+    task filed there. Personal-channel ("#me") tasks stay creator-only via
+    the control rules.
+    """
+    return task_control_q(user_id) | Q(channel__channel_type=Channel.ChannelType.PUBLIC, channel__deleted=False)
 
 
 def task_run_visibility_q(user_id: int | None) -> Q:

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -1,0 +1,134 @@
+# Channels & Threads (PostHog Code / Bluebird)
+
+Spec for the Slack-style channel revamp. A channel is a shared feed where each
+member message kicks off a task; the task renders as a card everyone in the
+channel can see. Every task is owned by a channel. Each task has one thread — a
+side-chain of human messages that never reach the agent unless the task author
+explicitly forwards one.
+
+## Django models
+
+```python
+class Channel(models.Model):
+    class ChannelType(models.TextChoices):
+        PUBLIC = "public", "Public"        # visible to the whole team
+        PERSONAL = "personal", "Personal"  # the user's private "#me" channel
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    name = models.CharField(max_length=128)  # rendered as "#<name>"; personal channels are named "me"
+    channel_type = models.CharField(max_length=16, choices=ChannelType, default=ChannelType.PUBLIC)
+    created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    deleted = models.BooleanField(default=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "posthog_task_channel"
+        constraints = [
+            # public channel names are unique per team (soft-deleted names are reusable)
+            models.UniqueConstraint(
+                fields=["team", "name"],
+                condition=Q(channel_type="public", deleted=False),
+                name="task_channel_team_name_public_unique",
+            ),
+            # exactly one live "#me" channel per user per team
+            models.UniqueConstraint(
+                fields=["team", "created_by"],
+                condition=Q(channel_type="personal", deleted=False),
+                name="task_channel_team_user_personal_unique",
+            ),
+        ]
+
+
+class Task(...):
+    # every new task is owned by the channel it was kicked off in; legacy tasks stay NULL
+    channel = models.ForeignKey(
+        "tasks.Channel", on_delete=models.SET_NULL, null=True, blank=True, related_name="tasks", db_index=False
+    )
+    # + Index(fields=["channel", "-created_at"], name="posthog_task_channel_feed_idx") for the feed
+
+
+class TaskThreadMessage(models.Model):
+    """One human message in a task's thread. Threads are human-only side
+    conversations; a message reaches the agent only when the task author
+    forwards it (send_to_agent), which stamps the forwarded_* fields."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
+    task = models.ForeignKey("tasks.Task", on_delete=models.CASCADE, related_name="thread_messages")
+    author = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    content = models.TextField()
+    forwarded_to_agent_at = models.DateTimeField(null=True, blank=True)
+    forwarded_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
+    forwarded_run = models.ForeignKey("tasks.TaskRun", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_index=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_thread_message"
+        indexes = [models.Index(fields=["task", "created_at"], name="task_thread_msg_task_created")]
+```
+
+### Visibility
+
+`task_visibility_q` gains `| Q(channel__channel_type=PUBLIC)`: a task filed to a
+public channel is visible to every team member (multiplayer feed). Tasks in a
+personal channel remain visible only via the existing `created_by` rule.
+Thread messages inherit the task's visibility.
+
+## API
+
+### `/api/projects/{id}/task_channels/`
+
+- `GET /` — list channels: all live public channels plus the requester's
+  personal channel. Listing lazily `get_or_create`s the personal `#me` channel,
+  so every user always has one.
+- `POST / {name}` — resolve-or-create a public channel by name
+  (`get_or_create`, so concurrent creates and name-bridging are race-safe).
+- `PATCH /{id}/ {name}` — rename a public channel. Personal channels cannot be renamed.
+- `DELETE /{id}/` — soft-delete a public channel. Personal channels cannot be deleted.
+
+### Task endpoints
+
+- `TaskWriteSerializer` accepts `channel` (UUID). Must belong to the team; a
+  personal channel is only accepted from its owner.
+- `TaskSerializer` / `TaskDetailDTO` emit `channel`.
+- `GET /tasks/?channel=<uuid>` filters the list to a channel's feed.
+
+### `/api/projects/{id}/tasks/{task_id}/thread_messages/`
+
+- `GET /` — thread messages, ascending `created_at` (paginated).
+- `POST / {content}` — add a message as the requester. Anyone who can see the task can post.
+- `DELETE /{id}/` — author-only.
+- `POST /{id}/send_to_agent/` — task author only. Signals the latest run's
+  workflow with `[Thread comment from <author>] <content>` via
+  `signal_task_run_user_message`, then stamps `forwarded_to_agent_at`,
+  `forwarded_by`, `forwarded_run`. 400 when the task has no signalable run.
+
+## Client (PostHog Code, bluebird mode)
+
+- **Channel feed** — the channel view becomes a Slack-like feed: each item is
+  the kickoff message (author avatar + name + prompt) with a task card
+  (title, status badge, repo, replies count) underneath. The composer at the
+  bottom kicks off a task owned by the channel; the author stays in the feed
+  and the card updates live (poll). The existing tabs (Inbox / Artifacts /
+  Recents / CONTEXT.md) stay above the feed.
+- **Threads** — a collapsible right-side panel shows a task's thread: message
+  list plus reply composer. Each message row has a hover menu; the task author
+  gets "Send to agent" there. Forwarded messages show a "Sent to agent" badge.
+  Opening a thread from a feed card shows the panel next to the feed; opening
+  a task shows the same panel next to the task detail (collapsible).
+- **#me** — the sidebar pins the personal channel (`#me`) above the channel
+  list; it is each user's private feed.
+- **Bridge** — sidebar channels remain desktop-file-system folders (CONTEXT.md,
+  dashboards and artifacts stay keyed to the folder id). Each folder channel is
+  mapped to a backend `Channel` by name via the resolve-or-create `POST`; the
+  `#me` entry maps to the personal channel. Task ownership, feeds and threads
+  key off the backend channel UUID.
+
+## Out of scope (v1)
+
+- Channel membership / invited private channels (only team-public + personal).
+- Message editing and emoji reactions.
+- Real-time push for feed/thread updates (clients poll; SSE can come later).
+- Backfilling `channel` onto existing tasks.

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -297,6 +297,48 @@ export interface PatchedTaskAutomationWriteApi {
 }
 
 /**
+ * Response shape for a task channel, read from a frozen ``ChannelDTO``.
+ */
+export interface ChannelDTOApi {
+    id: string
+    name: string
+    channel_type: string
+    created_at: string
+    created_by?: TaskUserBasicInfoApi | null
+}
+
+export interface PaginatedChannelDTOListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ChannelDTOApi[]
+}
+
+/**
+ * Request body for creating (resolve-or-create) or renaming a public channel.
+ */
+export interface ChannelWriteApi {
+    /**
+     * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
+     * @maxLength 128
+     */
+    name: string
+}
+
+/**
+ * Request body for creating (resolve-or-create) or renaming a public channel.
+ */
+export interface PatchedChannelWriteApi {
+    /**
+     * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
+     * @maxLength 128
+     */
+    name?: string
+}
+
+/**
  * @nullable
  */
 export type TaskDetailDTOApiJsonSchema = { [key: string]: unknown } | null
@@ -516,6 +558,11 @@ export interface TaskWriteApi {
      * * `xhigh` - xhigh
      * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi | null
+    /**
+     * Channel this task is owned by (the channel it was kicked off in).
+     * @nullable
+     */
+    channel?: string | null
 }
 
 /**
@@ -608,6 +655,11 @@ export interface PatchedTaskWriteApi {
      * * `xhigh` - xhigh
      * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi | null
+    /**
+     * Channel this task is owned by (the channel it was kicked off in).
+     * @nullable
+     */
+    channel?: string | null
 }
 
 /**
@@ -1688,6 +1740,37 @@ export interface StreamReadTokenResponseApi {
     stream_base_url: string | null
 }
 
+/**
+ * Response shape for one message in a task's thread.
+ */
+export interface TaskThreadMessageDTOApi {
+    id: string
+    task: string
+    content: string
+    created_at: string
+    author?: TaskUserBasicInfoApi | null
+    /** @nullable */
+    forwarded_to_agent_at?: string | null
+    forwarded_by?: TaskUserBasicInfoApi | null
+}
+
+export interface PaginatedTaskThreadMessageDTOListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TaskThreadMessageDTOApi[]
+}
+
+/**
+ * Request body for posting a thread message.
+ */
+export interface TaskThreadMessageWriteApi {
+    /** Message text. */
+    content: string
+}
+
 export interface TaskRepositoriesResponseApi {
     /** Distinct repositories in use by non-deleted, non-internal tasks for the current team. */
     repositories: string[]
@@ -2069,6 +2152,17 @@ export type TaskAutomationsListParams = {
     offset?: number
 }
 
+export type TaskChannelsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
 export type TasksListParams = {
     /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
@@ -2079,6 +2173,10 @@ export type TasksListParams = {
      * @minLength 1
      */
     archived?: TasksListArchived
+    /**
+     * Filter tasks to a channel's feed.
+     */
+    channel?: string
     /**
      * Filter by creator user ID
      */
@@ -2215,6 +2313,17 @@ export type TasksRunsStreamRetrieveParams = {
      * Set to `latest` to skip the event backlog and only receive events published after connecting.
      */
     start?: string
+}
+
+export type TasksThreadMessagesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
 }
 
 export type TasksRepositoryReadinessRetrieveParams = {

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -9,13 +9,18 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    ChannelDTOApi,
+    ChannelWriteApi,
     CodeInviteRedeemRequestApi,
     ConnectionTokenResponseApi,
+    PaginatedChannelDTOListApi,
     PaginatedSandboxEnvironmentDTOListApi,
     PaginatedTaskAutomationDTOListApi,
     PaginatedTaskDetailDTOListApi,
     PaginatedTaskRunDetailDTOListApi,
     PaginatedTaskSummaryDTOListApi,
+    PaginatedTaskThreadMessageDTOListApi,
+    PatchedChannelWriteApi,
     PatchedSandboxEnvironmentWriteApi,
     PatchedTaskAutomationWriteApi,
     PatchedTaskRunSetOutputRequestApi,
@@ -30,6 +35,7 @@ import type {
     TaskAutomationDTOApi,
     TaskAutomationWriteApi,
     TaskAutomationsListParams,
+    TaskChannelsListParams,
     TaskDetailDTOApi,
     TaskPresenceBeaconRequestApi,
     TaskRepositoriesResponseApi,
@@ -55,6 +61,8 @@ import type {
     TaskStagedArtifactsPrepareUploadRequestApi,
     TaskStagedArtifactsPrepareUploadResponseApi,
     TaskSummariesRequestApi,
+    TaskThreadMessageDTOApi,
+    TaskThreadMessageWriteApi,
     TaskWriteApi,
     TasksListParams,
     TasksRepositoryReadinessRetrieveParams,
@@ -63,6 +71,7 @@ import type {
     TasksRunsStreamRetrieveParams,
     TasksSlackThreadContextRetrieveParams,
     TasksSummariesCreateParams,
+    TasksThreadMessagesListParams,
     WarmTaskRequestApi,
     WarmTaskResponseApi,
 } from './api.schemas'
@@ -323,6 +332,99 @@ export const taskAutomationsRunCreate = async (
     return apiMutator<TaskAutomationDTOApi>(getTaskAutomationsRunCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getTaskChannelsListUrl = (projectId: string, params?: TaskChannelsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/task_channels/?${stringifiedParams}`
+        : `/api/projects/${projectId}/task_channels/`
+}
+
+/**
+ * All live public channels plus the requester's personal #me channel (created on first list).
+ * @summary List channels
+ */
+export const taskChannelsList = async (
+    projectId: string,
+    params?: TaskChannelsListParams,
+    options?: RequestInit
+): Promise<PaginatedChannelDTOListApi> => {
+    return apiMutator<PaginatedChannelDTOListApi>(getTaskChannelsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTaskChannelsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_channels/`
+}
+
+/**
+ * Returns the existing public channel with the (normalized) name, creating it if needed.
+ * @summary Resolve or create a public channel
+ */
+export const taskChannelsCreate = async (
+    projectId: string,
+    channelWriteApi: ChannelWriteApi,
+    options?: RequestInit
+): Promise<ChannelDTOApi> => {
+    return apiMutator<ChannelDTOApi>(getTaskChannelsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(channelWriteApi),
+    })
+}
+
+export const getTaskChannelsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/task_channels/${id}/`
+}
+
+/**
+ * API for task channels — the shared feeds tasks are kicked off in. Listing lazily
+ * provisions the requester's personal "#me" channel; creation is resolve-or-create
+ * by normalized name so clients can map channel-like surfaces onto backend channels.
+ * @summary Rename a public channel
+ */
+export const taskChannelsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedChannelWriteApi?: PatchedChannelWriteApi,
+    options?: RequestInit
+): Promise<ChannelDTOApi> => {
+    return apiMutator<ChannelDTOApi>(getTaskChannelsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedChannelWriteApi),
+    })
+}
+
+export const getTaskChannelsDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/task_channels/${id}/`
+}
+
+/**
+ * API for task channels — the shared feeds tasks are kicked off in. Listing lazily
+ * provisions the requester's personal "#me" channel; creation is resolve-or-create
+ * by normalized name so clients can map channel-like surfaces onto backend channels.
+ * @summary Delete a public channel
+ */
+export const taskChannelsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTaskChannelsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
     })
 }
 
@@ -1032,6 +1134,109 @@ export const tasksRunsStreamTokenRetrieve = async (
     return apiMutator<StreamReadTokenResponseApi>(getTasksRunsStreamTokenRetrieveUrl(projectId, taskId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getTasksThreadMessagesListUrl = (
+    projectId: string,
+    taskId: string,
+    params?: TasksThreadMessagesListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/tasks/${taskId}/thread_messages/?${stringifiedParams}`
+        : `/api/projects/${projectId}/tasks/${taskId}/thread_messages/`
+}
+
+/**
+ * The task's thread in chronological order.
+ * @summary List thread messages
+ */
+export const tasksThreadMessagesList = async (
+    projectId: string,
+    taskId: string,
+    params?: TasksThreadMessagesListParams,
+    options?: RequestInit
+): Promise<PaginatedTaskThreadMessageDTOListApi> => {
+    return apiMutator<PaginatedTaskThreadMessageDTOListApi>(getTasksThreadMessagesListUrl(projectId, taskId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTasksThreadMessagesCreateUrl = (projectId: string, taskId: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/thread_messages/`
+}
+
+/**
+ * API for a task's thread — the human-only side conversation around a task. Messages
+ * reach the agent only via the explicit send_to_agent action, gated to the task author.
+ * @summary Post a thread message
+ */
+export const tasksThreadMessagesCreate = async (
+    projectId: string,
+    taskId: string,
+    taskThreadMessageWriteApi: TaskThreadMessageWriteApi,
+    options?: RequestInit
+): Promise<TaskThreadMessageDTOApi> => {
+    return apiMutator<TaskThreadMessageDTOApi>(getTasksThreadMessagesCreateUrl(projectId, taskId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskThreadMessageWriteApi),
+    })
+}
+
+export const getTasksThreadMessagesDestroyUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/thread_messages/${id}/`
+}
+
+/**
+ * API for a task's thread — the human-only side conversation around a task. Messages
+ * reach the agent only via the explicit send_to_agent action, gated to the task author.
+ * @summary Delete own thread message
+ */
+export const tasksThreadMessagesDestroy = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksThreadMessagesDestroyUrl(projectId, taskId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getTasksThreadMessagesSendToAgentCreateUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/thread_messages/${id}/send_to_agent/`
+}
+
+/**
+ * Task author only: forwards the message into the task's latest live run.
+ * @summary Send a thread message to the agent
+ */
+export const tasksThreadMessagesSendToAgentCreate = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    taskThreadMessageDTOApi: TaskThreadMessageDTOApi,
+    options?: RequestInit
+): Promise<TaskThreadMessageDTOApi> => {
+    return apiMutator<TaskThreadMessageDTOApi>(getTasksThreadMessagesSendToAgentCreateUrl(projectId, taskId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskThreadMessageDTOApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -223,6 +223,39 @@ export const TaskAutomationsPartialUpdateBody = /* @__PURE__ */ zod
     .describe('Request body for creating or updating a task automation.')
 
 /**
+ * Returns the existing public channel with the (normalized) name, creating it if needed.
+ * @summary Resolve or create a public channel
+ */
+export const taskChannelsCreateBodyNameMax = 128
+
+export const TaskChannelsCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(taskChannelsCreateBodyNameMax)
+            .describe('Channel name, rendered as #<name>. Normalized to lowercase-dashed.'),
+    })
+    .describe('Request body for creating (resolve-or-create) or renaming a public channel.')
+
+/**
+ * API for task channels — the shared feeds tasks are kicked off in. Listing lazily
+ * provisions the requester's personal "#me" channel; creation is resolve-or-create
+ * by normalized name so clients can map channel-like surfaces onto backend channels.
+ * @summary Rename a public channel
+ */
+export const taskChannelsPartialUpdateBodyNameMax = 128
+
+export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(taskChannelsPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Channel name, rendered as #<name>. Normalized to lowercase-dashed.'),
+    })
+    .describe('Request body for creating (resolve-or-create) or renaming a public channel.')
+
+/**
  * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
  */
 export const tasksCreateBodyTitleMax = 255
@@ -326,6 +359,7 @@ export const TasksCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
             ),
+        channel: zod.uuid().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
     })
     .describe(
         'Request body for creating or updating a task.\n\nField required\/default semantics match the ``Task`` model. The view passes\n``validated_data`` (integration\/report PK fields already resolved to instances) to the\nfacade ``create_task`` \/ ``update_task`` functions.'
@@ -435,6 +469,7 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
             ),
+        channel: zod.uuid().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
     })
     .describe(
         'Request body for creating or updating a task.\n\nField required\/default semantics match the ``Task`` model. The view passes\n``validated_data`` (integration\/report PK fields already resolved to instances) to the\nfacade ``create_task`` \/ ``update_task`` functions.'
@@ -544,6 +579,7 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
             ),
+        channel: zod.uuid().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
     })
     .describe(
         'Request body for creating or updating a task.\n\nField required\/default semantics match the ``Task`` model. The view passes\n``validated_data`` (integration\/report PK fields already resolved to instances) to the\nfacade ``create_task`` \/ ``update_task`` functions.'
@@ -1490,6 +1526,67 @@ export const TasksRunsStartCreateBody = /* @__PURE__ */ zod.object({
             'Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.'
         ),
 })
+
+/**
+ * API for a task's thread — the human-only side conversation around a task. Messages
+ * reach the agent only via the explicit send_to_agent action, gated to the task author.
+ * @summary Post a thread message
+ */
+export const TasksThreadMessagesCreateBody = /* @__PURE__ */ zod
+    .object({
+        content: zod.string().describe('Message text.'),
+    })
+    .describe('Request body for posting a thread message.')
+
+/**
+ * Task author only: forwards the message into the task's latest live run.
+ * @summary Send a thread message to the agent
+ */
+export const TasksThreadMessagesSendToAgentCreateBody = /* @__PURE__ */ zod
+    .object({
+        id: zod.uuid(),
+        task: zod.uuid(),
+        content: zod.string(),
+        created_at: zod.iso.datetime({ offset: true }),
+        author: zod
+            .union([
+                zod
+                    .object({
+                        id: zod.number(),
+                        uuid: zod.uuid(),
+                        distinct_id: zod.string(),
+                        first_name: zod.string(),
+                        last_name: zod.string(),
+                        email: zod.string(),
+                        is_email_verified: zod.boolean().nullish(),
+                        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+                        role_at_organization: zod.string().nullish(),
+                    })
+                    .describe('Response shape for a task creator, mirroring core ``UserBasicSerializer`` output.'),
+                zod.null(),
+            ])
+            .optional(),
+        forwarded_to_agent_at: zod.iso.datetime({ offset: true }).nullish(),
+        forwarded_by: zod
+            .union([
+                zod
+                    .object({
+                        id: zod.number(),
+                        uuid: zod.uuid(),
+                        distinct_id: zod.string(),
+                        first_name: zod.string(),
+                        last_name: zod.string(),
+                        email: zod.string(),
+                        is_email_verified: zod.boolean().nullish(),
+                        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+                        role_at_organization: zod.string().nullish(),
+                    })
+                    .describe('Response shape for a task creator, mirroring core ``UserBasicSerializer`` output.'),
+                zod.null(),
+            ])
+            .optional(),
+    })
+    .describe("Response shape for one message in a task's thread.")
 
 /**
  * Returns summary for the requested tasks: `id`, `title`, `repository`, `created_at`, `updated_at`, and the latest run's `status` and `environment`.

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -48,6 +48,18 @@ tools:
     task-automations-run-create:
         operation: task_automations_run_create
         enabled: false
+    task-channels-create:
+        operation: task_channels_create
+        enabled: false
+    task-channels-destroy:
+        operation: task_channels_destroy
+        enabled: false
+    task-channels-list:
+        operation: task_channels_list
+        enabled: false
+    task-channels-partial-update:
+        operation: task_channels_partial_update
+        enabled: false
     tasks-create:
         operation: tasks_create
         enabled: false
@@ -248,6 +260,18 @@ tools:
         enabled: false
     tasks-summaries-create:
         operation: tasks_summaries_create
+        enabled: false
+    tasks-thread-messages-create:
+        operation: tasks_thread_messages_create
+        enabled: false
+    tasks-thread-messages-destroy:
+        operation: tasks_thread_messages_destroy
+        enabled: false
+    tasks-thread-messages-list:
+        operation: tasks_thread_messages_list
+        enabled: false
+    tasks-thread-messages-send-to-agent-create:
+        operation: tasks_thread_messages_send_to_agent_create
         enabled: false
     tasks-update:
         operation: tasks_update

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12424,6 +12424,40 @@ export namespace Schemas {
     }
 
     /**
+     * @nullable
+     */
+    export type TaskUserBasicInfoHedgehogConfig = { [key: string]: unknown } | null;
+
+    /**
+     * Response shape for a task creator, mirroring core ``UserBasicSerializer`` output.
+     */
+    export interface TaskUserBasicInfo {
+      id: number;
+      uuid: string;
+      distinct_id: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+      /** @nullable */
+      is_email_verified?: boolean | null;
+      /** @nullable */
+      hedgehog_config?: TaskUserBasicInfoHedgehogConfig;
+      /** @nullable */
+      role_at_organization?: string | null;
+    }
+
+    /**
+     * Response shape for a task channel, read from a frozen ``ChannelDTO``.
+     */
+    export interface ChannelDTO {
+      id: string;
+      name: string;
+      channel_type: string;
+      created_at: string;
+      created_by?: TaskUserBasicInfo | null;
+    }
+
+    /**
      * * `slack_channel_message` - Channel message
      * * `slack_bot_mention` - Bot mention
      * * `slack_emoji_reaction` - Emoji reaction
@@ -12464,6 +12498,17 @@ export namespace Schemas {
       Teams: 'teams',
       Github: 'github',
     } as const;
+
+    /**
+     * Request body for creating (resolve-or-create) or renaming a public channel.
+     */
+    export interface ChannelWrite {
+      /**
+         * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
+         * @maxLength 128
+         */
+      name: string;
+    }
 
     export interface CheckDatabaseNameResponse {
       name: string;
@@ -13451,29 +13496,6 @@ export namespace Schemas {
       DeepResearch: 'deep_research',
       Slack: 'slack',
     } as const;
-
-    /**
-     * @nullable
-     */
-    export type TaskUserBasicInfoHedgehogConfig = { [key: string]: unknown } | null;
-
-    /**
-     * Response shape for a task creator, mirroring core ``UserBasicSerializer`` output.
-     */
-    export interface TaskUserBasicInfo {
-      id: number;
-      uuid: string;
-      distinct_id: string;
-      first_name: string;
-      last_name: string;
-      email: string;
-      /** @nullable */
-      is_email_verified?: boolean | null;
-      /** @nullable */
-      hedgehog_config?: TaskUserBasicInfoHedgehogConfig;
-      /** @nullable */
-      role_at_organization?: string | null;
-    }
 
     /**
      * @nullable
@@ -31421,6 +31443,15 @@ export namespace Schemas {
       results: ChangeRequest[];
     }
 
+    export interface PaginatedChannelDTOList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: ChannelDTO[];
+    }
+
     export interface PaginatedClickhouseEventList {
       /** @nullable */
       next?: string | null;
@@ -34779,6 +34810,29 @@ export namespace Schemas {
     }
 
     /**
+     * Response shape for one message in a task's thread.
+     */
+    export interface TaskThreadMessageDTO {
+      id: string;
+      task: string;
+      content: string;
+      created_at: string;
+      author?: TaskUserBasicInfo | null;
+      /** @nullable */
+      forwarded_to_agent_at?: string | null;
+      forwarded_by?: TaskUserBasicInfo | null;
+    }
+
+    export interface PaginatedTaskThreadMessageDTOList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TaskThreadMessageDTO[];
+    }
+
+    /**
      * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
      * Also used for nested serializers.
      */
@@ -36392,6 +36446,17 @@ export namespace Schemas {
     export interface PatchedCanvasPublish {
       code?: string;
       prompt?: string;
+      name?: string;
+    }
+
+    /**
+     * Request body for creating (resolve-or-create) or renaming a public channel.
+     */
+    export interface PatchedChannelWrite {
+      /**
+         * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
+         * @maxLength 128
+         */
       name?: string;
     }
 
@@ -42041,6 +42106,11 @@ export namespace Schemas {
        * * `xhigh` - xhigh
        * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum | null;
+      /**
+         * Channel this task is owned by (the channel it was kicked off in).
+         * @nullable
+         */
+      channel?: string | null;
     }
 
     export type PatchedTeamDefaultModifiers = { [key: string]: unknown };
@@ -52832,6 +52902,14 @@ export namespace Schemas {
     }
 
     /**
+     * Request body for posting a thread message.
+     */
+    export interface TaskThreadMessageWrite {
+      /** Message text. */
+      content: string;
+    }
+
+    /**
      * Request body for creating or updating a task.
      *
      * Field required/default semantics match the ``Task`` model. The view passes
@@ -52921,6 +52999,11 @@ export namespace Schemas {
        * * `xhigh` - xhigh
        * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum | null;
+      /**
+         * Channel this task is owned by (the channel it was kicked off in).
+         * @nullable
+         */
+      channel?: string | null;
     }
 
     export type TeamDefaultModifiers = { [key: string]: unknown };
@@ -67317,6 +67400,17 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type TaskChannelsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
     export type TasksListParams = {
     /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
@@ -67327,6 +67421,10 @@ export namespace Schemas {
      * @minLength 1
      */
     archived?: TasksListArchived;
+    /**
+     * Filter tasks to a channel's feed.
+     */
+    channel?: string;
     /**
      * Filter by creator user ID
      */
@@ -67466,6 +67564,17 @@ export namespace Schemas {
      * Set to `latest` to skip the event backlog and only receive events published after connecting.
      */
     start?: string;
+    };
+
+    export type TasksThreadMessagesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
     };
 
     export type TasksRepositoryReadinessRetrieveParams = {

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -33,6 +33,7 @@ export const TasksListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.\n\n* `true` - true\n* `false` - false\n* `all` - all"
         ),
+    channel: zod.string().optional().describe("Filter tasks to a channel's feed."),
     created_by: zod.number().optional().describe('Filter by creator user ID'),
     internal: zod
         .enum(['true', 'false', 'all'])

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -26,6 +26,7 @@ const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.Pa
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/`,
             query: {
                 archived: params.archived,
+                channel: params.channel,
                 created_by: params.created_by,
                 internal: params.internal,
                 limit: params.limit,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
@@ -6,6 +6,10 @@
             "enum": ["true", "false", "all"],
             "type": "string"
         },
+        "channel": {
+            "description": "Filter tasks to a channel's feed.",
+            "type": "string"
+        },
         "created_by": {
             "description": "Filter by creator user ID",
             "type": "number"


### PR DESCRIPTION
## Summary

Backend for the Slack-style channel revamp in PostHog Code (bluebird mode). Full spec in `products/tasks/docs/CHANNELS.md`. Frontend counterpart: PostHog/code#3129.

### Django models (migration `0045`)

- **`Channel`** (`posthog_task_channel`): team-scoped channel with `channel_type` `public` | `personal`. Partial unique constraints: public names unique per team; one live personal channel per (team, user). The personal **#me** channel (name `me`) is provisioned lazily on first channel list, so every user always has a private feed.
- **`Task.channel`**: nullable `SET_NULL` FK — every task is owned by the channel it was kicked off in; legacy tasks stay `NULL`. New `(channel, -created_at)` feed index.
- **`TaskThreadMessage`** (`posthog_task_thread_message`): human-only side thread per task (task FK, author, content, `forwarded_to_agent_at` / `forwarded_by` / `forwarded_run`).

### Visibility

`task_visibility_q` / `task_run_visibility_q` now also match tasks in a live **public** channel — channel feeds are multiplayer, so every team member sees every task filed there. Personal-channel tasks stay creator-only via the existing rule.

### API

- `GET/POST /api/projects/{id}/task_channels/` — list (lazily provisions #me) and resolve-or-create by normalized name (idempotent `get_or_create`, race-safe); `PATCH`/`DELETE` rename and soft-delete public channels (both refused for personal channels).
- `GET /tasks/?channel=<uuid>` — a channel's feed; `channel` accepted on task create/update and emitted on task reads.
- `GET/POST/DELETE /tasks/{task_id}/thread_messages/` plus `POST {id}/send_to_agent/` — task-author-only forwarding that signals the latest live run via the existing `signal_task_run_user_message` workflow signal (content prefixed `[Thread comment from <author>]`) and stamps the forwarded fields. Message deletion is author-only.

Follows the existing presentation → facade DTO → model layering (new DTOs in `facade/contracts.py`, facade functions in `facade/api.py`, viewsets in `presentation/views/channels_api.py`).

### Tests

13 API tests in `products/tasks/backend/tests/test_channels_api.py`: personal-channel provisioning and per-user isolation, resolve-or-create dedupe, personal rename/delete refusal, public-channel team visibility vs personal privacy, filing into someone else's #me rejected, thread post/list/delete permissions, send_to_agent author gating, live-run requirement, forwarding + already-forwarded handling.

> Note: developed against the tasks product conventions; ruff lint/format clean. Please rely on CI for the migration check and pytest run — this environment couldn't run Django.

🤖 Generated with [Claude Code](https://claude.com/claude-code)