### PR TITLE
fix(batch-import-worker): stop infinite 1-byte crawl when part is consumed at EOF

### DIFF
--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -157,15 +157,20 @@ pub(crate) async fn select_and_fetch_next_chunk(
                 }
             }
 
-            if actual_size == 0 {
+            // Streaming sources only learn their size on the read that observes
+            // end-of-stream, which is usually also the read that consumed the last
+            // bytes - so by the time the size is known here, the offset may already
+            // be at (or past) the end. Re-check completion now: fetching again would
+            // return an empty chunk, and advancing on one would push the offset past
+            // the total, making the part permanently un-finishable.
+            if next_part.is_done() {
                 info!(
                     job_id = %job_id,
-                    "No data available for this key: {} try to get the next chunk",
-                    key
+                    "Part {} (size {}) was fully consumed when its size was discovered, moving on",
+                    key, actual_size
                 );
-                next_part.current_offset = actual_size;
                 return Ok(Some((
-                    key.clone(),
+                    key,
                     Parsed {
                         consumed: 0,
                         data: vec![],
@@ -183,12 +188,25 @@ pub(crate) async fn select_and_fetch_next_chunk(
         .await
         .context(format!("Fetching part chunk {next_part:?}"))?;
 
+    // `>=` because sources clamp reads to the end of the part, so the final chunk
+    // ends exactly at total_size - a strict `>` can never be true and would leave
+    // the unconsumed-bytes check below unreachable.
     let is_last_chunk = match next_part.total_size {
-        Some(total_size) => next_part.current_offset + next_chunk.len() as u64 > total_size,
+        Some(total_size) => next_part.current_offset + next_chunk.len() as u64 >= total_size,
         None => false,
     };
 
     let chunk_bytes = next_chunk.len();
+
+    // An empty chunk before the known end of the part means the source has nothing
+    // more to give at this offset (e.g. a stream already read to EOF). No further
+    // iteration can make progress, so fail rather than loop.
+    if chunk_bytes == 0 && !is_last_chunk {
+        return Err(Error::msg(format!(
+            "Source returned no data for part {} at offset {} before the end of the part",
+            next_part.key, next_part.current_offset
+        )));
+    }
 
     info!(job_id = %job_id, "Fetched part chunk {:?}", next_part);
     let m_tf = transform.clone();
@@ -209,6 +227,16 @@ pub(crate) async fn select_and_fetch_next_chunk(
         "Parsed part chunk {:?}, consumed {} bytes",
         next_part, parsed.consumed
     );
+
+    // Consuming more bytes than were read is always a parser bug: advancing the
+    // offset past real data would silently skip it, or overshoot the end of the
+    // part and make it permanently un-finishable.
+    if parsed.consumed > chunk_bytes {
+        return Err(Error::msg(format!(
+            "Parser consumed {} bytes but only {} were read from part {} at offset {}",
+            parsed.consumed, chunk_bytes, next_part.key, next_part.current_offset
+        )));
+    }
 
     // If this is the last chunk and we didn't consume all of it, we have leftover unparseable data.
     if parsed.consumed < chunk_bytes && is_last_chunk {
@@ -1389,6 +1417,197 @@ mod tests {
             assert_eq!(
                 peak_raw, 1,
                 "exactly one .raw should exist while the part is in flight"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_part_fully_consumed_at_eof_read_completes_without_offset_overshoot() {
+            // Streaming sources only learn a part's total size on the read that
+            // observes EOF. When that same read fully consumes the remaining bytes,
+            // the offset lands exactly at the total while the job still has
+            // total_size = None. The next loop iteration must then recognize the
+            // part as done — not fetch an empty chunk, "consume" a phantom byte,
+            // and push the offset past the total (which makes is_done() unreachable
+            // and the job crawl one byte per iteration forever).
+            let server = MockServer::start();
+            let mut body = String::new();
+            for i in 0..200 {
+                body.push_str(&format!("{{\"event\":\"e{i}\"}}\n"));
+            }
+            let total_size = body.len() as u64;
+            let _mock = server.mock(|when, then| {
+                when.method(Method::GET).path("/export");
+                then.status(200).body(gzip_bytes(body.as_bytes()));
+            });
+
+            let staging = TempDir::new().unwrap();
+            let source = build_source(server.url("/export"), staging.path(), 1);
+            source.prepare_for_job().await.unwrap();
+            let keys = source.keys().await.unwrap();
+            assert_eq!(keys.len(), 1);
+
+            let state = Mutex::new(job_state(&keys));
+            let model = Mutex::new(dummy_model(job_state(&keys)));
+            // Real newline parser so `consumed` behaves exactly as in production.
+            let transform = newline_consumed_transform();
+
+            // Generous iteration budget: a healthy run needs ~(total/chunk + 2)
+            // iterations. Far more than that means the loop is stuck.
+            let chunk_size = 1024usize;
+            let max_iterations = (total_size as usize / chunk_size) + 10;
+            let mut completed = false;
+            for _ in 0..max_iterations {
+                let next = select_and_fetch_next_chunk(
+                    &state,
+                    &model,
+                    &source,
+                    &transform,
+                    chunk_size,
+                    Uuid::now_v7(),
+                )
+                .await
+                .unwrap();
+
+                let offset = state.lock().await.parts[0].current_offset;
+                assert!(
+                    offset <= total_size,
+                    "part offset {offset} overshot total size {total_size}: the job would crawl forever"
+                );
+
+                if next.is_none() {
+                    completed = true;
+                    break;
+                }
+            }
+
+            assert!(
+                completed,
+                "job did not finish the part within {max_iterations} iterations (offset {} / total {total_size})",
+                state.lock().await.parts[0].current_offset
+            );
+        }
+
+        #[tokio::test]
+        async fn test_part_with_trailing_blank_lines_completes() {
+            // Data whose final bytes are blank lines must still complete: the blanks
+            // are only seen on the EOF read, after which the streaming source has
+            // freed the part and can never serve those bytes again.
+            let server = MockServer::start();
+            let mut body = String::new();
+            for i in 0..200 {
+                body.push_str(&format!("{{\"event\":\"e{i}\"}}\n"));
+            }
+            body.push('\n');
+            let total_size = body.len() as u64;
+            let _mock = server.mock(|when, then| {
+                when.method(Method::GET).path("/export");
+                then.status(200).body(gzip_bytes(body.as_bytes()));
+            });
+
+            let staging = TempDir::new().unwrap();
+            let source = build_source(server.url("/export"), staging.path(), 1);
+            source.prepare_for_job().await.unwrap();
+            let keys = source.keys().await.unwrap();
+
+            let state = Mutex::new(job_state(&keys));
+            let model = Mutex::new(dummy_model(job_state(&keys)));
+            let transform = newline_consumed_transform();
+
+            let chunk_size = 1024usize;
+            let max_iterations = (total_size as usize / chunk_size) + 10;
+            let mut completed = false;
+            for _ in 0..max_iterations {
+                let next = select_and_fetch_next_chunk(
+                    &state,
+                    &model,
+                    &source,
+                    &transform,
+                    chunk_size,
+                    Uuid::now_v7(),
+                )
+                .await
+                .unwrap();
+                if next.is_none() {
+                    completed = true;
+                    break;
+                }
+            }
+
+            assert!(completed, "trailing blank lines must not stall the part");
+            assert_eq!(state.lock().await.parts[0].current_offset, total_size);
+        }
+
+        #[tokio::test]
+        async fn test_poisoned_part_with_overshot_offset_self_heals() {
+            // A job written by a worker version with the overshoot bug has a part
+            // whose stored offset exceeds its total size. On resume that part must
+            // be treated as done (its real bytes were all consumed before the
+            // phantom crawl began) so the job can move on to the remaining parts.
+            let server = MockServer::start();
+            let mut body = String::new();
+            for i in 0..200 {
+                body.push_str(&format!("{{\"event\":\"e{i}\"}}\n"));
+            }
+            let _mock = server.mock(|when, then| {
+                when.method(Method::GET).path("/export");
+                then.status(200).body(gzip_bytes(body.as_bytes()));
+            });
+
+            let staging = TempDir::new().unwrap();
+            let source = build_source(server.url("/export"), staging.path(), 2);
+            source.prepare_for_job().await.unwrap();
+            let keys = source.keys().await.unwrap();
+            assert_eq!(keys.len(), 2);
+
+            // Part 1 poisoned as in production: offset way past its recorded total.
+            let poisoned = JobState {
+                parts: vec![
+                    PartState {
+                        key: keys[0].clone(),
+                        current_offset: 25_328_072,
+                        total_size: Some(24_441_157),
+                    },
+                    PartState {
+                        key: keys[1].clone(),
+                        current_offset: 0,
+                        total_size: None,
+                    },
+                ],
+            };
+            let state = Mutex::new(poisoned.clone());
+            let model = Mutex::new(dummy_model(poisoned));
+            let transform = newline_consumed_transform();
+
+            let mut completed = false;
+            for _ in 0..20 {
+                let next = select_and_fetch_next_chunk(
+                    &state,
+                    &model,
+                    &source,
+                    &transform,
+                    1024,
+                    Uuid::now_v7(),
+                )
+                .await
+                .unwrap();
+                if next.is_none() {
+                    completed = true;
+                    break;
+                }
+            }
+
+            assert!(
+                completed,
+                "job with an overshot part must skip it and finish the rest"
+            );
+            let state = state.lock().await;
+            assert_eq!(
+                state.parts[0].current_offset, 25_328_072,
+                "poisoned part must be skipped untouched, not re-read"
+            );
+            assert_eq!(
+                state.parts[1].total_size,
+                Some(state.parts[1].current_offset)
             );
         }
 

--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -68,7 +68,10 @@ pub struct PartState {
 impl PartState {
     pub fn is_done(&self) -> bool {
         match self.total_size {
-            Some(size) => self.current_offset == size,
+            // `>=` so a part whose stored offset overshot its total (written by a
+            // worker version that kept advancing past the end) still completes on
+            // resume instead of being permanently un-finishable.
+            Some(size) => self.current_offset >= size,
             None => false,
         }
     }
@@ -504,6 +507,28 @@ mod tests {
                     total_size: None,
                 })
                 .collect(),
+        }
+    }
+
+    #[test]
+    fn test_part_is_done() {
+        // (offset, total, expected). Overshot offsets (recorded by worker versions
+        // that advanced past the end of a part) must still count as done, or the
+        // part can never complete on resume.
+        let cases: [(u64, Option<u64>, bool); 5] = [
+            (0, None, false),
+            (99, Some(100), false),
+            (100, Some(100), true),
+            (101, Some(100), true),
+            (0, Some(0), true),
+        ];
+        for (offset, total, expected) in cases {
+            let part = PartState {
+                key: "k".to_string(),
+                current_offset: offset,
+                total_size: total,
+            };
+            assert_eq!(part.is_done(), expected, "offset {offset}, total {total:?}");
         }
     }
 

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -140,6 +140,16 @@ pub fn newline_delim<T: Send>(
     inner: impl Fn(&str) -> Result<T, Error> + Sync,
 ) -> impl Fn(Vec<u8>) -> Result<Parsed<Vec<T>>, Error> {
     move |data: Vec<u8>| {
+        // A zero-length chunk (e.g. a read at or past the end of a part) has nothing
+        // to consume. Reporting any consumed bytes for it would advance the caller's
+        // offset past real data, so it could never converge on the part's end.
+        if data.is_empty() {
+            return Ok(Parsed {
+                data: Vec::new(),
+                consumed: 0,
+            });
+        }
+
         let mut cursor = 0;
         let mut last_consumed_byte = 0;
 
@@ -170,8 +180,13 @@ pub fn newline_delim<T: Send>(
         // Sometimes we've split the file on a utf8 character boundary, and the last line is incomplete not just as
         // a line that can be fed to the inner parser, but as a utf8 string in general. If that's the case, just set
         // the remainder to be empty, and we can handle it in the next chunk.
-        let remainder = std::str::from_utf8(&data[last_consumed_byte..]).unwrap_or("");
-        let remainder = inner(remainder);
+        let remainder_str = std::str::from_utf8(&data[last_consumed_byte..]).ok();
+        // A blank remainder (e.g. a chunk ending in "\n" or trailing blank lines at the
+        // end of a part) has nothing to parse. When blank lines are skippable, count it
+        // as consumed so the caller's offset can reach the end of the part - at the end
+        // of a stream-decompressed part there is no next chunk to re-read it from.
+        let remainder_is_blank = remainder_str.is_some_and(|r| r.trim().is_empty());
+        let remainder = remainder_str.map(&inner);
 
         let mut output = Vec::with_capacity(lines.len());
         let intermediate: Vec<_> = lines
@@ -198,10 +213,12 @@ pub fn newline_delim<T: Send>(
 
         // If we managed to parse the last line, add it too, but if we didn't, assume it's due to this chunk being partway through the file,
         // and carry on.
-        if let Ok(parsed) = remainder {
+        if let Some(Ok(parsed)) = remainder {
             output.push(parsed);
             // -1 because at this point the cursor is pointing at the end of the data,
             // and we want to point at the last byte we actually consumed
+            last_validly_consumed_byte = cursor - 1;
+        } else if skip_blank_lines && remainder_is_blank {
             last_validly_consumed_byte = cursor - 1;
         }
 
@@ -436,6 +453,57 @@ mod tests {
         assert_eq!(parsed.data.len(), 1);
         // 26 "data" characters, plus the newline
         assert_eq!(parsed.consumed, 27);
+    }
+
+    #[test]
+    fn test_newline_delim_empty_input_consumes_nothing() {
+        // An empty chunk (e.g. a streaming source read past EOF) must report zero
+        // bytes consumed. Reporting consumed > 0 for empty input makes the job's
+        // part offset overshoot the part's total size and the job crawls forever.
+        let parsed = json_nd::<TestData>(true)(Vec::new()).unwrap();
+        assert!(parsed.data.is_empty());
+        assert_eq!(
+            parsed.consumed, 0,
+            "empty input must consume 0 bytes, got {}",
+            parsed.consumed
+        );
+    }
+
+    #[test]
+    fn test_newline_delim_blank_trailing_remainder() {
+        // A part's final chunk can end in blank content ("\n", trailing blank
+        // lines). With skip_blank_lines the blanks must count as consumed so the
+        // offset can reach the end of the part - at the end of a stream-decompressed
+        // part there is no next chunk to re-read them from.
+        let line = br#"{"id": 1, "name": "test1"}"#;
+        for tail in [b"\n\n".as_slice(), b"\n\n\n", b"\n \n"] {
+            let mut data = line.to_vec();
+            data.extend_from_slice(tail);
+            let len = data.len();
+
+            let parsed = json_nd::<TestData>(true)(data).unwrap();
+            assert_eq!(parsed.data.len(), 1, "tail {tail:?}");
+            assert_eq!(
+                parsed.consumed, len,
+                "blank tail {tail:?} must be fully consumed"
+            );
+        }
+
+        // Without skip_blank_lines a blank line is still an error, preserving the
+        // "blank lines in input should fail the inner parser" contract.
+        let mut data = line.to_vec();
+        data.extend_from_slice(b"\n\n");
+        assert!(json_nd::<TestData>(false)(data).is_err());
+
+        // An invalid-utf8 tail is not "blank" - it must be left unconsumed for the
+        // next chunk, exactly as before.
+        let mut data = line.to_vec();
+        data.extend_from_slice(b"\n{\"id\": 2, \"name\": \"\xf0\x9f");
+        let len = data.len();
+        let parsed = json_nd::<TestData>(true)(data).unwrap();
+        assert_eq!(parsed.data.len(), 1);
+        assert_eq!(parsed.consumed, line.len() + 1);
+        assert!(parsed.consumed < len);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Since the streaming decompression change (#67149), batch import jobs on streaming sources (Mixpanel/Amplitude date-range exports, gzipped S3) get permanently stuck the moment a part's final bytes are consumed: the worker keeps "running" but advances the part offset by exactly 1 phantom byte per iteration, emitting 0 events, doing a full Postgres pause/commit/unpause round trip every ~15 ms, forever. The part's stored `current_offset` ends up hundreds of KB **past** its `total_size` and can never complete.

The failure chain:

1. Streaming sources only learn a part's decompressed size on the read that observes EOF, which is usually also the read that consumes the last bytes. The reader and its backing `.raw` file are freed on that same read.
2. The next loop iteration discovers the size **after** the is-done check already ran (`total_size` was still `None` at that point), so it proceeds to fetch and gets an empty chunk.
3. `newline_delim` returned `consumed = 1` for empty input (`last_validly_consumed_byte + 1` with everything at zero), and none of the existing guards caught it (`chunk_bytes` was 0, not `chunk_size`, and `is_last_chunk` used a strict `>` that an end-clamped read can never satisfy).
4. The offset advances to `total + 1`, and `PartState::is_done()` used strict `==`, so the part is un-finishable from then on.

The strict `>` in `is_last_chunk` also made the "bytes left unconsumed on the last chunk" guard unreachable for every source (reads are clamped to the end of the part, so the final chunk ends exactly at `total_size`), which could silently drop an unparseable tail instead of failing loudly.

## Changes

- `parse/format.rs` (`newline_delim`)
  - Empty input now reports `consumed = 0` instead of 1.
  - A blank trailing remainder (final `"\n"`, trailing blank lines) counts as consumed when `skip_blank_lines` is set. At the end of a streamed part there is no next chunk to re-read it from, so leaving it unconsumed would now trip the revived last-chunk guard on valid data.
  - An invalid-utf8 tail is still left unconsumed for the next chunk, as before.
- `job/mod.rs` (`select_and_fetch_next_chunk`)
  - Re-check part completion immediately after size discovery, so a part fully consumed on its EOF read is marked done instead of fetching an empty chunk. This subsumes the old `actual_size == 0` special case.
  - `is_last_chunk` now uses `>=`, making the unconsumed-bytes-on-last-chunk guard reachable again (unparseable tails fail loudly instead of being silently skipped).
  - New hard guards: an empty chunk before the known end of a part is an error (no iteration can make progress), and `parsed.consumed > chunk_bytes` is an error (always a parser bug).
- `job/model.rs` (`PartState::is_done`)
  - `>=` instead of `==`, so jobs whose stored offsets already overshot their totals (written by the buggy version) complete on resume with no manual DB intervention. The overshot parts' real bytes were all consumed and committed before the phantom crawl began, so skipping them loses no data.

## How did you test this code?

Automated tests only (all run locally via `cargo test -p batch-import-worker`, 279 unit + integration tests pass, plus `cargo fmt` and `clippy` clean). Each new test was written first and confirmed to fail against the previous code:

- `test_newline_delim_empty_input_consumes_nothing` - catches the `consumed = 1` off-by-one for empty input (failed before with `left: 1, right: 0`).
- `test_part_fully_consumed_at_eof_read_completes_without_offset_overshoot` - end-to-end repro over the real `DateRangeExportSource` + gzip extractor + newline parser; before the fix it failed with `part offset 3291 overshot total size 3290`, reproducing the production signature exactly.
- `test_part_with_trailing_blank_lines_completes` - guards the blank-remainder handling; without it the revived last-chunk guard would fail valid data ending in blank lines.
- `test_poisoned_part_with_overshot_offset_self_heals` - a job resuming with a production-shaped poisoned part (offset > total) skips it untouched and completes the remaining parts.
- `test_newline_delim_blank_trailing_remainder` - blank tails consumed under `skip_blank_lines`, still an error without it, invalid-utf8 tails still deferred.
- `test_part_is_done` - overshot offsets count as done.

Diagnosis was confirmed against prod-us before writing the fix: stuck jobs' Postgres state showed `current_offset > total_size` growing by 1 per iteration, and Loki showed the `consumed 1 bytes` commit loop starting in the deploy window of #67149. One affected job had completed 790 of 4368 parts on the pre-streaming binary and stuck on its first part processed after the deploy, matching this root cause.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Cursor (Claude). Diagnosis used Grafana Loki logs and the production Postgres job state (via internal Metabase) to identify the offset-overshoot signature, then reproduced it locally with failing tests before making any code change.
- Decisions: chose `>=` semantics for both `is_done` and `is_last_chunk` over clamping offsets in place, so already-poisoned production jobs self-heal on resume and unparseable tails fail loudly. Added the blank-trailing-remainder handling after tracing that the revived last-chunk guard would otherwise regress valid exports ending in blank lines. Kept `consumed = 1` for non-empty unparseable chunks unchanged since the oversized-record guard keys on it.
