### PR TITLE
fix(ci): rebalance frontend jest into 6 shards to beat the 15-min timeout

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -625,7 +625,7 @@ jobs:
             # or skip jest entirely (should_run=false) when selection can't be
             # trusted. On ready PRs, master push, and merge_group it's skipped, so
             # we fall back to the full FOSS×EE × chunk fanout (the merge gate).
-            matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2,3,4]}') }}
+            matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2,3,4,5,6]}') }}
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -645,8 +645,9 @@ jobs:
                   SHARD_INDEX: ${{ matrix.chunk }}
                   # Keep shard runtime well under timeout-minutes: the EE suite at 2
                   # shards ran 13-15 min on the 2-worker config and regularly died at
-                  # the 15-min timeout, failing the whole run.
-                  SHARD_COUNT: 4
+                  # the 15-min timeout, failing the whole run. The suite has since grown
+                  # back to ~15 min at 4 shards (chunk 1 timing out), so bump to 6.
+                  SHARD_COUNT: 6
                   MODE: ${{ needs.select-jest-tests.outputs.mode }}
                   CHANGED_FILES: ${{ needs.select-jest-tests.outputs.changed_files }}
                   JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results


### PR DESCRIPTION
## Problem

The required `Frontend Tests Pass` check has been red on master and every PR since ~2026-07-05 16:37. Root cause: the frontend jest suite grew back to ~15 min per shard at 4 shards, so **chunk 1** (`Jest test (FOSS - 1)` and `(EE - 1)`) dies at the 15-min job `timeout-minutes` mid-run and fails the whole matrix. Chunks 2/3/4 finish fine. On a passing run the day before, chunk 1 ran ~5 min; it's now consistently >15 min.

This is the same failure mode the existing code comment describes from the 2-shard era ("regularly died at the 15-min timeout"), which was fixed by going 2 → 4. The suite has grown, so it needs 4 → 6.

## Changes

- `SHARD_COUNT: 4 → 6` and the fallback matrix `chunk: [1,2,3,4] → [1,2,3,4,5,6]` in `ci-frontend.yml`.
- Each shard now runs ~2/3 of its previous load (~10 min), comfortably under the 15-min timeout.

Nothing else hardcodes the shard count: the `Frontend Tests Pass` gate reads the single aggregated `needs.jest.result`, and junit uploads glob `junit-<segment>-*.xml`, so both handle 6 chunks automatically. Backwards compatible: unrebased PRs keep running 4 shards (no worse than today) until they rebase.

## How did you test this code?

This PR is labelled `run-ci-frontend` so its own run executes the full 6-shard matrix and self-validates: chunk 1 should now finish well under 15 min. I (Claude) confirmed the local TaxonomicFilter suite (a heavy contributor) passes — the tests aren't broken, the shard was just over budget — so redistributing is the correct fix, not masking a failure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) opened this while getting an unrelated notebooks PR (#68282) green. That PR's only red check was `Frontend Tests Pass`, which I traced to this master-wide chunk-1 timeout rather than anything in the PR. Diagnosis: compared jest-step durations across runs (chunk 1: ~5 min on 2026-07-05 12:41 → >15 min timeout since ~16:37), confirmed it reproduces on master itself and on a one-line-change PR, and matched it to the existing shard-count remedy. Chose 6 shards (mirroring the prior 2→4 fix) over a blind `timeout-minutes` bump because more shards addresses the cause and keeps per-shard runtime low without masking growth. Flagging for the frontend/infra owners in case a different split or a slow-test cleanup is preferred.
