### PR TITLE
fix(ci): post stamphog non-approve verdicts as one sticky comment

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -90,6 +90,9 @@ jobs:
                   # unlike GitHub App bot approvals which show author_association NONE.
                   GH_TOKEN_APPROVE: ${{ github.token }}
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  # Derived from the token step so the sticky-comment author
+                  # filter tracks an app rename instead of failing silent.
+                  BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
               run: |
                   PR=${{ github.event.pull_request.number }}
                   REPO=${{ github.repository }}
@@ -119,42 +122,77 @@ jobs:
                     # denial (e.g. the size gate) the refusals pile up — one PR
                     # collected 60+ near-identical stamphog reviews.
                     MARKER='<!-- stamphog-sticky-review -->'
-                    if [ -n "$REASONING" ]; then
-                      HEADLINE="stamphog reviewed \`${REVIEWED_SHA:-unknown}\` — verdict: **$VERDICT**"
-                      DETAIL="$REASONING"
-                    else
-                      HEADLINE="stamphog review failed before producing a verdict"
-                      DETAIL="Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry."
-                    fi
+                    RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-                      --jq "[.[] | select(.body | contains(\"$MARKER\"))][0] // empty")
+                    # Author + leading-marker filter: on a public repo anyone can
+                    # post a comment containing the marker; without the filter the
+                    # bot would PATCH (clobber) a third-party comment. Slurp so the
+                    # jq runs once over all pages — per-page --jq could emit one
+                    # object per page. The || guard keeps a transient lookup
+                    # failure from aborting the step before the label strip below
+                    # (it degrades to posting a fresh comment instead).
+                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp \
+                      --jq "[.[][] | select(.user.login == \"$BOT_LOGIN\" and (.body | startswith(\"$MARKER\")))][0] // empty" \
+                      || echo "")
                     COMMENT_ID=""
+                    EXISTING_BODY=""
                     PREV_COUNT=0
                     if [ -n "$EXISTING" ]; then
                       COMMENT_ID=$(jq -r '.id' <<<"$EXISTING")
-                      PREV_COUNT=$(jq -r '.body' <<<"$EXISTING" | sed -n 's/.*stamphog-review-count:\([0-9][0-9]*\).*/\1/p' | head -n1)
+                      EXISTING_BODY=$(jq -r '.body' <<<"$EXISTING")
+                      PREV_COUNT=$(jq -r '.body | (match("stamphog-review-count:([0-9]+)").captures[0].string // "0")' <<<"$EXISTING")
                       PREV_COUNT=${PREV_COUNT:-0}
                     fi
-                    COUNT=$((PREV_COUNT + 1))
 
-                    {
-                      echo "$MARKER"
-                      echo "<!-- stamphog-review-count:$COUNT -->"
-                      echo "> [!NOTE]"
-                      echo "> 🤖 $HEADLINE"
-                      echo
-                      echo "$DETAIL"
-                      if [ "$PREV_COUNT" -gt 0 ]; then
+                    # The append path requires an actual verdict in the prior body —
+                    # a crash-only prior comment goes through the rebuild branch so
+                    # it can't end up claiming "the verdict above" over no verdict.
+                    if [ -z "$REASONING" ] && [ -n "$COMMENT_ID" ] \
+                      && grep -q 'verdict: \*\*' <<<"$EXISTING_BODY"; then
+                      # Verdictless crash with a prior verdict on record: append the
+                      # failure note below it rather than clobbering the reasoning
+                      # the author still needs to act on. The anchored grep dedups
+                      # only the note itself, never verdict reasoning that happens
+                      # to mention review failures.
+                      { grep -v '^> ⚠️ A later review run failed' <<<"$EXISTING_BODY" || true; } > /tmp/stamphog-comment.md
+                      {
                         echo
-                        echo "_Updated in place — this replaces $PREV_COUNT earlier stamphog review(s) on this PR._"
+                        echo "> ⚠️ A later review run failed before producing a verdict — check the [workflow run]($RUN_URL). The verdict above is from an earlier run."
+                      } >> /tmp/stamphog-comment.md
+                    else
+                      COUNT=$((PREV_COUNT + 1))
+                      if [ -n "$REASONING" ]; then
+                        HEADLINE="stamphog reviewed \`${REVIEWED_SHA:-unknown}\` — verdict: **${VERDICT:-unknown}**"
+                        DETAIL="$REASONING"
+                      else
+                        HEADLINE="stamphog review failed before producing a verdict"
+                        DETAIL="Check the [workflow run]($RUN_URL) and re-apply the label to retry."
                       fi
-                    } > /tmp/stamphog-comment.md
+                      {
+                        echo "$MARKER"
+                        echo "<!-- stamphog-review-count:$COUNT -->"
+                        echo "> [!NOTE]"
+                        echo "> 🤖 $HEADLINE"
+                        echo
+                        echo "$DETAIL"
+                        if [ -n "$COMMENT_ID" ]; then
+                          echo
+                          [ "$PREV_COUNT" -gt 0 ] \
+                            && echo "_Updated in place — this replaces $PREV_COUNT earlier stamphog review(s) on this PR._" \
+                            || echo "_Updated in place from an earlier stamphog review._"
+                        fi
+                      } > /tmp/stamphog-comment.md
+                    fi
 
