### PR TITLE
fix(agent-proxy): treat teardown ingest disconnects as success

### DIFF
--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -4,12 +4,12 @@
 // Node services read/write the same Redis stream during the cutover window.
 //
 // HTTP status codes:
-//   200  success: {accepted, duplicate, last_accepted_seq}
+//   200  success, or post-turn client disconnect (sandbox teardown): {accepted, duplicate, last_accepted_seq}
 //   400  bad NDJSON: invalid JSON, non-object, wrong field types, ordering
 //   401  missing / invalid JWT
 //   403  JWT claims don't match URL params
 //   405  wrong HTTP method
-//   408  client disconnected mid-body: {error, last_accepted_seq}
+//   408  client disconnected mid-turn: {error, last_accepted_seq}
 //   409  SequenceGap / AlreadyCompleted / CompletionSequenceMismatch: {error, last_accepted_seq}
 //   413  payload too large: {error, last_accepted_seq}
 
@@ -41,7 +41,7 @@ import {
     type EventIngestResult,
     type SandboxEventIngestTokenPayload,
 } from '../lib/types.js'
-import { observeStreamIngestEvents } from './metrics.js'
+import { observeIngestClientDisconnect, observeStreamIngestEvents } from './metrics.js'
 
 // Diagnostic (temporary): records when request-body chunks arrive at the Node
 // process, to tell a live upload (chunks spread across the request lifetime)
