### PR TITLE
feat(batch-exports): add tracing for S3 consumer

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -641,6 +641,10 @@ class ConcurrentS3Consumer(Consumer):
             # Ensure that we give pending tasks a chance to run.
             await asyncio.sleep(0)
 
+    def reset_tracking(self) -> None:
+        super().reset_tracking()
+        self._upload_slot_wait_timer = CumulativeTimer()
+
     def get_destination_span_attributes(self) -> Attributes:
         return {
             "batch_export.s3.files_uploaded": len(self.files_uploaded),
@@ -747,47 +751,49 @@ class ConcurrentS3Consumer(Consumer):
             ):
                 recorder.add_bytes_processed(len(data))
 
-                while response is None:
-                    try:
-                        response = await client.upload_part(
-                            Bucket=self.bucket,
-                            Key=current_key,
-                            PartNumber=part_number,
-                            UploadId=self.upload_id,
-                            Body=data,
-                            **optional_kwargs,  # type: ignore
-                        )
-
-                    except botocore.exceptions.ClientError as err:
-                        error_code = err.response.get("Error", {}).get("Code", None)
+                # Recorded in a `finally` so the count still lands on the span when retries are
+                # exhausted and we raise, which is exactly when it's most diagnostic. Backoff sleeps
+                # happen inside this span, so the count also explains durations inflated by retries.
+                try:
+                    while response is None:
                         attempt += 1