+                    # A failed PATCH (comment deleted, transient API error) falls
+                    # back to posting fresh, so the only unguarded API call left
+                    # ahead of the label strip is the same single POST the old
+                    # COMMENT-review path had.
                     if [ -n "$COMMENT_ID" ]; then
                       gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" \
-                        -F "body=@/tmp/stamphog-comment.md"
-                    else
+                        -F "body=@/tmp/stamphog-comment.md" || COMMENT_ID=""
+                    fi
+                    if [ -z "$COMMENT_ID" ]; then
                       gh api -X POST "repos/$REPO/issues/$PR/comments" \
                         -F "body=@/tmp/stamphog-comment.md"
                     fi

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -141,7 +141,6 @@ jobs:
                       COMMENT_ID=$(jq -r '.id' <<<"$EXISTING")
                       EXISTING_BODY=$(jq -r '.body' <<<"$EXISTING")
                       PREV_COUNT=$(jq -r '.body | (match("stamphog-review-count:([0-9]+)").captures[0].string // "0")' <<<"$EXISTING")
-                      PREV_COUNT=${PREV_COUNT:-0}
                     fi
 
                     # The append path requires an actual verdict in the prior body —

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -160,11 +160,14 @@ jobs:
                         echo "> ⚠️ A later review run failed before producing a verdict — check the [workflow run]($RUN_URL). The verdict above is from an earlier run."
                       } >> /tmp/stamphog-comment.md
                     else
-                      COUNT=$((PREV_COUNT + 1))
+                      # The counter tracks verdicts only — a crash rebuild keeps
+                      # the previous count so repeated failures don't inflate it.
                       if [ -n "$REASONING" ]; then
+                        COUNT=$((PREV_COUNT + 1))
                         HEADLINE="stamphog reviewed \`${REVIEWED_SHA:-unknown}\` — verdict: **${VERDICT:-unknown}**"
                         DETAIL="$REASONING"
                       else
+                        COUNT=$PREV_COUNT
                         HEADLINE="stamphog review failed before producing a verdict"
                         DETAIL="Check the [workflow run]($RUN_URL) and re-apply the label to retry."
                       fi

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -111,16 +111,53 @@ jobs:
                       "${SHA_ARGS[@]}" \
                       -f event=APPROVE \
                       -f body="$REASONING"
-                  elif [ -n "$REASONING" ]; then
-                    gh api \
-                      -X POST "repos/$REPO/pulls/$PR/reviews" \
-                      "${SHA_ARGS[@]}" \
-                      -f event=COMMENT \
-                      -f body="$REASONING"
                   else
-                    gh pr comment "$PR" \
-                      --body "Review agent failed — check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry." \
-                      --repo "$REPO"
+                    # Non-approve verdicts share ONE sticky comment, updated in
+                    # place, instead of a fresh COMMENT review per run. Review
+                    # bodies can't be minimized or deleted, so when an automation
+                    # loop keeps re-applying the label against a deterministic
+                    # denial (e.g. the size gate) the refusals pile up — one PR
+                    # collected 60+ near-identical stamphog reviews.
+                    MARKER='<!-- stamphog-sticky-review -->'
+                    if [ -n "$REASONING" ]; then
+                      HEADLINE="stamphog reviewed \`${REVIEWED_SHA:-unknown}\` — verdict: **$VERDICT**"
+                      DETAIL="$REASONING"
+                    else
+                      HEADLINE="stamphog review failed before producing a verdict"
+                      DETAIL="Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry."
+                    fi
+
+                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                      --jq "[.[] | select(.body | contains(\"$MARKER\"))][0] // empty")
+                    COMMENT_ID=""
+                    PREV_COUNT=0
+                    if [ -n "$EXISTING" ]; then
+                      COMMENT_ID=$(jq -r '.id' <<<"$EXISTING")
+                      PREV_COUNT=$(jq -r '.body' <<<"$EXISTING" | sed -n 's/.*stamphog-review-count:\([0-9][0-9]*\).*/\1/p' | head -n1)
+                      PREV_COUNT=${PREV_COUNT:-0}
+                    fi
+                    COUNT=$((PREV_COUNT + 1))
+
+                    {
+                      echo "$MARKER"
+                      echo "<!-- stamphog-review-count:$COUNT -->"
+                      echo "> [!NOTE]"
+                      echo "> 🤖 $HEADLINE"
+                      echo
+                      echo "$DETAIL"
+                      if [ "$PREV_COUNT" -gt 0 ]; then
+                        echo
+                        echo "_Updated in place — this replaces $PREV_COUNT earlier stamphog review(s) on this PR._"
+                      fi
+                    } > /tmp/stamphog-comment.md
+
+                    if [ -n "$COMMENT_ID" ]; then
+                      gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" \
+                        -F "body=@/tmp/stamphog-comment.md"
+                    else
+                      gh api -X POST "repos/$REPO/issues/$PR/comments" \
+                        -F "body=@/tmp/stamphog-comment.md"
+                    fi
                   fi
 
                   # Only the two substantive verdicts strip the label — a

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -125,7 +125,7 @@ Final verdict → GitHub review (approve) or sticky comment (everything else)
 
 The bot never posts request-changes.
 Approvals are posted as real PR reviews (they must count toward branch protection).
