### PR TITLE
chore(dev): Limit local otel-collector perf impact

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -792,6 +792,22 @@ services:
             - jaeger
         networks:
             - otel_network
+        # Hard ceiling on the collector's footprint. It tails and parses every
+        # container's logs, so a single container that floods its logs (e.g. a
+        # crash or logging loop) would otherwise let the collector peg many cores
+        # and balloon RAM. The in-process memory_limiter sheds load under
+        # pressure; these bound the blast radius on the host.
+        cpus: 2
+        mem_limit: 2g
+        environment:
+            # Keep Go's GC under the container memory limit so pressure triggers
+            # collection instead of an OOM kill.
+            GOMEMLIMIT: 1750MiB
+        logging:
+            driver: json-file
+            options:
+                max-size: '50m'
+                max-file: '3'
 
     jaeger:
         image: jaegertracing/all-in-one:1.76.0

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -792,16 +792,12 @@ services:
             - jaeger
         networks:
             - otel_network
-        # Hard ceiling on the collector's footprint. It tails and parses every
-        # container's logs, so a single container that floods its logs (e.g. a
-        # crash or logging loop) would otherwise let the collector peg many cores
-        # and balloon RAM. The in-process memory_limiter sheds load under
-        # pressure; these bound the blast radius on the host.
+        # Cap the footprint: the collector parses every container's logs, so one
+        # log-flooding container could otherwise peg many cores and balloon RAM.
         cpus: 2
         mem_limit: 2g
         environment:
-            # Keep Go's GC under the container memory limit so pressure triggers
-            # collection instead of an OOM kill.
+            # Keep Go's GC under mem_limit so pressure triggers collection, not an OOM kill.
             GOMEMLIMIT: 1750MiB
         logging:
             driver: json-file

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -97,9 +97,7 @@ exporters:
         headers:
             # special "local" token is automatically mapped to team_id 1 in dev environments
             authorization: Bearer phc_local
-        # Give up quickly when capture-logs is down (the tracing profile can run
-        # without the logs/metrics ingestion stack) rather than retrying into the
-        # 5 min default and holding the data that whole time.
+        # Give up in 30s (vs the 5 min default) when capture-logs is down.
         retry_on_failure:
             max_elapsed_time: 30s
     otlphttp/logs:
@@ -123,10 +121,8 @@ exporters:
             max_elapsed_time: 30s
 
 processors:
-    # Hard-cap the collector's memory and push backpressure onto the receivers
-    # (incl. the container filelog tailer) when an exporter's downstream is
-    # unreachable. Without this the in-memory queue grows without bound: an
-    # absent capture-logs made the collector balloon to multiple GB of RAM.
+    # Shed load instead of buffering to multiple GB of RAM when a downstream
+    # (e.g. capture-logs) is unreachable.
     memory_limiter:
         check_interval: 1s
         limit_mib: 512

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -97,10 +97,9 @@ exporters:
         headers:
             # special "local" token is automatically mapped to team_id 1 in dev environments
             authorization: Bearer phc_local
-        # Drop data quickly when capture-logs is down (the tracing profile can run
-        # without the logs/metrics ingestion stack) instead of buffering unbounded.
-        sending_queue:
-            queue_size: 1000
+        # Give up quickly when capture-logs is down (the tracing profile can run
+        # without the logs/metrics ingestion stack) rather than retrying into the
+        # 5 min default and holding the data that whole time.
         retry_on_failure:
             max_elapsed_time: 30s
     otlphttp/logs:
@@ -111,8 +110,6 @@ exporters:
         headers:
             # special "local" token is automatically mapped to team_id 1 in dev environments
             authorization: Bearer phc_local
-        sending_queue:
-            queue_size: 1000
         retry_on_failure:
             max_elapsed_time: 30s
     otlphttp/metrics:
@@ -122,8 +119,6 @@ exporters:
             insecure: true
         headers:
             authorization: Bearer phc_local
-        sending_queue:
-            queue_size: 1000
         retry_on_failure:
             max_elapsed_time: 30s
 

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -97,6 +97,12 @@ exporters:
         headers:
             # special "local" token is automatically mapped to team_id 1 in dev environments
             authorization: Bearer phc_local
+        # Drop data quickly when capture-logs is down (the tracing profile can run
+        # without the logs/metrics ingestion stack) instead of buffering unbounded.
+        sending_queue:
+            queue_size: 1000
+        retry_on_failure:
+            max_elapsed_time: 30s
     otlphttp/logs:
         endpoint: 'http://host.docker.internal:4320'
         compression: none
@@ -105,6 +111,10 @@ exporters:
         headers:
             # special "local" token is automatically mapped to team_id 1 in dev environments
             authorization: Bearer phc_local
+        sending_queue:
+            queue_size: 1000
+        retry_on_failure:
+            max_elapsed_time: 30s
     otlphttp/metrics:
         endpoint: 'http://host.docker.internal:4320'
         compression: none
@@ -112,26 +122,39 @@ exporters:
             insecure: true
         headers:
             authorization: Bearer phc_local
+        sending_queue:
+            queue_size: 1000
+        retry_on_failure:
+            max_elapsed_time: 30s
 
 processors:
+    # Hard-cap the collector's memory and push backpressure onto the receivers
+    # (incl. the container filelog tailer) when an exporter's downstream is
+    # unreachable. Without this the in-memory queue grows without bound: an
+    # absent capture-logs made the collector balloon to multiple GB of RAM.
+    memory_limiter:
+        check_interval: 1s
+        limit_mib: 512
+        spike_limit_mib: 128
     batch:
 
 service:
     pipelines:
         traces:
             receivers: [otlp]
-            processors: [batch]
+            processors: [memory_limiter, batch]
             exporters: [otlp, otlphttp]
         logs:
             exporters:
                 - otlphttp/logs
             processors:
+                - memory_limiter
                 - batch
             receivers:
                 - otlp
                 - receiver_creator
         metrics:
             receivers: [otlp, prometheus]
-            processors: [batch]
+            processors: [memory_limiter, batch]
             exporters: [otlphttp/metrics]
     extensions: [docker_observer, health_check, zpages] # Enabling the declared extensions


### PR DESCRIPTION
## Problem

Two things in the dev OTel collector (`otel-collector-config.dev.yam)` made it a CPU/RAM hog:

1. You can enable the tracing profile just to get Jaeger, without running the separate logs/metrics ingestion stack that provides `capture-logs`. When that downstream is absent, the collector retried forever. Have seen the collector sit at ~6.4 GB RSS looping on `no more retries left. Dropping data`.
2. It had no container resource limits. In the issue that had me investigate this, a ClickHouse container spewed ~100k log lines/sec (due to a broken file handle on its own error log, fixed by restarting the container), and the collector took that to… ~400% CPU. ClickHouse itself stayed capped at ~120% because it already has `cpus`/`mem_limit` in dev.

## Changes

As summarized by Claude:

- Add a `memory_limiter` processor (512 MiB soft, 128 MiB spike) as the first processor in every pipeline, so the collector sheds load instead of buffering without bound.
- Bound `sending_queue` (`queue_size: 1000`) and cap `retry_on_failure` (`max_elapsed_time: 30s`) on the three `capture-logs` exporters, so an unreachable downstream drops data quickly.
- Add `cpus: 2` and `mem_limit: 2g` to the base `otel-collector` service, plus `GOMEMLIMIT: 1750MiB` so Go's GC runs before the cgroup OOM-kills, plus json-file log rotation. This matches the `cpus`/`mem_limit`/rotation the ClickHouse dev service already has. The in-process limiter sheds load; this bounds the absolute blast radius on the host.