### PR TITLE
fix(data-warehouse): harden v3 loader against claim degradation and silent wedging

### DIFF
--- a/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
@@ -76,10 +76,21 @@ class Command(BaseCommand):
             default=60.0,
             help="Health check timeout in seconds (default: 60.0)",
         )
+        parser.add_argument(
+            "--stuck-batch-timeout",
+            type=float,
+            default=7200.0,
+            help=(
+                "Stop reporting liveness once any single batch has been executing longer than this many "
+                "seconds, so a wedged sink connection becomes a pod restart instead of an invisible stall. "
+                "0 disables the watchdog (default: 7200.0)"
+            ),
+        )
 
     def handle(self, *args, **options):
         health_port = options["health_port"]
         health_timeout = options["health_timeout"]
+        stuck_batch_timeout = options["stuck_batch_timeout"] or None
 
         config = ConsumerConfig(
             database_url=WAREHOUSE_SOURCES_DATABASE_URL,
@@ -89,6 +100,7 @@ class Command(BaseCommand):
             max_attempts=options["max_attempts"],
             health_port=health_port,
             health_timeout_seconds=health_timeout,
+            stuck_batch_timeout_seconds=stuck_batch_timeout,
         )
 
         logger.info(
@@ -98,6 +110,7 @@ class Command(BaseCommand):
             poll_limit=config.poll_limit,
             max_attempts=config.max_attempts,
             health_port=health_port,
+            stuck_batch_timeout=stuck_batch_timeout,
         )
 
         health_state = HealthState(timeout_seconds=health_timeout)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -71,6 +71,12 @@ class BatchConsumerConfig:
     reconcile_grace_seconds: int = RECONCILE_GRACE_SECONDS
     reconcile_lookback_seconds: int = RECONCILE_LOOKBACK_SECONDS
     reconcile_limit: int = 100
+    # Ceilings on queue-DB operations. Without them a claim query or sweep that
+    # degrades past "slow" into "never returns" silently wedges the consumer:
+    # the awaiting task holds its slot forever, with no error and no log.
+    connect_timeout_seconds: int = 10
+    poll_timeout_seconds: float | None = 180.0
+    sweep_timeout_seconds: float | None = 300.0
     # When set, the consumer stops reporting itself healthy once any single batch
     # has been executing longer than this, so a wedged sink connection turns into
     # a liveness-probe restart instead of an indefinite, invisible stall.
@@ -238,7 +244,23 @@ class BatchConsumer:
         return await psycopg.AsyncConnection.connect(
             self._config.database_url,
             autocommit=True,
+            connect_timeout=self._config.connect_timeout_seconds,
         )
+
+    async def _drop_conn(self, attr: str) -> None:
+        """Close and forget a connection after a timed-out operation.
+
+        A cancelled psycopg operation can leave the connection mid-protocol;
+        re-dialing on the next cycle is cheaper than reasoning about its state.
+        """
+        conn: psycopg.AsyncConnection[Any] | None = getattr(self, attr)
+        setattr(self, attr, None)
+        if conn is None:
+            return
+        try:
+            await asyncio.wait_for(conn.close(), timeout=5.0)
+        except Exception:
+            pass
 
     async def _ensure_poll_conn(self) -> psycopg.AsyncConnection[Any]:
         """Return the poll connection, reconnecting if a failover/pgbouncer bounce dropped it."""
@@ -286,7 +308,7 @@ class BatchConsumer:
             # scans the whole queue and can outlast the health server's startup
             # grace window, and a pod liveness-killed mid-sweep can never boot.
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-            await self._recovery_sweep()
+            await self._recovery_sweep_with_timeout()
             self._recovery_task = asyncio.create_task(self._recovery_loop())
 
             while not self._shutdown.is_set():
@@ -307,13 +329,22 @@ class BatchConsumer:
                 poll_start = time.monotonic()
                 try:
                     conn = await self._ensure_poll_conn()
