### PR TITLE
fix(cli): capture cli errors with posthog-rs

### DIFF
--- a/cli/.sampo/changesets/cunning-earl-goulven.md
+++ b/cli/.sampo/changesets/cunning-earl-goulven.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Capture CLI errors with PostHog telemetry

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -113,6 +113,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +135,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "backtrace"
@@ -156,12 +191,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -190,9 +219,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -213,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -346,6 +384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -375,10 +432,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
+name = "compression-codecs"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -455,7 +529,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio 1.1.0",
  "parking_lot",
@@ -618,6 +692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +711,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -656,15 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -760,6 +841,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -907,25 +994,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,17 +1019,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -973,23 +1030,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -1000,8 +1046,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1010,36 +1056,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1051,8 +1067,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1064,33 +1080,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1104,14 +1106,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1297,7 +1299,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm 0.25.0",
  "dyn-clone",
  "fuzzy-matcher",
@@ -1326,16 +1328,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -1384,6 +1376,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,9 +1464,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1433,7 +1474,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1641,6 +1682,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1741,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,10 +1932,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "outref"
@@ -1894,16 +2128,22 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.3.7"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610d236077c94c96194b0d2b40989bda4bf8faf60e15a0da6ef8ffd4c78f6c1c"
+checksum = "78a4557dd7d995d8c86c74d9f0b5116db21ac3fd207413fbca820aaa6910b22b"
 dependencies = [
+ "backtrace",
  "chrono",
  "derive_builder",
- "reqwest 0.11.27",
+ "flate2",
+ "os_info",
+ "regex",
+ "reqwest 0.13.4",
  "semver",
  "serde",
  "serde_json",
+ "sha1",
+ "tracing",
  "uuid",
 ]
 
@@ -1990,8 +2230,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
- "socket2 0.6.1",
+ "rustls",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2004,13 +2244,14 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -2028,7 +2269,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2100,7 +2341,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2141,7 +2382,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2186,47 +2427,6 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
@@ -2236,11 +2436,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -2248,14 +2448,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2263,7 +2463,46 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.4",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2293,12 +2532,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2311,7 +2559,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2320,37 +2568,29 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "base64 0.21.7",
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2364,14 +2604,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "ring",
- "untrusted",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2379,6 +2636,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2403,6 +2661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2438,13 +2705,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2522,6 +2802,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,6 +2876,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,16 +2914,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2819,12 +3116,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2841,27 +3132,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3040,18 +3310,8 @@ dependencies = [
  "libc",
  "mio 1.1.0",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
 ]
 
 [[package]]
@@ -3060,7 +3320,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -3086,7 +3346,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3094,20 +3354,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "async-compression",
+ "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "iri-string",
+ "http",
+ "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3447,7 +3712,7 @@ version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3496,10 +3761,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "webpki-root-certs"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -3830,16 +4098,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1.41"
 uuid = { version = "1.16.0", features = ["v7"] }
 thiserror = "2.0.12"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-posthog-rs = { version = "0.3.5", default-features = false }
