### PR TITLE
chore(signals): drop error tracking backfill limit to 5

### DIFF
--- a/products/signals/backend/temporal/backfill_error_tracking.py
+++ b/products/signals/backend/temporal/backfill_error_tracking.py
@@ -33,7 +33,7 @@ class EmitBackfillSignalInput:
 @scoped_temporal()
 @close_db_connections
 async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput) -> list[ErrorTrackingIssueData]:
-    """Fetch the 100 most recent error tracking issues ordered by first seen."""
+    """Fetch the 5 most recent error tracking issues ordered by first seen."""
     from posthog.schema import DateRange, ErrorTrackingQuery
 
     from posthog.models import Team
@@ -52,7 +52,7 @@ async def fetch_error_tracking_issues_activity(input: BackfillErrorTrackingInput
                 orderBy="first_seen",
                 orderDirection="DESC",
                 volumeResolution=1,
-                limit=100,
+                limit=5,
                 withFirstEvent=True,
                 withAggregations=False,
             ),


### PR DESCRIPTION
## Problem

When error tracking is backfilled for the Signals product, the workflow fetches the 100 most recent error tracking issues and emits an `issue_created` signal for each. That's a lot of signals to fan out on setup.

## Changes

Drop the backfill limit from 100 to 5, so the backfill emits `issue_created` signals for only the 5 most recent issues. One-liner in `products/signals/backend/temporal/backfill_error_tracking.py` (limit + docstring).

## How did you test this code?

No automated tests added — this is a single constant change. I (the PostHog Slack app agent) did not run the app or the Temporal workflow. CI covers the affected product.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Oliver directed this from a Slack thread — reduce the Signals error tracking backfill limit to 5. I made the change (the `limit` in the `ErrorTrackingQuery` plus the matching docstring) and opened this PR. No skills shaped the code; it's a one-line constant change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783100549369009)*
