### PR TITLE
feat(shortcuts): report keybind triggered from legacy hotkey hook

### DIFF
--- a/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
+++ b/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
@@ -70,6 +70,7 @@ function triggerShortcut(shortcut: ShortcutType, triggeredKeybind: string[]): vo
         keybind: formatKeybind(triggeredKeybind),
         interaction: shortcut.interaction,
         scope: shortcut.scope ?? 'global',
+        mechanism: 'shortcut',
     })
 
     if (shortcut.interaction === 'click') {

--- a/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
+++ b/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
@@ -154,6 +154,8 @@ export const shortcutLogic = kea<shortcutLogicType>([
                 cache.sequenceKeys = []
                 cache.sequenceShortcut = null
 
+                // modifier vocabulary and order must stay in lockstep with formatTriggeredKeybind in
+                // lib/hooks/useKeyboardHotkeys.tsx, so the same chord reports the same `keybind` string
                 const pressedKeys: string[] = [COMMAND_OR_CTRL]
                 if (event.shiftKey) {
                     pressedKeys.push('shift')

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.test.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.test.tsx
@@ -1,0 +1,152 @@
+import { cleanup, renderHook } from '@testing-library/react'
+
+import posthog from 'lib/posthog-typed'
+
+import { useKeyboardHotkeys } from './useKeyboardHotkeys'
+
+jest.mock('lib/posthog-typed', () => ({
+    __esModule: true,
+    default: { __loaded: true, capture: jest.fn() },
+}))
+
+const mockPosthog = posthog as unknown as { __loaded: boolean; capture: jest.Mock }
+
+function press(key: string, init: KeyboardEventInit = {}, target: Element = document.body): void {
+    target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...init }))
+}
+
+describe('useKeyboardHotkeys', () => {
+    beforeEach(() => {
+        mockPosthog.__loaded = true
+        mockPosthog.capture.mockClear()
+    })
+
+    afterEach(() => {
+        // RTL auto-cleanup doesn't run in this jest setup - unmount so window keydown listeners don't leak between tests
+        cleanup()
+    })
+
+    it('runs the action and captures keybind triggered on a match', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ k: { action } }))
+
+        press('k')
+
+        expect(action).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).toHaveBeenCalledWith('keybind triggered', {
+            keybind: 'k',
+            mechanism: 'hotkey',
+        })
+    })
+
+    it('captures the normalized key name for space', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ space: { action } }))
+
+        press(' ')
+
+        expect(action).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).toHaveBeenCalledWith('keybind triggered', {
+            keybind: 'space',
+            mechanism: 'hotkey',
+        })
+    })
+
+    it('captures shift chords for hotkeys that do not handle modifiers themselves', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ k: { action } }))
+
+        press('K', { shiftKey: true })
+
+        expect(action).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).toHaveBeenCalledWith('keybind triggered', {
+            keybind: 'shift+k',
+            mechanism: 'hotkey',
+        })
+    })
+
+    it('captures modifiers in the same order as shortcutLogic (shift before option)', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ arrowleft: { action, willHandleEvent: true } }))
+
+        press('ArrowLeft', { shiftKey: true, altKey: true })
+
+        expect(action).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).toHaveBeenCalledWith('keybind triggered', {
+            keybind: 'shift+option+arrowleft',
+            mechanism: 'hotkey',
+        })
+    })
+
+    it('does not capture held-key repeats but still runs the action', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ arrowleft: { action, willHandleEvent: true } }))
+
+        press('ArrowLeft')
+        press('ArrowLeft', { repeat: true })
+        press('ArrowLeft', { repeat: true })
+
+        expect(action).toHaveBeenCalledTimes(3)
+        expect(mockPosthog.capture).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([{ metaKey: true }, { ctrlKey: true }])(
+        'does not capture ctrl/meta chords on willHandleEvent hotkeys, whose actions treat them as browser shortcuts and no-op (%o)',
+        (modifiers) => {
+            const action = jest.fn()
+            renderHook(() => useKeyboardHotkeys({ arrowleft: { action, willHandleEvent: true } }))
+
+            press('ArrowLeft', modifiers)
+
+            expect(action).toHaveBeenCalledTimes(1)
+            expect(mockPosthog.capture).not.toHaveBeenCalled()
+        }
+    )
+
+    it('does not run or capture modifier chords for hotkeys that do not handle events', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ k: { action } }))
+
+        press('k', { metaKey: true })
+        press('k', { ctrlKey: true })
+        press('k', { altKey: true })
+
+        expect(action).not.toHaveBeenCalled()
+        expect(mockPosthog.capture).not.toHaveBeenCalled()
+    })
+
+    it('does not capture when posthog is uninitialized, as in the toolbar bundle on customer sites', () => {
+        mockPosthog.__loaded = false
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ escape: { action, willHandleEvent: true } }))
+
+        press('Escape')
+
+        expect(action).toHaveBeenCalledTimes(1)
+        expect(mockPosthog.capture).not.toHaveBeenCalled()
+    })
+
+    it('does not run or capture disabled hotkeys', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ k: { action, disabled: true } }))
+
+        press('k')
+
+        expect(action).not.toHaveBeenCalled()
+        expect(mockPosthog.capture).not.toHaveBeenCalled()
+    })
+
+    it('does not run or capture while typing in an input', () => {
+        const action = jest.fn()
+        renderHook(() => useKeyboardHotkeys({ k: { action } }))
+
+        const input = document.createElement('input')
+        document.body.appendChild(input)
+        press('k', {}, input)
+        input.remove()
+
+        expect(action).not.toHaveBeenCalled()
+        expect(mockPosthog.capture).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -33,6 +33,8 @@ const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
 
 const exceptions = ['.hotkey-block', '.hotkey-block *']
 
+// modifier vocabulary and order must stay in lockstep with shortcutLogic.tsx's pressedKeys,
+// so the same chord reports the same `keybind` string from either mechanism
 function formatTriggeredKeybind(event: KeyboardEvent, key: string): string {
     const parts: string[] = []
     if (event.metaKey) {
@@ -93,7 +95,10 @@ export function useKeyboardHotkeys(hotkeys: HotkeysInterface, deps?: DependencyL
                     if (!hotkey.willHandleEvent) {
                         event.preventDefault()
                     }
-                    // posthog is uninitialized in the toolbar bundle on customer sites; capturing there only warns in the customer's console
+                    // don't capture: when posthog is uninitialized (the toolbar bundle on customer sites — capturing
+                    // there only warns in the customer's console), on held-key repeats (seeking by holding an arrow
+                    // counts once), or on ctrl/meta chords reaching willHandleEvent actions (they treat those as
+                    // browser shortcuts and no-op)
                     if (
                         posthog.__loaded &&
                         !event.repeat &&

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -93,7 +93,12 @@ export function useKeyboardHotkeys(hotkeys: HotkeysInterface, deps?: DependencyL
                     if (!hotkey.willHandleEvent) {
                         event.preventDefault()
                     }
-                    if (!event.repeat && !(hotkey.willHandleEvent && (event.metaKey || event.ctrlKey))) {
+                    // posthog is uninitialized in the toolbar bundle on customer sites; capturing there only warns in the customer's console
+                    if (
+                        posthog.__loaded &&
+                        !event.repeat &&
+                        !(hotkey.willHandleEvent && (event.metaKey || event.ctrlKey))
+                    ) {
                         posthog.capture('keybind triggered', {
                             keybind: formatTriggeredKeybind(event, normalizedKey),
                             mechanism: 'hotkey',

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -1,6 +1,7 @@
 import { DependencyList } from 'react'
 
 import { useEventListener } from 'lib/hooks/useEventListener'
+import posthog from 'lib/posthog-typed'
 
 import { HotKey } from '~/types'
 
@@ -31,6 +32,24 @@ const isToolbarInput = (event: Event, ignorableElements: string[]): boolean => {
 }
 
 const exceptions = ['.hotkey-block', '.hotkey-block *']
+
+function formatTriggeredKeybind(event: KeyboardEvent, key: string): string {
+    const parts: string[] = []
+    if (event.metaKey) {
+        parts.push('command')
+    }
+    if (event.ctrlKey) {
+        parts.push('ctrl')
+    }
+    if (event.altKey) {
+        parts.push('option')
+    }
+    if (event.shiftKey) {
+        parts.push('shift')
+    }
+    parts.push(key)
+    return parts.join('+')
+}
 
 /**
  *
@@ -73,6 +92,12 @@ export function useKeyboardHotkeys(hotkeys: HotkeysInterface, deps?: DependencyL
                 if (normalizedKey === relevantKey) {
                     if (!hotkey.willHandleEvent) {
                         event.preventDefault()
+                    }
+                    if (!event.repeat) {
+                        posthog.capture('keybind triggered', {
+                            keybind: formatTriggeredKeybind(event, normalizedKey),
+                            mechanism: 'hotkey',
+                        })
                     }
                     hotkey.action(event)
                     break

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -41,11 +41,11 @@ function formatTriggeredKeybind(event: KeyboardEvent, key: string): string {
     if (event.ctrlKey) {
         parts.push('ctrl')
     }
-    if (event.altKey) {
-        parts.push('option')
-    }
     if (event.shiftKey) {
         parts.push('shift')
+    }
+    if (event.altKey) {
+        parts.push('option')
     }
     parts.push(key)
     return parts.join('+')
@@ -93,7 +93,7 @@ export function useKeyboardHotkeys(hotkeys: HotkeysInterface, deps?: DependencyL
                     if (!hotkey.willHandleEvent) {
                         event.preventDefault()
                     }
-                    if (!event.repeat) {
+                    if (!event.repeat && !(hotkey.willHandleEvent && (event.metaKey || event.ctrlKey))) {
                         posthog.capture('keybind triggered', {
                             keybind: formatTriggeredKeybind(event, normalizedKey),
                             mechanism: 'hotkey',


### PR DESCRIPTION
## Problem

The `useShortcut` / `shortcutLogic` system captures a `keybind triggered` event for every shortcut registered through it (26 shortcuts reporting in production). But keyboard shortcuts bound through the older `useKeyboardHotkeys` hook fire no analytics at all. That silently excludes some of the most-used keyboard surfaces in the app:

- the session replay player (space, f, c, e, s, x, t, m, arrow seek, 0-9 speed, n for next)
- the logs viewer (j/k/h/l and arrow navigation, enter, r, space, p)
- AI observability and visual review p/n navigation
- instance config e/enter

So "how much do people use keyboard shortcuts" can only be answered for the new system, and per-feature analyses (like the recent zen mode one) keep rediscovering the same blind spot.

## Changes

- `useKeyboardHotkeys` now captures the same `keybind triggered` event when a hotkey fires, with the pressed `keybind` (modifiers included) and `mechanism: 'hotkey'`.
- Held-key repeats are not captured (`event.repeat` guard) - holding an arrow to seek in the replay player counts as one press, and the action itself still runs on every repeat.
- The existing `shortcutLogic` capture gains `mechanism: 'shortcut'` so the two sources are cleanly distinguishable in one event.

Scene context comes free via `$pathname`, so hotkey events don't need a name/intent of their own - the `keybind` value plus the page identifies them.

## How did you test this code?

Automated checks I (Claude) ran: oxlint and oxfmt on both changed files, clean. No kea action signatures changed, so no typegen needed. I did not manually exercise the hotkeys in a running app; the change is a thin capture layer inside the existing match branch and doesn't alter any hotkey behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up from the zen mode instrumentation work (#68270). Paul asked to make sure keyboard shortcut usage gets reported whatever the shortcut is. Investigating, I (Claude) found the `keybind triggered` event already exists and covers everything registered via `useShortcut` - including zen mode - but a repo sweep turned up a parallel legacy mechanism (`useKeyboardHotkeys`) used by the replay player, logs viewer, and several product scenes that fired nothing. Rather than instrument each feature, this instruments the mechanism, so any current or future `useKeyboardHotkeys` caller reports automatically.

Decisions: reuse the existing event name rather than minting a new one (one queryable event for all shortcut usage), add a `mechanism` property on both paths to keep them distinguishable, and skip `event.repeat` captures to bound volume on held-key seek/navigation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
