### PR TITLE
fix(data-warehouse): guide table naming on self-managed source setup

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/components/SelfManagedSourceForm.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/components/SelfManagedSourceForm.tsx
@@ -81,7 +81,10 @@ export function SelfManagedSourceForm({ onUpdate }: Props): JSX.Element {
                         />
                     )}
                 </LemonField>
-                <div className="mb-4 text-xs text-secondary">This will be the table name used when writing queries</div>
+                <div className="mb-4 text-xs text-secondary">
+                    This will be the table name used when writing queries. Use only letters, numbers, and underscores,
+                    and start with a letter or underscore.
+                </div>
                 <LemonField name="url_pattern" label="Files URL pattern">
                     {({ value = '', onChange }) => (
                         <LemonInput

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
@@ -103,7 +103,9 @@ export const selfManagedSourceLogic = kea<selfManagedSourceLogicType>([
             defaults: { ...NEW_WAREHOUSE_TABLE } as DataWarehouseTable,
             errors: ({ name, url_pattern, credential, format }) => {
                 const HOGQL_TABLE_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
-                if (!HOGQL_TABLE_NAME_REGEX.test(name)) {
+                // Let the empty-name case fall through to the friendlier "Please enter a name." below,
+                // rather than the naming-rules error which only makes sense once something's been typed.
+                if (name && !HOGQL_TABLE_NAME_REGEX.test(name)) {
                     return {
                         name: 'Invalid table name. Table names must start with a letter or underscore and contain only alphanumeric characters or underscores.',
                     }


### PR DESCRIPTION
## Problem

In the data-warehouse new-source wizard, self-managed sources (S3, GCS, Cloudflare R2, Azure) ask for a **Table name**. That field is validated against a HogQL identifier regex (must start with a letter/underscore, only letters/numbers/underscores), but nothing told the user the rules until they submitted and got blocked. Session summaries of real onboarding runs showed users typing an invalid table name, hitting the validation error, then correcting it — friction we can remove by stating the rule up front.

Two smaller issues in the same field:
- With the field empty, the regex check fired first and showed the aggressive "Invalid table name. Table names must start with a letter or underscore…" message rather than a plain "Please enter a name." (the friendlier branch was effectively dead code).

## Changes

- Added an upfront hint under the "Table name" field describing the naming rules, mirroring the wording already used for the managed-source prefix field.
- Guarded the regex check with a truthiness check on `name` so an empty field falls through to the "Please enter a name." message instead of the naming-rules error.

No change to validation strictness or sync behaviour — the accepted set of table names is identical.

## How did you test this code?

Frontend-only copy/validation-ordering change. I (the agent) could not run the JS formatter or typecheck in this environment (no `node_modules`); the edits are small and match the surrounding oxfmt style. No automated tests were added — the change is a copy hint plus reordering a validation branch, and there was no existing test for `selfManagedSourceLogic`'s form errors to extend.

## Docs update

No user-facing docs cover this field.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude Code) while synthesising friction themes from Replay Vision session summaries of the data-warehouse new-source onboarding flow. The observation driving this change was a user who hit a table-name validation error during self-managed object-storage setup and had to correct their input. Chose the minimal, self-contained fix (proactive hint + friendlier empty-field message) over reworking the validation itself. Ruled out a duplicate by scanning open data-warehouse onboarding PRs — none touch the self-managed source form.
