### PR TITLE
fix(postgres): absorb transient slot-active during CDC slot advance

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -7,6 +7,7 @@ approach — batch reads on a schedule.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import psycopg
 import structlog
+import psycopg.errors
 from psycopg import sql
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.types import ChangeEvent
@@ -28,6 +30,12 @@ if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 logger = structlog.get_logger(__name__)
+
+# pg_replication_slot_advance rejects the advance with SQLSTATE 55006 (ObjectInUse) while the slot
+# is still acquired by another backend. The advance runs on its own short-lived connection while the
+# streaming peek releases the slot, so the two can momentarily overlap; the slot frees on its own.
+_SLOT_ACTIVE_MARKER = "is active for pid"
+_SLOT_ADVANCE_MAX_ATTEMPTS = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,13 +200,33 @@ class PgCDCStreamReader:
             logger,
         )
         try:
-            with advance_conn.cursor() as cur:
-                cur.execute(query)
-            advance_conn.commit()
+            self._advance_slot(advance_conn, query)
         finally:
             advance_conn.close()
 
         logger.info("advanced_slot", slot_name=self._params.slot_name, position=position)
+
+    def _advance_slot(self, conn: psycopg.Connection, query: sql.Composed) -> None:
+        """Run the slot-advance query, retrying the brief window where the slot is still
+        held by another backend ("... is active for PID ...").
+
+        Advancing is idempotent (re-advancing past a confirmed LSN is a no-op), and the slot
+        frees on its own, so a short in-process retry absorbs a sub-second handoff instead of
+        failing — and replaying — the whole extraction. Exhausting the retries re-raises, so a
+        slot that stays held still surfaces as the retryable SLOT_IN_USE classification.
+        """
+        for attempt in range(_SLOT_ADVANCE_MAX_ATTEMPTS):
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(query)
+                conn.commit()
+                return
+            except psycopg.errors.ObjectInUse as e:
+                conn.rollback()
+                if _SLOT_ACTIVE_MARKER not in str(e).lower() or attempt == _SLOT_ADVANCE_MAX_ATTEMPTS - 1:
+                    raise
+                logger.warning("slot_advance_busy_retry", slot_name=self._params.slot_name, attempt=attempt + 1)
+                time.sleep(0.5 * 2**attempt)
 
     def get_primary_key_columns(self, schema_name: str, table_names: list[str]) -> dict[str, list[str]]:
         """Query information_schema for PK columns of the given tables.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -240,6 +240,9 @@ class TestPgCDCStreamReaderConfirmPosition:
             reader.confirm_position("0/1234ABCD")
 
         assert cur.execute.call_count == 2
+        # The failed advance aborts the transaction, so the retry must reset it first or real
+        # psycopg raises InFailedSqlTransaction.
+        conn.rollback.assert_called_once()
         conn.commit.assert_called_once()
         conn.close.assert_called_once()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -212,3 +212,56 @@ class TestPgCDCStreamReaderConfirmPosition:
                 reader.confirm_position("0/1234ABCD")
 
         assert connect.call_count == 1
+
+    def _reader_advancing(self, params, execute_side_effect):
+        conn = mock.MagicMock()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.execute.side_effect = execute_side_effect
+        connect = mock.MagicMock(return_value=conn)
+        reader = PgCDCStreamReader(params)
+        return reader, conn, cur, connect
+
+    def test_confirm_position_retries_while_slot_active(self, params):
+        # The slot is momentarily held while the streaming peek releases it; the advance
+        # self-heals on the next attempt instead of failing the whole extraction.
+        reader, conn, cur, connect = self._reader_advancing(
+            params,
+            [psycopg.errors.ObjectInUse('replication slot "posthog_slot" is active for PID 2999'), None],
+        )
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+            ),
+        ):
+            reader.confirm_position("0/1234ABCD")
+
+        assert cur.execute.call_count == 2
+        conn.commit.assert_called_once()
+        conn.close.assert_called_once()
+
+    def test_confirm_position_raises_when_slot_stays_active(self, params):
+        # A slot that never frees exhausts the in-process retries and re-raises, so the run
+        # still surfaces as the retryable SLOT_IN_USE classification rather than looping forever.
+        reader, conn, cur, connect = self._reader_advancing(
+            params,
+            psycopg.errors.ObjectInUse('replication slot "posthog_slot" is active for PID 2999'),
+        )
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+            ),
+        ):
+            with pytest.raises(psycopg.errors.ObjectInUse):
+                reader.confirm_position("0/1234ABCD")
+
+        assert cur.execute.call_count == 3
+        conn.commit.assert_not_called()
+        conn.close.assert_called_once()


### PR DESCRIPTION
## Problem

Postgres CDC imports occasionally fail with `ObjectInUse: replication slot "<redacted>" is active for PID <n>`, raised from `pg_replication_slot_advance` in `PgCDCStreamReader.confirm_position`. Surfaced by error tracking: [issue 019f36dc](https://us.posthog.com/project/2/error_tracking/019f36dc-7d6a-70b2-9fe9-c2f1035b4086).

The slot advance runs on its own short-lived connection while the streaming peek releases the slot, so the two can momentarily overlap and Postgres rejects the advance with SQLSTATE 55006 while another backend still holds the slot. It frees on its own, so this is transient. The error is already classified as `SLOT_IN_USE` (retryable), so nothing is broken. But the only recovery path today is a full Temporal retry of the entire (2h-capped) extraction activity, which re-decodes WAL and re-flushes micro-batches just to get past a sub-second slot handoff.

## Changes

Retry the slot advance in-process with a short bounded backoff (3 attempts) when it hits the "is active for pid" case, instead of letting a momentary overlap fail the whole activity. This mirrors how `confirm_position` already absorbs the sibling transient class (dropped connections) via `_connect_with_dropped_retry`, and matches the in-process transient-retry pattern used elsewhere in these sources.

Safety:
- Advancing is idempotent (re-advancing past a confirmed LSN is a no-op), so retrying is safe.
- Only the specific `ObjectInUse` + "is active for pid" case is retried; any other `ObjectInUse` re-raises immediately.
- Exhausting the retries re-raises, so a slot that genuinely stays held still surfaces as the retryable `SLOT_IN_USE` classification and falls back to today's Temporal-level retry. No change to global retry policy.

This is not a NonRetryableErrors case: the condition is transient and self-healing, so making it non-retryable would strand recoverable runs.

## How did you test this code?

Automated only (I, Claude, did not run the real import pipeline). Added two unit tests at the stream-reader layer in `test_stream_reader.py`:

- `test_confirm_position_retries_while_slot_active` catches the regression where a transient slot-active would again fail the whole extraction instead of self-healing on the next attempt. No existing test covered the `ObjectInUse` retry path (the existing retry tests only cover dropped connections on connect).
- `test_confirm_position_raises_when_slot_stays_active` locks in the bounded-retry contract: a slot that never frees exhausts the retries and re-raises rather than looping forever, so the run still surfaces as retryable `SLOT_IN_USE`.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py` (14 passed) and the CDC `test_errors.py` suite (all passed). Ran `ruff check` and `ruff format` on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from the error-tracking webhook. Confirmed the failure originates in `confirm_position` (top in-app frame at `stream_reader.py`), traced the call path (`_read_wal_loop` advances the slot mid-peek-loop after each micro-flush), and read the CDC error taxonomy.

Decision: this is a transient, self-healing condition, not a user/upstream error, so NOT a `NonRetryableErrors` change (that would strand recoverable runs). It is already classified retryable, so it is not a correctness bug either. I chose a scoped in-process retry in the exact failing frame as a robustness improvement that avoids replaying the whole extraction for a sub-second slot handoff, rather than concluding "no change". I rejected deferring all mid-loop advances until the cursor closes (would change the deliberate WAL-release/durability semantics documented in `activities.py`) as out of scope and risky.

Skills invoked: `/writing-tests`.
