### PR TITLE
fix(postgres): treat backward slot advance as a benign no-op

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -44,6 +44,17 @@ _SLOT_ADVANCE_MAX_ATTEMPTS = 3
 _SLOT_READ_MAX_ATTEMPTS = 4
 
 
+def _is_slot_already_ahead_error(exc: psycopg.errors.ObjectNotInPrerequisiteState) -> bool:
+    """Whether Postgres refused a slot advance because the slot is already at or past the target
+    LSN ("cannot advance replication slot to X, minimum is Y" with Y > X).
+
+    Distinct from slot invalidation (``is_slot_invalidation_error``): the slot is healthy and
+    simply ahead of the requested position, so the advance is a benign no-op rather than a failure.
+    """
+    message = str(exc).lower()
+    return "cannot advance replication slot to" in message and "minimum is" in message
+
+
 @dataclass(frozen=True, slots=True)
 class PgCDCConnectionParams:
     host: str
@@ -225,6 +236,14 @@ class PgCDCStreamReader:
         )
         try:
             self._advance_slot(advance_conn, query)
+        except psycopg.errors.ObjectNotInPrerequisiteState as e:
+            if not _is_slot_already_ahead_error(e):
+                raise
+            # The slot's confirmed position already sits at or beyond `position` — a retried or
+            # overlapping run advanced it further — so the WAL up to here is already released and
+            # there is nothing to do. Postgres refuses a backward advance; treat it as a no-op.
+            logger.info("slot_already_ahead", slot_name=self._params.slot_name, position=position)
+            return
         finally:
             advance_conn.close()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import psycopg
+import psycopg.errors
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader import (
     _SLOT_READ_MAX_ATTEMPTS,
@@ -336,4 +337,46 @@ class TestPgCDCStreamReaderConfirmPosition:
 
         assert cur.execute.call_count == 3
         conn.commit.assert_not_called()
+        conn.close.assert_called_once()
+
+    def test_confirm_position_tolerates_slot_already_ahead(self, params):
+        # A retried / overlapping run advanced the slot further, so Postgres refuses the backward
+        # advance. The WAL is already released past this LSN, so it must be a no-op, not a failure.
+        conn = mock.MagicMock()
+        conn.cursor.return_value.__enter__.return_value.execute.side_effect = (
+            psycopg.errors.ObjectNotInPrerequisiteState(
+                "cannot advance replication slot to B4/C7327D08, minimum is B4/CB22FB98"
+            )
+        )
+        connect = mock.MagicMock(return_value=conn)
+
+        reader = PgCDCStreamReader(params)
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+            connect,
+        ):
+            reader.confirm_position("B4/C7327D08")
+
+        conn.commit.assert_not_called()
+        conn.close.assert_called_once()
+
+    def test_confirm_position_reraises_other_prerequisite_errors(self, params):
+        # Slot invalidation is also ObjectNotInPrerequisiteState but must keep propagating so the
+        # slot gets recreated — only the "already ahead" case is swallowed.
+        conn = mock.MagicMock()
+        conn.cursor.return_value.__enter__.return_value.execute.side_effect = (
+            psycopg.errors.ObjectNotInPrerequisiteState(
+                "cannot advance replication slot that has not previously reserved WAL"
+            )
+        )
+        connect = mock.MagicMock(return_value=conn)
+
+        reader = PgCDCStreamReader(params)
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+            connect,
+        ):
+            with pytest.raises(psycopg.errors.ObjectNotInPrerequisiteState):
+                reader.confirm_position("B4/C7327D08")
+
         conn.close.assert_called_once()


### PR DESCRIPTION
## Problem

CDC extraction for Postgres sources was crashing with an uncaught `ObjectNotInPrerequisiteState`:

```
cannot advance replication slot to <redacted>, minimum is <redacted>
```

raised from `confirm_position` in `stream_reader.py`. Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f36dc-b6de-7292-97b7-43a7a9e580a2

Postgres raises this from `pg_replication_slot_advance` only when the target LSN is *behind* the slot's current confirmed position (the reported minimum is higher than the requested LSN). That is a benign situation: a retried or overlapping run already advanced the slot past this point, so the WAL up to here is already released and there is nothing left to do. Postgres refuses a backward advance, and we were letting it fail the entire extraction activity instead of shrugging it off.

This is distinct from slot invalidation, which is also an `ObjectNotInPrerequisiteState` but carries different wording ("has not previously reserved WAL" / "slot has been invalidated") and genuinely requires recreating the slot. That path must keep propagating.

## Changes

`confirm_position` now catches the specific "slot already ahead" case (message contains both `cannot advance replication slot to` and `minimum is`) and treats it as a no-op, logging `slot_already_ahead` and returning cleanly. Every other `ObjectNotInPrerequisiteState`, including slot invalidation, re-raises unchanged.

The match is on the stable message structure only. The two LSN values are not part of the match.

## How did you test this code?

Automated only. I (Claude) added two regression tests to `test_stream_reader.py` and ran the full file:

- `test_confirm_position_tolerates_slot_already_ahead` - the "minimum is" error is swallowed, connection closed, no commit.
- `test_confirm_position_reraises_other_prerequisite_errors` - a slot-invalidation `ObjectNotInPrerequisiteState` still propagates.

`.venv/bin/pytest .../cdc/tests/test_stream_reader.py` - 14 passed. `ruff check` and `ruff format` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Postgres data-warehouse source. I (Claude) confirmed the issue in error tracking (both sampled events point at `confirm_position` at `stream_reader.py`, `top_in_app_frame` in-app), read the CDC stream reader and its callers in `cdc/activities.py`, and classified this as a fixable bug rather than a user/upstream error or a transient infra error.

Decision: not a `NonRetryableErrors` candidate. Making it non-retryable would fail the sync permanently, but the correct outcome is success - the slot is already where we want it. So the fix makes `confirm_position` tolerant of a backward advance rather than reclassifying the error. Scoped strictly to this case; slot invalidation and all other prerequisite-state errors are untouched.
