### PR TITLE
perf(mcp-analytics): memoize session preview rows to cut re-render churn

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
@@ -239,6 +239,9 @@ function SessionsListPanel(): JSX.Element {
     )
 }
 
+// memo relies on stable identities: kea replaces the sessions array wholesale on load
+// (so unchanged rows keep their reference) and selectSession is a stable bound action.
+// A selector that maps or clones sessions would silently defeat this.
 const MCPSessionPreview = memo(function MCPSessionPreview({
     session,
     isActive,

--- a/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useRef } from 'react'
+import { memo, useRef } from 'react'
 
 import { IconBolt, IconClock, IconRefresh, IconSearch, IconSparkles } from '@posthog/icons'
 import {
@@ -134,8 +134,10 @@ function SessionDetailPanel({ className }: { className?: string }): JSX.Element 
 }
 
 function SessionsListPanel(): JSX.Element {
-    const { setFilters, setDateFilter, loadSessions, loadMoreSessions, setSorting } = useActions(mcpSessionsLogic)
-    const { sessions, sessionsLoading, filters, dateFilter, sorting, hasNext } = useValues(mcpSessionsLogic)
+    const { setFilters, setDateFilter, loadSessions, loadMoreSessions, setSorting, selectSession } =
+        useActions(mcpSessionsLogic)
+    const { sessions, sessionsLoading, filters, dateFilter, sorting, hasNext, selectedSessionId } =
+        useValues(mcpSessionsLogic)
 
     return (
         <div className="flex flex-col h-full min-h-0 overflow-hidden rounded border border-primary bg-surface-primary">
@@ -209,7 +211,11 @@ function SessionsListPanel(): JSX.Element {
                         <ul className="flex flex-col list-none pl-0 m-0 divide-y divide-primary">
                             {sessions.map((session) => (
                                 <li key={session.session_id}>
-                                    <MCPSessionPreview session={session} />
+                                    <MCPSessionPreview
+                                        session={session}
+                                        isActive={session.session_id === selectedSessionId}
+                                        onSelect={selectSession}
+                                    />
                                 </li>
                             ))}
                         </ul>
@@ -233,11 +239,15 @@ function SessionsListPanel(): JSX.Element {
     )
 }
 
-function MCPSessionPreview({ session }: { session: MCPSessionApi }): JSX.Element {
-    const { selectSession } = useActions(mcpSessionsLogic)
-    const { selectedSessionId } = useValues(mcpSessionsLogic)
-    const isActive = session.session_id === selectedSessionId
-
+const MCPSessionPreview = memo(function MCPSessionPreview({
+    session,
+    isActive,
+    onSelect,
+}: {
+    session: MCPSessionApi
+    isActive: boolean
+    onSelect: (sessionId: string) => void
+}): JSX.Element {
     const personLabel = session.person_name || session.person_email
     const durationMs = sessionDurationMs(session.session_start, session.session_end)
 
@@ -246,7 +256,7 @@ function MCPSessionPreview({ session }: { session: MCPSessionApi }): JSX.Element
             type="button"
             data-attr="mcp-session-preview"
             aria-pressed={isActive}
-            onClick={() => selectSession(session.session_id)}
+            onClick={() => onSelect(session.session_id)}
             className={cn(
                 'w-full text-left cursor-pointer border-l-2 px-2 py-1.5 text-xs flex flex-col gap-1',
                 isActive
@@ -284,4 +294,4 @@ function MCPSessionPreview({ session }: { session: MCPSessionApi }): JSX.Element
             </div>
         </button>
     )
-}
+})


### PR DESCRIPTION
## Problem

The detached-element telemetry flags `/mcp-analytics/sessions` as a new, growing memory-leak source. It has by far the highest per-scan detached count of any path (avg ~9,200 detached elements per scan). Digging in, the sessions list is a re-render amplifier: every row (`MCPSessionPreview`) subscribes to `mcpSessionsLogic` for `selectedSessionId`, so any store change (selecting a session, a loading toggle, a filter or search keystroke) re-renders all rows at once. The list grows past 150 rows via load-more, so this fires on every keystroke.

This is one contributor to the churn on that scene. It is not the whole story (see agent context), but it is a clean, low-risk reduction.

## Changes

- Lift the `selectedSessionId` read out of each row and into the parent `SessionsListPanel`.
- Pass `isActive` plus the stable `selectSession` kea action down to `MCPSessionPreview` as props.
- Wrap `MCPSessionPreview` in `React.memo`.

Net effect: a selection change now re-renders only the two rows whose `isActive` flips, instead of the entire list. No behavior or visual change. The hover timezone popover on each row stays.

## How did you test this code?

I (Claude, via PostHog Code) did not run the browser leak-repro loop for this PR. The `__leakHunter` forced-GC scan plus heap retainer trace needs Playwright and memlab MCP against a running stack, which were not connected in this session, so I have no before/after detached-count delta to quote.

What I did run:

- `oxlint` on the changed file: 0 warnings, 0 errors.
- `oxfmt` on the changed file: clean.
- `hogli ci:preflight --fix`: clean, nothing in the diff maps to a known CI failure class.

The remaining local `tsgo` errors on this scene are environmental in this worktree (missing kea typegen `*Type.ts` files and unbuilt quill packages), pre-existing, and unrelated to this change. CI regenerates typegen and builds quill.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this. I (Claude, via PostHog Code) investigated using the `hunt-detached-elements` skill. Flow: pulled the detached-element telemetry via HogQL to confirm and sharpen the report (project 2 `/mcp-analytics/sessions` is the worst path by a wide margin), then read the scene code.

Decisions along the way:

- First hypothesis was the per-row `TZLabel` hover popover, since `LemonDropdown.displayName` is `Dropdown` and that shows up in the telemetry. The obvious small fix was `showPopover={false}` on the list rows, but Paul chose to keep the popover and pursue the teardown instead.
- On inspection, the shared `Popover` teardown is already a clean post-RTG state machine (PR #56254), so there was no react-transition-group teardown bug to swap out there.
- The detached count is a point-in-time reading (~9k in one scan), which reads as several list generations retained at once, i.e. row-subtree retention rather than a transition-lag bug. Paul chose to ship the structural row fix (memoize + narrow the subscription) rather than block on standing up the repro loop.

Follow-up worth doing: run the `__leakHunter` before/after loop on this scene to measure the actual detached-count delta and check for any residual retainer (the per-row 1s `TZLabel` intervals, or Blink Oilpan-lag false positives that clear on forced GC).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
