### PR TITLE
fix(capture): ignore legacy ver query parameter

### DIFF
--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -419,7 +419,6 @@ mod tests {
         sent_at: Option<OffsetDateTime>,
     ) -> ProcessingContext {
         ProcessingContext {
-            lib_version: None,
             user_agent: None,
             sent_at,
             token: "test_token".to_string(),

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -569,7 +569,6 @@ mod tests {
             is_mirror_deploy: false,
             chatty_debug_enabled: false,
             user_agent: None,
-            lib_version: None,
             path: "/s/".to_string(),
         }
     }

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -26,16 +26,7 @@ use crate::{
 /// /i/v0/e/, /batch/, /e/, /capture/, /track/, and /engage/ endpoints
 #[instrument(
     skip_all,
-    fields(
-        method,
-        path,
-        token,
-        ip,
-        historical_migration,
-        compression,
-        lib_version,
-        batch_size
-    )
+    fields(method, path, token, ip, historical_migration, compression, batch_size)
 )]
 pub async fn handle_event_payload(
     state: &State<router::State>,
@@ -59,7 +50,6 @@ pub async fn handle_event_payload(
     // GET query params should contain the following:
     //     - data        = JSON payload which may itself be compressed or base64 encoded or both
     //     - compression = hint to how "data" is encoded or compressed
-    //     - lib_version = SDK version that submitted the request
 
     // Extract body with optional chunk timeout
     let body = extract_body_with_timeout(
@@ -77,11 +67,9 @@ pub async fn handle_event_payload(
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, "extracted metadata");
 
     // Extract payload bytes and metadata using shared helper
-    let (data, compression, lib_version) =
-        extract_payload_bytes(query_params, headers, method, body)?;
+    let (data, compression) = extract_payload_bytes(query_params, headers, method, body)?;
 
     Span::current().record("compression", format!("{compression}"));
-    Span::current().record("lib_version", &lib_version);
 
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, "extracted payload");
 
@@ -121,7 +109,6 @@ pub async fn handle_event_payload(
     let now = state.timesource.current_time();
 
     let context = ProcessingContext {
-        lib_version,
         sent_at,
         token,
         now,

--- a/rust/capture/src/payload/common.rs
+++ b/rust/capture/src/payload/common.rs
@@ -12,7 +12,7 @@ use crate::{
     api::CaptureError,
     payload::{Compression, EventFormData, EventQuery},
     utils::{
-        decode_base64, decode_form, extract_compression, extract_lib_version, is_likely_base64,
+        decode_base64, decode_form, extract_compression, is_likely_base64,
         is_likely_urlencoded_form, Base64Option, FORM_MIME_TYPE, MAX_PAYLOAD_SNIPPET_SIZE,
     },
 };
@@ -67,13 +67,13 @@ pub fn extract_and_record_metadata<'a>(
 }
 
 /// Extract payload bytes from request (handles query params, form data, base64 encoding)
-/// Returns (payload_bytes, compression, lib_version)
+/// Returns (payload_bytes, compression)
 pub fn extract_payload_bytes(
     query_params: &mut EventQuery,
     headers: &HeaderMap,
     method: &Method,
     body: Bytes,
-) -> Result<(Bytes, Compression, Option<String>), CaptureError> {
+) -> Result<(Bytes, Compression), CaptureError> {
     // Unpack the payload - it may be in a GET query param or POST body
     let raw_payload: Bytes = if query_params.data.as_ref().is_some_and(|d| !d.is_empty()) {
         let tmp_vec = std::mem::take(&mut query_params.data);
@@ -130,9 +130,8 @@ pub fn extract_payload_bytes(
         _ => EventFormData::default(),
     };
 
-    // Extract compression hint and lib_version from query params or form data
+    // Extract compression hint from query params, form data, or headers
     let compression = extract_compression(&form, query_params, headers);
-    let lib_version = extract_lib_version(&form, query_params);
 
     // Get the actual payload bytes (either from form data or direct body)
     let payload_bytes: Bytes = if form.data.is_some() {
@@ -141,7 +140,7 @@ pub fn extract_payload_bytes(
         payload
     };
 
-    Ok((payload_bytes, compression, lib_version))
+    Ok((payload_bytes, compression))
 }
 
 #[cfg(test)]
@@ -187,10 +186,9 @@ mod tests {
         let result = extract_payload_bytes(&mut query_params, &headers, &method, body);
         assert!(result.is_ok());
 
-        let (payload, compression, lib_version) = result.unwrap();
+        let (payload, compression) = result.unwrap();
         assert_eq!(payload, Bytes::from(r#"{"event":"test"}"#));
         assert_eq!(compression, Compression::Unsupported);
-        assert_eq!(lib_version, None);
     }
 
     #[test]
@@ -198,7 +196,6 @@ mod tests {
         let mut query_params = EventQuery {
             data: Some(r#"{"event":"test"}"#.to_string()),
             compression: None,
-            lib_version: None,
             sent_at: None,
             beacon: false,
         };
@@ -209,7 +206,7 @@ mod tests {
         let result = extract_payload_bytes(&mut query_params, &headers, &method, body);
         assert!(result.is_ok());
 
-        let (payload, _, _) = result.unwrap();
+        let (payload, _) = result.unwrap();
         assert_eq!(payload, Bytes::from(r#"{"event":"test"}"#));
     }
 
@@ -225,11 +222,26 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_payload_bytes_ignores_form_ver_field() {
+        let mut query_params = EventQuery::default();
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static(FORM_MIME_TYPE));
+        let method = Method::POST;
+        let body = Bytes::from(r#"ver=1.2.3&data={"event":"test"}"#);
+
+        let result = extract_payload_bytes(&mut query_params, &headers, &method, body);
+        assert!(result.is_ok());
+
+        let (payload, compression) = result.unwrap();
+        assert_eq!(payload, Bytes::from(r#"{"event":"test"}"#));
+        assert_eq!(compression, Compression::Unsupported);
+    }
+
+    #[test]
     fn test_extract_payload_bytes_with_compression_hint() {
         let mut query_params = EventQuery {
             data: Some(r#"{"event":"test"}"#.to_string()),
             compression: Some(Compression::Gzip),
-            lib_version: None,
             sent_at: None,
             beacon: false,
         };
@@ -240,27 +252,7 @@ mod tests {
         let result = extract_payload_bytes(&mut query_params, &headers, &method, body);
         assert!(result.is_ok());
 
-        let (_, compression, _) = result.unwrap();
+        let (_, compression) = result.unwrap();
         assert_eq!(compression, Compression::Gzip);
-    }
-
-    #[test]
-    fn test_extract_payload_bytes_with_lib_version() {
-        let mut query_params = EventQuery {
-            data: Some(r#"{"event":"test"}"#.to_string()),
-            compression: None,
-            lib_version: Some("1.2.3".to_string()),
-            sent_at: None,
-            beacon: false,
-        };
-        let headers = HeaderMap::new();
-        let method = Method::GET;
-        let body = Bytes::new();
-
-        let result = extract_payload_bytes(&mut query_params, &headers, &method, body);
-        assert!(result.is_ok());
-
-        let (_, _, lib_version) = result.unwrap();
-        assert_eq!(lib_version, Some("1.2.3".to_string()));
     }
 }

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -42,7 +42,7 @@ impl RecordingPayload {
 /// handle_recording_payload processes recording (session replay) payloads
 /// This is optimized to avoid the double serialization that would occur
 /// if we went through RawRequest -> Vec<RawEvent> -> process
-#[instrument(skip_all, fields(batch_size, params_lib_version, params_compression))]
+#[instrument(skip_all, fields(batch_size, params_compression))]
 pub async fn handle_recording_payload(
     state: &State<router::State>,
     InsecureClientIp(ip): &InsecureClientIp,
@@ -74,13 +74,11 @@ pub async fn handle_recording_payload(
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, "extracted metadata");
 
     // Extract payload bytes and metadata using shared helper
-    let (data, compression, lib_version) =
-        extract_payload_bytes(query_params, headers, method, body)?;
+    let (data, compression) = extract_payload_bytes(query_params, headers, method, body)?;
 
     Span::current().record("compression", format!("{compression}"));
-    Span::current().record("lib_version", &lib_version);
 
-    debug_or_info!(chatty_debug_enabled, metadata=?metadata, compression=?compression, lib_version=?lib_version, "extracted payload");
+    debug_or_info!(chatty_debug_enabled, metadata=?metadata, compression=?compression, "extracted payload");
 
     // Decompress the payload
     let payload = decompress_payload(
@@ -90,7 +88,7 @@ pub async fn handle_recording_payload(
         path.as_str(),
     )?;
 
-    debug_or_info!(chatty_debug_enabled, metadata=?metadata, compression=?compression, lib_version=?lib_version, "decompressed payload");
+    debug_or_info!(chatty_debug_enabled, metadata=?metadata, compression=?compression, "decompressed payload");
 
     // Deserialize to RecordingPayload (handles both single event and array)
     let recording_payload: RecordingPayload = serde_json::from_str(&payload)?;
@@ -118,7 +116,6 @@ pub async fn handle_recording_payload(
     let sent_at = query_params.sent_at();
 
     let context = ProcessingContext {
-        lib_version,
         sent_at,
         token,
         now,

--- a/rust/capture/src/payload/types.rs
+++ b/rust/capture/src/payload/types.rs
@@ -60,9 +60,6 @@ pub struct EventQuery {
     // legacy GET requests can include data as query param
     pub data: Option<String>,
 
-    #[serde(alias = "ver")]
-    pub lib_version: Option<String>,
-
     #[serde(alias = "_")]
     pub sent_at: Option<i64>,
 
@@ -103,8 +100,6 @@ impl EventQuery {
 pub struct EventFormData {
     pub data: Option<String>,
     pub compression: Option<Compression>,
-    #[serde(alias = "ver")]
-    pub lib_version: Option<String>,
 }
 
 #[cfg(test)]
@@ -200,15 +195,9 @@ mod tests {
     }
 
     #[test]
-    fn test_event_form_data_alias() {
-        // Test that "ver" is aliased to "lib_version"
+    fn test_event_query_ignores_ver() {
         let json = r#"{"ver":"1.2.3"}"#;
-        let form: EventFormData = serde_json::from_str(json).unwrap();
-        assert_eq!(form.lib_version, Some("1.2.3".to_string()));
-
-        // Test normal field name
-        let json = r#"{"lib_version":"1.2.3"}"#;
-        let form: EventFormData = serde_json::from_str(json).unwrap();
-        assert_eq!(form.lib_version, Some("1.2.3".to_string()));
+        let query: EventQuery = serde_json::from_str(json).unwrap();
+        assert_eq!(query.compression, None);
     }
 }

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -70,19 +70,6 @@ pub fn uuid_v7_from_datetime<Tz: TimeZone>(datetime: DateTime<Tz>) -> Uuid {
     uuid_v7(datetime.timestamp_millis().max(0) as u64)
 }
 
-pub fn extract_lib_version(form: &EventFormData, params: &EventQuery) -> Option<String> {
-    let form_lv = form.lib_version.as_ref();
-    let params_lv = params.lib_version.as_ref();
-    if form_lv.is_some_and(|lv| !lv.is_empty()) {
-        return Some(form_lv.unwrap().clone());
-    }
-    if params_lv.is_some_and(|lv| !lv.is_empty()) {
-        return Some(params_lv.unwrap().clone());
-    }
-
-    None
-}
-
 // the compression hint can be tucked away any number of places depending on the SDK submitting the request...
 pub fn extract_compression(
     form: &EventFormData,
@@ -113,15 +100,16 @@ pub fn extract_compression(
 
 // have we decoded sufficiently have a urlencoded data payload of the expected form yet?
 pub fn is_likely_urlencoded_form(payload: &[u8]) -> bool {
-    [
-        &b"data="[..],
-        &b"ver="[..],
-        &b"_="[..],
-        &b"ip="[..],
-        &b"compression="[..],
-    ]
-    .iter()
-    .any(|target: &&[u8]| payload.starts_with(target))
+    let prefix = &payload[..std::cmp::min(payload.len(), MAX_CHARS_TO_CHECK)];
+
+    [&b"data="[..], &b"_="[..], &b"ip="[..], &b"compression="[..]]
+        .iter()
+        .any(|target: &&[u8]| {
+            prefix.starts_with(target)
+                || prefix
+                    .windows(target.len() + 1)
+                    .any(|window| window[0] == b'&' && &window[1..] == *target)
+        })
 }
 
 // relatively cheap check for base64 encoded payload since these can show up at

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -13,10 +13,7 @@ use crate::{
     router,
 };
 
-#[instrument(
-    skip(state, body, meta),
-    fields(params_lib_version, params_compression)
-)]
+#[instrument(skip(state, body, meta), fields(params_compression))]
 #[debug_handler]
 pub async fn event(
     state: State<router::State>,
@@ -29,13 +26,7 @@ pub async fn event(
 ) -> Result<CaptureResponse, CaptureError> {
     let mut params: EventQuery = meta.0;
 
-    // TODO(eli): temporary peek at these
-    if params.lib_version.is_some() {
-        Span::current().record(
-            "params_lib_version",
-            format!("{:?}", params.lib_version.as_ref()),
-        );
-    }
+    // TODO(eli): temporary peek at compression
     if params.compression.is_some() {
         Span::current().record(
             "params_compression",

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -133,7 +133,6 @@ impl RawRequest {
 
 #[derive(Debug)]
 pub struct ProcessingContext {
-    pub lib_version: Option<String>,
     pub user_agent: Option<String>,
     pub sent_at: Option<OffsetDateTime>,
     pub token: String,
@@ -422,7 +421,7 @@ mod tests {
 
     #[test]
     fn extract_non_engage_event_without_name_fails() {
-        let path = "/e/?ip=192.0.0.1&ver=2.3.4";
+        let path = "/e/?ip=192.0.0.1";
         let parse_and_extract_events =
             |input: &'static str| -> Result<Vec<RawEvent>, CaptureError> {
                 RawRequest::from_bytes(
@@ -448,7 +447,7 @@ mod tests {
 
     #[test]
     fn extract_engage_event_without_name_is_resolved() {
-        let path = "/engage/?ip=10.0.0.1&ver=1.2.3";
+        let path = "/engage/?ip=10.0.0.1";
         let parse_and_extract_events =
             |input: &'static str| -> Result<Vec<RawEvent>, CaptureError> {
                 RawRequest::from_bytes(


### PR DESCRIPTION
## Problem

Capture v0 still parsed the legacy `ver` request hint and carried it into `ProcessingContext`, but the value was not used downstream by capture processing. The actual SDK version for ingested events comes from event properties such as `$lib_version`.

The same `ver` parameter is still used by feature flags for logging, so this PR only removes the dead capture path.

## Changes

- Remove `lib_version` from capture v0 query/form parsing and `ProcessingContext`.
- Stop tracing the capture `ver` query hint.
- Keep capture requests tolerant of `ver` when it is provided, including form bodies where `ver` appears before `data`.
- Leave feature flags `ver` handling untouched because it is still used.

## How did you test this code?

- `SQLX_OFFLINE=true cargo test --manifest-path rust/capture/Cargo.toml ignores --lib`
- `SQLX_OFFLINE=true cargo test --manifest-path rust/capture/Cargo.toml test_extract_payload_bytes_with_compression_hint --lib`
- `SQLX_OFFLINE=true cargo test --manifest-path rust/capture/Cargo.toml decode_compression_param --lib`
- `hogli ci:preflight --fix`
- Pre-push hook ran `hogli ci:preflight --strict`

Added tests cover the regression where capture should ignore `ver` without rejecting query or form requests. Existing compression tests confirm the active `compression` query path remains intact.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This removes unused capture-only internal handling while preserving request compatibility.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi/Codex made the code changes and opened this PR. Skills invoked: `/writing-tests` for the added regression tests and `/pr` for PR creation. I also used a scout subagent to verify whether `ver` was still used elsewhere, which found active feature flags usage. Based on that, this PR leaves feature flags unchanged and only removes the dead capture path.