### PR TITLE
fix(surveys): disable position controls for tab widget surveys

### DIFF
--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -173,9 +173,11 @@ export function SurveyContainerAppearance({
             <LemonField.Pure
                 label="Position"
                 info={
-                    surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector
-                        ? 'The "next to feedback button" option requires posthog.js version 1.235.2 or higher.'
-                        : undefined
+                    surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Tab
+                        ? 'Position is fixed next to the tab button for tab widget surveys.'
+                        : surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector
+                          ? 'The "next to feedback button" option requires posthog.js version 1.235.2 or higher.'
+                          : undefined
                 }
                 className="gap-1"
             >
@@ -183,7 +185,10 @@ export function SurveyContainerAppearance({
                     <SurveyPositionSelector
                         currentPosition={appearance.position}
                         onAppearanceChange={onAppearanceChange}
-                        disabled={disabled}
+                        disabled={
+                            disabled ||
+                            (surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Tab)
+                        }
                     />
                     <LemonSelect
                         value={appearance.position}
@@ -192,8 +197,15 @@ export function SurveyContainerAppearance({
                             label: positionDisplayNames[position],
                             value: position,
                         }))}
-                        disabled={disabled}
-                        disabledReason={disabledReason || undefined}
+                        disabled={
+                            disabled ||
+                            (surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Tab)
+                        }
+                        disabledReason={
+                            surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Tab
+                                ? 'Position is fixed next to the tab button for tab widget surveys'
+                                : disabledReason || undefined
+                        }
                     />
                 </div>
                 {surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector && (


### PR DESCRIPTION
## Problem

When a survey uses the Tab widget type, the position setting in the appearance editor has no effect — the popup is always rendered next to the tab button by the posthog-js SDK. However, the UI still shows the full position selector grid as interactive, misleading users into configuring a setting that does nothing.

Closes #31267

## Changes

In `SurveyAppearanceSections.tsx`, the position selector (`SurveyPositionSelector` + `LemonSelect`) is now disabled when `widgetType === SurveyWidgetType.Tab`. A tooltip explains why: "Position is fixed next to the tab button for tab widget surveys." The info label also surfaces this constraint inline.

All other widget types (Selector, non-widget surveys) retain existing behavior.

## How did you test this code?

Agent-authored. Verified the conditional logic targets only `SurveyWidgetType.Tab` and leaves `SurveyWidgetType.Selector` and non-widget surveys untouched. No automated tests added — the change is a UI state guard with no business logic.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Used Claude Code to identify the tab widget position bug. The fix follows the same pattern established in #29773. Disabled the controls with `disabledReason` rather than hiding them, so users understand the constraint without losing context about the setting's existence.