### PR TITLE
fix(data-warehouse): require the Stripe account when connecting by OAuth

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -175,7 +175,7 @@ class StripeSource(
                                         SourceFieldOauthConfig(
                                             name="stripe_integration_id",
                                             label="Stripe account",
-                                            required=False,
+                                            required=True,
                                             kind="stripe",
                                         ),
                                     ],


### PR DESCRIPTION
## Problem

When onboarding Stripe as a data warehouse source via OAuth, the wizard let users click Next without linking a Stripe account. The "Stripe account" OAuth field was marked `required=False`, so nothing gated submit on a completed connection. Validation only caught the gap later when credential validation looked up the integration and failed, surfacing the error far from where it was caused. This was the most common Stripe source-creation failure.

This mirrors the restricted-API-key path, which was just fixed the same way in #68427 (that PR explicitly left the OAuth path untouched).

## Changes

Flip the `stripe_integration_id` OAuth field to `required=True`, so the wizard validates it inline on submit like the sibling API-key field and the Google Ads OAuth field already do. The nested-select validation path only checks the fields under the currently selected auth option, so the API-key path is unaffected. The backend still translates a missing integration id into reconnect guidance as a safety net for any path that reaches it.

## How did you test this code?

Ran the existing Stripe source tests covering the backend missing-config translation (`test_validate_credentials_missing_config_returns_friendly_message`) locally with pytest, both pass. That backend safety net is unchanged. I (Claude) did not exercise the source-creation wizard in a browser. No test was added for the one-line config flag flip, matching how the sibling API-key change (#68427) was handled and avoiding a change-detector assertion on a config value.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code while triaging real Stripe new-source onboarding failures. The dominant one was OAuth selected but no account linked, producing a late "integration ID is not configured" validation error. I confirmed the sibling restricted-API-key field was fixed identically in #68427, that the Google Ads OAuth field already sets `required=True`, and that the nested-select validation only walks the selected auth option's fields, so flipping this flag is safe and scoped to the OAuth path. Kept the change to the single config flag; the backend friendly-message translation and its test already exist and stay as-is.
