### PR TITLE
feat(data-modeling): add Temporal schedule truth to internal ops API

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -525,7 +525,7 @@ urlpatterns = [
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_jobs"})),
     ),
     path(
-        "api/projects/<str:team_id>/internal/data_modeling_ops/schedules",
+        "api/internal/data_modeling_ops/schedules",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_schedules"})),
     ),
     path(

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -525,6 +525,10 @@ urlpatterns = [
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_saved_query_jobs"})),
     ),
     path(
+        "api/projects/<str:team_id>/internal/data_modeling_ops/schedules",
+        csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_schedules"})),
+    ),
+    path(
         "api/internal/data_modeling_ops/dags",
         csrf_exempt(InternalDataModelingOpsViewSet.as_view({"get": "internal_dags"})),
     ),

--- a/products/data_modeling/backend/facade/schedule_truth.py
+++ b/products/data_modeling/backend/facade/schedule_truth.py
@@ -1,0 +1,19 @@
+"""Facade re-exports for Temporal schedule inspection (data_modeling_ops internal API).
+
+Presentation consumes these through the facade per the "presentation must use facade"
+import contract; the implementation lives in logic.schedule_truth.
+"""
+
+from products.data_modeling.backend.logic.schedule_truth import (
+    SCHEDULE_CANDIDATE_CAP,
+    classify_workflow,
+    describe_schedules,
+    extract_schedule_info,
+)
+
+__all__ = [
+    "SCHEDULE_CANDIDATE_CAP",
+    "classify_workflow",
+    "describe_schedules",
+    "extract_schedule_info",
+]

--- a/products/data_modeling/backend/logic/schedule_truth.py
+++ b/products/data_modeling/backend/logic/schedule_truth.py
@@ -95,7 +95,11 @@ def _iso_or_none(value: Any) -> str | None:
 
 @async_to_sync
 async def describe_schedules(schedule_ids: list[str]) -> dict[str, dict[str, Any] | None]:
-    """Describe many schedules concurrently; NOT_FOUND maps to None."""
+    """Describe many schedules concurrently; NOT_FOUND maps to None.
+
+    Called from sync views: under WSGI async_to_sync just runs the loop; under ASGI it
+    hops to a fresh thread per call, which is fine at this route's call rate.
+    """
     if not schedule_ids:
         return {}
 

--- a/products/data_modeling/backend/logic/schedule_truth.py
+++ b/products/data_modeling/backend/logic/schedule_truth.py
@@ -1,0 +1,114 @@
+"""Read-only Temporal schedule inspection for the data_modeling_ops internal API.
+
+Resolves which Temporal schedule covers a data-modeling entity and in what state.
+Classification is by the schedule action's workflow name — NOT by the PostHogDagId
+search attribute, which v1 per-query schedules also carry when the saved query has
+a node.
+"""
+
+import asyncio
+from typing import Any
+
+from asgiref.sync import async_to_sync
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.temporal.common.client import async_connect
+
+DATA_MODELING_RUN_WORKFLOW = "data-modeling-run"
+DATA_MODELING_EXECUTE_DAG_WORKFLOW = "data-modeling-execute-dag"
+
+# Bounds concurrent describe RPCs and total candidates per request so one big team
+# cannot exhaust the Temporal namespace rate limit.
+DESCRIBE_CONCURRENCY = 10
+SCHEDULE_CANDIDATE_CAP = 500
+
+
+def classify_workflow(workflow_name: str | None) -> str:
+    if workflow_name == DATA_MODELING_RUN_WORKFLOW:
+        return "v1_saved_query"
+    if workflow_name == DATA_MODELING_EXECUTE_DAG_WORKFLOW:
+        return "v2_dag"
+    return "other"
+
+
+def extract_schedule_info(schedule_id: str, description: Any) -> dict[str, Any]:
+    """Flatten a temporalio ScheduleDescription into a JSON-safe dict.
+
+    Reads defensively with getattr: the temporalio dataclasses have grown fields
+    across versions and a missing attribute should degrade to null, not 500 an
+    ops endpoint.
+    """
+    schedule = getattr(description, "schedule", None)
+    action = getattr(schedule, "action", None)
+    spec = getattr(schedule, "spec", None)
+    state = getattr(schedule, "state", None)
+    info = getattr(description, "info", None)
+
+    workflow_name = getattr(action, "workflow", None)
+
+    next_action_times = getattr(info, "next_action_times", None) or []
+    recent_actions = []
+    for action_result in (getattr(info, "recent_actions", None) or [])[-5:]:
+        started = getattr(action_result, "action", None)
+        recent_actions.append(
+            {
+                "scheduled_at": _iso_or_none(getattr(action_result, "scheduled_at", None)),
+                "started_at": _iso_or_none(getattr(action_result, "started_at", None)),
+                "workflow_id": getattr(started, "workflow_id", None),
+                "workflow_run_id": getattr(started, "first_execution_run_id", None),
+            }
+        )
+
+    search_attributes: dict[str, Any] = {}
+    typed_attributes = getattr(getattr(description, "typed_search_attributes", None), "search_attributes", None) or []
+    for pair in typed_attributes:
+        key_name = getattr(getattr(pair, "key", None), "name", None)
+        if key_name:
+            search_attributes[key_name] = pair.value
+
+    return {
+        "schedule_id": schedule_id,
+        "exists": True,
+        "workflow_name": workflow_name,
+        "kind": classify_workflow(workflow_name),
+        "paused": getattr(state, "paused", None),
+        "note": getattr(state, "note", None),
+        "next_run_at": _iso_or_none(next_action_times[0]) if next_action_times else None,
+        "spec": {
+            "intervals": [
+                str(getattr(interval, "every", None)) for interval in (getattr(spec, "intervals", None) or [])
+            ],
+            "cron_expressions": list(getattr(spec, "cron_expressions", None) or []),
+            "calendar_count": len(getattr(spec, "calendars", None) or []),
+            "jitter": str(spec.jitter) if getattr(spec, "jitter", None) else None,
+            "time_zone": getattr(spec, "time_zone_name", None),
+        },
+        "recent_actions": recent_actions,
+        "search_attributes": search_attributes,
+    }
+
+
+def _iso_or_none(value: Any) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+@async_to_sync
+async def describe_schedules(schedule_ids: list[str]) -> dict[str, dict[str, Any] | None]:
+    """Describe many schedules concurrently; NOT_FOUND maps to None."""
+    if not schedule_ids:
+        return {}
+
+    temporal = await async_connect()
+    semaphore = asyncio.Semaphore(DESCRIBE_CONCURRENCY)
+
+    async def describe_one(schedule_id: str) -> tuple[str, dict[str, Any] | None]:
+        async with semaphore:
+            try:
+                description = await temporal.get_schedule_handle(schedule_id).describe()
+            except RPCError as error:
+                if error.status == RPCStatusCode.NOT_FOUND:
+                    return schedule_id, None
+                raise
+        return schedule_id, extract_schedule_info(schedule_id, description)
+
+    return dict(await asyncio.gather(*(describe_one(schedule_id) for schedule_id in schedule_ids)))

--- a/products/data_modeling/backend/logic/schedule_truth.py
+++ b/products/data_modeling/backend/logic/schedule_truth.py
@@ -45,6 +45,7 @@ def extract_schedule_info(schedule_id: str, description: Any) -> dict[str, Any]:
     info = getattr(description, "info", None)
 
     workflow_name = getattr(action, "workflow", None)
+    jitter = getattr(spec, "jitter", None)
 
     next_action_times = getattr(info, "next_action_times", None) or []
     recent_actions = []
@@ -80,7 +81,7 @@ def extract_schedule_info(schedule_id: str, description: Any) -> dict[str, Any]:
             ],
             "cron_expressions": list(getattr(spec, "cron_expressions", None) or []),
             "calendar_count": len(getattr(spec, "calendars", None) or []),
