### PR TITLE
fix(postgres): absorb transient slot-active during CDC WAL read

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -37,6 +37,12 @@ logger = structlog.get_logger(__name__)
 _SLOT_ACTIVE_MARKER = "is active for pid"
 _SLOT_ADVANCE_MAX_ATTEMPTS = 3
 
+# The first fetch of pg_logical_slot_peek_binary_changes acquires the replication slot, which
+# Postgres rejects with SQLSTATE 55006 (ObjectInUse, "... is active for PID ...") while a prior
+# run's connection is still releasing it. The slot frees on its own, so a short in-process retry
+# absorbs the handoff instead of failing — and replaying — the whole extraction attempt.
+_SLOT_READ_MAX_ATTEMPTS = 4
+
 
 @dataclass(frozen=True, slots=True)
 class PgCDCConnectionParams:
@@ -140,6 +146,7 @@ class PgCDCStreamReader:
         """
         if self._conn is None:
             raise RuntimeError("Not connected. Call connect() first.")
+        conn = self._conn
 
         self._last_rows_consumed = 0
         upto = sql.Literal(upto_nchanges) if upto_nchanges is not None else sql.SQL("NULL")
@@ -155,20 +162,37 @@ class PgCDCStreamReader:
             pub_name=sql.Literal(self._params.publication_name),
         )
 
-        with self._conn.cursor(name="cdc_stream") as cur:
-            cur.itersize = 1000
-            cur.execute(query)
+        # The named cursor runs the peek lazily, so the slot is acquired on the first fetch — that
+        # is where "... is active for PID ..." surfaces, before any event is yielded. Retry that
+        # handoff in-process so a prior run's still-releasing connection can't fail the whole
+        # attempt. Once a row lands the slot is ours, so never retry past that point; if it stays
+        # held the error propagates to the retryable SLOT_IN_USE path.
+        for attempt in range(_SLOT_READ_MAX_ATTEMPTS):
+            slot_acquired = False
+            try:
+                with conn.cursor(name="cdc_stream") as cur:
+                    cur.itersize = 1000
+                    cur.execute(query)
 
-            for row in cur:
-                self._last_rows_consumed += 1
-                if on_row is not None:
-                    on_row()
+                    for row in cur:
+                        slot_acquired = True
+                        self._last_rows_consumed += 1
+                        if on_row is not None:
+                            on_row()
 
-                lsn_str: str = row[0]
-                data: bytes = row[2]
+                        lsn_str: str = row[0]
+                        data: bytes = row[2]
 
-                events = self._decoder.decode_message(data, lsn_str)
-                yield from events
+                        events = self._decoder.decode_message(data, lsn_str)
+                        yield from events
+                return
+            except psycopg.errors.ObjectInUse as e:
+                conn.rollback()
+                if slot_acquired or _SLOT_ACTIVE_MARKER not in str(e).lower() or attempt == _SLOT_READ_MAX_ATTEMPTS - 1:
+                    raise
+                self._last_rows_consumed = 0
+                logger.warning("slot_read_busy_retry", slot_name=self._params.slot_name, attempt=attempt + 1)
+                time.sleep(0.5 * 2**attempt)
 
     def confirm_position(self, position: str) -> None:
         """Advance the replication slot to the given LSN.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -197,7 +197,8 @@ class TestPgCDCStreamReaderReadChangesSlotInUse:
 
         assert fake_cursor.__iter__.call_count == 2
         assert reader.last_rows_consumed == len(rows)
-        sleep.assert_called_once()
+        # First backoff is 0.5 * 2**0 — asserting the value locks the multiplier.
+        sleep.assert_called_once_with(0.5)
         reader._conn.rollback.assert_called_once()
 
     def test_read_changes_reraises_when_slot_stays_in_use(self, params):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import psycopg
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader import (
+    _SLOT_READ_MAX_ATTEMPTS,
     PgCDCConnectionParams,
     PgCDCStreamReader,
 )
@@ -164,6 +165,73 @@ class TestPgCDCStreamReaderReadChanges:
 
         assert on_row_calls == len(rows)
         assert reader.last_rows_consumed == len(rows)
+
+
+class TestPgCDCStreamReaderReadChangesSlotInUse:
+    def _reader_reading(self, params, iter_side_effect):
+        reader = PgCDCStreamReader(params)
+        fake_cursor = mock.MagicMock()
+        fake_cursor.__iter__.side_effect = iter_side_effect
+        reader._conn = mock.MagicMock()
+        reader._conn.cursor.return_value.__enter__.return_value = fake_cursor
+        # Isolate the read mechanics (retry + row count) from pgoutput decoding.
+        reader._decoder = mock.MagicMock()
+        reader._decoder.decode_message.return_value = []
+        return reader, fake_cursor
+
+    def test_read_changes_retries_slot_in_use_then_succeeds(self, params):
+        # A prior run's connection is still releasing the slot on the first fetch; the next
+        # attempt self-heals instead of failing the whole extraction.
+        rows = [("0/1", 1, b"a"), ("0/2", 1, b"b")]
+        reader, fake_cursor = self._reader_reading(
+            params,
+            [
+                psycopg.errors.ObjectInUse('replication slot "posthog_slot" is active for PID 2999'),
+                iter(rows),
+            ],
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+        ) as sleep:
+            list(reader.read_changes(upto_nchanges=10))
+
+        assert fake_cursor.__iter__.call_count == 2
+        assert reader.last_rows_consumed == len(rows)
+        sleep.assert_called_once()
+        reader._conn.rollback.assert_called_once()
+
+    def test_read_changes_reraises_when_slot_stays_in_use(self, params):
+        # A slot that never frees exhausts the in-process retries and re-raises, so the run still
+        # surfaces as the retryable SLOT_IN_USE classification rather than looping or silently
+        # returning no changes.
+        reader, fake_cursor = self._reader_reading(
+            params,
+            psycopg.errors.ObjectInUse('replication slot "posthog_slot" is active for PID 2999'),
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+        ) as sleep:
+            with pytest.raises(psycopg.errors.ObjectInUse):
+                list(reader.read_changes(upto_nchanges=10))
+
+        assert fake_cursor.__iter__.call_count == _SLOT_READ_MAX_ATTEMPTS
+        assert sleep.call_count == _SLOT_READ_MAX_ATTEMPTS - 1
+
+    def test_read_changes_does_not_retry_unrelated_object_in_use(self, params):
+        # A different SQLSTATE 55006 (not the transient slot handoff) is re-raised immediately,
+        # never retried, so an unrelated failure isn't silently delayed.
+        reader, fake_cursor = self._reader_reading(
+            params,
+            psycopg.errors.ObjectInUse("database is being accessed by other users"),
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+        ) as sleep:
+            with pytest.raises(psycopg.errors.ObjectInUse):
+                list(reader.read_changes(upto_nchanges=10))
+
+        assert fake_cursor.__iter__.call_count == 1
+        sleep.assert_not_called()
 
 
 class TestPgCDCStreamReaderConfirmPosition:


