### PR TITLE
feat(insights): convert insight options menu to quill behind flag

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -69,7 +69,7 @@ export function isDefaultTrendsLineDisplay(
     return !display && isTrendsQuery(querySource)
 }
 
-function useLineGraphState(): { isLineGraph: boolean; isLinearScale: boolean } {
+export function useLineGraphState(): { isLineGraph: boolean; isLinearScale: boolean } {
     const { insightProps } = useValues(insightLogic)
     const { querySource, display, yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
     const isLineDisplay = isDefaultTrendsLineDisplay(display, querySource) || displayMatches(display, LINE_DISPLAYS)
@@ -285,3 +285,5 @@ export const DisplayOptions = {
     RetentionDashboardDisplay: { label: () => <RetentionDashboardDisplayPicker /> },
     RetentionCohortLabelStart: { label: () => <RetentionCohortLabelStartIndexPicker /> },
 } satisfies Record<string, LemonMenuItem>
+
+export type DisplayOptionKey = keyof typeof DisplayOptions

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptionsNext.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptionsNext.tsx
@@ -1,0 +1,1130 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { type ChangeEvent, type KeyboardEvent, ReactNode, useEffect, useMemo, useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+
+import { IconInfo } from '@posthog/icons'
+import {
+    Button,
+    Input,
+    Label,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Separator,
+    Switch,
+    ToggleGroup,
+    ToggleGroupItem,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@posthog/quill'
+import { normalizeAxisLabel } from '@posthog/quill-charts'
+
+import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
+import { unitPickerModalLogic } from 'lib/components/UnitPicker/unitPickerModalLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
+import {
+    AggregationAxisFormat,
+    defaultAggregationAxisFormatForDisplay,
+    INSIGHT_UNIT_OPTIONS,
+    INSIGHT_UNIT_OPTIONS_SHORT,
+} from 'scenes/insights/aggregationAxisFormat'
+import { DirectionColorPickers } from 'scenes/insights/EditorFilters/MetricFilters'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import {
+    METRIC_COLOR_BY_DIRECTION_DEFAULT,
+    METRIC_DEFAULT_DECREASE_COLOR,
+    METRIC_DEFAULT_INCREASE_COLOR,
+    METRIC_SHOW_CHANGE_DEFAULT,
+    METRIC_SUMMARY_DEFAULT,
+    type MetricSummary,
+} from 'scenes/insights/views/Metric/Metric.utils'
+import { INTERVAL_TO_DEFAULT_MOVING_AVERAGE_PERIOD, trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { ResultCustomizationBy, type TrendsFilter } from '~/queries/schema/schema-general'
+import { isFunnelsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
+import { ChartDisplayType, RetentionDashboardDisplayType } from '~/types'
+
+import { DisplayOptionKey, useLineGraphState } from './DisplayOptions'
+
+export function OptionTooltip({ children }: { children: ReactNode }): JSX.Element {
+    return (
+        <Tooltip>
+            <TooltipTrigger render={<span className="inline-flex text-muted-foreground" />}>
+                <IconInfo />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-72">
+                {children}
+            </TooltipContent>
+        </Tooltip>
+    )
+}
+
+function OptionSwitchRow({
+    id,
+    label,
+    checked,
+    onCheckedChange,
+    disabledReason,
+    tooltip,
+}: {
+    id: string
+    label: string
+    checked: boolean
+    onCheckedChange: (checked: boolean) => void
+    disabledReason?: string
+    tooltip?: string
+}): JSX.Element {
+    return (
+        <div className="flex items-center gap-2 px-3 py-1.5" title={disabledReason}>
+            <Switch id={id} size="sm" checked={checked} onCheckedChange={onCheckedChange} disabled={!!disabledReason} />
+            <Label htmlFor={id} className="font-normal">
+                {label}
+            </Label>
+            {tooltip && <OptionTooltip>{tooltip}</OptionTooltip>}
+        </div>
+    )
+}
+
+function SmoothingNext(): JSX.Element | null {
+    const { insightProps, editingDisabledReason } = useValues(insightLogic)
+    const { isTrends, interval, trendsFilter } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (!isTrends || !interval) {
+        return null
+    }
+    const options = smoothingOptions[interval]
+    if (!options.length) {
+        return null
+    }
+    const items = Object.fromEntries(options.map((option) => [String(option.value), option.label]))
+
+    return (
+        <div className="px-3 py-1">
+            <Select
+                value={String(trendsFilter?.smoothingIntervals || 1)}
+                items={items}
+                onValueChange={(value: string | null) => {
+                    if (value) {
+                        updateInsightFilter({ smoothingIntervals: parseInt(value) })
+                    }
+                }}
+                disabled={!!editingDisabledReason}
+            >
+                <SelectTrigger
+                    size="sm"
+                    className="w-full"
+                    data-attr="smoothing-filter"
+                    title={editingDisabledReason ?? undefined}
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {options.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                            {option.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}
+
+function LegendNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showLegend } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-show-legend"
+            label="Show legend"
+            checked={!!showLegend}
+            onCheckedChange={() => updateInsightFilter({ showLegend: !showLegend })}
+        />
+    )
+}
+
+type LegendPosition = NonNullable<TrendsFilter['legendPosition']>
+
+const LEGEND_POSITION_OPTIONS: { value: LegendPosition; label: string }[] = [
+    { value: 'bottom', label: 'Bottom' },
+    { value: 'top', label: 'Top' },
+    { value: 'left', label: 'Left' },
+    { value: 'right', label: 'Right' },
+]
+
+function LegendOptionsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showLegend, legendPosition } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <div className="flex items-center justify-between gap-2 px-3 py-1.5">
+            <div className="flex items-center gap-2">
+                <Switch
+                    id="insight-option-legend-options"
+                    size="sm"
+                    checked={!!showLegend}
+                    onCheckedChange={(checked) =>
+                        updateInsightFilter({
+                            showLegend: checked,
+                            // Seed bottom on first enable — old insights without a saved position render right (chart-config fallback).
+                            ...(checked && legendPosition == null ? { legendPosition: 'bottom' } : {}),
+                        })
+                    }
+                />
+                <Label htmlFor="insight-option-legend-options" className="font-normal">
+                    Show legend
+                </Label>
+            </div>
+            <Select
+                value={(legendPosition ?? (showLegend ? 'right' : 'bottom')) as string}
+                items={Object.fromEntries(LEGEND_POSITION_OPTIONS.map((option) => [option.value, option.label]))}
+                onValueChange={(position: string | null) => {
+                    if (position) {
+                        updateInsightFilter({ legendPosition: position as LegendPosition })
+                    }
+                }}
+                disabled={!showLegend}
+            >
+                <SelectTrigger size="sm" title={!showLegend ? 'Enable the legend to set its position' : undefined}>
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {LEGEND_POSITION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}
+
+function ExcludeOutliersNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-exclude-outliers"
+            label="Exclude outliers"
+            tooltip="When enabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles. When disabled, the y-axis extends to show the full range including extreme values."
+            checked={trendsFilter?.excludeBoxPlotOutliers !== false}
+            onCheckedChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    updateQuerySource({
+                        ...querySource,
+                        trendsFilter: { ...trendsFilter, excludeBoxPlotOutliers: checked },
+                    })
+                }
+            }}
+        />
+    )
+}
+
+function MetricSummaryNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    const summary = trendsFilter?.metricSummary ?? METRIC_SUMMARY_DEFAULT
+
+    return (
+        <div className="flex items-center justify-between gap-2 px-3 py-1.5">
+            <span className="font-normal">Headline value</span>
+            <Select
+                value={summary}
+                items={{ total: 'Total', average: 'Average', latest: 'Latest' }}
+                onValueChange={(value: string | null) => {
+                    if (value) {
+                        updateInsightFilter({ metricSummary: value as MetricSummary })
+                    }
+                }}
+            >
+                <SelectTrigger size="sm">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="total">Total</SelectItem>
+                    <SelectItem value="average">Average</SelectItem>
+                    <SelectItem value="latest">Latest</SelectItem>
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}
+
+function MetricShowChangeNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    const showChange = trendsFilter?.metricShowChange ?? METRIC_SHOW_CHANGE_DEFAULT
+
+    return (
+        <div className="flex flex-col">
+            <OptionSwitchRow
+                id="insight-option-metric-show-change"
+                label="Show change"
+                checked={showChange}
+                onCheckedChange={() => updateInsightFilter({ metricShowChange: !showChange })}
+            />
+            {showChange && (
+                <DirectionColorPickers
+                    increaseColor={trendsFilter?.metricChangeIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
+                    decreaseColor={trendsFilter?.metricChangeDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
+                    onIncrease={(color) => updateInsightFilter({ metricChangeIncreaseColor: color })}
+                    onDecrease={(color) => updateInsightFilter({ metricChangeDecreaseColor: color })}
+                />
+            )}
+        </div>
+    )
+}
+
+function MetricColorNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    const colorByDirection = trendsFilter?.metricColorByDirection ?? METRIC_COLOR_BY_DIRECTION_DEFAULT
+
+    return (
+        <div className="flex flex-col">
+            <OptionSwitchRow
+                id="insight-option-metric-color"
+                label="Color by trend"
+                checked={colorByDirection}
+                onCheckedChange={() => updateInsightFilter({ metricColorByDirection: !colorByDirection })}
+            />
+            {colorByDirection && (
+                <DirectionColorPickers
+                    increaseColor={trendsFilter?.metricLineIncreaseColor ?? METRIC_DEFAULT_INCREASE_COLOR}
+                    decreaseColor={trendsFilter?.metricLineDecreaseColor ?? METRIC_DEFAULT_DECREASE_COLOR}
+                    onIncrease={(color) => updateInsightFilter({ metricLineIncreaseColor: color })}
+                    onDecrease={(color) => updateInsightFilter({ metricLineDecreaseColor: color })}
+                />
+            )}
+        </div>
+    )
+}
+
+function LifecycleStackingNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { lifecycleFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-lifecycle-stacking"
+            label="Stack bars"
+            checked={lifecycleFilter?.stacked ?? true}
+            onCheckedChange={(checked) => updateInsightFilter({ stacked: checked })}
+        />
+    )
+}
+
+function LifecyclePercentagesNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showPercentagesOnSeries } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-lifecycle-percentages"
+            label="Show percentages on series"
+            checked={!!showPercentagesOnSeries}
+            onCheckedChange={() => updateInsightFilter({ showPercentagesOnSeries: !showPercentagesOnSeries })}
+        />
+    )
+}
+
+function ValueLabelsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showValuesOnSeries } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-value-labels"
+            label="Show values on series"
+            checked={!!showValuesOnSeries}
+            onCheckedChange={() => updateInsightFilter({ showValuesOnSeries: !showValuesOnSeries })}
+        />
+    )
+}
+
+function PercentStackNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { display } = useValues(insightVizDataLogic(insightProps))
+    const { showPercentStackView, showValuesOnSeries } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(trendsDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-percent-stack"
+            label="Show as % of total"
+            checked={!!showPercentStackView}
+            onCheckedChange={(checked) => updateInsightFilter({ showPercentStackView: checked })}
+            // On a pie chart the percentage is rendered through the series value labels, so it has no
+            // effect while those labels are hidden.
+            disabledReason={
+                display === ChartDisplayType.ActionsPie && showValuesOnSeries === false
+                    ? "Enable 'Show values on series' to use this option"
+                    : undefined
+            }
+        />
+    )
+}
+
+function StackBreakdownNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(trendsDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-stack-breakdown"
+            label="Stack breakdown values"
+            checked={!!trendsFilter?.stackBreakdownValues}
+            onCheckedChange={(checked) => updateInsightFilter({ stackBreakdownValues: checked })}
+        />
+    )
+}
+
+function PieTotalNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { pieChartVizOptions } = useValues(trendsDataLogic(insightProps))
+    const { updateVizSpecificOptions } = useActions(insightVizDataLogic(insightProps))
+
+    const showTotal = !pieChartVizOptions?.hideAggregation
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-pie-total"
+            label="Show total below chart"
+            checked={showTotal}
+            onCheckedChange={() =>
+                updateVizSpecificOptions({
+                    [ChartDisplayType.ActionsPie]: { ...pieChartVizOptions, hideAggregation: showTotal },
+                })
+            }
+        />
+    )
+}
+
+function AlertThresholdLinesNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showAlertThresholdLines } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-alert-threshold-lines"
+            label="Show alert threshold lines"
+            checked={!!showAlertThresholdLines}
+            onCheckedChange={() => updateInsightFilter({ showAlertThresholdLines: !showAlertThresholdLines })}
+        />
+    )
+}
+
+function AlertAnomalyPointsNext(): JSX.Element | null {
+    const { insightProps, insight } = useValues(insightLogic)
+    const logic = insightAlertsLogic({ insightId: insight.id!, insightLogicProps: insightProps })
+    const { showAlertAnomalyPointsFlag, hasDetectorAlerts } = useValues(logic)
+    const { setShowAlertAnomalyPoints } = useActions(logic)
+
+    if (!hasDetectorAlerts) {
+        return null
+    }
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-alert-anomaly-points"
+            label="Show alert anomaly points"
+            checked={showAlertAnomalyPointsFlag}
+            onCheckedChange={() => setShowAlertAnomalyPoints(!showAlertAnomalyPointsFlag)}
+        />
+    )
+}
+
+function MultipleYAxesNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showMultipleYAxes } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-multiple-y-axes"
+            label="Show multiple Y-axes"
+            checked={!!showMultipleYAxes}
+            onCheckedChange={() => updateInsightFilter({ showMultipleYAxes: !showMultipleYAxes })}
+        />
+    )
+}
+
+function TrendLinesNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter, yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
+    const { isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+
+    const showTrendLines = isRetentionQuery(querySource)
+        ? querySource.retentionFilter.showTrendLines
+        : isTrendsQuery(querySource)
+          ? querySource.trendsFilter?.showTrendLines
+          : isFunnelsQuery(querySource)
+            ? querySource.funnelsFilter?.showTrendLines
+            : false
+
+    const isLinearScale = !yAxisScaleType || yAxisScaleType === 'linear'
+    const isLineGraph = isTrendsQuery(querySource)
+        ? (trendsFilter?.display || ChartDisplayType.ActionsLineGraph) === ChartDisplayType.ActionsLineGraph ||
+          (trendsFilter?.display || ChartDisplayType.ActionsLineGraph) === ChartDisplayType.ActionsLineGraphCumulative
+        : isFunnelsQuery(querySource)
+          ? isTrendsFunnel
+          : true // Retention graphs are always line graphs
+
+    const disabledReason = !isLineGraph
+        ? 'Trend lines are only available for line graphs'
+        : !isLinearScale
+          ? 'Trend lines are only supported for linear scale.'
+          : undefined
+
+    const toggleShowTrendLines = (): void => {
+        if (isRetentionQuery(querySource)) {
+            updateQuerySource({
+                retentionFilter: { ...querySource.retentionFilter, showTrendLines: !showTrendLines },
+            } as any)
+        } else if (isTrendsQuery(querySource)) {
+            updateQuerySource({ trendsFilter: { ...querySource.trendsFilter, showTrendLines: !showTrendLines } } as any)
+        } else if (isFunnelsQuery(querySource)) {
+            updateQuerySource({
+                funnelsFilter: { ...querySource.funnelsFilter, showTrendLines: !showTrendLines },
+            } as any)
+        }
+    }
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-trend-lines"
+            label="Show trend lines"
+            checked={!disabledReason && !!showTrendLines}
+            onCheckedChange={toggleShowTrendLines}
+            disabledReason={disabledReason}
+        />
+    )
+}
+
+function HideIncompleteFunnelPeriodsNext(): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (!isFunnelsQuery(querySource)) {
+        return null
+    }
+
+    const hideIncompleteConversionWindowPeriods =
+        querySource.funnelsFilter?.hideIncompleteConversionWindowPeriods ?? false
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-hide-incomplete-periods"
+            label="Hide incomplete periods"
+            tooltip="Hides recent periods whose conversion window hasn't fully elapsed, so the trend isn't dragged down by entrants who still have time to convert."
+            checked={hideIncompleteConversionWindowPeriods}
+            onCheckedChange={() =>
+                updateInsightFilter({ hideIncompleteConversionWindowPeriods: !hideIncompleteConversionWindowPeriods })
+            }
+        />
+    )
+}
+
+function HideWeekendsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-hide-weekends"
+            label="Hide weekend data"
+            checked={!!trendsFilter?.hideWeekends}
+            onCheckedChange={() => updateInsightFilter({ hideWeekends: !trendsFilter?.hideWeekends })}
+        />
+    )
+}
+
+function AnnotationsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showAnnotations } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-annotations"
+            label="Show annotations"
+            checked={showAnnotations !== false}
+            onCheckedChange={(checked) => updateInsightFilter({ showAnnotations: checked })}
+        />
+    )
+}
+
+function ResultCustomizationByNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { resultCustomizationBy } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(trendsDataLogic(insightProps))
+
+    return (
+        <div className="px-3 py-1">
+            <ToggleGroup size="sm" className="w-full" value={[resultCustomizationBy]}>
+                {[
+                    { value: ResultCustomizationBy.Value, label: 'By name' },
+                    { value: ResultCustomizationBy.Position, label: 'By rank' },
+                ].map((option) => (
+                    <ToggleGroupItem
+                        key={option.value}
+                        value={option.value}
+                        className="flex-1"
+                        onClick={() => updateInsightFilter({ resultCustomizationBy: option.value })}
+                    >
+                        {option.label}
+                    </ToggleGroupItem>
+                ))}
+            </ToggleGroup>
+        </div>
+    )
+}
+
+function UnitNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter, display } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { showCustomUnitModal } = useActions(unitPickerModalLogic)
+    const { reportAxisUnitsChanged } = useActions(eventUsageLogic)
+
+    const [open, setOpen] = useState(false)
+    const [localAxisFormat, setLocalAxisFormat] = useState(trendsFilter?.aggregationAxisFormat || undefined)
+    // Some display types (e.g. Metric) render a default unit when none is explicitly set — reflect it here.
+    const effectiveAxisFormat = localAxisFormat ?? defaultAggregationAxisFormatForDisplay(display)
+
+    const handleChange = ({
+        format,
+        prefix,
+        postfix,
+    }: {
+        format?: AggregationAxisFormat
+        prefix?: string
+        postfix?: string
+    }): void => {
+        setLocalAxisFormat(format)
+        updateInsightFilter({
+            aggregationAxisFormat: format,
+            aggregationAxisPrefix: prefix,
+            aggregationAxisPostfix: postfix,
+        })
+        reportAxisUnitsChanged({
+            format,
+            prefix,
+            postfix,
+            display,
+            unitIsSet: !!prefix || !!postfix || (format && format !== 'numeric'),
+        })
+        setOpen(false)
+    }
+
+    const displayValue = useMemo(() => {
+        let displayValue: ReactNode = 'None'
+        if (effectiveAxisFormat) {
+            displayValue = INSIGHT_UNIT_OPTIONS_SHORT[effectiveAxisFormat]
+        }
+        if (trendsFilter?.aggregationAxisPrefix?.length) {
+            displayValue = `Prefix: ${trendsFilter?.aggregationAxisPrefix}`
+        }
+        if (trendsFilter?.aggregationAxisPostfix?.length) {
+            displayValue = `Postfix: ${trendsFilter?.aggregationAxisPostfix}`
+        }
+        return displayValue
+    }, [effectiveAxisFormat, trendsFilter])
+
+    return (
+        <div className="px-3 py-1">
+            <Popover open={open} onOpenChange={setOpen}>
+                <PopoverTrigger
+                    render={
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            left
+                            className="w-full"
+                            data-attr="chart-aggregation-axis-format"
+                        />
+                    }
+                >
+                    <span className="min-w-0 truncate">{displayValue}</span>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-56 p-0">
+                    <div className="flex flex-col gap-px p-2">
+                        {INSIGHT_UNIT_OPTIONS.map(({ value, label }) => (
+                            <Button
+                                key={value}
+                                variant="default"
+                                size="sm"
+                                left
+                                className="w-full justify-start"
+                                aria-selected={value === effectiveAxisFormat}
+                                onClick={() => handleChange({ format: value })}
+                            >
+                                {label}
+                            </Button>
+                        ))}
+                        <Separator className="my-1" />
+                        <Button
+                            variant="default"
+                            size="sm"
+                            left
+                            className="w-full justify-start"
+                            aria-selected={!!trendsFilter?.aggregationAxisPrefix}
+                            onClick={() =>
+                                showCustomUnitModal({
+                                    type: 'prefix',
+                                    currentValue: trendsFilter?.aggregationAxisPrefix || '',
+                                    callback: (value: string) => handleChange({ prefix: value }),
+                                })
+                            }
+                        >
+                            Custom prefix
+                            {trendsFilter?.aggregationAxisPrefix
+                                ? `: ${trendsFilter?.aggregationAxisPrefix}...`
+                                : '...'}
+                        </Button>
+                        <Button
+                            variant="default"
+                            size="sm"
+                            left
+                            className="w-full justify-start"
+                            aria-selected={!!trendsFilter?.aggregationAxisPostfix}
+                            onClick={() =>
+                                showCustomUnitModal({
+                                    type: 'postfix',
+                                    currentValue: trendsFilter?.aggregationAxisPostfix || '',
+                                    callback: (value: string) => handleChange({ postfix: value }),
+                                })
+                            }
+                        >
+                            Custom postfix
+                            {trendsFilter?.aggregationAxisPostfix
+                                ? `: ${trendsFilter?.aggregationAxisPostfix}...`
+                                : '...'}
+                        </Button>
+                    </div>
+                </PopoverContent>
+            </Popover>
+        </div>
+    )
+}
+
+function ScaleNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <div className="px-3 py-1">
+            <ToggleGroup size="sm" className="w-full" value={[yAxisScaleType || 'linear']}>
+                {[
+                    { value: 'linear', label: 'Linear' },
+                    { value: 'log10', label: 'Logarithmic' },
+                ].map((option) => (
+                    <ToggleGroupItem
+                        key={option.value}
+                        value={option.value}
+                        className="flex-1"
+                        onClick={() => updateInsightFilter({ yAxisScaleType: option.value as 'linear' | 'log10' })}
+                    >
+                        {option.label}
+                    </ToggleGroupItem>
+                ))}
+            </ToggleGroup>
+        </div>
+    )
+}
+
+function ConfidenceIntervalNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { showConfidenceIntervals } = useValues(trendsDataLogic(insightProps))
+    const { isLineGraph, isLinearScale } = useLineGraphState()
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-confidence-intervals"
+            label="Show confidence intervals"
+            checked={showConfidenceIntervals}
+            disabledReason={
+                !isLineGraph
+                    ? 'Confidence intervals are only available for line graphs'
+                    : !isLinearScale
+                      ? 'Confidence intervals are only supported for linear scale.'
+                      : undefined
+            }
+            onCheckedChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    updateQuerySource({
+                        ...querySource,
+                        trendsFilter: { ...trendsFilter, showConfidenceIntervals: checked },
+                    })
+                }
+            }}
+        />
+    )
+}
+
+function ConfidenceLevelNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { confidenceLevel, showConfidenceIntervals } = useValues(trendsDataLogic(insightProps))
+    const { querySource } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const trendsFilter = isTrendsQuery(querySource) ? querySource.trendsFilter : undefined
+
+    const [localValue, setLocalValue] = useState(confidenceLevel)
+
+    useEffect(() => {
+        setLocalValue(confidenceLevel)
+    }, [confidenceLevel])
+
+    const debouncedUpdate = useDebouncedCallback((value: number) => {
+        if (isTrendsQuery(querySource)) {
+            updateQuerySource({ ...querySource, trendsFilter: { ...trendsFilter, confidenceLevel: value } })
+        }
+    }, 500)
+
+    return (
+        <div className="flex items-center justify-between gap-2 py-1.5 pr-3 pl-6">
+            <span className="flex items-center gap-1 font-normal">
+                Confidence level
+                <OptionTooltip>
+                    A 95% confidence level means that for each data point, we are 95% confident that the true value is
+                    within the confidence interval.
+                </OptionTooltip>
+            </span>
+            <div
+                className="flex items-center gap-1"
+                title={!showConfidenceIntervals ? 'Confidence intervals are only available for line graphs' : undefined}
+            >
+                <Input
+                    type="number"
+                    className="h-6 w-16"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={localValue}
+                    disabled={!showConfidenceIntervals}
+                    aria-label="Confidence level"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                        const numValue = e.target.value === '' ? 95 : Number(e.target.value)
+                        setLocalValue(numValue)
+                        debouncedUpdate(numValue)
+                    }}
+                />
+                <span className="text-xs">%</span>
+            </div>
+        </div>
+    )
+}
+
+function MovingAverageNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { showMovingAverage } = useValues(trendsDataLogic(insightProps))
+    const { isLineGraph, isLinearScale } = useLineGraphState()
+
+    return (
+        <OptionSwitchRow
+            id="insight-option-moving-average"
+            label="Show moving average"
+            checked={showMovingAverage}
+            disabledReason={
+                !isLineGraph
+                    ? 'Moving average is only available for line and area graphs'
+                    : !isLinearScale
+                      ? 'Moving average is only supported for linear scale.'
+                      : undefined
+            }
+            onCheckedChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    updateQuerySource({ ...querySource, trendsFilter: { ...trendsFilter, showMovingAverage: checked } })
+                }
+            }}
+        />
+    )
+}
+
+function MovingAverageIntervalsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { movingAverageIntervals, showMovingAverage } = useValues(trendsDataLogic(insightProps))
+    const { querySource } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const trendsFilter = isTrendsQuery(querySource) ? querySource.trendsFilter : undefined
+
+    const [localValue, setLocalValue] = useState(movingAverageIntervals)
+
+    useEffect(() => {
+        setLocalValue(movingAverageIntervals)
+    }, [movingAverageIntervals])
+
+    const debouncedUpdate = useDebouncedCallback((value: number) => {
+        if (isTrendsQuery(querySource)) {
+            updateQuerySource({ ...querySource, trendsFilter: { ...trendsFilter, movingAverageIntervals: value } })
+        }
+    }, 500)
+
+    const interval = isTrendsQuery(querySource) ? querySource.interval || 'day' : 'day'
+
+    return (
+        <div className="flex items-center justify-between gap-2 py-1.5 pr-3 pl-6">
+            <span className="flex items-center gap-1 font-normal">
+                Intervals
+                <OptionTooltip>
+                    The number of data points to use for calculating the moving average. A larger number will create a
+                    smoother line but with more lag. You can't use a number greater than the amount of intervals in your
+                    date range.
+                </OptionTooltip>
+            </span>
+            <div
+                className="flex items-center gap-1"
+                title={!showMovingAverage ? 'Moving averages are only available for line and area graphs' : undefined}
+            >
+                <Input
+                    type="number"
+                    className="h-6 w-16"
+                    min={2}
+                    step={1}
+                    value={localValue}
+                    disabled={!showMovingAverage}
+                    aria-label="Moving average intervals"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                        const numValue =
+                            e.target.value === ''
+                                ? INTERVAL_TO_DEFAULT_MOVING_AVERAGE_PERIOD[interval]
+                                : Number(e.target.value)
+                        setLocalValue(numValue)
+                        debouncedUpdate(numValue)
+                    }}
+                />
+                <span className="text-xs whitespace-nowrap">{`${interval}s`}</span>
+            </div>
+        </div>
+    )
+}
+
+function AxisLabelsNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const [xAxisLabelDraft, setXAxisLabelDraft] = useState(trendsFilter?.xAxisLabel ?? '')
+    const [yAxisLabelDraft, setYAxisLabelDraft] = useState(trendsFilter?.yAxisLabel ?? '')
+
+    useEffect(() => {
+        setXAxisLabelDraft(trendsFilter?.xAxisLabel ?? '')
+    }, [trendsFilter?.xAxisLabel])
+
+    useEffect(() => {
+        setYAxisLabelDraft(trendsFilter?.yAxisLabel ?? '')
+    }, [trendsFilter?.yAxisLabel])
+
+    const commitXAxisLabel = (): void => {
+        const normalized = normalizeAxisLabel(xAxisLabelDraft)
+        setXAxisLabelDraft(normalized ?? '')
+        updateInsightFilter({ xAxisLabel: normalized })
+    }
+
+    const commitYAxisLabel = (): void => {
+        const normalized = normalizeAxisLabel(yAxisLabelDraft)
+        setYAxisLabelDraft(normalized ?? '')
+        updateInsightFilter({ yAxisLabel: normalized })
+    }
+
+    return (
+        <div className="flex flex-col gap-2 px-3 py-1">
+            <div className="flex flex-col gap-1">
+                <Label htmlFor="insight-option-x-axis-label">X-axis label</Label>
+                <Input
+                    id="insight-option-x-axis-label"
+                    data-attr="trends-x-axis-label-input"
+                    value={xAxisLabelDraft}
+                    placeholder="X-axis label"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setXAxisLabelDraft(e.target.value)}
+                    onBlur={commitXAxisLabel}
+                    onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && commitXAxisLabel()}
+                />
+            </div>
+            <div className="flex flex-col gap-1">
+                <Label htmlFor="insight-option-y-axis-label">Y-axis label</Label>
+                <Input
+                    id="insight-option-y-axis-label"
+                    data-attr="trends-y-axis-label-input"
+                    value={yAxisLabelDraft}
+                    placeholder="Y-axis label"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setYAxisLabelDraft(e.target.value)}
+                    onBlur={commitYAxisLabel}
+                    onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && commitYAxisLabel()}
+                />
+            </div>
+        </div>
+    )
+}
+
+function DecimalPrecisionNext(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    const reportChange = useDebouncedCallback(() => {
+        posthog.capture('decimal places changed', {
+            decimal_places: trendsFilter?.decimalPlaces,
+        })
+    }, 500)
+
+    return (
+        <div className="px-3 py-1">
+            <Input
+                type="number"
+                step={1}
+                min={0}
+                max={9}
+                value={trendsFilter?.decimalPlaces ?? DEFAULT_DECIMAL_PLACES}
+                aria-label="Decimal places"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const parsed = parseInt(e.target.value)
+                    updateInsightFilter({ decimalPlaces: Number.isNaN(parsed) ? undefined : parsed })
+                    reportChange()
+                }}
+            />
+        </div>
+    )
+}
+
+function RetentionDashboardDisplayNext(): JSX.Element | null {
+    const { insightProps, canEditInsight } = useValues(insightLogic)
+    const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (!canEditInsight) {
+        return null
+    }
+
+    const options = [
+        { value: RetentionDashboardDisplayType.TableOnly, label: 'Show table only' },
+        { value: RetentionDashboardDisplayType.GraphOnly, label: 'Show graph only' },
+        { value: RetentionDashboardDisplayType.All, label: 'Show both' },
+    ]
+
+    return (
+        <div className="px-3 py-1">
+            <Select
+                value={retentionFilter?.dashboardDisplay || RetentionDashboardDisplayType.TableOnly}
+                items={Object.fromEntries(options.map((option) => [option.value, option.label]))}
+                onValueChange={(value: string | null) => {
+                    if (value) {
+                        updateInsightFilter({ dashboardDisplay: value as RetentionDashboardDisplayType })
+                    }
+                }}
+            >
+                <SelectTrigger size="sm" className="w-full">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}
+
+function RetentionCohortLabelStartNext(): JSX.Element | null {
+    const { insightProps, canEditInsight } = useValues(insightLogic)
+    const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (!canEditInsight) {
+        return null
+    }
+
+    const period = retentionFilter?.period || 'Day'
+
+    return (
+        <div className="px-3 py-1">
+            <ToggleGroup size="sm" className="w-full" value={[String(retentionFilter?.cohortLabelStartIndex ?? 0)]}>
+                {[0, 1].map((index) => (
+                    <ToggleGroupItem
+                        key={index}
+                        value={String(index)}
+                        className="flex-1"
+                        onClick={() => updateInsightFilter({ cohortLabelStartIndex: index })}
+                    >
+                        {`${period} ${index}`}
+                    </ToggleGroupItem>
+                ))}
+            </ToggleGroup>
+        </div>
+    )
+}
+
+// Quill twins of `DisplayOptions`, keyed identically so both shells consume the same
+// `useInsightDisplayOptionSections()` structure.
+export const DisplayOptionsNext: Record<DisplayOptionKey, () => JSX.Element | null> = {
+    Smoothing: SmoothingNext,
+    Legend: LegendNext,
+    LegendOptions: LegendOptionsNext,
+    ExcludeOutliers: ExcludeOutliersNext,
+    MetricSummary: MetricSummaryNext,
+    MetricShowChange: MetricShowChangeNext,
+    MetricColor: MetricColorNext,
+    LifecycleStacking: LifecycleStackingNext,
+    LifecyclePercentages: LifecyclePercentagesNext,
+    ValueLabels: ValueLabelsNext,
+    PercentStack: PercentStackNext,
+    StackBreakdown: StackBreakdownNext,
+    PieTotal: PieTotalNext,
+    AlertThresholdLines: AlertThresholdLinesNext,
+    AlertAnomalyPoints: AlertAnomalyPointsNext,
+    MultipleYAxes: MultipleYAxesNext,
+    TrendLines: TrendLinesNext,
+    HideIncompleteFunnelPeriods: HideIncompleteFunnelPeriodsNext,
+    HideWeekends: HideWeekendsNext,
+    Annotations: AnnotationsNext,
+    ResultCustomizationBy: ResultCustomizationByNext,
+    Unit: UnitNext,
+    Scale: ScaleNext,
+    ConfidenceInterval: ConfidenceIntervalNext,
+    ConfidenceLevel: ConfidenceLevelNext,
+    MovingAverage: MovingAverageNext,
+    MovingAverageIntervals: MovingAverageIntervalsNext,
+    AxisLabels: AxisLabelsNext,
+    DecimalPrecision: DecimalPrecisionNext,
+    RetentionDashboardDisplay: RetentionDashboardDisplayNext,
+    RetentionCohortLabelStart: RetentionCohortLabelStartNext,
+}

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -35,6 +35,7 @@ import { hasBreakdownFilter, isWebAnalyticsInsightQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
 import { useInsightDisplayOptions } from './insightDisplayOptions'
+import { InsightDisplayOptionsMenuNext } from './InsightDisplayOptionsMenuNext'
 
 export function InsightDisplayConfig(): JSX.Element {
     const { insightProps, canEditInsight, editingDisabledReason } = useValues(insightLogic)
@@ -141,7 +142,8 @@ export function InsightDisplayConfig(): JSX.Element {
                 )}
             </div>
             <div className="flex items-center gap-x-2">
-                {advancedOptions.length > 0 && (
+                {quillDateFilterEnabled && <InsightDisplayOptionsMenuNext />}
+                {!quillDateFilterEnabled && advancedOptions.length > 0 && (
                     <>
                         <LemonMenu items={advancedOptions} closeOnClickInside={false} placement="bottom-end">
                             <LemonButton

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayOptionsMenuNext.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayOptionsMenuNext.tsx
@@ -1,0 +1,88 @@
+import { useValues } from 'kea'
+
+import { IconEllipsis } from '@posthog/icons'
+import { Button, MenuLabel, Popover, PopoverContent, PopoverTrigger, TooltipProvider } from '@posthog/quill'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { DisplayOptionsNext, OptionTooltip } from './DisplayOptionsNext'
+import { DisplayOptionsSection, useInsightDisplayOptionSections } from './insightDisplayOptions'
+
+function OptionsPopoverContent({ sections }: { sections: DisplayOptionsSection[] }): JSX.Element {
+    return (
+        <PopoverContent align="end" className="w-72 p-0">
+            <TooltipProvider>
+                <div className="flex max-h-[70vh] flex-col overflow-y-auto py-1">
+                    {sections.map((section) => (
+                        <div key={section.key} className="flex flex-col gap-px pb-1">
+                            <MenuLabel data-attr={section.dataAttr} className="flex items-center gap-1">
+                                {section.title}
+                                {section.tooltip && <OptionTooltip>{section.tooltip}</OptionTooltip>}
+                            </MenuLabel>
+                            {section.items.map((key) => {
+                                const Option = DisplayOptionsNext[key]
+                                return <Option key={key} />
+                            })}
+                        </div>
+                    ))}
+                </div>
+            </TooltipProvider>
+        </PopoverContent>
+    )
+}
+
+export function InsightDisplayOptionsMenuNext(): JSX.Element | null {
+    const { editingDisabledReason } = useValues(insightLogic)
+    const { sections, count } = useInsightDisplayOptionSections()
+
+    const visibleSections = sections.filter((section) => section.items.length > 0)
+    if (visibleSections.length === 0) {
+        return null
+    }
+
+    return (
+        <>
+            <Popover>
+                <PopoverTrigger
+                    render={
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            data-quill
+                            data-attr="insight-display-options"
+                            aria-label="Options"
+                            className="@max-[780px]:hidden"
+                            disabled={!!editingDisabledReason}
+                            title={editingDisabledReason ?? undefined}
+                        />
+                    }
+                >
+                    <span className="whitespace-nowrap">
+                        Options
+                        {count ? <span className="ml-0.5 text-muted-foreground ligatures-none">({count})</span> : null}
+                    </span>
+                </PopoverTrigger>
+                <OptionsPopoverContent sections={visibleSections} />
+            </Popover>
+            <Popover>
+                <PopoverTrigger
+                    render={
+                        <Button
+                            variant="outline"
+                            size="icon-sm"
+                            data-quill
+                            data-attr="insight-display-options"
+                            aria-label="Options"
+                            className="hidden @max-[780px]:flex order-[999]"
+                            disabled={!!editingDisabledReason}
+                            title={editingDisabledReason ?? undefined}
+                        />
+                    }
+                >
+                    <IconEllipsis />
+                </PopoverTrigger>
+                <OptionsPopoverContent sections={visibleSections} />
+            </Popover>
+        </>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -4,7 +4,7 @@ import { normalizeAxisLabel } from '@posthog/quill-charts'
 
 import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
+import { LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
@@ -18,15 +18,25 @@ import { ChartDisplayType } from '~/types'
 import {
     BAR_DISPLAYS,
     displayMatches,
+    DisplayOptionKey,
     DisplayOptions,
     isDefaultTrendsLineDisplay,
     LINE_DISPLAYS,
     SectionHeader,
 } from './DisplayOptions'
 
-// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
-// active options, badged on the Options button.
-export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+export interface DisplayOptionsSection {
+    key: string
+    title: string
+    tooltip?: string
+    dataAttr?: string
+    items: DisplayOptionKey[]
+}
+
+// The structure of the "Options" menu in the insight editor's display config bar, shared between the
+// LemonMenu shell and the quill shell. `count` is the number of non-default active options, badged on
+// the Options button.
+export function useInsightDisplayOptionSections(): { sections: DisplayOptionsSection[]; count: number } {
     const { insightProps } = useValues(insightLogic)
     const {
         querySource,
@@ -103,14 +113,14 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
 
     // The box plot and slope graph only show a couple of options each; everything else falls
     // through to the full shared list.
-    const getDisplayItems = (): LemonMenuItem[] => {
-        const displayItems: LemonMenuItem[] = []
+    const getDisplayItems = (): DisplayOptionKey[] => {
+        const displayItems: DisplayOptionKey[] = []
 
         if (isBoxPlot) {
             if (hasLegend) {
-                displayItems.push(DisplayOptions.Legend)
+                displayItems.push('Legend')
             }
-            displayItems.push(DisplayOptions.ExcludeOutliers)
+            displayItems.push('ExcludeOutliers')
             return displayItems
         }
 
@@ -118,123 +128,124 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             // A slope only shows the first vs last interval of each series — the legend (when there
             // are multiple series) is the only display option that applies.
             if (hasLegend) {
-                displayItems.push(DisplayOptions.Legend)
+                displayItems.push('Legend')
             }
             return displayItems
         }
 
         if (isMetric) {
-            displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+            displayItems.push('MetricSummary', 'MetricShowChange', 'MetricColor')
         }
         if (isLifecycle) {
-            displayItems.push(DisplayOptions.LifecycleStacking)
+            displayItems.push('LifecycleStacking')
         }
         if (supportsValueOnSeries) {
-            displayItems.push(DisplayOptions.ValueLabels)
+            displayItems.push('ValueLabels')
         }
         if (isLifecycle) {
-            displayItems.push(DisplayOptions.LifecyclePercentages)
+            displayItems.push('LifecyclePercentages')
         }
         if (supportsPercentStackView) {
-            displayItems.push(DisplayOptions.PercentStack)
+            displayItems.push('PercentStack')
         }
         if (supportsBarValueStacking) {
-            displayItems.push(DisplayOptions.StackBreakdown)
+            displayItems.push('StackBreakdown')
         }
         if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions) {
-            displayItems.push(DisplayOptions.Legend)
+            displayItems.push('Legend')
         }
         if (display === ChartDisplayType.ActionsPie) {
-            displayItems.push(DisplayOptions.PieTotal)
+            displayItems.push('PieTotal')
         }
         if (showAlertThresholdLinesConfig) {
-            displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
+            displayItems.push('AlertThresholdLines', 'AlertAnomalyPoints')
         }
         if (showMultipleYAxesConfig) {
-            displayItems.push(DisplayOptions.MultipleYAxes)
+            displayItems.push('MultipleYAxes')
         }
         if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions) {
-            displayItems.push(DisplayOptions.TrendLines)
+            displayItems.push('TrendLines')
         }
         if (isTrendsFunnel && !hideContinuousChartOptions) {
-            displayItems.push(DisplayOptions.HideIncompleteFunnelPeriods)
+            displayItems.push('HideIncompleteFunnelPeriods')
         }
         if (isTrends && !hideContinuousChartOptions && hideWeekendsEnabled) {
-            displayItems.push(DisplayOptions.HideWeekends)
+            displayItems.push('HideWeekends')
         }
         if (showAnnotationsConfig) {
-            displayItems.push(DisplayOptions.Annotations)
+            displayItems.push('Annotations')
         }
         if (useQuillLegendOptions) {
-            displayItems.push(DisplayOptions.LegendOptions)
+            displayItems.push('LegendOptions')
         }
         return displayItems
     }
 
-    const items: LemonMenuItems = []
+    const sections: DisplayOptionsSection[] = []
 
     if (showSmoothing) {
-        items.push({ title: 'Smoothing', items: [DisplayOptions.Smoothing] })
+        sections.push({ key: 'smoothing', title: 'Smoothing', items: ['Smoothing'] })
     }
 
     if (showDisplaySection) {
-        items.push({
-            title: <SectionHeader dataAttr="options-display-section">Display</SectionHeader>,
+        sections.push({
+            key: 'display',
+            title: 'Display',
+            dataAttr: 'options-display-section',
             items: getDisplayItems(),
         })
     }
 
     if (supportsResultCustomizationBy) {
-        items.push({
-            title: (
-                <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
-                    Color customization by
-                </SectionHeader>
-            ),
-            items: [DisplayOptions.ResultCustomizationBy],
+        sections.push({
+            key: 'result-customization',
+            title: 'Color customization by',
+            tooltip:
+                "You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).",
+            items: ['ResultCustomizationBy'],
         })
     }
 
     if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
-        items.push({
+        sections.push({
+            key: 'unit',
             title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
-            items: [DisplayOptions.Unit],
+            items: ['Unit'],
         })
     }
 
     if (showYAxisScale) {
-        items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
+        sections.push({ key: 'y-axis-scale', title: 'Y-axis scale', items: ['Scale'] })
     }
 
     if (showYAxisScale && !isBoxPlot) {
-        const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
+        const statisticalItems: DisplayOptionKey[] = ['ConfidenceInterval']
         if (showConfidenceIntervals) {
-            statisticalItems.push(DisplayOptions.ConfidenceLevel)
+            statisticalItems.push('ConfidenceLevel')
         }
-        statisticalItems.push(DisplayOptions.MovingAverage)
+        statisticalItems.push('MovingAverage')
         if (showMovingAverage) {
-            statisticalItems.push(DisplayOptions.MovingAverageIntervals)
+            statisticalItems.push('MovingAverageIntervals')
         }
-        items.push({ title: 'Statistical analysis', items: statisticalItems })
+        sections.push({ key: 'statistical-analysis', title: 'Statistical analysis', items: statisticalItems })
     }
 
     if (showAxisLabelsConfig) {
-        items.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+        sections.push({ key: 'axis-labels', title: 'Axis labels', items: ['AxisLabels'] })
     }
 
     if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
-        items.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        sections.push({ key: 'decimal-places', title: 'Decimal places', items: ['DecimalPrecision'] })
     }
 
     if (isRetention) {
-        items.push({ title: 'On dashboards', items: [DisplayOptions.RetentionDashboardDisplay] })
-        items.push({
-            title: (
-                <SectionHeader tooltip="Controls the starting index used to label cohort columns. Display only, does not affect the calculations.">
-                    Cohort labels start at
-                </SectionHeader>
-            ),
-            items: [DisplayOptions.RetentionCohortLabelStart],
+        sections.push({ key: 'retention-dashboard', title: 'On dashboards', items: ['RetentionDashboardDisplay'] })
+        sections.push({
+            key: 'retention-cohort-label',
+            title: 'Cohort labels start at',
+            tooltip:
+                'Controls the starting index used to label cohort columns. Display only, does not affect the calculations.',
+            items: ['RetentionCohortLabelStart'],
         })
     }
 
@@ -259,6 +270,24 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
         (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
         (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)
+
+    return { sections, count }
+}
+
+export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+    const { sections, count } = useInsightDisplayOptionSections()
+
+    const items: LemonMenuItems = sections.map((section) => ({
+        title:
+            section.tooltip || section.dataAttr ? (
+                <SectionHeader tooltip={section.tooltip} dataAttr={section.dataAttr}>
+                    {section.title}
+                </SectionHeader>
+            ) : (
+                section.title
+            ),
+        items: section.items.map((key) => DisplayOptions[key]),
+    }))
 
     return { items, count }
 }

--- a/frontend/src/scenes/insights/EditorFilters/MetricFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/MetricFilters.tsx
@@ -19,7 +19,7 @@ import { insightLogic } from '../insightLogic'
 
 const PRESET_COLORS = getSeriesColorPalette()
 
-function DirectionColorPickers({
+export function DirectionColorPickers({
     increaseColor,
     decreaseColor,
     onIncrease,


### PR DESCRIPTION
## Problem

Stacked on #68460. That PR converted the chart header's pickers to quill behind `product-analytics-quill-date-filter`, but deliberately left out the biggest piece: the "Options" menu, a `LemonMenu` embedding ~25 controls (checkboxes, selects, segmented buttons, debounced inputs) defined in `DisplayOptions.tsx`. With the flag on it was the last LemonUI surface in the header.

## Changes

**Shared section structure.** `useInsightDisplayOptions` had all the visibility conditions (which sections and items appear per insight type) baked into LemonMenu item building. That logic is now extracted into `useInsightDisplayOptionSections()`, which returns plain data (`{ key, title, tooltip?, dataAttr?, items: DisplayOptionKey[] }`). The existing Lemon hook maps that structure to `LemonMenuItems` exactly as before, and the new quill shell consumes the same structure, so the two variants can't drift on which options show when.

**Quill shell.** `InsightDisplayOptionsMenuNext` renders the same responsive pair of triggers as the Lemon version (text "Options (N)" above the 780px container breakpoint, ellipsis icon below it) as quill `Popover`s with section `MenuLabel`s.

**Quill twin rows.** `DisplayOptionsNext.tsx` holds a quill counterpart for every `DisplayOptions` key, keyed identically:

- The ~18 checkbox toggles become quill `Switch` rows via a shared `OptionSwitchRow` helper (per quill guidance, immediate-effect settings are switches), preserving each original's state wiring, disabled reasons, and tooltips
- Smoothing, legend position, headline value, and retention dashboard display become quill `Select`s
- Result customization, Y-axis scale, and cohort label start become quill `ToggleGroup`s (segmented)
- Confidence level, moving average intervals, axis labels, and decimal places become quill `Input` rows, keeping the original debounce and commit-on-blur/enter behavior
- The unit picker becomes a nested quill `Popover` with a preset rail plus the existing custom prefix/postfix modal flow

One deliberate exception: the metric increase/decrease color pickers reuse the existing `LemonColorPicker` (via the now-exported `DirectionColorPickers`) since quill has no color picker primitive yet.

## How did you test this code?

- `frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx` passes (31 tests) — it exercises the flag-off Lemon menu heavily, which validates the section-structure refactor is behavior-preserving
- oxlint and oxfmt clean on all touched files; typecheck shows no new errors beyond the pre-existing stale-typegen noise that the untouched originals (`SmoothingFilter.tsx`, `UnitPicker.tsx`) show identically in the same environment
- I (the agent) could not verify visually in a running app (the local dev stack serves a different checkout), so the flag-on menu needs a manual pass on this branch across trends (line/bar/pie/metric/box plot/slope), lifecycle, retention, and funnel trends

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, flag-gated UI-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code); Sam approved this as the agreed follow-up to #68460. Key decision: rather than duplicating the ~30 visibility conditions in a quill variant, the conditions were refactored once into a shared data structure consumed by both shells — the existing jest suite pins the Lemon output. The alternative (making each `EditorFilters/*` component internally flag-aware) was rejected as harder to delete when the flag ships. Followed `packages/quill/packages/primitives/AGENTS.md` for component choice (Switch over Checkbox for immediate-effect settings, Popover for the menu shell since it embeds interactive controls, `Item`-free button rails matching the date filter's established pattern in this stack).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*