### PR TITLE
feat(llma): add by_day breakdown to personal spend endpoint

### DIFF
--- a/products/ai_observability/backend/api/personal_spend.py
+++ b/products/ai_observability/backend/api/personal_spend.py
@@ -28,6 +28,8 @@ from rest_framework import exceptions, permissions, serializers, status, viewset
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.schema import HogQLQueryModifiers
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
@@ -48,6 +50,8 @@ SUPPORTED_PRODUCTS = frozenset({"posthog_code"})
 
 DEFAULT_DATE_FROM = "-30d"
 MAX_WINDOW_DAYS = 90
+# The most calendar days a MAX_WINDOW_DAYS window can touch: partial days at both edges.
+BY_DAY_MAX_ROWS = MAX_WINDOW_DAYS + 1
 _RELATIVE_DATE_RE = re.compile(r"^-?\d+[hdwmqyHDWMQY](Start|End)?$")
 
 MIN_LIMIT = 1
@@ -278,13 +282,6 @@ class _ModelBreakdownSerializer(serializers.Serializer):
     )
 
 
-class _TopTracesSerializer(serializers.Serializer):
-    items = _TopTraceRowSerializer(many=True, help_text="Rows of top traces by cost, ordered by cost descending.")
-    truncated = serializers.BooleanField(
-        help_text="True when more rows exist beyond the requested `limit`. Re-request with a larger `limit` to retrieve them."
-    )
-
-
 class _DayBreakdownSerializer(serializers.Serializer):
     items = _DayBreakdownRowSerializer(
         many=True,
@@ -295,9 +292,17 @@ class _DayBreakdownSerializer(serializers.Serializer):
     )
     truncated = serializers.BooleanField(
         help_text=(
-            "Always false. A time series truncated by cost would be meaningless, so `by_day` is not "
-            f"subject to `limit` — the window is already capped at {MAX_WINDOW_DAYS} days."
+            "Effectively always false: `by_day` ignores `limit` because truncating a time series by "
+            f"cost would be meaningless, and the {MAX_WINDOW_DAYS}-day window cap already bounds the "
+            "series length."
         )
+    )
+
+
+class _TopTracesSerializer(serializers.Serializer):
+    items = _TopTraceRowSerializer(many=True, help_text="Rows of top traces by cost, ordered by cost descending.")
+    truncated = serializers.BooleanField(
+        help_text="True when more rows exist beyond the requested `limit`. Re-request with a larger `limit` to retrieve them."
     )
 
 
@@ -587,10 +592,13 @@ def _fetch_by_day(
             "email_filter": _email_filter(email),
             "timestamp_filter": _timestamp_filter(from_dt, to_dt),
             # Not the request `limit`: truncating a time series by cost makes no sense, and the
-            # window cap already bounds the row count. +2 covers partial days at both edges.
-            "limit": ast.Constant(value=MAX_WINDOW_DAYS + 2),
+            # window cap already bounds the row count. +1 is the truncation probe row.
+            "limit": ast.Constant(value=BY_DAY_MAX_ROWS + 1),
         },
         team=team,
+        # HogQL wraps `timestamp` in the team's configurable timezone by default, which would
+        # shift the day buckets; days here are documented as UTC, so pin them.
+        modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         query_type="PersonalSpendByDay",
     )
     rows = [
@@ -601,7 +609,7 @@ def _fetch_by_day(
         }
         for row in (result.results or [])
     ]
-    return {"items": rows, "truncated": False}
+    return _truncate(rows, BY_DAY_MAX_ROWS)
 
 
 class PersonalSpendViewSet(viewsets.ViewSet):

--- a/products/ai_observability/backend/api/personal_spend.py
+++ b/products/ai_observability/backend/api/personal_spend.py
@@ -203,6 +203,14 @@ class _ModelBreakdownRowSerializer(serializers.Serializer):
     output_tokens = serializers.IntegerField(help_text="Sum of `$ai_output_tokens` for this model.")
 
 
+class _DayBreakdownRowSerializer(serializers.Serializer):
+    day = serializers.DateField(help_text="UTC calendar day the events fall on (`toDate(timestamp)`).")
+    event_count = serializers.IntegerField(
+        help_text="Number of $ai_generation + $ai_embedding events on this day for the scoped product."
+    )
+    cost_usd = serializers.FloatField(help_text="Total cost in USD on this day for the scoped product.")
+
+
 class _TopTraceRowSerializer(serializers.Serializer):
     trace_id = serializers.CharField(
         allow_null=True,
@@ -277,6 +285,22 @@ class _TopTracesSerializer(serializers.Serializer):
     )
 
 
