### PR TITLE
fix(data-warehouse): tailor unindexed-field sync warning to source type

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6267,8 +6267,16 @@ export interface RowFilter {
     value: string | number | boolean
 }
 
+/** Backend-supplied copy for the "unindexed incremental field" warning, phrased in terms of the
+ *  source engine's native fast-lookup structure (index, sort key, clustering key, ...). */
+export interface IndexWarningCopy {
+    mechanism: string
+    suggestion: string
+}
+
 export type SchemaIncrementalFieldsResponse = {
     incremental_fields: IncrementalField[]
+    index_warning_copy?: IndexWarningCopy
     incremental_available: boolean
     append_available: boolean
     full_refresh_available: boolean
@@ -6304,6 +6312,7 @@ export interface ExternalDataSourceSyncSchema {
     incremental_field_lookback_seconds?: number | null
     sync_type: 'full_refresh' | 'incremental' | 'append' | 'webhook' | 'cdc' | 'xmin' | null
     incremental_fields: IncrementalField[]
+    index_warning_copy?: IndexWarningCopy
     incremental_available: boolean
     append_available: boolean
     cdc_available?: boolean

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6269,7 +6269,8 @@ export interface RowFilter {
 
 /** The fast-lookup structure the source engine's `is_indexed` detection checks — most databases
  *  use secondary indexes, but columnar warehouses prune scans via sort/clustering/partition keys.
- *  Mirrors IndexMechanism on the backend. */
+ *  Keep in sync with IndexMechanism in products/warehouse_sources/backend/types.py — backend
+ *  values missing here render the generic "index" warning copy. */
 export type IndexMechanism = 'index' | 'sort_key' | 'clustering_key' | 'partition_or_clustering' | 'sorting_key'
 
 export type SchemaIncrementalFieldsResponse = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6267,16 +6267,14 @@ export interface RowFilter {
     value: string | number | boolean
 }
 
-/** Backend-supplied copy for the "unindexed incremental field" warning, phrased in terms of the
- *  source engine's native fast-lookup structure (index, sort key, clustering key, ...). */
-export interface IndexWarningCopy {
-    mechanism: string
-    suggestion: string
-}
+/** The fast-lookup structure the source engine's `is_indexed` detection checks — most databases
+ *  use secondary indexes, but columnar warehouses prune scans via sort/clustering/partition keys.
+ *  Mirrors IndexMechanism on the backend. */
+export type IndexMechanism = 'index' | 'sort_key' | 'clustering_key' | 'partition_or_clustering' | 'sorting_key'
 
 export type SchemaIncrementalFieldsResponse = {
     incremental_fields: IncrementalField[]
-    index_warning_copy?: IndexWarningCopy
+    index_mechanism?: IndexMechanism
     incremental_available: boolean
     append_available: boolean
     full_refresh_available: boolean
@@ -6312,7 +6310,7 @@ export interface ExternalDataSourceSyncSchema {
     incremental_field_lookback_seconds?: number | null
     sync_type: 'full_refresh' | 'incremental' | 'append' | 'webhook' | 'cdc' | 'xmin' | null
     incremental_fields: IncrementalField[]
-    index_warning_copy?: IndexWarningCopy
+    index_mechanism?: IndexMechanism
     incremental_available: boolean
     append_available: boolean
     cdc_available?: boolean

--- a/products/data_warehouse/backend/presentation/views/external_data_schema.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_schema.py
@@ -1619,7 +1619,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         data = {
             "incremental_fields": schema.incremental_fields,
-            "index_warning_copy": new_source.index_warning_copy,
+            "index_mechanism": new_source.index_mechanism,
             "incremental_available": schema.supports_incremental,
             "append_available": schema.supports_append,
             "cdc_available": cdc_available,

--- a/products/data_warehouse/backend/presentation/views/external_data_schema.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_schema.py
@@ -1619,7 +1619,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         data = {
             "incremental_fields": schema.incremental_fields,
-            "index_mechanism": new_source.index_mechanism,
+            "index_mechanism": new_source.index_mechanism.value,
             "incremental_available": schema.supports_incremental,
             "append_available": schema.supports_append,
             "cdc_available": cdc_available,

--- a/products/data_warehouse/backend/presentation/views/external_data_schema.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_schema.py
@@ -1619,6 +1619,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         data = {
             "incremental_fields": schema.incremental_fields,
+            "index_warning_copy": new_source.index_warning_copy,
             "incremental_available": schema.supports_incremental,
             "append_available": schema.supports_append,
             "cdc_available": cdc_available,

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -3120,7 +3120,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 "label": schema.label,
                 "should_sync": False,
                 "incremental_fields": schema.incremental_fields,
-                "index_warning_copy": source.index_warning_copy,
+                "index_mechanism": source.index_mechanism,
                 "incremental_available": schema.supports_incremental,
                 "append_available": schema.supports_append,
                 "cdc_available": schema.supports_cdc if cdc_enabled else None,

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -3120,7 +3120,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 "label": schema.label,
                 "should_sync": False,
                 "incremental_fields": schema.incremental_fields,
-                "index_mechanism": source.index_mechanism,
+                "index_mechanism": source.index_mechanism.value,
                 "incremental_available": schema.supports_incremental,
                 "append_available": schema.supports_append,
                 "cdc_available": schema.supports_cdc if cdc_enabled else None,

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -3120,6 +3120,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 "label": schema.label,
                 "should_sync": False,
                 "incremental_fields": schema.incremental_fields,
+                "index_warning_copy": source.index_warning_copy,
                 "incremental_available": schema.supports_incremental,
                 "append_available": schema.supports_append,
                 "cdc_available": schema.supports_cdc if cdc_enabled else None,

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -111,6 +111,7 @@ class TestExternalDataSchema(APIBaseTest):
             "incremental_fields": [
                 {"label": "created_at", "type": "datetime", "field": "created", "field_type": "integer"}
             ],
+            "index_warning_copy": {"mechanism": "index", "suggestion": "Consider adding an index"},
             "incremental_available": False,
             "append_available": True,
             "cdc_available": None,
@@ -229,6 +230,7 @@ class TestExternalDataSchema(APIBaseTest):
                     "is_indexed": False,
                 },
             ],
+            "index_warning_copy": {"mechanism": "index", "suggestion": "Consider adding an index"},
             "incremental_available": True,
             "append_available": True,
             "cdc_available": None,

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -111,7 +111,7 @@ class TestExternalDataSchema(APIBaseTest):
             "incremental_fields": [
                 {"label": "created_at", "type": "datetime", "field": "created", "field_type": "integer"}
             ],
-            "index_warning_copy": {"mechanism": "index", "suggestion": "Consider adding an index"},
+            "index_mechanism": "index",
             "incremental_available": False,
             "append_available": True,
             "cdc_available": None,
@@ -230,7 +230,7 @@ class TestExternalDataSchema(APIBaseTest):
                     "is_indexed": False,
                 },
             ],
-            "index_warning_copy": {"mechanism": "index", "suggestion": "Consider adding an index"},
+            "index_mechanism": "index",
             "incremental_available": True,
             "append_available": True,
             "cdc_available": None,

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -58,7 +58,7 @@ from products.warehouse_sources.backend.facade.models import (
     PendingSourceCredential,
     sync_frequency_interval_to_sync_frequency,
 )
-from products.warehouse_sources.backend.facade.types import IncrementalFieldType
+from products.warehouse_sources.backend.facade.types import IncrementalFieldType, IndexMechanism
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import BigQuerySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
@@ -4470,6 +4470,8 @@ class TestExternalDataSource(APIBaseTest):
             SourceSchema(name="table_1", supports_incremental=False, supports_append=False, row_count=42)
         ]
         mock_source.get_endpoint_permissions.return_value = {}
+        # The response serializes this attribute; a bare MagicMock is not JSON-serializable.
+        mock_source.index_mechanism = IndexMechanism.INDEX
 
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
@@ -4554,6 +4556,7 @@ class TestExternalDataSource(APIBaseTest):
                             "is_indexed": True,
                         }
                     ],
+                    "index_mechanism": "index",
                     "incremental_available": True,
                     "append_available": True,
                     "cdc_available": None,
@@ -4625,6 +4628,7 @@ class TestExternalDataSource(APIBaseTest):
                             "is_indexed": True,
                         }
                     ],
