### PR TITLE
fix(postgres): give actionable error when a URL is entered as the host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -63,6 +63,12 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType, Inc
 
 log = logging.getLogger(__name__)
 
+_HOST_IS_URL_ERROR = (
+    "Enter just the hostname in the host field (for example, db.example.com), not a full URL or "
+    "connection string. Remove any scheme (like http:// or postgres://) and any username, "
+    "password, port, or path."
+)
+
 PostgresErrors = {
     "password authentication failed for user": "Invalid user or password",
     # libpq reports a bad password via SCRAM with a different wording than the line above.
@@ -827,6 +833,12 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
+
+        # A pasted URL or connection string in the host field otherwise fails DNS resolution with a
+        # misleading "check the spelling" message that echoes the raw value back (which can embed
+        # credentials). Catch it early with an actionable message that never reflects the input.
+        if "://" in config.host:
+            return False, _HOST_IS_URL_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(
             config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2648,6 +2648,36 @@ class TestValidateCredentialsErrorMapping:
         assert valid is False
         assert error == expected
 
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "https://db.example.com/",
+            "postgres://user:secret@db.example.com:5432/mydb",
+        ],
+    )
+    def test_url_in_host_field_rejected_without_echoing_input(self, source, host):
+        config = source.parse_config(
+            {
+                "host": host,
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "public",
+            }
+        )
+        with (
+            mock.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None)),
+            mock.patch.object(source, "is_database_host_valid", side_effect=AssertionError("should not resolve")),
+            mock.patch.object(source, "get_schemas", side_effect=AssertionError("should not connect")),
+        ):
+            valid, error = source.validate_credentials(config, team_id=1)
+
+        assert valid is False
+        # The raw host may embed credentials, so it must never be reflected back.
+        assert host not in (error or "")
+        assert "hostname" in (error or "")
+
 
 class TestPostgresSchemaDiscovery:
     def _mock_connection(self, *fetchall_results: list[tuple[object, ...]]):


### PR DESCRIPTION
## Problem

Triaging real Postgres source-creation failures, the confusing case was users pasting a URL or connection string into the host field: a scheme-prefixed host with a trailing slash (redacted shape: `<scheme>://<host>/`). That value fails DNS resolution, and the shared host validator surfaces a "couldn't resolve the host, check the spelling" message that echoes the raw input straight back. Two problems with that: it points the user at the wrong thing (the host is fine, the scheme is the problem), and echoing the raw input can reflect an embedded password when someone pastes a full connection string.

## Changes

Catch a host containing a scheme separator (`://`) early in `validate_credentials`, before it reaches DNS resolution, and return an actionable message telling the user to enter just the hostname and strip the scheme, credentials, port, and path. The message is a fixed string that never reflects the raw input, so a pasted connection string with an embedded password is not echoed back.

A hostname (or IPv6 literal) can never legitimately contain `://`, so the guard has no false positives.

## How did you test this code?

Added a parameterized case to `TestValidateCredentialsErrorMapping` covering a scheme-only host and a full connection string. It asserts validation fails, the raw input is not present in the returned message, and the message points at the hostname. This guards the regression where the guard is dropped and the raw value (possibly credential-bearing) is echoed back with a misleading DNS error. Ran it locally with pytest, passes. I (Claude) did not exercise the source-creation wizard in a browser.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged warehouse source-creation failures and found this host-field-as-URL pattern. Chose to reject with a clear message rather than silently strip the scheme: stripping a full connection string still drops the port and credentials the user pasted into it (they belong in separate fields), so a "just work" strip would fail later anyway, and an explicit message teaches the correct form. Kept the guard in the Postgres source only. MySQL shares the same root cause and is handled in a separate PR. Invoked the `/writing-tests` skill before adding the test.
