### PR TITLE
feat(experiments): Move cache health panel to its own tab

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5625,9 +5625,9 @@ snapshots:
     scenes-app-heatmap--generating--light:
         hash: v1.k794b7964.9e9c863c6e06c7e6e610353fbd826ee85406c86419eeba160ad2e525b66021bc.pQ8mxSWr4ScfBLrbe8Ppc_tyJdr0mNjKY5q71eurkBM
     scenes-app-heatmap--iframe-example--dark:
-        hash: v1.k794b7964.f85cb7ceb1ef6cd47c37a7408d2206432546a0509eae3aa957316dca54219fbf.NUQH6bQ3c0L52-B8eFHyvoPuGECuS2P3jOG_zPM1q1M
+        hash: v1.k794b7964.739b8f5ac461aff690d35b4622c683f5758d1a2f16d203cb315aaa449a954cb7.QT8KobMmRxytbOoCQFHYofq2yAHXDezRBTnyfgk91Ts
     scenes-app-heatmap--iframe-example--light:
-        hash: v1.k794b7964.99a49b92212947be5153f7f445fa411097ada9f02a03ce866069b1d9bd34a7ab.rx8z4wHw_ZSqa8jn4rAGQwVj_f6frnxQ5mpYIHZmc6w
+        hash: v1.k794b7964.1f8c1978a875ca2e7467d8f8fb5109f6a2d706d75535edb8a478be4365fcd613.RxyMDJcjQNBieIUkMwxqriiNth6u5_-VsGKAgyFWnoQ
     scenes-app-heatmap--new--dark:
         hash: v1.k794b7964.cfd075c10189496c867372e36391cf5985948fe5a8137c434545f5825b15ac7e.IUvQTi7vHNPSGeWj-q6upJsHMLU3UpumxHwGBndOhYE
     scenes-app-heatmap--new--light:
@@ -5636,6 +5636,10 @@ snapshots:
         hash: v1.k794b7964.cfd075c10189496c867372e36391cf5985948fe5a8137c434545f5825b15ac7e.CBhNqr7PbQNz8qkKG2U9CTIyRe5lDAYRM83-AJ8_zVw
     scenes-app-heatmap-new--new-form--light:
         hash: v1.k794b7964.efcfe6e747715ec98507ddc9a223cc52e821d9c44cde876551edc9e5813c2930.GJ6WxbvpypQJHEukgIxvQmhzq0GFcmtyTNZtdfA959A
+    scenes-app-heatmap-recording--recording-mode-with-clickmap--dark:
+        hash: v1.k794b7964.3499aad6c2502ef406a4482b07fc63e130419f017d378e67f368d037bcfe60cd.bq5I6_BkW5qM66IZeNnjtJhQ6b2_3ch-I0qGo_yKKT0
+    scenes-app-heatmap-recording--recording-mode-with-clickmap--light:
+        hash: v1.k794b7964.22f3a94ca40cb149e4304284f5a3ed613728ed22a1d4554fa94754aca6dc38e8.RL9cCxn6_8zy2HgMxnfhUCDvQk_-tWwn_vmZNIZjF4I
     scenes-app-heatmaps-saved--list--dark:
         hash: v1.k794b7964.8368377e136c567c3c500c97924486837234c230858baf0eb14678b6900d68c6.qpjMZIE3Ii8vpyLrfaKjCdym7waJtp38DGez1iugMMo
     scenes-app-heatmaps-saved--list--light:

--- a/frontend/src/scenes/instance/QueryPerformance/CacheHealth.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/CacheHealth.tsx
@@ -112,8 +112,11 @@ export function CacheHealth(): JSX.Element {
 
     return (
         <>
-            <div className="flex items-center gap-2">
-                <h2 className="mb-0">Cache health</h2>
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <p className="text-muted text-sm mb-0">
+                    Physical footprint of the experiment preaggregation tables (active parts across all shards, from
+                    ClickHouse system.parts).
+                </p>
                 <LemonButton
                     type="secondary"
                     size="small"
@@ -123,10 +126,6 @@ export function CacheHealth(): JSX.Element {
                     Refresh
                 </LemonButton>
             </div>
-            <p className="text-muted text-sm mt-1 mb-2">
-                Physical footprint of the experiment preaggregation tables — active parts across all shards, from
-                ClickHouse system.parts.
-            </p>
             <div className="flex flex-wrap gap-4 mb-4">
                 {!cacheHealth && cacheHealthLoading
                     ? [0, 1].map((i) => (

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -152,6 +152,7 @@ export function QueryPerformance(): JSX.Element {
         experimentIdFilter,
         metricTypeFilter,
         exceptionCodeFilter,
+        experimentsTab,
     } = useValues(queryPerformanceLogic)
     const {
         setSearch,
@@ -162,6 +163,7 @@ export function QueryPerformance(): JSX.Element {
         setExperimentIdFilter,
         setMetricTypeFilter,
         setExceptionCodeFilter,
+        setExperimentsTab,
     } = useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
@@ -497,155 +499,194 @@ export function QueryPerformance(): JSX.Element {
                         key: 'experiments',
                         label: 'Experiments',
                         content: (
-                            <>
-                                <CacheHealth />
-                                <h2>Slowest queries</h2>
-                                <div className="flex flex-wrap gap-2 mb-4 items-center">
-                                    {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
-                                        <LemonButton
-                                            key={hours}
-                                            type={hoursBack === hours ? 'primary' : 'tertiary'}
-                                            size="small"
-                                            onClick={() => setHoursBack(hours)}
-                                        >
-                                            {label}
-                                        </LemonButton>
-                                    ))}
-                                    <LemonInput
-                                        type="number"
-                                        min={1}
-                                        size="small"
-                                        placeholder="Team ID"
-                                        value={teamIdFilter ? Number(teamIdFilter) : undefined}
-                                        onChange={(value) => setTeamIdFilter(value != null ? String(value) : '')}
-                                        className="w-32"
-                                    />
-                                    <LemonInput
-                                        type="number"
-                                        min={1}
-                                        size="small"
-                                        placeholder="Experiment ID"
-                                        value={experimentIdFilter ? Number(experimentIdFilter) : undefined}
-                                        onChange={(value) => setExperimentIdFilter(value != null ? String(value) : '')}
-                                        className="w-36"
-                                    />
-                                    <LemonSelect
-                                        size="small"
-                                        value={metricTypeFilter}
-                                        onChange={(value) => setMetricTypeFilter(value ?? '')}
-                                        options={METRIC_TYPE_OPTIONS}
-                                        className="w-44"
-                                    />
-                                    <LemonSelect
-                                        size="small"
-                                        value={exceptionCodeFilter}
-                                        onChange={(value) => setExceptionCodeFilter(value ?? '')}
-                                        options={EXCEPTION_CODE_OPTIONS}
-                                        className="w-44"
-                                    />
-                                    <LemonButton
-                                        type="secondary"
-                                        size="small"
-                                        onClick={() => loadSlowestQueries()}
-                                        disabledReason={slowestQueriesLoading ? 'Loading...' : undefined}
-                                    >
-                                        Refresh
-                                    </LemonButton>
-                                </div>
-                                <LemonTable
-                                    columns={slowestQueryColumns}
-                                    dataSource={slowestQueries}
-                                    loading={slowestQueriesLoading}
-                                    emptyState="No queries found in this time range"
-                                    pagination={{ pageSize: 20 }}
-                                    className="overflow-visible! flex-none!"
-                                    expandable={{
-                                        expandedRowRender: function ExpandedQuery(item) {
-                                            return (
-                                                <div className="flex flex-col gap-2 p-2">
-                                                    <QueryStats {...item} />
-                                                    <div className="font-mono text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
-                                                        <span>
-                                                            query_id:{' '}
-                                                            <CopyToClipboardInline description="query ID">
-                                                                {item.query_id}
-                                                            </CopyToClipboardInline>
-                                                        </span>
-                                                        {item.experiment_query_group_id && (
-                                                            <span>
-                                                                group:{' '}
-                                                                <CopyToClipboardInline description="group ID">
-                                                                    {item.experiment_query_group_id}
-                                                                </CopyToClipboardInline>
-                                                            </span>
-                                                        )}
-                                                        <LinkMetabaseQuery queryId={item.query_id} />
-                                                    </div>
-                                                    {item.sub_queries && item.sub_queries.length > 0 && (
-                                                        <div>
-                                                            <h4 className="mb-1">Sub-queries (precompute builds)</h4>
-                                                            <LemonTable
-                                                                size="small"
-                                                                columns={subQueryColumns}
-                                                                dataSource={item.sub_queries}
-                                                                expandable={{
-                                                                    expandedRowRender: function ExpandedSubQuery(sub) {
-                                                                        return (
-                                                                            <div className="flex flex-col gap-2 p-2">
-                                                                                <QueryStats {...sub} />
-                                                                                <CodeSnippet
-                                                                                    language={Language.SQL}
-                                                                                    thing="query"
-                                                                                    maxLinesWithoutExpansion={10}
-                                                                                >
-                                                                                    {sub.query}
-                                                                                </CodeSnippet>
-                                                                            </div>
-                                                                        )
-                                                                    },
-                                                                }}
-                                                            />
-                                                        </div>
-                                                    )}
-                                                    {item.exception && (
-                                                        <CodeSnippet
-                                                            language={Language.Text}
-                                                            thing="error"
-                                                            maxLinesWithoutExpansion={5}
+                            <LemonTabs
+                                activeKey={experimentsTab}
+                                onChange={setExperimentsTab}
+                                tabs={[
+                                    {
+                                        key: 'slowest_queries',
+                                        label: 'Slowest queries',
+                                        content: (
+                                            <>
+                                                <div className="flex flex-wrap gap-2 mb-4 items-center">
+                                                    {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
+                                                        <LemonButton
+                                                            key={hours}
+                                                            type={hoursBack === hours ? 'primary' : 'tertiary'}
+                                                            size="small"
+                                                            onClick={() => setHoursBack(hours)}
                                                         >
-                                                            {item.exception}
-                                                        </CodeSnippet>
-                                                    )}
-                                                    <CodeSnippet
-                                                        language={Language.SQL}
-                                                        thing="query"
-                                                        maxLinesWithoutExpansion={10}
+                                                            {label}
+                                                        </LemonButton>
+                                                    ))}
+                                                    <LemonInput
+                                                        type="number"
+                                                        min={1}
+                                                        size="small"
+                                                        placeholder="Team ID"
+                                                        value={teamIdFilter ? Number(teamIdFilter) : undefined}
+                                                        onChange={(value) =>
+                                                            setTeamIdFilter(value != null ? String(value) : '')
+                                                        }
+                                                        className="w-32"
+                                                    />
+                                                    <LemonInput
+                                                        type="number"
+                                                        min={1}
+                                                        size="small"
+                                                        placeholder="Experiment ID"
+                                                        value={
+                                                            experimentIdFilter ? Number(experimentIdFilter) : undefined
+                                                        }
+                                                        onChange={(value) =>
+                                                            setExperimentIdFilter(value != null ? String(value) : '')
+                                                        }
+                                                        className="w-36"
+                                                    />
+                                                    <LemonSelect
+                                                        size="small"
+                                                        value={metricTypeFilter}
+                                                        onChange={(value) => setMetricTypeFilter(value ?? '')}
+                                                        options={METRIC_TYPE_OPTIONS}
+                                                        className="w-44"
+                                                    />
+                                                    <LemonSelect
+                                                        size="small"
+                                                        value={exceptionCodeFilter}
+                                                        onChange={(value) => setExceptionCodeFilter(value ?? '')}
+                                                        options={EXCEPTION_CODE_OPTIONS}
+                                                        className="w-44"
+                                                    />
+                                                    <LemonButton
+                                                        type="secondary"
+                                                        size="small"
+                                                        onClick={() => loadSlowestQueries()}
+                                                        disabledReason={
+                                                            slowestQueriesLoading ? 'Loading...' : undefined
+                                                        }
                                                     >
-                                                        {item.query}
-                                                    </CodeSnippet>
+                                                        Refresh
+                                                    </LemonButton>
                                                 </div>
-                                            )
-                                        },
-                                    }}
-                                />
+                                                <LemonTable
+                                                    columns={slowestQueryColumns}
+                                                    dataSource={slowestQueries}
+                                                    loading={slowestQueriesLoading}
+                                                    emptyState="No queries found in this time range"
+                                                    pagination={{ pageSize: 20 }}
+                                                    className="overflow-visible! flex-none!"
+                                                    expandable={{
+                                                        expandedRowRender: function ExpandedQuery(item) {
+                                                            return (
+                                                                <div className="flex flex-col gap-2 p-2">
+                                                                    <QueryStats {...item} />
+                                                                    <div className="font-mono text-xs text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+                                                                        <span>
+                                                                            query_id:{' '}
+                                                                            <CopyToClipboardInline description="query ID">
+                                                                                {item.query_id}
+                                                                            </CopyToClipboardInline>
+                                                                        </span>
+                                                                        {item.experiment_query_group_id && (
+                                                                            <span>
+                                                                                group:{' '}
+                                                                                <CopyToClipboardInline description="group ID">
+                                                                                    {item.experiment_query_group_id}
+                                                                                </CopyToClipboardInline>
+                                                                            </span>
+                                                                        )}
+                                                                        <LinkMetabaseQuery queryId={item.query_id} />
+                                                                    </div>
+                                                                    {item.sub_queries &&
+                                                                        item.sub_queries.length > 0 && (
+                                                                            <div>
+                                                                                <h4 className="mb-1">
+                                                                                    Sub-queries (precompute builds)
+                                                                                </h4>
+                                                                                <LemonTable
+                                                                                    size="small"
+                                                                                    columns={subQueryColumns}
+                                                                                    dataSource={item.sub_queries}
+                                                                                    expandable={{
+                                                                                        expandedRowRender:
+                                                                                            function ExpandedSubQuery(
+                                                                                                sub
+                                                                                            ) {
+                                                                                                return (
+                                                                                                    <div className="flex flex-col gap-2 p-2">
+                                                                                                        <QueryStats
+                                                                                                            {...sub}
+                                                                                                        />
+                                                                                                        <CodeSnippet
+                                                                                                            language={
+                                                                                                                Language.SQL
+                                                                                                            }
+                                                                                                            thing="query"
+                                                                                                            maxLinesWithoutExpansion={
+                                                                                                                10
+                                                                                                            }
+                                                                                                        >
+                                                                                                            {sub.query}
+                                                                                                        </CodeSnippet>
+                                                                                                    </div>
+                                                                                                )
+                                                                                            },
+                                                                                    }}
+                                                                                />
+                                                                            </div>
+                                                                        )}
+                                                                    {item.exception && (
+                                                                        <CodeSnippet
+                                                                            language={Language.Text}
+                                                                            thing="error"
+                                                                            maxLinesWithoutExpansion={5}
+                                                                        >
+                                                                            {item.exception}
+                                                                        </CodeSnippet>
+                                                                    )}
+                                                                    <CodeSnippet
+                                                                        language={Language.SQL}
+                                                                        thing="query"
+                                                                        maxLinesWithoutExpansion={10}
+                                                                    >
+                                                                        {item.query}
+                                                                    </CodeSnippet>
+                                                                </div>
+                                                            )
+                                                        },
+                                                    }}
+                                                />
 
-                                <h2 className="mt-8">Precomputation</h2>
-                                <LemonInput
-                                    type="search"
-                                    placeholder="Search by organization name..."
-                                    value={search}
-                                    onChange={setSearch}
-                                    className="mb-4 max-w-md"
-                                />
-                                <LemonTable
-                                    columns={precomputationColumns}
-                                    dataSource={precomputationTeams}
-                                    loading={precomputationTeamsLoading}
-                                    emptyState={search ? 'No teams found' : 'No teams have precomputation enabled'}
-                                    pagination={{ pageSize: 20 }}
-                                    className="overflow-visible! flex-none!"
-                                />
-                            </>
+                                                <h2 className="mt-8">Precomputation</h2>
+                                                <LemonInput
+                                                    type="search"
+                                                    placeholder="Search by organization name..."
+                                                    value={search}
+                                                    onChange={setSearch}
+                                                    className="mb-4 max-w-md"
+                                                />
+                                                <LemonTable
+                                                    columns={precomputationColumns}
+                                                    dataSource={precomputationTeams}
+                                                    loading={precomputationTeamsLoading}
+                                                    emptyState={
+                                                        search
+                                                            ? 'No teams found'
+                                                            : 'No teams have precomputation enabled'
+                                                    }
+                                                    pagination={{ pageSize: 20 }}
+                                                    className="overflow-visible! flex-none!"
+                                                />
+                                            </>
+                                        ),
+                                    },
+                                    {
+                                        key: 'cache_health',
+                                        label: 'Cache health',
+                                        content: <CacheHealth />,
+                                    },
+                                ]}
+                            />
                         ),
                     },
                 ]}

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -15,6 +15,8 @@ export interface PrecomputationTeam {
     experiment_precomputation_enabled: boolean
 }
 
+export type ExperimentsTab = 'slowest_queries' | 'cache_health'
+
 export interface CachePartitionStats {
     partition: string // YYYYMMDD — the expiry day of the partition (tables partition by toYYYYMMDD(expires_at))
     rows: number
@@ -89,6 +91,7 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
         setExperimentIdFilter: (experimentId: string) => ({ experimentId }),
         setMetricTypeFilter: (metricType: string) => ({ metricType }),
         setExceptionCodeFilter: (exceptionCode: string) => ({ exceptionCode }),
+        setExperimentsTab: (tab: ExperimentsTab) => ({ tab }),
     }),
     reducers({
         search: [
@@ -125,6 +128,12 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             '',
             {
                 setExceptionCodeFilter: (_, { exceptionCode }) => exceptionCode,
+            },
+        ],
+        experimentsTab: [
+            'slowest_queries' as ExperimentsTab,
+            {
+                setExperimentsTab: (_, { tab }) => tab,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

This is internal staff tooling. #68219 added the cache health panel above the slowest queries table on the Experiments tab of the query performance scene, which made that tab long and mixed two distinct concerns on one screen.

## Changes

- The Experiments tab now has two sub-tabs: "Slowest queries" (the existing table plus the precomputation section) and "Cache health" (the footprint panel).
- Dropped the headings that duplicated the tab labels; the cache health description and refresh button now sit on one row.
- Tab state lives in the kea logic.

No screenshot, the scene needs staff access plus real cache data.

## How did you test this code?

- Frontend typecheck (touched files clean) and lint; kea typegen regenerated.
- Layout-only change, no backend or data changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal staff tooling, no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as a follow-up to #68219 at the reviewer's request to move the panel under its own tab. Pure restructuring of the scene component: nested LemonTabs, a new `experimentsTab` reducer in `queryPerformanceLogic`, and removal of now-redundant section headings.