+                    "index_mechanism": "index",
                     "incremental_available": True,
                     "append_available": True,
                     "cdc_available": None,

--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -460,6 +460,7 @@ function SyncMethodSection({
                         <SyncMethodForm
                             ref={formRef}
                             hideFooter
+                            sourceType={source?.source_type}
                             onSaveDisabledReasonChange={setSaveDisabledReason}
                             saveButtonIsLoading={saving}
                             schema={{

--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -478,7 +478,7 @@ function SyncMethodSection({
                                 xmin_available: schemaIncrementalFields.xmin_available,
                                 cdc_table_mode: schema.cdc_table_mode,
                                 incremental_fields: schemaIncrementalFields.incremental_fields,
-                                index_warning_copy: schemaIncrementalFields.index_warning_copy,
+                                index_mechanism: schemaIncrementalFields.index_mechanism,
                                 supports_webhooks: schemaIncrementalFields.supports_webhooks ?? false,
                                 primary_key_columns: schema.primary_key_columns ?? null,
                                 available_columns: [],

--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -460,7 +460,6 @@ function SyncMethodSection({
                         <SyncMethodForm
                             ref={formRef}
                             hideFooter
-                            sourceType={source?.source_type}
                             onSaveDisabledReasonChange={setSaveDisabledReason}
                             saveButtonIsLoading={saving}
                             schema={{
@@ -479,6 +478,7 @@ function SyncMethodSection({
                                 xmin_available: schemaIncrementalFields.xmin_available,
                                 cdc_table_mode: schema.cdc_table_mode,
                                 incremental_fields: schemaIncrementalFields.incremental_fields,
+                                index_warning_copy: schemaIncrementalFields.index_warning_copy,
                                 supports_webhooks: schemaIncrementalFields.supports_webhooks ?? false,
                                 primary_key_columns: schema.primary_key_columns ?? null,
                                 available_columns: [],

--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -690,7 +690,7 @@ export default function SchemaForm(): JSX.Element {
 
 const SyncMethodModal = (): JSX.Element => {
     const { cancelSyncMethodModal, updateSchemaSyncType, toggleSchemaShouldSync } = useActions(sourceWizardLogic)
-    const { syncMethodModalOpen, currentSyncMethodModalSchema } = useValues(sourceWizardLogic)
+    const { syncMethodModalOpen, currentSyncMethodModalSchema, selectedConnector } = useValues(sourceWizardLogic)
 
     if (!currentSyncMethodModalSchema) {
         return <></>
@@ -708,6 +708,7 @@ const SyncMethodModal = (): JSX.Element => {
         >
             <SyncMethodForm
                 schema={currentSyncMethodModalSchema}
+                sourceType={selectedConnector?.name}
                 onClose={cancelSyncMethodModal}
                 isNewSource
                 onSave={(

--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -690,7 +690,7 @@ export default function SchemaForm(): JSX.Element {
 
 const SyncMethodModal = (): JSX.Element => {
     const { cancelSyncMethodModal, updateSchemaSyncType, toggleSchemaShouldSync } = useActions(sourceWizardLogic)
-    const { syncMethodModalOpen, currentSyncMethodModalSchema, selectedConnector } = useValues(sourceWizardLogic)
+    const { syncMethodModalOpen, currentSyncMethodModalSchema } = useValues(sourceWizardLogic)
 
     if (!currentSyncMethodModalSchema) {
         return <></>
@@ -708,7 +708,6 @@ const SyncMethodModal = (): JSX.Element => {
         >
             <SyncMethodForm
                 schema={currentSyncMethodModalSchema}
-                sourceType={selectedConnector?.name}
                 onClose={cancelSyncMethodModal}
                 isNewSource
                 onSave={(

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
@@ -1,7 +1,7 @@
-import { ExternalDataSourceSyncSchema } from '~/types'
+import { ExternalDataSourceSyncSchema, IndexMechanism } from '~/types'
 
 import { SyncTypeLabelMap } from '../../../utils'
-import { shouldOfferXmin } from './SyncMethodForm'
+import { getIndexWarningCopy, shouldOfferXmin } from './SyncMethodForm'
 
 const baseSchema: ExternalDataSourceSyncSchema = {
     table: 'orders',
@@ -34,4 +34,16 @@ describe('SyncMethodForm', () => {
     it('exposes a label for the xmin sync type', () => {
         expect(SyncTypeLabelMap.xmin).toBe('xmin')
     })
+
+    // Responses predating index_mechanism, or a mechanism added on the backend before this build
+    // knows it, must fall back to the generic copy rather than rendering "No undefined detected".
+    it.each([undefined, 'brand_new_mechanism' as IndexMechanism])(
+        'index warning copy falls back to generic index advice for %s',
+        (indexMechanism) => {
+            expect(getIndexWarningCopy(indexMechanism)).toEqual({
+                mechanism: 'index',
+                suggestion: 'Consider adding an index',
+            })
+        }
+    )
 })

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
@@ -1,8 +1,7 @@
-import { ExternalDataSourceType } from '~/queries/schema/schema-general'
 import { ExternalDataSourceSyncSchema } from '~/types'
 
 import { SyncTypeLabelMap } from '../../../utils'
-import { getIndexWarningCopy, shouldOfferXmin } from './SyncMethodForm'
+import { shouldOfferXmin } from './SyncMethodForm'
 
 const baseSchema: ExternalDataSourceSyncSchema = {
     table: 'orders',
@@ -34,16 +33,5 @@ describe('SyncMethodForm', () => {
 
     it('exposes a label for the xmin sync type', () => {
         expect(SyncTypeLabelMap.xmin).toBe('xmin')
-    })
-
-    it.each<[ExternalDataSourceType | undefined, string]>([
-        ['Redshift', 'sort key'],
-        ['BigQuery', 'partition or clustering column'],
-        ['Snowflake', 'clustering key'],
-        ['ClickHouse', 'sorting key'],
-        ['Postgres', 'index'],
-        [undefined, 'index'],
-    ])('index warning copy for %s speaks in terms of "%s"', (sourceType, mechanism) => {
-        expect(getIndexWarningCopy(sourceType).mechanism).toBe(mechanism)
     })
 })

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
@@ -1,7 +1,8 @@
+import { ExternalDataSourceType } from '~/queries/schema/schema-general'
 import { ExternalDataSourceSyncSchema } from '~/types'
 
 import { SyncTypeLabelMap } from '../../../utils'
-import { shouldOfferXmin } from './SyncMethodForm'
+import { getIndexWarningCopy, shouldOfferXmin } from './SyncMethodForm'
 
 const baseSchema: ExternalDataSourceSyncSchema = {
     table: 'orders',
@@ -33,5 +34,16 @@ describe('SyncMethodForm', () => {
 
     it('exposes a label for the xmin sync type', () => {
         expect(SyncTypeLabelMap.xmin).toBe('xmin')
+    })
+
+    it.each<[ExternalDataSourceType | undefined, string]>([
+        ['Redshift', 'sort key'],
+        ['BigQuery', 'partition or clustering column'],
+        ['Snowflake', 'clustering key'],
+        ['ClickHouse', 'sorting key'],
+        ['Postgres', 'index'],
+        [undefined, 'index'],
+    ])('index warning copy for %s speaks in terms of "%s"', (sourceType, mechanism) => {
+        expect(getIndexWarningCopy(sourceType).mechanism).toBe(mechanism)
     })
 })

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
@@ -7,8 +7,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 
-import { ExternalDataSourceType } from '~/queries/schema/schema-general'
-import { AvailableColumn, ExternalDataSourceSyncSchema } from '~/types'
+import { AvailableColumn, ExternalDataSourceSyncSchema, IndexWarningCopy } from '~/types'
 
 const LOOKBACK_UNIT_SECONDS = {
     minutes: 60,
@@ -23,33 +22,8 @@ const LOOKBACK_ELIGIBLE_TYPES = new Set(['datetime', 'date', 'timestamp'])
 export const isLookbackEligibleType = (fieldType: string | null | undefined): boolean =>
     !!fieldType && LOOKBACK_ELIGIBLE_TYPES.has(fieldType)
 
-// Some sources have no secondary indexes — the backend's is_indexed detection checks their native
-// scan-pruning mechanism instead (sort/clustering/partition keys), so the advice must match.
-const INDEX_WARNING_COPY: Partial<Record<ExternalDataSourceType, { mechanism: string; suggestion: string }>> = {
-    Redshift: {
-        mechanism: 'sort key',
-        suggestion: "Consider making this field the table's sort key (the leading column of a compound SORTKEY)",
-    },
-    BigQuery: {
-        mechanism: 'partition or clustering column',
-        suggestion: 'Consider partitioning or clustering the table on this column',
-    },
-    Snowflake: {
-        mechanism: 'clustering key',
-        suggestion: "Consider setting the table's clustering key to this column",
-    },
-    ClickHouse: {
-        mechanism: 'sorting key',
-        suggestion: "Consider using a field that leads the table's ORDER BY",
-    },
-}
-
-const DEFAULT_INDEX_WARNING_COPY = { mechanism: 'index', suggestion: 'Consider adding an index' }
-
-export const getIndexWarningCopy = (
-    sourceType: ExternalDataSourceType | undefined
-): { mechanism: string; suggestion: string } =>
-    (sourceType && INDEX_WARNING_COPY[sourceType]) || DEFAULT_INDEX_WARNING_COPY
+// Fallback when the backend response predates `index_warning_copy` being delivered per source.
+const DEFAULT_INDEX_WARNING_COPY: IndexWarningCopy = { mechanism: 'index', suggestion: 'Consider adding an index' }
 
 export const secondsToLookbackParts = (
     seconds: number | null | undefined
@@ -114,8 +88,6 @@ const getAppendOnlySyncSupported = (
 
 interface SyncMethodFormProps {
     schema: ExternalDataSourceSyncSchema
-    /** Tailors the unindexed-field warning to the source's native mechanism (e.g. Redshift sort keys). */
-    sourceType?: ExternalDataSourceType
     onClose: () => void
     onSave: (
         syncType: ExternalDataSourceSyncSchema['sync_type'],
@@ -207,7 +179,6 @@ const getInitialRadioState = (
 export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormProps>(function SyncMethodForm(
     {
         schema,
-        sourceType,
         onClose,
         onSave,
         availableColumns,
@@ -224,7 +195,7 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
     const cdcSyncSupported = getCdcSyncSupported(schema)
-    const indexWarningCopy = getIndexWarningCopy(sourceType)
+    const indexWarningCopy = schema.index_warning_copy ?? DEFAULT_INDEX_WARNING_COPY
 
     const columns = availableColumns ?? schema.available_columns ?? []
     const resolvedDetectedPks = detectedPrimaryKeys ?? schema.detected_primary_keys ?? null
@@ -607,8 +578,8 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                                         <LemonBanner type="warning" className="mt-2">
                                             No {indexWarningCopy.mechanism} detected on <code>{appendFieldValue}</code>.
                                             Append only syncs query this column on every run; without one, the source
-                                            database may scan the full table on each sync. {indexWarningCopy.suggestion}
-                                            , or pick a different field.
+                                            database may scan the full table on each sync.{' '}
+                                            {`${indexWarningCopy.suggestion}, or pick a different field.`}
                                         </LemonBanner>
                                     )}
                             </>

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
@@ -7,6 +7,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 
+import { ExternalDataSourceType } from '~/queries/schema/schema-general'
 import { AvailableColumn, ExternalDataSourceSyncSchema } from '~/types'
 
 const LOOKBACK_UNIT_SECONDS = {
@@ -21,6 +22,34 @@ type LookbackUnit = keyof typeof LOOKBACK_UNIT_SECONDS
 const LOOKBACK_ELIGIBLE_TYPES = new Set(['datetime', 'date', 'timestamp'])
 export const isLookbackEligibleType = (fieldType: string | null | undefined): boolean =>
     !!fieldType && LOOKBACK_ELIGIBLE_TYPES.has(fieldType)
+
+// Some sources have no secondary indexes — the backend's is_indexed detection checks their native
+// scan-pruning mechanism instead (sort/clustering/partition keys), so the advice must match.
+const INDEX_WARNING_COPY: Partial<Record<ExternalDataSourceType, { mechanism: string; suggestion: string }>> = {
+    Redshift: {
+        mechanism: 'sort key',
+        suggestion: "Consider making this field the table's sort key (the leading column of a compound SORTKEY)",
+    },
+    BigQuery: {
+        mechanism: 'partition or clustering column',
+        suggestion: 'Consider partitioning or clustering the table on this column',
+    },
+    Snowflake: {
+        mechanism: 'clustering key',
+        suggestion: "Consider setting the table's clustering key to this column",
+    },
+    ClickHouse: {
+        mechanism: 'sorting key',
+        suggestion: "Consider using a field that leads the table's ORDER BY",
+    },
+}
+
+const DEFAULT_INDEX_WARNING_COPY = { mechanism: 'index', suggestion: 'Consider adding an index' }
+
+export const getIndexWarningCopy = (
+    sourceType: ExternalDataSourceType | undefined
+): { mechanism: string; suggestion: string } =>
+    (sourceType && INDEX_WARNING_COPY[sourceType]) || DEFAULT_INDEX_WARNING_COPY
 
 export const secondsToLookbackParts = (
     seconds: number | null | undefined
@@ -85,6 +114,8 @@ const getAppendOnlySyncSupported = (
 
 interface SyncMethodFormProps {
     schema: ExternalDataSourceSyncSchema
+    /** Tailors the unindexed-field warning to the source's native mechanism (e.g. Redshift sort keys). */
+    sourceType?: ExternalDataSourceType
     onClose: () => void
     onSave: (
         syncType: ExternalDataSourceSyncSchema['sync_type'],
@@ -176,6 +207,7 @@ const getInitialRadioState = (
 export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormProps>(function SyncMethodForm(
     {
         schema,
+        sourceType,
         onClose,
         onSave,
         availableColumns,
@@ -192,6 +224,7 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
     const cdcSyncSupported = getCdcSyncSupported(schema)
+    const indexWarningCopy = getIndexWarningCopy(sourceType)
 
     const columns = availableColumns ?? schema.available_columns ?? []
     const resolvedDetectedPks = detectedPrimaryKeys ?? schema.detected_primary_keys ?? null
@@ -375,6 +408,11 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                             You should pick a field that increments or updates each time the row is updated, such as a{' '}
                             <code>updated_at</code> timestamp.
                         </p>
+                        <p className="mb-2">
+                            Rows deleted in the source are not removed from PostHog. If you need deletions reflected —
+                            for example a rolling-retention table — use full table replication
+                            {schema.cdc_available ? ' or CDC' : ''} instead.
+                        </p>
                         {!incrementalSyncSupported.disabled && (
                             <>
                                 <LemonSelect
@@ -411,10 +449,10 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                                     schema.incremental_fields.find((n) => n.field === incrementalFieldValue)
                                         ?.is_indexed === false && (
                                         <LemonBanner type="warning" className="mt-2">
-                                            No index detected on <code>{incrementalFieldValue}</code>. Incremental syncs
-                                            query this column on every run; without an index the source database may
-                                            scan the full table on each sync. Consider adding an index, or pick a
-                                            different incremental field.
+                                            No {indexWarningCopy.mechanism} detected on{' '}
+                                            <code>{incrementalFieldValue}</code>. Incremental syncs query this column on
+                                            every run; without one, the source database may scan the full table on each
+                                            sync. {indexWarningCopy.suggestion}, or pick a different incremental field.
                                         </LemonBanner>
                                     )}
                                 {radioValue === 'incremental' &&
@@ -567,10 +605,10 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                                     schema.incremental_fields.find((n) => n.field === appendFieldValue)?.is_indexed ===
                                         false && (
                                         <LemonBanner type="warning" className="mt-2">
-                                            No index detected on <code>{appendFieldValue}</code>. Append only syncs
-                                            query this column on every run; without an index the source database may
-                                            scan the full table on each sync. Consider adding an index, or pick a
-                                            different field.
+                                            No {indexWarningCopy.mechanism} detected on <code>{appendFieldValue}</code>.
+                                            Append only syncs query this column on every run; without one, the source
+                                            database may scan the full table on each sync. {indexWarningCopy.suggestion}
+                                            , or pick a different field.
                                         </LemonBanner>
                                     )}
                             </>
@@ -587,7 +625,7 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                         </div>
                         <p className="m-0">
                             We'll replicate the whole table on every sync. This can take longer to sync and increase
-                            your monthly billing.
+                            your monthly billing. The synced table always mirrors the source, including deletions.
                         </p>
                     </div>
                 ),

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
@@ -7,7 +7,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 
-import { AvailableColumn, ExternalDataSourceSyncSchema, IndexWarningCopy } from '~/types'
+import { AvailableColumn, ExternalDataSourceSyncSchema, IndexMechanism } from '~/types'
 
 const LOOKBACK_UNIT_SECONDS = {
     minutes: 60,
@@ -22,8 +22,34 @@ const LOOKBACK_ELIGIBLE_TYPES = new Set(['datetime', 'date', 'timestamp'])
 export const isLookbackEligibleType = (fieldType: string | null | undefined): boolean =>
     !!fieldType && LOOKBACK_ELIGIBLE_TYPES.has(fieldType)
 
-// Fallback when the backend response predates `index_warning_copy` being delivered per source.
-const DEFAULT_INDEX_WARNING_COPY: IndexWarningCopy = { mechanism: 'index', suggestion: 'Consider adding an index' }
+// Copy for the "unindexed field" warning, keyed by the fast-lookup structure the backend reports
+// for the engine. `mechanism` slots into "No {mechanism} detected on {field}"; `suggestion` is the
+// actionable advice for making the field fast to filter on.
+const INDEX_MECHANISM_COPY: Record<IndexMechanism, { mechanism: string; suggestion: string }> = {
+    index: { mechanism: 'index', suggestion: 'Consider adding an index' },
+    sort_key: {
+        mechanism: 'sort key',
+        suggestion: "Consider making this field the table's sort key (the leading column of a compound SORTKEY)",
+    },
+    clustering_key: {
+        mechanism: 'clustering key',
+        suggestion: "Consider setting the table's clustering key to this column",
+    },
+    partition_or_clustering: {
+        mechanism: 'partition or clustering column',
+        suggestion: 'Consider partitioning or clustering the table on this column',
+    },
+    sorting_key: {
+        mechanism: 'sorting key',
+        suggestion: "Consider using a field that leads the table's ORDER BY",
+    },
+}
+
+// Tolerates responses predating `index_mechanism` and mechanism values newer than this build.
+export const getIndexWarningCopy = (
+    indexMechanism: IndexMechanism | undefined
+): { mechanism: string; suggestion: string } =>
+    (indexMechanism && INDEX_MECHANISM_COPY[indexMechanism]) || INDEX_MECHANISM_COPY.index
 
 export const secondsToLookbackParts = (
     seconds: number | null | undefined
@@ -195,7 +221,7 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
     const appendSyncSupported = getAppendOnlySyncSupported(schema)
     const cdcSyncSupported = getCdcSyncSupported(schema)
-    const indexWarningCopy = schema.index_warning_copy ?? DEFAULT_INDEX_WARNING_COPY
+    const indexWarningCopy = getIndexWarningCopy(schema.index_mechanism)
 
     const columns = availableColumns ?? schema.available_columns ?? []
     const resolvedDetectedPks = detectedPrimaryKeys ?? schema.detected_primary_keys ?? null

--- a/products/warehouse_sources/backend/facade/types.py
+++ b/products/warehouse_sources/backend/facade/types.py
@@ -13,6 +13,7 @@ from products.warehouse_sources.backend.types import (
     ExternalDataSourceType,
     IncrementalField,
     IncrementalFieldType,
+    IndexMechanism,
     PartitionSettings,
 )
 
@@ -22,5 +23,6 @@ __all__ = [
     "ExternalDataSourceType",
     "IncrementalField",
     "IncrementalFieldType",
+    "IndexMechanism",
     "PartitionSettings",
 ]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -24,7 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BigQuerySourceConfig
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
 
 __all__ = ["BigQuerySource", "build_destination_table_prefix"]
 
@@ -34,6 +34,11 @@ _BIGQUERY_IMPLEMENTATION = BigQueryImplementation()
 @SourceRegistry.register
 class BigQuerySource(SQLSource[BigQuerySourceConfig]):
     api_docs_url = "https://cloud.google.com/bigquery/docs/release-notes"
+    # BigQuery has no indexes; `is_indexed` reflects the table's partitioning/clustering columns.
+    index_warning_copy: IndexWarningCopy = {
+        "mechanism": "partition or clustering column",
+        "suggestion": "Consider partitioning or clustering the table on this column",
+    }
 
     @property
     def get_implementation(self) -> BigQueryImplementation:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -24,7 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BigQuerySourceConfig
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexMechanism
 
 __all__ = ["BigQuerySource", "build_destination_table_prefix"]
 
@@ -35,10 +35,7 @@ _BIGQUERY_IMPLEMENTATION = BigQueryImplementation()
 class BigQuerySource(SQLSource[BigQuerySourceConfig]):
     api_docs_url = "https://cloud.google.com/bigquery/docs/release-notes"
     # BigQuery has no indexes; `is_indexed` reflects the table's partitioning/clustering columns.
-    index_warning_copy: IndexWarningCopy = {
-        "mechanism": "partition or clustering column",
-        "suggestion": "Consider partitioning or clustering the table on this column",
-    }
+    index_mechanism = IndexMechanism.PARTITION_OR_CLUSTERING
 
     @property
     def get_implementation(self) -> BigQueryImplementation:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -41,7 +41,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
     reconcile_source_schema_metadata,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ClickHouseSourceConfig
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexWarningCopy
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexMechanism
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -74,10 +74,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
 
     # ClickHouse data-skipping indexes aren't what `is_indexed` checks; it reflects the
     # leading column of the table's sorting key (ORDER BY).
-    index_warning_copy: IndexWarningCopy = {
-        "mechanism": "sorting key",
-        "suggestion": "Consider using a field that leads the table's ORDER BY",
-    }
+    index_mechanism = IndexMechanism.SORTING_KEY
 
     @property
     def source_type(self) -> ExternalDataSourceType:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -41,7 +41,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
     reconcile_source_schema_metadata,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ClickHouseSourceConfig
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexWarningCopy
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -71,6 +71,13 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     supports_row_filters: bool = True
 
     api_docs_url = "https://clickhouse.com/docs"
+
+    # ClickHouse data-skipping indexes aren't what `is_indexed` checks; it reflects the
+    # leading column of the table's sorting key (ORDER BY).
+    index_warning_copy: IndexWarningCopy = {
+        "mechanism": "sorting key",
+        "suggestion": "Consider using a field that leads the table's ORDER BY",
+    }
 
     @property
     def source_type(self) -> ExternalDataSourceType:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -161,6 +161,8 @@ class _BaseSource(ABC, Generic[ConfigType]):
     # Which fast-lookup structure this engine's `is_indexed` detection checks. Sources whose
     # engine has no secondary indexes (sort keys, clustering, partitioning) override this so
     # the sync-form warning for unindexed fields names a structure the user can create there.
+    # Any source that detects indexed columns must declare this explicitly rather than
+    # inherit it — test_index_mechanism.py enforces the pairing for SQL sources.
     index_mechanism: IndexMechanism = IndexMechanism.INDEX
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -36,7 +36,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.con
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import get_config_for_source
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexWarningCopy
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexMechanism
 
 logger = structlog.get_logger(__name__)
 
@@ -158,14 +158,10 @@ class _BaseSource(ABC, Generic[ConfigType]):
     # in-product deprecation warning; no per-source UI work.
     deprecated_versions: tuple[VersionDeprecation, ...] = ()
 
-    # Copy for the sync-method form's "unindexed incremental field" warning. `is_indexed`
-    # detection checks the engine's native fast-lookup structure, which isn't a secondary
-    # index everywhere — sources whose mechanism differs (sort keys, clustering, partitioning)
-    # override this so the warning suggests something the user can actually create there.
-    index_warning_copy: IndexWarningCopy = {
-        "mechanism": "index",
-        "suggestion": "Consider adding an index",
-    }
+    # Which fast-lookup structure this engine's `is_indexed` detection checks. Sources whose
+    # engine has no secondary indexes (sort keys, clustering, partitioning) override this so
+    # the sync-form warning for unindexed fields names a structure the user can create there.
+    index_mechanism: IndexMechanism = IndexMechanism.INDEX
 
     @property
     @abstractmethod

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -36,7 +36,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.con
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import get_config_for_source
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IndexWarningCopy
 
 logger = structlog.get_logger(__name__)
 
@@ -157,6 +157,15 @@ class _BaseSource(ABC, Generic[ConfigType]):
     # Versions from `supported_versions` the vendor has deprecated. Drives the generic
     # in-product deprecation warning; no per-source UI work.
     deprecated_versions: tuple[VersionDeprecation, ...] = ()
+
+    # Copy for the sync-method form's "unindexed incremental field" warning. `is_indexed`
+    # detection checks the engine's native fast-lookup structure, which isn't a secondary
+    # index everywhere — sources whose mechanism differs (sort keys, clustering, partitioning)
+    # override this so the warning suggests something the user can actually create there.
+    index_warning_copy: IndexWarningCopy = {
+        "mechanism": "index",
+        "suggestion": "Consider adding an index",
+    }
 
     @property
     @abstractmethod

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/implementation.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/implementation.py
@@ -203,6 +203,10 @@ class SQLSourceImplementation(Generic[ConfigT, ConnT, CursorT], ABC):
         empty set mean "we looked, no indexes here — warn for every
         candidate". Drivers opt in by overriding; the default skips the
         feature (every field reported as indexed).
+
+        Overriding drivers must pair the override with an explicit
+        `index_mechanism` on the source class, so the warning names the
+        structure this method checks (test_index_mechanism.py enforces it).
         """
         return None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_mechanism.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_mechanism.py
@@ -2,6 +2,12 @@ import pytest
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.source import ClickHouseSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import _BaseSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.implementation import (
+    SQLSourceImplementation,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source import RedshiftSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source import SnowflakeSource
@@ -22,3 +28,29 @@ from products.warehouse_sources.backend.types import IndexMechanism
 )
 def test_index_mechanism_names_the_engines_native_structure(source_class, mechanism):
     assert source_class.index_mechanism is mechanism
+
+
+def test_sql_sources_that_detect_indexed_columns_declare_a_mechanism():
+    # A source that detects indexed columns can emit `is_indexed=False`, which shows the
+    # "No {mechanism} detected" warning — silently inheriting the default mechanism there
+    # is how a new warehouse source ends up telling users to add an index it can't have.
+    offenders = []
+    for source in SourceRegistry.get_all_sources().values():
+        if not isinstance(source, SQLSource):
+            continue
+        detects_indexed_columns = (
+            type(source.get_implementation).get_leading_index_columns
+            is not SQLSourceImplementation.get_leading_index_columns
+            or type(source).get_schemas is not SQLSource.get_schemas
+        )
+        declares_mechanism = any(
+            "index_mechanism" in vars(klass) for klass in type(source).__mro__ if klass is not _BaseSource
+        )
+        if detects_indexed_columns and not declares_mechanism:
+            offenders.append(type(source).__name__)
+
+    assert not offenders, (
+        f"{offenders} detect indexed columns but inherit the default index_mechanism. "
+        "Declare `index_mechanism = IndexMechanism.<X>` on the source class so the sync-form "
+        "warning names the engine's actual fast-lookup structure (sort key, clustering key, ...)."
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_mechanism.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_mechanism.py
@@ -5,6 +5,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source import RedshiftSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source import SnowflakeSource
+from products.warehouse_sources.backend.types import IndexMechanism
 
 
 # These engines have no secondary indexes, so losing an override would make the sync-form
@@ -12,14 +13,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.
 @pytest.mark.parametrize(
     "source_class,mechanism",
     [
-        (RedshiftSource, "sort key"),
-        (BigQuerySource, "partition or clustering column"),
-        (SnowflakeSource, "clustering key"),
-        (ClickHouseSource, "sorting key"),
-        (PostgresSource, "index"),
+        (RedshiftSource, IndexMechanism.SORT_KEY),
+        (BigQuerySource, IndexMechanism.PARTITION_OR_CLUSTERING),
+        (SnowflakeSource, IndexMechanism.CLUSTERING_KEY),
+        (ClickHouseSource, IndexMechanism.SORTING_KEY),
+        (PostgresSource, IndexMechanism.INDEX),
     ],
 )
-def test_index_warning_copy_names_the_engines_native_mechanism(source_class, mechanism):
-    copy = source_class.index_warning_copy
-    assert copy["mechanism"] == mechanism
-    assert copy["suggestion"]
+def test_index_mechanism_names_the_engines_native_structure(source_class, mechanism):
+    assert source_class.index_mechanism is mechanism

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_warning_copy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_index_warning_copy.py
@@ -1,0 +1,25 @@
+import pytest
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
+from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.source import ClickHouseSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source import RedshiftSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source import SnowflakeSource
+
+
+# These engines have no secondary indexes, so losing an override would make the sync-form
+# warning suggest an action ("add an index") that's impossible to follow there.
+@pytest.mark.parametrize(
+    "source_class,mechanism",
+    [
+        (RedshiftSource, "sort key"),
+        (BigQuerySource, "partition or clustering column"),
+        (SnowflakeSource, "clustering key"),
+        (ClickHouseSource, "sorting key"),
+        (PostgresSource, "index"),
+    ],
+)
+def test_index_warning_copy_names_the_engines_native_mechanism(source_class, mechanism):
+    copy = source_class.index_warning_copy
+    assert copy["mechanism"] == mechanism
+    assert copy["suggestion"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -28,7 +28,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssq
     MSSQLImplementation,
     retry_on_transient_connection_error,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexMechanism
 
 MSSQLErrors = {
     # SQL Server error 18456 is an authentication failure (wrong username/password, or the login is
@@ -44,6 +44,10 @@ _MSSQL_IMPLEMENTATION = MSSQLImplementation()
 
 @SourceRegistry.register
 class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
+    # Declared explicitly (not inherited) because this source detects indexed columns:
+    # test_index_mechanism.py requires detection and mechanism to be paired consciously.
+    index_mechanism = IndexMechanism.INDEX
+
     @property
     def get_implementation(self) -> MSSQLImplementation:
         return _MSSQL_IMPLEMENTATION

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -34,7 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     MySQLImplementation,
     get_connection_metadata as get_mysql_connection_metadata,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexMechanism
 
 _MYSQL_IMPLEMENTATION = MySQLImplementation()
 
@@ -81,6 +81,10 @@ _HOST_IS_URL_ERROR = (
 
 @SourceRegistry.register
 class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
+    # Declared explicitly (not inherited) because this source detects indexed columns:
+    # test_index_mechanism.py requires detection and mechanism to be paired consciously.
+    index_mechanism = IndexMechanism.INDEX
+
     @property
     def get_implementation(self) -> MySQLImplementation:
         return _MYSQL_IMPLEMENTATION

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -60,7 +60,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.p
     postgres_source,
     source_requires_ssl,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IncrementalFieldType
+from products.warehouse_sources.backend.types import (
+    ExternalDataSourceType,
+    IncrementalField,
+    IncrementalFieldType,
+    IndexMechanism,
+)
 
 log = logging.getLogger(__name__)
 
@@ -195,6 +200,10 @@ _FOREIGN_SERVER_UNREACHABLE_ERROR = (
 
 @SourceRegistry.register
 class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
+    # Declared explicitly (not inherited) because this source detects indexed columns:
+    # test_index_mechanism.py requires detection and mechanism to be paired consciously.
+    index_mechanism = IndexMechanism.INDEX
+
     def __init__(self, source_name: str = "Postgres"):
         super().__init__()
         self.source_name = source_name

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -34,7 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.r
     RedshiftImplementation,
     get_connection_metadata as get_connection_metadata_redshift,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexMechanism
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -56,10 +56,7 @@ RedshiftErrors = {
 @SourceRegistry.register
 class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
     # Redshift has no secondary indexes; `is_indexed` reflects the table's sort key.
-    index_warning_copy: IndexWarningCopy = {
-        "mechanism": "sort key",
-        "suggestion": "Consider making this field the table's sort key (the leading column of a compound SORTKEY)",
-    }
+    index_mechanism = IndexMechanism.SORT_KEY
 
     def __init__(self, source_name: str = "Redshift"):
         super().__init__()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -34,7 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.r
     RedshiftImplementation,
     get_connection_metadata as get_connection_metadata_redshift,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -55,6 +55,12 @@ RedshiftErrors = {
 
 @SourceRegistry.register
 class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
+    # Redshift has no secondary indexes; `is_indexed` reflects the table's sort key.
+    index_warning_copy: IndexWarningCopy = {
+        "mechanism": "sort key",
+        "suggestion": "Consider making this field the table's sort key (the leading column of a compound SORTKEY)",
+    }
+
     def __init__(self, source_name: str = "Redshift"):
         super().__init__()
         self.source_name = source_name

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -27,7 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.
     SnowflakeImplementation,
     get_connection_metadata as get_connection_metadata_snowflake,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexMechanism
 
 _SNOWFLAKE_IMPLEMENTATION = SnowflakeImplementation()
 
@@ -69,10 +69,7 @@ SnowflakeErrors = {
 @SourceRegistry.register
 class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
     # Snowflake has no indexes on standard tables; `is_indexed` reflects the clustering key.
-    index_warning_copy: IndexWarningCopy = {
-        "mechanism": "clustering key",
-        "suggestion": "Consider setting the table's clustering key to this column",
-    }
+    index_mechanism = IndexMechanism.CLUSTERING_KEY
 
     @property
     def get_implementation(self) -> SnowflakeImplementation:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -27,7 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.
     SnowflakeImplementation,
     get_connection_metadata as get_connection_metadata_snowflake,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IndexWarningCopy
 
 _SNOWFLAKE_IMPLEMENTATION = SnowflakeImplementation()
 
@@ -68,6 +68,12 @@ SnowflakeErrors = {
 
 @SourceRegistry.register
 class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
+    # Snowflake has no indexes on standard tables; `is_indexed` reflects the clustering key.
+    index_warning_copy: IndexWarningCopy = {
+        "mechanism": "clustering key",
+        "suggestion": "Consider setting the table's clustering key to this column",
+    }
+
     @property
     def get_implementation(self) -> SnowflakeImplementation:
         return _SNOWFLAKE_IMPLEMENTATION

--- a/products/warehouse_sources/backend/types.py
+++ b/products/warehouse_sources/backend/types.py
@@ -37,6 +37,10 @@ class IndexMechanism(StrEnum):
     Most databases use secondary indexes, but columnar warehouses prune scans differently —
     the sync-form warning shown for `is_indexed=False` fields is phrased per mechanism, so the
     advice names a structure the user can actually create on their engine.
+
+    Keep in sync with `IndexMechanism` in frontend/src/types.ts: these values cross the API as
+    plain strings (no codegen), and the UI renders the generic "index" copy for any member it
+    doesn't know. Adding it to the frontend union forces the copy map update via typechecking.
     """
 
     INDEX = "index"

--- a/products/warehouse_sources/backend/types.py
+++ b/products/warehouse_sources/backend/types.py
@@ -29,15 +29,19 @@ class IncrementalField(typing.TypedDict, total=False):
     is_indexed: bool
 
 
-class IndexWarningCopy(typing.TypedDict):
-    """UI copy for the sync-form warning shown when an incremental field has `is_indexed=False`.
+class IndexMechanism(StrEnum):
+    """The fast-lookup structure `is_indexed` detection checks for an engine.
 
-    `mechanism` names the engine's fast-lookup structure the detection checked (index, sort key,
-    clustering key, ...); `suggestion` is the actionable advice for making the field fast to filter on.
+    Most databases use secondary indexes, but columnar warehouses prune scans differently —
+    the sync-form warning shown for `is_indexed=False` fields is phrased per mechanism, so the
+    advice names a structure the user can actually create on their engine.
     """
 
-    mechanism: str
-    suggestion: str
+    INDEX = "index"
+    SORT_KEY = "sort_key"
+    CLUSTERING_KEY = "clustering_key"
+    PARTITION_OR_CLUSTERING = "partition_or_clustering"
+    SORTING_KEY = "sorting_key"
 
 
 class PartitionSettings(typing.NamedTuple):

--- a/products/warehouse_sources/backend/types.py
+++ b/products/warehouse_sources/backend/types.py
@@ -26,6 +26,8 @@ class IncrementalField(typing.TypedDict, total=False):
     # structure for the engine: clustering key, sortkey, partition column, etc.).
     # Used to warn users picking an incremental field that would force a full scan
     # on every sync. Defaults to True when omitted so missing detection never warns.
+    # Sources that can emit False must declare `index_mechanism` on their source class
+    # so the warning names the structure the detection actually checked.
     is_indexed: bool
 
 

--- a/products/warehouse_sources/backend/types.py
+++ b/products/warehouse_sources/backend/types.py
@@ -29,6 +29,17 @@ class IncrementalField(typing.TypedDict, total=False):
     is_indexed: bool
 
 
+class IndexWarningCopy(typing.TypedDict):
+    """UI copy for the sync-form warning shown when an incremental field has `is_indexed=False`.
+
+    `mechanism` names the engine's fast-lookup structure the detection checked (index, sort key,
+    clustering key, ...); `suggestion` is the actionable advice for making the field fast to filter on.
+    """
+
+    mechanism: str
+    suggestion: str
+
+
 class PartitionSettings(typing.NamedTuple):
     """Settings used when partitioning data warehouse tables.
 


### PR DESCRIPTION
## Problem

The sync method form warns "No index detected... Consider adding an index" whenever the chosen incremental/append field is unindexed — but Redshift, BigQuery, Snowflake, and ClickHouse have no secondary indexes; the backend's `is_indexed` detection checks sort keys, clustering keys, and partition columns there, so the advice was impossible to follow (hit by a user on Redshift Serverless). The form also never mentioned that incremental/append sync doesn't remove source-deleted rows.

## Changes

- Each source class declares an `IndexMechanism` enum (`index` / `sort_key` / `clustering_key` / `partition_or_clustering` / `sorting_key`) next to its `is_indexed` detection; the `database_schema` and `incremental_fields` endpoints return it, and the frontend maps mechanism → warning copy (with a generic fallback). No source-specific logic in the frontend, no prose in the API contract — same shape as ingestion warnings' `type` key.
- A registry test enforces the pairing: any SQL-family source that detects indexed columns must declare its mechanism explicitly, so a future source can't silently inherit `index` advice its engine can't follow. Postgres/MySQL/MSSQL now declare `INDEX` consciously.
- Copy: the incremental option now notes source deletions aren't mirrored (use full refresh/CDC for that); full refresh notes it mirrors deletions; fixed a stray space in the append banner.

## How did you test this code?

- `test_index_mechanism.py` (6/6): per-source mechanism values + the declaration-enforcement sweep — catches an override being dropped or a new detecting source forgetting to declare.
- Endpoint payload tests updated for the new field; `SyncMethodForm.test.tsx` (7/7) includes an unknown-mechanism fallback case (newer backend, older frontend must degrade to generic copy, not "No undefined detected").
- ruff/oxfmt/tsc clean; `hogli build:openapi` shows no drift (these endpoints return plain dicts with handwritten frontend types). No live UI walkthrough.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Follow-up in the posthog.com repo: Redshift source doc should recommend a SORTKEY on the incremental field and document delete semantics for incremental vs full refresh.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code); skills: `/writing-tests`, `/improving-drf-endpoints`. Design landed on a semantic enum after review feedback (no source-specific logic in the frontend) and a pass against existing warning-passing precedents (`rls_warning`, `HogQLNotice`, ingestion warnings).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
