### PR TITLE
feat(insights): presets-first quill date filter behind a flag

### DIFF
--- a/frontend/src/lib/components/DateRangeFilter/DateExclusionsControl.tsx
+++ b/frontend/src/lib/components/DateRangeFilter/DateExclusionsControl.tsx
@@ -1,6 +1,16 @@
-import { useEffect, useId, useRef, useState } from 'react'
+import { useId } from 'react'
 
-import { Button, Label, Separator, Switch, ToggleGroup, ToggleGroupItem } from '@posthog/quill'
+import {
+    Button,
+    Label,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Separator,
+    Switch,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@posthog/quill'
 
 const DAY_LABELS_SINGLE: Record<number, string> = { 1: 'M', 2: 'T', 3: 'W', 4: 'T', 5: 'F', 6: 'S', 7: 'S' }
 const DAY_LABELS: Record<number, string> = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri', 6: 'Sat', 7: 'Sun' }
@@ -28,29 +38,15 @@ function excludedDaysSummary(days: number[]): string {
 }
 
 /** "+ Exclude" link opening a panel with an incomplete-period toggle and exclude-day chips.
- *  Made for the date filter's `footerExtra` slot; the panel opens upward from the actions bar. */
+ *  Made for the date filter's `footerExtra` slot. A nested Popover portals the panel out,
+ *  so the host popover's overflow can't clip it. */
 export function DateExclusionsControl({
     excludedDays,
     onExcludedDaysChange,
     excludeIncomplete,
     onExcludeIncompleteChange,
 }: DateExclusionsControlProps): JSX.Element {
-    const [open, setOpen] = useState(false)
-    const rootRef = useRef<HTMLDivElement>(null)
     const incompleteId = useId()
-
-    useEffect(() => {
-        if (!open) {
-            return
-        }
-        const onPointerDown = (event: PointerEvent): void => {
-            if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
-                setOpen(false)
-            }
-        }
-        document.addEventListener('pointerdown', onPointerDown)
-        return () => document.removeEventListener('pointerdown', onPointerDown)
-    }, [open])
 
     const showDays = excludedDays !== undefined && onExcludedDaysChange !== undefined
     const showIncomplete = excludeIncomplete !== undefined && onExcludeIncompleteChange !== undefined
@@ -64,68 +60,60 @@ export function DateExclusionsControl({
     }
 
     return (
-        <div className="relative" ref={rootRef}>
-            <Button
-                variant="link"
-                size="xs"
-                aria-expanded={open}
-                onClick={() => setOpen((prev) => !prev)}
-                data-attr="date-exclusions-control"
-            >
+        <Popover>
+            <PopoverTrigger render={<Button variant="link" size="xs" />} data-attr="date-exclusions-control">
                 {parts.length > 0 ? `Excluding ${parts.join(', ')}` : '+ Exclude'}
-            </Button>
-            {open && (
-                <div className="bg-card absolute bottom-full left-0 z-10 mb-1 flex w-64 flex-col rounded-md border shadow-md">
-                    {showIncomplete && (
-                        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-                            <Label htmlFor={incompleteId}>Incomplete period</Label>
-                            <Switch
-                                id={incompleteId}
-                                size="sm"
-                                checked={excludeIncomplete}
-                                onCheckedChange={onExcludeIncompleteChange}
-                                data-attr="date-exclusions-incomplete"
-                            />
+            </PopoverTrigger>
+            <PopoverContent side="top" align="start" className="w-64 gap-0 p-0" data-lemon-skin="true">
+                {showIncomplete && (
+                    <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+                        <Label htmlFor={incompleteId}>Incomplete period</Label>
+                        <Switch
+                            id={incompleteId}
+                            size="sm"
+                            checked={excludeIncomplete}
+                            onCheckedChange={onExcludeIncompleteChange}
+                            data-attr="date-exclusions-incomplete"
+                        />
+                    </div>
+                )}
+                {showIncomplete && showDays && <Separator />}
+                {showDays && (
+                    <div className="flex flex-col gap-2 px-3 py-2.5">
+                        <ToggleGroup
+                            multiple
+                            size="sm"
+                            className="w-full"
+                            value={excludedDays.map(String)}
+                            onValueChange={(days) => onExcludedDaysChange(days.map(Number))}
+                        >
+                            {Object.keys(DAY_LABELS_SINGLE).map((day) => (
+                                <ToggleGroupItem
+                                    key={day}
+                                    value={day}
+                                    className="flex-1"
+                                    aria-label={`Exclude ${DAY_LABELS[Number(day)]}`}
+                                    title={`Exclude ${DAY_LABELS[Number(day)]}`}
+                                    data-attr={`date-exclusions-day-${day}`}
+                                >
+                                    {DAY_LABELS_SINGLE[Number(day)]}
+                                </ToggleGroupItem>
+                            ))}
+                        </ToggleGroup>
+                        <div className="flex items-center justify-center gap-3">
+                            <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKENDS)}>
+                                Weekends
+                            </Button>
+                            <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKDAYS)}>
+                                Weekdays
+                            </Button>
+                            <Button variant="link" size="xs" onClick={() => onExcludedDaysChange([])}>
+                                Clear
+                            </Button>
                         </div>
-                    )}
-                    {showIncomplete && showDays && <Separator />}
-                    {showDays && (
-                        <div className="flex flex-col gap-2 px-3 py-2.5">
-                            <ToggleGroup
-                                multiple
-                                size="sm"
-                                className="w-full"
-                                value={excludedDays.map(String)}
-                                onValueChange={(days) => onExcludedDaysChange(days.map(Number))}
-                            >
-                                {Object.keys(DAY_LABELS_SINGLE).map((day) => (
-                                    <ToggleGroupItem
-                                        key={day}
-                                        value={day}
-                                        className="flex-1"
-                                        aria-label={`Exclude ${DAY_LABELS[Number(day)]}`}
-                                        title={`Exclude ${DAY_LABELS[Number(day)]}`}
-                                        data-attr={`date-exclusions-day-${day}`}
-                                    >
-                                        {DAY_LABELS_SINGLE[Number(day)]}
-                                    </ToggleGroupItem>
-                                ))}
-                            </ToggleGroup>
-                            <div className="flex items-center justify-center gap-3">
-                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKENDS)}>
-                                    Weekends
-                                </Button>
-                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKDAYS)}>
-                                    Weekdays
-                                </Button>
-                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange([])}>
-                                    Clear
-                                </Button>
-                            </div>
-                        </div>
-                    )}
-                </div>
-            )}
-        </div>
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
     )
 }