-            "jitter": str(spec.jitter) if getattr(spec, "jitter", None) else None,
+            "jitter": str(jitter) if jitter else None,
             "time_zone": getattr(spec, "time_zone_name", None),
         },
         "recent_actions": recent_actions,

--- a/products/data_modeling/backend/presentation/internal_serializers.py
+++ b/products/data_modeling/backend/presentation/internal_serializers.py
@@ -77,6 +77,51 @@ class InternalSavedQueryNodeContextSerializer(serializers.Serializer):
     )
 
 
+class InternalScheduleRecentActionSerializer(serializers.Serializer):
+    scheduled_at = serializers.CharField(allow_null=True, help_text="When the action was scheduled to run (ISO).")
+    started_at = serializers.CharField(allow_null=True, help_text="When the action actually started (ISO).")
+    workflow_id = serializers.CharField(allow_null=True, help_text="Workflow id the action started.")
+    workflow_run_id = serializers.CharField(
+        allow_null=True, help_text="First execution run id of the started workflow."
+    )
+
+
+class InternalScheduleInfoSerializer(serializers.Serializer):
+    schedule_id = serializers.CharField(help_text="Temporal schedule id (saved query id for v1, DAG id for v2).")
+    exists = serializers.BooleanField(help_text="Whether the schedule exists in Temporal.")
+    workflow_name = serializers.CharField(
+        allow_null=True, help_text="Workflow the schedule starts — the authoritative v1/v2 discriminator."
+    )
+    kind = serializers.ChoiceField(
+        choices=["v1_saved_query", "v2_dag", "other"],
+        help_text="Classification by workflow name: data-modeling-run = v1, data-modeling-execute-dag = v2.",
+    )
+    paused = serializers.BooleanField(allow_null=True, help_text="Whether the schedule is paused.")
+    note = serializers.CharField(allow_null=True, help_text="Operator note on the schedule state, if any.")
+    next_run_at = serializers.CharField(allow_null=True, help_text="Next scheduled action time (ISO), if any.")
+    spec = serializers.JSONField(help_text="Spec summary: intervals, cron expressions, calendar count, jitter, tz.")
+    recent_actions = InternalScheduleRecentActionSerializer(
+        many=True, help_text="Up to 5 most recent schedule actions with started workflow ids."
+    )
+    search_attributes = serializers.JSONField(
+        help_text="Temporal search attributes on the schedule (PostHogTeamId, PostHogDagId, PostHogScheduleType...). "
+        "Informational only — never used for classification."
+    )
+
+
+class InternalEntityScheduleSerializer(serializers.Serializer):
+    entity_type = serializers.ChoiceField(
+        choices=["dag", "saved_query"], help_text="Kind of entity this schedule slot belongs to."
+    )
+    entity_id = serializers.CharField(help_text="DAG or saved query id — also the expected Temporal schedule id.")
+    entity_name = serializers.CharField(help_text="Name of the DAG or saved query.")
+    schedule = InternalScheduleInfoSerializer(
+        allow_null=True,
+        help_text="Live Temporal schedule state, or null when no schedule exists for this entity — "
+        "a materialized entity with null here is unscheduled.",
+    )
+
+
 class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
     query = serializers.JSONField(read_only=True, help_text="Stored HogQL query payload (JSON with a 'query' key).")
     columns = serializers.JSONField(
@@ -98,6 +143,10 @@ class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
         "More than one entry means duplicate backing tables — treat as a lead, not proof: the match "
         "is by name, so an unrelated table of the same name also shows up here."
     )
