### PR TITLE
feat(insights): convert chart header pickers to quill behind flag

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilterNext.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilterNext.tsx
@@ -1,0 +1,239 @@
+import { useActions, useValues } from 'kea'
+import { ReactNode } from 'react'
+
+import { IconGlobe, IconGraph, IconPieChart, IconRetentionHeatmap, IconTrends } from '@posthog/icons'
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectGroupLabel,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@posthog/quill'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Icon123, IconAreaChart, IconCumulativeChart, IconTableChart } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { ChartDisplayType } from '~/types'
+
+interface ChartOption {
+    value: ChartDisplayType
+    icon: ReactNode
+    label: string
+    description: string
+    disabledReason?: string
+}
+
+interface ChartOptionGroup {
+    title: string
+    options: ChartOption[]
+}
+
+export function ChartFilterNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { display } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const { isTrends, isSingleSeriesOutput, formula, breakdownFilter } = useValues(insightVizDataLogic(insightProps))
+
+    const trendsOnlyDisabledReason = !isTrends ? 'This type is only available in Trends.' : undefined
+    const singleSeriesOnlyDisabledReason = !isSingleSeriesOutput
+        ? 'This type currently only supports insights with one series, and this insight has multiple series.'
+        : undefined
+
+    const groups: ChartOptionGroup[] = [
+        {
+            title: 'Time series',
+            options: [
+                {
+                    value: ChartDisplayType.ActionsLineGraph,
+                    icon: <IconTrends />,
+                    label: 'Line chart',
+                    description: 'Trends over time plotted as a continuous line.',
+                },
+                {
+                    value: ChartDisplayType.ActionsAreaGraph,
+                    icon: <IconAreaChart />,
+                    label: 'Area chart',
+                    description: 'Trends over time plotted as a shaded area.',
+                },
+                {
+                    value: ChartDisplayType.ActionsUnstackedBar,
+                    icon: <IconGraph />,
+                    label: 'Bar chart',
+                    description: 'Trends over time as vertical bars side-by-side.',
+                },
+                {
+                    value: ChartDisplayType.ActionsBar,
+                    icon: <IconGraph />,
+                    label: 'Stacked bar chart',
+                    description: 'Trends over time as vertical bars.',
+                },
+                ...(featureFlags[FEATURE_FLAGS.BOX_PLOT_INSIGHT]
+                    ? [
+                          {
+                              value: ChartDisplayType.BoxPlot,
+                              icon: <IconGraph />,
+                              label: 'Box plot',
+                              description: 'Distribution of a property over time showing quartiles.',
+                              disabledReason: trendsOnlyDisabledReason,
+                          },
+                      ]
+                    : []),
+                ...(featureFlags[FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT]
+                    ? [
+                          {
+                              value: ChartDisplayType.SlopeGraph,
+                              icon: <IconTrends />,
+                              label: 'Slope graph',
+                              description: 'Change from the start to the end of the range, one line per series.',
+                              disabledReason: trendsOnlyDisabledReason,
+                          },
+                      ]
+                    : []),
+            ],
+        },
+        {
+            title: 'Cumulative time series',
+            options: [
+                {
+                    value: ChartDisplayType.ActionsLineGraphCumulative,
+                    icon: <IconCumulativeChart />,
+                    label: 'Line chart (cumulative)',
+                    description: 'Accumulating values over time as a continuous line.',
+                    disabledReason: trendsOnlyDisabledReason,
+                },
+            ],
+        },
+        {
+            title: 'Total value',
+            options: [
+                {
+                    value: ChartDisplayType.BoldNumber,
+                    icon: <Icon123 />,
+                    label: 'Number',
+                    description: 'A big number showing the total value.',
+                    disabledReason: trendsOnlyDisabledReason || singleSeriesOnlyDisabledReason,
+                },
+                ...(featureFlags[FEATURE_FLAGS.METRIC_INSIGHT]
+                    ? [
+                          {
+                              value: ChartDisplayType.Metric,
+                              icon: <IconTrends />,
+                              label: 'Metric',
+                              description: 'A headline value with a sparkline and period-over-period change.',
+                              disabledReason: trendsOnlyDisabledReason || singleSeriesOnlyDisabledReason,
+                          },
+                      ]
+                    : []),
+                {
+                    value: ChartDisplayType.ActionsPie,
+                    icon: <IconPieChart />,
+                    label: 'Pie chart',
+                    description: 'Proportions of a whole as a pie.',
+                    disabledReason: trendsOnlyDisabledReason,
+                },
+                {
+                    value: ChartDisplayType.ActionsBarValue,
+                    icon: <IconGraph className="rotate-90" />,
+                    label: 'Bar chart',
+                    description: 'Total values as horizontal bars.',
+                    disabledReason: trendsOnlyDisabledReason,
+                },
+                {
+                    value: ChartDisplayType.ActionsTable,
+                    icon: <IconTableChart />,
+                    label: 'Table',
+                    description: 'Total values in a table view.',
+                },
+            ],
+        },
+        {
+            title: 'Visualizations',
+            options: [
+                {
+                    value: ChartDisplayType.WorldMap,
+                    icon: <IconGlobe />,
+                    label: 'World map',
+                    description: 'Values per country on a map.',
+                    disabledReason:
+                        trendsOnlyDisabledReason ||
+                        (formula
+                            ? "This type isn't available, because it doesn't support formulas."
+                            : !!breakdownFilter?.breakdown &&
+                                breakdownFilter.breakdown !== '$geoip_country_code' &&
+                                breakdownFilter.breakdown !== '$geoip_country_name'
+                              ? "This type isn't available, because there's a breakdown other than by Country Code or Country Name properties."
+                              : undefined),
+                },
+                ...(featureFlags[FEATURE_FLAGS.CALENDAR_HEATMAP_INSIGHT]
+                    ? [
+                          {
+                              value: ChartDisplayType.CalendarHeatmap,
+                              icon: <IconRetentionHeatmap />,
+                              label: 'Calendar heatmap',
+                              description: 'Values per day and hour.',
+                          },
+                      ]
+                    : []),
+            ],
+        },
+    ]
+
+    const items = Object.fromEntries(
+        groups.flatMap((group) =>
+            group.options.map((option) => [
+                option.value,
+                <span className="flex items-center gap-2" key={option.value}>
+                    {option.icon}
+                    {option.label}
+                </span>,
+            ])
+        )
+    )
+
+    return (
+        <Select
+            value={display || ChartDisplayType.ActionsLineGraph}
+            items={items}
+            onValueChange={(value: string | null) => {
+                if (value) {
+                    updateInsightFilter({ display: value as ChartDisplayType })
+                }
+            }}
+            disabled={!!editingDisabledReason}
+        >
+            <SelectTrigger size="sm" data-quill data-attr="chart-filter" title={editingDisabledReason ?? undefined}>
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end" alignItemWithTrigger={false}>
+                {groups.map((group) => (
+                    <SelectGroup key={group.title}>
+                        <SelectGroupLabel>{group.title}</SelectGroupLabel>
+                        {group.options.map((option) => (
+                            <SelectItem
+                                key={option.value}
+                                value={option.value}
+                                disabled={!!option.disabledReason}
+                                title={option.disabledReason}
+                            >
+                                {option.icon}
+                                <span className="flex flex-col">
+                                    <span>{option.label}</span>
+                                    <span className="text-xs font-normal whitespace-normal text-muted-foreground">
+                                        {option.description}
+                                    </span>
+                                </span>
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                ))}
+            </SelectContent>
+        </Select>
+    )
+}

--- a/frontend/src/lib/components/CompareFilter/CompareFilterNext.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilterNext.tsx
@@ -1,0 +1,177 @@
+import { type ChangeEvent, useState } from 'react'
+
+import { IconClock } from '@posthog/icons'
+import {
+    Button,
+    Input,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@posthog/quill'
+
+import { useWindowSize } from 'lib/hooks/useWindowSize'
+import { dateFromToText } from 'lib/utils/dateFilters'
+
+import { CompareFilter as CompareFilterType } from '~/queries/schema/schema-general'
+
+const COMPARE_UNITS: Record<string, string> = {
+    d: 'days',
+    w: 'weeks',
+    m: 'months',
+    y: 'years',
+}
+
+const COMPARE_TO_REGEX = /^-(\d+)([dwmy])$/
+const DEFAULT_COMPARE_COUNT = '1'
+const DEFAULT_COMPARE_UNIT = 'm'
+
+type CompareFilterNextProps = {
+    compareFilter?: CompareFilterType | null
+    updateCompareFilter: (compareFilter: CompareFilterType) => void
+    disabled?: boolean
+    disableReason?: string | null
+    /** Shown on hover, e.g. the resolved comparison date range */
+    tooltip?: string | null
+}
+
+export function CompareFilterNext({
+    compareFilter,
+    updateCompareFilter,
+    disabled,
+    disableReason,
+    tooltip,
+}: CompareFilterNextProps): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const [compareCount, setCompareCount] = useState<string>(DEFAULT_COMPARE_COUNT)
+    const [compareUnit, setCompareUnit] = useState<string>(DEFAULT_COMPARE_UNIT)
+
+    const { isWindowLessThan } = useWindowSize()
+    const isHugeScreen = !isWindowLessThan('2xl')
+
+    const compareTo = compareFilter?.compare_to
+    const value = compareFilter?.compare ? (compareTo ? 'compareTo' : 'previous') : 'none'
+
+    let label: string
+    if (value === 'compareTo' && compareTo) {
+        label = isHugeScreen
+            ? `Compare to ${dateFromToText(compareTo)} earlier`
+            : `${dateFromToText(compareTo)} earlier`
+    } else if (value === 'previous') {
+        label = isHugeScreen ? 'Compare to previous period' : 'Previous period'
+    } else {
+        label = isHugeScreen ? 'No comparison between periods' : 'No comparison'
+    }
+
+    const handleOpenChange = (nextOpen: boolean): void => {
+        if (nextOpen) {
+            const compareToMatch = COMPARE_TO_REGEX.exec(compareTo ?? '')
+            setCompareCount(compareToMatch?.[1] ?? DEFAULT_COMPARE_COUNT)
+            setCompareUnit(compareToMatch?.[2] ?? DEFAULT_COMPARE_UNIT)
+        }
+        setOpen(nextOpen)
+    }
+
+    const applyNone = (): void => {
+        updateCompareFilter({ compare: false, compare_to: undefined })
+        setOpen(false)
+    }
+    const applyPrevious = (): void => {
+        updateCompareFilter({ compare: true, compare_to: undefined })
+        setOpen(false)
+    }
+    const applyCompareTo = (): void => {
+        const count = Math.max(1, parseInt(compareCount) || 1)
+        updateCompareFilter({ compare: true, compare_to: `-${count}${compareUnit}` })
+        setOpen(false)
+    }
+
+    return (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+            <PopoverTrigger
+                render={
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        data-attr="compare-filter"
+                        data-quill
+                        disabled={disabled || !!disableReason}
+                        title={disableReason ?? tooltip ?? undefined}
+                    >
+                        <IconClock />
+                        {label}
+                    </Button>
+                }
+            />
+            <PopoverContent align="start" className="w-auto p-0 overflow-hidden">
+                <div className="flex w-72 flex-col gap-px p-2">
+                    <Button
+                        variant="default"
+                        size="sm"
+                        left
+                        className="w-full justify-start"
+                        aria-selected={value === 'none'}
+                        onClick={applyNone}
+                        data-attr="compare-filter-none"
+                    >
+                        No comparison between periods
+                    </Button>
+                    <Button
+                        variant="default"
+                        size="sm"
+                        left
+                        className="w-full justify-start"
+                        aria-selected={value === 'previous'}
+                        onClick={applyPrevious}
+                        data-attr="compare-filter-previous"
+                    >
+                        Compare to previous period
+                    </Button>
+                    <div className="flex items-center gap-1 px-2 py-1">
+                        <span className="text-xs whitespace-nowrap">Compare to</span>
+                        <Input
+                            type="number"
+                            min={1}
+                            value={compareCount}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                                setCompareCount(e.target.value.replace(/[^0-9]/g, ''))
+                            }
+                            className="h-6 w-12"
+                            aria-label="Comparison period count"
+                            data-attr="compare-filter-compare-to-count"
+                        />
+                        <Select
+                            value={compareUnit}
+                            onValueChange={(unit: string | null) => setCompareUnit(unit ?? DEFAULT_COMPARE_UNIT)}
+                            items={COMPARE_UNITS}
+                        >
+                            <SelectTrigger size="sm" aria-label="Comparison period unit">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {Object.entries(COMPARE_UNITS).map(([unitValue, unitLabel]) => (
+                                    <SelectItem key={unitValue} value={unitValue}>
+                                        {unitLabel}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <span className="text-xs whitespace-nowrap">earlier</span>
+                        <Button
+                            size="sm"
+                            onClick={applyCompareTo}
+                            aria-selected={value === 'compareTo'}
+                            data-attr="compare-filter-compare-to-apply"
+                        >
+                            Apply
+                        </Button>
+                    </div>
+                </div>
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilterNext.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilterNext.tsx
@@ -1,0 +1,80 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPin } from '@posthog/icons'
+import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@posthog/quill'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { InsightQueryNode } from '~/queries/schema/schema-general'
+import { IntervalType } from '~/types'
+
+export function IntervalFilterNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { interval, enabledIntervals, isIntervalManuallySet } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource, setIsIntervalManuallySet } = useActions(insightVizDataLogic(insightProps))
+
+    const options = Object.entries(enabledIntervals)
+        .filter(([, option]) => !option.hidden)
+        .map(([value, { label, disabledReason }]) => ({
+            value: value as IntervalType,
+            label,
+            disabledReason,
+        }))
+    // Hidden intervals (e.g. quarter) can still be the current value, so the trigger label needs them
+    const items = Object.fromEntries(Object.entries(enabledIntervals).map(([value, { label }]) => [value, label]))
+
+    return (
+        <span className="flex items-center gap-2">
+            <span className="@max-[780px]:hidden">
+                <span className="hidden md:inline">grouped </span>by
+            </span>
+            {isIntervalManuallySet ? (
+                <Button
+                    variant="outline"
+                    size="sm"
+                    data-quill
+                    data-attr="interval-filter-unpin"
+                    onClick={() => setIsIntervalManuallySet(false)}
+                    disabled={!!editingDisabledReason}
+                    title={editingDisabledReason ?? 'Unpin interval'}
+                >
+                    <IconPin color="var(--content-warning)" />
+                    {interval || 'day'}
+                </Button>
+            ) : (
+                <Select
+                    value={interval || 'day'}
+                    items={items}
+                    onValueChange={(value: string | null) => {
+                        if (value) {
+                            updateQuerySource({ interval: value as IntervalType } as Partial<InsightQueryNode>)
+                        }
+                    }}
+                    disabled={!!editingDisabledReason}
+                >
+                    <SelectTrigger
+                        size="sm"
+                        data-quill
+                        data-attr="interval-filter"
+                        title={editingDisabledReason ?? undefined}
+                    >
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {options.map((option) => (
+                            <SelectItem
+                                key={option.value}
+                                value={option.value}
+                                disabled={!!option.disabledReason}
+                                title={option.disabledReason ?? undefined}
+                            >
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+        </span>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -5,8 +5,11 @@ import { IconEllipsis } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
+import { ChartFilterNext } from 'lib/components/ChartFilter/ChartFilterNext'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
+import { CompareFilterNext } from 'lib/components/CompareFilter/CompareFilterNext'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
+import { IntervalFilterNext } from 'lib/components/IntervalFilter/IntervalFilterNext'
 import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -15,13 +18,18 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { InsightDateFilter } from 'scenes/insights/filters/InsightDateFilter'
 import { InsightDateFilterNext } from 'scenes/insights/filters/InsightDateFilter/InsightDateFilterNext'
 import { RetentionChartPicker } from 'scenes/insights/filters/RetentionChartPicker'
+import { RetentionChartPickerNext } from 'scenes/insights/filters/RetentionChartPickerNext'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { RetentionDatePicker } from 'scenes/insights/RetentionDatePicker'
 import { FunnelBinsPicker } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
+import { FunnelBinsPickerNext } from 'scenes/insights/views/Funnels/FunnelBinsPickerNext'
 import { FunnelDisplayLayoutPicker } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
+import { FunnelDisplayLayoutPickerNext } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPickerNext'
 import { PathStepPicker } from 'scenes/insights/views/Paths/PathStepPicker'
+import { PathStepPickerNext } from 'scenes/insights/views/Paths/PathStepPickerNext'
 import { RetentionBreakdownFilter } from 'scenes/retention/RetentionBreakdownFilter'
+import { RetentionBreakdownFilterNext } from 'scenes/retention/RetentionBreakdownFilterNext'
 
 import { hasBreakdownFilter, isWebAnalyticsInsightQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
@@ -76,6 +84,16 @@ export function InsightDisplayConfig(): JSX.Element {
 
     const { items: advancedOptions, count: advancedOptionsCount } = useInsightDisplayOptions()
 
+    const compareFilterProps = {
+        compareFilter,
+        updateCompareFilter,
+        disabled: !canEditInsight || !supportsCompare,
+        disableReason: editingDisabledReason,
+        tooltip: formatResolvedDateRange(
+            alignResolvedDateRangeToInterval(insightData?.resolved_compare_date_range, interval)
+        ),
+    }
+
     return (
         <div
             className="InsightDisplayConfig @container flex justify-between items-center flex-wrap gap-2 [&_.LemonButton--small]:[--lemon-button-gap:0.25rem] [&_.LemonButton--small]:[--lemon-button-padding-horizontal:0.375rem]"
@@ -93,9 +111,7 @@ export function InsightDisplayConfig(): JSX.Element {
                 )}
 
                 {showInterval && (
-                    <ConfigFilter>
-                        <IntervalFilter />
-                    </ConfigFilter>
+                    <ConfigFilter>{quillDateFilterEnabled ? <IntervalFilterNext /> : <IntervalFilter />}</ConfigFilter>
                 )}
 
                 {!!isRetention && !quillDateFilterEnabled && (
@@ -106,27 +122,21 @@ export function InsightDisplayConfig(): JSX.Element {
 
                 {!!isRetention && hasBreakdownFilter(breakdownFilter) && (
                     <ConfigFilter>
-                        <RetentionBreakdownFilter />
+                        {quillDateFilterEnabled ? <RetentionBreakdownFilterNext /> : <RetentionBreakdownFilter />}
                     </ConfigFilter>
                 )}
 
                 {!!isPaths && (
-                    <ConfigFilter>
-                        <PathStepPicker />
-                    </ConfigFilter>
+                    <ConfigFilter>{quillDateFilterEnabled ? <PathStepPickerNext /> : <PathStepPicker />}</ConfigFilter>
                 )}
 
                 {showCompare && (
                     <ConfigFilter>
-                        <CompareFilter
-                            compareFilter={compareFilter}
-                            updateCompareFilter={updateCompareFilter}
-                            disabled={!canEditInsight || !supportsCompare}
-                            disableReason={editingDisabledReason}
-                            tooltip={formatResolvedDateRange(
-                                alignResolvedDateRangeToInterval(insightData?.resolved_compare_date_range, interval)
-                            )}
-                        />
+                        {quillDateFilterEnabled ? (
+                            <CompareFilterNext {...compareFilterProps} />
+                        ) : (
+                            <CompareFilter {...compareFilterProps} />
+                        )}
                     </ConfigFilter>
                 )}
             </div>
@@ -162,23 +172,21 @@ export function InsightDisplayConfig(): JSX.Element {
                     </>
                 )}
                 {supportsDisplay && (
-                    <ConfigFilter>
-                        <ChartFilter />
-                    </ConfigFilter>
+                    <ConfigFilter>{quillDateFilterEnabled ? <ChartFilterNext /> : <ChartFilter />}</ConfigFilter>
                 )}
                 {!!isRetention && (
                     <ConfigFilter>
-                        <RetentionChartPicker />
+                        {quillDateFilterEnabled ? <RetentionChartPickerNext /> : <RetentionChartPicker />}
                     </ConfigFilter>
                 )}
                 {!!isStepsFunnel && (
                     <ConfigFilter>
-                        <FunnelDisplayLayoutPicker />
+                        {quillDateFilterEnabled ? <FunnelDisplayLayoutPickerNext /> : <FunnelDisplayLayoutPicker />}
                     </ConfigFilter>
                 )}
                 {!!isTimeToConvertFunnel && (
                     <ConfigFilter>
-                        <FunnelBinsPicker />
+                        {quillDateFilterEnabled ? <FunnelBinsPickerNext /> : <FunnelBinsPicker />}
                     </ConfigFilter>
                 )}
             </div>

--- a/frontend/src/scenes/insights/filters/RetentionChartPickerNext.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionChartPickerNext.tsx
@@ -1,0 +1,89 @@
+import { useActions, useValues } from 'kea'
+import { ReactNode } from 'react'
+
+import { IconGraph, IconTrends } from '@posthog/icons'
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectGroupLabel,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@posthog/quill'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { ChartDisplayType } from '~/types'
+
+interface RetentionChartOption {
+    value: ChartDisplayType
+    icon: ReactNode
+    label: string
+    description: string
+}
+
+const OPTIONS: RetentionChartOption[] = [
+    {
+        value: ChartDisplayType.ActionsLineGraph,
+        icon: <IconTrends />,
+        label: 'Line chart',
+        description: 'Retention over time plotted as a continuous line for each cohort.',
+    },
+    {
+        value: ChartDisplayType.ActionsBar,
+        icon: <IconGraph />,
+        label: 'Bar chart',
+        description: 'Retention over time as vertical bars for each cohort.',
+    },
+]
+
+const ITEMS = Object.fromEntries(
+    OPTIONS.map((option) => [
+        option.value,
+        <span className="flex items-center gap-2" key={option.value}>
+            {option.icon}
+            {option.label}
+        </span>,
+    ])
+)
+
+export function RetentionChartPickerNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <Select
+            value={retentionFilter?.display || ChartDisplayType.ActionsLineGraph}
+            items={ITEMS}
+            onValueChange={(value: string | null) => {
+                if (value) {
+                    updateInsightFilter({ display: value as ChartDisplayType })
+                }
+            }}
+            disabled={!!editingDisabledReason}
+        >
+            <SelectTrigger size="sm" data-quill data-attr="chart-filter" title={editingDisabledReason ?? undefined}>
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end" alignItemWithTrigger={false}>
+                <SelectGroup>
+                    <SelectGroupLabel>Time series</SelectGroupLabel>
+                    {OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                            {option.icon}
+                            <span className="flex flex-col">
+                                <span>{option.label}</span>
+                                <span className="text-xs font-normal whitespace-normal text-muted-foreground">
+                                    {option.description}
+                                </span>
+                            </span>
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SelectContent>
+        </Select>
+    )
+}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPickerNext.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPickerNext.tsx
@@ -1,0 +1,94 @@
+import { useActions, useValues } from 'kea'
+import { type ChangeEvent, useState } from 'react'
+
+import { IconGraph } from '@posthog/icons'
+import { Button, Input, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill'
+
+import { BIN_COUNT_AUTO } from 'lib/constants'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { BinCountValue } from '~/types'
+
+// Constraints as defined in funnel_time_to_convert.py:34
+const MIN = 1
+const MAX = 90
+const NUMBER_PRESETS = [5, 15, 25, 50, 90]
+
+export function FunnelBinsPickerNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { funnelsFilter, numericBinCount } = useValues(funnelDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
+    const [open, setOpen] = useState(false)
+
+    const setBinCount = (binCount: BinCountValue): void => {
+        updateInsightFilter({ binCount: binCount && binCount !== BIN_COUNT_AUTO ? binCount : undefined })
+    }
+
+    const selectedValue = funnelsFilter?.binCount || BIN_COUNT_AUTO
+    const label = selectedValue === BIN_COUNT_AUTO ? 'Auto bins' : `${selectedValue} bins`
+
+    const presets: { value: BinCountValue; label: string }[] = [
+        { value: BIN_COUNT_AUTO, label: 'Auto bins' },
+        ...NUMBER_PRESETS.map((value) => ({ value, label: `${value} bins` })),
+    ]
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger
+                render={
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        data-attr="funnel-bin-filter"
+                        data-quill
+                        disabled={!!editingDisabledReason}
+                        title={editingDisabledReason ?? undefined}
+                    >
+                        <IconGraph />
+                        {label}
+                    </Button>
+                }
+            />
+            <PopoverContent align="end" className="w-auto p-0 overflow-hidden">
+                <div className="flex w-40 flex-col gap-px p-2">
+                    {presets.map((preset) => (
+                        <Button
+                            key={String(preset.value)}
+                            variant="default"
+                            size="sm"
+                            left
+                            className="w-full justify-start"
+                            aria-selected={preset.value === selectedValue}
+                            onClick={() => {
+                                setOpen(false)
+                                setBinCount(preset.value)
+                            }}
+                            data-attr={`funnel-bin-preset-${preset.value}`}
+                        >
+                            {preset.label}
+                        </Button>
+                    ))}
+                    <div className="flex items-center gap-1 px-2 py-1">
+                        <Input
+                            type="number"
+                            min={MIN}
+                            max={MAX}
+                            value={numericBinCount}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                                const parsedCount = parseInt(e.target.value)
+                                if (parsedCount) {
+                                    setBinCount(parsedCount)
+                                }
+                            }}
+                            className="h-6 w-16"
+                            aria-label="Custom bin count"
+                            data-attr="funnel-bin-custom-count"
+                        />
+                        <span className="text-xs whitespace-nowrap">bins</span>
+                    </div>
+                </div>
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPickerNext.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelDisplayLayoutPickerNext.tsx
@@ -1,0 +1,70 @@
+import { useActions, useValues } from 'kea'
+
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectGroupLabel,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@posthog/quill'
+
+import { FunnelLayout } from 'lib/constants'
+import { IconFunnelHorizontal, IconFunnelVertical } from 'lib/lemon-ui/icons'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+const OPTIONS = [
+    { value: FunnelLayout.vertical, icon: <IconFunnelVertical />, label: 'Left to right' },
+    { value: FunnelLayout.horizontal, icon: <IconFunnelHorizontal />, label: 'Top to bottom' },
+]
+
+const ITEMS = Object.fromEntries(
+    OPTIONS.map((option) => [
+        option.value,
+        <span className="flex items-center gap-2" key={option.value}>
+            {option.icon}
+            {option.label}
+        </span>,
+    ])
+)
+
+export function FunnelDisplayLayoutPickerNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
+
+    return (
+        <Select
+            value={funnelsFilter?.layout || FunnelLayout.vertical}
+            items={ITEMS}
+            onValueChange={(layout: string | null) => {
+                if (layout) {
+                    updateInsightFilter({ layout: layout as FunnelLayout })
+                }
+            }}
+            disabled={!!editingDisabledReason}
+        >
+            <SelectTrigger
+                size="sm"
+                data-quill
+                data-attr="funnel-bar-layout-selector"
+                title={editingDisabledReason ?? undefined}
+            >
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end" alignItemWithTrigger={false}>
+                <SelectGroup>
+                    <SelectGroupLabel>Graph display options</SelectGroupLabel>
+                    {OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                            {option.icon}
+                            {option.label}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SelectContent>
+        </Select>
+    )
+}

--- a/frontend/src/scenes/insights/views/Paths/PathStepPickerNext.tsx
+++ b/frontend/src/scenes/insights/views/Paths/PathStepPickerNext.tsx
@@ -1,0 +1,52 @@
+import { useActions, useValues } from 'kea'
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@posthog/quill'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { DEFAULT_STEP_LIMIT } from 'scenes/paths/pathsDataLogic'
+import { pathsDataLogic } from 'scenes/paths/pathsDataLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { AvailableFeature } from '~/types'
+
+const MIN_STEPS = 2
+
+export function PathStepPickerNext(): JSX.Element {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { pathsFilter } = useValues(pathsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
+    const { hasAvailableFeature } = useValues(userLogic)
+
+    const { stepLimit } = pathsFilter || {}
+
+    const maxSteps = hasAvailableFeature(AvailableFeature.PATHS_ADVANCED) ? 20 : 5
+    const options = Array.from({ length: maxSteps - MIN_STEPS + 1 }, (_, index) => {
+        const steps = MIN_STEPS + index
+        return { value: String(steps), label: `${steps} Steps` }
+    })
+    const items = Object.fromEntries(options.map((option) => [option.value, option.label]))
+
+    return (
+        <Select
+            value={String(stepLimit || DEFAULT_STEP_LIMIT)}
+            items={items}
+            onValueChange={(value: string | null) => {
+                if (value) {
+                    updateInsightFilter({ stepLimit: parseInt(value) })
+                }
+            }}
+            disabled={!!editingDisabledReason}
+        >
+            <SelectTrigger size="sm" data-quill data-attr="path-step-filter" title={editingDisabledReason ?? undefined}>
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                {options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    )
+}

--- a/frontend/src/scenes/retention/RetentionBreakdownFilterNext.tsx
+++ b/frontend/src/scenes/retention/RetentionBreakdownFilterNext.tsx
@@ -1,0 +1,60 @@
+import { useActions, useValues } from 'kea'
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@posthog/quill'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { retentionLogic } from './retentionLogic'
+
+const ALL_KEY = '$all'
+
+export function RetentionBreakdownFilterNext(): JSX.Element | null {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { breakdownValues, selectedBreakdownValue, breakdownDisplayNames } = useValues(retentionLogic(insightProps))
+    const { setSelectedBreakdownValue } = useActions(retentionLogic(insightProps))
+
+    if (!breakdownValues || breakdownValues.length === 0) {
+        return null
+    }
+
+    const options = [
+        { key: ALL_KEY, value: null as string | number | boolean | null, label: 'All breakdown values' },
+        ...breakdownValues.map((value, index) => ({
+            key: `value-${index}`,
+            value: value as string | number | boolean | null,
+            label:
+                breakdownDisplayNames[String(value ?? '')] ||
+                (value === null || value === '' ? '(empty)' : String(value)),
+        })),
+    ]
+    const items = Object.fromEntries(options.map((option) => [option.key, option.label]))
+    const selectedKey = options.find((option) => option.value === selectedBreakdownValue)?.key ?? ALL_KEY
+
+    return (
+        <Select
+            value={selectedKey}
+            items={items}
+            onValueChange={(key: string | null) => {
+                const option = options.find((o) => o.key === key)
+                setSelectedBreakdownValue(option?.value ?? null)
+            }}
+            disabled={!!editingDisabledReason}
+        >
+            <SelectTrigger
+                size="sm"
+                data-quill
+                data-attr="retention-breakdown-filter"
+                title={editingDisabledReason ?? undefined}
+            >
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                {options.map((option) => (
+                    <SelectItem key={option.key} value={option.key}>
+                        {option.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    )
+}


### PR DESCRIPTION
## Problem

Stacked on #68359. With the quill date filter flag on, the date filter looks visibly different from every other control in the insight chart header row, which are all still LemonUI (`LemonSelect`, `LemonButton`, `LemonDropdown`). The header reads as two design systems at once.

## Changes

Converts the remaining pickers in the insight chart header to quill, behind the same `product-analytics-quill-date-filter` flag, so the whole header flips together:

| Control | Before | After |
| --- | --- | --- |
| Interval ("grouped by") | `LemonSelect` | quill `Select` (pinned state stays a button with the pin icon) |
| Compare filter | `LemonSelect` with embedded rolling picker | quill `Popover` with an option list plus inline count input and unit select, mirroring the date filter's rolling row |
| Chart type | `LemonSelect` with groups and descriptions | quill `Select` with `SelectGroup` labels, icons, and descriptions |
| Retention chart picker | `LemonSelect` | quill `Select` |
| Retention breakdown filter | `LemonSelect` | quill `Select` |
| Path step picker | `LemonSelect` | quill `Select` |
| Funnel display layout | `LemonSelect` | quill `Select` |
| Funnel bins picker | `LemonButton` + `LemonDropdown` + `LemonInput` | quill `Popover` with preset list and numeric input |

Each conversion is a new `*Next.tsx` component next to the original, following the `InsightDateFilterNext` pattern from #68359. Originals are untouched since they have other callers (web analytics uses `CompareFilter` and `IntervalFilterStandalone`). `InsightDisplayConfig` picks the variant off the flag.

Out of scope: the "Options" menu (~25 embedded controls in `insightDisplayOptions.tsx`) stays LemonUI for now and is planned as a stacked follow-up.

## How did you test this code?

- `frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx` passes (31 tests), covering the flag-off path
- oxlint and oxfmt clean on all touched files; typecheck shows no new errors beyond pre-existing stale-typegen noise that the untouched originals also show
- I (the agent) was not able to verify visually in a running app because the local dev stack serves a different checkout, so flag-on behavior needs a manual pass on this branch: trends (interval, compare, chart type), retention (chart picker, breakdown), paths (step picker), step funnel (layout), and time-to-convert funnel (bins)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, flag-gated UI-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code). Sam scoped the work: reuse the existing flag rather than adding a new one, and split the Options menu into a follow-up PR to keep this reviewable. Components follow the quill primitives guide (`packages/quill/packages/primitives/AGENTS.md`): `Select` for value pickers, `Popover` with a button rail for the two controls that embed inputs (compare, funnel bins), Base UI `render` prop on triggers, `data-quill` on inline triggers for the color bridge. Kept the originals' `data-attr` values so existing selectors keep working when the flag flips.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*