-                    batches = await self._adapter.fetch_and_lock(
-                        conn,
-                        limit=self._fetch_limit(available),
-                        retry_backoff_base_seconds=self._config.retry_backoff_base_seconds,
-                        owner_token=self._owner_token,
-                        lease_ttl_seconds=self._lease_ttl_seconds,
+                    async with asyncio.timeout(self._config.poll_timeout_seconds):
+                        batches = await self._adapter.fetch_and_lock(
+                            conn,
+                            limit=self._fetch_limit(available),
+                            retry_backoff_base_seconds=self._config.retry_backoff_base_seconds,
+                            owner_token=self._owner_token,
+                            lease_ttl_seconds=self._lease_ttl_seconds,
+                        )
+                except TimeoutError:
+                    logger.exception(
+                        self._event("poll_timed_out"),
+                        timeout_seconds=self._config.poll_timeout_seconds,
                     )
+                    await self._drop_conn("_poll_conn")
+                    await self._wait_or_shutdown(self._config.poll_interval_seconds)
+                    continue
                 except psycopg.OperationalError as e:
                     logger.exception(self._event("poll_failed_queue_db_unreachable"))
                     capture_exception(e)
@@ -718,7 +749,7 @@ class BatchConsumer:
                 break
 
             try:
-                await self._recovery_sweep()
+                await self._recovery_sweep_with_timeout()
             except Exception as e:
                 logger.exception(self._event("recovery_sweep_error"))
                 capture_exception(e)
@@ -727,10 +758,29 @@ class BatchConsumer:
             if now - self._last_reconcile_monotonic >= self._config.reconcile_interval_seconds:
                 self._last_reconcile_monotonic = now
                 try:
-                    await self._reconcile_failed_runs()
+                    async with asyncio.timeout(self._config.sweep_timeout_seconds):
+                        await self._reconcile_failed_runs()
+                except TimeoutError:
+                    logger.exception(
+                        self._event("reconcile_sweep_timed_out"),
+                        timeout_seconds=self._config.sweep_timeout_seconds,
+                    )
+                    await self._drop_conn("_recovery_conn")
                 except Exception as e:
                     logger.exception(self._event("reconcile_sweep_error"))
                     capture_exception(e)
+
+    async def _recovery_sweep_with_timeout(self) -> None:
+        """Run the recovery sweep under the sweep timeout; a sweep that never returns must not stall the consumer."""
+        try:
+            async with asyncio.timeout(self._config.sweep_timeout_seconds):
+                await self._recovery_sweep()
+        except TimeoutError:
+            logger.exception(
+                self._event("recovery_sweep_timed_out"),
+                timeout_seconds=self._config.sweep_timeout_seconds,
+            )
+            await self._drop_conn("_recovery_conn")
 
     async def _reconcile_failed_runs(self) -> None:
         """Reconcile runs whose queue batch failed but whose terminal-state write never landed."""

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -350,8 +350,18 @@ class BatchConsumer:
                     capture_exception(e)
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
                     continue
-                self._metrics.poll_duration_seconds.observe(time.monotonic() - poll_start)
+                poll_duration = time.monotonic() - poll_start
+                self._metrics.poll_duration_seconds.observe(poll_duration)
                 self._metrics.poll_batches_fetched.observe(len(batches))
+                if poll_duration > self._lease_ttl_seconds / 2:
+                    # Leases are claimed at query start, so a poll this slow hands
+                    # groups over with most of their TTL already burned — the
+                    # leading indicator of fetch-expire-refetch churn fleet-wide.
+                    logger.warning(
+                        self._event("poll_duration_approaching_lease_ttl"),
+                        poll_duration_seconds=round(poll_duration, 3),
+                        lease_ttl_seconds=self._lease_ttl_seconds,
+                    )
 
                 if not batches:
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
@@ -438,6 +448,25 @@ class BatchConsumer:
             else:
                 group_conn = self._poll_conn
                 assert group_conn is not None
+
+            # The lease was claimed when the poll query started; a slow poll can
+            # burn most of its TTL before the group task runs. Re-up it here so
+            # processing starts with a full window instead of expiring mid-batch
+            # and churning the group to another pod.
+            renewed = await self._adapter.renew_lease(
+                group_conn,
+                team_id=team_id,
+                schema_id=schema_id,
+                owner_token=self._owner_token,
+                lease_ttl_seconds=self._lease_ttl_seconds,
+            )
+            if not renewed:
+                logger.warning(
+                    self._event("lease_lost_before_dispatch"),
+                    team_id=team_id,
+                    schema_id=schema_id,
+                )
+                return
 
             for batch in batches:
                 if self._shutdown.is_set():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -282,9 +282,12 @@ class BatchConsumer:
         )
 
         try:
