### PR TITLE
fix(error-tracking): handle symbol set release conflicts per chunk

### DIFF
--- a/products/error_tracking/backend/facade/symbol_sets.py
+++ b/products/error_tracking/backend/facade/symbol_sets.py
@@ -98,6 +98,7 @@ def bulk_start_upload(
     force: bool,
     skip_on_conflict: bool,
     distinct_id: str | None,
+    skip_release_on_conflict: bool = False,
 ) -> dict[str, dict[str, str]]:
     return _logic.bulk_start_upload(
         team,
@@ -107,6 +108,7 @@ def bulk_start_upload(
         force=force,
         skip_on_conflict=skip_on_conflict,
         distinct_id=distinct_id,
+        skip_release_on_conflict=skip_release_on_conflict,
     )
 
 

--- a/products/error_tracking/backend/logic/symbol_sets.py
+++ b/products/error_tracking/backend/logic/symbol_sets.py
@@ -141,13 +141,48 @@ def create_symbol_set(
         return symbol_set
 
 
-@posthoganalytics.scoped()
+@posthoganalytics.scoped(capture_exceptions=False)
 def bulk_create_symbol_sets(
     new_symbol_sets: list[SymbolSetUpload],
     team: Team,
     force: bool = False,
     skip_on_conflict: bool = False,
     distinct_id: str | None = None,
+    skip_release_on_conflict: bool = False,
+) -> dict[str, dict[str, str]]:
+    try:
+        return _bulk_create_symbol_sets(
+            new_symbol_sets,
+            team,
+            force=force,
+            skip_on_conflict=skip_on_conflict,
+            distinct_id=distinct_id,
+            skip_release_on_conflict=skip_release_on_conflict,
+        )
+    except ValidationError as e:
+        # Upload-contract rejections are expected 400s the CLI knows how to handle;
+        # track them as analytics instead of capturing them as exceptions.
+        posthoganalytics.capture(
+            "error_tracking_symbol_set_upload_rejected",
+            properties={
+                "file_count": len(new_symbol_sets),
+                "failure_code": _get_failure_code(e),
+            },
+            groups=groups(team.organization, team),
+        )
+        raise
+    except Exception as e:
+        posthoganalytics.capture_exception(e)
+        raise
+
+
+def _bulk_create_symbol_sets(
+    new_symbol_sets: list[SymbolSetUpload],
+    team: Team,
+    force: bool,
+    skip_on_conflict: bool,
+    distinct_id: str | None,
+    skip_release_on_conflict: bool,
 ) -> dict[str, dict[str, str]]:
     accelerate = bool(
         distinct_id
@@ -215,17 +250,28 @@ def bulk_create_symbol_sets(
             upload = new_symbol_set_map[existing.ref]
             dirty = False
 
-            # Allow adding an "orphan" symbol set to a release, but not
-            # moving symbols sets between releases
+            # Allow adding an "orphan" symbol set to a release, but never move a
+            # symbol set between releases - that would re-attribute existing stack
+            # traces. When the conflict is benign (identical content, e.g. an
+            # unchanged artifact rebuilt under a new release) or the caller opted
+            # in, keep the existing association instead of failing the whole batch.
             if upload.release_id:
                 if existing.release_id is None:
                     existing.release_id = upload.release_id
                     dirty = True
                 elif str(existing.release_id) != upload.release_id:
-                    raise ValidationError(
-                        code="release_id_mismatch",
-                        detail=f"Symbol set {existing.ref} already has a release ID",
-                    )
+                    content_unchanged = upload.content_hash is not None and existing.content_hash == upload.content_hash
+                    if content_unchanged or skip_release_on_conflict:
+                        logger.warning(
+                            "symbol_set_release_conflict_skipped",
+                            ref=existing.ref,
+                            team_id=team.id,
+                        )
+                    else:
+                        raise ValidationError(
+                            code="release_id_mismatch",
+                            detail=f"Symbol set {existing.ref} already has a release ID",
+                        )
 
             if upload.content_hash is None:
                 if existing.content_hash is not None:
@@ -436,6 +482,7 @@ def bulk_start_upload(
     force: bool,
     skip_on_conflict: bool,
     distinct_id: str | None,
+    skip_release_on_conflict: bool = False,
 ) -> dict[str, dict[str, str]]:
     uploads = [SymbolSetUpload(**data) for data in symbol_sets]
     uploads.extend([SymbolSetUpload(chunk_id, release_id, None) for chunk_id in chunk_ids])
@@ -452,6 +499,7 @@ def bulk_start_upload(
         force=force,
         skip_on_conflict=skip_on_conflict,
         distinct_id=distinct_id,
+        skip_release_on_conflict=skip_release_on_conflict,
     )
 
 

--- a/products/error_tracking/backend/presentation/views/symbol_sets.py
+++ b/products/error_tracking/backend/presentation/views/symbol_sets.py
@@ -76,6 +76,11 @@ class ErrorTrackingSymbolSetBulkStartUploadSerializer(serializers.Serializer):
         default=False,
         help_text="Whether to skip uploaded symbol sets whose content hash changed instead of failing.",
     )
+    skip_release_on_conflict = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Whether to keep an uploaded symbol set's existing release association instead of failing when a different release ID is provided. Symbol sets are never moved between releases.",
+    )
 
     def validate(self, attrs: dict[str, object]) -> dict[str, object]:
         if attrs.get("force") and attrs.get("skip_on_conflict"):
@@ -297,6 +302,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
 
         force: bool = upload_data["force"]
         skip_on_conflict: bool = upload_data["skip_on_conflict"]
+        skip_release_on_conflict: bool = upload_data["skip_release_on_conflict"]
 
         posthoganalytics.capture(
             "error_tracking_symbol_set_upload_started",
@@ -305,6 +311,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
                 "endpoint": "bulk_start_upload",
                 "force": force,
                 "skip_on_conflict": skip_on_conflict,
+                "skip_release_on_conflict": skip_release_on_conflict,
             },
             groups=groups(self.team.organization, self.team),
         )
@@ -317,6 +324,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
             force=force,
             skip_on_conflict=skip_on_conflict,
             distinct_id=str(request.user.pk) if request.user.pk else None,
+            skip_release_on_conflict=skip_release_on_conflict,
         )
         return Response({"id_map": id_map}, status=status.HTTP_201_CREATED)
 

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1034,7 +1034,27 @@ class TestErrorTracking(APIBaseTest):
         assert symbol_set.storage_ptr != initial_storage_ptr
         assert id_map[str(chunk_id)]["symbol_set_id"] == str(symbol_set.id)
 
