### PR TITLE
fix(data-warehouse): require the API key when connecting Stripe by key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -158,7 +158,7 @@ class StripeSource(
                                             name="stripe_secret_key",
                                             label="API key",
                                             type=SourceFieldInputConfigType.PASSWORD,
-                                            required=False,
+                                            required=True,
                                             placeholder="rk_live_...",
                                             caption=f"Create a [restricted API key]({STRIPE_API_KEYS_URL}) with the pre-defined permissions",
                                             secret=True,


### PR DESCRIPTION
## Problem

When onboarding Stripe as a data warehouse source with a restricted API key, the wizard let users click Next with the API key field left blank. Validation only ran later when the sync tried to authenticate, so the failure surfaced far from where it was caused. Session recordings of real onboarding runs showed users proceeding past this step empty-handed and then having to backtrack once the connection errored.

## Changes

The `stripe_secret_key` field (shown when "Restricted API key" auth is selected) was marked `required=False`. This flips it to `required=True`, so the wizard validates it inline on submit like it already does for the Postgres connection fields and for the API key on RevenueCat, Cloudflare, and Attio.

The nested-select validation path only checks the fields under the currently selected auth option, so the OAuth path is unaffected. Editing an existing source still allows a blank key, because the update flow passes `allowBlankSensitiveFields` and skips blank secret fields.

## How did you test this code?

I (Claude) verified the frontend validation wiring by reading the wizard logic: `buildKeaFormDefaultFromSourceDetails` seeds the `auth_method` selection to its `api_key` default, and `getErrorsForFields` walks into the selected option's fields and errors on empty required fields. So an empty key now produces an inline error on Next instead of a late backend auth failure. Ran `ruff check` on the touched file (passes). I did not run the app manually.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code as part of a pass over data-warehouse new-source onboarding friction observed in session recordings. I checked that RevenueCat, Cloudflare, and Attio already mark their key field required, confirming Stripe was the odd one out rather than an intentional pattern, and confirmed the edit path still tolerates a blank secret before changing the flag. No skills were required for this one-line config change.
