### PR TITLE
fix(llm-gateway): launch uvicorn via python -m so a moved checkout still boots

### DIFF
--- a/bin/start-llm-gateway
+++ b/bin/start-llm-gateway
@@ -32,7 +32,11 @@ export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
 
 uv sync --quiet
 
-exec .venv/bin/uvicorn llm_gateway.main:app \
+# `python -m uvicorn` instead of the uvicorn console script: a venv carried over from a moved or
+# renamed checkout passes `uv sync`, but its console-script shebangs still point at the old repo
+# path and fail with "bad interpreter". Module invocation resolves through the venv's interpreter
+# symlink, which survives the move.
+exec .venv/bin/python -m uvicorn llm_gateway.main:app \
     --host 0.0.0.0 \
     --port "${LLM_GATEWAY_PORT:-3308}" \
     --reload


### PR DESCRIPTION
## Problem

The llm-gateway dev process crash-loops (exit 126) when the repo checkout has been moved or renamed since the service's `.venv` was created. `uv sync` passes — the venv's interpreter symlink is absolute and still valid — but every console-script shebang (e.g. `.venv/bin/uvicorn`) still points at the old checkout path, so `exec .venv/bin/uvicorn` dies with "bad interpreter: no such file or directory". The only remedy was knowing to manually `rm -rf` the venv.

## Changes

`bin/start-llm-gateway` now launches `.venv/bin/python -m uvicorn` instead of the `uvicorn` console script. Module invocation resolves through the venv's interpreter symlink, which survives a checkout move, so the service boots without manual venv surgery.

## How did you test this code?

- Reproduced the failure on a checkout moved from `~/posthog` to `~/posthog-dev/posthog`: the stale venv's `.venv/bin/uvicorn` shebang pointed at the old path and exec failed with exit 126.
- Verified `.venv/bin/python -m uvicorn --version` runs correctly against the same venv layout.
- No behavior change for healthy venvs — same interpreter, same app, same flags.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code while debugging a local dev stack where llm-gateway showed as crashed in the process manager. Considered adding a stale-venv detection + `rm -rf` guard, but the interpreter symlink was actually valid in the observed failure — only the shebangs were stale — so switching to module invocation is the complete and simpler fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)