### PR TITLE
fix(warehouse-sources): cap queue partition DDL lock waits

### DIFF
--- a/posthog/temporal/tests/warehouse_sources_queue_partition_management/test_activities.py
+++ b/posthog/temporal/tests/warehouse_sources_queue_partition_management/test_activities.py
@@ -7,7 +7,9 @@ from datetime import date
 from typing import Any, Literal
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import psycopg
 
 from posthog.temporal.warehouse_sources_queue_partition_management import activities as activities_module
 from posthog.temporal.warehouse_sources_queue_partition_management.activities import (
@@ -378,3 +380,52 @@ async def test_activity_logs_s3_deleted_count(activity_environment) -> None:
     ]
     assert len(completion_calls) == 1
     assert completion_calls[0].kwargs["s3_deleted_count"] == 2
+
+
+# DDL lock retry
+
+
+class _LockFlakyConn:
+    def __init__(self, failures: int, error: type[Exception]) -> None:
+        self.failures = failures
+        self.error = error
+        self.calls = 0
+
+    def execute(self, _sql: Any, _params: Any = None) -> MagicMock:
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.error()
+        return MagicMock()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failures", "error", "expected_calls", "raises"),
+    [
+        # transient lock timeouts retry until the DDL goes through
+        (2, psycopg.errors.LockNotAvailable, 3, None),
+        # persistent lock timeouts give up after the attempt cap instead of retrying forever
+        (
+            99,
+            psycopg.errors.LockNotAvailable,
+            activities_module.DDL_LOCK_MAX_ATTEMPTS,
+            psycopg.errors.LockNotAvailable,
+        ),
+        # non-lock errors surface immediately — retrying would mask real failures
+        (99, psycopg.errors.UndefinedTable, 1, psycopg.errors.UndefinedTable),
+    ],
+)
+async def test_ddl_lock_retry(
+    failures: int, error: type[Exception], expected_calls: int, raises: type[Exception] | None
+) -> None:
+    conn = _LockFlakyConn(failures, error)
+    with patch("asyncio.sleep", new=AsyncMock()):
+        if raises is None:
+            await activities_module._execute_ddl_with_lock_retry(conn, "DROP TABLE IF EXISTS sourcebatch_20260101")  # type: ignore[arg-type]
+        else:
+            with pytest.raises(raises):
+                await activities_module._execute_ddl_with_lock_retry(
+                    conn,  # type: ignore[arg-type]
+                    "DROP TABLE IF EXISTS sourcebatch_20260101",
+                )
+    assert conn.calls == expected_calls

--- a/posthog/temporal/warehouse_sources_queue_partition_management/activities.py
+++ b/posthog/temporal/warehouse_sources_queue_partition_management/activities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 
@@ -15,6 +16,29 @@ logger = structlog.get_logger(__name__)
 PARTITIONED_TABLES = ["sourcebatch", "sourcebatchstatus", "sourcebatchduckgresstatus"]
 PARTITIONS_AHEAD = 7
 RETENTION_DAYS = 7
+
+# CREATE/DROP of a partition takes ACCESS EXCLUSIVE on the parent table, and a
+# *waiting* ACCESS EXCLUSIVE blocks every query that arrives after it — so an
+# unbounded lock wait behind one long-running query stalls all queue traffic
+# (consumers, producers, temporal workers) until the blocker finishes.
+# lock_timeout caps each wait; on timeout we back off so queued traffic drains,
+# then retry.
+DDL_LOCK_TIMEOUT = "5s"
+DDL_LOCK_MAX_ATTEMPTS = 6
+DDL_LOCK_RETRY_PAUSE_SECONDS = 10.0
+
+
+async def _execute_ddl_with_lock_retry(conn: psycopg.Connection, sql: str) -> None:
+    for attempt in range(1, DDL_LOCK_MAX_ATTEMPTS + 1):
+        try:
+            conn.execute(sql)
+            return
+        except psycopg.errors.LockNotAvailable:
+            if attempt == DDL_LOCK_MAX_ATTEMPTS:
+                raise
+            logger.warning("partition_ddl_lock_timeout", sql=sql, attempt=attempt)
+            await asyncio.sleep(DDL_LOCK_RETRY_PAUSE_SECONDS)
+
 
 # The duckgres apply-marker table is unpartitioned (small rows, UNIQUE-constrained),
 # so retention is DELETE-based. Must comfortably exceed the consumers' eligibility
@@ -43,7 +67,9 @@ async def manage_warehouse_sources_queue_partitions() -> dict:
     dropped: list[str] = []
     errors: list[str] = []
 
