### PR TITLE
fix(clickhouse): retry transient egress-proxy gateway drops in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -104,6 +104,14 @@ _TRANSIENT_CONNECT_DROP_SUBSTRINGS = (
     "EOF occurred in violation of protocol",
     "Connection reset by peer",
     "Connection aborted",
+    # The egress proxy answered our CONNECT with a transient gateway status
+    # (`http.client` raises `OSError("Tunnel connection failed: <code> ...")`).
+    # 502/503/504 are the proxy or its upstream being briefly unreachable or
+    # overloaded, so a fresh attempt recovers. We match only these gateway
+    # codes, not deterministic proxy responses like 407 (auth required).
+    "Tunnel connection failed: 502",
+    "Tunnel connection failed: 503",
+    "Tunnel connection failed: 504",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -680,6 +680,13 @@ class TestIsTransientConnectDrop:
             "EOF occurred in violation of protocol",
             "Connection reset by peer",
             "('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))",
+            # The exact wrapped message that reached error tracking: the egress proxy
+            # returned a 502 while opening the CONNECT tunnel to a ClickHouse host.
+            "Error HTTPSConnectionPool(host='h', port=8443): Max retries exceeded with url: /? "
+            "(Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: "
+            "502 Bad gateway'))) executing HTTP request attempt 1",
+            "Tunnel connection failed: 503 Service Unavailable",
+            "Tunnel connection failed: 504 Gateway Timeout",
         ],
     )
     def test_matches_transient_drops(self, message):
@@ -692,6 +699,8 @@ class TestIsTransientConnectDrop:
             "[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2657)",
             "Code: 516. DB::Exception: Authentication failed",
             "HTTPDriver for https://host:8443 returned response code 404",
+            # A proxy 407 is a deterministic auth-config failure, not a transient gateway blip.
+            "Tunnel connection failed: 407 Proxy Authentication Required",
         ],
     )
     def test_does_not_match_deterministic_failures(self, message):


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse import source hit a burst of `OSError: Tunnel connection failed: 502 Bad gateway` errors surfaced by error tracking. The failures came from our egress proxy answering a CONNECT tunnel with a `502 Bad gateway` while opening a connection to the customer's ClickHouse host, wrapped up the stack as `ProxyError -> MaxRetryError -> OperationalError -> ClickHouseConnectionError` and raised out of `_get_client` during schema discovery (`get_schemas`).

The shape of the burst (a cluster of occurrences across several sources inside a short window, then gone) points squarely at a transient proxy hiccup, not anything the customer configured. Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f2c3d-b7cd-75c0-bd90-2fc289c52cdf

## Changes

`_get_client` already re-opens the connection in-process on transient connect-time drops (TLS EOF, connection reset, connection aborted). A proxy CONNECT tunnel that comes back with a `502`/`503`/`504` is the same category of transient failure, but it wasn't in the allowlist, so a brief proxy blip failed the whole discovery/sync activity instead of being retried in place.

I added the three proxy gateway codes to `_TRANSIENT_CONNECT_DROP_SUBSTRINGS`:

- `Tunnel connection failed: 502`
- `Tunnel connection failed: 503`
- `Tunnel connection failed: 504`

We match only these gateway codes, not deterministic proxy responses like `407 Proxy Authentication Required`. This is deliberately scoped to the in-process connect retry. The error stays retryable everywhere else too - it is **not** added to `NonRetryableErrors`, consistent with the existing design where transient gateway codes stay retryable.

## How did you test this code?

Automated only, no manual run.

- Extended `TestIsTransientConnectDrop::test_matches_transient_drops` with the exact wrapped proxy-502 message plus a 503 and 504 form - locks in that `_get_client` now retries these gateway drops. Without the new substrings these cases fail.
- Extended `TestIsTransientConnectDrop::test_does_not_match_deterministic_failures` with a `407 Proxy Authentication Required` case - guards against widening the match to every `Tunnel connection failed` (a deterministic proxy-auth failure must not be retried forever).
- Ran the `TestIsTransientConnectDrop`, `TestGetClientTransientRetry`, and the retryable/non-retryable classification tests locally: all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue by Claude. I pulled the issue's stack trace and sampled events, confirmed the real failure originates in `clickhouse.py::_get_client` (the top in-app frame), and classified it as transient egress-proxy infrastructure rather than a user/upstream error or a code bug.

Decisions:
- Rejected adding it to `NonRetryableErrors`: a 502/503/504 from the proxy is transient and can recover on retry, and the source already documents keeping gateway codes retryable (only proxy 404 is treated as permanent).
- Chose to extend the existing in-process connect-retry allowlist rather than change any global/Temporal retry policy, so the fix stays scoped to absorbing brief proxy blips at connect time.
- Matched on the stable `Tunnel connection failed: 50x` prefix (no host/URL/port), and excluded 407 so we don't retry a deterministic proxy-auth misconfiguration.

Invoked the `/writing-tests` skill before touching the test file.
