### PR TITLE
feat(signals): default PR auto-start threshold to P3

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -455,7 +455,7 @@ Per-team singleton config for Signals settings, including the default autonomy p
 Notes:
 
 - Auto-created as a team extension via `register_team_extension_signal`
-- `default_autostart_priority` defaults to `P4` (every report priority auto-starts). The threshold is no longer user-configurable in the inbox UI; everyone runs on this default.
+- `default_autostart_priority` defaults to `P3` (P0-P3 auto-start; P4, the lowest priority, does not). The threshold is no longer user-configurable in the inbox UI; everyone runs on this default.
 - `SignalUserAutonomyConfig.autostart_priority` can still hold a per-user override at the data layer (`null` = use the team default), but there is no UI to set it.
 
 ### `SignalUserAutonomyConfig`

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -294,7 +294,7 @@ async def maybe_autostart_implementation_task(
     assert priority is not None  # narrowed by the `priority is None` skip_reason guard above
 
     team_config = await SignalTeamConfig.objects.filter(team_id=team_id).afirst()
-    team_default_priority = Priority(team_config.default_autostart_priority) if team_config else Priority.P4
+    team_default_priority = Priority(team_config.default_autostart_priority) if team_config else Priority.P3
 
     # A user-triggered auto-start runs as the triggering user; otherwise resolve a trusted
     # (commit-authorship) reviewer. Either way the task's user is never an attacker-named colleague.

--- a/products/signals/backend/migrations/0055_signalteamconfig_default_autostart_priority_p3.py
+++ b/products/signals/backend/migrations/0055_signalteamconfig_default_autostart_priority_p3.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("signals", "0054_alter_signalsourceconfig_source_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="signalteamconfig",
+            name="default_autostart_priority",
+            field=models.CharField(
+                choices=[("P0", "P0"), ("P1", "P1"), ("P2", "P2"), ("P3", "P3"), ("P4", "P4")],
+                default="P3",
+                max_length=2,
+            ),
+        ),
+    ]

--- a/products/signals/backend/migrations/0056_signalteamconfig_backfill_default_autostart_p3.py
+++ b/products/signals/backend/migrations/0056_signalteamconfig_backfill_default_autostart_p3.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def reset_everyone_to_p3_default(apps, schema_editor):
+    """Land everyone on the new P3 auto-start default so P4 reports no longer auto-start.
+
+    The threshold is not user-configurable in the inbox UI, so everyone runs on the team
+    default. That default is now P3, meaning only P0-P3 reports auto-open a PR and P4 (all
+    priorities / lowest) reports stop auto-starting.
+
+    1. Move every team config to P3. There is one row per team, so a single unfiltered UPDATE
+       is cheap. After the previous P4 backfill every row sits at P4; this brings them to P3.
+    2. Clear any per-user override (set ``autostart_priority`` to NULL) so it falls back to the
+       team default of P3. The rest of the row is left intact, so Slack notification settings on
+       the same model are preserved. Users who explicitly opted out delete their whole config
+       row, so they have no row here and stay opted out — this only touches rows that exist.
+    """
+    SignalTeamConfig = apps.get_model("signals", "SignalTeamConfig")
+    SignalTeamConfig.objects.exclude(default_autostart_priority="P3").update(default_autostart_priority="P3")
+
+    SignalUserAutonomyConfig = apps.get_model("signals", "SignalUserAutonomyConfig")
+    SignalUserAutonomyConfig.objects.exclude(autostart_priority__isnull=True).update(autostart_priority=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("signals", "0055_signalteamconfig_default_autostart_priority_p3"),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_everyone_to_p3_default, migrations.RunPython.noop),
+    ]

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0054_alter_signalsourceconfig_source_type
+0056_signalteamconfig_backfill_default_autostart_p3

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -134,7 +134,7 @@ class SignalTeamConfig(UUIDModel):
         on_delete=models.CASCADE,
         related_name="signal_team_config",
     )