+posthog-rs = { version = "0.15.0", default-features = false, features = ["error-tracking"] }
 sha2 = "0.10.9"
 urlencoding = "2.1.3"
 rayon = "1.11.0"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::{
     api_proxy,
@@ -10,7 +10,7 @@ use crate::{
     dsym::DsymSubcommand,
     error::CapturedError,
     experimental::{endpoints::EndpointCommand, query::command::QueryCommand, tasks::TaskCommand},
-    invocation_context::{context, init_context, INVOCATION_CONTEXT},
+    invocation_context::{context, init_context, set_telemetry_command_name, INVOCATION_CONTEXT},
     proguard::ProguardSubcommand,
     sourcemaps::{hermes::HermesSubcommand, plain::SourcemapCommand},
 };
@@ -243,20 +243,98 @@ pub enum SchemaCommand {
     Status,
 }
 
+impl Commands {
+    fn telemetry_command_name(&self) -> &'static str {
+        match self {
+            Commands::Login => "login",
+            Commands::Exp { cmd } => cmd.telemetry_command_name(),
+            Commands::Sourcemap { cmd } => match cmd {
+                SourcemapCommand::Inject(_) => "sourcemap_inject",
+                SourcemapCommand::Upload(_) => "sourcemap_upload",
+                SourcemapCommand::Process(_) => "sourcemap_process",
+            },
+            Commands::Dsym { cmd } => match cmd {
+                DsymSubcommand::Upload(_) => "dsym_upload",
+            },
+            Commands::Hermes { cmd } => match cmd {
+                HermesSubcommand::Inject(_) => "hermes_inject",
+                HermesSubcommand::Upload(_) => "hermes_upload",
+                HermesSubcommand::Clone(_) => "hermes_clone",
+            },
+            Commands::Proguard { cmd } => match cmd {
+                ProguardSubcommand::Upload(_) => "proguard_upload",
+            },
+            Commands::SymbolSets { cmd } => match cmd {
+                SymbolSetsSubcommand::Upload(_) => "symbolset_upload",
+                SymbolSetsSubcommand::Download(_) => "symbolset_download",
+                SymbolSetsSubcommand::Extract(_) => "symbolset_extract",
+            },
+            Commands::Api { .. } => "api",
+        }
+    }
+}
+
+impl ExpCommand {
+    fn telemetry_command_name(&self) -> &'static str {
+        match self {
+            ExpCommand::Task { cmd, .. } => match cmd {
+                TaskCommand::List { .. } => "task_list",
+                TaskCommand::Progress { .. } => "task_progress",
+                TaskCommand::UpdateStage { .. } => "task_update_stage",
+            },
+            ExpCommand::Query { cmd } => match cmd {
+                QueryCommand::Editor { .. } => "query_editor",
+                QueryCommand::Run { .. } => "query_run",
+                QueryCommand::Check { .. } => "query_check",
+            },
+            ExpCommand::Endpoints { cmd } => match cmd {
+                EndpointCommand::List(_) => "endpoints_list",
+                EndpointCommand::Get(_) => "endpoints_get",
+                EndpointCommand::Open(_) => "endpoints_open",
+                EndpointCommand::Run(_) => "endpoints_run",
+                EndpointCommand::Push(_) => "endpoints_push",
+                EndpointCommand::Pull(_) => "endpoints_pull",
+                EndpointCommand::Diff(_) => "endpoints_diff",
+            },
+            ExpCommand::Hermes { cmd } => match cmd {
+                HermesSubcommand::Inject(_) => "hermes_inject",
+                HermesSubcommand::Upload(_) => "hermes_upload",
+                HermesSubcommand::Clone(_) => "hermes_clone",
+            },
+            ExpCommand::Proguard { cmd } => match cmd {
+                ProguardSubcommand::Upload(_) => "proguard_upload",
+            },
+            ExpCommand::Dsym { cmd } => match cmd {
+                DsymSubcommand::Upload(_) => "dsym_upload",
+            },
+            ExpCommand::Schema { cmd } => match cmd {
+                SchemaCommand::Pull { .. } => "schema_pull",
+                SchemaCommand::Status => "schema_status",
+            },
+        }
+    }
+}
+
 impl Cli {
     pub fn run() -> Result<(), CapturedError> {
         let command = Cli::parse();
         let no_fail = command.no_fail;
+        set_telemetry_command_name(command.command.telemetry_command_name());
 
-        match command.run_impl() {
+        let result = command.run_impl().map_err(|error| error.capture());
+
+        if INVOCATION_CONTEXT.get().is_some() {
+            context().finish();
+        }
+
+        match result {
             Ok(_) => Ok(()),
             Err(e) => {
-                let msg = match &e.exception_id {
-                    Some(id) => format!("Oops! {} (ID: {})", e.inner, id),
-                    None => format!("Oops! {:?}", e.inner),
-                };
-                error!(msg);
                 if no_fail {
+                    match &e.exception_id {
+                        Some(id) => eprintln!("Oops! {} (ID: {})", e.inner, id),
+                        None => eprintln!("Oops! {:?}", e.inner),
+                    };
                     Ok(())
                 } else {
                     Err(e)
@@ -413,10 +491,6 @@ impl Cli {
                     }
                 },
             },
-        }
-
-        if INVOCATION_CONTEXT.get().is_some() {
-            context().finish();
         }
 
         Ok(())

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,8 +1,25 @@
+use std::{
+    error::Error as StdError,
+    fmt::{self, Display},
+};
+
 use anyhow::Error;
+use posthog_rs::CaptureExceptionOptions;
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::{api::client::ClientError, invocation_context::current_telemetry_command_name};
 
 pub struct CapturedError {
     pub inner: Error,
     pub exception_id: Option<String>,
+}
+
+impl CapturedError {
+    pub fn capture(self) -> Self {
+        capture_exception(ErrorTelemetryMetadata::from_error(&self.inner));
+        self
+    }
 }
 
 impl From<Error> for CapturedError {
@@ -11,5 +28,175 @@ impl From<Error> for CapturedError {
             inner,
             exception_id: None,
         }
+    }
+}
+
+#[derive(Debug)]
+struct SanitizedCliError;
+
+impl Display for SanitizedCliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CLI command failed")
+    }
+}
+
+impl StdError for SanitizedCliError {}
+
+struct ErrorTelemetryMetadata {
+    error_kind: &'static str,
+    command_name: String,
+    chain_depth: usize,
+    http_status: Option<u16>,
+    api_error_code: Option<String>,
+    is_timeout: Option<bool>,
+    is_connect: Option<bool>,
+}
+
+impl ErrorTelemetryMetadata {
+    fn from_error(error: &Error) -> Self {
+        let command_name =
+            current_telemetry_command_name().unwrap_or_else(|| "unknown".to_string());
+        let chain_depth = error.chain().count();
+
+        let Some(client_error) = error
+            .chain()
+            .find_map(|source| source.downcast_ref::<ClientError>())
+        else {
+            return Self {
+                error_kind: "other",
+                command_name,
+                chain_depth,
+                http_status: None,
+                api_error_code: None,
+                is_timeout: None,
+                is_connect: None,
+            };
+        };
+
+        match client_error {
+            ClientError::ApiError(status, _, body) => Self {
+                error_kind: "api_error",
+                command_name,
+                chain_depth,
+                http_status: Some(*status),
+                api_error_code: safe_api_error_code(body),
+                is_timeout: None,
+                is_connect: None,
+            },
+            ClientError::RequestError(err) => Self {
+                error_kind: "request_error",
+                command_name,
+                chain_depth,
+                http_status: None,
+                api_error_code: None,
+                is_timeout: Some(err.is_timeout()),
+                is_connect: Some(err.is_connect()),
+            },
+            ClientError::InvalidUrl(_) => Self {
+                error_kind: "invalid_url",
+                command_name,
+                chain_depth,
+                http_status: None,
+                api_error_code: None,
+                is_timeout: None,
+                is_connect: None,
+            },
+        }
+    }
+
+    fn fingerprint(&self) -> String {
+        let mut parts = vec![
+            "posthog-cli".to_string(),
+            self.command_name.clone(),
+            self.error_kind.to_string(),
+        ];
+
+        if let Some(status) = self.http_status {
+            parts.push(status.to_string());
+        }
+
+        if let Some(api_error_code) = &self.api_error_code {
+            parts.push(api_error_code.clone());
+        }
+
+        parts.join(":")
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiErrorCodeResponse {
+    code: Option<String>,
+}
+
+fn safe_api_error_code(body: &str) -> Option<String> {
+    let code = serde_json::from_str::<ApiErrorCodeResponse>(body)
+        .ok()?
+        .code?;
+    if code.len() > 64
+        || !code
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return None;
+    }
+    Some(code)
+}
+
+fn capture_exception(metadata: ErrorTelemetryMetadata) {
+    let mut options = match CaptureExceptionOptions::new()
+        .fingerprint(metadata.fingerprint())
+        .property("error_kind", metadata.error_kind)
+        .and_then(|options| options.property("error_chain_depth", metadata.chain_depth))
+        .and_then(|options| options.property("command_name", metadata.command_name.as_str()))
+    {
+        Ok(options) => options,
+        Err(err) => {
+            debug!("Failed to build exception capture options: {err:?}");
+            return;
+        }
+    };
+
+    if let Some(http_status) = metadata.http_status {
+        options = match options.property("http_status", http_status) {
+            Ok(options) => options,
+            Err(err) => {
+                debug!("Failed to attach exception status: {err:?}");
+                return;
+            }
+        };
+    }
+
+    if let Some(api_error_code) = metadata.api_error_code {
+        options = match options.property("api_error_code", api_error_code) {
+            Ok(options) => options,
+            Err(err) => {
+                debug!("Failed to attach exception API error code: {err:?}");
+                return;
+            }
+        };
+    }
+
+    if let Some(is_timeout) = metadata.is_timeout {
+        options = match options.property("is_timeout", is_timeout) {
+            Ok(options) => options,
+            Err(err) => {
+                debug!("Failed to attach exception timeout flag: {err:?}");
+                return;
+            }
+        };
+    }
+
+    if let Some(is_connect) = metadata.is_connect {
+        options = match options.property("is_connect", is_connect) {
+            Ok(options) => options,
+            Err(err) => {
+                debug!("Failed to attach exception connection flag: {err:?}");
+                return;
+            }
+        };
+    }
+
+    if let Err(err) = posthog_rs::capture_exception_with(&SanitizedCliError, options) {
+        debug!("Failed to capture exception: {err:?}");
     }
 }

--- a/cli/src/invocation_context.rs
+++ b/cli/src/invocation_context.rs
@@ -3,9 +3,8 @@ use inquire::{
     validator::{ErrorMessage, Validation},
     CustomUserError,
 };
-use posthog_rs::Event;
+use posthog_rs::{ErrorTrackingOptionsBuilder, Event};
 use reqwest::blocking::Client;
-use serde_json::json;
 use std::{
     io::{self, IsTerminal},
     path::PathBuf,
@@ -13,6 +12,7 @@ use std::{
     thread::JoinHandle,
 };
 use tracing::debug;
+use uuid::Uuid;
 
 use crate::{
     api::client::PHClient,
@@ -30,8 +30,121 @@ pub struct InvocationContext {
     handles: Mutex<Vec<JoinHandle<()>>>,
 }
 
+struct TelemetryContext {
+    invocation_id: String,
+    command_name: Option<String>,
+    env_id: Option<String>,
+    is_terminal: bool,
+}
+
+static TELEMETRY_CONTEXT: OnceLock<Mutex<TelemetryContext>> = OnceLock::new();
+
+fn telemetry_context() -> &'static Mutex<TelemetryContext> {
+    TELEMETRY_CONTEXT.get_or_init(|| {
+        Mutex::new(TelemetryContext {
+            invocation_id: Uuid::now_v7().to_string(),
+            command_name: None,
+            env_id: None,
+            is_terminal: io::stdout().is_terminal(),
+        })
+    })
+}
+
+pub fn set_telemetry_command_name(command_name: &str) {
+    if let Ok(mut context) = telemetry_context().lock() {
+        context.command_name = Some(command_name.to_string());
+    }
+}
+
+fn set_telemetry_env_id(env_id: &str) {
+    if let Ok(mut context) = telemetry_context().lock() {
+        context.env_id = Some(env_id.to_string());
+    }
+}
+
+fn apply_telemetry_properties(event: &mut Event) {
+    let _ = event.insert_prop("cli_version", env!("CARGO_PKG_VERSION"));
+    let _ = event.insert_prop("invocation_id", telemetry_invocation_id());
+    let _ = event.insert_prop("is_ci", std::env::var_os("CI").is_some());
+    let _ = event.insert_prop("is_terminal", telemetry_is_terminal());
+    let _ = event.insert_prop("os", std::env::consts::OS);
+    let _ = event.insert_prop("arch", std::env::consts::ARCH);
+
+    if let Some(command_name) = telemetry_command_name() {
+        let _ = event.insert_prop("command_name", command_name);
+    }
+
+    if let Some(env_id) = telemetry_env_id() {
+        let _ = event.insert_prop("env_id", env_id);
+    }
+}
+
+fn telemetry_invocation_id() -> String {
+    telemetry_context()
+        .lock()
+        .map(|context| context.invocation_id.clone())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn telemetry_command_name() -> Option<String> {
+    telemetry_context()
+        .lock()
+        .ok()
+        .and_then(|context| context.command_name.clone())
+}
+
+pub fn current_telemetry_command_name() -> Option<String> {
+    telemetry_command_name()
+}
+
+fn telemetry_env_id() -> Option<String> {
+    telemetry_context()
+        .lock()
+        .ok()
+        .and_then(|context| context.env_id.clone())
+}
+
+fn telemetry_is_terminal() -> bool {
+    telemetry_context()
+        .lock()
+        .map(|context| context.is_terminal)
+        .unwrap_or_else(|_| io::stdout().is_terminal())
+}
+
 pub fn context() -> &'static InvocationContext {
     INVOCATION_CONTEXT.get().expect("Context has been set up")
+}
+
+pub fn init_posthog_telemetry() {
+    let Some(token) = option_env!("POSTHOG_API_TOKEN") else {
+        debug!("Posthog api token not set at build time - is this a debug build?");
+        return;
+    };
+
+    let error_tracking = ErrorTrackingOptionsBuilder::default()
+        .capture_panics(true)
+        .build()
+        .expect("Building error tracking config succeeds");
+    let ph_config = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(token.to_string())
+        .request_timeout_seconds(5) // It's a CLI, 5 seconds is an eternity
+        .error_tracking(error_tracking)
+        .before_send(|mut event| {
+            apply_telemetry_properties(&mut event);
+            Some(event)
+        })
+        .build()
+        .expect("Building PH config succeeds");
+
+    match posthog_rs::init_global(ph_config) {
+        Ok(()) => {}
+        Err(posthog_rs::Error::AlreadyInitialized) => {
+            debug!("PostHog client already initialized");
+        }
+        Err(err) => {
+            debug!("PostHog client unavailable: {err:?}");
+        }
+    }
 }
 
 pub fn init_context(
@@ -50,22 +163,11 @@ pub fn init_context(
     };
 
     config.validate()?;
+    set_telemetry_env_id(&config.env_id);
 
     let client: PHClient = PHClient::from_config(config.clone())?;
 
     INVOCATION_CONTEXT.get_or_init(|| InvocationContext::new(config, client));
-
-    // This is pulled at compile time, not runtime - we set it at build.
-    if let Some(token) = option_env!("POSTHOG_API_TOKEN") {
-        let ph_config = posthog_rs::ClientOptionsBuilder::default()
-            .api_key(token.to_string())
-            .request_timeout_seconds(5) // It's a CLI, 5 seconds is an eternity
-            .build()
-            .expect("Building PH config succeeds");
-        posthog_rs::init_global(ph_config).expect("Initializing PostHog client");
-    } else {
-        debug!("Posthog api token not set at build time - is this a debug build?");
-    };
 
     Ok(())
 }
@@ -117,14 +219,11 @@ impl InvocationContext {
     }
 
     pub fn capture_command_invoked(&self, command: &str) {
-        self.capture_event(
-            "posthog cli command run",
-            vec![("command_name", json!(command))],
-        );
+        set_telemetry_command_name(command);
+        self.capture_event("posthog cli command run", Vec::new());
     }
 
     pub fn capture_event(&self, event_name: &str, props: Vec<(&str, serde_json::Value)>) {
-        let env_id = self.client.get_env_id().clone();
         let event_name = event_name.to_string();
         let props: Vec<(String, serde_json::Value)> =
             props.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
@@ -138,17 +237,9 @@ impl InvocationContext {
                     .expect("Inserting prop succeeds");
             }
 
-            event
-                .insert_prop("env_id", env_id)
-                .expect("Inserting env_id prop succeeds");
-
             debug!("Capturing event");
-            let res = posthog_rs::capture(event); // Purposefully ignore errors here
-            if let Err(err) = res {
-                debug!("Failed to capture event: {:?}", err);
-            } else {
-                debug!("Event captured successfully");
-            }
+            posthog_rs::capture(event);
+            debug!("Event queued successfully");
         });
 
         self.handles.lock().unwrap().push(handle);
@@ -160,5 +251,6 @@ impl InvocationContext {
             .unwrap()
             .drain(..)
             .for_each(|handle| handle.join().unwrap());
+        posthog_rs::flush();
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use posthog_cli::cmd;
+use posthog_cli::{cmd, invocation_context::init_posthog_telemetry};
 use rayon::ThreadPoolBuilder;
 
 fn main() {
@@ -18,8 +18,12 @@ fn main() {
         .expect("We successfully install a global thread pool");
 
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
+    init_posthog_telemetry();
 
-    match cmd::Cli::run() {
+    let result = cmd::Cli::run();
+    posthog_rs::flush();
+
+    match result {
         Ok(_) => {}
         Err(e) => {
             match e.exception_id {


### PR DESCRIPTION
## Problem

The CLI was still on an old `posthog-rs` version and only captured command usage. That made runtime failures harder to diagnose because handled command errors and panics were not sent through PostHog Error tracking.

## Changes

- Bump the CLI `posthog-rs` dependency to `0.15.0` with Error tracking enabled.
- Initialize PostHog telemetry at CLI startup so early failures can be captured.
- Enable the SDK's built-in panic autocapture via `ErrorTrackingOptions::capture_panics`.
- Capture handled command errors with a sanitized exception payload and safe classification properties.
- Attach common CLI context to all SDK events: `cli_version`, `invocation_id`, `command_name`, `env_id`, `is_ci`, `is_terminal`, `os`, and `arch`.
- Flush the SDK at command teardown and at process exit.
- Add a Sampo patch changeset for `posthog-cli`.

## How did you test this code?

- `cargo check --manifest-path cli/Cargo.toml`
- `flox activate -- bash -c "./bin/hogli test cli"`

I also attempted `flox activate -- bash -c "./bin/hogli ci:preflight --fix"`, but it failed because `ci:preflight` could not detect this jj worktree as a git repository. I sent devex feedback for that tooling issue.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This changes internal CLI telemetry and error capture behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex in pi made the changes and pushed the PR branch. Skills invoked: `/writing-tests`, `/running-ci-preflight`, and `/pr`.

I used the built-in panic autocapture added in `posthog-rs` 0.15.0 rather than maintaining a custom panic hook in the CLI. No new tests were added because existing CLI tests already exercise the command paths, and this change primarily wires telemetry capture around those paths.
