### PR TITLE
fix(navigation): match Health badge size to icon slot

### DIFF
--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -194,7 +194,7 @@ export function HelpMenu({ iconOnly = false }: { iconOnly?: boolean }): JSX.Elem
                                         >
                                             Health
                                             <LemonBadge
-                                                size="small"
+                                                size="xsmall"
                                                 content={triggerBadgeContent}
                                                 status={triggerBadgeStatus}
                                             />


### PR DESCRIPTION
## Problem

The "More" menu's Health item shows a status badge that's slightly taller than the 16px icon slot used by every other row, so the row reads as misaligned. #67927 already fixed the equivalent Status badge, but a later reorder in that same PR (`refactor: Declutter even more`) accidentally reverted the Health badge back to the larger size while moving the item around.

## Changes

One-line revert of the regression: `LemonBadge size="small"` (18px) back to `size="xsmall"` (14px) on the Health menu item in `HelpMenu.tsx`, matching the Status badge and the icon slot.

## How did you test this code?

Traced the history of the badge's `size` prop with `git log -p` to confirm the intended value and where it regressed. Did not run the app locally to visually confirm — no automated test covers this, and a one-line prop revert doesn't warrant a new one.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A – internal UI-only tweak.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This was found and fixed by an automated `/review-triage` pass on #67927: a Greptile bot comment flagged the Health badge as larger than its icon slot. Investigation showed #67927 had already fixed this exact issue for the Status badge, but a later commit in the same PR reordered the Health menu item and silently reverted its badge size. By the time the fix was ready, #67927 had already merged, so this follow-up PR carries the same one-line change forward.
