### PR TITLE
fix(cdp): hogvm shadow heap cap and nondeterministic function handling

### DIFF
--- a/nodejs/src/cdp/hog-transformations/rust-vm-shadow.test.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-shadow.test.ts
@@ -170,6 +170,19 @@ describe('RustVmShadow', () => {
             expect(await outcomeCounts()).toEqual({ dropped: 1, match: 1 })
         })
 
+        it('functions calling nondeterministic stl fns are skipped at capture, not compared', async () => {
+            // CALL_GLOBAL randomFloat — two executions legitimately differ, comparison is meaningless.
+            shadow.capture({ ...capture('fn-rng', { name: 'a' }, 'ok'), bytecode: ['_H', 1, 2, 'randomFloat', 0, 38] })
+            // A string literal containing a fn name (preceded by the STRING op 32) must not skip.
+            shadow.capture({ ...capture('fn-str', { name: 'b' }, 'now'), bytecode: ['_H', 1, 32, 'now', 38] })
+
+            mockHogvmNode.executeBatch.mockResolvedValue([{ result: 'now', durationUs: 5 }])
+            await shadow.flush()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
+            expect(await outcomeCounts()).toEqual({ skipped_nondeterministic: 1, match: 1 })
+        })
+
         it('captures beyond the buffer cap are counted as dropped, not as rust errors', async () => {
             for (let i = 0; i < 10_001; i++) {
                 shadow.capture(capture('fn-a', { name: 'a' }, 'ok'))

--- a/nodejs/src/cdp/hog-transformations/rust-vm-shadow.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-shadow.ts
@@ -21,6 +21,10 @@ import { KNOWN_BOT_IP_LIST, KNOWN_BOT_UA_LIST } from './bots/bots'
 // The Rust VM budgets steps, not wall-clock time; generous so it never trips before the Node VM's
 // timeout would.
 const RUST_MAX_STEPS = 1_000_000
+// STL functions whose output legitimately differs between two executions — programs calling them
+// can never be compared, so they're skipped at capture time.
+const NONDETERMINISTIC_FNS = new Set(['randomFloat', 'generateUUIDv4', 'now', 'today'])
+const CALL_GLOBAL_OP = 2
 // Safety cap so a stalled flush can't grow the buffer unboundedly.
 const MAX_BUFFER_SIZE = 10_000
 
@@ -56,6 +60,7 @@ export type ShadowOutcome =
     | 'status_mismatch'
     | 'rust_error'
     | 'skipped_unsupported'
+    | 'skipped_nondeterministic'
     | 'dropped'
 
 export interface ShadowNodeResult {
@@ -116,6 +121,7 @@ export class RustVmShadow {
     private buffer: ShadowCapturedInvocation[] = []
     private module_: HogvmNodeModule | null | undefined = undefined
     private flushInFlight = false
+    private nondeterministicByFunction = new Map<string, boolean>()
 
     constructor(
         private options: {
@@ -133,11 +139,35 @@ export class RustVmShadow {
     }
 
     public capture(item: ShadowCapturedInvocation): void {
+        if (this.isNondeterministic(item.functionId, item.bytecode)) {
+            shadowComparison.inc({ outcome: 'skipped_nondeterministic' })
+            return
+        }
         if (this.buffer.length >= MAX_BUFFER_SIZE) {
             shadowComparison.inc({ outcome: 'dropped' })
             return
         }
         this.buffer.push(item)
+    }
+
+    // Every string literal in hog bytecode is preceded by the STRING op (32); only CALL_GLOBAL (2)
+    // is directly followed by the function name, so this pair scan cannot false-positive on string
+    // literals that merely contain a function name.
+    private isNondeterministic(functionId: string, bytecode: HogBytecode): boolean {
+        let cached = this.nondeterministicByFunction.get(functionId)
+        if (cached === undefined) {
+            cached = bytecode.some(
+                (token, index) =>
+                    token === CALL_GLOBAL_OP &&
+                    typeof bytecode[index + 1] === 'string' &&
+                    NONDETERMINISTIC_FNS.has(bytecode[index + 1] as string)
+            )
+            if (this.nondeterministicByFunction.size >= MAX_BUFFER_SIZE) {
+                this.nondeterministicByFunction.clear()
+            }
+            this.nondeterministicByFunction.set(functionId, cached)
+        }
+        return cached
     }
 
     /**

--- a/rust/common/hogvm/node/src/exec.rs
+++ b/rust/common/hogvm/node/src/exec.rs
@@ -11,6 +11,10 @@ use crate::ext_fns::transformation_ext_fns;
 
 const PARALLEL_CHUNK_SIZE: usize = 500;
 
+// The Node VM has no heap ceiling; the crate's 1MB default trips on real events with large
+// properties. A cap (not a preallocation), and rayon bounds how many contexts run at once.
+const MAX_HEAP_SIZE_BYTES: usize = 64 * 1024 * 1024;
+
 #[napi(object)]
 pub struct HogExecResult {
     /// The program's return value; None when the execution errored.
@@ -56,6 +60,7 @@ fn run_chunk(tokens: &[Value], chunk: &[Value], max_steps: Option<usize>) -> Vec
     };
 
     let mut ctx = ExecutionContext::with_defaults(program).with_ext_fns(transformation_ext_fns());
+    ctx.max_heap_size = MAX_HEAP_SIZE_BYTES;
     if let Some(max_steps) = max_steps {
         ctx.max_steps = max_steps;
     }


### PR DESCRIPTION
## Problem

Production shadow execution (merged in #67901) still reports two divergence classes that have nothing to do with VM correctness:

- `Out of resource: Heap Memory` — the napi binding runs the Rust VM with the crate's 1MB default heap cap; the Node VM has no ceiling, so real events with large properties fail on the Rust side only. Currently the largest remaining `status_mismatch` class (~1k per 10 minutes).
- `result_mismatch` on transformations calling `randomFloat()`/`now()`/`generateUUIDv4()`/`today()` — two executions legitimately differ, so comparing them is pure noise (~3k per 10 minutes, dominated by client-side sampling transformations).

These two commits were authored on the #67901 branch but landed after its squash-merge, so they never reached master.

## Changes

- Raise the binding's execution context heap cap to 64MB. It is a cap, not a preallocation, and rayon bounds how many contexts run concurrently.
- Detect nondeterministic transformations at capture time by scanning bytecode for `CALL_GLOBAL` of a nondeterministic STL function (every string literal in hog bytecode is preceded by the STRING op, so the op/name pair scan cannot false-positive on string literals). Skipped invocations count under a new `skipped_nondeterministic` outcome, cached per function id.

## How did you test this code?

- Binding suite (`cargo test --features noop`, 15 tests) and the shadow jest suite (17 tests) pass on this branch against master. The jest suite includes a case asserting a `randomFloat`-calling function is skipped while a function merely containing the string literal `'now'` is still compared — the regression that scan could realistically have.
- The heap cap has no new test: it is a config value; the regression it prevents (rust-side OOM on large events) is visible in the production shadow metrics this PR exists to clean up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code, driven by José. Both changes were root-caused from the shadow's production divergence logs (function ids → bytecode replay through both VMs), alongside the VM coercion fixes that went to #68355.
- Cherry-picked from the original shadow branch: #67901 was squash-merged before these were pushed, leaving them orphaned there.
