### PR TITLE
feat(heatmaps): split clickmap settings into their own menu

### DIFF
--- a/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
+++ b/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
@@ -1,7 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconGear, IconLaptop, IconPhone, IconTabletLandscape, IconTabletPortrait } from '@posthog/icons'
+import {
+    IconCursorClick,
+    IconGear,
+    IconLaptop,
+    IconPhone,
+    IconTabletLandscape,
+    IconTabletPortrait,
+} from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -130,6 +137,7 @@ export function FilterPanel({
     onClickmapEnabledChange?: (enabled: boolean) => void
 }): JSX.Element {
     const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+    const [isClickmapSettingsOpen, setIsClickmapSettingsOpen] = useState(false)
     const {
         heatmapFilters,
         heatmapColorPalette,
@@ -223,34 +231,6 @@ export function FilterPanel({
                                             />
                                         </SectionSetting>
                                     )}
-                                    {clickmapEnabled !== undefined && onClickmapEnabledChange && (
-                                        <SectionSetting
-                                            title="Clickmap"
-                                            info="Overlay click counts on the elements users actually clicked"
-                                        >
-                                            <LemonSwitch
-                                                checked={clickmapEnabled}
-                                                onChange={onClickmapEnabledChange}
-                                                label="Show clickmap"
-                                                size="small"
-                                            />
-                                        </SectionSetting>
-                                    )}
-                                    <SectionSetting
-                                        title="Internal and test users filter"
-                                        info="Filter out internal and test users"
-                                    >
-                                        <TestAccountFilter
-                                            size="small"
-                                            filters={{ filter_test_accounts: commonFilters?.filter_test_accounts }}
-                                            onChange={(value) => {
-                                                setCommonFilters?.({
-                                                    ...commonFilters,
-                                                    filter_test_accounts: value.filter_test_accounts,
-                                                })
-                                            }}
-                                        />
-                                    </SectionSetting>
                                 </div>
                             }
                             visible={isSettingsOpen}
@@ -270,6 +250,53 @@ export function FilterPanel({
                                 Heatmap settings
                             </LemonButton>
                         </Popover>
+                    </div>
+                    {clickmapEnabled !== undefined && onClickmapEnabledChange && (
+                        <div className="mt-2 md:mt-0">
+                            <Popover
+                                overlay={
+                                    <div className="p-2 w-80 deprecated-space-y-2">
+                                        <LemonSwitch
+                                            checked={clickmapEnabled}
+                                            onChange={onClickmapEnabledChange}
+                                            label="Show clickmap"
+                                            size="small"
+                                        />
+                                        <div className="text-xs text-muted">
+                                            Overlay click counts on the elements users actually clicked.
+                                        </div>
+                                    </div>
+                                }
+                                visible={isClickmapSettingsOpen}
+                                onClickOutside={() => {
+                                    setIsClickmapSettingsOpen(false)
+                                }}
+                                placement="bottom"
+                            >
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    onClick={() => setIsClickmapSettingsOpen(!isClickmapSettingsOpen)}
+                                    icon={<IconCursorClick />}
+                                    tooltip="Clickmap settings"
+                                    data-attr="clickmap-settings"
+                                >
+                                    Clickmap settings
+                                </LemonButton>
+                            </Popover>
+                        </div>
+                    )}
+                    <div className="mt-2 md:mt-0">
+                        <TestAccountFilter
+                            size="small"
+                            filters={{ filter_test_accounts: commonFilters?.filter_test_accounts }}
+                            onChange={(value) => {
+                                setCommonFilters?.({
+                                    ...commonFilters,
+                                    filter_test_accounts: value.filter_test_accounts,
+                                })
+                            }}
+                        />
                     </div>
                 </div>
                 <ViewportChooser />


### PR DESCRIPTION
## Problem

The heatmap settings popover had become a grab-bag: heatmap rendering options, the capture-method choice, the clickmap toggle, and the internal-and-test-users filter all lived in one menu, and the frequently-used test-users switch required opening it every time.

## Changes

- The clickmap toggle moves to its own "Clickmap settings" popover, next to "Heatmap settings" in the filter bar (rendered only where the clickmap is available, i.e. recording mode with the `heatmaps-recording-clickmap` flag).
- The internal-and-test-users switch moves out of the menu entirely, inline in the filter bar via the standard `TestAccountFilter` component (which brings the settings-page link with it).
- Heatmap settings keeps the rendering options and the capture-method choice.

Stacked on #68418 (both touch `FilterPanel.tsx`).

## How did you test this code?

Pure layout restructure of existing wired controls — no logic changes, all 12 heatmaps jest tests pass. Visual regression snapshots for the heatmap scenes will change intentionally; the recording-mode story covers the new clickmap settings button placement. No new tests: there's no behavior here a test could pin beyond what the stories snapshot.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) from direct dogfooding feedback on the menu layout. The clickmap section could have stayed a bar-level switch instead of a popover, but a dedicated settings menu was chosen to give future clickmap options (event-type includes, count thresholds) a home without another restructure.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