+            # Liveness must be reporting before the startup sweep runs: the sweep
+            # scans the whole queue and can outlast the health server's startup
+            # grace window, and a pod liveness-killed mid-sweep can never boot.
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             await self._recovery_sweep()
             self._recovery_task = asyncio.create_task(self._recovery_loop())
-            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
             while not self._shutdown.is_set():
                 self._report_health()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -338,7 +338,9 @@ class BatchConsumer:
                             lease_ttl_seconds=self._lease_ttl_seconds,
                         )
                 except TimeoutError:
-                    logger.exception(
+                    # error, not exception: the timeout is the designed recovery
+                    # path and its traceback carries no diagnostic value.
+                    logger.error(  # noqa: TRY400
                         self._event("poll_timed_out"),
                         timeout_seconds=self._config.poll_timeout_seconds,
                     )
@@ -790,7 +792,7 @@ class BatchConsumer:
                     async with asyncio.timeout(self._config.sweep_timeout_seconds):
                         await self._reconcile_failed_runs()
                 except TimeoutError:
-                    logger.exception(
+                    logger.error(  # noqa: TRY400 — designed recovery path, traceback is noise
                         self._event("reconcile_sweep_timed_out"),
                         timeout_seconds=self._config.sweep_timeout_seconds,
                     )
@@ -805,7 +807,7 @@ class BatchConsumer:
             async with asyncio.timeout(self._config.sweep_timeout_seconds):
                 await self._recovery_sweep()
         except TimeoutError:
-            logger.exception(
+            logger.error(  # noqa: TRY400 — designed recovery path, traceback is noise
                 self._event("recovery_sweep_timed_out"),
                 timeout_seconds=self._config.sweep_timeout_seconds,
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -59,6 +59,32 @@ def pending_batch_select_columns(status_alias: str) -> str:
     """
 
 
+def latest_status_lateral(batch_alias: str, status_alias: str, *, join: str = "LEFT") -> str:
+    """Per-batch latest-status lookup, driven by the (batch_id, created_at DESC, id DESC) index.
+
+    Replaces joins against the ``DISTINCT ON`` latest-status view: the view has
+    to reduce the *entire* status table before the planner can join it, so its
+    cost grows with total queue history no matter how few batches the outer
+    query touches — under backlog that made every poll and sweep degrade
+    together. A lateral LIMIT 1 probe costs one index descent per outer batch
+    instead.
+
+    ``join="LEFT"`` keeps outer batches with no status row (``status_alias``
+    columns come back NULL); ``join="INNER"`` drops them.
+    """
+    join_kw = "LEFT JOIN" if join == "LEFT" else "JOIN"
+    return f"""
+        {join_kw} LATERAL (
+            SELECT id, batch_id, job_state, attempt, exec_time, error_response, created_at
+            FROM {STATUS_TABLE}
+            WHERE batch_id = {batch_alias}.id
+              AND created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+        ) {status_alias} ON true
+    """
+
+
 # Retained for the duckgres sink, which still coordinates via session advisory
 # locks (see duckgres/jobs_db.py). The delta queue now uses leases instead.
 async def unlock_advisory_locks(
@@ -296,7 +322,7 @@ class BatchQueue:
                     SELECT
                         {pending_batch_select_columns("s")}
                     FROM {BATCH_TABLE} b
-                    LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                    {latest_status_lateral("b", "s")}
                     WHERE
                         b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                         AND (
@@ -311,7 +337,7 @@ class BatchQueue:
                         AND NOT EXISTS (
                             SELECT 1
                             FROM {BATCH_TABLE} b_prev
-                            LEFT JOIN {STATUS_VIEW} s_prev ON b_prev.id = s_prev.batch_id
+                            {latest_status_lateral("b_prev", "s_prev")}
                             WHERE b_prev.run_uuid = b.run_uuid
                                 AND b_prev.batch_index < b.batch_index
                                 AND b_prev.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
@@ -325,17 +351,18 @@ class BatchQueue:
                                     )
                                 )
                         )
-                        AND b.run_uuid NOT IN (
-                            SELECT DISTINCT b2.run_uuid
+                        AND NOT EXISTS (
+                            SELECT 1
                             FROM {BATCH_TABLE} b2
-                            JOIN {STATUS_VIEW} s2 ON b2.id = s2.batch_id
-                            WHERE b2.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                            {latest_status_lateral("b2", "s2", join="INNER")}
+                            WHERE b2.run_uuid = b.run_uuid
+                                AND b2.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                                 AND s2.job_state = 'failed'
                         )
                         AND NOT EXISTS (
                             SELECT 1
                             FROM {BATCH_TABLE} b_busy
-                            JOIN {STATUS_VIEW} s_busy ON b_busy.id = s_busy.batch_id
+                            {latest_status_lateral("b_busy", "s_busy", join="INNER")}
                             WHERE b_busy.team_id = b.team_id
                                 AND b_busy.schema_id = b.schema_id
                                 AND b_busy.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
@@ -485,7 +512,7 @@ class BatchQueue:
                 SELECT
                     {pending_batch_select_columns("s")}
                 FROM {BATCH_TABLE} b
-                JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                {latest_status_lateral("b", "s", join="INNER")}
                 LEFT JOIN {LEASE_TABLE} l ON l.team_id = b.team_id AND l.schema_id = b.schema_id
                 WHERE
                     b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
@@ -513,7 +540,7 @@ class BatchQueue:
             INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, exec_time, error_response, created_at)
             SELECT b.id, 'failed', 0, now(), %(error_response)s, now()
             FROM {BATCH_TABLE} b
-            LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+            {latest_status_lateral("b", "s")}
             WHERE
                 b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                 AND b.run_uuid = %(run_uuid)s
@@ -539,7 +566,7 @@ class BatchQueue:
             INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, exec_time, error_response, created_at)
             SELECT b.id, 'failed', 0, now(), %(error_response)s, now()
             FROM {BATCH_TABLE} b
-            LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+            {latest_status_lateral("b", "s")}
             WHERE
                 b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                 AND b.job_id = %(job_id)s
@@ -576,7 +603,7 @@ class BatchQueue:
                         b.run_uuid, b.job_id, b.team_id, b.schema_id, b.metadata, s.error_response,
                         s.created_at AS failed_at
                     FROM {BATCH_TABLE} b
-                    JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                    {latest_status_lateral("b", "s", join="INNER")}
                     WHERE
                         b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                         AND s.job_state = 'failed'
@@ -670,7 +697,7 @@ class BatchQueue:
                     ) AS non_terminal_count,
                     GREATEST(MAX(s.created_at), MAX(b.created_at)) AS latest_activity_at
                 FROM {BATCH_TABLE} b
-                LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                {latest_status_lateral("b", "s")}
                 WHERE
                     b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                     AND b.job_id = %(job_id)s

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -84,6 +84,18 @@ def _make_healthy_conn(closed: bool = False, broken: bool = False) -> AsyncMock:
     return conn
 
 
+@pytest.fixture(autouse=True)
+def _lease_renewal_succeeds():
+    # Group dispatch renews the lease before processing; the real SQL can't run
+    # against mock connections. Tests exercising renewal failure re-patch this.
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.renew_lease",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        yield
+
+
 class TestProcessSingle:
     @pytest.mark.asyncio
     async def test_success_updates_status_to_executing_then_succeeded(self):
@@ -280,6 +292,29 @@ class TestProcessGroup:
             await consumer._process_group((1, "schema-1"), batches)
 
         assert processed == [0]
+
+    @pytest.mark.asyncio
+    async def test_abandons_group_when_lease_lost_before_dispatch(self):
+        consumer = _make_consumer()
+        batch = _make_batch()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.renew_lease",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                new_callable=AsyncMock,
+            ) as mock_unlock,
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=_make_healthy_conn()),
+        ):
+            await consumer._process_group((1, "schema-1"), [batch])
+
+        # Another pod owns the group now — processing it here would double-write.
+        consumer._process_batch.assert_not_called()
+        mock_unlock.assert_called_once()
 
 
 class TestRecoverySweep:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -313,7 +313,7 @@ class TestProcessGroup:
             await consumer._process_group((1, "schema-1"), [batch])
 
         # Another pod owns the group now — processing it here would double-write.
-        consumer._process_batch.assert_not_called()
+        cast(AsyncMock, consumer._process_batch).assert_not_called()
         mock_unlock.assert_called_once()
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -368,6 +368,42 @@ class TestRecoverySweep:
         )
 
 
+class TestStartupLiveness:
+    @pytest.mark.asyncio
+    async def test_heartbeat_reports_liveness_while_startup_sweep_runs(self):
+        health_reported = asyncio.Event()
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            heartbeat_interval_seconds=0.01,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock(), health_reporter=health_reported.set)
+
+        release_sweep = asyncio.Event()
+
+        async def blocking_sweep(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            await release_sweep.wait()
+            return []
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=_make_healthy_conn()),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                side_effect=blocking_sweep,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            # With the sweep blocked indefinitely, liveness must still be reported.
+            await asyncio.wait_for(health_reported.wait(), timeout=1.0)
+            consumer._shutdown.set()
+            release_sweep.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+
 class TestFailRun:
     @pytest.mark.asyncio
     async def test_does_not_raise_when_job_status_update_fails(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -404,6 +404,92 @@ class TestStartupLiveness:
             await asyncio.wait_for(run_task, timeout=5.0)
 
 
+class TestQueueOperationTimeouts:
+    @pytest.mark.asyncio
+    async def test_hung_poll_times_out_and_consumer_keeps_polling(self):
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+            poll_timeout_seconds=0.05,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        second_poll_started = asyncio.Event()
+        fetch_calls = 0
+
+        async def hung_fetch(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls >= 2:
+                second_poll_started.set()
+            await asyncio.sleep(3600)
+            return []
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=hung_fetch,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            # A second poll can only start if the first hung one timed out instead of wedging.
+            await asyncio.wait_for(second_poll_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_hung_startup_sweep_times_out_and_polling_starts(self):
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+            sweep_timeout_seconds=0.05,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        polling_started = asyncio.Event()
+
+        async def hung_sweep(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            await asyncio.sleep(3600)
+            return []
+
+        async def fetch(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            polling_started.set()
+            return []
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                side_effect=hung_sweep,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=fetch,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            # Polling can only begin if the hung startup sweep was abandoned by the timeout.
+            await asyncio.wait_for(polling_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+
 class TestFailRun:
     @pytest.mark.asyncio
     async def test_does_not_raise_when_job_status_update_fails(self):


### PR DESCRIPTION
## Problem

During a recent production incident the v3 warehouse loader (`warehouse-sources-load`) stopped completing work fleet-wide for over a day while its pods stayed `Running` with healthy-looking signals. Extraction kept producing, so unprocessed batches piled up and every schema's next scheduled run force-failed its predecessor with `Lock takeover: workflow terminated but job was stuck in RUNNING`, flooding users with failure noise that was really one platform outage.

The investigation found a chain of mechanisms rather than one bug:

1. Every poll and sweep joined `v_latest_source_batch_status`, a `DISTINCT ON` over the entire status table. Its cost grows with total queue history, so a backlog made polls slower, which grew the backlog further – a death spiral.
2. Queue operations had no timeouts. A claim query that degraded from slow to never-returns wedged its consumer slot forever, silently.
3. Group leases are claimed when the poll query starts, so slow polls handed groups over with most of their TTL burned. They expired mid-batch and other pods refetched the same groups in a loop (constant fetch volume, zero processing).
4. The startup recovery sweep ran before liveness reporting began. Once the sweep outlasted the health server's 60s startup grace, every new pod was liveness-killed mid-sweep – the fleet could not boot itself back up, and a redeploy crash-looped instead of recovering.
5. The engine's stuck-batch watchdog existed but was never enabled by the management command, so a wedged sink connection never turned into a restart.

## Changes

One commit per fix, reviewable independently:

1. **Start the liveness heartbeat before the startup recovery sweep** so a slow sweep can't get pods killed mid-boot.
2. **Add timeouts to queue operations**: `connect_timeout` on queue connections, `asyncio.timeout` around the poll fetch (180s) and recovery/reconcile sweeps (300s). On timeout the connection is dropped and re-dialed, with explicit `poll_timed_out` / `*_sweep_timed_out` error logs replacing silence.
3. **Renew the group lease at dispatch** so processing starts with a full TTL window, abandon the group if renewal fails (another pod owns it – processing would double-write), and warn when poll duration crosses half the lease TTL, the leading indicator of fetch-expire-refetch churn.
4. **Replace latest-status view joins with indexed lateral probes** in all six queue queries (claim x4, stale sweep, fail run, supersede, reconcile, takeover activity). Each is now a per-batch `LATERAL ... LIMIT 1` probe on the `(batch_id, created_at DESC, id DESC)` index, and the failed-run `NOT IN` became a correlated `NOT EXISTS`. Claim cost now scales with the poll window, not queue history. The view itself stays for operational queries.
5. **Enable the stuck-batch liveness watchdog** via a new `--stuck-batch-timeout` flag (default 2h, 0 disables), so a batch wedged on a dead sink connection becomes a pod restart instead of an invisible stall.

Deliberately unchanged: `sourcebatchstatus` stays strictly append-only (an in-place `exec_time` update was prototyped and rejected to preserve the queue's immutability design – with the lateral probes, heartbeat re-stamp rows are cheap to read past). Lock takeover semantics are untouched. The duckgres sink keeps its advisory-lock behavior.

## How did you test this code?

Automated tests only, all run locally by the agent (no manual prod testing):

- `postgres_queue/test_consumer.py` (52 passed): 5 new engine tests. New coverage catches regressions no existing test did: liveness starving while the startup sweep runs (the boot crash-loop), a hung poll wedging the loop forever instead of timing out, a hung startup sweep preventing polling from ever starting, and a lost lease at dispatch leading to double-processing.
- `postgres_queue/test_jobs_db.py` (37 passed, real Postgres): the existing claim/lease/recovery suite is the semantic net for the lateral rewrite – eligibility, failed-run exclusion, head-of-line gating, busy-schema gating, lease claiming/expiry/renewal, and per-team fairness all pass unchanged.
- `duckgres/test_consumer.py` (11 passed) and `postgres_queue/test_producer.py` (11 passed): unaffected sinks stay green.

Follow-ups tracked separately: an alert on batch-processing rate hitting zero while pods are up, suppressing user-facing failure digests for takeover-artifact errors, and bounding the candidate scan for very large backlogs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected; this changes internal loader infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). The work followed a production investigation session (Grafana Loki/VictoriaMetrics + federated queue tables via PostHog MCP) that identified each mechanism above from live incident data; the commits map 1:1 to the confirmed root causes.
- Skills invoked: `/writing-tests` (gated every new test against the "what regression does this catch" bar).
- Decisions: an in-place `UPDATE` of `exec_time` for heartbeats was implemented, then reverted after review discussion to preserve the append-only queue design – the lateral-probe commit removes the read-path cost that motivated it. History was rebased to keep one commit per fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*