### PR TITLE
fix(insights): hide sample-data placeholder on shared pages

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/sampleDataStateLogic.ts
+++ b/frontend/src/scenes/insights/EmptyStates/sampleDataStateLogic.ts
@@ -2,11 +2,17 @@ import { connect, kea, path, selectors } from 'kea'
 
 import { teamLogic } from 'scenes/teamLogic'
 
+import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
+
 import type { sampleDataStateLogicType } from './sampleDataStateLogicType'
 
 /**
  * Gates the pre-ingestion sample-data placeholder: only projects that never ingested an event see
  * it. The wizard setup status shown on the placeholder comes from `setupWizardStatusLogic`.
+ *
+ * Never shown on shared/exported pages: the viewer there isn't the project owner, the "install
+ * PostHog" guidance is meaningless to them, and rendering it would mount the wizard status logic,
+ * which calls team-scoped APIs an unauthenticated visitor is not allowed to hit.
  */
 export const sampleDataStateLogic = kea<sampleDataStateLogicType>([
     path(['scenes', 'insights', 'EmptyStates', 'sampleDataStateLogic']),
@@ -16,7 +22,8 @@ export const sampleDataStateLogic = kea<sampleDataStateLogicType>([
     selectors({
         shouldShowSampleData: [
             (s) => [s.currentTeam],
-            (currentTeam): boolean => !!currentTeam && !currentTeam.ingested_event && !currentTeam.is_demo,
+            (currentTeam): boolean =>
+                !getCurrentExporterData() && !!currentTeam && !currentTeam.ingested_event && !currentTeam.is_demo,
         ],
     }),
 ])


### PR DESCRIPTION
## Problem

The pre-ingestion sample-data placeholder (#68089) mounts `setupWizardStatusLogic`, which queries the team-scoped tasks API (`/api/projects/:id/tasks/?origin_product=onboarding`). On a shared/exported insight, an unauthenticated viewer fires that request, gets a 403, and trips the shared-mode API-leak guard in `shared-insight-unauthenticated.spec.ts` — flakily, since it only reproduces when the shared insight renders its empty state. Example failure: https://github.com/PostHog/posthog/actions/runs/28707915016/job/85136630689

The placeholder is also semantically wrong there: a logged-out viewer can't act on "install PostHog" guidance.

## Changes

- `shouldShowSampleData` now returns `false` whenever exporter data is present (shared/embedded/exported pages), so `SampleDataState` — and with it `setupWizardStatusLogic` and its tasks API call — never mounts in shared mode.

## How did you test this code?

- `hogli test frontend/src/scenes/insights/EmptyStates/` — 6 passing. No new test: the regression is covered by the existing Playwright shared-mode leak guard, which is the test that caught this.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal empty-state gating.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while babysitting #68248: its Playwright job failed on the shared-mode leak guard with no related changes in that PR; root cause traced to the sample-data placeholder mounting the wizard status logic on shared pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)