### PR TITLE
chore: add trailing newlines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+


### PR DESCRIPTION
## 💡 Motivation

Adds a couple of trailing newlines to the end of `README.md`.

## 🔬 Changes

Appended two newlines to the end of the README.

## 🤖 Agent context

Requested from a Slack thread: add a couple of newlines to the end of the README.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783114954303399)*