--- a/frontend/src/lib/components/DateRangeFilter/DateExclusionsControl.tsx
+++ b/frontend/src/lib/components/DateRangeFilter/DateExclusionsControl.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useId, useRef, useState } from 'react'
+
+import { Button, Label, Separator, Switch, ToggleGroup, ToggleGroupItem } from '@posthog/quill'
+
+const DAY_LABELS_SINGLE: Record<number, string> = { 1: 'M', 2: 'T', 3: 'W', 4: 'T', 5: 'F', 6: 'S', 7: 'S' }
+const DAY_LABELS: Record<number, string> = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri', 6: 'Sat', 7: 'Sun' }
+const WEEKDAYS = [1, 2, 3, 4, 5]
+const WEEKENDS = [6, 7]
+
+export interface DateExclusionsControlProps {
+    /** ISO days (1=Mon…7=Sun) excluded from the range; omit to hide the days section. */
+    excludedDays?: number[]
+    onExcludedDaysChange?: (days: number[]) => void
+    /** Omit to hide the incomplete-period row. */
+    excludeIncomplete?: boolean
+    onExcludeIncompleteChange?: (checked: boolean) => void
+}
+
+function excludedDaysSummary(days: number[]): string {
+    const sorted = [...days].sort((a, b) => a - b)
+    if (sorted.length === WEEKENDS.length && WEEKENDS.every((day) => sorted.includes(day))) {
+        return 'weekends'
+    }
+    if (sorted.length === WEEKDAYS.length && WEEKDAYS.every((day) => sorted.includes(day))) {
+        return 'weekdays'
+    }
+    return sorted.length <= 2 ? sorted.map((day) => DAY_LABELS[day]).join(', ') : `${sorted.length} days`
+}
+
+/** "+ Exclude" link opening a panel with an incomplete-period toggle and exclude-day chips.
+ *  Made for the date filter's `footerExtra` slot; the panel opens upward from the actions bar. */
+export function DateExclusionsControl({
+    excludedDays,
+    onExcludedDaysChange,
+    excludeIncomplete,
+    onExcludeIncompleteChange,
+}: DateExclusionsControlProps): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const rootRef = useRef<HTMLDivElement>(null)
+    const incompleteId = useId()
+
+    useEffect(() => {
+        if (!open) {
+            return
+        }
+        const onPointerDown = (event: PointerEvent): void => {
+            if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [open])
+
+    const showDays = excludedDays !== undefined && onExcludedDaysChange !== undefined
+    const showIncomplete = excludeIncomplete !== undefined && onExcludeIncompleteChange !== undefined
+
+    const parts: string[] = []
+    if (showDays && excludedDays.length > 0) {
+        parts.push(excludedDaysSummary(excludedDays))
+    }
+    if (showIncomplete && excludeIncomplete) {
+        parts.push('incomplete')
+    }
+
+    return (
+        <div className="relative" ref={rootRef}>
+            <Button
+                variant="link"
+                size="xs"
+                aria-expanded={open}
+                onClick={() => setOpen((prev) => !prev)}
+                data-attr="date-exclusions-control"
+            >
+                {parts.length > 0 ? `Excluding ${parts.join(', ')}` : '+ Exclude'}
+            </Button>
+            {open && (
+                <div className="bg-card absolute bottom-full left-0 z-10 mb-1 flex w-64 flex-col rounded-md border shadow-md">
+                    {showIncomplete && (
+                        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+                            <Label htmlFor={incompleteId}>Incomplete period</Label>
+                            <Switch
+                                id={incompleteId}
+                                size="sm"
+                                checked={excludeIncomplete}
+                                onCheckedChange={onExcludeIncompleteChange}
+                                data-attr="date-exclusions-incomplete"
+                            />
+                        </div>
+                    )}
+                    {showIncomplete && showDays && <Separator />}
+                    {showDays && (
+                        <div className="flex flex-col gap-2 px-3 py-2.5">
+                            <ToggleGroup
+                                multiple
+                                size="sm"
+                                className="w-full"
+                                value={excludedDays.map(String)}
+                                onValueChange={(days) => onExcludedDaysChange(days.map(Number))}
+                            >
+                                {Object.keys(DAY_LABELS_SINGLE).map((day) => (
+                                    <ToggleGroupItem
+                                        key={day}
+                                        value={day}
+                                        className="flex-1"
+                                        aria-label={`Exclude ${DAY_LABELS[Number(day)]}`}
+                                        title={`Exclude ${DAY_LABELS[Number(day)]}`}
+                                        data-attr={`date-exclusions-day-${day}`}
+                                    >
+                                        {DAY_LABELS_SINGLE[Number(day)]}
+                                    </ToggleGroupItem>
+                                ))}
+                            </ToggleGroup>
+                            <div className="flex items-center justify-center gap-3">
+                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKENDS)}>
+                                    Weekends
+                                </Button>
+                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange(WEEKDAYS)}>
+                                    Weekdays
+                                </Button>
+                                <Button variant="link" size="xs" onClick={() => onExcludedDaysChange([])}>
+                                    Clear
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { DateRangeFilter, type DateRangePreset } from './DateRangeFilter'
+
+const PRESETS: DateRangePreset<string>[] = [
+    { id: '-7d', label: 'Last 7 days', value: '-7d', previewStart: (now) => new Date(now.getFullYear(), 0, 1) },
+    { id: '-30d', label: 'Last 30 days', value: '-30d' },
+]
+
+describe('DateRangeFilter', () => {
+    afterEach(cleanup)
+
+    it('routes preset clicks through onPresetSelect, and an unedited calendar Apply keeps preset semantics', async () => {
+        const onPresetSelect = jest.fn()
+        const onCustomApply = jest.fn()
+        render(
+            <DateRangeFilter
+                presets={PRESETS}
+                selectedPresetId="-7d"
+                onPresetSelect={onPresetSelect}
+                onCustomApply={onCustomApply}
+                trigger={<button>Dates</button>}
+            />
+        )
+
+        await userEvent.click(screen.getByText('Dates'))
+        await userEvent.click(screen.getByTitle('Last 30 days'))
+        expect(onPresetSelect).toHaveBeenCalledTimes(1)
+        expect(onPresetSelect.mock.calls[0][0]).toMatchObject({ id: '-30d', value: '-30d' })
+
+        // Opening the calendar and applying without edits must NOT pin concrete dates —
+        // the staged preset survives and the rolling range is preserved.
+        await userEvent.click(screen.getByText('Dates'))
+        await userEvent.click(screen.getByText('Custom range…'))
+        await userEvent.click(screen.getByLabelText('Apply date range'))
+        expect(onCustomApply).not.toHaveBeenCalled()
+        expect(onPresetSelect).toHaveBeenCalledTimes(2)
+        expect(onPresetSelect.mock.calls[1][0]).toMatchObject({ id: '-7d', value: '-7d' })
+    })
+
+    it('opens straight to the calendar when a custom range is active, and Apply commits concrete dates', async () => {
+        const onPresetSelect = jest.fn()
+        const onCustomApply = jest.fn()
+        render(
+            <DateRangeFilter
+                presets={PRESETS}
+                customActive
+                customStart={new Date(2023, 0, 10)}
+                customEnd={new Date(2023, 0, 20)}
+                onPresetSelect={onPresetSelect}
+                onCustomApply={onCustomApply}
+                trigger={<button>Dates</button>}
+            />
+        )
+
+        await userEvent.click(screen.getByText('Dates'))
+        await userEvent.click(screen.getByLabelText('Apply date range'))
+
+        expect(onCustomApply).toHaveBeenCalledTimes(1)
+        expect(onCustomApply.mock.calls[0][0]).toEqual(new Date(2023, 0, 10))
+        expect(onCustomApply.mock.calls[0][1]).toEqual(new Date(2023, 0, 20))
+        expect(onPresetSelect).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.tsx
@@ -1,0 +1,132 @@
+import { useMemo, useState } from 'react'
+
+import {
+    CUSTOM_RANGE,
+    DateTimePicker,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    type DateTimeRange,
+    type DateTimeValue,
+    type Day,
+} from '@posthog/quill'
+
+import { dayjs } from 'lib/dayjs'
+
+export interface DateRangePreset<T = unknown> {
+    id: string
+    label: string
+    /** Opaque payload couriered back through `onPresetSelect`; never interpreted here. */
+    value?: T
+    /** Preview span shown in the custom calendar while this preset is active. */
+    previewStart?: (now: Date) => Date
+    previewEnd?: (now: Date) => Date
+}
+
+export interface DateRangeFilterProps<T = unknown> {
+    presets: DateRangePreset<T>[]
+    selectedPresetId?: string | null
+    /** Presets apply immediately on click and close the popover. */
+    onPresetSelect: (preset: DateRangePreset<T>) => void
+    /** Custom calendar applies commit concrete browser-local dates. */
+    onCustomApply: (start: Date, end: Date) => void
+    /** Marks the current value as a custom range: the popover opens straight to the calendar. */
+    customActive?: boolean
+    customStart?: Date
+    customEnd?: Date
+    trigger: React.ReactElement
+    /** Host content in the picker's actions bar (e.g. an exclusions control); stays reachable in the collapsed list view. */
+    footerExtra?: React.ReactNode
+    weekStartsOn?: Day
+    /** Extra props for the popover surface (portaled to <body>) — e.g. skin opt-in data attributes. */
+    contentProps?: React.ComponentProps<typeof PopoverContent>
+}
+
+/** Presets-first date range filter: a trigger opening quill's `DateTimePicker` in `presetsFirst`
+ *  mode. Owns only the popover shell and the preset payload routing — what a preset *means* stays
+ *  with the host, which gets its `value` back verbatim on selection. */
+export function DateRangeFilter<T = unknown>({
+    presets,
+    selectedPresetId,
+    onPresetSelect,
+    onCustomApply,
+    customActive = false,
+    customStart,
+    customEnd,
+    trigger,
+    footerExtra,
+    weekStartsOn,
+    contentProps,
+}: DateRangeFilterProps<T>): JSX.Element {
+    const [open, setOpen] = useState(false)
+    // Base UI keeps the popup mounted across closes; remount the picker per open so its staged
+    // state and collapsed/expanded view re-derive from the current value instead of going stale.
+    const [openKey, setOpenKey] = useState(0)
+    const handleOpenChange = (nextOpen: boolean): void => {
+        if (nextOpen) {
+            setOpenKey((prev) => prev + 1)
+        }
+        setOpen(nextOpen)
+    }
+
+    // Picker-rail mirror of `presets`: numeric ids are 1-based indexes (0 is CUSTOM_RANGE)
+    const ranges = useMemo(
+        (): DateTimeRange[] =>
+            presets.map((preset, index) => ({
+                id: index + 1,
+                name: preset.label,
+                rangeSetter: (now: Date) => preset.previewStart?.(now) ?? dayjs(now).subtract(7, 'day').toDate(),
+                endSetter: preset.previewEnd,
+            })),
+        [presets]
+    )
+
+    const pickerValue = useMemo((): DateTimeValue => {
+        const now = new Date()
+        if (customActive && customStart && customEnd) {
+            return { start: customStart, end: customEnd, range: CUSTOM_RANGE }
+        }
+        const selectedIndex = presets.findIndex((preset) => preset.id === selectedPresetId)
+        const selected = selectedIndex >= 0 ? presets[selectedIndex] : undefined
+        return {
+            start: selected?.previewStart?.(now) ?? dayjs(now).subtract(7, 'day').toDate(),
+            end: selected?.previewEnd?.(now) ?? now,
+            range: selectedIndex >= 0 ? ranges[selectedIndex] : CUSTOM_RANGE,
+        }
+    }, [customActive, customStart, customEnd, presets, selectedPresetId, ranges])
+
+    const handleApply = (applied: DateTimeValue): void => {
+        const preset = applied.range.id !== CUSTOM_RANGE.id ? presets[applied.range.id - 1] : undefined
+        if (preset) {
+            onPresetSelect(preset)
+        } else {
+            onCustomApply(applied.start, applied.end)
+        }
+        setOpen(false)
+    }
+
+    return (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+            <PopoverTrigger render={trigger} />
+            <PopoverContent
+                align="start"
+                // Pinned: expanding the calendar must not shift the preset list under the cursor
+                collisionAvoidance={{ align: 'none' }}
+                {...contentProps}
+                className={`w-auto overflow-hidden border-none p-0 shadow-none ring-0 ${contentProps?.className ?? ''}`}
+            >
+                <DateTimePicker
+                    key={openKey}
+                    value={pickerValue}
+                    ranges={ranges}
+                    presetsFirst
+                    showHeader={false}
+                    showTime={false}
+                    weekStartsOn={weekStartsOn}
+                    footerExtra={footerExtra}
+                    onApply={handleApply}
+                />
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -427,6 +427,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS: 'product-analytics-insights-tooltips', // owner: #team-product-analytics, gates the unified quill DefaultTooltip for trends/retention/stickiness insight charts
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUARTER_YEAR_INTERVALS: 'product-analytics-quarter-year-intervals', // owner: @sampennington #team-product-analytics, gates quarter/year interval selection on insights
+    PRODUCT_ANALYTICS_QUILL_DATE_FILTER: 'product-analytics-quill-date-filter', // owner: @sampennington #team-product-analytics, gates the quill-based insight date filter (absorbs days-of-week and exclude incomplete period)
     PRODUCT_ANALYTICS_QUILL_LEGEND: 'product-analytics-quill-legend', // owner: #team-product-analytics, gates the in-chart quill legend replacing the legacy side InsightLegend
     PRODUCT_ANALYTICS_QUILL_SQL_CHARTS: 'product-analytics-quill-sql-charts', // owner: #team-data-tools, gates rendering DataVisualization line/area charts via @posthog/quill-charts
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/lib/utils/dateFilters.ts
+++ b/frontend/src/lib/utils/dateFilters.ts
@@ -6,7 +6,7 @@ import { UnexpectedNeverError } from 'lib/utils/guards'
 import { DateMappingOption, IntervalType } from '~/types'
 
 /** Returns the start of the current week, respecting the team's week start day (0=Sunday, 1=Monday). */
-function startOfWeek(date: dayjs.Dayjs, weekStartDay?: number | null): dayjs.Dayjs {
+export function startOfWeek(date: dayjs.Dayjs, weekStartDay?: number | null): dayjs.Dayjs {
     const start = weekStartDay === 1 ? 1 : 0
     return date.subtract((date.day() - start + 7) % 7, 'day').startOf('day')
 }

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -7,11 +7,13 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
-import { NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
+import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { alignResolvedDateRangeToInterval, formatResolvedDateRange } from 'lib/utils/datetime'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { InsightDateFilter } from 'scenes/insights/filters/InsightDateFilter'
+import { InsightDateFilterNext } from 'scenes/insights/filters/InsightDateFilter/InsightDateFilterNext'
 import { RetentionChartPicker } from 'scenes/insights/filters/RetentionChartPicker'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -49,6 +51,9 @@ export function InsightDisplayConfig(): JSX.Element {
     const { isTrendsFunnel, isStepsFunnel, isTimeToConvertFunnel, isEmptyFunnel } = useValues(
         funnelDataLogic(insightProps)
     )
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillDateFilterEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_DATE_FILTER]
+
     const isMetric = display === ChartDisplayType.Metric
     // The slope graph shows the first vs last interval, so it drops the options that need the points
     // between them (compare, smoothing, multiple axes, alert/annotation overlays, statistical analysis).
@@ -76,9 +81,13 @@ export function InsightDisplayConfig(): JSX.Element {
             data-attr="insight-filters"
         >
             <div className="flex items-center gap-x-2 flex-wrap gap-y-2">
-                {!isRetention && (
+                {(quillDateFilterEnabled || !isRetention) && (
                     <ConfigFilter>
-                        <InsightDateFilter disabled={isFunnels && !!isEmptyFunnel} />
+                        {quillDateFilterEnabled ? (
+                            <InsightDateFilterNext disabled={isFunnels && !!isEmptyFunnel} />
+                        ) : (
+                            <InsightDateFilter disabled={isFunnels && !!isEmptyFunnel} />
+                        )}
                     </ConfigFilter>
                 )}
 
@@ -88,10 +97,15 @@ export function InsightDisplayConfig(): JSX.Element {
                     </ConfigFilter>
                 )}
 
-                {!!isRetention && (
+                {!!isRetention && !quillDateFilterEnabled && (
                     <ConfigFilter>
                         <RetentionDatePicker />
-                        {hasBreakdownFilter(breakdownFilter) && <RetentionBreakdownFilter />}
+                    </ConfigFilter>
+                )}
+
+                {!!isRetention && hasBreakdownFilter(breakdownFilter) && (
+                    <ConfigFilter>
+                        <RetentionBreakdownFilter />
                     </ConfigFilter>
                 )}
 
@@ -172,5 +186,5 @@ export function InsightDisplayConfig(): JSX.Element {
 }
 
 function ConfigFilter({ children }: { children: ReactNode }): JSX.Element {
-    return <span className="deprecated-space-x-2 flex items-center text-sm">{children}</span>
+    return <span className="flex items-center gap-2 text-sm">{children}</span>
 }

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -2,6 +2,11 @@ import { useValues } from 'kea'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import {
+    DAYS_IN_WEEK,
+    daysOfWeekLabel,
+    getEffectiveDaysOfWeek,
+} from 'scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
@@ -17,8 +22,14 @@ export const InsightResultMetadata = ({
     disableLastComputationRefresh,
 }: InsightResultMetadataProps): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
-    const { samplingFactor, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { samplingFactor, trendsFilter, dateRange } = useValues(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
+    const effectiveDays = getEffectiveDaysOfWeek(dateRange, trendsFilter)
+    const daysRestrict = effectiveDays.length > 0 && effectiveDays.length < DAYS_IN_WEEK
+    const showDaysPill =
+        daysRestrict &&
+        ((dateRange?.daysOfWeek && dateRange.daysOfWeek.length > 0) ||
+            (trendsFilter?.hideWeekends && featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]))
     return (
         <>
             {!disableLastComputation && <ComputationTimeWithRefresh disableRefresh={disableLastComputationRefresh} />}
@@ -28,10 +39,10 @@ export const InsightResultMetadata = ({
                     Results calculated from {samplingFactor * 100}% of users
                 </span>
             ) : null}
-            {trendsFilter?.hideWeekends && featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS] ? (
+            {showDaysPill ? (
                 <span className="text-secondary">
                     <span className="mx-1">•</span>
-                    Weekends hidden
+                    {daysOfWeekLabel(effectiveDays)} only
                 </span>
             ) : null}
         </>

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -62,7 +62,10 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         showMovingAverage,
     } = useValues(trendsDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
-    const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
+    // The quill date filter's day-of-week chips supersede the legacy hide-weekends checkbox
+    const hideWeekendsEnabled =
+        !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS] &&
+        !featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_DATE_FILTER]
     const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
     const styleRefreshEnabled = !!featureFlags[FEATURE_FLAGS.QUILL_CHART_STYLE_REFRESH]
 

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilterNext.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilterNext.tsx
@@ -1,0 +1,144 @@
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IconCalendar } from '@posthog/icons'
+import { Button, CUSTOM_RANGE, Day } from '@posthog/quill'
+
+import { DateExclusionsControl } from 'lib/components/DateRangeFilter/DateExclusionsControl'
+import { DateRangeFilter, type DateRangePreset } from 'lib/components/DateRangeFilter/DateRangeFilter'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import {
+    ALL_DAY_NUMBERS,
+    computeDaysOfWeekUpdate,
+    daysOfWeekLabel,
+    getEffectiveDaysOfWeek,
+    type IsoDayOfWeek,
+} from './daysOfWeekFilterUtils'
+import {
+    ALL_TIME_PRESET,
+    DEFAULT_DATE_FROM,
+    INSIGHT_DATE_PRESETS,
+    type InsightDatePreset,
+    dateRangeUpdateForPickerValue,
+    insightDateLabel,
+    insightDateRanges,
+    pickerValueForDateRange,
+    presetForDateStrings,
+    retentionDatePresets,
+} from './insightDateFilterNextUtils'
+
+const ROLLING_DATE_FROM = /^-(\d+)([hdwmy])$/
+
+type InsightDateFilterNextProps = {
+    disabled: boolean
+}
+
+export function InsightDateFilterNext({ disabled }: InsightDateFilterNextProps): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { querySource, dateRange, trendsFilter, retentionFilter, isTrends, isRetention } = useValues(
+        insightVizDataLogic(insightProps)
+    )
+    const { updateDateRange, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { weekStartDay } = useValues(teamLogic)
+
+    // Retention's range selects cohort-start buckets, so its presets scale with the period.
+    const retentionPeriod = isRetention ? (retentionFilter?.period ?? 'Day') : null
+    const presets = useMemo(
+        () => [...(retentionPeriod ? retentionDatePresets(retentionPeriod) : INSIGHT_DATE_PRESETS), ALL_TIME_PRESET],
+        [retentionPeriod]
+    )
+
+    const ranges = useMemo(() => insightDateRanges(weekStartDay, presets), [weekStartDay, presets])
+    const pickerValue = useMemo(
+        () => pickerValueForDateRange(dateRange?.date_from, dateRange?.date_to, ranges, undefined, presets),
+        [dateRange?.date_from, dateRange?.date_to, ranges, presets]
+    )
+
+    // The filter couriers each preset back verbatim; PostHog's relative date strings ride in `value`.
+    const filterPresets = useMemo(
+        (): DateRangePreset<InsightDatePreset>[] =>
+            presets.map((preset) => ({
+                id: preset.dateFrom,
+                label: preset.name,
+                value: preset,
+                previewStart: (now: Date) => preset.rangeSetter(now, weekStartDay),
+                previewEnd: preset.endSetter ? (now: Date) => preset.endSetter!(now, weekStartDay) : undefined,
+            })),
+        [presets, weekStartDay]
+    )
+
+    const activePreset = presetForDateStrings(dateRange?.date_from ?? DEFAULT_DATE_FROM, dateRange?.date_to, presets)
+    const isRolling = ROLLING_DATE_FROM.test(dateRange?.date_from ?? '')
+    const isCustom = pickerValue.range.id === CUSTOM_RANGE.id && !isRolling && !!dateRange?.date_from
+
+    // The exclusions control speaks excluded days; the query schema stores included days.
+    const includedDays = getEffectiveDaysOfWeek(dateRange, trendsFilter)
+    const excludedDays = includedDays.length === 0 ? [] : ALL_DAY_NUMBERS.filter((day) => !includedDays.includes(day))
+    const setExcludedDays = (excluded: number[]): void => {
+        const included = excluded.length === 0 ? [] : ALL_DAY_NUMBERS.filter((day) => !excluded.includes(day))
+        updateQuerySource(computeDaysOfWeekUpdate(included as IsoDayOfWeek[], querySource, dateRange))
+    }
+
+    const labelParts = [insightDateLabel(dateRange?.date_from, dateRange?.date_to, presets)]
+    if (isTrends && includedDays.length > 0) {
+        labelParts.push(daysOfWeekLabel(includedDays))
+    }
+    if (dateRange?.excludeIncompletePeriods) {
+        labelParts.push('Excl. incomplete')
+    }
+
+    const showExclusions = isTrends || !isRetention
+    const footerExtra = showExclusions ? (
+        <DateExclusionsControl
+            excludedDays={isTrends ? excludedDays : undefined}
+            onExcludedDaysChange={isTrends ? setExcludedDays : undefined}
+            excludeIncomplete={!isRetention ? !!dateRange?.excludeIncompletePeriods : undefined}
+            onExcludeIncompleteChange={
+                !isRetention
+                    ? (checked) => updateDateRange({ excludeIncompletePeriods: checked ? true : null }, true)
+                    : undefined
+            }
+        />
+    ) : undefined
+
+    // data-lemon-skin opts these surfaces into the quill-as-lemon skin (lemon-skin.scss) so the
+    // filter sits next to Lemon chrome without a visual jump. The trigger carries it directly;
+    // the popover surface portals to <body>, so it rides in via contentProps.
+    return (
+        <DateRangeFilter
+            presets={filterPresets}
+            selectedPresetId={activePreset?.dateFrom ?? null}
+            onPresetSelect={(preset) =>
+                updateDateRange({ date_from: preset.value!.dateFrom, date_to: preset.value!.dateTo }, true)
+            }
+            onCustomApply={(start, end) =>
+                updateDateRange(dateRangeUpdateForPickerValue({ start, end, range: CUSTOM_RANGE }, presets), true)
+            }
+            customActive={isCustom}
+            customStart={isCustom ? pickerValue.start : undefined}
+            customEnd={isCustom ? pickerValue.end : undefined}
+            weekStartsOn={weekStartDay === 1 ? Day.MONDAY : Day.SUNDAY}
+            footerExtra={footerExtra}
+            contentProps={
+                { 'data-lemon-skin': 'true' } as unknown as React.ComponentProps<typeof DateRangeFilter>['contentProps']
+            }
+            trigger={
+                <Button
+                    variant="outline"
+                    size="default"
+                    data-attr="insight-date-filter-next"
+                    data-quill
+                    data-lemon-skin
+                    disabled={disabled || !!editingDisabledReason}
+                    title={editingDisabledReason ?? undefined}
+                >
+                    <IconCalendar />
+                    {labelParts.join(' · ')}
+                </Button>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
@@ -1,0 +1,57 @@
+import { DateRange, TrendsFilter, TrendsQuery } from '~/queries/schema/schema-general'
+
+import {
+    type IsoDayOfWeek,
+    computeDaysOfWeekUpdate,
+    daysOfWeekLabel,
+    getEffectiveDaysOfWeek,
+} from './daysOfWeekFilterUtils'
+
+describe('daysOfWeekFilterUtils', () => {
+    it.each<[string, DateRange, TrendsFilter | undefined, IsoDayOfWeek[]]>([
+        ['daysOfWeek set', { daysOfWeek: [2, 1] }, undefined, [1, 2]],
+        ['legacy hideWeekends reads as weekdays', {}, { hideWeekends: true }, [1, 2, 3, 4, 5]],
+        ['daysOfWeek wins over hideWeekends', { daysOfWeek: [6, 7] }, { hideWeekends: true }, [6, 7]],
+        ['neither set means all days', {}, {}, []],
+    ])('getEffectiveDaysOfWeek: %s', (_name, dateRange, trendsFilter, expected) => {
+        expect(getEffectiveDaysOfWeek(dateRange, trendsFilter)).toEqual(expected)
+    })
+
+    it.each<[IsoDayOfWeek[], string]>([
+        [[], 'All days'],
+        [[1, 2, 3, 4, 5, 6, 7], 'All days'],
+        [[1, 2, 3, 4, 5], 'Weekdays'],
+        [[6, 7], 'Weekends'],
+        [[1, 3], 'Mon, Wed'],
+    ])('daysOfWeekLabel(%p) is %s', (days, expected) => {
+        expect(daysOfWeekLabel(days)).toBe(expected)
+    })
+
+    it.each<[string, IsoDayOfWeek[], Partial<TrendsQuery> | null, object, object]>([
+        ['empty selection normalises to null daysOfWeek', [], null, {}, { dateRange: { daysOfWeek: null } }],
+        [
+            'all 7 days normalises to null daysOfWeek',
+            [1, 2, 3, 4, 5, 6, 7],
+            null,
+            {},
+            { dateRange: { daysOfWeek: null } },
+        ],
+        ['partial selection is sorted', [5, 1, 3], null, {}, { dateRange: { daysOfWeek: [1, 3, 5] } }],
+        [
+            'clears legacy hideWeekends when it was set',
+            [1, 2, 3],
+            { kind: 'TrendsQuery', trendsFilter: { hideWeekends: true } } as Partial<TrendsQuery>,
+            {},
+            { dateRange: { daysOfWeek: [1, 2, 3] }, trendsFilter: { hideWeekends: undefined } },
+        ],
+        [
+            'does not add trendsFilter key when hideWeekends was not set',
+            [1, 2, 3],
+            { kind: 'TrendsQuery', trendsFilter: {} } as Partial<TrendsQuery>,
+            {},
+            { dateRange: { daysOfWeek: [1, 2, 3] } },
+        ],
+    ])('computeDaysOfWeekUpdate: %s', (_name, days, querySource, dateRange, expected) => {
+        expect(computeDaysOfWeekUpdate(days, querySource, dateRange)).toEqual(expected)
+    })
+})

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
@@ -1,0 +1,78 @@
+import { DateRange, TrendsFilter, TrendsQuery } from '~/queries/schema/schema-general'
+import { isTrendsQuery } from '~/queries/utils'
+
+export type IsoDayOfWeek = NonNullable<DateRange['daysOfWeek']>[number]
+
+export const DAYS_IN_WEEK = 7
+export const WEEKDAYS: IsoDayOfWeek[] = [1, 2, 3, 4, 5]
+export const WEEKENDS: IsoDayOfWeek[] = [6, 7]
+export const DAY_LABELS: Record<number, string> = {
+    1: 'Mon',
+    2: 'Tue',
+    3: 'Wed',
+    4: 'Thu',
+    5: 'Fri',
+    6: 'Sat',
+    7: 'Sun',
+}
+
+export const DAY_LABELS_SINGLE: Record<number, string> = {
+    1: 'M',
+    2: 'T',
+    3: 'W',
+    4: 'T',
+    5: 'F',
+    6: 'S',
+    7: 'S',
+}
+
+export const ALL_DAY_NUMBERS: IsoDayOfWeek[] = [1, 2, 3, 4, 5, 6, 7]
+
+export function sortDays(days: IsoDayOfWeek[]): IsoDayOfWeek[] {
+    return [...days].sort((a, b) => a - b)
+}
+
+/** Selected ISO days (1=Mon…7=Sun); [] means all days. Legacy hideWeekends reads as Mon–Fri. */
+export function getEffectiveDaysOfWeek(
+    dateRange: DateRange | null | undefined,
+    trendsFilter: TrendsFilter | null | undefined
+): IsoDayOfWeek[] {
+    if (dateRange?.daysOfWeek?.length) {
+        return sortDays(dateRange.daysOfWeek)
+    }
+    if (trendsFilter?.hideWeekends) {
+        return WEEKDAYS
+    }
+    return []
+}
+
+export function daysOfWeekLabel(days: IsoDayOfWeek[]): string {
+    if (days.length === 0 || days.length === DAYS_IN_WEEK) {
+        return 'All days'
+    }
+    if (days.length === WEEKDAYS.length && WEEKDAYS.every((day) => days.includes(day))) {
+        return 'Weekdays'
+    }
+    if (days.length === WEEKENDS.length && WEEKENDS.every((day) => days.includes(day))) {
+        return 'Weekends'
+    }
+    return days.map((day) => DAY_LABELS[day]).join(', ')
+}
+
+/**
+ * Returns the TrendsQuery patch for a days-of-week selection.
+ * Normalises 0 or 7 selected days to null (meaning "all days").
+ * Also clears the legacy hideWeekends flag when daysOfWeek takes over.
+ */
+export function computeDaysOfWeekUpdate(
+    days: IsoDayOfWeek[],
+    querySource: TrendsQuery | Record<string, any> | null | undefined,
+    dateRange: DateRange | null | undefined
+): Partial<TrendsQuery> {
+    const daysOfWeek = days.length === 0 || days.length === DAYS_IN_WEEK ? null : sortDays(days)
+    const update: Partial<TrendsQuery> = { dateRange: { ...dateRange, daysOfWeek } }
+    if (isTrendsQuery(querySource) && querySource.trendsFilter?.hideWeekends) {
+        update.trendsFilter = { ...querySource.trendsFilter, hideWeekends: undefined }
+    }
+    return update
+}

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterNextUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterNextUtils.test.ts
@@ -1,0 +1,95 @@
+import { CUSTOM_RANGE } from '@posthog/quill'
+
+import { dayjs } from 'lib/dayjs'
+
+import {
+    INSIGHT_DATE_PRESETS,
+    dateRangeUpdateForPickerValue,
+    insightDateLabel,
+    insightDateRanges,
+    pickerValueForDateRange,
+    retentionDatePresets,
+} from './insightDateFilterNextUtils'
+
+// Friday May 15 2026, mid-Q2
+const NOW = new Date(2026, 4, 15, 12, 0, 0)
+
+describe('insightDateFilterNextUtils', () => {
+    const ranges = insightDateRanges(1)
+
+    test.each(INSIGHT_DATE_PRESETS.map((p) => ({ name: p.name, dateFrom: p.dateFrom, dateTo: p.dateTo })))(
+        'round-trips $name through picker value and back to $dateFrom..$dateTo',
+        ({ name, dateFrom, dateTo }) => {
+            const value = pickerValueForDateRange(dateFrom, dateTo, ranges, NOW)
+            expect(value.range.name).toBe(name)
+            expect(dateRangeUpdateForPickerValue(value)).toEqual({ date_from: dateFrom, date_to: dateTo })
+        }
+    )
+
+    test.each([
+        { name: 'This quarter', start: '2026-04-01', end: '2026-05-15' },
+        { name: 'Last quarter', start: '2026-01-01', end: '2026-03-31' },
+        { name: 'Last month', start: '2026-04-01', end: '2026-04-30' },
+        { name: 'Year to date', start: '2026-01-01', end: '2026-05-15' },
+        { name: 'This week', start: '2026-05-11', end: '2026-05-15' },
+        { name: 'Last week', start: '2026-05-04', end: '2026-05-10' },
+    ])('$name previews $start..$end in the calendar (week starts Monday)', ({ name, start, end }) => {
+        const preset = INSIGHT_DATE_PRESETS.find((p) => p.name === name)!
+        const value = pickerValueForDateRange(preset.dateFrom, preset.dateTo, ranges, NOW)
+        expect(dayjs(value.start).format('YYYY-MM-DD')).toBe(start)
+        expect(dayjs(value.end).format('YYYY-MM-DD')).toBe(end)
+    })
+
+    it('starts weeks on Sunday when the team week starts on Sunday', () => {
+        const sundayRanges = insightDateRanges(0)
+        const value = pickerValueForDateRange('wStart', null, sundayRanges, NOW)
+        expect(dayjs(value.start).format('YYYY-MM-DD')).toBe('2026-05-10')
+    })
+
+    it('maps a custom calendar selection to absolute day-granular dates', () => {
+        const update = dateRangeUpdateForPickerValue({
+            start: new Date(2026, 2, 3),
+            end: new Date(2026, 2, 20, 23, 59, 59),
+            range: CUSTOM_RANGE,
+        })
+        expect(update).toEqual({ date_from: '2026-03-03', date_to: '2026-03-20' })
+    })
+
+    it('falls back to a custom picker value for absolute date strings', () => {
+        const value = pickerValueForDateRange('2026-03-03', '2026-03-20', ranges, NOW)
+        expect(value.range).toBe(CUSTOM_RANGE)
+        expect(dayjs(value.start).format('YYYY-MM-DD')).toBe('2026-03-03')
+        expect(dayjs(value.end).format('YYYY-MM-DD')).toBe('2026-03-20')
+    })
+
+    it('falls back to now-7d..now for unparseable non-preset date strings', () => {
+        const value = pickerValueForDateRange('-3w', null, ranges, NOW)
+        expect(value.range).toBe(CUSTOM_RANGE)
+        expect(dayjs(value.start).format('YYYY-MM-DD')).toBe('2026-05-08')
+        expect(value.end).toBe(NOW)
+    })
+
+    test.each([
+        { dateFrom: 'qStart', dateTo: null, expected: 'This quarter' },
+        { dateFrom: '-1qStart', dateTo: '-1qEnd', expected: 'Last quarter' },
+        { dateFrom: '-3w', dateTo: null, expected: 'Last 3 weeks' },
+        { dateFrom: 'all', dateTo: null, expected: 'All time' },
+        { dateFrom: null, dateTo: null, expected: 'Last 7 days' },
+    ])('labels $dateFrom..$dateTo as $expected', ({ dateFrom, dateTo, expected }) => {
+        expect(insightDateLabel(dateFrom, dateTo)).toBe(expected)
+    })
+
+    test.each([
+        { period: 'Hour', name: 'Last 14 hours', dateFrom: '-14h' },
+        { period: 'Day', name: 'Last 90 days', dateFrom: '-90d' },
+        { period: 'Week', name: 'Last 7 weeks', dateFrom: '-7w' },
+        { period: 'Month', name: 'Last 30 months', dateFrom: '-30m' },
+    ])('retention presets scale to the $period period ($name → $dateFrom)', ({ period, name, dateFrom }) => {
+        const presets = retentionDatePresets(period)
+        const preset = presets.find((p) => p.name === name)
+        expect(preset?.dateFrom).toBe(dateFrom)
+        expect(preset?.dateTo).toBeNull()
+        // Retention writes date_to: 'now' on period changes — must still match the preset.
+        expect(insightDateLabel(dateFrom, 'now', presets)).toBe(name)
+    })
+})

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterNextUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterNextUtils.ts
@@ -1,0 +1,221 @@
+import { CUSTOM_RANGE, type DateTimeRange, type DateTimeValue } from '@posthog/quill'
+
+import { dayjs } from 'lib/dayjs'
+import { dateFilterToText, startOfWeek } from 'lib/utils/dateFilters'
+
+import { DateRange } from '~/queries/schema/schema-general'
+
+export const DEFAULT_DATE_FROM = '-7d'
+const DEFAULT_DATE_LABEL = 'Last 7 days'
+
+export interface InsightDatePreset {
+    name: string
+    dateFrom: string
+    dateTo: string | null
+    rangeSetter: (now: Date, weekStartDay: number) => Date
+    endSetter?: (now: Date, weekStartDay: number) => Date
+}
+
+/** Insight quick ranges: each maps to a PostHog relative date string (so queries stay
+ * rolling) plus concrete date setters that preview the range in the quill calendar. */
+export const INSIGHT_DATE_PRESETS: InsightDatePreset[] = [
+    {
+        name: 'Today',
+        dateFrom: 'dStart',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).startOf('day').toDate(),
+    },
+    {
+        name: 'Yesterday',
+        dateFrom: '-1dStart',
+        dateTo: '-1dEnd',
+        rangeSetter: (now) => dayjs(now).subtract(1, 'day').startOf('day').toDate(),
+        endSetter: (now) => dayjs(now).subtract(1, 'day').endOf('day').toDate(),
+    },
+    {
+        name: 'Last 24 hours',
+        dateFrom: '-24h',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(24, 'hour').toDate(),
+    },
+    {
+        name: 'Last 7 days',
+        dateFrom: '-7d',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(7, 'day').toDate(),
+    },
+    {
+        name: 'Last 14 days',
+        dateFrom: '-14d',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(14, 'day').toDate(),
+    },
+    {
+        name: 'Last 30 days',
+        dateFrom: '-30d',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(30, 'day').toDate(),
+    },
+    {
+        name: 'Last 90 days',
+        dateFrom: '-90d',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(90, 'day').toDate(),
+    },
+    {
+        name: 'Last 180 days',
+        dateFrom: '-180d',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).subtract(180, 'day').toDate(),
+    },
+    {
+        name: 'This week',
+        dateFrom: 'wStart',
+        dateTo: null,
+        rangeSetter: (now, weekStartDay) => startOfWeek(dayjs(now), weekStartDay).toDate(),
+    },
+    {
+        name: 'Last week',
+        dateFrom: '-1wStart',
+        dateTo: '-1wEnd',
+        rangeSetter: (now, weekStartDay) => startOfWeek(dayjs(now), weekStartDay).subtract(7, 'day').toDate(),
+        endSetter: (now, weekStartDay) =>
+            startOfWeek(dayjs(now), weekStartDay).subtract(1, 'day').endOf('day').toDate(),
+    },
+    {
+        name: 'This month',
+        dateFrom: 'mStart',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).startOf('month').toDate(),
+    },
+    {
+        name: 'Last month',
+        dateFrom: '-1mStart',
+        dateTo: '-1mEnd',
+        rangeSetter: (now) => dayjs(now).subtract(1, 'month').startOf('month').toDate(),
+        endSetter: (now) => dayjs(now).subtract(1, 'month').endOf('month').toDate(),
+    },
+    {
+        name: 'This quarter',
+        dateFrom: 'qStart',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).startOf('quarter').toDate(),
+    },
+    {
+        name: 'Last quarter',
+        dateFrom: '-1qStart',
+        dateTo: '-1qEnd',
+        rangeSetter: (now) => dayjs(now).subtract(1, 'quarter').startOf('quarter').toDate(),
+        endSetter: (now) => dayjs(now).subtract(1, 'quarter').endOf('quarter').toDate(),
+    },
+    {
+        name: 'Year to date',
+        dateFrom: 'yStart',
+        dateTo: null,
+        rangeSetter: (now) => dayjs(now).startOf('year').toDate(),
+    },
+]
+
+/** "All time" flows through the same preset machinery; the calendar preview just needs
+ * some concrete span, so it shows the last 5 years. */
+export const ALL_TIME_PRESET: InsightDatePreset = {
+    name: 'All time',
+    dateFrom: 'all',
+    dateTo: null,
+    rangeSetter: (now) => dayjs(now).subtract(5, 'year').toDate(),
+}
+
+const RETENTION_PRESET_COUNTS = [7, 14, 30, 90]
+
+/** Retention quick ranges scale with the retention period (the range selects cohort-start
+ * buckets), mirroring the legacy RetentionDatePicker options. */
+export function retentionDatePresets(period: string | null | undefined): InsightDatePreset[] {
+    const unit = (period ?? 'Day').toLowerCase() as 'hour' | 'day' | 'week' | 'month'
+    return [
+        ...RETENTION_PRESET_COUNTS.map((count) => ({
+            name: `Last ${count} ${unit}s`,
+            dateFrom: `-${count}${unit.charAt(0)}`,
+            dateTo: null,
+            rangeSetter: (now: Date) => dayjs(now).subtract(count, unit).toDate(),
+        })),
+        INSIGHT_DATE_PRESETS.find((preset) => preset.name === 'Year to date')!,
+    ]
+}
+
+export function insightDateRanges(
+    weekStartDay: number,
+    presets: InsightDatePreset[] = INSIGHT_DATE_PRESETS
+): DateTimeRange[] {
+    return presets.map((preset, index) => ({
+        id: index + 1,
+        name: preset.name,
+        rangeSetter: (now: Date) => preset.rangeSetter(now, weekStartDay),
+        endSetter: preset.endSetter ? (now: Date) => preset.endSetter!(now, weekStartDay) : undefined,
+    }))
+}
+
+export function presetForDateStrings(
+    dateFrom: string | null | undefined,
+    dateTo: string | null | undefined,
+    presets: InsightDatePreset[] = INSIGHT_DATE_PRESETS
+): InsightDatePreset | undefined {
+    // Retention writes date_to: 'now' on period changes — same open end as null.
+    const normalizedTo = dateTo === 'now' ? null : (dateTo ?? null)
+    return presets.find((preset) => preset.dateFrom === dateFrom && preset.dateTo === normalizedTo)
+}
+
+export function pickerValueForDateRange(
+    dateFrom: string | null | undefined,
+    dateTo: string | null | undefined,
+    ranges: DateTimeRange[],
+    now: Date = new Date(),
+    presets: InsightDatePreset[] = INSIGHT_DATE_PRESETS
+): DateTimeValue {
+    const preset = presetForDateStrings(dateFrom ?? DEFAULT_DATE_FROM, dateTo, presets)
+    if (preset) {
+        const range = ranges.find((r) => r.name === preset.name)
+        if (range) {
+            return { start: range.rangeSetter(now), end: range.endSetter?.(now) ?? now, range }
+        }
+    }
+    const parsedFrom = dateFrom ? dayjs(dateFrom) : null
+    const parsedTo = dateTo ? dayjs(dateTo) : null
+    return {
+        start: parsedFrom?.isValid() ? parsedFrom.toDate() : dayjs(now).subtract(7, 'day').toDate(),
+        end: parsedTo?.isValid() ? parsedTo.toDate() : now,
+        range: CUSTOM_RANGE,
+    }
+}
+
+export function dateRangeUpdateForPickerValue(
+    value: DateTimeValue,
+    presets: InsightDatePreset[] = INSIGHT_DATE_PRESETS
+): Pick<DateRange, 'date_from' | 'date_to'> {
+    if (value.range.id !== CUSTOM_RANGE.id) {
+        const preset = presets.find((p) => p.name === value.range.name)
+        if (preset) {
+            return { date_from: preset.dateFrom, date_to: preset.dateTo }
+        }
+    }
+    // Custom ranges commit day-granular browser-local dates; presets stay relative strings the
+    // backend resolves in project timezone, so the calendar is a local-time preview by design.
+    return {
+        date_from: dayjs(value.start).format('YYYY-MM-DD'),
+        date_to: dayjs(value.end).format('YYYY-MM-DD'),
+    }
+}
+
+export function insightDateLabel(
+    dateFrom: string | null | undefined,
+    dateTo: string | null | undefined,
+    presets: InsightDatePreset[] = INSIGHT_DATE_PRESETS
+): string {
+    if (!dateFrom) {
+        return DEFAULT_DATE_LABEL
+    }
+    return (
+        presetForDateStrings(dateFrom, dateTo, presets)?.name ??
+        dateFilterToText(dateFrom, dateTo, DEFAULT_DATE_LABEL) ??
+        DEFAULT_DATE_LABEL
+    )
+}


### PR DESCRIPTION
## Problem

The insight date filter is being rebuilt on quill (behind the `product-analytics-quill-date-filter` flag).
The interaction converged through several prototypes (mode props in #69870, a block in #70284 — both closed): a presets-first list with the calendar revealed in place, and exclusions (incomplete period, excluded days) behind a single "+ Exclude" control on the calendar surface, Amplitude-style.

## Changes

Stacked on #70304 (quill `DateTimePicker` `presetsFirst` mode + `footerExtra` slot).

**`lib/components/DateRangeFilter/`** (new, cross-product home — successor shape for the legacy `DateFilter`)

- `DateRangeFilter`: trigger + pinned popover hosting the picker in `presetsFirst` mode. Presets carry an opaque `value` payload routed back verbatim on selection; custom calendar applies return concrete dates. An unedited calendar Apply keeps the staged preset's semantics, so rolling ranges never silently pin. Remounts the picker per open (Base UI keeps popups mounted, which would leak staged state across opens).
- `DateExclusionsControl`: "+ Exclude" link opening a panel with an incomplete-period toggle and exclude-day chips (Weekends / Weekdays / Clear shortcuts); summary reads "Excluding weekends, incomplete".

**`InsightDateFilterNext`** (product analytics, flag-gated)

- Thin wiring: PostHog presets map to relative date strings (`-7d`, `mStart`, `all`) in the preset payload so saved queries stay rolling; retention gets period-scaled presets; custom applies commit day-granular dates.
- Exclusions invert at this boundary: the control speaks excluded days, the query schema stores included `daysOfWeek`. Day exclusion is trends-only; incomplete-period hidden for retention.

**Not in this PR:** lemon-skin rules (belong on #69824; pre-restack delta archived at `posthog-code/date-5-archive-pre-restack`).

## How did you test this code?

- `lib/components/DateRangeFilter` tests (2): payload routing including the unedited-Apply-keeps-preset trap (caught a real bug during development — Base UI popup persistence leaking staged picker state across opens), and custom-active opening straight to the calendar with concrete-date applies.
- Existing `InsightDateFilter` utils tests (48) unchanged and passing; picker interaction contracts are tested in #70304.
- Frontend typecheck clean on touched files. Not yet re-verified in a running app since the rework — draft until visually checked behind the flag.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: flag-gated rebuild of an existing filter, no behavior change with the flag off.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session), directed by Sam through live Storybook iteration. Architecture settled after three attempts: picker mode props (#69870, closed), consumer-owned popover, then a quill block (#70284, closed) — the converged answer is the interaction in the picker (#70304), the popover shell + PostHog vocabulary in `lib/components`, and product specifics here.
- Skills invoked: /writing-tests.
- Decisions: exclusions are exclude-framed in the UI (matches "hide weekends" intent and Amplitude convention) and inverted to the schema's included-days at the consumer boundary; day-of-week + incomplete stay product-gated props, not baked into the shared control.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