-Every other verdict (REFUSE, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter noting how many earlier stamphog reviews it replaces — repeated refusals don't stack up as separate review comments on the PR.
+Every other verdict (REFUSED, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter of how many verdicts the comment has carried (failure notes append without bumping it) — repeated refusals don't stack up as separate review comments on the PR.
 
 ## Tiers
 

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -120,10 +120,12 @@ LLM Review
   - Gates are authoritative — LLM can tighten but never loosen
   │
   ▼
-Final verdict → GitHub review (approve or comment)
+Final verdict → GitHub review (approve) or sticky comment (everything else)
 ```
 
-The bot never posts request-changes — only approves or comments.
+The bot never posts request-changes.
+Approvals are posted as real PR reviews (they must count toward branch protection).
+Every other verdict (REFUSE, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter noting how many earlier stamphog reviews it replaces — repeated refusals don't stack up as separate review comments on the PR.
 
 ## Tiers
 


### PR DESCRIPTION
## Problem

When stamphog refuses a PR, the workflow posts the refusal as a new COMMENT review. There's no dedup, so a PR that keeps re-triggering the review against a deterministic denial piles up near-identical refusals. PR #68191 collected 60+ of them: an automation kept re-applying the `stamphog` label every ~15 minutes, the size gate (883L/16F vs the 500L/20F ceiling) denied every run, and each run added another review. Review bodies can't be minimized, dismissed (COMMENTED state), or edited by anyone but the author, so the noise is permanent once posted.

## Changes

- Approvals are unchanged: still posted as real PR reviews via `GITHUB_TOKEN`, since they must count toward branch protection.
- Every other outcome (REFUSED, ESCALATE, WAIT, ERROR, and the crash fallback that previously used `gh pr comment`) now upserts a single sticky issue comment, found via a hidden `<!-- stamphog-sticky-review -->` marker and updated in place with PATCH.
- The comment carries a run counter (`<!-- stamphog-review-count:N -->`) and, from the second run on, a footer noting how many earlier stamphog reviews it replaces.
- Updated `tools/pr-approval-agent/README.md` to describe the new posting behavior.

Example rendered body:

> [!NOTE]
> 🤖 stamphog reviewed `abc1234` — verdict: **REFUSED**

Gates denied this PR for exceeding the size ceiling.

_Updated in place — this replaces 7 earlier stamphog review(s) on this PR._

## How did you test this code?

- Validated the workflow YAML parses and extracted the edited `Post review` step through `bash -n` for syntax.
- Smoke-tested the sticky-comment shell logic in isolation (marker lookup, counter parsing from an existing body, first-run vs update paths, rendered markdown output).
- `hogli ci:preflight --fix` passes (workflow-lint, staleness).
- Not exercised against a live PR; the first real refusal after merge is the end-to-end check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Covered in this PR: `tools/pr-approval-agent/README.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude via PostHog Code) diagnosed the comment pile-up on PR #68191 by reading the review timeline and label history, traced it to the no-dedup COMMENT-review posting in `pr-approval-agent.yml`, and implemented the sticky-comment upsert. Considered minimizing or dismissing old refusal reviews instead, but GitHub doesn't allow either for COMMENTED-state reviews, so the fix is forward-looking only. Kept the logic inline in the workflow step to match the existing posting code rather than adding a new script.
