### PR TITLE
fix(mongodb): make the no-collections validation error actionable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -68,6 +68,16 @@ _MONGO_CONNECT_FAILED_MESSAGE = (
     "Could not connect to your MongoDB database. Check your connection string and credentials, then try again."
 )
 
+# Connection succeeded but nothing importable came back. This is usually a wrong-database or
+# permission problem rather than a genuinely empty database: a connection string ending in /admin
+# or /test lands on an empty system database, and a user without read access sees no collections.
+_MONGO_NO_COLLECTIONS_MESSAGE = (
+    "PostHog connected to MongoDB but found no collections in the selected database. Check that "
+    "your connection string points at the database that holds your data (a string ending in /admin "
+    "or /test connects to an empty system database) or set the Database name field, and make sure "
+    "your user has read access to that database's collections."
+)
+
 # Substrings pymongo embeds in ServerSelectionTimeoutError when the OS can't resolve the host.
 _DNS_RESOLUTION_FAILURE_MARKERS = (
     "No address associated with hostname",
@@ -209,7 +219,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         try:
             collection_names = get_collection_names(config, team_id=team_id)
             if len(collection_names) == 0:
-                return False, "No collections found in database"
+                return False, _MONGO_NO_COLLECTIONS_MESSAGE
         except OperationFailure as e:
             # pymongo's OperationFailure stringifies the full server response — clusterTime,
             # signature hashes, BSON ids — so str(e) must never be surfaced. Map the stable error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -13,6 +13,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.so
     _MONGO_AUTHENTICATION_FAILED_MESSAGE,
     _MONGO_CONNECT_FAILED_MESSAGE,
     _MONGO_HOST_UNRESOLVED_MESSAGE,
+    _MONGO_NO_COLLECTIONS_MESSAGE,
     _MONGO_NOT_AUTHORIZED_MESSAGE,
     _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
     _MONGO_UNREACHABLE_MESSAGE,
@@ -59,6 +60,18 @@ class TestMongoValidateCredentialsDatabaseName:
 
         assert ok is True
         assert err is None
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_no_collections_returns_actionable_error(self, mock_get_collections):
+        # Connecting to /admin or /test, or a user lacking read access, surfaces zero collections.
+        # That must fail with guidance about the wrong database / missing access, not a terse message.
+        mock_get_collections.return_value = []
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_NO_COLLECTIONS_MESSAGE
 
 
 class TestMongoValidateCredentialsServerSelection:


### PR DESCRIPTION
## Problem

The most common MongoDB source-creation failure was validation reporting that no collections were found, with a terse message that gave the user nothing to act on. In practice this is rarely a genuinely empty database. It is usually one of two things:

- The connection string points at the wrong database. A string ending in `/admin` or `/test` lands on an empty system database (their user collections are all system-prefixed and filtered out), so validation sees zero collections even though the cluster has data elsewhere.
- The user lacks read access. Collection listing is filtered to what the user is authorized to read, so a user without a read role on the target database sees an empty list.

Either way the old message did not hint at the cause, so the user had no next step.

## Changes

Replace the terse "no collections" message with actionable guidance: check that the connection string (or the Database name field) points at the database that holds your data, note that `/admin` and `/test` are empty system databases, and make sure the user has read access to that database's collections.

No behavior change beyond the message. The empty-collections case still fails validation.

## How did you test this code?

Added a case to `TestMongoValidateCredentialsDatabaseName` that mocks collection listing to return empty and asserts validation fails with the actionable message. This locks in that the empty-collections path stays a failure with guidance, which had no test coverage before. Ran the class locally with pytest, passes. I (Claude) did not exercise the source-creation wizard in a browser.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged real MongoDB source-creation failures. The dominant one was this no-collections case. Traced the listing path and confirmed collections are enumerated with an authorized-only filter, so a wrong system database or a missing read role both surface as an empty list with no distinguishing signal. Kept the fix to the message rather than changing the listing behavior (e.g. retrying without the authorization filter), since that would risk surfacing collections the user cannot actually read and would change sync behavior. Invoked the `/writing-tests` skill before adding the test.