+    schedule_truth = serializers.SerializerMethodField(
+        help_text="Live Temporal coverage: covered_by (v1/v2/none), the v1 per-query schedule, and per-DAG "
+        "v2 schedules. Degrades to {'error': ...} when Temporal is unreachable."
+    )
 
     class Meta(InternalSavedQuerySummarySerializer.Meta):
         fields = [
@@ -109,6 +158,7 @@ class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
             "nodes",
             "double_materialized",
             "backing_tables",
+            "schedule_truth",
         ]
         read_only_fields = fields
 
@@ -129,6 +179,9 @@ class InternalSavedQueryDetailSerializer(InternalSavedQuerySummarySerializer):
         return list(
             InternalBackingTableSerializer(self.context.get("backing_tables", []), many=True, context=self.context).data
         )
+
+    def get_schedule_truth(self, saved_query: DataWarehouseSavedQuery) -> dict:
+        return self.context.get("schedule_truth") or {}
 
 
 class InternalDataModelingJobSerializer(serializers.ModelSerializer):

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -35,7 +35,7 @@ from products.data_modeling.backend.facade.models import (
     Edge,
     Node,
 )
-from products.data_modeling.backend.logic.schedule_truth import SCHEDULE_CANDIDATE_CAP, describe_schedules
+from products.data_modeling.backend.facade.schedule_truth import SCHEDULE_CANDIDATE_CAP, describe_schedules
 from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsAuthenticationMixin
 from products.data_modeling.backend.presentation.internal_serializers import (
     InternalDAGSummarySerializer,

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -35,11 +35,13 @@ from products.data_modeling.backend.facade.models import (
     Edge,
     Node,
 )
+from products.data_modeling.backend.logic.schedule_truth import SCHEDULE_CANDIDATE_CAP, describe_schedules
 from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsAuthenticationMixin
 from products.data_modeling.backend.presentation.internal_serializers import (
     InternalDAGSummarySerializer,
     InternalDataModelingJobSerializer,
     InternalEdgeSerializer,
+    InternalEntityScheduleSerializer,
     InternalNodeSerializer,
     InternalSavedQueryDetailSerializer,
     InternalSavedQuerySummarySerializer,
@@ -64,6 +66,31 @@ def _is_v2_backend_enabled(team_id: int, organization_id: str) -> bool:
             "project": {"id": str(team_id)},
         },
     )
