### PR TITLE
feat(quill): custom ranges prop for DateTimePicker + quarter axis ticks

### DIFF
--- a/packages/quill/packages/charts/src/utils/dates.test.ts
+++ b/packages/quill/packages/charts/src/utils/dates.test.ts
@@ -30,6 +30,12 @@ describe('createXAxisTickCallback', () => {
             expected: ['2025', 'February', 'March'],
         },
         {
+            scenario: 'inferred quarter interval from ~90 day gaps',
+            interval: undefined,
+            allDays: ['2025-04-01', '2025-07-01', '2025-10-01'],
+            expected: ['Q2', 'Q3', 'Q4'],
+        },
+        {
             scenario: 'inferred day interval from 1 day gaps',
             interval: undefined,
             allDays: ['2025-04-01', '2025-04-02', '2025-04-03'],
@@ -76,6 +82,18 @@ describe('createXAxisTickCallback', () => {
             interval: 'month' as const,
             allDays: ['2025-11-01', '2025-12-01', '2026-01-01', '2026-02-01'],
             expected: ['November', 'December', '2026', 'February'],
+        },
+        {
+            scenario: 'quarterly, cross year → year at Q1 boundary, [Q]Q otherwise',
+            interval: 'quarter' as const,
+            allDays: ['2025-07-01', '2025-10-01', '2026-01-01', '2026-04-01'],
+            expected: ['Q3', 'Q4', '2026', 'Q2'],
+        },
+        {
+            scenario: 'yearly → plain years',
+            interval: 'year' as const,
+            allDays: ['2024-01-01', '2025-01-01', '2026-01-01'],
+            expected: ['2024', '2025', '2026'],
         },
         {
             scenario: 'daily, short span → full month name on 1st, MMM D otherwise',

--- a/packages/quill/packages/charts/src/utils/dates.ts
+++ b/packages/quill/packages/charts/src/utils/dates.ts
@@ -12,6 +12,8 @@ interface CreateXAxisTickCallbackArgs {
 
 type TickMode =
     | { type: 'month' }
+    | { type: 'quarter' }
+    | { type: 'year' }
     | { type: 'day' }
     | { type: 'monthly'; visibleBoundaries: Set<number> }
     | { type: 'hourly' }
@@ -57,7 +59,13 @@ function pickMode(interval: TimeInterval, parsedDates: Dayjs[], first: Dayjs, la
     const spanMonths = (last.year() - first.year()) * 12 + last.month() - first.month()
     const spanDays = last.diff(first, 'day')
 
-    if (interval === 'month' || interval === 'quarter' || interval === 'year') {
+    if (interval === 'quarter') {
+        return { type: 'quarter' }
+    }
+    if (interval === 'year') {
+        return { type: 'year' }
+    }
+    if (interval === 'month') {
         return { type: 'month' }
     }
     if ((interval === 'day' || interval === 'week') && spanMonths >= 3) {
@@ -94,6 +102,10 @@ function formatTick(mode: TickMode, date: Dayjs, index: number): string {
         case 'month':
         case 'monthly':
             return formatMonthLabel(date)
+        case 'quarter':
+            return formatQuarterLabel(date)
+        case 'year':
+            return String(date.year())
         case 'day':
             return date.date() === 1 ? formatMonthLabel(date) : date.format('MMM D')
         case 'hourly-multi-day':
@@ -110,6 +122,14 @@ function formatMonthLabel(date: Dayjs): string {
     return date.format('MMMM')
 }
 
+// Mirrors formatMonthLabel's convention: the year marks the year boundary, "Q2".."Q4" otherwise.
+function formatQuarterLabel(date: Dayjs): string {
+    if (date.month() === 0) {
+        return String(date.year())
+    }
+    return `Q${Math.floor(date.month() / 3) + 1}`
+}
+
 function inferInterval(parsedDates: Dayjs[]): TimeInterval {
     if (parsedDates.length < 2) {
         return 'day'
@@ -122,6 +142,12 @@ function inferInterval(parsedDates: Dayjs[]): TimeInterval {
         return 'hour'
     }
     const diffDays = parsedDates[1].diff(parsedDates[0], 'day')
+    if (diffDays >= 300) {
+        return 'year'
+    }
+    if (diffDays >= 80) {
+        return 'quarter'
+    }
     if (diffDays >= 25) {
         return 'month'
     }

--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -65,6 +65,7 @@ Rules:
 - Dual-calendar layout appears at the `lg` breakpoint unless `compact` forces a single calendar.
 - `minDate`/`maxDate` are day-granular; time inputs are independent of those bounds.
 - `weekStartsOn` affects the calendar grid only, not quick-range math.
+- Embedding in a host surface (e.g. inside a popover with the host's own sections): `showHeader={false}` drops the caps header band, `showTime={false}` switches to day-granular mode (no time segments, no "Now", date-only footer readout) — pair with a `className` that strips the card chrome (`shadow-none ring-0`).
 
 ## DatePicker
 

--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -59,7 +59,8 @@ import { CUSTOM_RANGE, DateTimePicker, quickRanges } from '@posthog/quill-compon
 
 Rules:
 
-- `value.range` is one of `quickRanges` (15 presets, "Last 5 minutes" → "Last 1 year") or `CUSTOM_RANGE` for manual selection.
+- `value.range` is one of the offered presets or `CUSTOM_RANGE` for manual selection. Presets default to `quickRanges` (15 presets, "Last 5 minutes" → "Last 1 year"); pass `ranges` to offer your own `DateTimeRange[]` (any `CUSTOM_RANGE` entry is filtered out of the list).
+- A `DateTimeRange` computes its start from "now" via `rangeSetter`; the end defaults to "now" unless `endSetter` is given (needed for closed periods like "Last month"). `name` is any string.
 - Changes are staged until `onApply` fires — don't treat intermediate calendar clicks as committed.
 - Dual-calendar layout appears at the `lg` breakpoint unless `compact` forces a single calendar.
 - `minDate`/`maxDate` are day-granular; time inputs are independent of those bounds.

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -1,11 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { format, subDays } from 'date-fns'
+import {
+    endOfMonth,
+    endOfQuarter,
+    format,
+    startOfMonth,
+    startOfQuarter,
+    startOfYear,
+    subDays,
+    subMonths,
+    subQuarters,
+} from 'date-fns'
 import { Clock } from 'lucide-react'
 import * as React from 'react'
 
 import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill-primitives'
 
-import { CUSTOM_RANGE } from './date-time-ranges'
+import { CUSTOM_RANGE, type DateTimeRange } from './date-time-ranges'
 import { DateTimePicker, type DateTimeValue } from './date-time-picker'
 import { quickRanges } from './date-time-ranges'
 import { Day } from './use-calendar'
@@ -147,6 +157,26 @@ export const WithSettingsLink: Story = {
                 onDateTimeSettings={() => alert('Open date & time settings')}
             />
         )
+    },
+}
+
+const calendarRanges: DateTimeRange[] = [
+    { id: 1, name: 'This month', rangeSetter: (d) => startOfMonth(d) },
+    { id: 2, name: 'Last month', rangeSetter: (d) => startOfMonth(subMonths(d, 1)), endSetter: (d) => endOfMonth(subMonths(d, 1)) },
+    { id: 3, name: 'This quarter', rangeSetter: (d) => startOfQuarter(d) },
+    { id: 4, name: 'Last quarter', rangeSetter: (d) => startOfQuarter(subQuarters(d, 1)), endSetter: (d) => endOfQuarter(subQuarters(d, 1)) },
+    { id: 5, name: 'Year to date', rangeSetter: (d) => startOfYear(d) },
+]
+
+export const CustomRanges: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: startOfMonth(new Date()),
+            end: new Date(),
+            range: calendarRanges[0],
+        })
+        return <DateTimePicker value={value} onApply={setValue} ranges={calendarRanges} />
     },
 }
 

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -180,6 +180,27 @@ export const CustomRanges: Story = {
     },
 }
 
+export const EmbeddedDayGranular: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: startOfMonth(new Date()),
+            end: new Date(),
+            range: calendarRanges[0],
+        })
+        return (
+            <DateTimePicker
+                value={value}
+                onApply={setValue}
+                ranges={calendarRanges}
+                showHeader={false}
+                showTime={false}
+                className="shadow-none ring-1"
+            />
+        )
+    },
+}
+
 export const WeekStartsThursday: Story = {
     args: baseArgs,
     render: () => {

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { CUSTOM_RANGE } from './date-time-ranges'
+import { CUSTOM_RANGE, type DateTimeRange } from './date-time-ranges'
 import { DateTimePicker } from './date-time-picker'
 
 // The day grid wraps each Button in a div carrying the data-is-* range flags.
@@ -43,5 +43,37 @@ describe('DateTimePicker', () => {
         const applied = onApply.mock.calls[0][0]
         expect([applied.start.getDate(), applied.end.getDate()]).toEqual([10, 20])
         expect(applied.range).toBe(CUSTOM_RANGE)
+    })
+
+    it('renders the provided ranges instead of the default quick ranges', () => {
+        const ranges: DateTimeRange[] = [
+            { id: 1, name: 'This month', rangeSetter: (d) => d },
+            { id: 2, name: 'Year to date', rangeSetter: (d) => d },
+        ]
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={jest.fn()} ranges={ranges} />)
+
+        expect(screen.getByTitle('This month')).toBeTruthy()
+        expect(screen.getByTitle('Year to date')).toBeTruthy()
+        expect(screen.queryByTitle('Last 7 days')).toBeNull()
+    })
+
+    it('applies both edges from a preset with an endSetter', async () => {
+        const onApply = jest.fn()
+        const lastMonth: DateTimeRange = {
+            id: 1,
+            name: 'Last month',
+            rangeSetter: () => new Date(2022, 11, 1),
+            endSetter: () => new Date(2022, 11, 31, 23, 59, 59),
+        }
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={onApply} ranges={[lastMonth]} />)
+
+        await userEvent.click(screen.getByTitle('Last month'))
+        await userEvent.click(screen.getByLabelText('Apply date range'))
+
+        expect(onApply).toHaveBeenCalledTimes(1)
+        const applied = onApply.mock.calls[0][0]
+        expect(applied.start).toEqual(new Date(2022, 11, 1))
+        expect(applied.end).toEqual(new Date(2022, 11, 31, 23, 59, 59))
+        expect(applied.range).toBe(lastMonth)
     })
 })

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -49,6 +49,8 @@ export interface DateTimePickerProps {
     weekStartsOn?: Day
     onDateTimeSettings?: () => void
     compact?: boolean
+    /** Quick-range presets to offer. Defaults to `quickRanges`; `CUSTOM_RANGE` entries are filtered out. */
+    ranges?: DateTimeRange[]
     className?: string
 }
 