-    def test_bulk_start_upload_rejects_release_change(self) -> None:
+    @parameterized.expand(
+        [
+            ("identical_content_skips", "hash", {}, status.HTTP_201_CREATED, None),
+            ("changed_content_rejects", "different_hash", {}, status.HTTP_400_BAD_REQUEST, "release_id_mismatch"),
+            (
+                "changed_content_skip_release_flag",
+                "different_hash",
+                {"skip_release_on_conflict": True, "skip_on_conflict": True},
+                status.HTTP_201_CREATED,
+                None,
+            ),
+        ]
+    )
+    def test_bulk_start_upload_handles_release_change(
+        self,
+        _name: str,
+        upload_content_hash: str,
+        request_flags: dict[str, bool],
+        expected_status: int,
+        expected_code: str | None,
+    ) -> None:
         chunk_id = str(uuid7())
 
         first_release = ErrorTrackingRelease.objects.create(
@@ -1065,17 +1085,82 @@ class TestErrorTracking(APIBaseTest):
                     {
                         "chunk_id": chunk_id,
                         "release_id": str(second_release.id),
-                        "content_hash": symbol_set.content_hash,
+                        "content_hash": upload_content_hash,
                     }
-                ]
+                ],
+                **request_flags,
             },
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == expected_status
+        if expected_code:
+            assert response.json()["code"] == expected_code
+        else:
+            # The conflicting chunk is skipped, not re-uploaded or re-associated
+            assert chunk_id not in response.json()["id_map"]
 
         symbol_set.refresh_from_db()
         assert symbol_set.release_id == first_release.id
