### PR TITLE
fix(outbrain): treat 400 Bad Request as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/source.py
@@ -52,7 +52,7 @@ class OutbrainSource(ResumableSource[OutbrainSourceConfig, OutbrainResumeConfig]
         return {
             "401 Client Error: Unauthorized for url: https://api.outbrain.com/amplify/v0.1/login": "Outbrain authentication failed. Please check your username and password.",
             "403 Client Error: Forbidden for url: https://api.outbrain.com": "Outbrain denied access. Please check that your account has Amplify API access (requested via your account manager).",
-            # A 400 on a well-formed, static request is deterministic — retrying can never succeed.
+            # A 400 on a well-formed, static request is deterministic, so retrying can never succeed.
             # It surfaces when one of the marketers returned by /marketers can't be queried through
             # the Amplify API, so match the stable prefix, not the volatile marketer id and query.
             "400 Client Error: Bad Request for url: https://api.outbrain.com": "Outbrain rejected the request (400 Bad Request). One of the marketers on your account may not be accessible via the Amplify API. Please confirm your account's Amplify API access with your Outbrain account manager.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/source.py
@@ -52,6 +52,10 @@ class OutbrainSource(ResumableSource[OutbrainSourceConfig, OutbrainResumeConfig]
         return {
             "401 Client Error: Unauthorized for url: https://api.outbrain.com/amplify/v0.1/login": "Outbrain authentication failed. Please check your username and password.",
             "403 Client Error: Forbidden for url: https://api.outbrain.com": "Outbrain denied access. Please check that your account has Amplify API access (requested via your account manager).",
+            # A 400 on a well-formed, static request is deterministic — retrying can never succeed.
+            # It surfaces when one of the marketers returned by /marketers can't be queried through
+            # the Amplify API, so match the stable prefix, not the volatile marketer id and query.
+            "400 Client Error: Bad Request for url: https://api.outbrain.com": "Outbrain rejected the request (400 Bad Request). One of the marketers on your account may not be accessible via the Amplify API. Please confirm your account's Amplify API access with your Outbrain account manager.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/tests/test_outbrain_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outbrain/tests/test_outbrain_source.py
@@ -49,6 +49,7 @@ class TestOutbrainSource:
         [
             "401 Client Error: Unauthorized for url: https://api.outbrain.com/amplify/v0.1/login",
             "403 Client Error: Forbidden for url: https://api.outbrain.com/amplify/v0.1/marketers",
+            "400 Client Error: Bad Request for url: https://api.outbrain.com/amplify/v0.1/marketers/marketer/campaigns?limit=100&offset=0",
         ],
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):


### PR DESCRIPTION
## Problem

Outbrain error tracking surfaced a recurring `HTTPError` in the warehouse import source:

`400 Client Error: Bad Request for url: https://api.outbrain.com/amplify/v0.1/marketers/<redacted>/campaigns?limit=100&offset=0`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3553-a3c0-74c3-8aa2-27d9479ee156

The stack trace confirms it originates in our source: `get_rows` -> `fetch` in `outbrain.py`, raised by `response.raise_for_status()`. The marketer id in the URL came from a successful `/marketers` listing, yet Outbrain rejects that marketer's `campaigns` endpoint with a 400. Temporal kept retrying the activity against a request that can never succeed.

## Changes

Classify Outbrain 400 Bad Request responses as non-retryable, alongside the existing 401/403 entries.

A 400 on a well-formed, static request is deterministic: our request shape is fixed (`limit=100&offset=0`, well within Outbrain's documented bounds, and rate issues return 429 not 400), so retrying will always fail. This surfaces when one of the marketers returned by `/marketers` can't be queried through the Amplify API, which is an account-side condition the customer resolves with Outbrain. Stopping the retries surfaces a clear, actionable message instead of looping.

The match uses the stable host prefix `400 Client Error: Bad Request for url: https://api.outbrain.com`, not the volatile marketer id or query string. This mirrors the existing `403 ... https://api.outbrain.com` entry.

I considered a graceful per-marketer skip instead, but a blanket skip on 400 risks silently masking a genuinely malformed request (returning empty data). Non-retryable classification stops the wasteful retries while keeping the failure visible, which is the safer choice.

## How did you test this code?

Added the observed 400 error shape (with a placeholder marketer id) as a case to the existing parameterized `test_non_retryable_errors_match_auth_failures` in `test_outbrain_source.py`. It guards against the entry being dropped or broken, which would send Outbrain campaigns 400s back into an infinite retry loop. No existing case covered the 400 path. Ran the outbrain source test file locally (16 passed) plus ruff check/format. I did not exercise the live Outbrain API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook by Claude (claude-opus-4-8) via Claude Code, using the PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace. Confirmed the failure genuinely originates in the outbrain source (`get_rows` -> `fetch`), not just serialized log context.

Decision path: web research ruled out `limit` size (limits up to 10,000 are allowed; rate limits return 429 not 400) and confirmed the request is well-formed, so the 400 is an upstream/account condition rather than a code bug. Weighed a graceful per-marketer skip against non-retryable classification and chose the latter because a skip could mask a real malformed request; non-retryable stops the retries while keeping the failure visible. No skills were required for this change.
