### PR TITLE
fix(proxy): stop following redirects in proxy liveness check

### DIFF
--- a/posthog/temporal/proxy_service/monitor.py
+++ b/posthog/temporal/proxy_service/monitor.py
@@ -255,13 +255,26 @@ async def check_proxy_is_live(inputs: CheckActivityInput) -> CheckActivityOutput
 
     # send dummy event to check the proxy is working
     try:
+        # A monitoring ping to a customer-controlled domain must not follow redirects: a malicious
+        # domain could 307-redirect us (preserving method + body) to an internal host, turning this
+        # into an SSRF sink. The proxy is expected to answer the event directly with a 2xx.
         response = requests.post(
             f"https://{proxy_record.domain}/i/v0/e/",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"event": "test", "api_key": "test", "distinct_id": "test"}),
+            allow_redirects=False,
+            timeout=5,
         )
 
         response.raise_for_status()
+
+        # With redirects disabled, raise_for_status() does not flag 3xx; a healthy proxy answers
+        # directly, so treat a redirect as a misconfiguration rather than silently passing.
+        if response.is_redirect or response.is_permanent_redirect:
+            return CheckActivityOutput(
+                errors=[f"Proxy returned an unexpected redirect (status {response.status_code})"],
+                warnings=[],
+            )
 
         # fetch the cert info to see how far away the expiry is - if less than 2 weeks we have a problem
         ctx = ssl.create_default_context()
@@ -284,6 +297,11 @@ async def check_proxy_is_live(inputs: CheckActivityInput) -> CheckActivityOutput
     except requests.exceptions.SSLError:
         return CheckActivityOutput(
             errors=["Failed to connect to proxy: invalid SSL certificate"],
+            warnings=[],
+        )
+    except requests.exceptions.Timeout:
+        return CheckActivityOutput(
+            errors=["Failed to connect to proxy: request timed out"],
             warnings=[],
         )
     except requests.exceptions.ConnectionError:

--- a/posthog/temporal/proxy_service/test/monitor_test.py
+++ b/posthog/temporal/proxy_service/test/monitor_test.py
@@ -44,6 +44,8 @@ class TestCheckProxyIsLive(TestCase):
         # Mock successful HTTP response
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
+        mock_response.is_redirect = False
+        mock_response.is_permanent_redirect = False
         mock_post.return_value = mock_response
 
         # Mock SSL certificate check with fixed future date (20 days from frozen time)
@@ -65,6 +67,8 @@ class TestCheckProxyIsLive(TestCase):
             f"https://{self.proxy_record.domain}/i/v0/e/",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"event": "test", "api_key": "test", "distinct_id": "test"}),
+            allow_redirects=False,
+            timeout=5,
         )
 
         self.assertEqual(result.errors, [])
@@ -99,6 +103,44 @@ class TestCheckProxyIsLive(TestCase):
     @pytest.mark.asyncio
     @patch("posthog.temporal.proxy_service.monitor.requests.post")
     @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_timeout(self, mock_get_record, mock_post):
+        """Test request timeout handling"""
+        mock_get_record.return_value = self.proxy_record
+        mock_post.side_effect = requests.exceptions.ReadTimeout("timed out")
+
+        result = await check_proxy_is_live(self.input)
+
+        self.assertEqual(result.errors, ["Failed to connect to proxy: request timed out"])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.socket.socket")
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_rejects_redirect(self, mock_get_record, mock_post, mock_socket):
+        """A redirect response is treated as an error and never followed (SSRF guard)"""
+        mock_get_record.return_value = self.proxy_record
+
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.is_redirect = True
+        mock_response.is_permanent_redirect = False
+        mock_response.status_code = 307
+        mock_post.return_value = mock_response
+
+        result = await check_proxy_is_live(self.input)
+
+        # redirects are disabled at the request layer, and a redirect response is reported
+        # rather than silently passing the health check or being followed to an internal host
+        self.assertEqual(mock_post.call_args.kwargs["allow_redirects"], False)
+        self.assertEqual(result.errors, ["Proxy returned an unexpected redirect (status 307)"])
+        self.assertEqual(result.warnings, [])
+        # we must not have reached the certificate socket connection
+        mock_socket.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
     async def test_check_proxy_is_live_http_error(self, mock_get_record, mock_post):
         """Test HTTP error handling"""
         mock_get_record.return_value = self.proxy_record
@@ -124,6 +166,8 @@ class TestCheckProxyIsLive(TestCase):
         # Mock successful HTTP response
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
+        mock_response.is_redirect = False
+        mock_response.is_permanent_redirect = False
         mock_post.return_value = mock_response
 
         # Mock SSL certificate that expires in 9 days (less than 14 day threshold)


### PR DESCRIPTION
## Problem

The proxy liveness monitor sends a POST to a customer-controlled proxy domain and followed HTTP redirects by default. A malicious proxy domain could 307-redirect the worker (method and body preserved) to an internal host, making the check a server-side request forgery sink. The request also had no timeout.

## Changes

- Disable redirect following on the liveness request, which closes the SSRF vector
- Add a request timeout so a hostile or slow proxy can't hang the monitor activity
- Report a redirect response as a proxy error instead of silently passing the health check

## How did you test this code?

- 8 backend unit tests pass locally, including 2 new cases: redirect response rejected, and request timeout handled

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?