### PR TITLE
fix(convex): mask deployment URL in credential-validation errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -244,14 +244,12 @@ def validate_credentials(deploy_url: str, deploy_key: str) -> tuple[bool, str | 
                 pass
             if e.response.status_code in (401, 403):
                 return False, "Invalid deploy key. Check your Convex deploy key and try again."
-            return (
-                False,
-                f"The Convex deployment rejected the request (HTTP {e.response.status_code}). "
-                "Check your deployment URL and deploy key, then try again.",
-            )
+        # Any other status falls through to a generic message. Keep the raw error
+        # (which embeds the deployment URL) out of what the user sees.
+        detail = f" (HTTP {e.response.status_code})" if e.response is not None else ""
         return (
             False,
-            "The Convex deployment rejected the request. Check your deployment URL and deploy key, then try again.",
+            f"The Convex deployment rejected the request{detail}. Check your deployment URL and deploy key, then try again.",
         )
     except RequestsConnectionError:
         return False, "Could not connect to the Convex deployment. Check your deployment URL and try again."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -244,7 +244,15 @@ def validate_credentials(deploy_url: str, deploy_key: str) -> tuple[bool, str | 
                 pass
             if e.response.status_code in (401, 403):
                 return False, "Invalid deploy key. Check your Convex deploy key and try again."
-        return False, str(e)
+            return (
+                False,
+                f"The Convex deployment rejected the request (HTTP {e.response.status_code}). "
+                "Check your deployment URL and deploy key, then try again.",
+            )
+        return (
+            False,
+            "The Convex deployment rejected the request. Check your deployment URL and deploy key, then try again.",
+        )
     except RequestsConnectionError:
         return False, "Could not connect to the Convex deployment. Check your deployment URL and try again."
     except RequestException as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock, Mock, patch
 
 from parameterized import parameterized
+from requests.exceptions import HTTPError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex import (
@@ -108,6 +109,21 @@ class TestValidateDeployUrl:
         assert err is None
         called_url = mock_get.return_value.get.call_args.args[0]
         assert called_url.startswith("https://swift-lemur-123.convex.cloud/api/")
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_validate_credentials_does_not_leak_url_on_http_error(self, mock_get):
+        err_response = Mock(status_code=400)
+        err_response.json.return_value = {"code": "SomethingUnexpected"}
+        response = Mock()
+        response.raise_for_status.side_effect = HTTPError(response=err_response)
+        mock_get.return_value.get.return_value = response
+
+        ok, err = validate_credentials("https://swift-lemur-123.convex.cloud", "prod:abc123")
+        assert not ok
+        assert err is not None
+        assert "swift-lemur-123" not in err
+        assert "convex.cloud" not in err
+        assert "400" in err
 
 
 class TestListSnapshotResumable:


### PR DESCRIPTION
## Problem

When someone connects a Convex source in the new-source wizard, we probe the deployment's `json_schemas` endpoint to validate credentials. We already return clean, actionable messages for the two cases we recognize (streaming export not enabled, and a 401/403 bad deploy key). Every other `HTTPError` fell through to `return False, str(e)`.

`str(e)` on a `requests.HTTPError` is the raw library string, which embeds the full request URL, e.g.:

```
Non-OK response ... (status 400) for url: https://<redacted-deployment>.convex.cloud/api/json_schemas?deltaSchema=true&format=json
```

That gives the user nothing to act on and leaks the deployment ref into both the error banner and the `warehouse credentials invalid` analytics event. We saw a real 400 fall through this way during setup.

## Changes

Replaced the `str(e)` fallthrough with a status-based, actionable message that does not include the URL, following the same shape as the existing handled cases:

- Response present: `The Convex deployment rejected the request (HTTP <status>). Check your deployment URL and deploy key, then try again.`
- No response on the error: a generic variant without the status code.

No sync behavior or schema changes.

## How did you test this code?

Added one unit test (`test_validate_credentials_does_not_leak_url_on_http_error`) that simulates a 400 `HTTPError` whose code is not one of the recognized ones and asserts the returned message contains the status but not the deployment host or `convex.cloud`. It guards against reverting to the raw `str(e)` leak, which no existing test covered (existing cases only cover bad-URL, the 200 success path, and the sync-path non-retryable matcher).

Ran the `TestValidateDeployUrl` class locally: 25 passed. Ran `ruff check`/`ruff format` over both touched files.

I (Claude) was not able to exercise the real Convex API or the full wizard flow in this environment, so the verification is limited to the unit test above.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced by Claude while triaging a batch of data-warehouse source-creation failures. Most source types in that batch were clean, actionable user errors or already addressed by other open PRs and needed no change. This Convex path was the one clear internal-error leak: a raw `requests` HTTPError string reaching the user. Invoked the `/writing-tests` skill to gate the single added test against a named regression (re-leaking the URL). Kept the change minimal and scoped to the credential-validation fallthrough.