+
+
+def _saved_query_schedule_truth(saved_query: DataWarehouseSavedQuery, nodes: list[dict]) -> dict:
+    """Which Temporal schedule covers this saved query: its own v1 schedule, a v2
+    schedule on one of its DAGs, or none. Degrades to an error payload so a Temporal
+    outage never takes down the detail endpoint."""
+    try:
+        own_id = str(saved_query.id)
+        dag_ids = [str(node["dag_id"]) for node in nodes]
+        descriptions = describe_schedules([own_id, *dag_ids])
+
+        own = descriptions.get(own_id)
+        dag_schedules = [
+            {"dag_id": dag_id, "dag_name": node["dag_name"], "schedule": descriptions.get(dag_id)}
+            for dag_id, node in zip(dag_ids, nodes)
+        ]
+        if any(entry["schedule"] and entry["schedule"]["kind"] == "v2_dag" for entry in dag_schedules):
+            covered_by = "v2"
+        elif own and own["kind"] == "v1_saved_query":
+            covered_by = "v1"
+        else:
+            covered_by = "none"
+        return {"covered_by": covered_by, "v1_schedule": own, "dag_schedules": dag_schedules}
+    except Exception as error:
+        return {"error": str(error)}
 
 
 def team_id_filter(request: Request) -> int | None:
@@ -213,9 +240,34 @@ class InternalDataModelingOpsViewSet(
                 "backing_tables": backing_tables,
                 "linked_table_id": saved_query.table_id,
                 "last_successful_job_at": last_successful_job_at,
+                "schedule_truth": _saved_query_schedule_truth(saved_query, nodes),
             },
         )
         return Response(serializer.data)
+
+    @extend_schema(exclude=True)
+    def internal_schedules(self, request: Request, team_id: str) -> Response:
+        entities = [
+            {"entity_type": "dag", "entity_id": str(dag["id"]), "entity_name": dag["name"]}
+            for dag in DAG.objects.filter(team_id=int(team_id)).values("id", "name")
+        ] + [
+            {"entity_type": "saved_query", "entity_id": str(sq["id"]), "entity_name": sq["name"]}
+            for sq in DataWarehouseSavedQuery.objects.filter(team_id=int(team_id))
+            .exclude(deleted=True)
+            .filter(Q(is_materialized=True) | Q(sync_frequency_interval__isnull=False))
+            .values("id", "name")
+        ]
+        truncated = len(entities) > SCHEDULE_CANDIDATE_CAP
+        entities = entities[:SCHEDULE_CANDIDATE_CAP]
+
+        descriptions = describe_schedules([entity["entity_id"] for entity in entities])
+        results = [{**entity, "schedule": descriptions.get(entity["entity_id"])} for entity in entities]
+        return Response(
+            {
+                "results": InternalEntityScheduleSerializer(results, many=True).data,
+                "truncated": truncated,
+            }
+        )
 
     @extend_schema(exclude=True)
     def internal_saved_query_jobs(self, request: Request, saved_query_id: str, **kwargs: Any) -> Response:

