### PR TITLE
fix(bigquery): retry transient per-second rate quotas in place

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -134,11 +134,31 @@ BIGQUERY_INVALID_IDENTIFIER_ERROR = (
 _BIGQUERY_JOB_RETRY_RECOMMENDED = "Retrying the job may solve the problem"
 
 
+def _is_transient_rate_quota_exceeded(exc: Exception) -> bool:
+    """True for BigQuery's per-second rate quotas, which are transient and recover on their own.
+
+    BigQuery caps some operations by a per-second rate (e.g. "Quota exceeded: Your project ...
+    exceeded quota for tabledata.list bytes per second per project."), surfaced from
+    `jobs.getQueryResults` as a `Forbidden` (403, reason `quotaExceeded`). The quota window resets
+    each second, so a query that trips one recovers within moments — but the library's own retry
+    predicates only cover `rateLimitExceeded` / `backendError` / `internalError`, not
+    `quotaExceeded`, so neither the API-call retry nor the job retry waits it out and the read/copy
+    query crashes the whole sync. This is distinct from the administrator-set "Custom quota
+    exceeded" daily cost cap (kept non-retryable in `get_non_retryable_errors`), which resets only
+    on Google's daily schedule and must not be retried in place. Matched on the stable "per second"
+    wording rather than the volatile project/quota id.
+    """
+    message = str(exc)
+    return "per second" in message and "Custom quota exceeded" not in message
+
+
 def _query_job_should_retry(exc: Exception) -> bool:
     # Defer to the library's own default predicate for the reasons it already covers; importing it
     # directly (rather than reading the private `Retry._predicate`) means a library rename fails
     # loudly at import instead of silently dropping that default coverage.
-    return _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or _job_should_retry(exc)
+    return (
+        _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or _is_transient_rate_quota_exceeded(exc) or _job_should_retry(exc)
+    )
 
 
 BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_retry)
@@ -884,7 +904,7 @@ def _run_destination_query_with_job_retry(
 
     def _run() -> None:
         job = client.query(query, job_config=job_config, project=project)
-        job.result()
+        job.result(job_retry=BIGQUERY_QUERY_JOB_RETRY)
 
     _with_job_not_found_retry(_run)
 
@@ -907,7 +927,7 @@ def _query_result_with_job_retry(
 
     def _run() -> RowIterator:
         job = client.query(query, job_config=job_config, project=project)
-        return job.result(page_size=page_size)
+        return job.result(page_size=page_size, job_retry=BIGQUERY_QUERY_JOB_RETRY)
 
     return _with_job_not_found_retry(_run)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -26,6 +26,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     _get_rows_to_sync,
     _has_duplicate_primary_keys,
     _is_transient_job_not_found,
+    _query_result_with_job_retry,
     _resolve_dataset_id,
     _resolve_dataset_project_id,
     _resolve_project_id,
@@ -1122,6 +1123,15 @@ def test_has_duplicate_primary_keys_captures_unexpected_errors():
         # The library default's own retryable reasons must still be honoured.
         BadRequest("query failed", errors=[{"reason": "backendError", "message": "internal error"}]),
         BadRequest("query failed", errors=[{"reason": "rateLimitExceeded", "message": "slow down"}]),
+        # A per-second rate quota (reason `quotaExceeded`, which the library's own predicates don't
+        # retry) is transient — the quota window resets each second — so it must be retried in place
+        # rather than crashing the sync. Volatile project/job ids redacted.
+        Forbidden(
+            "GET https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/queries/<redacted>"
+            "?maxResults=0&location=US&prettyPrint=false: Quota exceeded: Your project:<redacted> "
+            "exceeded quota for tabledata.list bytes per second per project. For more information, "
+            "see https://cloud.google.com/bigquery/docs/troubleshoot-quotas"
+        ),
     ],
 )
 def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
@@ -1134,6 +1144,12 @@ def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
         # A genuinely malformed query is deterministic — retrying never helps, so it must surface.
         BadRequest("Syntax error: Unexpected keyword SELECT"),
         BadRequest("query failed", errors=[{"reason": "invalidQuery", "message": "bad SQL"}]),
+        # The administrator-set "Custom quota exceeded" daily cost cap resets only on Google's daily
+        # schedule — the per-second rate-quota retry must not catch it and hammer the endpoint.
+        Forbidden(
+            "Custom quota exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, "
+            "which is set by your administrator.; reason: quotaExceeded"
+        ),
     ],
 )
 def test_bigquery_query_job_retry_does_not_retry_deterministic_errors(exc):