-
-                        self.logger.warning(
-                            "Caught ClientError while uploading file %s part %s: %s (attempt %s/%s)",
-                            self.current_file_index,
-                            part_number,
-                            error_code,
-                            attempt,
-                            self.UPLOAD_PART_MAX_ATTEMPTS,
-                        )
-
-                        if error_code is not None and error_code == "RequestTimeout":
-                            if attempt >= self.UPLOAD_PART_MAX_ATTEMPTS:
-                                raise IntermittentUploadPartTimeoutError(part_number=part_number) from err
-
-                            retry_delay = min(
-                                self.MAX_RETRY_DELAY,
-                                self.INITIAL_RETRY_DELAY * (attempt**self.EXPONENTIAL_BACKOFF_COEFFICIENT),
+                        try:
+                            response = await client.upload_part(
+                                Bucket=self.bucket,
+                                Key=current_key,
+                                PartNumber=part_number,
+                                UploadId=self.upload_id,
+                                Body=data,
+                                **optional_kwargs,  # type: ignore
                             )
-                            self.logger.warning("Retrying part %s upload in %s seconds", part_number, retry_delay)
-                            await asyncio.sleep(retry_delay)
-                            continue
-                        else:
-                            raise
 
-                # Retry backoff sleeps happen inside this span, so the attempt count
-                # explains part upload durations inflated by retries.
-                span.set_attribute("batch_export.s3.upload_attempts", attempt + 1)
+                        except botocore.exceptions.ClientError as err:
+                            error_code = err.response.get("Error", {}).get("Code", None)
+
+                            self.logger.warning(
+                                "Caught ClientError while uploading file %s part %s: %s (attempt %s/%s)",
+                                self.current_file_index,
+                                part_number,
+                                error_code,
+                                attempt,
+                                self.UPLOAD_PART_MAX_ATTEMPTS,
+                            )
+
+                            if error_code is not None and error_code == "RequestTimeout":
+                                if attempt >= self.UPLOAD_PART_MAX_ATTEMPTS:
+                                    raise IntermittentUploadPartTimeoutError(part_number=part_number) from err
+
+                                retry_delay = min(
+                                    self.MAX_RETRY_DELAY,
+                                    self.INITIAL_RETRY_DELAY * (attempt**self.EXPONENTIAL_BACKOFF_COEFFICIENT),
+                                )
+                                self.logger.warning("Retrying part %s upload in %s seconds", part_number, retry_delay)
+                                await asyncio.sleep(retry_delay)
+                                continue
+                            else:
+                                raise
+                finally:
+                    span.set_attribute("batch_export.s3.upload_attempts", attempt)
 
             part_info: CompletedPartTypeDef = {
                 "ETag": response["ETag"],

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -9,6 +9,7 @@ import aioboto3
 import botocore.exceptions
 from aiobotocore.config import AioConfig
 from aiobotocore.session import ClientCreatorContext
+from opentelemetry import trace
 
 if typing.TYPE_CHECKING:
     from types_aiobotocore_s3.client import S3Client
@@ -47,7 +48,7 @@ from products.batch_exports.backend.temporal.destinations.constants import (
     S3_SUPPORTED_COMPRESSIONS as SUPPORTED_COMPRESSIONS,
 )
 from products.batch_exports.backend.temporal.destinations.utils import get_manifest_key, get_object_key
-from products.batch_exports.backend.temporal.metrics import ExecutionTimeRecorder
+from products.batch_exports.backend.temporal.metrics import Attributes, CumulativeTimer, ExecutionTimeRecorder
 from products.batch_exports.backend.temporal.pipeline.consumer import Consumer, run_consumer_from_stage
 from products.batch_exports.backend.temporal.pipeline.entrypoint import execute_batch_export_using_internal_stage
 from products.batch_exports.backend.temporal.pipeline.producer import Producer as ProducerFromInternalStage
@@ -99,6 +100,7 @@ COMPRESSION_EXTENSIONS = {
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
+TRACER = trace.get_tracer(__name__)
 
 
 class UnsupportedFileFormatError(Exception):
@@ -531,6 +533,10 @@ class ConcurrentS3Consumer(Consumer):
         self.part_size = part_size
         self.max_concurrent_uploads = max_concurrent_uploads
         self.upload_semaphore = asyncio.Semaphore(max_concurrent_uploads)
+        # Time spent blocked waiting for an upload slot (i.e. `max_concurrent_uploads` parts are
+        # already in flight), reported as a span attribute. When this dominates the consumer's
+        # consume time, the bottleneck is upload throughput to the destination.
+        self._upload_slot_wait_timer = CumulativeTimer()
 
         self._session = aioboto3.Session()
         self._s3_client: S3Client | None = None  # Shared S3 client
@@ -635,6 +641,12 @@ class ConcurrentS3Consumer(Consumer):
             # Ensure that we give pending tasks a chance to run.
             await asyncio.sleep(0)
 
+    def get_destination_span_attributes(self) -> Attributes:
+        return {
+            "batch_export.s3.files_uploaded": len(self.files_uploaded),
+            "batch_export.s3.total_upload_slot_wait_seconds": self._upload_slot_wait_timer.total_seconds,
+        }
+
     async def _upload_next_part(self, final: bool = False):
         """Extract a part from buffer and upload it"""
         if not len(self.current_buffer):
@@ -658,7 +670,8 @@ class ConcurrentS3Consumer(Consumer):
         self.part_counter += 1
 
         # Acquire upload semaphore (blocks if too many uploads in flight)
-        await self.upload_semaphore.acquire()
+        with self._upload_slot_wait_timer.time():
+            await self.upload_semaphore.acquire()
 
         # Create upload task
         upload_task = asyncio.create_task(self._upload_part_with_cleanup(part_data, part_number))
@@ -707,21 +720,31 @@ class ConcurrentS3Consumer(Consumer):
             response: UploadPartOutputTypeDef | None = None
             attempt = 0
 
-            with ExecutionTimeRecorder(
-                "s3_batch_export_upload_part_duration",
-                description="Total duration of the upload of a part of a multi-part upload",
-                log_message=(
-                    "Finished uploading file number %(file_number)d part %(part_number)d"
-                    " with upload id '%(upload_id)s' with status '%(status)s'."
-                    " File size: %(mb_processed).2f MB, upload time: %(duration_seconds)d"
-                    " seconds, speed: %(mb_per_second).2f MB/s"
-                ),
-                log_attributes={
-                    "file_number": self.current_file_index,
-                    "upload_id": self.upload_id,
-                    "part_number": part_number,
-                },
-            ) as recorder:
+            with (
+                TRACER.start_as_current_span(
+                    "batch_export.s3.upload_part",
+                    attributes={
+                        "batch_export.s3.file_number": self.current_file_index,
+                        "batch_export.s3.part_number": part_number,
+                        "batch_export.s3.part_bytes": len(data),
+                    },
+                ) as span,
+                ExecutionTimeRecorder(
+                    "s3_batch_export_upload_part_duration",
+                    description="Total duration of the upload of a part of a multi-part upload",
+                    log_message=(
+                        "Finished uploading file number %(file_number)d part %(part_number)d"
+                        " with upload id '%(upload_id)s' with status '%(status)s'."
+                        " File size: %(mb_processed).2f MB, upload time: %(duration_seconds)d"
+                        " seconds, speed: %(mb_per_second).2f MB/s"
+                    ),
+                    log_attributes={
+                        "file_number": self.current_file_index,
+                        "upload_id": self.upload_id,
+                        "part_number": part_number,
+                    },
+                ) as recorder,
+            ):
                 recorder.add_bytes_processed(len(data))
 
                 while response is None:
@@ -761,6 +784,10 @@ class ConcurrentS3Consumer(Consumer):
                             continue
                         else:
                             raise
+
+                # Retry backoff sleeps happen inside this span, so the attempt count
+                # explains part upload durations inflated by retries.
+                span.set_attribute("batch_export.s3.upload_attempts", attempt + 1)
 
             part_info: CompletedPartTypeDef = {
                 "ETag": response["ETag"],
@@ -872,11 +899,15 @@ class ConcurrentS3Consumer(Consumer):
 
         current_key = self._get_current_key()
         client = await self._get_s3_client()
-        response = await client.create_multipart_upload(
-            Bucket=self.bucket,
-            Key=current_key,
-            **optional_kwargs,  # type: ignore
-        )
+        with TRACER.start_as_current_span(
+            "batch_export.s3.create_multipart_upload",
+            attributes={"batch_export.s3.file_number": self.current_file_index},
+        ):
+            response = await client.create_multipart_upload(
+                Bucket=self.bucket,
+                Key=current_key,
+                **optional_kwargs,  # type: ignore
+            )
         self.upload_id = response["UploadId"]
         self.logger.debug("Initialized multipart upload for key %s with upload id %s", current_key, self.upload_id)
 
@@ -927,12 +958,13 @@ class ConcurrentS3Consumer(Consumer):
         if self.endpoint_url is None:
             optional_kwargs["ChecksumAlgorithm"] = "CRC64NVME"
 
-        await client.put_object(
-            Bucket=self.bucket,
-            Key=manifest_key,
-            Body=json.dumps({"files": files_uploaded}),
-            **optional_kwargs,  # type: ignore
-        )
+        with TRACER.start_as_current_span("batch_export.s3.upload_manifest"):
+            await client.put_object(
+                Bucket=self.bucket,
+                Key=manifest_key,
+                Body=json.dumps({"files": files_uploaded}),
+                **optional_kwargs,  # type: ignore
+            )
 
         if self._s3_client is not None and self._s3_client_ctx is not None:
             await self._s3_client_ctx.__aexit__(None, None, None)
@@ -959,12 +991,19 @@ class ConcurrentS3Consumer(Consumer):
 
         current_key = self._get_current_key()
         client = await self._get_s3_client()
-        await client.complete_multipart_upload(
-            Bucket=self.bucket,
-            Key=current_key,
-            UploadId=self.upload_id,
-            MultipartUpload={"Parts": sorted_parts},
-        )
+        with TRACER.start_as_current_span(
+            "batch_export.s3.complete_multipart_upload",
+            attributes={
+                "batch_export.s3.file_number": self.current_file_index,
+                "batch_export.s3.num_parts": len(sorted_parts),
+            },
+        ):
+            await client.complete_multipart_upload(
+                Bucket=self.bucket,
+                Key=current_key,
+                UploadId=self.upload_id,
+                MultipartUpload={"Parts": sorted_parts},
+            )
 
     async def _abort(self):
         """Abort this S3 multi-part upload and cancel any in-flight part uploads."""

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -751,9 +751,6 @@ class ConcurrentS3Consumer(Consumer):
             ):
                 recorder.add_bytes_processed(len(data))
 
-                # Recorded in a `finally` so the count still lands on the span when retries are
-                # exhausted and we raise, which is exactly when it's most diagnostic. Backoff sleeps
-                # happen inside this span, so the count also explains durations inflated by retries.
                 try:
                     while response is None:
                         attempt += 1
@@ -793,6 +790,8 @@ class ConcurrentS3Consumer(Consumer):
                             else:
                                 raise
                 finally:
+                    # Backoff sleeps happen inside this span, so the count also explains durations
+                    # inflated by retries.
                     span.set_attribute("batch_export.s3.upload_attempts", attempt)
 
             part_info: CompletedPartTypeDef = {

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -12,6 +12,7 @@ from opentelemetry import trace
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
 
 from products.batch_exports.backend.temporal.metrics import (
+    Attributes,
     CumulativeTimer,
     get_bytes_exported_metric,
     get_rows_exported_metric,
@@ -174,8 +175,17 @@ class Consumer:
                 "batch_export.consumer.total_queue_get_wait_seconds": queue_get_wait_seconds,
                 "batch_export.consumer.total_consume_seconds": consume_seconds,
                 "batch_export.consumer.total_transform_seconds": transform_seconds,
+                **self.get_destination_span_attributes(),
             }
         )
+
+    def get_destination_span_attributes(self) -> Attributes:
+        """Destination-specific attributes to report on the consumer span.
+
+        Subclasses can override this to break down where their consume time goes
+        (e.g. time blocked on destination upload capacity).
+        """
+        return {}
 
     def collect_result(self) -> BatchExportResult:
         """Collect the result of the consumer.


### PR DESCRIPTION
## Problem

#68233 added pipeline spans that attribute batch export time to producer, transformer, or consumer. But when the consumer is the slow stage of an S3 export, the trace can't say why: is it a slow part upload, retries, waiting for an upload slot, etc? This PR instruments one destination (S3) as a first step, paving the way for other destinations if the data proves to be useful.

## Changes

All in `ConcurrentS3Consumer`, stacked on #68233 (base branch is `posthog-code/batch-export-pipeline-spans`):

- A `batch_export.s3.upload_part` span per part upload, wrapping the same window as the existing `s3_batch_export_upload_part_duration` Prometheus metric. Attributes: `file_number`, `part_number`, `part_bytes`, and `upload_attempts` (retry backoff sleeps happen inside the span, so the attempt count explains inflated durations). Parts upload as background asyncio tasks, so these spans overlap in the trace timeline, up to `max_concurrent_uploads` at once, parented under `batch_export.consumer`.
- Spans for the multipart lifecycle calls: `create_multipart_upload`, `complete_multipart_upload` (with `num_parts`, since this call gets slower with part count), and `upload_manifest`.
- A cumulative `batch_export.s3.total_upload_slot_wait_seconds` attribute on the consumer span, measuring time `consume_chunk` spent blocked on the upload semaphore. When this dominates `total_consume_seconds`, the export is limited by upload throughput to the destination bucket rather than by transform or produce. Reported through a new overridable `get_destination_span_attributes()` hook on the base `Consumer` (the only shared-code change), plus `files_uploaded`.

On cardinality: parts are 50 MB by default, so even a large export produces a bounded number of part spans per trace.

## How did you test this code?

- Automated tests: `products/batch_exports/backend/tests/temporal/pipeline/test_consumer.py` and `products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py`
- Also ran tests against AWS S3 test bucket.
- No new unit tests: the change adds observability around existing behavior, and span emission is a no-op without an OTel SDK configured, so there's no realistic regression a test would catch.
- Validated locally by running a batch export and checking spans produced in the Jaeger UI:

<img width="1128" height="173" alt="image" src="https://github.com/user-attachments/assets/ac4510d1-4db8-4fa3-bf28-b69922833cce" />


<img width="1933" height="475" alt="image" src="https://github.com/user-attachments/assets/61021beb-0263-40bb-8b31-416fb9906e47" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with PostHog Code (Claude). Third PR in the batch export tracing series, after #67772 (trace attributes) and #68233 (pipeline spans); the goal here is to trial per-destination instrumentation on S3 before deciding whether to roll it out to other destinations.
- Per-part spans were chosen over cumulative attributes here (the opposite call from #68233) because part counts are bounded by the 50 MB part size, and per-part durations plus retry counts are exactly the signal wanted.
- Attributes are passed inline to `start_as_current_span` where known upfront (reviewer-suggested), so they're visible to samplers; only end-of-run values use `set_attribute(s)`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*