--- a/products/data_modeling/backend/presentation/internal_views.py
+++ b/products/data_modeling/backend/presentation/internal_views.py
@@ -246,13 +246,14 @@ class InternalDataModelingOpsViewSet(
         return Response(serializer.data)
 
     @extend_schema(exclude=True)
-    def internal_schedules(self, request: Request, team_id: str) -> Response:
+    def internal_schedules(self, request: Request, **kwargs: Any) -> Response:
+        team_id = team_id_filter(request)
         entities = [
             {"entity_type": "dag", "entity_id": str(dag["id"]), "entity_name": dag["name"]}
-            for dag in DAG.objects.filter(team_id=int(team_id)).values("id", "name")
+            for dag in scoped_to_team(DAG.objects.all(), team_id).values("id", "name")
         ] + [
             {"entity_type": "saved_query", "entity_id": str(sq["id"]), "entity_name": sq["name"]}
-            for sq in DataWarehouseSavedQuery.objects.filter(team_id=int(team_id))
+            for sq in scoped_to_team(DataWarehouseSavedQuery.objects.all(), team_id)
             .exclude(deleted=True)
             .filter(Q(is_materialized=True) | Q(sync_frequency_interval__isnull=False))
             .values("id", "name")
@@ -260,12 +261,20 @@ class InternalDataModelingOpsViewSet(
         truncated = len(entities) > SCHEDULE_CANDIDATE_CAP
         entities = entities[:SCHEDULE_CANDIDATE_CAP]
 
-        descriptions = describe_schedules([entity["entity_id"] for entity in entities])
+        temporal_error: str | None = None
+        try:
+            descriptions = describe_schedules([entity["entity_id"] for entity in entities])
+        except Exception as error:
+            # Same degradation as the detail route: the entity list is DB-derived, so a
+            # Temporal outage nulls the schedule column instead of 500ing the view.
+            descriptions = {}
+            temporal_error = str(error)
         results = [{**entity, "schedule": descriptions.get(entity["entity_id"])} for entity in entities]
         return Response(
             {
                 "results": InternalEntityScheduleSerializer(results, many=True).data,
                 "truncated": truncated,
+                "temporal_error": temporal_error,
             }
         )
 

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team
+
 from products.data_modeling.backend.logic.schedule_truth import extract_schedule_info
 from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node, NodeType
 from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
@@ -30,14 +31,7 @@ class InternalOpsAPITestCase(OidcAuthTestMixin, APIBaseTest):
 class TestInternalDataModelingOpsAPI(InternalOpsAPITestCase):
     # The client is session-logged-in (APIBaseTest), so the no-bearer row also proves
     # session auth cannot reach these routes.
-    
 
-    
-    
-
-    
-
-    
     @parameterized.expand(
         [
             ("session_only_no_bearer", lambda: None),
@@ -91,7 +85,8 @@ class TestInternalDataModelingOpsAPI(InternalOpsAPITestCase):
         self.assertEqual(data["failing_saved_query_count"], 1)
         self.assertEqual(data["saved_queries_with_sync_frequency_count"], 1)
 
-    def test_saved_query_detail_surfaces_duplicate_backing_tables_and_dag_context(self):
+    @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules", return_value={})
+    def test_saved_query_detail_surfaces_duplicate_backing_tables_and_dag_context(self, _mock_describe):
         saved_query = DataWarehouseSavedQuery.objects.create(
             team=self.team, name="my_view", query={"query": "select * from events"}
         )
@@ -284,6 +279,20 @@ class TestInternalSchedulesAPI(InternalOpsAPITestCase):
         self.assertEqual(truth["covered_by"], "v2")
         self.assertIsNone(truth["v1_schedule"])
         self.assertEqual(truth["dag_schedules"][0]["schedule"]["kind"], "v2_dag")
+
+    @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules")
+    def test_schedules_list_survives_temporal_outage(self, mock_describe):
+        mock_describe.side_effect = RuntimeError("temporal unreachable")
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}, is_materialized=True
+        )
+
+        response = self._get("/schedules", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["temporal_error"], "temporal unreachable")
+        self.assertIsNone(data["results"][0]["schedule"])
 
     @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules")
     def test_detail_survives_temporal_outage(self, mock_describe):

--- a/products/data_modeling/backend/tests/api/test_internal_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_ops_api.py
@@ -1,20 +1,22 @@
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team
-
+from products.data_modeling.backend.logic.schedule_truth import extract_schedule_info
 from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Edge, Node, NodeType
 from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
-class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
+class InternalOpsAPITestCase(OidcAuthTestMixin, APIBaseTest):
     def _get(self, path: str, token: str | None = None):
         base = "/api/internal/data_modeling_ops"
         if token is not None:
@@ -24,8 +26,18 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
     def _token(self) -> str:
         return mint_oidc_token()
 
+
+class TestInternalDataModelingOpsAPI(InternalOpsAPITestCase):
     # The client is session-logged-in (APIBaseTest), so the no-bearer row also proves
     # session auth cannot reach these routes.
+    
+
+    
+    
+
+    
+
+    
     @parameterized.expand(
         [
             ("session_only_no_bearer", lambda: None),
@@ -184,3 +196,103 @@ class TestInternalDataModelingOpsAPI(OidcAuthTestMixin, APIBaseTest):
         self.assertEqual({n["name"] for n in data["nodes"]}, {"events", "my_view"})
         self.assertEqual(len(data["edges"]), 1)
         self.assertEqual(data["edges"][0]["source_id"], str(events_table.id))
+
+
+def _fake_schedule_description(workflow: str, dag_attr: str | None = None):
+    spec = SimpleNamespace(
+        intervals=[SimpleNamespace(every=timedelta(hours=24))],
+        cron_expressions=[],
+        calendars=[],
+        jitter=None,
+        time_zone_name=None,
+    )
+    attrs = []
+    if dag_attr:
+        attrs.append(SimpleNamespace(key=SimpleNamespace(name="PostHogDagId"), value=dag_attr))
+    return SimpleNamespace(
+        schedule=SimpleNamespace(
+            action=SimpleNamespace(workflow=workflow),
+            spec=spec,
+            state=SimpleNamespace(paused=True, note="paused by ops"),
+        ),
+        info=SimpleNamespace(
+            next_action_times=[datetime(2026, 7, 4, 12, 0, tzinfo=UTC)],
+            recent_actions=[
+                SimpleNamespace(
+                    scheduled_at=datetime(2026, 7, 3, 12, 0, tzinfo=UTC),
+                    started_at=datetime(2026, 7, 3, 12, 0, 5, tzinfo=UTC),
+                    action=SimpleNamespace(workflow_id="data-modeling-run-abc", first_execution_run_id="run-1"),
+                )
+            ],
+        ),
+        typed_search_attributes=SimpleNamespace(search_attributes=attrs),
+    )
+
+
+class TestExtractScheduleInfo(SimpleTestCase):
+    def test_classifies_by_workflow_name_even_when_dag_attribute_present(self):
+        description = _fake_schedule_description("data-modeling-run", dag_attr="0198-some-dag")
+
+        info = extract_schedule_info("0197-some-saved-query", description)
+
+        self.assertEqual(info["kind"], "v1_saved_query")
+        self.assertEqual(info["search_attributes"], {"PostHogDagId": "0198-some-dag"})
+        self.assertTrue(info["paused"])
+        self.assertEqual(info["note"], "paused by ops")
+        self.assertEqual(info["next_run_at"], "2026-07-04T12:00:00+00:00")
+        self.assertEqual(info["spec"]["intervals"], ["1 day, 0:00:00"])
+        self.assertEqual(info["recent_actions"][0]["workflow_id"], "data-modeling-run-abc")
+
+
+class TestInternalSchedulesAPI(InternalOpsAPITestCase):
+    @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules")
+    def test_schedules_keeps_unscheduled_materialized_entities_visible(self, mock_describe):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}, is_materialized=True
+        )
+        mock_describe.return_value = {
+            str(dag.id): extract_schedule_info(str(dag.id), _fake_schedule_description("data-modeling-execute-dag")),
+            str(saved_query.id): None,
+        }
+
+        response = self._get("/schedules", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        by_entity = {r["entity_id"]: r for r in response.json()["results"]}
+        self.assertEqual(set(by_entity), {str(dag.id), str(saved_query.id)})
+        self.assertEqual(by_entity[str(dag.id)]["schedule"]["kind"], "v2_dag")
+        self.assertIsNone(by_entity[str(saved_query.id)]["schedule"])
+        self.assertFalse(response.json()["truncated"])
+
+    @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules")
+    def test_detail_reports_v2_coverage_from_dag_schedule(self, mock_describe):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}, is_materialized=True
+        )
+        Node.objects.create(team=self.team, dag=dag, saved_query=saved_query, type=NodeType.MAT_VIEW)
+        mock_describe.return_value = {
+            str(saved_query.id): None,
+            str(dag.id): extract_schedule_info(str(dag.id), _fake_schedule_description("data-modeling-execute-dag")),
+        }
+
+        response = self._get(f"/saved_queries/{saved_query.id}", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        truth = response.json()["schedule_truth"]
+        self.assertEqual(truth["covered_by"], "v2")
+        self.assertIsNone(truth["v1_schedule"])
+        self.assertEqual(truth["dag_schedules"][0]["schedule"]["kind"], "v2_dag")
+
+    @patch("products.data_modeling.backend.presentation.internal_views.describe_schedules")
+    def test_detail_survives_temporal_outage(self, mock_describe):
+        mock_describe.side_effect = RuntimeError("temporal unreachable")
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}
+        )
+
+        response = self._get(f"/saved_queries/{saved_query.id}", self._token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["schedule_truth"], {"error": "temporal unreachable"})


### PR DESCRIPTION
## Problem

Stacked on #68238. That PR reads Postgres state, but the other half of debugging a materialization is Temporal: which schedule covers this entity, is it paused, when does it run next, what did it start. Today that means the Temporal UI plus knowing the id conventions by heart.

There's a trap here. v1 per-query schedules also carry the `PostHogDagId` search attribute when the saved query has a node, so classifying by that attribute reads v1 schedules as v2. The only reliable discriminator is the workflow the schedule starts.

## Changes

- `GET api/internal/data_modeling_ops/schedules` (`?team_id=` to narrow). Candidates come from the DB, DAG ids plus saved queries that are materialized or still carry `sync_frequency_interval`, then get described concurrently against Temporal. Entities with no schedule stay in the response with a null slot, so "materialized but unscheduled" is visible rather than silently dropped. Bounded at concurrency 10 and 500 candidates, with a `truncated` flag.
- Saved-query detail gains `schedule_truth`: `covered_by` (its own v1 schedule, a v2 schedule on one of its DAGs, or none), paused state, operator note, next run, spec summary, and the 5 most recent actions with started workflow ids. Degrades to `{"error": ...}` so a Temporal outage never 500s the page.
- `logic/schedule_truth.py` holds extraction and classification. Classification is by workflow name only: `data-modeling-run` is v1, `data-modeling-execute-dag` is v2. Search attributes are surfaced as data, never used to classify.

## How did you test this code?

5 new tests, each tied to a regression:

- `extract_schedule_info` classifies a schedule carrying `PostHogDagId` as v1 when its workflow is `data-modeling-run`. Guards against reintroducing attribute-based classification.
- the schedules route keeps unscheduled materialized entities visible with a null slot.
- detail reports `covered_by: v2` from a DAG schedule when there's no v1 schedule, locking the resolution order.
- detail returns 200 with an error payload when Temporal raises.

85 tests green at this tip.

I also ran this branch against the local dev stack with its real Temporal, which caught two mismatches the mocks hid: `ScheduleActionResult` uses `scheduled_at`/`started_at`, and typed attributes live on `ScheduleDescription.typed_search_attributes` (the legacy `search_attributes` mapping silently returned an empty dict).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8). Skills invoked: `/writing-tests`, `/verifying-posthog-local`.

The local-Temporal run was the load-bearing step. Both object-shape bugs passed every mocked test and would have shipped as empty or missing fields.