@@ -1153,6 +1169,29 @@ def test_bigquery_get_primary_keys_for_table_passes_job_retry():
     client.query.return_value.result.return_value = []
 
     _get_primary_keys_for_table(table, client)
+
+    assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+
+
+def test_run_destination_query_passes_job_retry():
+    """The copy-into-temp-table query — where the production sync crashed on a transient per-second
+    rate quota — must run under the extended job retry so it waits the rate limit out in place
+    instead of aborting the import."""
+    client = mock.MagicMock()
+
+    _run_destination_query_with_job_retry(
+        client, "SELECT 1", destination_table=mock.MagicMock(), query_parameters=[], project="prj"
+    )
+
+    assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+
+
+def test_query_result_passes_job_retry():
+    """The read/count query must likewise run under the extended job retry so a transient per-second
+    rate quota is retried in place rather than surfacing."""
+    client = mock.MagicMock()
+
+    _query_result_with_job_retry(client, "SELECT COUNT(*)", job_config=mock.MagicMock(), project="prj")
 
     assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a BigQuery import crash: a `Forbidden` (403) raised from a query job's `result()` on the temp-table copy path.
The message is `Quota exceeded: Your project ... exceeded quota for tabledata.list bytes per second per project`.

This is a per-second rate quota. The window resets each second, so a query that trips one recovers on its own within moments. It should be waited out, not treated as fatal.

BigQuery surfaces it with reason `quotaExceeded`. The google-cloud-bigquery retry predicates (`_should_retry`, `_job_should_retry`) only cover `rateLimitExceeded` / `backendError` / `internalError` / `badGateway`, not `quotaExceeded`. So neither the API-call retry nor the job retry waits it out, and the read/copy query crashes the in-progress sync. The crash site, `_run_destination_query_with_job_retry`, ran a plain `job.result()` under the library default, unlike its sibling `_get_primary_keys_for_table` which already runs under the extended `BIGQUERY_QUERY_JOB_RETRY`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f2a6d-e8b2-7152-9473-784400689278

## Changes

I extended `_query_job_should_retry` to also treat BigQuery's per-second rate quotas as retryable, matched on the stable `per second` wording. This is deliberately kept distinct from the administrator-set `Custom quota exceeded` daily cost cap, which resets only on Google's daily schedule and stays non-retryable in `get_non_retryable_errors` (the predicate explicitly excludes it).

I then applied `BIGQUERY_QUERY_JOB_RETRY` to the two query helpers that still used the library default, `_run_destination_query_with_job_retry` (the crash site) and `_query_result_with_job_retry`, so the sync waits the rate limit out in place instead of aborting.

I did not add this to `NonRetryableErrors`. It is transient by definition, and doing so would permanently fail syncs on a temporary rate limit. The existing tests already assert that transient `Quota exceeded` errors must stay retryable, so this is consistent with that intent.

## How did you test this code?

Automated only (I am an agent and did not run a live BigQuery sync). Ran the full source test file, 122 passed.

New tests, and the regression each catches that no existing test did:
- Added a `Forbidden` per-second rate quota case to `test_bigquery_query_job_retry_retries_transient_job_errors` — catches a regression where the rate-quota wording stops being recognized and the exact production crash returns.
- Added a `Forbidden` `Custom quota exceeded` case to `test_bigquery_query_job_retry_does_not_retry_deterministic_errors` — guards the boundary so the new retry never starts hammering the daily cost cap in place.
- Added `test_run_destination_query_passes_job_retry` and `test_query_result_passes_job_retry` — catch a regression where someone drops the `job_retry` kwarg, reverting to the library default that does not retry the quota.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the BigQuery warehouse source and shipped the fix. Tools: PostHog error-tracking MCP (`query-error-tracking-issue`) to confirm the stack, frequency, and representative message. Skills invoked: `/writing-tests` (to gate the regression tests).

Key decision: user/upstream error vs fixable bug vs transient. I classified this as transient and fixed the retry gap rather than extending `NonRetryableErrors`. I confirmed against the installed google-cloud-bigquery `retry.py` that `quotaExceeded` is in none of the retryable-reason sets, which is why the error escaped both retry layers. I scoped the match to `per second` (transient rate quotas reset each second) and explicitly excluded `Custom quota exceeded` (a daily hard cap) so the two error classes can never overlap. I applied the existing `BIGQUERY_QUERY_JOB_RETRY` pattern that the maintainer already uses elsewhere in this file rather than inventing a new mechanism.