+        assert symbol_set.content_hash == "hash"
+        assert symbol_set.storage_ptr == "stored"
+
+    def test_bulk_start_upload_release_conflict_does_not_poison_batch(self) -> None:
+        conflicting_chunk_id = str(uuid7())
+        new_chunk_id = str(uuid7())
+
+        first_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="first-release",
+            version="1.0.0",
+            project="test",
+        )
+        second_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="second-release",
+            version="1.0.1",
+            project="test",
+        )
+
+        ErrorTrackingSymbolSet.objects.create(
+            team=self.team,
+            ref=conflicting_chunk_id,
+            storage_ptr="stored",
+            content_hash="hash",
+            release=first_release,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
+            data={
+                "symbol_sets": [
+                    {
+                        "chunk_id": conflicting_chunk_id,
+                        "release_id": str(second_release.id),
+                        "content_hash": "different_hash",
+                    },
+                    {
+                        "chunk_id": new_chunk_id,
+                        "release_id": str(second_release.id),
+                        "content_hash": "new_hash",
+                    },
+                ],
+                "skip_release_on_conflict": True,
+                "skip_on_conflict": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        id_map = response.json()["id_map"]
+        assert conflicting_chunk_id not in id_map
+        assert new_chunk_id in id_map
+
+        conflicting = ErrorTrackingSymbolSet.objects.get(ref=conflicting_chunk_id)
+        assert conflicting.release_id == first_release.id
+
+        created = ErrorTrackingSymbolSet.objects.get(ref=new_chunk_id)
+        assert created.release_id == second_release.id
 
     @patch("posthog.storage.object_storage.head_object")
     def test_can_finish_bulk_symbol_set_upload(self, patched_object_storage) -> None:

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -1724,6 +1724,8 @@ export interface ErrorTrackingSymbolSetBulkStartUploadApi {
     force?: boolean
     /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
     skip_on_conflict?: boolean
+    /** Whether to keep an uploaded symbol set's existing release association instead of failing when a different release ID is provided. Symbol sets are never moved between releases. */
+    skip_release_on_conflict?: boolean
 }
 
 export type ErrorTrackingAssignmentRulesListParams = {

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -1042,6 +1042,7 @@ export const ErrorTrackingSymbolSetsBulkFinishUploadCreateBody = /* @__PURE__ */
 
 export const errorTrackingSymbolSetsBulkStartUploadCreateBodyForceDefault = false
 export const errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault = false
+export const errorTrackingSymbolSetsBulkStartUploadCreateBodySkipReleaseOnConflictDefault = false
 
 export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ zod.object({
     chunk_ids: zod
@@ -1073,4 +1074,10 @@ export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ 
         .boolean()
         .default(errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault)
         .describe('Whether to skip uploaded symbol sets whose content hash changed instead of failing.'),
+    skip_release_on_conflict: zod
+        .boolean()
+        .default(errorTrackingSymbolSetsBulkStartUploadCreateBodySkipReleaseOnConflictDefault)
+        .describe(
+            "Whether to keep an uploaded symbol set's existing release association instead of failing when a different release ID is provided. Symbol sets are never moved between releases."
+        ),
 })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20413,6 +20413,8 @@ export namespace Schemas {
       force?: boolean;
       /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
       skip_on_conflict?: boolean;
+      /** Whether to keep an uploaded symbol set's existing release association instead of failing when a different release ID is provided. Symbol sets are never moved between releases. */
+      skip_release_on_conflict?: boolean;
     }
 
     export interface ErrorTrackingSymbolSetFinishUpload {


### PR DESCRIPTION
## Problem

The `bulk_start_upload` symbol set endpoint rejects the whole batch with `release_id_mismatch` whenever a chunk's ref already exists under a different release, even when the uploaded content is byte-identical. This is a common CI pattern: native debug IDs are content-derived and stable across rebuilds, so re-uploading an unchanged artifact from a new commit (= new release) hits the guard on every run.

The failure mode is worse than a noisy 400:

- The CLI's default `--skip-release-on-fail` fallback retries the entire batch with release IDs stripped, so one stale chunk silently costs the release association of every genuinely new chunk in the batch (up to 50).
- The endpoint's `@posthoganalytics.scoped()` decorator captures these expected contract rejections as `$exception` events, generating a steady stream of noise in our own [error tracking](https://us.posthog.com/project/2/error_tracking/019ef3e1-b651-7a70-9d25-5f895ade8a96) - and the issue gets re-fingerprinted into a fresh one every time this file moves (it has three siblings dating back to October 2025).

## Changes

All backward compatible - old CLIs send no new fields and get identical request handling, and the response contract (absent from `id_map` = skipped) is unchanged.

- **Identical-content release conflicts are skipped instead of failing.** When the uploaded `content_hash` matches the stored one, the existing release association is kept, a `symbol_set_release_conflict_skipped` warning is logged, and the batch continues. End state is exactly what the CLI's strip-and-retry fallback converged to anyway, minus the extra round trips. Symbol sets are still never moved between releases.
- **New opt-in `skip_release_on_conflict` request flag** extends the same keep-existing behavior to changed-content conflicts, resolving release conflicts per chunk instead of failing the batch. A follow-up CLI PR will send it; old servers ignore the unknown field so the CLI keeps its existing fallback for them.
- **Expected `ValidationError`s are no longer captured as exceptions.** The scoped context now has `capture_exceptions=False`; contract rejections emit an `error_tracking_symbol_set_upload_rejected` analytics event with the failure code, and unexpected exceptions are still captured explicitly.
- Regenerated OpenAPI types (`api.schemas.ts`, `api.zod.ts`, MCP `generated.ts`) - diff is purely the new optional field.

## How did you test this code?

Automated tests only, no manual testing:

- Rewrote `test_bulk_start_upload_rejects_release_change` into a parameterized `test_bulk_start_upload_handles_release_change`: identical content now skips (catches a revert of the reordering), changed content still 400s (catches the skip logic swallowing genuine conflicts), and the new flag + `skip_on_conflict` succeeds - all asserting the stored release, content hash, and storage pointer never change.
- Added `test_bulk_start_upload_release_conflict_does_not_poison_batch`: a conflicting chunk and a fresh chunk in one batch with the flag on - the fresh chunk must be created with the new release. Catches both a batch-poisoning regression and broken view→facade→logic plumbing of the flag. No existing test covered a mixed batch.
- Ran the full bulk upload suite in `test_error_tracking_api.py` (17 tests) locally - all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference these endpoint flags today.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). The work started as a root-cause investigation of the error tracking issue linked above: querying our own error data showed the exception stream dates back to October 2025 and only looked new because two refactors re-fingerprinted it, with volume driven by recurring CI uploads of unchanged artifacts under new releases.
- Skills invoked: `/error-tracking`, `/improving-drf-endpoints`, `/writing-tests`, `posthog:investigating-error-issue`.
- Decisions: kept the identical-content skip unconditional (rather than gated behind the new flag) because the end state matches what the default CLI fallback already produces; chose a new analytics event name over reusing `error_tracking_symbol_set_uploaded` to avoid distorting existing success-rate metrics; left the CLI changes (send the flag, stop retrying deterministic 4xx) for a follow-up PR so old servers keep working with new CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)