### PR TITLE
fix(max): gate code capability badge behind PRODUCT_AUTONOMY flag

### DIFF
--- a/frontend/src/scenes/max/components/CapabilityBadges.tsx
+++ b/frontend/src/scenes/max/components/CapabilityBadges.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { IconCode } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
@@ -40,13 +41,19 @@ export function CapabilityBadges({
     onSelect,
     className,
 }: CapabilityBadgesProps): JSX.Element | null {
+    const isProductAutonomyEnabled = useFeatureFlag('PRODUCT_AUTONOMY')
+
     if (!capabilities.length) {
         return null
     }
 
     return (
         <div
-            className={cn('flex flex-wrap items-center justify-center gap-1.5 w-full px-3', COLORFUL_ICONS, className)}
+            className={cn(
+                'flex flex-wrap items-center justify-center gap-1.5 max-w-[500px] px-3',
+                COLORFUL_ICONS,
+                className
+            )}
         >
             {capabilities.map((capability) => (
                 <LemonButton
@@ -61,20 +68,23 @@ export function CapabilityBadges({
                     {capability.label}
                 </LemonButton>
             ))}
-            <LemonButton
-                size="small"
-                type="secondary"
-                to={CODE_CAPABILITY.to}
-                icon={<IconCode />}
-                data-attr="capability-badge-code"
-            >
-                <span className="flex items-center gap-1.5">
-                    {CODE_CAPABILITY.label}
-                    <LemonTag type="completion" size="small">
-                        Beta
-                    </LemonTag>
-                </span>
-            </LemonButton>
+
+            {isProductAutonomyEnabled && (
+                <LemonButton
+                    size="small"
+                    type="secondary"
+                    to={CODE_CAPABILITY.to}
+                    icon={<IconCode />}
+                    data-attr="capability-badge-code"
+                >
+                    <span className="flex items-center gap-1.5">
+                        {CODE_CAPABILITY.label}
+                        <LemonTag type="completion" size="small">
+                            Beta
+                        </LemonTag>
+                    </span>
+                </LemonButton>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/max/components/CapabilityBadges.tsx
+++ b/frontend/src/scenes/max/components/CapabilityBadges.tsx
@@ -79,7 +79,7 @@ export function CapabilityBadges({
                 >
                     <span className="flex items-center gap-1.5">
                         {CODE_CAPABILITY.label}
-                        <LemonTag type="completion" size="small">
+                        <LemonTag type="warning" size="small">
                             Beta
                         </LemonTag>
                     </span>

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -455,7 +455,7 @@ function IdleGrid(): JSX.Element {
             // capability cards are always the same height. Only shown at @xl+ where columns sit in a row.
             className={cn(
                 'flex flex-col @xl/main-content:flex-row gap-8 @xl/main-content:gap-2 w-full px-3 outline-none h-full',
-                hasExtraMarginTop && 'mt-2'
+                hasExtraMarginTop && 'mt-8'
             )}
             tabIndex={-1}
             onFocus={(e) => {
@@ -558,7 +558,7 @@ export function HomepageInput(): JSX.Element {
                             than squeezing their heights, which would reflow the cards/grid mid-animation.
                             gap-6 spaces the badges from the row below — it's part of the flex column's
                             laid-out height, so it's counted in the collapse and the vertical centering. */}
-                        <div className="overflow-hidden flex flex-col gap-6">
+                        <div className="overflow-hidden flex flex-col items-center gap-6">
                             <CapabilityBadges
                                 className="shrink-0"
                                 capabilities={capabilities}


### PR DESCRIPTION
Gates the "Code" capability badge behind the `PRODUCT_AUTONOMY` feature flag, so it only appears for users with that flag enabled.

Also fixes layout issues in the homepage input: increases the top margin from `mt-2` to `mt-8` in the idle grid when extra margin is needed, centers the capability badges container with `items-center`, and constrains the badges wrapper to a max width of `500px` instead of stretching full width.