### PR TITLE
fix(hogql): make group key created_at cutoff timezone-aware

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1988,7 +1988,12 @@ def _setup_group_key_fields(database: Database, group_types: list[dict[str, Any]
             raw_field_name = f"_{field_name}_raw"
             table.fields[raw_field_name] = original_field.model_copy(update={"hidden": True})
 
-            created_at_str = group_mapping["created_at"].strftime("%Y-%m-%d %H:%M:%S")
+            # Must stay a datetime constant: a naive string literal would be parsed by ClickHouse in the
+            # project's timezone (the comparison is against toTimeZone(timestamp, <project tz>)), shifting
+            # the cutoff by the project's UTC offset.
+            created_at = group_mapping["created_at"]
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=UTC)
 
             table.fields[field_name] = ExpressionField(
                 name=field_name,
@@ -1998,7 +2003,7 @@ def _setup_group_key_fields(database: Database, group_types: list[dict[str, Any]
                         ast.CompareOperation(
                             left=ast.Field(chain=["timestamp"]),
                             op=ast.CompareOperationOp.Lt,
-                            right=ast.Constant(value=created_at_str),
+                            right=ast.Constant(value=created_at),
                         ),
                         ast.Constant(value=""),
                         ast.Field(chain=[raw_field_name]),

--- a/posthog/hogql/test/test_group_filtering.py
+++ b/posthog/hogql/test/test_group_filtering.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime
 
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
+
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_select
@@ -32,8 +34,15 @@ class TestGroupKeyFiltering(APIBaseTest):
         self.database = Database.create_for(team=self.team)
         self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
 
-    def test_group_field_with_mapping_and_created_at(self):
-        """Test that $group_0 gets filtering when GroupTypeMapping exists with created_at"""
+    # The created_at cutoff must be printed as a timezone-aware constant: a naive string literal is
+    # parsed by ClickHouse in the project's timezone, shifting the cutoff by the project's UTC offset.
+    @parameterized.expand(
+        [
+            ("UTC", "toDateTime64('2023-01-15 12:00:00.000000', 6, 'UTC')"),
+            ("America/Mexico_City", "toDateTime64('2023-01-15 06:00:00.000000', 6, 'America/Mexico_City')"),
+        ]
+    )
+    def test_group_field_with_mapping_and_created_at(self, timezone: str, expected_cutoff: str):
         self._create_mapping_and_rebuild(
             team=self.team,
             project=self.team.project,
@@ -41,6 +50,8 @@ class TestGroupKeyFiltering(APIBaseTest):
             group_type_index=0,
             created_at=datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
+        self.team.timezone = timezone
+        self.team.save()
         self._rebuild_database()
 
         query = "SELECT $group_0 FROM events"
@@ -49,7 +60,7 @@ class TestGroupKeyFiltering(APIBaseTest):
         sql, _ = prepare_and_print_ast(parsed, context=self.context, dialect="clickhouse")
 
         self.assertIn(
-            "SELECT if(less(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s), %(hogql_val_2)s, events.`$group_0`) AS `$group_0` FROM events WHERE equals(events.team_id,",
+            f"SELECT if(less(toTimeZone(events.timestamp, %(hogql_val_0)s), {expected_cutoff}), %(hogql_val_1)s, events.`$group_0`) AS `$group_0` FROM events WHERE equals(events.team_id,",
             sql,
         )
 
@@ -192,7 +203,7 @@ class TestGroupKeyFiltering(APIBaseTest):
         sql, _ = prepare_and_print_ast(parsed, context=self.context, dialect="clickhouse")
 
         self.assertIn(
-            "ON equals(if(less(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s), %(hogql_val_4)s, events.`$group_0`), events__group_0.key)",
+            "ON equals(if(less(toTimeZone(events.timestamp, %(hogql_val_2)s), toDateTime64('2023-01-15 12:00:00.000000', 6, 'UTC')), %(hogql_val_3)s, events.`$group_0`), events__group_0.key)",
             sql,
         )
 
@@ -213,4 +224,7 @@ class TestGroupKeyFiltering(APIBaseTest):
         sql, _ = prepare_and_print_ast(parsed, context=self.context, dialect="clickhouse")
 
         self.assertIn("ON equals(if(less(toTimeZone(events.timestamp,", sql)
-        self.assertIn("), %(hogql_val_3)s), %(hogql_val_4)s, events.`$group_0`), events__group_0.key)", sql)
+        self.assertIn(
+            "toDateTime64('2023-01-15 12:00:00.000000', 6, 'UTC')), %(hogql_val_3)s, events.`$group_0`), events__group_0.key)",
+            sql,
+        )

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_base.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_base.ambr
@@ -146,7 +146,7 @@
 # name: TestExperimentQueryRunner.test_query_runner_group_aggregation_mean_metric
   '''
   WITH exposures AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
             max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
@@ -173,7 +173,7 @@
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
      GROUP BY entity_id),
        metric_events AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS timestamp,
             coalesce(accurateCastOrNull(1, 'Float64'), 0) AS value
      FROM events
@@ -211,7 +211,7 @@
 # name: TestExperimentQueryRunner.test_query_runner_group_aggregation_mean_property_sum_metric
   '''
   WITH exposures AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
             max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
@@ -238,7 +238,7 @@
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
      GROUP BY entity_id),
        metric_events AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS timestamp,
             coalesce(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), 0) AS value
      FROM events
@@ -2700,7 +2700,7 @@
 # name: TestExperimentQueryRunner.test_query_runner_with_unique_group_metric
   '''
   WITH exposures AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
             max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
@@ -2727,7 +2727,7 @@
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
      GROUP BY entity_id),
        metric_events AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2020-01-01 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS timestamp,
             1 AS value
      FROM events

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -387,7 +387,7 @@
 # name: TestExperimentExposuresQueryRunner.test_exposure_query_using_group_aggregation_0_direct
   '''
   WITH first_exposures AS
-    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), '2024-01-07 12:00:00'), '', events.`$group_0`) AS entity_id,
+    (SELECT if(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), '', events.`$group_0`) AS entity_id,
             if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
             toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day
      FROM events


### PR DESCRIPTION
## Problem

`$group_N` on events is masked at query time to hide values predating the group type mapping's `created_at`. The cutoff was rendered as a naive datetime string, which ClickHouse parses in the timezone of the value it's compared against (`toTimeZone(timestamp, <project tz>)`), so on non-UTC projects the cutoff silently shifts by the project's UTC offset – on a UTC-6 project this hid 6 extra hours of correctly materialized group keys.

## Changes

Pass the tz-aware `created_at` datetime into the AST constant instead of a `strftime` string, so the printer inlines a timezone-correct `toDateTime64(...)`. Semantics for UTC projects are unchanged.

## How did you test this code?

Parameterized the mask test in `test_group_filtering.py` over team timezone (UTC and America/Mexico_City) – the non-UTC case fails without the fix, and no existing test used a non-UTC team, which is how this slipped through. Also verified on production data (an affected project's event) that the as-executed expression returned `''` while the fixed expression returns the stored group key.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed – internal query-layer behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored with PostHog Code (Claude). Root-caused by pulling the executed SQL from ClickHouse `query_log` via internal Metabase, which showed the naive literal compared against a project-timezone DateTime, then reproduced buggy vs fixed expressions on an affected row. Skills invoked: `query-clickhouse-via-metabase`, `writing-tests`. Considered comparing in UTC via an explicit `toDateTime(..., 'UTC')` call node, but the printer already renders tz-aware datetime constants correctly, so passing the datetime through is the smaller change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
