### PR TITLE
fix(bigquery): reconnect storage reads on transient RST_STREAM

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -148,7 +148,7 @@ BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_re
 # The Storage Read API can drop a ReadRows stream mid-flight with a transient gRPC INTERNAL error
 # ("Received RST_STREAM with error code 2"). The client's default ReadRows retry only reconnects on
 # ServiceUnavailable, so the INTERNAL escapes as an unhandled InternalServerError and fails the whole
-# read — and with it the import activity, which then re-runs the (potentially large) temp-table copy
+# read, and with it the import activity, which then re-runs the (potentially large) temp-table copy
 # from scratch. Reconnecting resumes the stream from the last-read offset, so widen the default
 # predicate to also retry INTERNAL. Parameters mirror the library's default ReadRows retry.
 BIGQUERY_READ_ROWS_RETRY = Retry(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -25,7 +25,8 @@ from urllib.parse import urlparse
 
 import pyarrow as pa
 import structlog
-from google.api_core.exceptions import BadRequest, Forbidden, NotFound
+from google.api_core.exceptions import BadRequest, Forbidden, InternalServerError, NotFound, ServiceUnavailable
+from google.api_core.retry import Retry, if_exception_type
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import bigquery, bigquery_storage
@@ -142,6 +143,21 @@ def _query_job_should_retry(exc: Exception) -> bool:
 
 
 BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_retry)
+
+
+# The Storage Read API can drop a ReadRows stream mid-flight with a transient gRPC INTERNAL error
+# ("Received RST_STREAM with error code 2"). The client's default ReadRows retry only reconnects on
+# ServiceUnavailable, so the INTERNAL escapes as an unhandled InternalServerError and fails the whole
+# read — and with it the import activity, which then re-runs the (potentially large) temp-table copy
+# from scratch. Reconnecting resumes the stream from the last-read offset, so widen the default
+# predicate to also retry INTERNAL. Parameters mirror the library's default ReadRows retry.
+BIGQUERY_READ_ROWS_RETRY = Retry(
+    predicate=if_exception_type(ServiceUnavailable, InternalServerError),
+    initial=0.1,
+    maximum=60.0,
+    multiplier=1.3,
+    deadline=86400.0,
+)
 
 
 class BigQueryDatasetNotFoundError(Exception):
@@ -1357,7 +1373,7 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                         return
 
                     stream_name = read_session.streams[0].name
-                    read_rows_stream = bq_storage.read_rows(stream_name)
+                    read_rows_stream = bq_storage.read_rows(stream_name, retry=BIGQUERY_READ_ROWS_RETRY)
                     rows_iterator = read_rows_stream.rows()
 
                     record_batches = []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -5,7 +5,15 @@ from freezegun import freeze_time
 from unittest import mock
 
 from dateutil import parser
-from google.api_core.exceptions import BadRequest, Forbidden, InvalidArgument, NotFound, PermissionDenied
+from google.api_core.exceptions import (
+    BadRequest,
+    Forbidden,
+    InternalServerError,
+    InvalidArgument,
+    NotFound,
+    PermissionDenied,
+    ServiceUnavailable,
+)
 from google.auth.exceptions import RefreshError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
@@ -14,6 +22,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_QUERY_JOB_RETRY,
+    BIGQUERY_READ_ROWS_RETRY,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryCredentialsRejectedError,
     BigQueryDatasetNotFoundError,
@@ -1138,6 +1147,31 @@ def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
 )
 def test_bigquery_query_job_retry_does_not_retry_deterministic_errors(exc):
     assert BIGQUERY_QUERY_JOB_RETRY._predicate(exc) is False
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # The observed transient: a dropped Storage Read stream surfaced as a gRPC INTERNAL. The
+        # library default only reconnects on ServiceUnavailable, so this escaped and crashed the read.
+        InternalServerError("Received RST_STREAM with error code 2"),
+        ServiceUnavailable("503 The service is currently unavailable."),
+    ],
+)
+def test_bigquery_read_rows_retry_reconnects_on_transient_stream_errors(exc):
+    assert BIGQUERY_READ_ROWS_RETRY._predicate(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # Deterministic failures must surface rather than reconnect forever.
+        NotFound("404 Requested stream was not found."),
+        BadRequest("400 request failed"),
+    ],
+)
+def test_bigquery_read_rows_retry_does_not_reconnect_on_deterministic_errors(exc):
+    assert BIGQUERY_READ_ROWS_RETRY._predicate(exc) is False
 
 
 def test_bigquery_get_primary_keys_for_table_passes_job_retry():


### PR DESCRIPTION
## Problem

BigQuery imports crash when the Storage Read API drops a `ReadRows` stream mid-flight with a transient gRPC INTERNAL error (`Received RST_STREAM with error code 2`). This surfaced in error tracking as an unhandled `google.api_core.exceptions.InternalServerError` raised from `get_rows` in the BigQuery source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f34ca-517d-7d52-88da-8c649232f519)).

Root cause: we call `bq_storage.read_rows(stream_name)` with the client's default retry, and that default only reconnects the stream on `ServiceUnavailable`. An `RST_STREAM` maps to gRPC INTERNAL, so it slips past the default predicate and propagates out of the read, failing the whole import activity.

## Changes

`read_rows` now runs under a retry that reconnects on `InternalServerError` as well as `ServiceUnavailable`. The reader tracks the last-read offset and resumes the stream from there, so reconnecting is cheap and idempotent. Without this, the transient bubbles up and the activity is retried from scratch by Temporal, which re-runs the (potentially large) temp-table copy for incremental, view, and row-filtered syncs.

Retry parameters mirror the library's default `ReadRows` retry (same backoff and deadline); only the predicate is widened. This is the same shape as the existing `BIGQUERY_QUERY_JOB_RETRY` in this file, which already extends a default BigQuery retry predicate for a known transient.

This is a transient infrastructure error, so it stays retryable. It was deliberately not added to `NonRetryableErrors`.

## How did you test this code?

Automated only, run locally by me (Claude):

- Added `test_bigquery_read_rows_retry_reconnects_on_transient_stream_errors` and `test_bigquery_read_rows_retry_does_not_reconnect_on_deterministic_errors`, mirroring the existing `BIGQUERY_QUERY_JOB_RETRY` predicate tests. They lock in that the read-rows retry treats the observed `RST_STREAM` INTERNAL (and `ServiceUnavailable`) as retryable while still failing fast on deterministic errors (`NotFound`, `BadRequest`). Regression caught: a change that drops the retry or narrows the predicate would let the transient crash the import again, which no existing test covered.
- `pytest` for the retry tests in this file passes (9 passed). `ruff check` and `ruff format --check` clean on both changed files.
- I did not run a live BigQuery import.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude while triaging a live error-tracking issue for the BigQuery warehouse source. I confirmed the stack originates in `bigquery.py` `get_rows` at the `bq_storage.read_rows(...)` call, traced the library's default `ReadRows` retry (retries only `ServiceUnavailable`), and confirmed `RST_STREAM` maps to gRPC INTERNAL and so was not being reconnected.

Decision: this is a transient infra error, so it must stay retryable. I ruled out `NonRetryableErrors` and instead fixed the retry at the storage-read layer so the stream resumes from its offset instead of failing the activity and re-running the temp-table copy. Considered matching narrowly on the `RST_STREAM` message but chose a type-based predicate (`InternalServerError`) to match how the library declares its own default and to cover the sibling transient-stream-reset family. Checked open PRs (including the maintainer's) for a duplicate; the nearest BigQuery retry PR is about per-second rate quotas on the job path, not the storage read.

Skills invoked: `/writing-tests`.
