### PR TITLE
fix(cli): resolve symbol set release conflicts per chunk

### DIFF
--- a/cli/.sampo/changesets/symbol-set-release-conflict-handling.md
+++ b/cli/.sampo/changesets/symbol-set-release-conflict-handling.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Symbol set uploads now ask the server to resolve release conflicts per chunk (`skip_release_on_conflict`) when `--skip-release-on-fail` is enabled (the default), so one already-uploaded chunk no longer strips the release association from every other chunk in the batch. Against older servers the previous behavior is unchanged: the whole upload is retried without release IDs, and the warning now says how many symbol sets lose their release association. Deterministic API rejections (4xx other than 408/429) are no longer retried three times before failing.

--- a/cli/src/api/client.rs
+++ b/cli/src/api/client.rs
@@ -52,6 +52,25 @@ mod tests {
 
         assert!(error.has_api_error_code("release_id_mismatch"));
     }
+
+    #[test]
+    fn deterministic_client_errors_are_not_retryable() {
+        let status_error = |status: u16| {
+            ClientError::ApiError(
+                status,
+                Box::new(Url::parse("https://example.com/api/test").unwrap()),
+                String::new(),
+            )
+        };
+
+        assert!(!status_error(400).is_retryable());
+        assert!(!status_error(403).is_retryable());
+        assert!(status_error(408).is_retryable());
+        assert!(status_error(429).is_retryable());
+        assert!(status_error(500).is_retryable());
+        assert!(status_error(503).is_retryable());
+        assert!(!ClientError::InvalidUrl("nope".to_string()).is_retryable());
+    }
 }
 
 #[derive(Error, Debug)]
@@ -99,6 +118,18 @@ impl ClientError {
 
         api_error_code(body).is_some_and(|code| code == expected_code)
             || body.contains(expected_code)
+    }
+
+    /// Whether a retry could plausibly succeed. Deterministic client errors
+    /// (4xx other than 408/429) and unbuildable URLs never will.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            ClientError::RequestError(_) => true,
+            ClientError::ApiError(status, _, _) => {
+                *status >= 500 || *status == 408 || *status == 429
+            }
+            ClientError::InvalidUrl(_) => false,
+        }
     }
 }
 

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use crate::{
+    api::client::ClientError,
     invocation_context::context,
     utils::{files::content_hash, raise_for_err},
 };
