### PR TITLE
fix(mysql): give actionable error when a URL is entered as the host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -72,6 +72,12 @@ _VALIDATE_CONNECTION_HINTS: list[tuple[str, str]] = [
     ("Unknown database", "Database does not exist. Check the database name is correct."),
 ]
 
+_HOST_IS_URL_ERROR = (
+    "Enter just the hostname in the host field (for example, db.example.com), not a full URL or "
+    "connection string. Remove any scheme (like http:// or mysql://) and any username, password, "
+    "port, or path."
+)
+
 
 @SourceRegistry.register
 class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
@@ -285,6 +291,12 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
+
+        # A pasted URL or connection string in the host field otherwise fails DNS resolution with a
+        # misleading "check the spelling" message that echoes the raw value back (which can embed
+        # credentials). Catch it early with an actionable message that never reflects the input.
+        if "://" in config.host:
+            return False, _HOST_IS_URL_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(
             config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1687,6 +1687,25 @@ class TestMySQLSourceValidateCredentials:
         assert error == expected_error
         capture.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "https://db.example.com/",
+            "mysql://root:secret@db.example.com:3306/mydb",
+        ],
+    )
+    def test_url_in_host_field_rejected_without_echoing_input(self, source, mocker, host):
+        # If the guard is dropped, the raw host reaches host validation / DNS and the
+        # message would echo it (leaking a pasted password), so assert it is never reached.
+        mocker.patch.object(source, "is_database_host_valid", side_effect=AssertionError("should not resolve"))
+        mocker.patch.object(source, "get_schemas", side_effect=AssertionError("should not connect"))
+
+        valid, error = source.validate_credentials(_make_config(host=host), team_id=1)
+
+        assert valid is False
+        assert host not in (error or "")
+        assert "hostname" in (error or "")
+
     def test_unexpected_errors_are_still_captured(self, source, mocker):
         capture = mocker.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.source.capture_exception"


### PR DESCRIPTION
## Problem

Triaging real MySQL source-creation failures, one user pasted a full connection string into the host field (redacted shape: `mysql://<user>:<password>@<host>:<port>/<db>`). That value fails DNS resolution and the shared host validator returns a "couldn't resolve the host, check the spelling" message that echoes the raw input straight back. Two problems: it points the user at the wrong thing (the scheme and extra parts are the issue, not spelling), and the echoed input reflects the pasted password back at the user.

## Changes

Catch a host containing a scheme separator (`://`) early in `validate_credentials`, before it reaches DNS resolution, and return an actionable message telling the user to enter just the hostname and strip the scheme, credentials, port, and path. The message is a fixed string that never reflects the raw input, so a pasted connection string with an embedded password is not echoed back.

A hostname (or IPv6 literal) can never legitimately contain `://`, so the guard has no false positives.

## How did you test this code?

Added a parameterized case to `TestMySQLSourceValidateCredentials` covering a scheme-only host and a full connection string. It asserts validation fails, host validation and connection are never reached, the raw input is not present in the returned message, and the message points at the hostname. This guards the regression where the guard is dropped and the raw value (possibly credential-bearing) is echoed back with a misleading DNS error. Ran it locally with pytest, passes. I (Claude) did not exercise the source-creation wizard in a browser.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged warehouse source-creation failures and found this host-field-as-URL pattern. Chose to reject with a clear message rather than silently strip the scheme: stripping a full connection string still drops the port and credentials the user pasted into it (they belong in separate fields), so a "just work" strip would fail later anyway, and an explicit message teaches the correct form. Postgres shares the same root cause and is handled in a separate PR. Invoked the `/writing-tests` skill before adding the test.
