### PR TITLE
fix(agent-platform): de-flake queued-followups SSE user_message test

### DIFF
--- a/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
@@ -150,10 +150,19 @@ describe('queued follow-ups: real e2e', () => {
         await c.drain()
         await sendDone!
         await c.drain()
-        unsubscribe()
 
-        const userMessageEvts = events.filter((e) => e.kind === 'user_message')
-        expect(userMessageEvts.map((e) => e.data.text)).toEqual(['follow'])
+        // `emit('user_message')` only awaits the Redis PUBLISH; delivery to the
+        // bus's separate subscriber connection and this listener is async and
+        // not awaited by drain(). Asserting synchronously here races that
+        // delivery and flakes on contended runners. Wait for the event to land.
+        await vi.waitFor(
+            () => {
+                const texts = events.filter((e) => e.kind === 'user_message').map((e) => e.data.text)
+                expect(texts).toEqual(['follow'])
+            },
+            { timeout: 5_000, interval: 25 }
+        )
+        unsubscribe()
     })
 
     it('a /send BEFORE the worker dequeues is durable (lands in conversation, not lost)', async () => {

--- a/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
@@ -151,10 +151,6 @@ describe('queued follow-ups: real e2e', () => {
         await sendDone!
         await c.drain()
 
-        // `emit('user_message')` only awaits the Redis PUBLISH; delivery to the
-        // bus's separate subscriber connection and this listener is async and
-        // not awaited by drain(). Asserting synchronously here races that
-        // delivery and flakes on contended runners. Wait for the event to land.
         await vi.waitFor(
             () => {
                 const texts = events.filter((e) => e.kind === 'user_message').map((e) => e.data.text)


### PR DESCRIPTION
## Problem

The `agent-tests` e2e job flakes on `queued-followups.test.ts > emits user_message via SSE when a mid-turn /send is drained at the next turn`, failing with `expected [] to deeply equal [ 'follow' ]`. Reported from [this run](https://github.com/PostHog/posthog/actions/runs/28780717330/job/85335506724?pr=67917).

## Changes

Root cause is a delivery race in the test, not the product. The runner's `emit('user_message', ...)` awaits only the Redis `PUBLISH`. Delivery to the bus's *separate* subscriber connection and the local listener callback is asynchronous and is not awaited by `c.drain()`. The test asserted on the captured events synchronously right after `drain()` returned, so on a contended runner the message hadn't been dispatched to the listener yet and the array was still empty.

The fix waits for the specific condition (the `user_message` event landing) with `vi.waitFor` instead of asserting synchronously. The assertion stays strict (`toEqual(['follow'])`), so a genuine regression where the event never fires still fails, just after delivery has had a fair chance rather than in a fixed instant.

No sleeps, no loosened assertions, no timeout bumps on the product side. The production bus deliberately tolerates this publish/deliver lag (it is best-effort live transport), so the synchronization belongs in the test.

The sibling `listen-sse.test.ts` cases share the same subscribe → drain → assert shape and the same latent race, but haven't been observed flaking. Left as a follow-up rather than folded in here to keep the change focused.

## How did you test this code?

The e2e harness needs real Postgres, Redis, Kafka and SeaweedFS, none of which were available in the agent environment, so I (Claude, via the PostHog Slack app) could not run it here. Validation is analytical: traced the failure to the unawaited pub/sub delivery in `agent-shared/src/runtime/bus.ts` (`subscribe` fire-and-forgets `ensureSubscribed`; `publish` returns on PUBLISH accept) against the emit site in `agent-runner/src/loop/driver.ts`. The `vi.waitFor` change makes the assertion wait for delivery rather than race it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie asked the PostHog Slack app to fix this flaky test. I invoked the `/fixing-flaky-tests` skill, pulled the failing job log to get the exact test id and assertion, then read the bus and runner code to establish the root cause (async pub/sub delivery unawaited by `drain()`). I chose `vi.waitFor` on the exact event condition over any masking move (sleep, retry, loosened assert). Local N-run validation wasn't possible without the backing services, so validation here is analytical and noted as such above.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1783330870518689?thread_ts=1783330870.518689&cid=C09ADEV3AJD)*
