### PR TITLE
fix(ci): run frontend checks on snapshot-only bot pushes

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -34,9 +34,9 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run frontend checks
         # A snapshot-only bot push (Visual Review auto-commits frontend/snapshots.yml after
-        # approval) skips only the visual regression suites (ci-storybook, ci-e2e-playwright),
-        # not these checks. Jest, TypeScript, format, and bundle-size don't depend on the
-        # baseline and still gate merge, so they run purely off the paths filter here.
+        # approval) skips ci-storybook and ci-e2e-playwright (the snapshot-baseline-dependent
+        # suites), not these checks. Jest, TypeScript, format, and bundle-size don't depend on
+        # the baseline and still gate merge, so they run purely off the paths filter here.
         outputs:
             # AND the broad filter with `exclude` (below): a PR that touches only
             # Node-only product workspaces (their own ci-agents.yml suite, no stories,

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -33,11 +33,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run frontend checks
-        # Skip when a bot's push adds only snapshot baselines — Visual Review auto-commits
-        # frontend/snapshots.yml after human review and CI approval, so re-running the suite
-        # on that commit is pure waste. The detect step keys off the push delta (this push's
-        # commits), not the whole-PR diff dorny reports, so it fires even when the PR also
-        # carries real code changes. The aggregator (frontend_tests) treats skips as success.
+        # A snapshot-only bot push (Visual Review auto-commits frontend/snapshots.yml after
+        # approval) skips only the visual regression suites (ci-storybook, ci-e2e-playwright),
+        # not these checks. Jest, TypeScript, format, and bundle-size don't depend on the
+        # baseline and still gate merge, so they run purely off the paths filter here.
         outputs:
             # AND the broad filter with `exclude` (below): a PR that touches only
             # Node-only product workspaces (their own ci-agents.yml suite, no stories,
@@ -45,15 +44,12 @@ jobs:
             # derived from pnpm-workspace.yaml, not hardcoded — see the exclude step.
             frontend: >-
                 ${{ (steps.filter.outputs.frontend || 'true') == 'true'
-                    && (steps.exclude.outputs.outside_node_product_workspaces || 'true') == 'true'
-                    && steps.baseline_push.outputs.result != 'true' }}
+                    && (steps.exclude.outputs.outside_node_product_workspaces || 'true') == 'true' }}
             frontend_code: >-
                 ${{ (steps.filter.outputs.frontend_code || 'true') == 'true'
-                    && (steps.exclude.outputs.outside_node_product_workspaces || 'true') == 'true'
-                    && steps.baseline_push.outputs.result != 'true' }}
+                    && (steps.exclude.outputs.outside_node_product_workspaces || 'true') == 'true' }}
             replay_shared: >-
-                ${{ (steps.filter.outputs.replay_shared || 'true') == 'true'
-                    && steps.baseline_push.outputs.result != 'true' }}
+                ${{ (steps.filter.outputs.replay_shared || 'true') == 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -138,36 +134,6 @@ jobs:
                         - pnpm-lock.yaml
                         - .nvmrc
                         - .github/workflows/ci-frontend.yml
-
-            - name: Detect Visual Review baseline-only push
-              id: baseline_push
-              if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  REPO: ${{ github.repository }}
-                  ACTOR: ${{ github.actor }}
-                  BEFORE: ${{ github.event.before }}
-                  AFTER: ${{ github.event.after }}
-              run: |
-                  set -euo pipefail
-                  result=false
-                  # Visual Review commits the approved baseline as a bot (a [bot] app or posthog-bot).
-                  case "$ACTOR" in
-                      *'[bot]' | posthog-bot) is_bot=true ;;
-                      *) is_bot=false ;;
-                  esac
-                  zero=0000000000000000000000000000000000000000
-                  if [ "$is_bot" = true ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$zero" ] && [ -n "$AFTER" ]; then
-                      # Diff only the commits this push added. compare uses merge-base(before, after),
-                      # which for an appended commit is exactly the push delta; a force-push/rebase
-                      # widens it and won't match. dorny above already covers the whole-PR diff.
-                      files=$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" --jq '.files[].filename' || true)
-                      if [ -n "$files" ] && ! grep -qvE '^(frontend|playwright)/snapshots\.yml$' <<<"$files"; then
-                          result=true
-                      fi
-                  fi
-                  echo "result=$result" >>"$GITHUB_OUTPUT"
-                  echo "Visual Review baseline-only push: $result"
 
             # The broad `products/**/*.ts(x)` rules above correctly match all product
             # frontend code (which doesn't always live under frontend/ — see


### PR DESCRIPTION
## Problem

Snapshot-only bot pushes were skipping every frontend check, not just visual regression. When Visual Review approves a baseline and appends a `frontend/snapshots.yml` commit to a PR, the `synchronize` event fires as a bot with a snapshot-only push delta. `ci-frontend.yml` treated that as a reason to skip its whole suite, so a real frontend-only PR could merge with jest, TypeScript, format, and bundle-size never having run on the head commit. That is how a frontend-only change sailed through with all frontend checking skipped.

The skip only belongs on the visual regression workflows. jest, TypeScript, format, and bundle-size don't depend on the snapshot baseline, and they gate merge, so they should always run.

## Changes

Removed the "Detect Visual Review baseline-only push" step and its gating from `ci-frontend.yml`. Its `frontend` / `frontend_code` outputs now come purely from the paths filter (plus the existing node-workspace exclusion). A genuinely snapshot-only PR still won't spin up code jobs it doesn't need, because the paths filter drives that.

The two visual regression workflows (`ci-storybook.yml`, `ci-e2e-playwright.yml`) keep their baseline-only skip. So the net behavior is exactly the rule we want: a snapshot-only push skips visual regression, but still runs everything else.

## How did you test this code?

This is a CI workflow change, so I (the PostHog Slack app) validated it by inspection rather than a live run. I confirmed `ci-frontend.yml` contains no visual regression jobs (only jest, select-jest-tests, frontend-format, frontend-bundle-size, frontend-typescript-checks), and that after the edit there are no dangling references to `baseline_push`. The real signal is the next Visual Review baseline push on a PR: the frontend checks should now run instead of being skipped.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul asked (in a Slack thread, after his frontend-only PR merged to master with all frontend checks skipped) to make snapshot-only pushes skip only the visual regression tests while still running the rest. I (the PostHog Slack app) traced the skip chain across the three CI workflows: all three share the same baseline-only detection, but only two of them actually run visual regression. The fix is to drop the detection from the odd one out (`ci-frontend.yml`) rather than trying to make the detection smarter. Considered narrowing the detection to inspect the whole-PR diff instead of the push delta, but that wouldn't fix the core mismatch: this workflow has nothing to skip in the first place. No skills were needed for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1783326087362319?thread_ts=1783326087.362319&cid=C09ADEV3AJD)*