@@ -63,8 +65,10 @@ export function DateTimePicker({
     weekStartsOn,
     onDateTimeSettings,
     compact = false,
+    ranges = quickRanges,
     className,
 }: DateTimePickerProps): React.ReactElement {
+    const presetRanges = ranges.filter((r) => r.id !== CUSTOM_RANGE.id)
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
     // The second calendar only renders at `lg`; below it (and in compact) there's
@@ -166,12 +170,13 @@ export function DateTimePicker({
     const handleQuickRange = (next: DateTimeRange): void => {
         const now = new Date()
         const nextStart = next.rangeSetter(now)
+        const nextEnd = next.endSetter?.(now) ?? now
         setStart(nextStart)
-        setEnd(now)
+        setEnd(nextEnd)
         setRange(next)
         setLastSet(null)
-        setRightViewing(now)
-        setLeftViewing(subMonths(now, 1))
+        setRightViewing(nextEnd)
+        setLeftViewing(subMonths(nextEnd, 1))
     }
 
     const dateTimeFormat = DATE_TIME_FORMATS[dateFormat]
@@ -289,7 +294,7 @@ export function DateTimePicker({
                             ? 'flex flex-row p-2 gap-px max-h-[320px]'
                             : 'flex flex-row lg:flex-col p-2 gap-px max-h-[320px]'
                         }>
-                            {quickRanges.slice(1).map((quick) => (
+                            {presetRanges.map((quick) => (
                                 <li key={quick.id} className={compact ? undefined : 'lg:w-full'}>
                                     <Button
                                         variant="default"
@@ -319,7 +324,7 @@ export function DateTimePicker({
             {/* Actions */}
             <div className="flex justify-end px-3 py-2 items-center gap-2 bg-muted/30">
                 <span className="text-[10px] text-muted-foreground flex items-center gap-1 tabular-nums mr-auto">
-                    {range.name === 'Custom' ? <>{presentationalStart} <ArrowRight className="size-3" /> {presentationalEnd}</> : range.name}
+                    {range.id === CUSTOM_RANGE.id ? <>{presentationalStart} <ArrowRight className="size-3" /> {presentationalEnd}</> : range.name}
                 </span>
                 {onCancel ? (
                     <Button variant="outline" size="sm" onClick={onCancel} aria-label="Cancel" data-attr="date-time-picker-cancel">

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -17,6 +17,12 @@ const DATE_TIME_FORMATS: Record<DateFormatOrder, string> = {
     YMD: 'yy-MM-dd HH:mm:ss',
 }
 
+const DATE_FORMATS: Record<DateFormatOrder, string> = {
+    MDY: 'MM/dd/yy',
+    DMY: 'dd/MM/yy',
+    YMD: 'yy-MM-dd',
+}
+
 // Tailwind `lg` breakpoint — matches the `lg:` classes that switch this picker
 // between a single calendar and the side-by-side dual-calendar layout.
 const LG_QUERY = '(min-width: 64rem)'
@@ -51,6 +57,10 @@ export interface DateTimePickerProps {
     compact?: boolean
     /** Quick-range presets to offer. Defaults to `quickRanges`; `CUSTOM_RANGE` entries are filtered out. */
     ranges?: DateTimeRange[]
+    /** Hide the "Choose date range / Quick ranges" header band when embedding in a host surface. */
+    showHeader?: boolean
+    /** Day-granular mode: hides the time segments and "Now", and drops time from the footer readout. */
+    showTime?: boolean
     className?: string
 }
 
@@ -66,6 +76,8 @@ export function DateTimePicker({
     onDateTimeSettings,
     compact = false,
     ranges = quickRanges,
+    showHeader = true,
+    showTime = true,
     className,
 }: DateTimePickerProps): React.ReactElement {
     const presetRanges = ranges.filter((r) => r.id !== CUSTOM_RANGE.id)
@@ -179,7 +191,7 @@ export function DateTimePicker({
         setLeftViewing(subMonths(nextEnd, 1))
     }
 
-    const dateTimeFormat = DATE_TIME_FORMATS[dateFormat]
+    const dateTimeFormat = showTime ? DATE_TIME_FORMATS[dateFormat] : DATE_FORMATS[dateFormat]
     const presentationalStart = format(start, dateTimeFormat)
     const presentationalEnd = format(end, dateTimeFormat)
 
@@ -192,7 +204,7 @@ export function DateTimePicker({
             )}
         >
             {/* Headers */}
-            {!compact && (
+            {!compact && showHeader && (
                 <div className="hidden lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]">
                     <div className="flex items-center gap-2 px-2 py-1 bg-muted/30 border-b border-border rounded-tl-lg">
                         <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Choose date range</span>
@@ -232,18 +244,20 @@ export function DateTimePicker({
                                         <SettingsIcon />
                                     </Button>
                                 )}
-                                <SegmentedDateInput date={start} maxDate={maxDate} onChange={handleStartChange} dateFormat={dateFormat} showTime />
+                                <SegmentedDateInput date={start} maxDate={maxDate} onChange={handleStartChange} dateFormat={dateFormat} showTime={showTime} />
                                 <span className="text-xs text-muted-foreground">to</span>
-                                <SegmentedDateInput date={end} maxDate={maxDate} onChange={handleEndChange} dateFormat={dateFormat} showTime />
-                                <Button
-                                    variant="link"
-                                    size="xs"
-                                    onClick={handleNow}
-                                    aria-label="Set end to now"
-                                    title="Set end to now"
-                                >
-                                    Now
-                                </Button>
+                                <SegmentedDateInput date={end} maxDate={maxDate} onChange={handleEndChange} dateFormat={dateFormat} showTime={showTime} />
+                                {showTime && (
+                                    <Button
+                                        variant="link"
+                                        size="xs"
+                                        onClick={handleNow}
+                                        aria-label="Set end to now"
+                                        title="Set end to now"
+                                    >
+                                        Now
+                                    </Button>
+                                )}
                             </div>
                         </div>
                     )}

--- a/packages/quill/packages/components/src/date-time-ranges.ts
+++ b/packages/quill/packages/components/src/date-time-ranges.ts
@@ -1,27 +1,14 @@
 import { subDays, subHours, subMinutes, subMonths, subYears } from 'date-fns'
 
-export type DateTimeRangeName =
-    | 'Custom'
-    | 'Last 5 minutes'
-    | 'Last 15 minutes'
-    | 'Last 30 minutes'
-    | 'Last 1 hour'
-    | 'Last 3 hours'
-    | 'Last 6 hours'
-    | 'Last 12 hours'
-    | 'Last 24 hours'
-    | 'Last 2 days'
-    | 'Last 7 days'
-    | 'Last 30 days'
-    | 'Last 90 days'
-    | 'Last 6 months'
-    | 'Last 1 year'
-    | 'Last 2 years'
+export type DateTimeRangeName = string
 
 export interface DateTimeRange {
     id: number
     name: DateTimeRangeName
+    /** Returns the range's start for a given "now". */
     rangeSetter: (date: Date) => Date
+    /** Returns the range's end for a given "now". Defaults to "now" itself. */
+    endSetter?: (date: Date) => Date
 }
 
 export const CUSTOM_RANGE: DateTimeRange = {


### PR DESCRIPTION
## Problem

The insight date filter redesign (stacking on the date-querying chain #68287 → #68303; the standalone day-of-week UI PR #68304 was closed and consolidated into #68359) needs the quill `DateTimePicker` to offer insight-specific presets like This month, Last quarter, and Year to date. Today the preset list is hard-coded (`quickRanges` in `date-time-ranges.ts`), preset names are a closed union type, and a preset's end is always "now", which can't express closed periods like Last month.

Separately, quarter/year interval charts render month names at quarter starts on the x-axis (April, July, October), inconsistent with their `[Q]Q YYYY` tooltip formats. This blocks unhiding the `product-analytics-quarter-year-intervals` flag.

## Changes

`@posthog/quill-components` DateTimePicker:

- New `ranges?: DateTimeRange[]` prop to supply custom quick-range presets (defaults to `quickRanges`; `CUSTOM_RANGE` entries are filtered out of the list)
- New optional `endSetter?: (now: Date) => Date` on `DateTimeRange` so a preset can set a closed end (Last month, Last quarter); the end still defaults to now
- `DateTimeRangeName` loosened to `string` so custom presets can use any label
- Footer summary now identifies the custom range by `CUSTOM_RANGE.id` instead of the name string
- New `CustomRanges` story with calendar-period presets; AGENTS.md updated

`@posthog/quill-charts` x-axis ticks:

- Quarter interval gets its own tick mode: `Q2`..`Q4` with the year at the Q1 boundary (mirrors the month mode's year-at-January convention and matches the `[Q]Q YYYY` tooltips)
- Year interval renders the plain year
- `inferInterval` now recognizes quarterly (~90 day) and yearly (~365 day) gaps when no interval is passed

## How did you test this code?

- Extended `date-time-picker.test.tsx` with 2 tests: custom `ranges` rendering instead of the defaults (catches the prop being ignored and defaults leaking through) and a preset with `endSetter` staging and applying both edges (catches the end silently reverting to "now"). No existing test covered either path.
- Added 3 parameterized rows to `dates.test.ts`: inferred quarter interval, explicit quarter crossing a year boundary, and yearly ticks (catch quarter starts regressing to month names). All 319 cases pass.
- Built both packages (`turbo build`) and ran oxlint (only pre-existing warnings in untouched files).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal component library only, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) as PR 7 of the date-querying stack, directed by Sam; plan in the session's handoff notes.
- Skills invoked: /writing-tests.
- Decisions: added `endSetter` beyond the originally scoped `ranges` prop because closed calendar periods (Last month) can't be expressed with a start-only setter and end pinned to now; computed the quarter number arithmetically instead of adding the dayjs `advancedFormat`/`quarterOfYear` plugins to the charts package's self-contained dayjs setup; kept year-at-boundary labeling over `[Q]Q YYYY` on every tick to match the existing month-mode axis convention.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