@@ -119,15 +119,25 @@ export async function handleIngest(
         result = await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming)
     } catch (err: unknown) {
         if (err instanceof ClientDisconnected) {
+            const classification = await classifyDisconnect(redisStream)
+            observeIngestClientDisconnect(classification)
+            observeStreamIngestEvents({ accepted: err.accepted, duplicate: err.duplicate })
             logger.info('ingest:client_disconnect', {
                 run: claims.runId,
+                classification,
                 accepted: err.accepted,
                 duplicate: err.duplicate,
                 lastSeq: err.lastAcceptedSeq,
                 chunks: bodyTiming.chunks,
                 bodyBytes: bodyTiming.bytes,
             })
-            return c.json({ error: 'Client disconnected', last_accepted_seq: err.lastAcceptedSeq }, 408)
+            if (classification === 'mid_turn') {
+                return c.json({ error: 'Client disconnected', last_accepted_seq: err.lastAcceptedSeq }, 408)
+            }
+            return c.json(
+                { accepted: err.accepted, duplicate: err.duplicate, last_accepted_seq: err.lastAcceptedSeq },
+                200
+            )
         }
         if (err instanceof EventIngestBadRequest) {
             return c.json({ error: err.message }, 400)
@@ -175,6 +185,20 @@ export async function handleIngest(
         },
         200
     )
+}
+
+type DisconnectClassification = 'run_over' | 'idle' | 'mid_turn'
+
+// Post-turn disconnects are expected sandbox teardown; fail toward 'mid_turn' so real cuts stay visible.
+async function classifyDisconnect(redisStream: TaskRunRedisStream): Promise<DisconnectClassification> {
+    try {
+        if (await redisStream.isComplete()) {
+            return 'run_over'
+        }
+        return (await redisStream.getAgentActive()) ? 'mid_turn' : 'idle'
+    } catch {
+        return 'mid_turn'
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -35,6 +35,7 @@ import {
     TaskRunStreamSequenceGap,
     TaskRunStreamAlreadyCompleted,
     TaskRunStreamCompletionSequenceMismatch,
+    type DisconnectClassification,
     type IngestEventLine,
     type IngestCompleteLine,
     type IngestLine,
@@ -186,8 +187,6 @@ export async function handleIngest(
         200
     )
 }
-
-type DisconnectClassification = 'run_over' | 'idle' | 'mid_turn'
 
 // Post-turn disconnects are expected sandbox teardown; fail toward 'mid_turn' so real cuts stay visible.
 async function classifyDisconnect(redisStream: TaskRunRedisStream): Promise<DisconnectClassification> {

--- a/services/agent-proxy/src/hono/metrics.ts
+++ b/services/agent-proxy/src/hono/metrics.ts
@@ -83,6 +83,14 @@ export const streamIngestEventsTotal = new Counter({
     registers: [register],
 })
 
+// 'run_over'/'idle' are expected sandbox teardown; 'mid_turn' is a genuine cut worth alerting on.
+export const ingestClientDisconnectsTotal = new Counter({
+    name: 'agent_proxy_ingest_client_disconnects_total',
+    help: 'Ingest requests whose client disconnected mid-body, by stream state at disconnect',
+    labelNames: ['classification'],
+    registers: [register],
+})
+
 // ---------------------------------------------------------------------------
 // HTTP infrastructure metrics
 // ---------------------------------------------------------------------------
@@ -112,11 +120,12 @@ export const httpRequestsTotal = new Counter({
     registers: [register],
 })
 
+// Ingest requests are long-lived chunked POSTs (30-300s); without buckets up there percentiles pin at 10s.
 export const httpRequestDurationSeconds = new Histogram({
     name: 'agent_proxy_http_request_duration_seconds',
     help: 'HTTP request duration in seconds',
     labelNames: ['method', 'route', 'status'],
-    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
     registers: [register],
 })
 
@@ -178,4 +187,8 @@ export function observeStreamIngestEvents(opts: { accepted: number; duplicate: n
     if (opts.duplicate > 0) {
         streamIngestEventsTotal.labels({ result: 'duplicate' }).inc(opts.duplicate)
     }
+}
+
+export function observeIngestClientDisconnect(classification: 'run_over' | 'idle' | 'mid_turn'): void {
+    ingestClientDisconnectsTotal.labels({ classification }).inc()
 }

--- a/services/agent-proxy/src/hono/metrics.ts
+++ b/services/agent-proxy/src/hono/metrics.ts
@@ -10,7 +10,7 @@
 
 import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client'
 
-import type { StreamConnectionOutcome } from '../lib/types.js'
+import type { DisconnectClassification, StreamConnectionOutcome } from '../lib/types.js'
 
 export const register = new Registry()
 
@@ -189,6 +189,6 @@ export function observeStreamIngestEvents(opts: { accepted: number; duplicate: n
     }
 }
 
-export function observeIngestClientDisconnect(classification: 'run_over' | 'idle' | 'mid_turn'): void {
+export function observeIngestClientDisconnect(classification: DisconnectClassification): void {
     ingestClientDisconnectsTotal.labels({ classification }).inc()
 }

--- a/services/agent-proxy/src/lib/redis-stream.ts
+++ b/services/agent-proxy/src/lib/redis-stream.ts
@@ -364,6 +364,11 @@ export class TaskRunRedisStream {
         return raw === '1'
     }
 
+    // EXISTS completed-key -> bool
+    async isComplete(): Promise<boolean> {
+        return (await this.redis.exists(getCompletedKey(this.streamKey))) > 0
+    }
+
     // SET heartbeat-key '1' EX throttleSeconds NX. True if claimed.
     async claimAgentActiveHeartbeat(throttleSeconds: number): Promise<boolean> {
         const result = await this.redis.set(getHeartbeatKey(this.streamKey), '1', 'EX', throttleSeconds, 'NX')

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -108,6 +108,8 @@ export interface SandboxEventIngestTokenPayload {
 
 export type StreamConnectionOutcome = 'completed' | 'stream_error' | 'unavailable' | 'client_disconnect'
 
+export type DisconnectClassification = 'run_over' | 'idle' | 'mid_turn'
+
 // ---------------------------------------------------------------------------
 // Ingest HTTP response shape (200 OK body)
 // ---------------------------------------------------------------------------

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -26,7 +26,7 @@ import {
     HEARTBEAT_THROTTLE_SECONDS,
 } from '@/lib/constants.js'
 import { logger } from '@/lib/logging.js'
-import { TaskRunRedisStream, getStreamKey } from '@/lib/redis-stream.js'
+import { TaskRunRedisStream, getCompletedKey, getStreamKey } from '@/lib/redis-stream.js'
 import { heartbeatWorkflowIfNeeded } from '@/lib/side-effects.js'
 import type { SandboxEventIngestTokenPayload } from '@/lib/types.js'
 
@@ -917,17 +917,83 @@ describe('ingest-handler', () => {
 
         const res = await handleIngest(makeContext({ body }), fakeRedis as unknown as Redis, config, [] as CryptoKey[])
 
-        expect(res.status).toBe(408)
-        const responseBody = (await decodeJson(res)) as { last_accepted_seq: number }
+        expect(res.status).toBe(200)
+        const responseBody = (await decodeJson(res)) as { accepted: number; last_accepted_seq: number }
+        expect(responseBody.accepted).toBe(1)
         expect(responseBody.last_accepted_seq).toBe(1)
 
         const entries = await fakeRedis.xrange(getStreamKey(RUN_ID))
         expect(entries).toHaveLength(1)
 
         const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest:client_disconnect')?.[1] as Record<string, unknown>
-        expect(log).toMatchObject({ run: RUN_ID, accepted: 1, lastSeq: 1 })
+        expect(log).toMatchObject({ run: RUN_ID, accepted: 1, lastSeq: 1, classification: 'idle' })
         expect(errorSpy).not.toHaveBeenCalledWith('http.unhandled_error', expect.anything())
     })
+
+    it.each([
+        {
+            state: 'agent actively streaming',
+            classification: 'mid_turn',
+            setup: async (): Promise<void> => {
+                await redisStream.setAgentActive(true)
+            },
+            sendEventBeforeDrop: true,
+            expectedStatus: 408,
+        },
+        {
+            state: 'agent idle after turn-complete',
+            classification: 'idle',
+            setup: async (): Promise<void> => {
+                await redisStream.setAgentActive(false)
+            },
+            sendEventBeforeDrop: true,
+            expectedStatus: 200,
+        },
+        {
+            state: 'stream already completed',
+            classification: 'run_over',
+            setup: async (): Promise<void> => {
+                await fakeRedis.set(getCompletedKey(getStreamKey(RUN_ID)), '1')
+            },
+            sendEventBeforeDrop: false,
+            expectedStatus: 200,
+        },
+    ])(
+        'classifies a disconnect with $state as $classification -> $expectedStatus',
+        async ({ classification, setup, sendEventBeforeDrop, expectedStatus }) => {
+            const infoSpy = vi.spyOn(logger, 'info')
+            const config = makeConfig()
+            const enc = new TextEncoder()
+            const line = enc.encode(JSON.stringify({ seq: 1, event: { type: 'before-drop' } }) + '\n')
+            await setup()
+
+            let sentFirstChunk = false
+            const body = new ReadableStream<Uint8Array>({
+                pull(controller) {
+                    if (sendEventBeforeDrop && !sentFirstChunk) {
+                        sentFirstChunk = true
+                        controller.enqueue(line)
+                        return
+                    }
+                    controller.error(Object.assign(new Error('read failed'), { code: 'ECONNRESET' }))
+                },
+            })
+
+            const res = await handleIngest(
+                makeContext({ body }),
+                fakeRedis as unknown as Redis,
+                config,
+                [] as CryptoKey[]
+            )
+
+            expect(res.status).toBe(expectedStatus)
+            const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest:client_disconnect')?.[1] as Record<
+                string,
+                unknown
+            >
+            expect(log).toMatchObject({ classification })
+        }
+    )
 
     // -----------------------------------------------------------------------
     // Empty body

--- a/services/agent-proxy/tests/setup.ts
+++ b/services/agent-proxy/tests/setup.ts
@@ -42,6 +42,7 @@ vi.mock('@/hono/metrics.js', () => ({
     taskRunStreamResumeGapTotal: mockCounter,
     taskRunStreamConnectionsRejectedTotal: mockCounter,
     streamIngestEventsTotal: mockCounter,
+    ingestClientDisconnectsTotal: mockCounter,
     httpRequestsTotal: mockCounter,
     httpRequestDurationSeconds: mockHistogram,
     inflightRequests: mockGauge,
@@ -53,4 +54,5 @@ vi.mock('@/hono/metrics.js', () => ({
     observeStreamResumeGap: vi.fn(),
     observeStreamConnectionRejected: vi.fn(),
     observeStreamIngestEvents: vi.fn(),
+    observeIngestClientDisconnect: vi.fn(),
 }))


### PR DESCRIPTION
## Problem

The agent-proxy ingest route (`POST /v1/runs/:run/ingest`) reports a steady stream of 408s, plus occasional 409s, on our error-rate dashboards.

Digging in, the 408s are not failures. In keep-stream-open mode the sandbox agent holds one long-lived chunked POST open and rotates it periodically. When a run ends, the Temporal workflow destroys the sandbox (`cleanup_sandbox` publishes stream completion only after the kill), which severs the in-flight POST mid-body. The proxy maps that read-abort to a 408 response that nobody can receive, since the peer is already gone. Production logs confirm the shape: every 408 is the final request of its run, arriving right after the turn-complete event.

The Python implementation this service replaced (`event_ingest.py`) logged these disconnects silently and sent no response at all. The Node port (#67555) introduced the 408 mapping, so every completed run now shows up as an "error" on the dashboard, drowning out genuine mid-stream cuts.

Two smaller issues in the same area:

- The request duration histogram buckets top out at 10s, while healthy ingest requests legitimately run 30-300s (the client rotates at 900 events or ~5 minutes). Every ingest latency percentile pins at 10s, which reads as a timeout that doesn't exist.
- Events accepted before a disconnect were never counted in `posthog_tasks_stream_ingest_events_total`, undercounting the accepted-events panel.

The 409s (`AlreadyCompleted` / `SequenceGap`) are left as is. They are delivered to live clients, carry `last_accepted_seq` for resync, and are the protocol working as designed during the same end-of-run race.

## Changes

- `ingest-handler.ts`: on client disconnect, classify by stream state the ingest plane already tracks. Stream completed means `run_over`, agent-active key off (turn-complete was ingested) means `idle`, agent actively streaming means `mid_turn`. Teardown-shaped disconnects (`run_over` / `idle`) now return the normal 200 success body. Only `mid_turn` cuts, where events can actually be stranded client-side, keep the 408. Classification failures fall back to `mid_turn` so Redis trouble can't hide real cuts. The response is never delivered either way (the peer is gone), so this only changes what metrics and logs record. No data handling changes: everything received before a cut was already durably written, and `last_accepted_seq` stays authoritative.
- `metrics.ts`: new `agent_proxy_ingest_client_disconnects_total{classification}` counter so teardown vs real-cut rates stay observable, duration buckets extended to 600s, and accepted/duplicate events from disconnected requests now counted in `posthog_tasks_stream_ingest_events_total`.
- `redis-stream.ts`: small `isComplete()` helper (EXISTS on the completed key).

After deploy, 408s on this route should collapse to near zero. Residual 408s mean genuinely severed mid-turn connections, which is exactly what that signal should mean.

## How did you test this code?

- `pnpm --filter @posthog/agent-proxy test`: 191/191 pass.
- `pnpm --filter @posthog/agent-proxy typecheck`: clean.
- Updated the existing disconnect-variant tests (default state is now classified `idle`, so they assert the 200 success shape) and added one parameterized classification test covering the three states. The regression it catches: inverting or dropping the classification would either flood dashboards with teardown 408s again or silently misreport genuine mid-turn cuts as 200s, and no existing test distinguished those states.
- Not manually tested against a live sandbox run; the disconnect paths are exercised through the handler's public interface with erroring request bodies.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected. The status-code contract is documented in the handler header comment, updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Fable 5). I directed the investigation from production dashboards and logs; Claude traced the root cause through the proxy, the Python reference implementation, and the Temporal workflow teardown path, then implemented the fix and tests.
- Skills invoked: /writing-tests.
- Decisions: considered keeping 408 and only fixing dashboards (rejected, dashboards live elsewhere and the status is semantically wrong for an expected teardown), and classifying via the completed key alone (rejected, completion is published after sandbox destroy so the key isn't set yet at disconnect time; the agent-active key flips on turn-complete ingest, before teardown, so it's the reliable signal).