-    default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P4)
+    default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P3)
     default_slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
     autostart_base_branches = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/products/signals/backend/test/test_signal_team_config_api.py
+++ b/products/signals/backend/test/test_signal_team_config_api.py
@@ -20,7 +20,7 @@ class TestSignalTeamConfigAPI(APIBaseTest):
         data = response.json()
         assert response.status_code == status.HTTP_200_OK, data
         assert data["default_slack_notification_channel"] is None
-        assert data["default_autostart_priority"] == "P4"
+        assert data["default_autostart_priority"] == "P3"
 
     def test_get_config_lazily_creates_when_no_config_exists(self):
         self.config.delete()
@@ -28,7 +28,7 @@ class TestSignalTeamConfigAPI(APIBaseTest):
         response = self.client.get(self._url())
         data = response.json()
         assert response.status_code == status.HTTP_200_OK, data
-        assert data["default_autostart_priority"] == "P4"
+        assert data["default_autostart_priority"] == "P3"
         assert data["default_slack_notification_channel"] is None
         assert SignalTeamConfig.objects.filter(team=self.team).exists()
 


### PR DESCRIPTION
## Problem

Auto-start currently opens a PR for every actionable report down to P4, the lowest priority. In practice P4 covers issues that are actionable and fixable but not worth the interruption of a PR (third-party ad-script network noise, expected-ENOENT self-reporting, and similar). A new tenant hitting an untriaged backlog can get a wave of low-value P4 PRs on day one, which is a poor first experience.

This lowers the single auto-start threshold from P4 to P3 so P0-P3 still auto-open a PR and P4 no longer does. P4 reports still land in the inbox; they just wait for a human to promote them rather than auto-starting.

## Changes

- `SignalTeamConfig.default_autostart_priority` now defaults to `P3` (was `P4`), and the no-team-config fallback in `auto_start.py` is `P3`.
- New data migration (`0056`) lands everyone on the P3 default:
  - every team config is moved to **P3**;
  - every per-user `autostart_priority` override is **cleared to NULL** so it inherits the team default. Slack settings on the same row are preserved. Users who explicitly opted out (deleted their config row) have no row and stay opted out.

The threshold is still not user-configurable in the inbox UI (that UI was removed previously), so everyone runs on this default. The `autostart_priority` data fields and write endpoints are left intact.

This mirrors the earlier P2 → P4 change (#65263) in the opposite direction, minus the UI removal (already done).

## How did you test this code?

I'm an agent (PostHog Slack app / Claude). I ran:
- `python3 -m py_compile` on the changed backend modules, both new migrations, and the updated test — all compile.
- Verified the migration chain is linear: `0056` → `0055` → `0054`, and `max_migration.txt` points at `0056`.
- Confirmed the existing `test_auto_start.py` parametrizations pass `team_default_priority` explicitly (they exercise the ranking logic, not the no-config fallback), so they remain valid.

I did **not** run the Django test suite or apply the migration against a database (deps not installed in this environment). Updated `test_signal_team_config_api.py` to expect the new `P3` default.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Josh directed this from a Slack thread about tuning which report priorities auto-start PRs. I (the PostHog Slack app, running Claude) found the prior threshold change (#65263, P2 → P4 with a backfill) and copied its shape: an `AlterField` default bump plus a `RunPython` backfill that lands every team config on the new default and clears per-user overrides. Because the threshold UI was already removed in #65263, this PR is backend-only — no frontend changes were needed.

Skills invoked: `/django-migrations` (repo skill) to confirm the migration safety workflow. `signalteamconfig` is a small, one-row-per-team table (not a hot table), and the default change is a Python-only `default=` bump with no DDL, so no locking or `db_default` concerns apply.

Decision on the backfill: I mirrored the reference and forced every team config to P3 uniformly (rather than only moving rows currently at P4), since there's no UI to diverge from the team default and everyone should land on the same value. Clearing user overrides is defensive — they were already NULL'd by the previous backfill.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782999061194709?thread_ts=1782999061.194709&cid=C09SK2PAGKF)*
