### PR TITLE
fix(data-warehouse): support wordpress.com sites in wordpress source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/settings.py
@@ -106,6 +106,10 @@ WORDPRESS_ENDPOINTS: dict[str, WordpressEndpointConfig] = {
 
 ENDPOINTS = tuple(WORDPRESS_ENDPOINTS.keys())
 
+# public-api.wordpress.com serves these collections only with wp.com OAuth, which we don't support
+# (free-plan sites have no core Application Passwords) -> excluded from proxied syncs.
+WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS: frozenset[str] = frozenset({"media", "users"})
+
 INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
     name: config.incremental_fields for name, config in WORDPRESS_ENDPOINTS.items()
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
@@ -24,11 +24,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
+    WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.wordpress import (
     HOST_NOT_ALLOWED_ERROR,
     HTTP_NOT_ALLOWED_ERROR,
+    WPCOM_AUTH_REQUIRED_TABLE_ERROR,
+    WPCOM_PRIVATE_SITE_ERROR,
     WordpressResumeConfig,
+    uses_wordpress_com_proxy,
     validate_credentials as validate_wordpress_credentials,
     wordpress_source,
 )
@@ -54,11 +58,11 @@ class WordpressSource(ResumableSource[WordpressSourceConfig, WordpressResumeConf
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="WordPress",
             releaseStatus=ReleaseStatus.ALPHA,
-            caption="""Sync posts, pages, comments, media, categories, tags, and users from a self-hosted WordPress site via the core REST API (`/wp-json/wp/v2`).
+            caption="""Sync posts, pages, comments, media, categories, tags, and users from a WordPress site via the WordPress REST API.
 
-Enter your site URL (for example `https://example.com`). Public, published content syncs without credentials.
+**Self-hosted sites and WordPress.com Business/Commerce plans:** enter the site URL (for WordPress.com Business/Commerce, use your custom domain). Public, published content syncs without credentials. To sync protected content, create an [Application Password](https://wordpress.org/documentation/article/application-passwords/) under **Users > Profile > Application Passwords** (requires WordPress 5.6+ and HTTPS) and enter your username and that password.
 
-To sync private content or authenticate, create an [Application Password](https://wordpress.org/documentation/article/application-passwords/) under **Users > Profile > Application Passwords** and enter your username and that password. Application passwords require WordPress 5.6+ and an HTTPS site.""",
+**Free, Personal, and Premium WordPress.com sites:** the site must be launched and public. Content syncs anonymously through the WordPress.com public API, so leave username and password empty. The media and users tables are not available on these plans, and private WordPress.com sites are not supported.""",
             iconPath="/static/services/wordpress.png",
             docsUrl="https://posthog.com/docs/cdp/sources/wordpress",
             fields=cast(
@@ -70,6 +74,7 @@ To sync private content or authenticate, create an [Application Password](https:
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="https://example.com",
+                        caption="For example https://example.com, or yoursite.wordpress.com for WordPress.com sites",
                         secret=False,
                     ),
                     SourceFieldInputConfig(
@@ -78,6 +83,7 @@ To sync private content or authenticate, create an [Application Password](https:
                         type=SourceFieldInputConfigType.TEXT,
                         required=False,
                         placeholder="admin",
+                        caption="Self-hosted and WordPress.com Business sites only. Leave empty for free WordPress.com sites",
                         secret=False,
                     ),
                     SourceFieldInputConfig(
@@ -86,6 +92,7 @@ To sync private content or authenticate, create an [Application Password](https:
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=False,
                         placeholder="xxxx xxxx xxxx xxxx xxxx xxxx",
+                        caption="Created under Users > Profile > Application Passwords. Leave empty for free WordPress.com sites",
                         secret=True,
                     ),
                 ],
@@ -95,8 +102,10 @@ To sync private content or authenticate, create an [Application Password](https:
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "401 Client Error": "Invalid WordPress username or application password. Create a new application password and reconnect.",
-            "403 Client Error": "Your WordPress credentials lack permission to read this data. Check the user's role and try again.",
+            "403 Client Error": "WordPress denied access to this data (HTTP 403). If you provided credentials, check the user's role; otherwise a security plugin, firewall, or the site's privacy settings may be blocking REST API access.",
             "404 Client Error": "WordPress returned 404 (Not Found) for this collection. The REST API or this specific endpoint (for example /users, which security plugins often block to prevent user enumeration) may be disabled or restricted on your site. Enable REST API access for it, or remove this table from the sync.",
+            WPCOM_PRIVATE_SITE_ERROR: "This WordPress.com site is private or not yet launched. Launch the site and set its privacy to Public, then sync again.",
+            WPCOM_AUTH_REQUIRED_TABLE_ERROR: "Free WordPress.com sites only expose public content, so the media and users tables are not available for this site. Remove them from the sync.",
             HOST_NOT_ALLOWED_ERROR: "The WordPress site URL is not allowed. Please use a publicly reachable site URL.",
             HTTP_NOT_ALLOWED_ERROR: "The WordPress site URL must use HTTPS when credentials are provided. Please update the site URL to use https://.",
         }
@@ -116,6 +125,11 @@ To sync private content or authenticate, create an [Application Password](https:
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
+        endpoints: tuple[str, ...] = ENDPOINTS
+        if uses_wordpress_com_proxy(config.site_url):
+            # The wp.com proxy only serves media/users with OAuth; hide them so the wizard doesn't
+            # offer tables that can never sync.
+            endpoints = tuple(e for e in ENDPOINTS if e not in WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS)
         schemas = [
             SourceSchema(
                 name=endpoint,
@@ -123,7 +137,7 @@ To sync private content or authenticate, create an [Application Password](https:
                 supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
                 incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
             )
-            for endpoint in ENDPOINTS
+            for endpoint in endpoints
         ]
         if names is not None:
             names_set = set(names)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
@@ -7,25 +7,44 @@ from unittest import mock
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress import wordpress as wordpress_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import WORDPRESS_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.wordpress import (
+    ANONYMOUS_FORBIDDEN_ERROR,
+    AUTH_REQUIRED_ERROR,
+    CREDENTIALS_IGNORED_ERROR,
     HOST_NOT_ALLOWED_ERROR,
     HTTP_NOT_ALLOWED_ERROR,
+    INVALID_CREDENTIALS_ERROR,
+    USER_AGENT,
+    WPCOM_AUTH_REQUIRED_TABLE_ERROR,
+    WPCOM_PRIVATE_SITE_ERROR,
+    WPCOM_SITE_NOT_FOUND_ERROR,
+    WordpressComAccessError,
     WordpressHostNotAllowedError,
     WordpressResumeConfig,
     _build_initial_params,
     _build_initial_url,
+    _direct_api_base,
     _format_incremental_value,
     _get_headers,
-    _is_same_host,
+    _is_within_api_base,
+    _is_wpcom_host,
     _parse_next_url,
+    _proxy_api_base,
     get_rows,
     normalize_host,
     validate_credentials,
     wordpress_source,
 )
 
+WPCOM_PROXY_BASE = "https://public-api.wordpress.com/wp/v2/sites/example.wordpress.com"
+
 
 def _response(
-    *, status_code: int = 200, json_data: Any = None, link: Optional[str] = None, text: str = ""
+    *,
+    status_code: int = 200,
+    json_data: Any = None,
+    link: Optional[str] = None,
+    text: str = "",
+    headers: Optional[dict[str, str]] = None,
 ) -> mock.MagicMock:
     response = mock.MagicMock()
     response.status_code = status_code
@@ -34,7 +53,7 @@ def _response(
     response.is_permanent_redirect = status_code in (301, 308)
     response.text = text
     response.json.return_value = json_data
-    response.headers = {"Link": link} if link else {}
+    response.headers = {**({"Link": link} if link else {}), **(headers or {})}
     return response
 
 
@@ -93,6 +112,8 @@ class TestGetHeaders:
         headers = _get_headers(None, None)
         assert "Authorization" not in headers
         assert headers["Accept"] == "application/json"
+        # Some hosts/WAFs 403 the default python-requests User-Agent, so we must identify ourselves.
+        assert headers["User-Agent"] == USER_AGENT
 
     def test_partial_credentials_are_anonymous(self):
         # A username without a password (or vice versa) is not enough to authenticate.
@@ -105,6 +126,23 @@ class TestGetHeaders:
         headers = _get_headers("admin", "abcd efgh")
         expected = base64.b64encode(b"admin:abcd efgh").decode()
         assert headers["Authorization"] == f"Basic {expected}"
+        assert headers["User-Agent"] == USER_AGENT
+
+
+class TestIsWpcomHost:
+    @pytest.mark.parametrize(
+        "host, expected",
+        [
+            ("example.wordpress.com", True),
+            ("wordpress.com", True),
+            ("example.com", False),
+            # Suffix matching must not swallow lookalike hosts.
+            ("evil-wordpress.com", False),
+            ("example.wordpress.com.evil.com", False),
+        ],
+    )
+    def test_is_wpcom_host(self, host, expected):
+        assert _is_wpcom_host(host) is expected
 
 
 class TestFormatIncrementalValue:
@@ -206,12 +244,16 @@ class TestBuildInitialParams:
 
 class TestBuildInitialUrl:
     def test_builds_url_with_params(self):
-        url = _build_initial_url("https://example.com", WORDPRESS_ENDPOINTS["posts"], {"per_page": 100})
+        url = _build_initial_url(
+            _direct_api_base("https://example.com"), WORDPRESS_ENDPOINTS["posts"], {"per_page": 100}
+        )
         assert url == "https://example.com/wp-json/wp/v2/posts?per_page=100"
 
-    def test_accepts_bare_hostname(self):
-        url = _build_initial_url("example.com", WORDPRESS_ENDPOINTS["users"], {})
-        assert url == "https://example.com/wp-json/wp/v2/users"
+    def test_builds_proxy_url(self):
+        url = _build_initial_url(
+            _proxy_api_base("example.wordpress.com"), WORDPRESS_ENDPOINTS["posts"], {"per_page": 100}
+        )
+        assert url == f"{WPCOM_PROXY_BASE}/posts?per_page=100"
 
 
 class TestParseNextUrl:
@@ -230,49 +272,111 @@ class TestParseNextUrl:
         assert _parse_next_url(header) == expected
 
 
-class TestIsSameHost:
+class TestIsWithinApiBase:
     @pytest.mark.parametrize(
-        "url, site_url, expected",
+        "url, api_base, expected",
         [
-            ("https://example.com/wp-json/wp/v2/posts?page=2", "https://example.com", True),
+            ("https://example.com/wp-json/wp/v2/posts?page=2", "https://example.com/wp-json/wp/v2", True),
             # Scheme downgrade to http when configured https must be rejected (credential exposure).
-            ("http://example.com/wp-json/wp/v2/posts?page=2", "https://example.com", False),
+            ("http://example.com/wp-json/wp/v2/posts?page=2", "https://example.com/wp-json/wp/v2", False),
             # Foreign / internal host must be rejected (SSRF).
-            ("https://169.254.169.254/latest/meta-data/", "https://example.com", False),
+            ("https://169.254.169.254/latest/meta-data/", "https://example.com/wp-json/wp/v2", False),
             # Anonymous http site: an http next URL on the same host is allowed.
-            ("http://example.com/wp-json/wp/v2/posts?page=2", "http://example.com", True),
+            ("http://example.com/wp-json/wp/v2/posts?page=2", "http://example.com/wp-json/wp/v2", True),
+            # Same host but outside the API base path.
+            ("https://example.com/xmlrpc.php", "https://example.com/wp-json/wp/v2", False),
+            # Proxied pagination stays inside the proxied site's base.
+            (f"{WPCOM_PROXY_BASE}/posts?page=2", WPCOM_PROXY_BASE, True),
+            # A stale direct-style resume URL is outside the proxy base.
+            ("https://example.wordpress.com/wp-json/wp/v2/posts?page=2", WPCOM_PROXY_BASE, False),
+            # Another site's path on the shared proxy host must be rejected.
+            ("https://public-api.wordpress.com/wp/v2/sites/other.wordpress.com/posts", WPCOM_PROXY_BASE, False),
+            (f"{WPCOM_PROXY_BASE}-evil/posts", WPCOM_PROXY_BASE, False),
         ],
     )
-    def test_is_same_host(self, url, site_url, expected):
-        assert _is_same_host(url, site_url) is expected
+    def test_is_within_api_base(self, url, api_base, expected):
+        assert _is_within_api_base(url, api_base) is expected
 
 
 class TestValidateCredentials:
-    def _patch_session(self, response=None, raises=None):
+    def _patch_session(self, response=None, raises=None, responses=None):
         session = mock.MagicMock()
         if raises is not None:
             session.get.side_effect = raises
+        elif responses is not None:
+            session.get.side_effect = responses
         else:
             session.get.return_value = response
         return mock.patch.object(wordpress_module, "make_tracked_session", return_value=session)
 
     @pytest.mark.parametrize(
-        "status_code, expected_valid, expected_msg_substr",
+        "status_code, expected_valid, expected_msg",
         [
             (200, True, None),
-            (401, False, "Invalid WordPress username or application password"),
-            (403, False, "lack permission"),
+            (401, False, AUTH_REQUIRED_ERROR),
+            (403, False, ANONYMOUS_FORBIDDEN_ERROR),
             (404, False, "REST API not found"),
         ],
     )
-    def test_status_code_mapping(self, status_code, expected_valid, expected_msg_substr):
-        with self._patch_session(_response(status_code=status_code)):
+    def test_anonymous_status_code_mapping(self, status_code, expected_valid, expected_msg):
+        with self._patch_session(_response(status_code=status_code)) as patched:
             valid, msg = validate_credentials("https://example.com", None, None)
             assert valid is expected_valid
-            if expected_msg_substr is None:
+            if expected_msg is None:
                 assert msg is None
             else:
-                assert expected_msg_substr in (msg or "")
+                assert expected_msg in (msg or "")
+            probe_url = patched.return_value.get.call_args.args[0]
+            assert probe_url == "https://example.com/wp-json/wp/v2/posts?per_page=1"
+
+    def test_anonymous_403_does_not_blame_credentials(self):
+        # The customer-facing regression: with no credentials supplied, a 403 must not claim
+        # "these credentials lack permission".
+        with self._patch_session(_response(status_code=403)):
+            _valid, msg = validate_credentials("https://example.com", None, None)
+            assert "credentials lack" not in (msg or "")
+
+    def test_credentialed_probe_uses_users_me(self):
+        # /users/me exercises auth for real; a public-collection probe silently validates garbage
+        # credentials on sites where application passwords are unavailable.
+        with self._patch_session(_response(status_code=200)) as patched:
+            valid, msg = validate_credentials("https://example.com", "admin", "app pass word")
+            assert (valid, msg) == (True, None)
+            probe_url = patched.return_value.get.call_args.args[0]
+            assert probe_url == "https://example.com/wp-json/wp/v2/users/me"
+
+    @pytest.mark.parametrize(
+        "json_data, expected_msg",
+        [
+            ({"code": "rest_not_logged_in", "message": "You are not currently logged in."}, CREDENTIALS_IGNORED_ERROR),
+            ({"code": "incorrect_password", "message": "..."}, INVALID_CREDENTIALS_ERROR),
+            ({"code": "invalid_username", "message": "..."}, INVALID_CREDENTIALS_ERROR),
+            (None, INVALID_CREDENTIALS_ERROR),
+        ],
+    )
+    def test_credentialed_401_mapping(self, json_data, expected_msg):
+        with self._patch_session(_response(status_code=401, json_data=json_data)):
+            valid, msg = validate_credentials("https://example.com", "admin", "app pass word")
+            assert valid is False
+            assert msg == expected_msg
+
+    def test_credentialed_403_blames_credentials(self):
+        with self._patch_session(_response(status_code=403)):
+            valid, msg = validate_credentials("https://example.com", "admin", "app pass word")
+            assert valid is False
+            assert "credentials lack permission" in (msg or "")
+
+    def test_users_route_blocked_falls_back_to_posts_probe(self):
+        # Security plugins often hide the users routes (rest_no_route) while the REST API itself works.
+        blocked = _response(status_code=404, json_data={"code": "rest_no_route", "message": "No route"})
+        with self._patch_session(responses=[blocked, _response(status_code=200)]) as patched:
+            valid, msg = validate_credentials("https://example.com", "admin", "app pass word")
+            assert (valid, msg) == (True, None)
+            urls = [call.args[0] for call in patched.return_value.get.call_args_list]
+            assert urls == [
+                "https://example.com/wp-json/wp/v2/users/me",
+                "https://example.com/wp-json/wp/v2/posts?per_page=1",
+            ]
 
     def test_invalid_site_url(self):
         valid, msg = validate_credentials("", None, None)
@@ -287,12 +391,29 @@ class TestValidateCredentials:
             assert valid is False
             assert "boom" in (msg or "")
 
-    def test_rejects_redirect_response(self):
+    def test_rejects_redirect_response_without_location(self):
         with self._patch_session(_response(status_code=302)) as patched:
             valid, msg = validate_credentials("https://example.com", None, None)
             assert valid is False
             assert msg == HOST_NOT_ALLOWED_ERROR
             assert patched.return_value.get.call_args.kwargs["allow_redirects"] is False
+
+    def test_redirect_surfaces_target_url(self):
+        # www canonicalization and Business-plan subdomain redirects are legit; tell the user which
+        # URL to enter instead of a bare "not allowed".
+        redirect = _response(status_code=301, headers={"Location": "https://www.example.com/wp-json/wp/v2/posts?a=1"})
+        with self._patch_session(redirect):
+            valid, msg = validate_credentials("https://example.com", None, None)
+            assert valid is False
+            assert "https://www.example.com" in (msg or "")
+            assert "a=1" not in (msg or "")  # query stripped: Location is server-controlled
+
+    def test_redirect_to_wpcom_typo_page_means_no_such_site(self):
+        redirect = _response(status_code=302, headers={"Location": "https://wordpress.com/typo/?subdomain=examplee"})
+        with self._patch_session(redirect):
+            valid, msg = validate_credentials("https://examplee.wordpress.com", None, None)
+            assert valid is False
+            assert msg == WPCOM_SITE_NOT_FOUND_ERROR
 
     def test_rejects_plaintext_http_when_credentials_present(self):
         # Basic-auth credentials must never be sent over plaintext HTTP.
@@ -318,6 +439,51 @@ class TestValidateCredentials:
             assert valid is False
             assert msg == "internal address"
             patched.return_value.get.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status_code, expected_valid, expected_msg",
+        [
+            (200, True, None),
+            (401, False, WPCOM_PRIVATE_SITE_ERROR),
+            (403, False, WPCOM_PRIVATE_SITE_ERROR),
+            (404, False, WPCOM_SITE_NOT_FOUND_ERROR),
+        ],
+    )
+    def test_wpcom_host_probes_via_proxy(self, status_code, expected_valid, expected_msg):
+        with (
+            mock.patch.object(wordpress_module, "_is_host_safe") as host_safe,
+            self._patch_session(_response(status_code=status_code, json_data=[])) as patched,
+        ):
+            valid, msg = validate_credentials("https://example.wordpress.com", None, None, team_id=99)
+            assert valid is expected_valid
+            assert msg == expected_msg
+            probe_url = patched.return_value.get.call_args.args[0]
+            assert probe_url == f"{WPCOM_PROXY_BASE}/posts?per_page=1"
+            # Proxied traffic only ever reaches the fixed public proxy host, so the per-host SSRF
+            # check is skipped.
+            host_safe.assert_not_called()
+
+    def test_wpcom_host_never_sends_credentials(self):
+        # wp.com "application passwords" are OAuth credentials for wordpress.com itself; forwarding
+        # them as Basic auth would leak them without ever working.
+        with self._patch_session(_response(status_code=200, json_data=[])) as patched:
+            valid, _msg = validate_credentials("https://example.wordpress.com", "admin", "app pass word")
+            assert valid is True
+            sent_headers = patched.return_value.get.call_args.kwargs["headers"]
+            assert "Authorization" not in sent_headers
+
+    def test_wpcom_served_custom_domain_falls_back_to_proxy(self):
+        # Personal/Premium wp.com sites on custom domains 404 the direct REST path but stamp the
+        # wp.com host header; their content is only served by the proxy.
+        direct_404 = _response(status_code=404, headers={"host-header": "WordPress.com"})
+        with self._patch_session(responses=[direct_404, _response(status_code=200, json_data=[])]) as patched:
+            valid, msg = validate_credentials("https://example.com", None, None)
+            assert (valid, msg) == (True, None)
+            urls = [call.args[0] for call in patched.return_value.get.call_args_list]
+            assert urls == [
+                "https://example.com/wp-json/wp/v2/posts?per_page=1",
+                "https://public-api.wordpress.com/wp/v2/sites/example.com/posts?per_page=1",
+            ]
 
 
 class TestWordpressSourceResponse:
@@ -355,7 +521,16 @@ class TestWordpressSourceResponse:
 
 
 class TestGetRows:
-    def _run(self, manager, responses, endpoint="posts", site_url="https://example.com", **kwargs):
+    def _run(
+        self,
+        manager,
+        responses,
+        endpoint="posts",
+        site_url="https://example.com",
+        username=None,
+        application_password=None,
+        **kwargs,
+    ):
         session = mock.MagicMock()
         session.get.side_effect = responses
         with (
@@ -365,8 +540,8 @@ class TestGetRows:
             rows: list[Any] = []
             for table in get_rows(
                 site_url=site_url,
-                username=None,
-                application_password=None,
+                username=username,
+                application_password=application_password,
                 endpoint=endpoint,
                 logger=mock.MagicMock(),
                 resumable_source_manager=manager,
@@ -503,6 +678,95 @@ class TestGetRows:
         manager.can_resume.return_value = False
         _rows, session = self._run(manager, [_response(json_data=[{"id": 1}])])
         assert session.get.call_args.kwargs["allow_redirects"] is False
+
+    def test_wpcom_site_paginates_via_proxy(self):
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        page1 = _response(json_data=[{"id": 1}], link=f'<{WPCOM_PROXY_BASE}/posts?page=2>; rel="next"')
+        page2 = _response(json_data=[{"id": 2}])
+        rows, session = self._run(manager, [page1, page2], site_url="https://example.wordpress.com")
+
+        assert [r["id"] for r in rows] == [1, 2]
+        urls = [call.args[0] for call in session.get.call_args_list]
+        assert urls[0].startswith(f"{WPCOM_PROXY_BASE}/posts?")
+        assert urls[1] == f"{WPCOM_PROXY_BASE}/posts?page=2"
+
+    def test_wpcom_site_never_sends_credentials(self):
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        _rows, session = self._run(
+            manager,
+            [_response(json_data=[{"id": 1}])],
+            site_url="https://example.wordpress.com",
+            username="admin",
+            application_password="app pass word",
+        )
+        assert "Authorization" not in session.get.call_args.kwargs["headers"]
+
+    def test_wpcom_served_direct_failure_falls_back_to_proxy(self):
+        # Personal/Premium wp.com sites on custom domains 404 the direct REST path but stamp the
+        # wp.com host header; the run must restart on the proxy, without forwarding credentials.
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        direct_404 = _response(status_code=404, headers={"host-header": "WordPress.com"})
+        rows, session = self._run(
+            manager,
+            [direct_404, _response(json_data=[{"id": 7}])],
+            username="admin",
+            application_password="app pass word",
+        )
+
+        assert [r["id"] for r in rows] == [7]
+        first_call, second_call = session.get.call_args_list
+        assert first_call.args[0].startswith("https://example.com/wp-json/wp/v2/posts?")
+        assert "Authorization" in first_call.kwargs["headers"]
+        assert second_call.args[0].startswith("https://public-api.wordpress.com/wp/v2/sites/example.com/posts?")
+        assert "Authorization" not in second_call.kwargs["headers"]
+
+    def test_wpcom_served_failure_mid_pagination_raises(self):
+        # Flipping to the proxy after pages were already yielded would mix bases mid-run.
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        page1 = _response(
+            json_data=[{"id": 1}],
+            link='<https://example.com/wp-json/wp/v2/posts?page=2>; rel="next"',
+        )
+        direct_404 = _response(status_code=404, headers={"host-header": "WordPress.com"})
+        with pytest.raises(WordpressComAccessError) as exc:
+            self._run(manager, [page1, direct_404])
+        assert WPCOM_PRIVATE_SITE_ERROR in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_msg",
+        [
+            ("media", WPCOM_AUTH_REQUIRED_TABLE_ERROR),
+            ("users", WPCOM_AUTH_REQUIRED_TABLE_ERROR),
+            ("posts", WPCOM_PRIVATE_SITE_ERROR),
+        ],
+    )
+    def test_proxied_auth_failure_maps_to_wpcom_error(self, endpoint, expected_msg):
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        with pytest.raises(WordpressComAccessError) as exc:
+            self._run(
+                manager,
+                [_response(status_code=401, json_data={"code": "unauthorized"})],
+                endpoint=endpoint,
+                site_url="https://example.wordpress.com",
+            )
+        assert expected_msg in str(exc.value)
+
+    def test_stale_direct_resume_url_restarts_at_proxy_initial(self):
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = WordpressResumeConfig(
+            next_url="https://example.wordpress.com/wp-json/wp/v2/posts?page=5"
+        )
+        rows, session = self._run(manager, [_response(json_data=[{"id": 3}])], site_url="https://example.wordpress.com")
+
+        assert [r["id"] for r in rows] == [3]
+        first_url = session.get.call_args_list[0].args[0]
+        assert first_url.startswith(f"{WPCOM_PROXY_BASE}/posts?")
 
 
 class TestRetryAfter:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
@@ -4,9 +4,16 @@ from unittest import mock
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import (
+    ENDPOINTS,
+    WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.source import WordpressSource
-from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.wordpress import WordpressResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.wordpress import (
+    WPCOM_AUTH_REQUIRED_TABLE_ERROR,
+    WPCOM_PRIVATE_SITE_ERROR,
+    WordpressResumeConfig,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
@@ -51,13 +58,33 @@ class TestWordpressSource:
         assert pass_field.required is False
         assert pass_field.secret is True
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "404 Client Error"])
+    @pytest.mark.parametrize(
+        "expected_key",
+        [
+            "401 Client Error",
+            "403 Client Error",
+            "404 Client Error",
+            WPCOM_PRIVATE_SITE_ERROR,
+            WPCOM_AUTH_REQUIRED_TABLE_ERROR,
+        ],
+    )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {s.name for s in schemas} == set(ENDPOINTS)
+
+    def test_get_schemas_excludes_oauth_only_tables_for_wpcom_sites(self):
+        # The wp.com proxy withholds media/users without OAuth; the wizard must not offer tables
+        # that can never sync.
+        self.config.site_url = "https://example.wordpress.com"
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS) - WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS
+
+    def test_get_schemas_wpcom_names_filter_cannot_reintroduce_excluded_tables(self):
+        self.config.site_url = "https://example.wordpress.com"
+        assert self.source.get_schemas(self.config, self.team_id, names=["media"]) == []
 
     @pytest.mark.parametrize(
         "endpoint, incremental",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
@@ -16,18 +16,52 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.htt
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import (
+    WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS,
     WORDPRESS_ENDPOINTS,
     WordpressEndpointConfig,
 )
 
 REQUEST_TIMEOUT_SECONDS = 60
+VALIDATION_TIMEOUT_SECONDS = 10
 MAX_RETRIES = 5
 MAX_RETRY_AFTER_SECONDS = 60
 
 API_PREFIX = "/wp-json/wp/v2"
 
+# Some WordPress hosts and WAFs reject the default python-requests User-Agent with a 403, so we
+# identify ourselves explicitly (same convention as other sources, e.g. squarespace/cimis).
+USER_AGENT = "PostHog-DataWarehouse/1.0 (+https://posthog.com)"
+
+# Simple-plan wordpress.com sites don't serve /wp-json on the site host (verified live: it 404s, and
+# ?rest_route= isn't processed either, despite wp.com docs claiming otherwise). Their core REST API is
+# only reachable through this fixed proxy, and only anonymously: wp.com "application passwords" are
+# account-level OAuth credentials, not core Application Passwords, so Basic auth can never work there.
+WPCOM_PROXY_ORIGIN = "https://public-api.wordpress.com"
+# Response header wordpress.com-served sites carry on every response, including 404s.
+WPCOM_HOST_HEADER = "WordPress.com"
+
 HOST_NOT_ALLOWED_ERROR = "WordPress site URL is not allowed"
 HTTP_NOT_ALLOWED_ERROR = "WordPress site URL must use HTTPS when credentials are provided"
+WPCOM_PRIVATE_SITE_ERROR = (
+    "This WordPress.com site is private or not yet launched. Launch the site and set its privacy to "
+    "Public. Private WordPress.com sites are not supported yet"
+)
+WPCOM_SITE_NOT_FOUND_ERROR = "No WordPress.com site exists at this address"
+WPCOM_AUTH_REQUIRED_TABLE_ERROR = "WordPress.com does not expose this table without OAuth"
+CREDENTIALS_IGNORED_ERROR = (
+    "The site ignored the provided credentials. Application passwords may be unavailable on this site "
+    "(they require HTTPS and WordPress 5.6+)"
+)
+INVALID_CREDENTIALS_ERROR = "Invalid WordPress username or application password"
+ANONYMOUS_FORBIDDEN_ERROR = (
+    "This WordPress site blocked anonymous API access (HTTP 403). A security plugin, firewall, or the "
+    "site's privacy settings may be blocking the REST API. Try providing a username and application password"
+)
+AUTH_REQUIRED_ERROR = "This WordPress site requires authentication. Provide a username and application password"
+FORBIDDEN_WITH_CREDENTIALS_ERROR = (
+    "These credentials lack permission to read this WordPress site. Check the user's role"
+)
+REST_NOT_FOUND_ERROR = "WordPress REST API not found at this URL. Confirm the site URL and that the REST API is enabled"
 
 # WordPress `after`/`modified_after` filter on the site-LOCAL post_date/post_modified columns, which
 # can be non-monotonic across a DST transition. We re-request a small overlap on each incremental run
@@ -44,6 +78,16 @@ class WordpressRetryableError(Exception):
 
 class WordpressHostNotAllowedError(Exception):
     pass
+
+
+class WordpressComAccessError(Exception):
+    """Non-retryable wordpress.com proxy access failure (private site / OAuth-only table).
+
+    Matched by substring in get_non_retryable_errors(), so it must carry one of the WPCOM_* messages."""
+
+
+class _WordpressComProxyRequired(Exception):
+    """Control-flow signal: the direct REST probe hit a wordpress.com-served 403/404, retry via the proxy."""
 
 
 @dataclasses.dataclass
@@ -86,7 +130,7 @@ def normalize_host(site_url: str | None) -> str:
     return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{path}"
 
 
-def _base_url(site_url: str | None) -> str:
+def _direct_api_base(site_url: str | None) -> str:
     return f"{normalize_host(site_url)}{API_PREFIX}"
 
 
@@ -98,6 +142,63 @@ def _scheme(site_url: str | None) -> str:
     return urlparse(normalize_host(site_url)).scheme
 
 
+def _is_wpcom_host(host: str) -> bool:
+    # Leading-dot suffix match so evil-wordpress.com doesn't count as wordpress.com-hosted.
+    return host == "wordpress.com" or host.endswith(".wordpress.com")
+
+
+def _proxy_api_base(host: str) -> str:
+    return f"{WPCOM_PROXY_ORIGIN}/wp/v2/sites/{host}"
+
+
+def uses_wordpress_com_proxy(site_url: str | None) -> bool:
+    """Whether this site's REST API is only reachable via the wordpress.com proxy (see WPCOM_PROXY_ORIGIN)."""
+    return _is_wpcom_host(_host_only(site_url))
+
+
+def _is_wpcom_served(response: requests.Response) -> bool:
+    return response.headers.get("host-header") == WPCOM_HOST_HEADER
+
+
+def _json_error_code(response: requests.Response) -> str:
+    """The ``code`` of a WP REST error body ({"code": ..., "message": ...}), or "" when absent."""
+    try:
+        body = response.json()
+    except Exception:
+        return ""
+    if isinstance(body, dict):
+        code = body.get("code")
+        return code if isinstance(code, str) else ""
+    return ""
+
+
+def _response_error_message(response: requests.Response) -> str:
+    try:
+        body = response.json()
+    except Exception:
+        return response.text
+    if isinstance(body, dict):
+        message = body.get("message")
+        if isinstance(message, str) and message:
+            return message
+    return response.text
+
+
+def _redirect_error(response: requests.Response) -> str:
+    """Actionable message for a refused redirect. We never follow redirects (SSRF), but the Location
+    target usually IS the correct site URL (www canonicalization, wp.com Business subdomain pointing
+    at the custom domain), so surface it. Location is server-controlled and shown verbatim in the UI,
+    so rebuild scheme://host/path only and drop anything unparseable."""
+    location = (response.headers.get("Location") or "").strip()
+    if location.startswith("https://wordpress.com/typo"):
+        # wordpress.com 302s nonexistent subdomains to its typo page.
+        return WPCOM_SITE_NOT_FOUND_ERROR
+    parsed = urlparse(location)
+    if parsed.scheme in ("http", "https") and parsed.hostname:
+        return f"The site redirected to {parsed.scheme}://{parsed.netloc}{parsed.path}. Enter that as the site URL"
+    return HOST_NOT_ALLOWED_ERROR
+
+
 def _has_credentials(username: str | None, application_password: str | None) -> bool:
     return bool((username or "").strip()) and bool((application_password or "").strip())
 
@@ -105,7 +206,7 @@ def _has_credentials(username: str | None, application_password: str | None) -> 
 def _get_headers(username: str | None, application_password: str | None) -> dict[str, str]:
     """Application Passwords authenticate via HTTP Basic. Public read endpoints work unauthenticated,
     so the Authorization header is only added when both credentials are present."""
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
     if _has_credentials(username, application_password):
         # Application passwords are shown with spaces for readability; WordPress accepts them verbatim.
         token = base64.b64encode(f"{username}:{application_password}".encode()).decode()
@@ -172,8 +273,8 @@ def _build_initial_params(
     return params
 
 
-def _build_initial_url(site_url: str | None, config: WordpressEndpointConfig, params: dict[str, Any]) -> str:
-    url = f"{_base_url(site_url)}{config.path}"
+def _build_initial_url(api_base: str, config: WordpressEndpointConfig, params: dict[str, Any]) -> str:
+    url = f"{api_base}{config.path}"
     if not params:
         return url
     return f"{url}?{urlencode(params)}"
@@ -191,19 +292,21 @@ def _parse_next_url(link_header: str) -> str | None:
     return None
 
 
-def _is_same_host(url: str, site_url: str | None) -> bool:
-    """Whether ``url`` points at the configured WordPress host with the configured scheme.
+def _is_within_api_base(url: str, api_base: str) -> bool:
+    """Whether ``url`` points inside the effective API base: same scheme, host, port, and path prefix.
 
-    Pagination/resume URLs are server-controlled (Link header / Redis), so we pin them to the
-    validated host and scheme to avoid being redirected at an arbitrary internal address (SSRF) or
-    downgraded from https to http (which would expose Basic-auth credentials)."""
+    Pagination/resume URLs are server-controlled (Link header / Redis), so we pin them to the base we
+    validated to avoid being pointed at an arbitrary internal address (SSRF) or downgraded from https
+    to http (which would expose Basic-auth credentials). The path-prefix check matters on the shared
+    wordpress.com proxy host, where the path is what scopes a request to the configured site."""
     try:
         parsed = urlparse(url)
-        configured = urlparse(normalize_host(site_url))
+        base = urlparse(api_base)
         return (
-            parsed.scheme == configured.scheme
-            and (parsed.hostname or "").lower() == (configured.hostname or "").lower()
-            and (parsed.port or _default_port(parsed.scheme)) == (configured.port or _default_port(configured.scheme))
+            parsed.scheme == base.scheme
+            and (parsed.hostname or "").lower() == (base.hostname or "").lower()
+            and (parsed.port or _default_port(parsed.scheme)) == (base.port or _default_port(base.scheme))
+            and (parsed.path == base.path or parsed.path.startswith(f"{base.path}/"))
         )
     except Exception:
         return False
@@ -213,16 +316,50 @@ def _default_port(scheme: str) -> int:
     return 443 if scheme == "https" else 80
 
 
+def _validation_get(url: str, headers: dict[str, str]) -> requests.Response:
+    return make_tracked_session().get(url, headers=headers, timeout=VALIDATION_TIMEOUT_SECONDS, allow_redirects=False)
+
+
+def _validate_via_wpcom_proxy(host: str) -> tuple[bool, str | None]:
+    """Anonymous readability probe through the wordpress.com proxy (see WPCOM_PROXY_ORIGIN).
+
+    Always anonymous: wp.com auth is OAuth, which we don't support, so any provided credentials are
+    intentionally unused. Requests go only to the fixed public proxy host, so the per-host SSRF check
+    doesn't apply here."""
+    try:
+        response = _validation_get(f"{_proxy_api_base(host)}/posts?per_page=1", _get_headers(None, None))
+    except requests.exceptions.RequestException as e:
+        return False, str(e)
+
+    if response.is_redirect or response.is_permanent_redirect:
+        return False, _redirect_error(response)
+
+    if response.status_code == 200:
+        return True, None
+
+    if response.status_code in (401, 403):
+        # Anonymous reads only work on launched, public sites.
+        return False, WPCOM_PRIVATE_SITE_ERROR
+
+    if response.status_code == 404:
+        return False, WPCOM_SITE_NOT_FOUND_ERROR
+
+    return False, _response_error_message(response)
+
+
 def validate_credentials(
     site_url: str | None,
     username: str | None,
     application_password: str | None,
     team_id: Optional[int] = None,
 ) -> tuple[bool, str | None]:
-    """Probe the site's REST root to confirm it's reachable and any credentials are genuine."""
+    """Probe the site's REST API to confirm it's reachable and any credentials are genuine."""
     host_only = _host_only(site_url)
     if not host_only:
         return False, "Invalid WordPress site URL"
+
+    if _is_wpcom_host(host_only):
+        return _validate_via_wpcom_proxy(host_only)
 
     has_credentials = _has_credentials(username, application_password)
 
@@ -238,38 +375,51 @@ def validate_credentials(
         if not host_ok:
             return False, host_err or HOST_NOT_ALLOWED_ERROR
 
-    # A cheap, always-present collection that exercises auth when credentials are set.
-    url = f"{_base_url(site_url)}/posts?per_page=1"
+    headers = _get_headers(username, application_password)
+
+    # /users/me exercises authentication for real: WordPress silently ignores a bad Authorization
+    # header when Application Passwords are unavailable on the site, so a public-collection probe
+    # would happily validate garbage credentials. Anonymous validation keeps the cheap posts probe.
+    probe_path = "/users/me" if has_credentials else "/posts?per_page=1"
     try:
-        response = make_tracked_session().get(
-            url,
-            headers=_get_headers(username, application_password),
-            timeout=10,
-            allow_redirects=False,
-        )
+        response = _validation_get(f"{_direct_api_base(site_url)}{probe_path}", headers)
     except requests.exceptions.RequestException as e:
         return False, str(e)
 
+    if has_credentials and response.status_code == 404 and _json_error_code(response) == "rest_no_route":
+        # The REST API is up but a security plugin hides the users routes; fall back to confirming the
+        # posts collection is readable. Credentials stay unverified on such sites.
+        try:
+            response = _validation_get(f"{_direct_api_base(site_url)}/posts?per_page=1", headers)
+        except requests.exceptions.RequestException as e:
+            return False, str(e)
+
     if response.is_redirect or response.is_permanent_redirect:
-        return False, HOST_NOT_ALLOWED_ERROR
+        return False, _redirect_error(response)
 
     if response.status_code == 200:
         return True, None
 
+    # Custom-domain simple wp.com sites (Personal/Premium plans) 404 or 403 the direct REST path but
+    # stamp the wp.com host header; their content is served by the wp.com proxy instead.
+    if response.status_code in (403, 404) and _is_wpcom_served(response):
+        return _validate_via_wpcom_proxy(host_only)
+
     if response.status_code == 401:
-        return False, "Invalid WordPress username or application password"
+        if not has_credentials:
+            return False, AUTH_REQUIRED_ERROR
+        if _json_error_code(response) == "rest_not_logged_in":
+            # The site processed the request anonymously: the Authorization header was ignored, not rejected.
+            return False, CREDENTIALS_IGNORED_ERROR
+        return False, INVALID_CREDENTIALS_ERROR
 
     if response.status_code == 403:
-        return False, "These credentials lack permission to read this WordPress site"
+        return False, FORBIDDEN_WITH_CREDENTIALS_ERROR if has_credentials else ANONYMOUS_FORBIDDEN_ERROR
 
     if response.status_code == 404:
-        return False, "WordPress REST API not found at this URL — confirm the site URL and that the REST API is enabled"
+        return False, REST_NOT_FOUND_ERROR
 
-    try:
-        body = response.json()
-        return False, body.get("message", response.text)
-    except Exception:
-        return False, response.text
+    return False, _response_error_message(response)
 
 
 def _parse_retry_after(response: requests.Response) -> float | None:
@@ -300,34 +450,41 @@ def get_rows(
     incremental_field: str | None = None,
 ) -> Iterator[Any]:
     config = WORDPRESS_ENDPOINTS[endpoint]
-    headers = _get_headers(username, application_password)
     batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
-    # Re-check HTTPS at run time (host could have been edited after source creation) before any
-    # credential-bearing request goes out. Non-retryable — see get_non_retryable_errors().
-    if _has_credentials(username, application_password) and _scheme(site_url) != "https":
-        raise WordpressHostNotAllowedError(HTTP_NOT_ALLOWED_ERROR)
+    host_only = _host_only(site_url)
+    is_proxied = _is_wpcom_host(host_only)
+    # Credentials never accompany proxied requests: wp.com auth is OAuth, not Basic (see WPCOM_PROXY_ORIGIN).
+    headers = _get_headers(None, None) if is_proxied else _get_headers(username, application_password)
 
-    # Re-check at run time (not just at source-create) in case the host now resolves to an internal
-    # address (SSRF / DNS rebinding). Only enforced on cloud.
-    host_ok, host_err = _is_host_safe(_host_only(site_url), team_id)
-    if not host_ok:
-        raise WordpressHostNotAllowedError(
-            f"{HOST_NOT_ALLOWED_ERROR}: {host_err}" if host_err else HOST_NOT_ALLOWED_ERROR
-        )
+    if not is_proxied:
+        # Re-check HTTPS at run time (host could have been edited after source creation) before any
+        # credential-bearing request goes out. Non-retryable — see get_non_retryable_errors().
+        if _has_credentials(username, application_password) and _scheme(site_url) != "https":
+            raise WordpressHostNotAllowedError(HTTP_NOT_ALLOWED_ERROR)
 
+        # Re-check at run time (not just at source-create) in case the host now resolves to an internal
+        # address (SSRF / DNS rebinding). Only enforced on cloud. The proxied path skips this: its
+        # requests only ever reach the fixed public proxy host, never the customer-controlled one.
+        host_ok, host_err = _is_host_safe(host_only, team_id)
+        if not host_ok:
+            raise WordpressHostNotAllowedError(
+                f"{HOST_NOT_ALLOWED_ERROR}: {host_err}" if host_err else HOST_NOT_ALLOWED_ERROR
+            )
+
+    api_base = _proxy_api_base(host_only) if is_proxied else _direct_api_base(site_url)
     params = _build_initial_params(
         config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
     )
-    initial_url = _build_initial_url(site_url, config, params)
+    initial_url = _build_initial_url(api_base, config, params)
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None and _is_same_host(resume_config.next_url, site_url):
+    if resume_config is not None and _is_within_api_base(resume_config.next_url, api_base):
         url: str = resume_config.next_url
         logger.debug(f"WordPress: resuming from URL: {url}")
     else:
         if resume_config is not None:
-            logger.warning("WordPress: ignoring resume URL whose host does not match the configured host")
+            logger.warning("WordPress: ignoring resume URL that is outside the configured API base")
         url = initial_url
 
     @retry(
@@ -336,10 +493,10 @@ def get_rows(
         wait=_retry_wait,
         reraise=True,
     )
-    def fetch_page(page_url: str) -> requests.Response:
+    def fetch_page(page_url: str, page_headers: dict[str, str], proxied: bool) -> requests.Response:
         # Don't follow redirects: an attacker-controlled host could 3xx to an internal address (SSRF).
         response = make_tracked_session().get(
-            page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
+            page_url, headers=page_headers, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
         )
 
         if response.status_code == 429 or response.status_code >= 500:
@@ -350,9 +507,17 @@ def get_rows(
             )
 
         if response.is_redirect or response.is_permanent_redirect:
-            raise WordpressHostNotAllowedError(
-                f"{HOST_NOT_ALLOWED_ERROR}: WordPress API returned an unexpected redirect "
-                f"(status={response.status_code}); refusing to follow it"
+            raise WordpressHostNotAllowedError(f"{HOST_NOT_ALLOWED_ERROR}: {_redirect_error(response)}")
+
+        if not proxied and response.status_code in (403, 404) and _is_wpcom_served(response):
+            # Custom-domain simple wp.com sites don't serve /wp-json; retry via the proxy.
+            raise _WordpressComProxyRequired()
+
+        if proxied and response.status_code in (401, 403):
+            raise WordpressComAccessError(
+                WPCOM_AUTH_REQUIRED_TABLE_ERROR
+                if endpoint in WORDPRESS_COM_AUTH_REQUIRED_ENDPOINTS
+                else WPCOM_PRIVATE_SITE_ERROR
             )
 
         if not response.ok:
@@ -361,9 +526,26 @@ def get_rows(
 
         return response
 
+    pages_fetched = 0
     while True:
-        response = fetch_page(url)
+        try:
+            response = fetch_page(url, headers, is_proxied)
+        except _WordpressComProxyRequired:
+            if pages_fetched > 0:
+                # The direct API vanished mid-pagination (site migrated or flipped private); restarting
+                # on the proxy inside the same run would mix bases, so fail with the actionable message.
+                raise WordpressComAccessError(WPCOM_PRIVATE_SITE_ERROR) from None
+            is_proxied = True
+            api_base = _proxy_api_base(host_only)
+            headers = _get_headers(None, None)
+            url = _build_initial_url(api_base, config, params)
+            logger.info(
+                "WordPress: direct REST API unavailable and the response is WordPress.com-served; "
+                "retrying via the public-api proxy"
+            )
+            continue
 
+        pages_fetched += 1
         data = response.json()
         if not isinstance(data, list) or not data:
             break
@@ -385,9 +567,9 @@ def get_rows(
         if not next_url:
             break
 
-        # The next-page URL is server-controlled; only follow it if it stays on the configured host.
-        if not _is_same_host(next_url, site_url):
-            logger.warning("WordPress: stopping pagination, next URL host does not match the configured host")
+        # The next-page URL is server-controlled; only follow it if it stays inside the API base.
+        if not _is_within_api_base(next_url, api_base):
+            logger.warning("WordPress: stopping pagination, next URL is outside the configured API base")
             break
 
         url = next_url


### PR DESCRIPTION
## Problem

A customer with a free WordPress.com site couldn't connect the new WordPress source at all. Every onboarding attempt (with or without an application password, site private or public) failed, most visibly with "These credentials lack permission to read this WordPress site".

The root cause, verified against live sites: free/simple WordPress.com sites don't serve the core REST API at `<site>/wp-json` on the site domain. It 404s on public sites and 403s on private/unlaunched ones (new wp.com sites default to "Coming Soon"). Their REST API is only reachable through the `public-api.wordpress.com/wp/v2/sites/<host>/` proxy, and wp.com "application passwords" are account-level OAuth credentials, not core Application Passwords, so Basic auth can never work there. The source, built around direct `/wp-json` plus Basic auth, structurally couldn't connect any of these sites, and its error messages pointed users at their credentials instead.

Along the way I found three more validation bugs affecting all sites, including self-hosted ones:

- invalid Basic auth silently passes validation on sites where application passwords are unavailable, because WordPress ignores the Authorization header there (verified live with garbage credentials)
- any redirect (like www canonicalization) fails with a bare "WordPress site URL is not allowed" instead of telling the user which URL to enter
- no User-Agent was sent, and some WordPress hosts/WAFs 403 the default python-requests one

## Changes

- Route `*.wordpress.com` sites through the wp.com public API proxy, anonymously. Verified live that the proxy serves posts/pages/comments/categories/tags with the same `Link: rel="next"` pagination the source already consumes, and honors `modified_after` incremental filters.
- Detect custom-domain wp.com sites (Personal/Premium plans, which also don't serve `/wp-json`) via the `host-header: WordPress.com` response header, and fall back to the proxy in both validation and sync.
- Hide the media/users tables for proxied wp.com sites (the proxy only serves them with OAuth); give proxied 401/403s actionable messages ("launch the site / set privacy to Public") instead of credential blame.
- Pin pagination and resume URLs to the effective API base (scheme, host, port, and path prefix) rather than just the site host, so proxied Link headers are followed but another site's path on the shared proxy host is not.
- Verify supplied credentials against `/users/me` (the endpoint form the WP REST auth docs use), mapping WordPress's error codes to distinct messages: ignored credentials vs wrong credentials vs insufficient role. Falls back to a posts probe when a security plugin hides the users routes.
- Surface redirect targets in validation errors ("The site redirected to X. Enter that as the site URL"), with a special case for wp.com's typo redirect meaning the subdomain doesn't exist.
- Send an explicit `User-Agent`, matching what other sources do for WAF-fronted APIs.
- Update the source caption and field captions to explain the wp.com plan differences.

Private WordPress.com sites remain unsupported (they need wp.com OAuth, a follow-up), but now say so clearly instead of blaming credentials.

## How did you test this code?

- `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/` - 141 tests pass. New test groups and the regression each catches: proxy routing/pagination (proxied Link next-URLs would otherwise be rejected and pagination would silently stop after page 1), credentials never sent to the proxy host (credential leak), `_is_within_api_base` path-prefix cases (cross-site reads on the shared proxy host, scheme downgrades), `/users/me` 401 code mapping (garbage credentials false-validating), anonymous 403 message (the customer-facing bug), host-header fallback in validation and sync, wp.com schema filtering (wizard offering tables that can never sync).
- Live read-only smoke checks against real WordPress.com sites with the exact headers the new code sends: free-site direct `/wp-json` returns 404 with `host-header: WordPress.com` (the fallback trigger), and the proxy URL returns 200 with post JSON and pagination headers.
- I did not run a full end-to-end sync in the UI against a wp.com site.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The posthog.com source doc (`docsUrl` points at posthog.com/docs/cdp/sources/wordpress) lives in the posthog.com repo and needs a follow-up there to describe the wp.com behavior and plan limitations. The in-product caption in this PR covers the same ground.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with PostHog Code (Claude). The investigation started from a customer support report; I (actually Claude) reproduced the failure mode against live WordPress.com sites with curl, cross-checked the WordPress REST API and wordpress.com developer docs, and wrote the fix and tests.
- Skills invoked: /writing-tests.
- Notable decisions: route wp.com subdomain hosts through the proxy unconditionally (live behavior contradicts the wp.com doc page that claims subdomain sites serve `/wp-json`; the host-header fallback keeps custom-domain sites working either way), keep the proxy/direct resolution computed from `site_url` rather than persisted (no config or migration changes), and validate credentials via `/users/me` after proving a posts probe accepts garbage credentials on sites without application passwords.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
