### PR TITLE
feat(logs): add transactions view mode behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -362,6 +362,7 @@ export const FEATURE_FLAGS = {
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
+    LOGS_TRANSACTIONS: 'logs-transactions', // owner: #team-logs
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MARKDOWN_NOTEBOOKS: 'markdown-notebooks', // owner: #team-platform-features, enables Markdown notebooks upgrade path
     MARKETING_ANALYTICS_AI: 'marketing-analytics-ai', // owner: @jabahamondes #team-web-analytics

--- a/products/logs/frontend/components/LogsTransactions/LogsTransactions.tsx
+++ b/products/logs/frontend/components/LogsTransactions/LogsTransactions.tsx
@@ -1,0 +1,11 @@
+/**
+ * Placeholder results region for the Transactions view mode (behind the `logs-transactions` flag).
+ * Swapped in by LogsViewer the same way LogsPatterns is; the actual transactions UI lands here.
+ */
+export function LogsTransactions(): JSX.Element {
+    return (
+        <div className="flex-1 min-h-0 flex items-center justify-center" data-attr="logs-transactions">
+            <span className="text-muted text-sm">Transactions view coming soon</span>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -21,8 +21,9 @@ export interface LogsDisplayBarProps {
 /**
  * The bar above the results, grouped by scope rather than by widget kind:
  *
- *  - persistent-left "frame": controls that belong to the results region in *both* lenses —
- *    the filters toggle, the Logs⇄Patterns switch, and a lens-aware count indicator.
+ *  - persistent-left "frame": controls that belong to the results region in *all* lenses —
+ *    the filters toggle, the view-mode switch (Logs / Patterns / Transactions), and a lens-aware
+ *    count indicator.
  *  - contextual-right: the Logs-only presentation tools (sort, wrap, timezone, export, shortcuts),
  *    hidden entirely in Patterns mode where none of them apply.
  *
@@ -36,8 +37,11 @@ export const LogsDisplayBar = ({
     const { facetRailCollapsed, viewMode } = useValues(logsViewerConfigLogic)
     const { setFacetRailCollapsed, setViewMode } = useActions(logsViewerConfigLogic)
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
+    const showTransactionsView = useFeatureFlag('LOGS_TRANSACTIONS')
 
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
+    const inTransactionsMode = showTransactionsView && viewMode === 'transactions'
+    const inLogsMode = !inPatternsMode && !inTransactionsMode
 
     return (
         <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -52,27 +56,26 @@ export const LogsDisplayBar = ({
                         {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
                     </LemonButton>
                 )}
-                {showPatternsView && (
+                {(showPatternsView || showTransactionsView) && (
                     <LemonSegmentedButton
                         size="small"
                         value={viewMode}
                         onChange={setViewMode}
                         options={[
-                            { value: 'logs', label: 'Logs' },
-                            { value: 'patterns', label: 'Patterns' },
+                            { value: 'logs' as const, label: 'Logs' },
+                            ...(showPatternsView ? [{ value: 'patterns' as const, label: 'Patterns' }] : []),
+                            ...(showTransactionsView
+                                ? [{ value: 'transactions' as const, label: 'Transactions' }]
+                                : []),
                         ]}
                     />
                 )}
-                {inPatternsMode ? (
-                    <PatternsCountIndicator id={id} />
-                ) : (
-                    totalLogsCount !== undefined &&
-                    totalLogsCount > 0 && (
-                        <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
-                    )
+                {inPatternsMode && <PatternsCountIndicator id={id} />}
+                {inLogsMode && totalLogsCount !== undefined && totalLogsCount > 0 && (
+                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
                 )}
             </div>
-            {!inPatternsMode && <LogsViewerToolbar totalLogsCount={totalLogsCount} />}
+            {inLogsMode && <LogsViewerToolbar totalLogsCount={totalLogsCount} />}
         </div>
     )
 }

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -9,6 +9,7 @@ import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { UniversalFiltersGroup } from '~/types'
 
 import { LogsPatterns } from 'products/logs/frontend/components/LogsPatterns/LogsPatterns'
+import { LogsTransactions } from 'products/logs/frontend/components/LogsTransactions/LogsTransactions'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
@@ -122,6 +123,7 @@ function LogsViewerContent({
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
     const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
+    const showTransactionsView = useFeatureFlag('LOGS_TRANSACTIONS')
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
     const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
@@ -348,16 +350,23 @@ function LogsViewerContent({
         </>
     )
 
-    // Patterns is a mode of the Viewer, not a separate tab: it swaps only the results region
-    // and reuses the same filter bar / FacetRail / date range (shared via logsViewerFiltersLogic).
-    // Gate on the flag too, so the patterns query stays unreachable when the flag is off regardless
-    // of the (non-persisted) viewMode state.
+    // Patterns and Transactions are modes of the Viewer, not separate tabs: they swap only the
+    // results region and reuse the same filter bar / FacetRail / date range (shared via
+    // logsViewerFiltersLogic). Gate on the flags too, so the flagged views stay unreachable when
+    // their flag is off regardless of the (non-persisted) viewMode state.
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
-    const resultsRegion = inPatternsMode ? <LogsPatterns id={id} /> : logList
+    const inTransactionsMode = showTransactionsView && viewMode === 'transactions'
+    const resultsRegion = inPatternsMode ? (
+        <LogsPatterns id={id} />
+    ) : inTransactionsMode ? (
+        <LogsTransactions />
+    ) : (
+        logList
+    )
 
     // Both layouts share the same results column; only the results bar above it differs (the facet-rail
-    // layout adds the rail toggle). The bar owns the Logs⇄Patterns switch and hides its Logs-only tools
-    // in Patterns mode, so it renders in both modes — keeping the frame (toggle, count) persistent.
+    // layout adds the rail toggle). The bar owns the view-mode switch and hides its Logs-only tools
+    // outside Logs mode, so it renders in every mode — keeping the frame (toggle, count) persistent.
     const resultsColumn = (bar: JSX.Element): JSX.Element => (
         <>
             {bar}

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -22,7 +22,7 @@ export const DEFAULT_SPARKLINE_BREAKDOWN_BY: LogsSparklineBreakdownBy = 'severit
 
 export const DEFAULT_ORDER_BY: LogsOrderBy = 'latest'
 
-export type LogsViewerViewMode = 'logs' | 'patterns'
+export type LogsViewerViewMode = 'logs' | 'patterns' | 'transactions'
 export const DEFAULT_VIEW_MODE: LogsViewerViewMode = 'logs'
 
 export interface LogsViewerConfigProps {


### PR DESCRIPTION
## Problem

The logs product needs to support a new "Transactions" view mode alongside the existing Logs and Patterns views. This should be gated behind a feature flag to allow controlled rollout and testing.

## Changes

- Added `LOGS_TRANSACTIONS` feature flag constant to enable/disable the transactions view mode
- Created new `LogsTransactions` component as a placeholder for the transactions view (displays "Transactions view coming soon")
- Updated `LogsDisplayBar` to:
  - Include the transactions option in the view-mode segmented button when the flag is enabled
  - Dynamically show/hide button options based on feature flags
  - Updated documentation to reflect support for all three view modes (Logs, Patterns, Transactions)
  - Refactored conditional rendering to properly handle the three-mode system
- Updated `LogsViewer` to:
  - Import and render `LogsTransactions` component when in transactions mode
  - Check the `LOGS_TRANSACTIONS` flag and conditionally swap in the transactions results region
  - Updated comments to reflect that both Patterns and Transactions are view modes of the main viewer

## How did you test this code?

The changes are straightforward feature flag integration and component wiring following the existing pattern used for Patterns view. The placeholder component renders basic placeholder UI, and the conditional rendering logic mirrors the established Patterns implementation. Manual verification would involve:
- Enabling the `logs-transactions` feature flag
- Confirming the "Transactions" button appears in the segmented control
- Clicking the button and verifying the placeholder message displays
- Disabling the flag and confirming the button disappears

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*