### PR TITLE
feat(managed-migrations): surface in nav tree and cmd+k search

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -312,6 +312,13 @@
         },
         { "path": "Endpoints", "category": "Tools", "iconType": null, "type": null, "intents": [] },
         {
+            "path": "Managed migrations",
+            "category": "Pipeline",
+            "iconType": "data_pipeline_metadata",
+            "type": null,
+            "intents": []
+        },
+        {
             "path": "Event definitions",
             "category": "Schema",
             "iconType": "event_definition",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -2394,6 +2394,14 @@ export const getTreeItemsMetadata = (): FileSystemImport[] => [
         sceneKeys: ['IngestionWarnings'],
     },
     {
+        path: 'Managed migrations',
+        category: 'Pipeline',
+        iconType: 'data_pipeline_metadata',
+        href: urls.managedMigration(),
+        sceneKey: 'ManagedMigration',
+        sceneKeys: ['ManagedMigration', 'ManagedMigrationNew'],
+    },
+    {
         path: 'Managed viewsets',
         category: 'Unreleased',
         iconType: 'managed_viewsets',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -757,7 +757,11 @@ export const productConfiguration: Record<string, any> = {
         activityScope: ActivityScope.LOG,
         layout: 'app-container',
     },
-    ManagedMigration: { name: 'Managed migrations', projectBased: true },
+    ManagedMigration: {
+        name: 'Managed migrations',
+        description: 'Managed migrations provide an automated way to migrate your historical data into PostHog.',
+        projectBased: true,
+    },
     ManagedMigrationNew: { name: 'Managed migrations', projectBased: true },
     MCPAnalytics: {
         projectBased: true,

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -15,7 +15,8 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { SceneExport } from 'scenes/sceneTypes'
+import { sceneConfigurations } from 'scenes/scenes'
+import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -308,6 +309,7 @@ export function ManagedMigrations(): JSX.Element {
                 <>
                     <SceneTitleSection
                         name="Managed migrations"
+                        description={sceneConfigurations[Scene.ManagedMigration].description}
                         resourceType={{
                             type: 'managed_migration',
                             forceIcon: <IconSort />,

--- a/products/managed_migrations/manifest.tsx
+++ b/products/managed_migrations/manifest.tsx
@@ -1,3 +1,5 @@
+import { urls } from 'scenes/urls'
+
 import { ProductManifest } from '../../frontend/src/types'
 
 export const manifest: ProductManifest = {
@@ -22,4 +24,14 @@ export const manifest: ProductManifest = {
         managedMigration: (): string => '/managed_migrations',
         managedMigrationNew: (): string => '/managed_migrations/new',
     },
+    treeItemsMetadata: [
+        {
+            path: 'Managed migrations',
+            category: 'Pipeline',
+            iconType: 'data_pipeline_metadata',
+            href: urls.managedMigration(),
+            sceneKey: 'ManagedMigration',
+            sceneKeys: ['ManagedMigration', 'ManagedMigrationNew'],
+        },
+    ],
 }

--- a/products/managed_migrations/manifest.tsx
+++ b/products/managed_migrations/manifest.tsx
@@ -8,6 +8,7 @@ export const manifest: ProductManifest = {
         ManagedMigration: {
             import: () => import('./frontend/ManagedMigration'),
             name: 'Managed migrations',
+            description: 'Managed migrations provide an automated way to migrate your historical data into PostHog.',
             projectBased: true,
         },
         ManagedMigrationNew: {


### PR DESCRIPTION
## Problem

Managed migrations (`/managed_migrations`) is effectively hidden. It has no entry in the left nav, doesn't show up in Cmd+K search (typing "migration" finds nothing), and no other page links to it. The only way in is knowing the URL and typing it by hand.

Root cause: `products/managed_migrations/manifest.tsx` only declares scenes, routes, and URLs. It never registers a tree item, and the generated `frontend/src/products.tsx` tree item lists are the single data source for both the nav panels and Cmd+K search.

## Changes

Registers a `treeItemsMetadata` entry for Managed migrations under the `Pipeline` category, modeled on the Data warehouse "Sources" entry. This surfaces it in two places:

- the Data management nav panel, listed alphabetically next to Sources, Transformations, and Event ingestion filtering
- Cmd+K search, under the "Data management" category

The search side needs no keyword plumbing. The Fuse config in `Search/utils.ts` uses `ignoreLocation`, so "migration" matches the name "Managed migrations" directly.

The entry is not feature flagged, matching the scene itself (only the Amplitude import sub-options are flagged, inside the scene).

`frontend/src/products.tsx` and `frontend/src/products.json` are regenerated output from `pnpm build:products`.

## How did you test this code?

- `pnpm build:products` succeeds and the entry lands inside `getTreeItemsMetadata()` in the generated output, shaped identically to the neighboring Pipeline entries
- Verified search matching against the real `fuse.js` with the exact `FUSE_OPTIONS` from `Search/utils.ts` and items shaped as `searchLogic.dataManagementItems` builds them: "migration" ranks "Managed migrations" first, "migrate" and "managed migrations" also match
- Tested locally to verify the fix (Luke)
- No new tests: a test asserting this static entry exists wouldn't catch a regression the build and type layer doesn't already catch

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke reported that Managed migrations can't be found via Cmd+K and asked how anyone would navigate to it without a link. I (Claude, via PostHog Code) traced the Cmd+K search data sources to the generated tree item lists, confirmed zero inbound links to the scene anywhere in the frontend, and proposed registering it in either the Products tree or the Data management group. Luke chose Data management → Pipeline. Considered adding a per-item `searchKeywords` mechanism but dropped it after confirming Fuse's `ignoreLocation` config already matches "migration" against the name.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
