### PR TITLE
feat(navigation): instrument zen mode enter/exit events

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -79,7 +79,7 @@ export function GlobalShortcuts(): null {
         keybind: [keyBinds.zenMode],
         intent: 'Toggle zen mode',
         interaction: 'function',
-        callback: toggleZenMode,
+        callback: () => toggleZenMode('shortcut'),
     })
 
     useShortcut({

--- a/frontend/src/layout/navigation-3000/components/ZenModeButton.tsx
+++ b/frontend/src/layout/navigation-3000/components/ZenModeButton.tsx
@@ -18,7 +18,7 @@ export function ZenModeButton(): JSX.Element | null {
             type="secondary"
             size="small"
             icon={<IconX />}
-            onClick={() => setZenMode(false)}
+            onClick={() => setZenMode(false, 'exit_button')}
             tooltip="Exit zen mode"
         >
             Exit zen mode

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -242,7 +242,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             { persist: true },
             {
                 setZenMode: (_, { zenMode }) => zenMode,
-                toggleZenMode: (state) => !state,
             },
         ],
     }),
@@ -251,7 +250,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             posthog.capture('zen mode toggled', { enabled: zenMode, trigger })
         },
         toggleZenMode: ({ trigger }) => {
-            posthog.capture('zen mode toggled', { enabled: values.zenMode, trigger })
+            actions.setZenMode(!values.zenMode, trigger)
         },
         initiateNewItemInCategory: ({ category: categoryKey }) => {
             let category = values.activeNavbarItem?.logic.values.contents?.find((item) => item.key === categoryKey)

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -57,6 +57,8 @@ export const ITEM_KEY_PART_SEPARATOR = '::'
 
 export type Navigation3000Mode = 'none' | 'minimal' | 'zen' | 'full'
 
+export type ZenModeTrigger = 'shortcut' | 'account_menu' | 'help_menu' | 'exit_button' | 'url'
+
 const MINIMUM_SIDEBAR_WIDTH_PX: number = 192
 const DEFAULT_SIDEBAR_WIDTH_PX: number = 288
 const MAXIMUM_SIDEBAR_WIDTH_PX: number = 1024
@@ -107,8 +109,8 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         focusPreviousItem: true,
         toggleAccordion: (key: string) => ({ key }),
         toggleListItemAccordion: (key: string) => ({ key }),
-        setZenMode: (zenMode: boolean) => ({ zenMode }),
-        toggleZenMode: true,
+        setZenMode: (zenMode: boolean, trigger: ZenModeTrigger) => ({ zenMode, trigger }),
+        toggleZenMode: (trigger: ZenModeTrigger) => ({ trigger }),
     }),
     reducers({
         isSidebarShown: [
@@ -245,6 +247,12 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        setZenMode: ({ zenMode, trigger }) => {
+            posthog.capture('zen mode toggled', { enabled: zenMode, trigger })
+        },
+        toggleZenMode: ({ trigger }) => {
+            posthog.capture('zen mode toggled', { enabled: values.zenMode, trigger })
+        },
         initiateNewItemInCategory: ({ category: categoryKey }) => {
             let category = values.activeNavbarItem?.logic.values.contents?.find((item) => item.key === categoryKey)
             if (!category) {
@@ -820,7 +828,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             // Enable zen mode when URL parameter is present (e.g., ?zen or ?zen=true)
             // Only enable, never disable from URL - user can manually disable
             if (zenModeFromUrl && !values.zenMode) {
-                actions.setZenMode(true)
+                actions.setZenMode(true, 'url')
             }
         },
     })),

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -315,7 +315,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                         <ButtonPrimitive
                             tooltip="Hide navigation and focus on content"
                             tooltipPlacement="right"
-                            onClick={toggleZenMode}
+                            onClick={() => toggleZenMode('account_menu')}
                             menuItem
                         >
                             <IconExpand45 />

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -385,7 +385,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                     }
                                 />
                                 <Menu.Item
-                                    onClick={toggleZenMode}
+                                    onClick={() => toggleZenMode('help_menu')}
                                     render={
                                         <ButtonPrimitive menuItem data-attr="more-menu-zen-mode-button">
                                             <IconExpand45 />


### PR DESCRIPTION
## Problem

Zen mode toggling fired no analytics event at all. The `toggleZenMode` / `setZenMode` actions were pure kea reducers with zero instrumentation. That left two blind spots:

- Keyboard-shortcut usage (Cmd+Opt+Z) was completely invisible. No click, no event.
- Button and menu usage was only observable indirectly through PostHog's own autocapture on the button elements, which can't distinguish enter from exit cleanly and misses the shortcut and `?zen` URL paths entirely.

So questions like "how often is zen mode entered via shortcut vs button", "how often is it a repeat use", and "what's the retention" could not be answered from the data. The autocapture-only view systematically undercounts power users, who are exactly the ones likely to adopt the shortcut.

## Changes

One event, `zen mode toggled`, fired on every enter and exit, with two properties:

- `enabled` (boolean) - `true` when entering, `false` when exiting.
- `trigger` - which surface caused it: `shortcut`, `account_menu`, `help_menu`, `exit_button`, or `url`.

Implementation lives in `navigation3000Logic`: both actions now take a typed `trigger` arg, and two small listeners do the capture. Because kea listeners run after reducers, `toggleZenMode`'s listener reads the already-flipped `values.zenMode` as the resulting state. All five call sites pass their source. The persisted-state reload path fires no action (no spurious event on refresh), and the URL path stays guarded by `!values.zenMode` so it captures once per entry.

## How did you test this code?

Automated checks I (Claude) actually ran:

- oxlint and oxfmt on the five changed files - clean, 0 warnings/errors.
- Regenerated the kea typegen for `navigationLogic` and confirmed no type errors on any of the changed lines or the four call sites. (A full repo `tsgo` run reports errors across hundreds of untouched files because kea typegen isn't generated in a fresh worktree without the dev server - that's an environment artifact, and CI regenerates typegen.)

I did not manually exercise the toggle in a running app, and I did not add a test. The change is a thin instrumentation layer over existing actions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul asked first for an analysis of how often zen mode is toggled - by button vs shortcut, repeat usage, and 30-day retention. That analysis surfaced the root cause: there is no event to measure, only autocapture on the buttons, and the shortcut is unmeasurable. He then asked to add the instrumentation for entering and exiting.

I (Claude) chose a single `zen mode toggled` event carrying `enabled` and `trigger` rather than separate enter/exit events, so the four original questions all fall out of one event via breakdowns. Trigger source is threaded through the action args from each of the five call sites (shortcut, account menu, help menu, exit button, URL param) instead of inferred, so button-vs-shortcut is a clean property rather than a guess.

No skills were required for this change (no migration, serializer, or API surface touched). The repo-wide `format` script's `oxlint --fix-dangerously` corrupted two unrelated files mid-session; I reverted both so this PR contains only the intended zen-mode changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
