### PR TITLE
fix(meta_ads): catch requests' JSONDecodeError on truncated 200 bodies

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from django.db import OperationalError, close_old_connections
 
 from requests import Response
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
 
@@ -218,11 +219,11 @@ PAGE_LIMIT_FALLBACK_SIZES = [500, 100, 50]
 
 # Meta's Graph API intermittently returns HTTP 200 with a truncated/partial JSON
 # body — a server-side serialization hiccup under load — so ``response.json()``
-# raises ``JSONDecodeError``. The body is fully received but unparseable, so the
-# only recovery is to re-issue the same request; a couple of immediate retries
-# almost always returns a complete body. If it stays malformed we let the error
-# propagate (it remains retryable, so Temporal re-runs the activity from saved
-# resume state) rather than silently dropping the page.
+# raises ``requests.exceptions.JSONDecodeError``. The body is fully received but
+# unparseable, so the only recovery is to re-issue the same request; a couple of
+# immediate retries almost always returns a complete body. If it stays malformed
+# we let the error propagate (it remains retryable, so Temporal re-runs the
+# activity from saved resume state) rather than silently dropping the page.
 MALFORMED_JSON_MAX_ATTEMPTS = 3
 
 
@@ -379,10 +380,13 @@ def _iter_simple_pagination(
 
         try:
             response_payload = response.json()
-        except json.JSONDecodeError:
+        except RequestsJSONDecodeError:
             # Truncated 200 body — re-issue the same request. Re-fetching is safe
             # (the initial request has yielded nothing yet, and a cursor points at
-            # the start of the next not-yet-yielded page).
+            # the start of the next not-yet-yielded page). ``response.json()`` raises
+            # requests' own JSONDecodeError, which subclasses simplejson's (not the
+            # stdlib json's) when simplejson is installed — catching the stdlib type
+            # would miss it entirely.
             malformed_json_attempts += 1
             if malformed_json_attempts >= MALFORMED_JSON_MAX_ATTEMPTS:
                 raise
@@ -514,7 +518,7 @@ def _iter_time_range_pagination(
 
             try:
                 response_payload = response.json()
-            except json.JSONDecodeError:
+            except RequestsJSONDecodeError:
                 # Truncated 200 body — re-issue whichever request produced it. A
                 # cursor points at the start of the not-yet-yielded page and the
                 # initial chunk request has yielded nothing, so no rows are re-emitted.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -8,6 +8,8 @@ from unittest import mock
 
 from django.db import OperationalError
 
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads import meta_ads as meta_ads_module
@@ -42,10 +44,12 @@ def _mock_response(status: int, body: dict) -> mock.MagicMock:
 
 def _mock_truncated_response() -> mock.MagicMock:
     # Meta occasionally returns HTTP 200 with a truncated JSON body, so `.json()`
-    # raises JSONDecodeError even though the status is healthy.
+    # raises JSONDecodeError even though the status is healthy. requests raises its
+    # own JSONDecodeError (subclass of simplejson's, not the stdlib json's, when
+    # simplejson is installed), so mirror that here rather than the stdlib type.
     response = mock.MagicMock()
     response.status_code = 200
-    response.json.side_effect = json.JSONDecodeError("Unterminated string starting at", "{", 98254)
+    response.json.side_effect = RequestsJSONDecodeError("Unterminated string starting at", "{", 98254)
     response.text = '{"data": [{"id": "1"'
     return response
 
@@ -366,7 +370,7 @@ class TestSimplePaginationMalformedJson:
             "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
         ) as mock_get:
             mock_get.return_value.get.side_effect = responses
-            with pytest.raises(json.JSONDecodeError):
+            with pytest.raises(RequestsJSONDecodeError):
                 list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
 
         # Bounded: one attempt per allowed try, then it gives up (stays retryable upstream).
@@ -1003,7 +1007,7 @@ class TestTimeRangeMalformedJson:
             "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
         ) as mock_get:
             mock_get.return_value.get.side_effect = responses
-            with pytest.raises(json.JSONDecodeError):
+            with pytest.raises(RequestsJSONDecodeError):
                 list(
                     _iter_time_range_pagination(
                         self.URL, self.PARAMS, {"since": "2026-04-21", "until": "2026-04-21"}, None, manager


### PR DESCRIPTION
## Problem

Meta Ads imports were crashing with `JSONDecodeError: Unterminated string starting at: line 1 column ...` raised from `_iter_simple_pagination` in `meta_ads.py`. Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3312-fc2a-70c3-bb20-cd7c398b0aa2

The Graph API intermittently returns HTTP 200 with a truncated JSON body under load. The source already had retry logic for exactly this: catch the decode error, re-issue the same request up to `MALFORMED_JSON_MAX_ATTEMPTS`, and only then propagate (still retryable, so Temporal re-runs the activity). The retry never fired.

The catch was `except json.JSONDecodeError` (the stdlib type). But `requests`' `response.json()` raises `requests.exceptions.JSONDecodeError`, which subclasses simplejson's `JSONDecodeError`, not the stdlib one, when simplejson is installed (it is in prod - the captured exception module is `simplejson.errors`). The stdlib and simplejson classes are siblings, both subclassing `ValueError` but neither the other, so `except json.JSONDecodeError` never caught the real exception. The in-place retry was dead code and truncated bodies propagated on the very first hit.

## Changes

- Catch `requests.exceptions.JSONDecodeError` in both pagination paths (`_iter_simple_pagination` and `_iter_time_range_pagination`) instead of the stdlib `json.JSONDecodeError`. This is what `response.json()` actually raises, and it works whether or not simplejson is installed.
- The truncated-body test fixture mocked `json.JSONDecodeError` (the stdlib type), which is exactly why the bug shipped green. It now raises `requests.exceptions.JSONDecodeError`, mirroring production.

This stays a code fix, not a `NonRetryableErrors` change: a truncated 200 is a transient upstream hiccup that should be retried, and the existing retry design is correct. It just wasn't being reached.

## How did you test this code?

Automated tests only (I, Claude, ran these; I did not manually trigger a real Meta import):

- `pytest .../meta_ads/test_meta_ads.py` - all 71 pass.
- Verified the fix is load-bearing: with the fixture raising the real `requests.exceptions.JSONDecodeError`, I temporarily reverted the catch to `except json.JSONDecodeError` and all 7 truncated-body tests failed (the retry no longer fires and the body propagates); restoring the fix makes them pass again. So these tests now guard the exact regression - narrowing the catch back to the stdlib type breaks them.

The regression each test group catches: the retry-then-succeed and persistent-then-raise cases in `TestSimplePaginationMalformedJson` / `TestTimeRangeMalformedJson` now catch a catch-clause that doesn't match what `response.json()` raises. Previously they mocked the wrong exception type and passed regardless.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Pulled the issue's full stack trace via the PostHog error-tracking MCP tools, which showed the exception module as `simplejson.errors` / `requests.exceptions` - the tell that the stdlib `json.JSONDecodeError` catch could never match. Confirmed the class hierarchy against the installed `requests`/`simplejson` (`requests.exceptions.JSONDecodeError` subclasses simplejson's, not the stdlib's).

Considered `NonRetryableErrors` and rejected it: a truncated 200 is transient and the source already intends to retry it, so the right fix was making the existing retry actually catch the exception. Kept the change scoped to the two catch sites plus the test fixture. Invoked the `/writing-tests` skill before touching tests; chose to fix the shared fixture rather than add near-duplicate tests, which turns the existing retry tests into genuine regression guards.
