### PR TITLE
fix(llma): skip tool calls when picking last trace output message

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityTracesScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTracesScene.tsx
@@ -32,6 +32,10 @@ import {
     formatLLMUsage,
     getTraceStepCount,
     getTraceTimestamp,
+    INTERNAL_TOOL_RESULT_ROLE,
+    isInternalToolResultUserMessage,
+    isToolResult,
+    isToolStepItem,
     LLM_TRACES_PAGE_SIZE,
     sanitizeTraceUrlSearchParams,
 } from './utils'
@@ -461,12 +465,39 @@ export function pickLastInputMessage(
 }
 
 /**
- * Preferred → fallback cascade for the trace output column. We prefer the
- * last assistant message with real content, but fall back to the last
- * displayable message (e.g. tool_calls) so tool-calling traces still show
- * something useful instead of a dash.
+ * A message is "tool traffic" (a tool call or a tool result) rather than a
+ * user-facing turn. Tool calls frequently end an agent chain, but the traces
+ * list should surface the last human-readable answer, not the machinery that
+ * produced it. Covers the explicit `tool_calls` field, tool-result roles, and
+ * content arrays made up entirely of tool-call / tool-result parts — while
+ * still treating a message that mixes real text with a tool call as
+ * user-facing.
  */
-function pickLastOutputMessage(
+function isToolMessage(message: NormalizedMessage): boolean {
+    const { role, content, tool_calls } = message as NormalizedMessage & { tool_calls?: unknown }
+    const hasText =
+        (typeof content === 'string' && content.trim().length > 0) ||
+        (Array.isArray(content) && content.some((item) => !isToolStepItem(item) && !isToolResult(item)))
+    if (Array.isArray(tool_calls) && tool_calls.length > 0) {
+        return !hasText
+    }
+    if (role === 'tool' || role === INTERNAL_TOOL_RESULT_ROLE || isInternalToolResultUserMessage(message)) {
+        return true
+    }
+    if (Array.isArray(content) && content.length > 0 && !hasText) {
+        return true
+    }
+    return false
+}
+
+/**
+ * Preferred → fallback cascade for the trace output column. We prefer the last
+ * assistant message that carries user-facing content, skipping pure tool calls
+ * and tool results so a tool-calling agent chain still shows its last readable
+ * answer. Only when a trace has nothing but tool traffic do we fall back to the
+ * last displayable message, so those traces still show something instead of a dash.
+ */
+export function pickLastOutputMessage(
     raw: unknown,
     { strict }: { strict: boolean } = { strict: false }
 ): NormalizedMessage | null {
@@ -474,15 +505,15 @@ function pickLastOutputMessage(
     if (normalized.length === 0) {
         return null
     }
-    for (let i = normalized.length - 1; i >= 0; i--) {
-        if (normalized[i].role === 'assistant' && hasDisplayableContent(normalized[i])) {
-            return normalized[i]
-        }
+    const lastAssistant = normalized.findLast(
+        (m) => m.role === 'assistant' && hasDisplayableContent(m) && !isToolMessage(m)
+    )
+    if (lastAssistant) {
+        return lastAssistant
     }
-    for (let i = normalized.length - 1; i >= 0; i--) {
-        if (hasDisplayableContent(normalized[i])) {
-            return normalized[i]
-        }
+    const lastDisplayable = normalized.findLast(hasDisplayableContent)
+    if (lastDisplayable) {
+        return lastDisplayable
     }
     return normalized[normalized.length - 1]
 }

--- a/products/ai_observability/frontend/tracesOutputPreview.test.ts
+++ b/products/ai_observability/frontend/tracesOutputPreview.test.ts
@@ -1,0 +1,73 @@
+import { pickLastOutputMessage } from './AIObservabilityTracesScene'
+
+describe('pickLastOutputMessage', () => {
+    it('returns null for empty or unusable input', () => {
+        expect(pickLastOutputMessage(null)).toBeNull()
+        expect(pickLastOutputMessage([])).toBeNull()
+    })
+
+    it('skips a trailing tool call and picks the last user-facing assistant answer', () => {
+        const conversation = [
+            { role: 'user', content: 'what is the weather?' },
+            { role: 'assistant', content: 'It is 72F.' },
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [{ id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{}' } }],
+            },
+        ]
+        expect(pickLastOutputMessage(conversation)).toMatchObject({ role: 'assistant', content: 'It is 72F.' })
+    })
+
+    it('skips a trailing tool result and picks the last assistant answer', () => {
+        const conversation = [
+            { role: 'assistant', content: 'Let me check.' },
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [{ id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{}' } }],
+            },
+            { role: 'tool', content: '72F', tool_call_id: 'c1' },
+        ]
+        expect(pickLastOutputMessage(conversation)).toMatchObject({ role: 'assistant', content: 'Let me check.' })
+    })
+
+    it('keeps an assistant message that mixes real text with a tool call', () => {
+        const conversation = [
+            { role: 'user', content: 'book a table' },
+            {
+                role: 'assistant',
+                content: 'Booking that now.',
+                tool_calls: [{ id: 'c1', type: 'function', function: { name: 'book', arguments: '{}' } }],
+            },
+        ]
+        expect(pickLastOutputMessage(conversation)).toMatchObject({
+            role: 'assistant',
+            content: 'Booking that now.',
+        })
+    })
+
+    it('falls back to the tool call when the trace has nothing but tool traffic', () => {
+        const conversation = [
+            { role: 'user', content: 'what is the weather?' },
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [{ id: 'c1', type: 'function', function: { name: 'get_weather', arguments: '{}' } }],
+            },
+        ]
+        const picked = pickLastOutputMessage(conversation)
+        expect(picked).not.toBeNull()
+        expect(picked?.tool_calls?.[0]?.function?.name).toBe('get_weather')
+    })
+
+    it('unwraps a { messages } state container before picking the output', () => {
+        const state = {
+            messages: [
+                { role: 'assistant', content: 'final answer' },
+                { role: 'tool', content: 'tool output', tool_call_id: 'c1' },
+            ],
+        }
+        expect(pickLastOutputMessage(state)).toMatchObject({ role: 'assistant', content: 'final answer' })
+    })
+})

--- a/products/ai_observability/frontend/tracesOutputPreview.test.ts
+++ b/products/ai_observability/frontend/tracesOutputPreview.test.ts
@@ -70,4 +70,8 @@ describe('pickLastOutputMessage', () => {
         }
         expect(pickLastOutputMessage(state)).toMatchObject({ role: 'assistant', content: 'final answer' })
     })
+
+    it('rejects unknown state-wrapper shapes in strict mode', () => {
+        expect(pickLastOutputMessage({ current_step: 3 }, { strict: true })).toBeNull()
+    })
 })


### PR DESCRIPTION
## Problem

On the AI observability Traces list, the output column should show the last user-facing message of an agent chain. But `pickLastOutputMessage` picked the last *displayable* assistant message, and `hasDisplayableContent` counts a message with only `tool_calls` as displayable. So when an agent chain ended on a tool call (common for tool-using agents), the column surfaced the tool invocation instead of the last human-readable answer.

## Changes

- Added an `isToolMessage` helper that classifies a normalized message as tool traffic — an explicit `tool_calls` field with no text, a tool-result role (`tool` / internal tool-result), or a content array made up entirely of tool-call/tool-result parts — while still treating a message that mixes real text with a tool call as user-facing. It reuses the existing tool-detection utils (`isToolStepItem`, `isToolResult`, `isInternalToolResultUserMessage`).
- `pickLastOutputMessage` now prefers the last assistant message with user-facing content (skipping pure tool calls/results). When a trace has nothing but tool traffic, it still falls back to the last displayable message so those traces render something instead of a dash.
- Exported `pickLastOutputMessage` and added a focused test file.

## How did you test this code?

Added `tracesOutputPreview.test.ts` (mirrors the existing `tracesInputPreview.test.ts`). Cases lock in: skipping a trailing tool call to pick the prior assistant answer, skipping a trailing tool result, keeping an assistant message that mixes text with a tool call, and the fallback to a tool call when the trace is tool-only (so it doesn't render a dash). Ran the new suite plus the sibling input-preview suite (11 tests pass), `pnpm --filter=@posthog/frontend typescript:check` (passes), and oxlint (clean). No manual UI testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread. Invoked the `/writing-tests` skill before adding the test file to gate its value. The initial implementation had an intermediate fallback tier that picked the last non-tool displayable message of any role; a test caught that this wrongly surfaced the user's *input* message as the output for tool-only traces, so it was dropped in favor of falling straight back to the last displayable message (the original last-resort behavior). Verified the normalized message shapes (`tool_calls` field, `role: 'tool'`) against the recipe normalizer's coercion output before writing assertions.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783103223245229?thread_ts=1783103223.245229&cid=C0ACRAMJUAG)*