-    with psycopg.Connection.connect(database_url, autocommit=True) as conn:
+    with psycopg.Connection.connect(
+        database_url, autocommit=True, options=f"-c lock_timeout={DDL_LOCK_TIMEOUT}"
+    ) as conn:
         today = datetime.now(UTC).date()
 
         for table in PARTITIONED_TABLES:
@@ -51,10 +77,11 @@ async def manage_warehouse_sources_queue_partitions() -> dict:
                 d = today + timedelta(days=offset)
                 partition_name = f"{table}_{d.strftime('%Y%m%d')}"
                 try:
-                    conn.execute(
+                    await _execute_ddl_with_lock_retry(
+                        conn,
                         f"CREATE TABLE IF NOT EXISTS {partition_name} "
                         f"PARTITION OF {table} "
-                        f"FOR VALUES FROM ('{d.isoformat()}') TO ('{(d + timedelta(days=1)).isoformat()}')"
+                        f"FOR VALUES FROM ('{d.isoformat()}') TO ('{(d + timedelta(days=1)).isoformat()}')",
                     )
                     ensured.append(partition_name)
                 except Exception as e:
@@ -82,7 +109,7 @@ async def manage_warehouse_sources_queue_partitions() -> dict:
                     continue
                 if partition_date < cutoff:
                     try:
-                        conn.execute(f"DROP TABLE IF EXISTS {partition_name}")
+                        await _execute_ddl_with_lock_retry(conn, f"DROP TABLE IF EXISTS {partition_name}")
                         dropped.append(partition_name)
                     except Exception as e:
                         errors.append(f"Failed to drop {partition_name}: {e}")


### PR DESCRIPTION
## Problem

The daily `warehouse-sources-queue-partition-management` run (08:00 UTC) creates the next days' partitions and drops expired ones on the queue tables (`sourcebatch`, `sourcebatchstatus`, `sourcebatchduckgresstatus`). Both `CREATE TABLE ... PARTITION OF` and `DROP TABLE` take **ACCESS EXCLUSIVE on the parent table**, and in Postgres a *waiting* ACCESS EXCLUSIVE blocks every query that arrives after it, plain SELECTs included.

The activity's connection sets no `lock_timeout`, so when the DDL queues behind one long-running query, the whole queue DB stalls: consumers, producers, and temporal workers all freeze mid-query until the blocker finishes, and the sink/import alerts fire. The `postgres_queue/README.md` already flags partition DDL as "O(1) metadata-only" - which is true once the lock is *held*; the unbounded *wait* for it was the gap.

## Changes

- Open the activity's connection with `options="-c lock_timeout=5s"` so no statement in this job can sit in the lock queue indefinitely.
- Wrap the partition `CREATE`/`DROP` in `_execute_ddl_with_lock_retry`: on `LockNotAvailable` it backs off 10s (letting the traffic that queued behind the failed attempt drain) and retries up to 6 attempts, then surfaces the error into the existing `errors` -> Slack-alert path. Non-lock errors propagate immediately, unretried.

> Follow-up worth considering (not in this PR): `ALTER TABLE ... DETACH PARTITION CONCURRENTLY` + drop for the removal path, which avoids the ACCESS EXCLUSIVE window entirely. The lock_timeout guard already removes the outage class, so keeping this PR minimal.

## How did you test this code?

Tests - one parameterized case in `posthog/temporal/tests/warehouse_sources_queue_partition_management/test_activities.py` (mocked connection, patched sleep): transient lock timeout retries then succeeds, persistent lock timeout gives up after the attempt cap instead of retrying forever, and non-lock errors are not retried. Catches removal of the lock-retry guard, which no existing test did. Ran ruff + ty locally (via lint-staged); pytest will run in CI - this worktree has no venv per my local setup.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code during an incident investigation session driven by @a-lider: Grafana metrics showed the queue DB's in-flight queries freezing daily right after 08:00 UTC (pgbouncer server-active connections pinned flat, consumers silent, recovering the moment the blocker ended), which pointed at this job's unbounded ACCESS EXCLUSIVE waits. Skills used: /writing-tests, pr-writer-alex. Considered setting only a session `lock_timeout` without retries (simplest), but a single 5s timeout would make partition maintenance fail on any busy morning - the bounded retry keeps the job reliable while never parking in the lock queue for more than 5s at a time. Constants (5s/6 attempts/10s pause) are judgment calls, easy to tune if the team prefers different bounds.
