### PR TITLE
fix(notebooks): send draft base version in legacy notebook save

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.test.ts
@@ -1,0 +1,120 @@
+import { JSONContent } from '@tiptap/core'
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel } from '~/types'
+
+import { NotebookType } from '../types'
+import { SYNC_DELAY, notebookLogic } from './notebookLogic'
+
+// Skip the API-driven query upgrade step inside migrate — fixture content has no
+// insight nodes, and migrate's per-node walk is out of scope for this test.
+jest.mock('./migrations/migrate', () => {
+    const actual = jest.requireActual('./migrations/migrate')
+    return {
+        ...actual,
+        migrate: jest.fn(async (notebook) => notebook),
+    }
+})
+
+const SHORT_ID = 'test-stale-save'
+
+const doc = (text: string): JSONContent => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+})
+
+const notebookFixture = (version: number, text: string): NotebookType =>
+    ({
+        id: 'notebook-id',
+        short_id: SHORT_ID,
+        title: 'Test',
+        content: doc(text),
+        text_content: text,
+        version,
+        deleted: false,
+        is_template: false,
+        user_access_level: AccessControlLevel.Editor,
+        created_at: '2025-01-01T00:00:00Z',
+        created_by: null,
+        last_modified_at: '2025-01-01T00:00:00Z',
+        last_modified_by: null,
+    }) as unknown as NotebookType
+
+describe('notebookLogic stale-draft saves', () => {
+    let logic: ReturnType<typeof notebookLogic.build>
+    let serverNotebook: NotebookType
+    let apiUpdateSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        serverNotebook = notebookFixture(1, 'server v1')
+        useMocks({
+            get: {
+                [`/api/projects/@current/notebooks/${SHORT_ID}/`]: () => [200, serverNotebook],
+                [`/api/projects/:project_id/notebooks/${SHORT_ID}/`]: () => [200, serverNotebook],
+                [`/api/projects/:project_id/notebooks/${SHORT_ID}/kernel/status/`]: () => [200, { backend: null }],
+            },
+        })
+        initKeaTests()
+        // collabStream opens an SSE connection that never resolves in production —
+        // resolve immediately in tests so the listener doesn't dangle.
+        jest.spyOn(api.notebooks, 'collabStream').mockResolvedValue(undefined as any)
+        // Server-side optimistic concurrency: accept only when the submitted version
+        // matches the server head, exactly like the backend's select_for_update check.
+        apiUpdateSpy = jest.spyOn(api.notebooks, 'update').mockImplementation(async (_id, data) => {
+            if (data.version === serverNotebook.version) {
+                serverNotebook = { ...serverNotebook, ...data, version: serverNotebook.version + 1 } as NotebookType
+                return serverNotebook
+            }
+            const conflict: any = new Error('Someone else edited the Notebook')
+            conflict.status = 409
+            conflict.code = 'conflict'
+            throw conflict
+        })
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('saves a stale draft against its base version so a concurrent edit conflicts instead of being clobbered', async () => {
+        logic = notebookLogic({ shortId: SHORT_ID, mode: 'notebook' })
+        logic.mount()
+        logic.actions.loadNotebook()
+        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
+        expect(logic.values.notebook!.version).toBe(1)
+
+        // The user starts a draft based on v1. Autosave is paused while we arrange
+        // the concurrent edit so the debounce can't fire mid-setup.
+        logic.actions.setAutosavePaused(true)
+        logic.actions.setLocalContent(doc('local draft based on v1'))
+
+        // Meanwhile another writer saves v2 and the periodic poll refreshes this
+        // tab's notebook (version included) without touching the local draft.
+        serverNotebook = notebookFixture(2, 'external edit v2')
+        logic.actions.loadNotebook()
+        await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
+        expect(logic.values.notebook!.version).toBe(2)
+        expect(logic.values.localContent).toEqual(doc('local draft based on v1'))
+
+        // The user keeps typing; the autosave fires with the stale draft.
+        logic.actions.setAutosavePaused(false)
+        logic.actions.setLocalContent(doc('local draft based on v1'))
+        await expectLogic(logic)
+            .delay(SYNC_DELAY + 100)
+            .toFinishAllListeners()
+
+        // The save must carry the version the draft was based on (1), not the
+        // refreshed head (2) — otherwise the server accepts it and the external
+        // edit is silently destroyed.
+        expect(apiUpdateSpy).toHaveBeenCalledWith(SHORT_ID, expect.objectContaining({ version: 1 }))
+        // With the honest base version the server 409s and the existing conflict
+        // flow takes over instead of clobbering.
+        expect(logic.values.conflictWarningVisible).toBe(true)
+        expect(logic.values.localContent).toBeNull()
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -317,6 +317,7 @@ export const notebookLogic = kea<notebookLogicType>([
             skipCapture,
         }),
         clearLocalContent: true,
+        setLocalContentBaseVersion: (version: number | null) => ({ version }),
         setPreviewContent: (jsonContent: JSONContent) => ({ jsonContent }),
         clearPreviewContent: true,
         loadNotebook: true,
@@ -398,6 +399,19 @@ export const notebookLogic = kea<notebookLogicType>([
             { persist: props.mode !== 'canvas', prefix: NOTEBOOKS_VERSION },
             {
                 setLocalContent: (_, { jsonContent }) => jsonContent,
+                clearLocalContent: () => null,
+            },
+        ],
+        // The notebook version the local draft is based on — the optimistic-concurrency
+        // baseline for the legacy full-doc save. The periodic refresh advances
+        // `notebook.version` underneath an open draft, so saving with the latest known
+        // version lets a stale draft silently overwrite a concurrent edit. Persisted with
+        // the same options as `localContent` so the pair survives reloads together.
+        localContentBaseVersion: [
+            null as number | null,
+            { persist: props.mode !== 'canvas', prefix: NOTEBOOKS_VERSION },
+            {
+                setLocalContentBaseVersion: (_, { version }) => version,
                 clearLocalContent: () => null,
             },
         ],
@@ -823,7 +837,7 @@ export const notebookLogic = kea<notebookLogicType>([
                     // Legacy path: full-doc PATCH
                     try {
                         const response = await api.notebooks.update(values.notebook.short_id, {
-                            version: values.notebook.version,
+                            version: values.localContentBaseVersion ?? values.notebook.version,
                             content: notebookContent,
                             text_content: getNotebookTextContent(notebookContent, values.editor?.getText() || ''),
                             title: notebook.title,
@@ -1782,6 +1796,9 @@ export const notebookLogic = kea<notebookLogicType>([
                 // We don't want to modify the content if we are viewing a preview
                 return
             }
+            if (values.localContentBaseVersion === null && values.notebook) {
+                actions.setLocalContentBaseVersion(values.notebook.version)
+            }
             if (updateEditor) {
                 values.editor?.setContent(jsonContent)
             }
@@ -1893,6 +1910,11 @@ export const notebookLogic = kea<notebookLogicType>([
                     objectsEqual(values.notebook?.content, attemptedContent))
             ) {
                 actions.clearLocalContent()
+            }
+            if (values.localContent !== null && values.notebook) {
+                // Edits that arrived while the save was in flight are based on the
+                // version the server just assigned.
+                actions.setLocalContentBaseVersion(values.notebook.version)
             }
             actions.scheduleNotebookRefresh()
             if (values.showHistory) {


### PR DESCRIPTION
## Problem

The legacy full-doc notebook save sends `values.notebook.version` — the newest version the client has heard of — as its optimistic-concurrency token. Two client behaviors combine to defeat the backend's version check:

- `localContent` (the draft, a persisted reducer) shadows server content and is never rebased when fresher server state arrives.
- The periodic notebook refresh (every 30s) advances `notebook.version` underneath an open draft.

So a tab holding a stale draft can save it with a fresh version token: the backend's `select_for_update` version check passes, and a concurrent edit from another session (another user, another tab, or an API writer) is silently overwritten. No conflict warning is shown because, from the server's perspective, nothing conflicted. We hit this in practice: content written via the API was destroyed within seconds by an open tab's autosave.

The collab (prosemirror steps) and markdown-realtime paths already send proper baselines; only the legacy path conflates "latest known version" with "version my edits are based on".

## Changes

- New `localContentBaseVersion` reducer in `notebookLogic`: captured when a draft first diverges from the loaded notebook, rebased to the server-assigned version after a successful save, cleared together with the draft, and persisted with the same options as `localContent` so the pair survives reloads together.
- The legacy full-doc PATCH now sends `localContentBaseVersion ?? notebook.version`. With an honest baseline, a concurrent edit makes the save 409 into the existing conflict flow (`clearLocalContent` + conflict warning) instead of clobbering.
- No backend changes; collab and markdown save paths untouched.

Possible follow-up for the owning team: the markdown path reads `values.notebook.version` at save time too — its merge-on-409 machinery softens the impact, but the same baseline treatment may be worth considering.

## How did you test this code?

I am an agent (Claude Code). Automated tests:

- New `notebookLogic.test.ts` reproducing the incident deterministically: draft starts on v1, an external writer saves v2, the poll refreshes the tab, autosave fires. The mock server enforces the same version check as the backend. Watched it fail before the fix for the exact defect (save carried `version: 2` and was accepted, silently overwriting) and pass after (save carries `version: 1`, gets a conflict, the warning surfaces and the draft clears). No existing test covered `notebookLogic` save concurrency.
- Full notebook test directory: 18 suites / 230 tests pass, covering the collab, markdown, revert, and history save flows.
- `oxlint`/`oxfmt` clean on changed files; kea typegen regenerated for the logic. Note: full-app `typescript:check` is red on my checkout from pre-existing stale generated `*LogicType.ts` artifacts in unrelated files — none of the errors touch the changed files; CI regenerates types and is authoritative.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (Fable 5); session linked below. Skills invoked: systematic-debugging, test-driven-development, /writing-tests, /writing-kea-logics.
- Root-caused from a live incident during a pairing session (an API notebook edit was overwritten by an open tab within seconds). Verified each link before fixing: backend version check is correct; the poll refresh and the persisted, never-rebased draft are what let a stale draft ride a fresh token past it.
- Considered rebasing local content on refresh instead; rejected as far more invasive — sending the honest base version reuses the entire existing conflict UX and touches one save path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHNqSqPGjvFfgv6ahQn7hQ