+class _DayBreakdownSerializer(serializers.Serializer):
+    items = _DayBreakdownRowSerializer(
+        many=True,
+        help_text=(
+            "One row per UTC day that has events, ordered by day ascending. Days with no events are "
+            "omitted — zero-fill client-side when rendering a continuous series."
+        ),
+    )
+    truncated = serializers.BooleanField(
+        help_text=(
+            "Always false. A time series truncated by cost would be meaningless, so `by_day` is not "
+            f"subject to `limit` — the window is already capped at {MAX_WINDOW_DAYS} days."
+        )
+    )
+
+
 class PersonalSpendAnalysisResponseSerializer(serializers.Serializer):
     """Structured personal LLM spend analysis for the requesting user."""
 
@@ -286,6 +310,9 @@ class PersonalSpendAnalysisResponseSerializer(serializers.Serializer):
     )
     by_tool = _ToolBreakdownSerializer(help_text="Spend grouped by tool. Scoped to `product` when set.")
     by_model = _ModelBreakdownSerializer(help_text="Spend grouped by `$ai_model`. Scoped to `product` when set.")
+    by_day = _DayBreakdownSerializer(
+        help_text="Spend grouped by UTC day, ordered ascending. Scoped to `product`. Not subject to `limit`."
+    )
     top_traces = _TopTracesSerializer(
         help_text=(
             "Deprecated — always returns `{items: [], truncated: false}`. Trace IDs are opaque strings "
@@ -529,6 +556,54 @@ def _fetch_by_model(
     return _truncate(rows, limit)
 
 
+def _fetch_by_day(
+    team: Team,
+    email: str,
+    from_dt: datetime.datetime,
+    to_dt: datetime.datetime,
+    product: str,
+) -> dict[str, Any]:
+    query = parse_select(
+        """
+        SELECT
+            toDate(timestamp) AS day,
+            count() AS event_count,
+            round(sum(toFloat(properties.$ai_total_cost_usd)), 6) AS cost_usd
+        FROM events
+        WHERE {event_in}
+            AND {product_filter}
+            AND {email_filter}
+            AND {timestamp_filter}
+        GROUP BY day
+        ORDER BY day ASC
+        LIMIT {limit}
+        """
+    )
+    result = execute_hogql_query(
+        query=query,
+        placeholders={
+            "event_in": _event_in(["$ai_generation", "$ai_embedding"]),
+            "product_filter": _product_filter(product),
+            "email_filter": _email_filter(email),
+            "timestamp_filter": _timestamp_filter(from_dt, to_dt),
+            # Not the request `limit`: truncating a time series by cost makes no sense, and the
+            # window cap already bounds the row count. +2 covers partial days at both edges.
+            "limit": ast.Constant(value=MAX_WINDOW_DAYS + 2),
+        },
+        team=team,
+        query_type="PersonalSpendByDay",
+    )
+    rows = [
+        {
+            "day": row[0],
+            "event_count": int(row[1] or 0),
+            "cost_usd": float(row[2] or 0.0),
+        }
+        for row in (result.results or [])
+    ]
+    return {"items": rows, "truncated": False}
+
+
 class PersonalSpendViewSet(viewsets.ViewSet):
     """
     Returns the requesting user's personal LLM spend analysis across PostHog products.
@@ -593,10 +668,10 @@ class PersonalSpendViewSet(viewsets.ViewSet):
             "Return a structured personal LLM spend analysis for the requesting user. Pass "
             "`date_from` / `date_to` (absolute like `2026-04-23` or relative like `-7d`) to bound "
             "the window — defaults to the last 30 days, max 90 days. The `product=<ai_product>` "
-            "query param is required and scopes the tool / model / trace breakdowns to a single "
+            "query param is required and scopes the tool / model / day / trace breakdowns to a single "
             f"product; supported values: {', '.join(sorted(SUPPORTED_PRODUCTS))}. `by_product` is "
-            "always returned for cross-product visibility. Use `refresh=true` to bypass the "
-            "5-minute response cache."
+            "always returned for cross-product visibility. `by_day` returns a day-ascending spend "
+            "series for the scoped product. Use `refresh=true` to bypass the 5-minute response cache."
         ),
         tags=["AI observability"],
     )
@@ -648,6 +723,7 @@ class PersonalSpendViewSet(viewsets.ViewSet):
                 "by_product": _fetch_by_product(team, email, from_dt, to_dt, limit),
                 "by_tool": by_tool,
                 "by_model": _fetch_by_model(team, email, from_dt, to_dt, product, limit),
+                "by_day": _fetch_by_day(team, email, from_dt, to_dt, product),
                 # Deprecated — trace IDs are opaque and unactionable in the UI. Returned empty so
                 # existing consumers don't crash while they remove the rendering. Drop the field
                 # entirely once no consumer reads it.

--- a/products/ai_observability/backend/api/test/__snapshots__/test_personal_spend.ambr
+++ b/products/ai_observability/backend/api/test/__snapshots__/test_personal_spend.ambr
@@ -168,7 +168,7 @@
 # name: TestPersonalSpendQueries.test_empty_result_when_no_events.4
   '''
   /* user_id:0 request:_snapshot_@me_spend_ */
-  SELECT toDate(toTimeZone(events.timestamp, 'UTC')) AS day,
+  SELECT toDate(events.timestamp) AS day,
          count() AS event_count,
          round(sum(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64')), 6) AS cost_usd
   FROM events
@@ -188,7 +188,7 @@
                                                     FROM person
                                                     WHERE equals(person.team_id, 99999)
                                                     GROUP BY person.id
-                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(person.created_at, person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
   WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_generation', '$ai_embedding')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'ai_product'), ''), 'null'), '^"|"$', ''), 'posthog_code'), 0), ifNull(equals(events__person.properties___email, 'user1@posthog.com'), 0), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(events.timestamp, toDateTime64('today', 6, 'UTC'))))
   GROUP BY day
   ORDER BY day ASC

--- a/products/ai_observability/backend/api/test/__snapshots__/test_personal_spend.ambr
+++ b/products/ai_observability/backend/api/test/__snapshots__/test_personal_spend.ambr
@@ -165,3 +165,44 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestPersonalSpendQueries.test_empty_result_when_no_events.4
+  '''
+  /* user_id:0 request:_snapshot_@me_spend_ */
+  SELECT toDate(toTimeZone(events.timestamp, 'UTC')) AS day,
+         count() AS event_count,
+         round(sum(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64')), 6) AS cost_usd
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  LEFT JOIN
+    (SELECT person.id AS id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_generation', '$ai_embedding')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'ai_product'), ''), 'null'), '^"|"$', ''), 'posthog_code'), 0), ifNull(equals(events__person.properties___email, 'user1@posthog.com'), 0), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(events.timestamp, toDateTime64('today', 6, 'UTC'))))
+  GROUP BY day
+  ORDER BY day ASC
+  LIMIT 92 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---

--- a/products/ai_observability/backend/api/test/test_personal_spend.py
+++ b/products/ai_observability/backend/api/test/test_personal_spend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from posthog.test.base import (
     APIBaseTest,
@@ -193,6 +193,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         input_tokens: int = 100000,
         output_tokens: int = 500,
         event_name: str = "$ai_generation",
+        timestamp: datetime | None = None,
     ) -> None:
         props: dict = {
             "$ai_total_cost_usd": cost,
@@ -204,11 +205,15 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         }
         if tool is not None:
             props["$ai_tools_called"] = tool
+        kwargs: dict = {}
+        if timestamp is not None:
+            kwargs["timestamp"] = timestamp
         _create_event(
             event=event_name,
             team=self.team,
             distinct_id=self.user.distinct_id or self.user.email,
             properties=props,
+            **kwargs,
         )
 
     @snapshot_clickhouse_queries
@@ -223,6 +228,7 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         assert body["by_product"] == {"items": [], "truncated": False}
         assert body["by_tool"] == {"items": [], "truncated": False}
         assert body["by_model"] == {"items": [], "truncated": False}
+        assert body["by_day"] == {"items": [], "truncated": False}
         assert body["top_traces"] == {"items": [], "truncated": False}
 
     def test_summary_reports_cross_product_totals_alongside_scoped(self) -> None:
@@ -339,9 +345,9 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
             response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&date_from=-7d")
 
         assert response.status_code == status.HTTP_200_OK
-        # 4 fetchers run once (summary, by_product, by_tool, by_model). top_traces is
-        # deprecated and returned empty without a query.
-        assert mock_exec.call_count == 4
+        # 5 fetchers run once (summary, by_product, by_tool, by_model, by_day). top_traces
+        # is deprecated and returned empty without a query.
+        assert mock_exec.call_count == 5
 
     def test_second_call_serves_from_cache(self) -> None:
         with patch("products.ai_observability.backend.api.personal_spend.execute_hogql_query") as mock_exec:
@@ -399,6 +405,40 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         # Each tool drove half of the scoped spend.
         assert rows["Bash"]["share_of_scoped"] == 0.5
         assert rows["Read"]["share_of_scoped"] == 0.5
+
+    def test_by_day_groups_spend_per_utc_day_scoped_to_product(self) -> None:
+        earlier = timezone.now() - timedelta(days=2)
+        self._create_generation(cost=1.0, trace_id="old-1", timestamp=earlier)
+        self._create_generation(cost=0.5, trace_id="old-2", timestamp=earlier)
+        self._create_generation(cost=2.0, trace_id="today")
+        # Same day as `earlier` but another product — must not leak into the scoped series.
+        self._create_generation(ai_product="background_agents", cost=99.0, timestamp=earlier)
+        flush_persons_and_events()
+
+        response = self.client.get(ENDPOINT_OK)
+        by_day = response.json()["by_day"]
+        assert by_day["truncated"] is False
+        rows = by_day["items"]
+        assert len(rows) == 2
+        # Ordered by day ascending, not by cost.
+        assert rows[0]["day"] == earlier.date().isoformat()
+        assert rows[0]["event_count"] == 2
+        assert rows[0]["cost_usd"] == 1.5
+        assert rows[1]["day"] == timezone.now().date().isoformat()
+        assert rows[1]["event_count"] == 1
+        assert rows[1]["cost_usd"] == 2.0
+
+    def test_by_day_ignores_request_limit(self) -> None:
+        self._create_generation(cost=1.0, trace_id="a", timestamp=timezone.now() - timedelta(days=3))
+        self._create_generation(cost=2.0, trace_id="b", timestamp=timezone.now() - timedelta(days=2))
+        self._create_generation(cost=3.0, trace_id="c", timestamp=timezone.now() - timedelta(days=1))
+        flush_persons_and_events()
+
+        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&limit=1")
+        body = response.json()
+        # by_model honors the limit; by_day returns the full series regardless.
+        assert len(body["by_day"]["items"]) == 3
+        assert body["by_day"]["truncated"] is False
 
 
 class TestPersonalSpendNonSessionAuth(APIBaseTest):

--- a/products/ai_observability/backend/api/test/test_personal_spend.py
+++ b/products/ai_observability/backend/api/test/test_personal_spend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from posthog.test.base import (
     APIBaseTest,
@@ -189,20 +189,21 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         model: str = "claude-opus-4-8",
         tool: str | None = "Bash",
         trace_id: str = "trace-1",
-        cost: float = 1.5,
+        cost: float | None = 1.5,
         input_tokens: int = 100000,
         output_tokens: int = 500,
         event_name: str = "$ai_generation",
         timestamp: datetime | None = None,
     ) -> None:
         props: dict = {
-            "$ai_total_cost_usd": cost,
             "$ai_input_tokens": input_tokens,
             "$ai_output_tokens": output_tokens,
             "$ai_model": model,
             "$ai_trace_id": trace_id,
             "ai_product": ai_product,
         }
+        if cost is not None:
+            props["$ai_total_cost_usd"] = cost
         if tool is not None:
             props["$ai_tools_called"] = tool
         kwargs: dict = {}
@@ -407,38 +408,59 @@ class TestPersonalSpendQueries(ClickhouseTestMixin, APIBaseTest):
         assert rows["Read"]["share_of_scoped"] == 0.5
 
     def test_by_day_groups_spend_per_utc_day_scoped_to_product(self) -> None:
-        earlier = timezone.now() - timedelta(days=2)
+        earlier = datetime(2026, 6, 13, 9, 0, tzinfo=UTC)
+        later = datetime(2026, 6, 15, 20, 0, tzinfo=UTC)
         self._create_generation(cost=1.0, trace_id="old-1", timestamp=earlier)
         self._create_generation(cost=0.5, trace_id="old-2", timestamp=earlier)
-        self._create_generation(cost=2.0, trace_id="today")
-        # Same day as `earlier` but another product — must not leak into the scoped series.
+        self._create_generation(cost=2.0, trace_id="new", timestamp=later)
+        # Same day as `earlier` but another product: must not leak into the scoped series.
         self._create_generation(ai_product="background_agents", cost=99.0, timestamp=earlier)
         flush_persons_and_events()
 
-        response = self.client.get(ENDPOINT_OK)
+        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&date_from=2026-06-10&date_to=2026-06-16")
         by_day = response.json()["by_day"]
         assert by_day["truncated"] is False
-        rows = by_day["items"]
-        assert len(rows) == 2
         # Ordered by day ascending, not by cost.
-        assert rows[0]["day"] == earlier.date().isoformat()
-        assert rows[0]["event_count"] == 2
-        assert rows[0]["cost_usd"] == 1.5
-        assert rows[1]["day"] == timezone.now().date().isoformat()
-        assert rows[1]["event_count"] == 1
-        assert rows[1]["cost_usd"] == 2.0
+        assert by_day["items"] == [
+            {"day": "2026-06-13", "event_count": 2, "cost_usd": 1.5},
+            {"day": "2026-06-15", "event_count": 1, "cost_usd": 2.0},
+        ]
 
     def test_by_day_ignores_request_limit(self) -> None:
-        self._create_generation(cost=1.0, trace_id="a", timestamp=timezone.now() - timedelta(days=3))
-        self._create_generation(cost=2.0, trace_id="b", timestamp=timezone.now() - timedelta(days=2))
-        self._create_generation(cost=3.0, trace_id="c", timestamp=timezone.now() - timedelta(days=1))
+        self._create_generation(cost=1.0, trace_id="a", timestamp=datetime(2026, 6, 12, 12, 0, tzinfo=UTC))
+        self._create_generation(cost=2.0, trace_id="b", timestamp=datetime(2026, 6, 13, 12, 0, tzinfo=UTC))
+        self._create_generation(cost=3.0, trace_id="c", timestamp=datetime(2026, 6, 14, 12, 0, tzinfo=UTC))
         flush_persons_and_events()
 
-        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&limit=1")
+        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&date_from=2026-06-10&date_to=2026-06-16&limit=1")
         body = response.json()
         # by_model honors the limit; by_day returns the full series regardless.
         assert len(body["by_day"]["items"]) == 3
         assert body["by_day"]["truncated"] is False
+
+    def test_by_day_uses_utc_days_regardless_of_team_timezone(self) -> None:
+        self.team.timezone = "Asia/Tokyo"
+        self.team.save()
+        # 20:00 UTC on Jun 15 is already Jun 16 in Tokyo; the bucket must stay on the UTC day.
+        self._create_generation(cost=1.0, timestamp=datetime(2026, 6, 15, 20, 0, tzinfo=UTC))
+        flush_persons_and_events()
+
+        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&date_from=2026-06-10&date_to=2026-06-16")
+        assert [r["day"] for r in response.json()["by_day"]["items"]] == ["2026-06-15"]
+
+    def test_by_day_counts_embeddings_and_costless_events(self) -> None:
+        day_one = datetime(2026, 6, 13, 9, 0, tzinfo=UTC)
+        self._create_generation(cost=1.0, timestamp=day_one)
+        self._create_generation(cost=0.5, event_name="$ai_embedding", timestamp=day_one)
+        # A generation captured without `$ai_total_cost_usd` must count but cost nothing.
+        self._create_generation(cost=None, timestamp=datetime(2026, 6, 15, 12, 0, tzinfo=UTC))
+        flush_persons_and_events()
+
+        response = self.client.get(f"{ENDPOINT}?{PRODUCT_QS}&date_from=2026-06-10&date_to=2026-06-16")
+        assert response.json()["by_day"]["items"] == [
+            {"day": "2026-06-13", "event_count": 2, "cost_usd": 1.5},
+            {"day": "2026-06-15", "event_count": 1, "cost_usd": 0.0},
+        ]
 
 
 class TestPersonalSpendNonSessionAuth(APIBaseTest):

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -89,6 +89,22 @@ export interface _ModelBreakdownApi {
     truncated: boolean
 }
 
+export interface _DayBreakdownRowApi {
+    /** UTC calendar day the events fall on (`toDate(timestamp)`). */
+    day: string
+    /** Number of $ai_generation + $ai_embedding events on this day for the scoped product. */
+    event_count: number
+    /** Total cost in USD on this day for the scoped product. */
+    cost_usd: number
+}
+
+export interface _DayBreakdownApi {
+    /** One row per UTC day that has events, ordered by day ascending. Days with no events are omitted — zero-fill client-side when rendering a continuous series. */
+    items: _DayBreakdownRowApi[]
+    /** Always false. A time series truncated by cost would be meaningless, so `by_day` is not subject to `limit` — the window is already capped at 90 days. */
+    truncated: boolean
+}
+
 export interface _TopTraceRowApi {
     /**
      * `$ai_trace_id` of the session — opaque string scoped to the originating product. Format is not stable: most are UUIDs but some SDK wrappers emit JSON-shaped strings like `{"device_id":"...","session_id":"..."}`. Callers should treat this as an opaque identifier (URL-encode before linking to a trace view).
@@ -125,6 +141,8 @@ export interface PersonalSpendAnalysisResponseApi {
     by_tool: _ToolBreakdownApi
     /** Spend grouped by `$ai_model`. Scoped to `product` when set. */
     by_model: _ModelBreakdownApi
+    /** Spend grouped by UTC day, ordered ascending. Scoped to `product`. Not subject to `limit`. */
+    by_day: _DayBreakdownApi
     /** Deprecated — always returns `{items: [], truncated: false}`. Trace IDs are opaque strings that aren't actionable in the UI. Kept in the response shape so existing consumers don't crash; remove your rendering of this field and we'll drop it from the response entirely in a follow-up. */
     top_traces: _TopTracesApi
 }

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -101,7 +101,7 @@ export interface _DayBreakdownRowApi {
 export interface _DayBreakdownApi {
     /** One row per UTC day that has events, ordered by day ascending. Days with no events are omitted — zero-fill client-side when rendering a continuous series. */
     items: _DayBreakdownRowApi[]
-    /** Always false. A time series truncated by cost would be meaningless, so `by_day` is not subject to `limit` — the window is already capped at 90 days. */
+    /** Effectively always false: `by_day` ignores `limit` because truncating a time series by cost would be meaningless, and the 90-day window cap already bounds the series length. */
     truncated: boolean
 }
 

--- a/products/ai_observability/frontend/generated/api.ts
+++ b/products/ai_observability/frontend/generated/api.ts
@@ -139,7 +139,7 @@ export const getLlmAnalyticsPersonalSpendListUrl = (params: LlmAnalyticsPersonal
 }
 
 /**
- * Return a structured personal LLM spend analysis for the requesting user. Pass `date_from` / `date_to` (absolute like `2026-04-23` or relative like `-7d`) to bound the window — defaults to the last 30 days, max 90 days. The `product=<ai_product>` query param is required and scopes the tool / model / trace breakdowns to a single product; supported values: posthog_code. `by_product` is always returned for cross-product visibility. Use `refresh=true` to bypass the 5-minute response cache.
+ * Return a structured personal LLM spend analysis for the requesting user. Pass `date_from` / `date_to` (absolute like `2026-04-23` or relative like `-7d`) to bound the window — defaults to the last 30 days, max 90 days. The `product=<ai_product>` query param is required and scopes the tool / model / day / trace breakdowns to a single product; supported values: posthog_code. `by_product` is always returned for cross-product visibility. `by_day` returns a day-ascending spend series for the scoped product. Use `refresh=true` to bypass the 5-minute response cache.
  */
 export const llmAnalyticsPersonalSpendList = async (
     params: LlmAnalyticsPersonalSpendListParams,

--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -480,10 +480,11 @@ tools:
         title: Get my LLM spend analysis
         description: >
             Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days
-            (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. The
-            `product` query param is required and scopes the tool / model / trace breakdowns to a single product;
-            currently only `posthog_code` is supported. `by_product` always returns the cross-product view. Pass
-            `refresh=true` to bypass the 5-minute cache.
+            (default 30, max 90). Returns a summary plus breakdowns by product, tool, model and UTC day. The
+            `product` query param is required and scopes the tool / model / day breakdowns to a single product;
+            currently only `posthog_code` is supported. `by_product` always returns the cross-product view, and
+            `by_day` is a day-ascending series for spend-over-time questions. Pass `refresh=true` to bypass the
+            5-minute cache.
     llma-prompt-archive:
         operation: llm_prompts_name_archive_create
         enabled: false

--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -480,11 +480,10 @@ tools:
         title: Get my LLM spend analysis
         description: >
             Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days
-            (default 30, max 90). Returns a summary plus breakdowns by product, tool, model and UTC day. The
-            `product` query param is required and scopes the tool / model / day breakdowns to a single product;
-            currently only `posthog_code` is supported. `by_product` always returns the cross-product view, and
-            `by_day` is a day-ascending series for spend-over-time questions. Pass `refresh=true` to bypass the
-            5-minute cache.
+            (default 30, max 90). Returns a summary plus breakdowns by product, tool, model and UTC day. The `product`
+            query param is required and scopes the tool / model / day breakdowns to a single product; currently only
+            `posthog_code` is supported. `by_product` always returns the cross-product view, and `by_day` is a
+            day-ascending series for spend-over-time questions. Pass `refresh=true` to bypass the 5-minute cache.
     llma-prompt-archive:
         operation: llm_prompts_name_archive_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4762,7 +4762,7 @@
         }
     },
     "llma-personal-spend": {
-        "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. The `product` query param is required and scopes the tool / model / trace breakdowns to a single product; currently only `posthog_code` is supported. `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
+        "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model and UTC day. The `product` query param is required and scopes the tool / model / day breakdowns to a single product; currently only `posthog_code` is supported. `by_product` always returns the cross-product view, and `by_day` is a day-ascending series for spend-over-time questions. Pass `refresh=true` to bypass the 5-minute cache.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5058,7 +5058,7 @@
         }
     },
     "llma-personal-spend": {
-        "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model, and top traces. The `product` query param is required and scopes the tool / model / trace breakdowns to a single product; currently only `posthog_code` is supported. `by_product` always returns the cross-product view. Pass `refresh=true` to bypass the 5-minute cache.",
+        "description": "Retrieve the current user's personal LLM spend analysis across PostHog products over the last N days (default 30, max 90). Returns a summary plus breakdowns by product, tool, model and UTC day. The `product` query param is required and scopes the tool / model / day breakdowns to a single product; currently only `posthog_code` is supported. `by_product` always returns the cross-product view, and `by_day` is a day-ascending series for spend-over-time questions. Pass `refresh=true` to bypass the 5-minute cache.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get my LLM spend analysis",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43079,6 +43079,22 @@ export namespace Schemas {
       truncated: boolean;
     }
 
+    export interface _DayBreakdownRow {
+      /** UTC calendar day the events fall on (`toDate(timestamp)`). */
+      day: string;
+      /** Number of $ai_generation + $ai_embedding events on this day for the scoped product. */
+      event_count: number;
+      /** Total cost in USD on this day for the scoped product. */
+      cost_usd: number;
+    }
+
+    export interface _DayBreakdown {
+      /** One row per UTC day that has events, ordered by day ascending. Days with no events are omitted — zero-fill client-side when rendering a continuous series. */
+      items: _DayBreakdownRow[];
+      /** Always false. A time series truncated by cost would be meaningless, so `by_day` is not subject to `limit` — the window is already capped at 90 days. */
+      truncated: boolean;
+    }
+
     export interface _TopTraceRow {
       /**
          * `$ai_trace_id` of the session — opaque string scoped to the originating product. Format is not stable: most are UUIDs but some SDK wrappers emit JSON-shaped strings like `{"device_id":"...","session_id":"..."}`. Callers should treat this as an opaque identifier (URL-encode before linking to a trace view).
@@ -43115,6 +43131,8 @@ export namespace Schemas {
       by_tool: _ToolBreakdown;
       /** Spend grouped by `$ai_model`. Scoped to `product` when set. */
       by_model: _ModelBreakdown;
+      /** Spend grouped by UTC day, ordered ascending. Scoped to `product`. Not subject to `limit`. */
+      by_day: _DayBreakdown;
       /** Deprecated — always returns `{items: [], truncated: false}`. Trace IDs are opaque strings that aren't actionable in the UI. Kept in the response shape so existing consumers don't crash; remove your rendering of this field and we'll drop it from the response entirely in a follow-up. */
       top_traces: _TopTraces;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43091,7 +43091,7 @@ export namespace Schemas {
     export interface _DayBreakdown {
       /** One row per UTC day that has events, ordered by day ascending. Days with no events are omitted — zero-fill client-side when rendering a continuous series. */
       items: _DayBreakdownRow[];
-      /** Always false. A time series truncated by cost would be meaningless, so `by_day` is not subject to `limit` — the window is already capped at 90 days. */
+      /** Effectively always false: `by_day` ignores `limit` because truncating a time series by cost would be meaningless, and the 90-day window cap already bounds the series length. */
       truncated: boolean;
     }
 

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -9,7 +9,7 @@
 import * as zod from 'zod'
 
 /**
- * Return a structured personal LLM spend analysis for the requesting user. Pass `date_from` / `date_to` (absolute like `2026-04-23` or relative like `-7d`) to bound the window — defaults to the last 30 days, max 90 days. The `product=<ai_product>` query param is required and scopes the tool / model / trace breakdowns to a single product; supported values: posthog_code. `by_product` is always returned for cross-product visibility. Use `refresh=true` to bypass the 5-minute response cache.
+ * Return a structured personal LLM spend analysis for the requesting user. Pass `date_from` / `date_to` (absolute like `2026-04-23` or relative like `-7d`) to bound the window — defaults to the last 30 days, max 90 days. The `product=<ai_product>` query param is required and scopes the tool / model / day / trace breakdowns to a single product; supported values: posthog_code. `by_product` is always returned for cross-product visibility. `by_day` returns a day-ascending spend series for the scoped product. Use `refresh=true` to bypass the 5-minute response cache.
  */
 export const llmAnalyticsPersonalSpendListQueryDateFromDefault = `-30d`
 export const llmAnalyticsPersonalSpendListQueryDateFromMax = 32


### PR DESCRIPTION
## Problem

PostHog Code is getting a dedicated usage page (PostHog/code#3160) that charts a user's LLM spend day by day. The personal spend endpoint only returns window aggregates (summary, by product/tool/model), so there is no time series to draw.

## Changes

- Adds a `by_day` breakdown to `GET /api/llm_analytics/@me/spend/`: one row per UTC day that has events (`day`, `event_count`, `cost_usd`), scoped to the `product` filter, ordered day ascending
- Day buckets are pinned to UTC with `convertToProjectTimezone=False`, the same idiom tracing and logs use. Without the pin, HogQL buckets `toDate(timestamp)` in the internal analytics team's configurable timezone while the schema documents UTC days
- `by_day` is deliberately exempt from the `limit` param. Truncating a time series by cost makes no sense, and the 90-day window cap already bounds the row count. `truncated` is computed from the row count via the shared `_truncate` helper rather than hardcoded, so an invariant break would surface instead of silently dropping the newest days
- Mentions the day breakdown in the `llma-personal-spend` MCP tool description so agents route daily-trend questions to it
- Regenerated OpenAPI schemas, generated clients and MCP tool definitions via `hogli build:openapi`

## How did you test this code?

- `hogli test products/ai_observability/backend/api/test/test_personal_spend.py` passes (47 tests)
- New `test_by_day_uses_utc_days_regardless_of_team_timezone` catches day buckets following the team timezone instead of UTC. I verified it fails when the `convertToProjectTimezone` pin is removed
- New `test_by_day_counts_embeddings_and_costless_events` catches `$ai_embedding` events being dropped from the series and a crash on events captured without `$ai_total_cost_usd`
- `test_by_day_groups_spend_per_utc_day_scoped_to_product` catches per-day grouping, day-ascending ordering and cross-product leaks; `test_by_day_ignores_request_limit` catches the series getting truncated by a small `limit`. Both run on fixed dates with explicit `date_from`/`date_to` so they can't flake across a UTC midnight rollover
- Updated the empty-shape and fetcher-count assertions and regenerated the ClickHouse query snapshot
- No manual testing was done here; the consuming UI was exercised in the PostHog Code repo

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Field-level docs live in the serializer help texts and the regenerated OpenAPI spec. No page under `docs/` covers this endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this change and Claude Code (Claude Fable 5) wrote it. The agent read the existing endpoint, mirrored the `by_product`/`by_tool` fetcher pattern for the day series, and chose to keep `by_day` outside the `limit` semantics after rejecting cost-ordered truncation for a time series.

A follow-up multi-agent review pass found that `toDate(timestamp)` followed the team's configurable timezone (reproduced with a non-UTC team) and that `truncated` was asserted rather than computed; both are fixed in this PR. The review also suggested versioning the response cache key against stale pre-deploy shapes, which I decided against since nothing consumes `by_day` yet. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/implementing-mcp-tools`.