### PR DESCRIPTION
## Problem

Postgres CDC imports occasionally fail with `ObjectInUse: replication slot "<redacted>" is active for PID <n>`, raised from `PgCDCStreamReader.read_changes`. Surfaced by error tracking: [issue 019f36dc-7904](https://us.posthog.com/project/2/error_tracking/019f36dc-7904-7f00-8036-286939dc023b).

The stream reader peeks the WAL through a named server-side cursor over `pg_logical_slot_peek_binary_changes`. That cursor executes the peek lazily, so the replication slot is acquired on the first fetch (the top in-app frame is the `for row in cur` line, not the `execute`). A prior run's connection can still be releasing the slot at that moment, so Postgres rejects the fetch with SQLSTATE 55006 while another backend still holds it. It frees on its own, so this is transient.

The error is already classified as `SLOT_IN_USE` (retryable), so nothing is broken. But the only recovery today is a full Temporal retry of the entire (2h-capped) extraction activity, which re-decodes WAL and marks the schemas failed just to get past a sub-second slot handoff.

This is the read-path twin of the slot-advance case handled in #68544 (a different frame, `confirm_position`, and a different error-tracking issue). That fix does not touch `read_changes`, so the acquisition path stayed unhandled.

## Changes

Retry the slot acquisition in-process with a short bounded backoff (4 attempts, exponential) when the first fetch hits the "is active for pid" case, instead of letting a momentary overlap fail the whole activity. This mirrors how the advance path and the connect path (`_connect_with_dropped_retry`) already absorb their sibling transient classes.

Safety:
- The retry only fires before any event is yielded. Once a row lands the slot is ours (`slot_acquired`), so it never retries past that point and can't replay partially-yielded events.
- The peek is non-consuming and `last_rows_consumed` is reset on retry, so a retried attempt reads the same backlog cleanly.
- Only the specific `ObjectInUse` + "is active for pid" case is retried. Any other `ObjectInUse` re-raises immediately.
- Exhausting the retries re-raises, so a slot that genuinely stays held still surfaces as the retryable `SLOT_IN_USE` classification and falls back to today's Temporal-level retry. No change to global retry policy.

This is not a `NonRetryableErrors` case: the condition is transient and self-healing, so making it non-retryable would strand recoverable runs.

## How did you test this code?

Automated only (I, Claude, did not run the real import pipeline). Added three unit tests at the stream-reader layer in `test_stream_reader.py`:

- `test_read_changes_retries_slot_in_use_then_succeeds` catches the regression where a transient slot-active on the peek's first fetch would again fail the whole extraction instead of self-healing. No existing test covered the `ObjectInUse` retry on the read path (the existing retry tests cover dropped connections on connect, and #68544's cover the advance path).
- `test_read_changes_reraises_when_slot_stays_in_use` locks in the bounded-retry contract: a slot that never frees exhausts the retries and re-raises rather than looping forever or silently returning no changes (which would look like data loss).
- `test_read_changes_does_not_retry_unrelated_object_in_use` guards the message-match precision so a different SQLSTATE 55006 isn't silently retried and delayed.

Ran `pytest .../postgres/cdc/tests/test_stream_reader.py` (15 passed) and the wider postgres CDC + CDC `test_errors.py` suites (147 passed; the one error is an environment-only DB fixture that needs a live Postgres, unrelated to this change). Ran `ruff check`/`ruff format` and `hogli ci:preflight --fix` (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from the error-tracking webhook. Confirmed the failure originates in `read_changes` (top in-app frame at `stream_reader.py`, the `for row in cur` first fetch), traced the call path (`_read_wal_loop` → `read_changes` → the named-cursor peek that acquires the slot), and read the CDC error taxonomy.

Decision: this is a transient, self-healing condition, not a user/upstream error, so NOT a `NonRetryableErrors` change (that would strand recoverable runs). It is already classified retryable, so it is not a correctness bug either. I chose a scoped in-process retry in the exact failing frame as a robustness improvement that avoids replaying the whole extraction for a sub-second slot handoff, rather than concluding "no change". I checked the maintainer's open PRs and found #68544, which fixes the same exception on the slot-advance path; I confirmed it does not touch `read_changes`, so this read-path fix is complementary, not a duplicate. I rejected a graceful skip (returning cleanly) because it would leave schemas in a misleading status and delay data up to a full schedule interval.

Skills invoked: `/writing-tests`.
