### PR TITLE
fix(mssql): treat dropped-table metadata lookup as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/mssql.py
@@ -97,6 +97,16 @@ _MAX_DEADLOCK_ATTEMPTS = 5
 # `MSSQLSource.get_non_retryable_errors`) — same gateway-config class as a wrapped tunnel failure.
 _SSH_HANDSHAKE_EOF_ERROR = "SSH gateway closed the connection during the SSH handshake"
 
+# Raised by `get_table_metadata` when INFORMATION_SCHEMA.COLUMNS returns no rows for a table we
+# were asked to sync — the table was dropped or renamed at the source after schema discovery (or
+# its schema/name no longer matches under the server's collation). Unlike a live SELECT against a
+# missing object (SQL Server error 208, "Invalid object name"), this metadata lookup returns an
+# empty result set rather than erroring, so this guard fires first. Retrying replays the identical
+# lookup and gets the same empty result, so it's classified non-retryable (see
+# `MSSQLSource.get_non_retryable_errors`). Kept as a stable prefix so the match stays clear of the
+# volatile schema/table name that follows it.
+_TABLE_NOT_FOUND_ERROR = "Table not found when reading column metadata"
+
 
 def _is_transient_connection_error(error: BaseException) -> bool:
     """True for a mid-stream TDS connection death that a fresh connection recovers from."""
@@ -680,7 +690,7 @@ class MSSQLImplementation(SQLSourceImplementation[MSSQLSourceConfig, pymssql.Con
             )
 
         if not columns:
-            raise ValueError(f"Table {table_name} not found")
+            raise ValueError(f"{_TABLE_NOT_FOUND_ERROR}: {schema}.{table_name}")
 
         return Table(
             name=table_name,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -24,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MSSQLSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssql import (
     _SSH_HANDSHAKE_EOF_ERROR,
+    _TABLE_NOT_FOUND_ERROR,
     MSSQLImplementation,
     retry_on_transient_connection_error,
 )
@@ -111,6 +112,13 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
             "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            # Raised by `get_table_metadata` when INFORMATION_SCHEMA.COLUMNS returns no columns for a
+            # table we were asked to sync — the table was dropped or renamed at the source after
+            # schema discovery. This is the metadata-lookup counterpart of "Invalid object name"
+            # (SQL Server error 208): the lookup returns an empty result set rather than erroring, so
+            # our own guard fires before the SELECT. The table is gone from the source, so retrying
+            # replays the identical empty lookup. Match the stable prefix, not the schema/table name.
+            _TABLE_NOT_FOUND_ERROR: "One of the tables you're syncing no longer exists in your SQL Server — it was likely dropped or renamed after it was first discovered. Remove it from the sync or restore it at the source, then re-enable the sync.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -651,6 +651,16 @@ class TestMSSQLSourceNonRetryableErrors:
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
 
+    def test_table_not_found_is_non_retryable(self, impl, cursor):
+        # Drive the real raise site so the message and the rule can't drift apart: a table dropped
+        # after schema discovery yields no columns from INFORMATION_SCHEMA and must stop retrying.
+        cursor.__iter__.return_value = iter([])
+        with pytest.raises(ValueError) as exc_info:
+            impl.get_table_metadata(cursor, "dbo", "dropped_table")
+
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in str(exc_info.value) for pattern in non_retryable.keys())
+
 
 class TestIsTransientConnectionError:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `ValueError: Table <name> not found` from the MSSQL data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f2911-ed16-72c3-85af-233a53e8cb62)). It fires in `get_table_metadata` in `products/warehouse_sources/backend/temporal/data_imports/sources/mssql/mssql.py`, on the import pipeline path (`import_data_activity_sync` → `build_pipeline` → `get_table_metadata`).

The root cause is user/upstream, not a bug in our request shaping. `get_table_metadata` queries `INFORMATION_SCHEMA.COLUMNS` for a table that was selected for sync. When that returns no rows, the table no longer exists in the source database. It was dropped or renamed after schema discovery (or its name no longer matches under the server's collation). Retrying replays the identical lookup and gets the same empty result, so today the job just keeps failing.

## Changes

This is the metadata-lookup counterpart of SQL Server error 208 ("Invalid object name"), which we already treat as non-retryable. The difference is that a live `SELECT` against a missing object errors, while the `INFORMATION_SCHEMA` lookup returns an empty result set, so our own guard fires first and the existing 208 rule never matches.

- Give the `ValueError` a stable prefix marker (`_TABLE_NOT_FOUND_ERROR`) shared between the raise site and the rule, mirroring `_SSH_HANDSHAKE_EOF_ERROR`, so the two can't drift apart. The volatile schema/table name stays out of the matched substring.
- Add the marker to `MSSQLSource.get_non_retryable_errors` with actionable copy telling the user the table no longer exists and to remove it from the sync or restore it at the source.

Scoped strictly to this error. No change to global retry policy. Transient connection errors stay retryable.

## How did you test this code?

Automated tests I ran locally (`pytest` on `test_mssql.py`, 89 passed):

- Added `test_table_not_found_is_non_retryable`, which drives the real raise site (empty `INFORMATION_SCHEMA` result) and asserts the resulting message is matched by `get_non_retryable_errors`. This ties the raised message to the rule so they can't drift apart. No existing test covered the metadata `ValueError` being classified non-retryable.
- Existing `TestGetTableMetadata` and `TestMSSQLSourceNonRetryableErrors` cases still pass.

I (Claude) could not exercise a live MSSQL sync end to end from this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Pulled the issue and a representative event via the PostHog error-tracking MCP tools, confirmed the failure originates in the mssql source (`build_pipeline` → `get_table_metadata`), and read the source plus its `NonRetryableErrors` set.

Decision: user/upstream error, not a fixable code bug. The request we build is valid; the table is simply gone from the source. Considered a graceful skip instead, but the established pattern for "object dropped/renamed after discovery" here (error 208, 207, 245) is to classify as non-retryable with clear copy, so I matched that for consistency. Matched a stable prefix substring rather than the volatile schema/table name, per the source's existing conventions.