@@ -51,6 +52,12 @@ struct BulkUploadStartRequest {
     /// When true, allow overwriting symbol sets whose content has changed.
     #[serde(default)]
     force: bool,
+    /// When true, keep an existing symbol set's release association instead of
+    /// failing with release_id_mismatch when a different release ID is provided.
+    /// Older servers ignore this field, so the client-side release fallback in
+    /// `upload_with_retry` still applies for them.
+    #[serde(default)]
+    skip_release_on_conflict: bool,
     /// When true, skip symbol sets whose content changed instead of failing.
     #[serde(default)]
     skip_on_conflict: bool,
@@ -67,8 +74,10 @@ struct BulkUploadFinishRequest {
 }
 
 /// Upload symbol sets with optional retry on release_id_mismatch error.
-/// If `skip_release_on_fail` is true and the server returns a release_id_mismatch error,
-/// the upload will be retried without release IDs.
+/// If `skip_release_on_fail` is true, the server is asked to keep the existing release
+/// association of conflicting symbol sets (skip_release_on_conflict) so the rest of the
+/// batch keeps its release; older servers ignore that field and may still return a
+/// release_id_mismatch error, in which case the upload is retried without release IDs.
 /// If `force` is true, symbol sets whose content has changed are overwritten rather than skipped.
 /// If `skip_on_conflict` is true, symbol sets whose content has changed are skipped rather than failing.
 pub fn upload_with_retry(
@@ -78,11 +87,23 @@ pub fn upload_with_retry(
     force: bool,
     skip_on_conflict: bool,
 ) -> Result<()> {
-    let res = upload_inner(&input_sets, batch_size, force, skip_on_conflict);
+    let res = upload_inner(
+        &input_sets,
+        batch_size,
+        force,
+        skip_on_conflict,
+        skip_release_on_fail,
+    );
     match res {
         Ok(()) => Ok(()),
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
-            warn!("Release ID mismatch detected. Retrying upload without release IDs...");
+            let with_release = input_sets.iter().filter(|s| s.release_id.is_some()).count();
+            warn!(
+                "Release ID mismatch: at least one symbol set already belongs to a different release. \
+                 Retrying the upload without release IDs - {with_release} symbol set(s) will not be \
+                 associated with this release. This usually means unchanged artifacts were rebuilt \
+                 under a new release."
+            );
             let sets_without_release: Vec<_> = input_sets
                 .into_iter()
                 .map(|s| SymbolSetUpload {
@@ -91,8 +112,14 @@ pub fn upload_with_retry(
                     data: s.data,
                 })
                 .collect();
-            upload_inner(&sets_without_release, batch_size, force, skip_on_conflict)
-                .map_err(|e| e.into())
+            upload_inner(
+                &sets_without_release,
+                batch_size,
+                force,
+                skip_on_conflict,
+                skip_release_on_fail,
+            )
+            .map_err(|e| e.into())
         }
         Err(e) => Err(e.into()),
     }
@@ -103,6 +130,7 @@ fn upload_inner(
     batch_size: usize,
     force: bool,
     skip_on_conflict: bool,
+    skip_release_on_conflict: bool,
 ) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
@@ -119,7 +147,8 @@ fn upload_inner(
 
     for (i, batch) in upload_requests.chunks(batch_size).enumerate() {
         info!("Starting upload of batch {i}, {} symbol sets", batch.len());
-        let start_response = start_upload(batch, force, skip_on_conflict)?;
+        let start_response =
+            start_upload(batch, force, skip_on_conflict, skip_release_on_conflict)?;
 
         let id_map: HashMap<_, _> = batch.iter().map(|u| (u.chunk_id.as_str(), u)).collect();
 
@@ -156,6 +185,7 @@ fn start_upload(
     symbol_sets: &[&SymbolSetUpload],
     force: bool,
     skip_on_conflict: bool,
+    skip_release_on_conflict: bool,
 ) -> Result<BulkUploadStartResponse, UploadError> {
     let client = &context().client;
 
@@ -165,15 +195,20 @@ fn start_upload(
             .map(|s| CreateSymbolSetRequest::new(s))
             .collect(),
         force,
+        skip_release_on_conflict,
         skip_on_conflict,
     };
 
-    let res = retry(retry_policy(500, 2, 3), |_| {
-        client.send_post(
-            client.project_url("error_tracking/symbol_sets/bulk_start_upload")?,
-            |req| req.json(&request),
-        )
-    });
+    let res = retry_if(
+        retry_policy(500, 2, 3),
+        |_| {
+            client.send_post(
+                client.project_url("error_tracking/symbol_sets/bulk_start_upload")?,
+                |req| req.json(&request),
+            )
+        },
+        ClientError::is_retryable,
+    );
 
     match res {
         Ok(response) => Ok(response
@@ -215,12 +250,16 @@ fn finish_upload(content_hashes: HashMap<String, String>) -> Result<(), UploadEr
     let client = &context().client;
     let request = BulkUploadFinishRequest { content_hashes };
 
-    retry(retry_policy(500, 2, 3), |_| {
-        client.send_post(
-            client.project_url("error_tracking/symbol_sets/bulk_finish_upload")?,
-            |req| req.json(&request),
-        )
-    })
+    retry_if(
+        retry_policy(500, 2, 3),
+        |_| {
+            client.send_post(
+                client.project_url("error_tracking/symbol_sets/bulk_finish_upload")?,
+                |req| req.json(&request),
+            )
+        },
+        ClientError::is_retryable,
+    )
     .map_err(|e| UploadError::Other(anyhow::anyhow!(e).context(FINISH_UPLOAD_ERROR_MESSAGE)))?;
 
     Ok(())
@@ -341,11 +380,21 @@ fn retry_policy(duration: u64, factor: u64, max_attempts: usize) -> impl Iterato
         .take(max_attempts)
 }
 
-fn retry<I, F, E, R>(iterable: I, mut func: F) -> Result<R, E>
+fn retry<I, F, E, R>(iterable: I, func: F) -> Result<R, E>
 where
     I: Iterator<Item = Duration>,
     F: FnMut(usize) -> Result<R, E>,
     E: Debug,
+{
+    retry_if(iterable, func, |_| true)
+}
+
+fn retry_if<I, F, E, R, P>(iterable: I, mut func: F, should_retry: P) -> Result<R, E>
+where
+    I: Iterator<Item = Duration>,
+    F: FnMut(usize) -> Result<R, E>,
+    E: Debug,
+    P: Fn(&E) -> bool,
 {
     let mut attempt = 0;
     let mut last_error: Option<E> = None;
@@ -354,9 +403,16 @@ where
         match func(attempt) {
             Ok(res) => return Ok(res),
             Err(e) => {
+                let retryable = should_retry(&e);
                 last_error = Some(e);
                 attempt += 1;
                 warn!("Operation failed: {last_error:?}");
+                if !retryable {
+                    // Deterministic failures (e.g. 4xx API rejections) will never
+                    // succeed on retry - fail fast instead of sleeping through the
+                    // remaining attempts.
+                    break;
+                }
                 if delays.peek().is_some() {
                     warn!("Retrying in {delay:?}, attempt {attempt}");
                     sleep(delay);
@@ -421,6 +477,22 @@ mod tests {
 
         let captured = messages.lock().unwrap().clone();
         captured
+    }
+
+    #[test]
+    fn retry_if_stops_after_first_non_retryable_error() {
+        let mut attempts = 0;
+        let result: Result<(), &str> = retry_if(
+            vec![Duration::ZERO, Duration::ZERO, Duration::ZERO].into_iter(),
+            |_| {
+                attempts += 1;
+                Err("bad request")
+            },
+            |_| false,
+        );
+
+        assert_eq!(result.unwrap_err(), "bad request");
+        assert_eq!(attempts, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a symbol set ref already exists on the server under a different release (common in CI: native debug IDs are content-derived and stable across rebuilds, and the CLI creates a new release per commit), the server rejects the whole batch with `release_id_mismatch`. The CLI's default `--skip-release-on-fail` fallback then retries the **entire batch** with release IDs stripped, so one stale chunk silently costs the release association of every genuinely new chunk in the upload.

Two smaller issues compound it:

- The request retry helper retries **any** error, including deterministic 400s that can never succeed - each conflicting CI run sends the rejected request 3 times, sleeping ~1.5s in between.
- The fallback warning doesn't tell users what they're losing or why.

Server-side counterpart: #68518 (adds the `skip_release_on_conflict` endpoint flag and skips identical-content conflicts server-side).

## Changes

All backward compatible in both directions - the CLI flag defaults are unchanged, and the new request field is ignored by older servers (including self-hosted), for which the existing strip-and-retry fallback is kept as a last resort.

- **Send `skip_release_on_conflict` on bulk uploads** whenever `--skip-release-on-fail` is enabled (the default). Servers that support it keep the conflicting chunk's existing release association and continue, so the rest of the batch keeps its release. Older servers ignore the unknown field and may still return `release_id_mismatch`, which triggers the legacy fallback exactly as before.
- **Stop retrying deterministic API rejections.** New `retry_if` variant of the retry helper takes a retryability predicate; `ClientError::is_retryable` classifies network errors, 5xx, 408, and 429 as retryable and other 4xx as terminal. Applied to `bulk_start_upload` and `bulk_finish_upload` calls; the S3 upload path keeps blind retries since its errors aren't classified.
- **Louder fallback warning**: states how many symbol sets will lose their release association and the usual cause (unchanged artifacts rebuilt under a new release).
- Added a sampo changeset (patch bump).

## How did you test this code?

Automated tests only, no manual testing:

- `retry_if_stops_after_first_non_retryable_error` (in `symbol_sets.rs`): a non-retryable error must produce exactly one attempt - catches a revert to blind retrying.
- `deterministic_client_errors_are_not_retryable` (in `client.rs`): table test over 400/403/408/429/500/503/invalid-URL encoding the contract that only transient failures retry - catches a misclassification that would either re-hammer 400s or stop retrying 5xx.
- Full `cargo test` for the CLI crate passes (131 tests), plus `cargo fmt` and `cargo clippy --all-targets` clean.
- No existing test covered the retry helper's error classification; the wire-level effect of the new request field is exercised end to end by the server-side tests in #68518.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the CLI's conflict-handling internals; `--skip-release-on-fail` semantics are unchanged from the user's perspective.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), as the CLI half of the investigation and fix that produced #68518 - see that PR for the full root-cause analysis of the `release_id_mismatch` noise.
- Decisions: mapped the existing `--skip-release-on-fail` flag onto the new server field instead of adding a new CLI flag, since it expresses the same intent and keeps CI configs untouched; kept the strip-all fallback (rather than parsing conflicting refs out of error details) because old servers only name the first conflicting ref, making targeted retry unreliable; left S3 upload retries blind because those errors are anyhow-wrapped and presigned-POST failures are usually transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)