### PR TITLE
fix(agent-platform): stop flaky queued-followup SSE test racing subscribe

### DIFF
--- a/products/agent_platform/services/agent-shared/src/runtime/bus.test.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/bus.test.ts
@@ -78,6 +78,34 @@ maybeDescribe('RedisSessionEventBus', () => {
         await sub.disconnect()
     })
 
+    it('whenSubscribed() resolves only once the channel is live — no sleep needed before publish', async () => {
+        if (!reachable) {
+            return
+        }
+        // The other cases sleep 50ms after subscribe() to let the fire-and-forget
+        // SUBSCRIBE ACK land. whenSubscribed() replaces that race with a deterministic
+        // wait: awaiting it, then publishing immediately (no sleep), still delivers.
+        const prefix = `test_ready_${Date.now()}`
+        const pub = new RedisSessionEventBus({ url: REDIS_URL, channelPrefix: prefix })
+        const sub = new RedisSessionEventBus({ url: REDIS_URL, channelPrefix: prefix })
+        await pub.connect()
+        await sub.connect()
+
+        const received: SessionEvent[] = []
+        sub.subscribe('r1', (e) => received.push(e))
+        await sub.whenSubscribed('r1')
+
+        await pub.publish(mkEvent('r1', 'completed'))
+        // Only the broker round-trip needs a beat now; the SUBSCRIBE is already ACKed.
+        await new Promise((r) => setTimeout(r, 50))
+
+        expect(received).toHaveLength(1)
+        expect(received[0]).toMatchObject({ session_id: 'r1', kind: 'completed' })
+
+        await pub.disconnect()
+        await sub.disconnect()
+    })
+
     it('does not deliver events for other session ids', async () => {
         if (!reachable) {
             return

--- a/products/agent_platform/services/agent-shared/src/runtime/bus.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/bus.ts
@@ -272,6 +272,13 @@ export class RedisSessionEventBus implements SessionEventBus {
      * — it's a readiness probe for deterministic tests, not a prod concern.
      */
     async whenSubscribed(sessionId: string): Promise<void> {
+        // Guard the precondition: without a registered listener the message
+        // handler has no `subs` entry to dispatch to, so it would silently
+        // drop every event while this still resolves "channel live" — the
+        // exact symptom we're guarding against. Fail loudly instead.
+        if (!this.subs.has(sessionId)) {
+            throw new Error(`whenSubscribed('${sessionId}') called before subscribe() — register a listener first`)
+        }
         await this.ensureSubscribed(sessionId)
     }
 

--- a/products/agent_platform/services/agent-shared/src/runtime/bus.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/bus.ts
@@ -261,6 +261,20 @@ export class RedisSessionEventBus implements SessionEventBus {
         }
     }
 
+    /**
+     * Resolves once the Redis SUBSCRIBE for this session's channel has been
+     * ACKed. `subscribe()` is deliberately fire-and-forget — prod tolerates
+     * missing the at-most-one event published before the ACK, because a
+     * long-lived /listen connection attaches before the turn begins. Tests
+     * that assert on a *specific* published event have no such slack: they
+     * subscribe and then immediately trigger the publish, so they need the
+     * channel confirmed live first. Kept off the `SessionEventBus` interface
+     * — it's a readiness probe for deterministic tests, not a prod concern.
+     */
+    async whenSubscribed(sessionId: string): Promise<void> {
+        await this.ensureSubscribed(sessionId)
+    }
+
     private async ensureSubscribed(sessionId: string): Promise<void> {
         if (!this.subscriber) {
             await this.connect()

--- a/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/queued-followups.test.ts
@@ -146,6 +146,10 @@ describe('queued follow-ups: real e2e', () => {
 
         const events: SessionEvent[] = []
         const unsubscribe = c.bus.subscribe(sid, (e) => events.push(e))
+        // `subscribe()` fires the Redis SUBSCRIBE off without awaiting it;
+        // wait for the channel to be live before draining, else the
+        // `user_message` published mid-drain races the ACK and gets dropped.
+        await c.bus.whenSubscribed(sid)
 
         await c.drain()
         await sendDone!

--- a/products/agent_platform/services/agent-tests/src/harness/cluster.ts
+++ b/products/agent_platform/services/agent-tests/src/harness/cluster.ts
@@ -28,7 +28,7 @@ import { Express } from 'express'
 import { Pool } from 'pg'
 import request from 'supertest'
 
-import { AuthProvider, buildApp, SessionEventBus } from '@posthog/agent-ingress'
+import { AuthProvider, buildApp } from '@posthog/agent-ingress'
 import { buildJanitorApp } from '@posthog/agent-janitor'
 import { McpTransportFactory, Worker } from '@posthog/agent-runner'
 import type { AnalyticsEvent, IdentityStore, LogEntry } from '@posthog/agent-shared'
@@ -172,7 +172,7 @@ export interface Cluster {
     bundle: S3BundleStore
     /** Per-cluster bucket prefix the bundle store is rooted at. */
     bundlePrefix: string
-    bus: SessionEventBus
+    bus: RedisSessionEventBus
     identities: IdentityStore
     logs: CollectingLogSink
     /** Tapped `$ai_generation` / `$ai_span` / `$ai_trace` the runner emitted, with the resolved per-team key. */
@@ -311,8 +311,7 @@ export async function buildCluster(opts: BuildClusterOpts = {}): Promise<Cluster
     // files don't deliver each other's events. Same impl prod runs; in-memory
     // bus has been removed. Teardown disconnects.
     const busChannelPrefix = `harness_${Math.random().toString(36).slice(2, 10)}`
-    const bus: SessionEventBus & { connect: () => Promise<void>; disconnect: () => Promise<void> } =
-        new RedisSessionEventBus({ url: REDIS_URL, channelPrefix: busChannelPrefix })
+    const bus: RedisSessionEventBus = new RedisSessionEventBus({ url: REDIS_URL, channelPrefix: busChannelPrefix })
     await bus.connect()
     const identities: IdentityStore = new PgIdentityStore(pool)
     // Real KafkaLogSink against the local broker. The tap captures wire


### PR DESCRIPTION
## Problem

The agent-platform e2e case "emits user_message via SSE when a mid-turn /send is drained at the next turn" is flaky. It failed on an unrelated PR's CI run with `expected [] to deeply equal [ 'follow' ]` — zero `user_message` events captured.

Root cause: the test subscribes to the Redis session event bus and then immediately drains. `RedisSessionEventBus.subscribe()` issues the Redis `SUBSCRIBE` fire-and-forget (prod tolerates missing the at-most-one event before the ACK, because a long-lived `/listen` connection attaches before the turn begins). A test has no such slack: it subscribes and then triggers the publish right away, so under CI load the ACK can land after the `user_message` was published and the event is dropped.

## Changes

- Add `whenSubscribed(sessionId)` to `RedisSessionEventBus` — a readiness probe that resolves once the channel's `SUBSCRIBE` is ACKed. Kept off the `SessionEventBus` interface since it's a test concern, not a prod one.
- Await `c.bus.whenSubscribed(sid)` before draining in the flaky case, so the channel is confirmed live before the publish.
- Type the harness `Cluster.bus` as the concrete `RedisSessionEventBus` so tests can reach the probe.
- Add a deterministic unit test in `bus.test.ts` that publishes immediately after `whenSubscribed()` (no sleep) and asserts delivery.

## How did you test this code?

I (Claude, via the PostHog Slack app) ran `tsc --noEmit`, oxlint, and oxfmt on all four changed files — all clean. I could not run the e2e suite or the Redis-backed unit test in this sandbox: it has no Postgres/Redis/Kafka/SeaweedFS, and the bus unit tests skip when Redis is unreachable. They will run in CI, which has the stack.

The new unit test catches a concrete regression: if `whenSubscribed()` stops actually awaiting the SUBSCRIBE ACK, the no-sleep publish races and the assertion fails every run. No existing bus test exercised `whenSubscribed` (the others sleep 50ms after `subscribe()`), and the e2e only caught the race flakily.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie asked the PostHog Slack app (Claude Opus 4.8) to fix a flaky test surfaced on a CI run. I traced the failure to `queued-followups.test.ts` and root-caused it to the fire-and-forget SUBSCRIBE in `RedisSessionEventBus`.

I considered hardening every bus-subscribe test site (listen-sse, log-entries, client-tool) since they share the same latent race, but kept the change scoped to the reported failure plus the reusable `whenSubscribed` mechanism rather than ballooning the diff. Those sites can adopt the probe if they flake.

Invoked the `/writing-tests` skill before adding the unit test to check it earns its place (it locks the readiness contract the flaky-test fix depends on).
