### PR TITLE
fix(dashboards): keep layouts identity stable across per-tile refreshes

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -306,6 +306,24 @@ describe('dashboardLogic', () => {
             logic.mount()
         })
 
+        it('keeps the layouts reference stable when a tile refresh changes results but not geometry', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const initialLayouts = logic.values.layouts
+            const firstTile = logic.values.dashboard!.tiles[0]
+
+            await expectLogic(logic, () => {
+                // A refresh response: same insight, new object identity and results, untouched layouts.
+                dashboardsModel.actions.updateDashboardInsight({
+                    ...firstTile.insight!,
+                    result: [{ count: 42 }],
+                })
+            }).toFinishAllListeners()
+
+            expect(logic.values.tiles[0].insight!.result).toEqual([{ count: 42 }])
+            expect(logic.values.layouts).toBe(initialLayouts)
+        })
+
         it('saving without changes does not call api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -44,6 +44,7 @@ import { featureFlagLogic, getFeatureFlagPayload } from 'lib/logic/featureFlagLo
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { clearDOMTextSelection, getJSHeapMemory, uuid } from 'lib/utils/dom'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { objectsEqual } from 'lib/utils/objects'
 import { shouldCancelQuery } from 'lib/utils/requests'
 import { toParams } from 'lib/utils/url'
 import { BREAKPOINTS, dashboardToSaveableTemplate, getDashboardTileDisplayName } from 'scenes/dashboard/dashboardUtils'
@@ -1858,7 +1859,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return size
             },
         ],
-        layouts: [(s) => [s.tiles], (tiles) => calculateLayouts(tiles)],
+        layouts: [
+            (s) => [s.tiles],
+            (tiles) => calculateLayouts(tiles),
+            // Tile refreshes replace `tiles` once per insight response without touching geometry;
+            // keeping the result reference stable stops react-grid-layout re-laying-out every tile
+            // N times per dashboard refresh cycle.
+            { resultEqualityCheck: objectsEqual },
+        ],
         layout: [
             (s) => [s.layouts, s.sizeKey],
             (layouts: ResponsiveLayouts, sizeKey: DashboardLayoutSize | undefined) =>


### PR DESCRIPTION
## Problem

During a dashboard refresh cycle, each insight's response dispatches `updateDashboardInsight`, which replaces the `dashboard` (and therefore `tiles`) references. The `layouts` selector recomputed from the new `tiles` and returned a brand-new object every time, even though `calculateLayouts` only reads tile geometry (id + layout fields), which the refresh never touches. `ReactGridLayout` then received a new `layouts` prop once per refreshed insight, re-laying-out every tile each time: O(N^2) grid work and DOM churn per refresh cycle on an N-tile dashboard.

Found while investigating app-wide detached-element telemetry, where dashboard paths show a heavy `DraggableCore`-attributed detached DOM signature (11M nodes over 7 days).

## Changes

Add `{ resultEqualityCheck: objectsEqual }` to the `layouts` selector in `dashboardLogic`, following the existing pattern in `dataTableLogic` / `breadcrumbsLogic` / `sceneLogic`. When a `tiles` change doesn't alter geometry, the selector now returns the previous `layouts` reference, so the grid doesn't re-process.

## How did you test this code?

Added one logic-level regression test: dispatching `updateDashboardInsight` with a same-geometry insight (new object identity, new results) must keep `logic.values.layouts` reference-equal. No existing test covers layouts identity. Mutation-verified: with the `resultEqualityCheck` removed the new test fails; with it, the full `dashboardLogic.test.ts` suite passes (75 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) during a detached-elements structural investigation driven by Paul. Skills invoked: `/writing-tests`. A broader refactor (memoizing `InsightCard` behind an intermediate tile component, isolating `refreshStatus` subscriptions, preserving insight identity in the reducer) was scoped out of this PR deliberately: this one-line selector change is the provable, precedented core of the churn, while the rest needs its own careful pass. The remaining candidates are documented in the investigation notes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*