### PR TITLE
feat(data-warehouse): implement simplecast import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -303,6 +303,7 @@ the row lists both.
 | shipstation             | HTTP                        | requests                                                        | ✅                          |
 | shopify                 | HTTP                        | requests                                                        | ✅                          |
 | shortcut                | HTTP                        | requests                                                        | ✅                          |
+| simplecast              | HTTP                        | requests                                                        | ✅                          |
 | simplesat               | HTTP                        | requests                                                        | ✅                          |
 | slack                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | smartsheet              | HTTP                        | requests                                                        | ✅                          |
@@ -658,6 +659,7 @@ doesn't conflict with concurrent PRs.
 - signnow
 - simfin
 - simplecast
+- simplesat
 - smaily
 - smartengage
 - smartreach

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -3024,7 +3024,7 @@ class SimFinSourceConfig(config.Config):
 
 @config.config
 class SimpleCastSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/canonical_descriptions.py
@@ -1,0 +1,22 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Descriptions sourced from the Simplecast API docs (https://apidocs.simplecast.com).
+# Partial coverage is fine — uncovered columns fall back to LLM enrichment.
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "podcasts": {
+        "description": "A podcast (show) hosted on Simplecast that the account's token can access.",
+        "docs_url": "https://apidocs.simplecast.com",
+        "columns": {
+            "id": "The unique ID of the podcast.",
+            "title": "The podcast's title.",
+            "account_id": "The ID of the account that owns the podcast.",
+            "status": "The publication status of the podcast.",
+            "episodes": "A reference to the podcast's episodes collection.",
+            "created_at": "When the podcast was created.",
+            "updated_at": "When the podcast was last updated.",
+            "href": "The API URL of the podcast resource.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/settings.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SimpleCastEndpointConfig:
+    name: str
+    path: str
+    # Simplecast resource IDs are globally unique UUIDs, so `id` is a safe primary key.
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+# Simplecast top-level list endpoints. Only account-level lists that need no parent id are
+# included; per-podcast resources (episodes, analytics, seasons) are fan-out endpoints and are
+# intentionally excluded from v1. All are full-refresh only: Simplecast exposes no documented
+# server-side timestamp/cursor filter, so there is no incremental cursor to advance safely.
+SIMPLECAST_ENDPOINTS: dict[str, SimpleCastEndpointConfig] = {
+    "podcasts": SimpleCastEndpointConfig(name="podcasts", path="/podcasts"),
+}
+
+ENDPOINTS = tuple(SIMPLECAST_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[dict[str, str]]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/simplecast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/simplecast.py
@@ -1,0 +1,166 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.settings import SIMPLECAST_ENDPOINTS
+
+SIMPLECAST_BASE_URL = "https://api.simplecast.com"
+# The list endpoints accept a `limit` of up to 100; the largest page minimises round trips.
+PAGE_SIZE = 100
+REQUEST_TIMEOUT_SECONDS = 60
+# Cheap endpoint used to confirm a token is genuine. The token is account-wide, so one probe
+# validates access to every list endpoint.
+DEFAULT_PROBE_PATH = "/podcasts"
+
+
+class SimpleCastRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class SimpleCastResumeConfig:
+    # Offset of the next page to fetch. Offset pagination is deterministic, so a crashed
+    # full-refresh sync resumes from the page after the last one yielded; merge dedupes on `id`.
+    offset: int = 0
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+
+@retry(
+    retry=retry_if_exception_type((SimpleCastRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(
+    session: requests.Session,
+    path: str,
+    offset: int,
+    limit: int,
+    logger: FilteringBoundLogger,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Fetch one page and report whether it is the last one.
+
+    Returns ``(items, is_last_page)``. Simplecast wraps rows in a ``collection`` array and reports
+    paging state under ``pages`` (``{"total": N, "current": N}``), so we can terminate either on a
+    short/empty collection or once the current page reaches the total.
+    """
+    response = session.get(
+        f"{SIMPLECAST_BASE_URL}{path}",
+        params={"limit": limit, "offset": offset},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise SimpleCastRetryableError(f"Simplecast API error (retryable): status={response.status_code}, path={path}")
+
+    if not response.ok:
+        logger.error(f"Simplecast API error: status={response.status_code}, body={response.text}, path={path}")
+        response.raise_for_status()
+
+    data = response.json()
+    # Simplecast list endpoints return an object envelope: {"collection": [...], "pages": {...}}.
+    if not isinstance(data, dict) or not isinstance(data.get("collection"), list):
+        raise SimpleCastRetryableError(f"Simplecast returned an unexpected payload for {path}: {type(data).__name__}")
+
+    items: list[dict[str, Any]] = data["collection"]
+
+    pages = data.get("pages")
+    is_last_page = False
+    if isinstance(pages, dict):
+        total = pages.get("total")
+        current = pages.get("current")
+        if isinstance(total, int) and isinstance(current, int):
+            is_last_page = current >= total
+
+    return items, is_last_page
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SimpleCastResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = SIMPLECAST_ENDPOINTS[endpoint]
+    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    offset = resume.offset if resume else 0
+    if resume and resume.offset > 0:
+        logger.debug(f"Simplecast: resuming {endpoint} from offset {offset}")
+
+    while True:
+        items, is_last_page = _fetch_page(session, config.path, offset, PAGE_SIZE, logger)
+        if items:
+            yield items
+
+        # A short/empty page or the paging metadata signalling the final page ends the collection.
+        if is_last_page or len(items) < PAGE_SIZE:
+            break
+
+        offset += PAGE_SIZE
+        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
+        # persisted); merge dedupes the re-pulled page on the primary key.
+        resumable_source_manager.save_state(SimpleCastResumeConfig(offset=offset))
+
+
+def simplecast_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SimpleCastResumeConfig],
+) -> SourceResponse:
+    config = SIMPLECAST_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+    )
+
+
+def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+    """Probe a single endpoint to validate the API token.
+
+    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
+    connection problem, other HTTP status otherwise.
+    """
+    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
+    try:
+        response = session.get(f"{SIMPLECAST_BASE_URL}{path}", params={"limit": 1}, timeout=15)
+    except Exception as e:
+        return 0, f"Could not connect to Simplecast: {e}"
+
+    if response.status_code in (401, 403):
+        return response.status_code, None
+
+    if not response.ok:
+        return response.status_code, f"Simplecast returned HTTP {response.status_code}"
+
+    return 200, None
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    status, message = check_access(api_key)
+    if status == 200:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Simplecast API token"
+    return False, message or "Could not validate Simplecast API token"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/source.py
@@ -27,8 +27,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.simplecast import (
     SimpleCastResumeConfig,
-    check_access,
     simplecast_source,
+    validate_credentials as _validate_credentials,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -110,12 +110,7 @@ You can create an API token on the **Private Apps** page in [Simplecast](https:/
         self, config: SimpleCastSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
         # The token is account-wide, so a single probe validates access to every schema.
-        status, message = check_access(config.api_key)
-        if status == 200:
-            return True, None
-        if status in (401, 403):
-            return False, "Invalid Simplecast API token"
-        return False, message or "Could not validate Simplecast API token"
+        return _validate_credentials(config.api_key)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[SimpleCastResumeConfig]:
         return ResumableSourceManager[SimpleCastResumeConfig](inputs, SimpleCastResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/source.py
@@ -1,19 +1,42 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SimpleCastSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.settings import (
+    ENDPOINTS,
+    SIMPLECAST_ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.simplecast import (
+    SimpleCastResumeConfig,
+    check_access,
+    simplecast_source,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class SimpleCastSource(SimpleSource[SimpleCastSourceConfig]):
+class SimpleCastSource(ResumableSource[SimpleCastSourceConfig, SimpleCastResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SIMPLECAST
@@ -24,7 +47,91 @@ class SimpleCastSource(SimpleSource[SimpleCastSourceConfig]):
             name=SchemaExternalDataSourceType.SIMPLE_CAST,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="SimpleCast",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Enter your Simplecast API token to pull your podcast data into the PostHog Data warehouse.
+
+You can create an API token on the **Private Apps** page in [Simplecast](https://dashboard.simplecast.com). The token grants read access to the podcasts your account can see.
+""",
             iconPath="/static/services/simplecast.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/simplecast",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.simplecast.com": "Your Simplecast API token is invalid or has been revoked. Generate a new token on the Private Apps page, then reconnect.",
+            "403 Client Error: Forbidden for url: https://api.simplecast.com": "Your Simplecast API token does not have access to this data. Check the token's permissions, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: SimpleCastSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Every endpoint is full refresh only — Simplecast's list endpoints expose no reliably
+        # ordered server-side timestamp filter, so there is no incremental cursor to advance.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: SimpleCastSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        # The token is account-wide, so a single probe validates access to every schema.
+        status, message = check_access(config.api_key)
+        if status == 200:
+            return True, None
+        if status in (401, 403):
+            return False, "Invalid Simplecast API token"
+        return False, message or "Could not validate Simplecast API token"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[SimpleCastResumeConfig]:
+        return ResumableSourceManager[SimpleCastResumeConfig](inputs, SimpleCastResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: SimpleCastSourceConfig,
+        resumable_source_manager: ResumableSourceManager[SimpleCastResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        if inputs.schema_name not in SIMPLECAST_ENDPOINTS:
+            raise ValueError(f"Unknown Simplecast schema '{inputs.schema_name}'")
+
+        return simplecast_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
@@ -1,0 +1,235 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast import simplecast
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.settings import (
+    ENDPOINTS,
+    SIMPLECAST_ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.simplecast import (
+    PAGE_SIZE,
+    SimpleCastResumeConfig,
+    SimpleCastRetryableError,
+    check_access,
+    get_rows,
+    simplecast_source,
+    validate_credentials,
+)
+
+# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
+_fetch_page_unwrapped = simplecast._fetch_page.__wrapped__  # type: ignore[attr-defined]
+
+
+class _FakeResumableManager:
+    def __init__(self, state: SimpleCastResumeConfig | None = None) -> None:
+        self._state = state
+        self.saved: list[SimpleCastResumeConfig] = []
+
+    def can_resume(self) -> bool:
+        return self._state is not None
+
+    def load_state(self) -> SimpleCastResumeConfig | None:
+        return self._state
+
+    def save_state(self, data: SimpleCastResumeConfig) -> None:
+        self.saved.append(data)
+
+
+def _full_page(start_id: int) -> list[dict]:
+    return [{"id": start_id + i} for i in range(PAGE_SIZE)]
+
+
+def _envelope(items: list[dict], total: int, current: int) -> dict:
+    return {"collection": items, "pages": {"total": total, "current": current}}
+
+
+class TestGetRows:
+    @staticmethod
+    def _collect(
+        manager: _FakeResumableManager,
+        monkeypatch: Any,
+        pages: dict[int, tuple[list[dict], bool]],
+        endpoint: str = "podcasts",
+    ) -> list[dict]:
+        def fake_fetch(session: Any, path: str, offset: int, limit: int, logger: Any) -> tuple[list[dict], bool]:
+            return pages[offset]
+
+        monkeypatch.setattr(simplecast, "_fetch_page", fake_fetch)
+        monkeypatch.setattr(simplecast, "make_tracked_session", lambda **kwargs: MagicMock())
+
+        rows: list[dict] = []
+        for batch in get_rows(
+            api_key="sc-token",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=manager,  # type: ignore[arg-type]
+        ):
+            rows.extend(batch)
+        return rows
+
+    def test_single_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: ([{"id": 1}, {"id": 2}], False)})
+        assert rows == [{"id": 1}, {"id": 2}]
+        # The page is short (< PAGE_SIZE), so we stop without persisting resume state.
+        assert manager.saved == []
+
+    def test_stops_on_last_page_flag_even_when_full(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        # A full page that the paging metadata marks as the last one must terminate the loop.
+        rows = self._collect(manager, monkeypatch, {0: (_full_page(0), True)})
+        assert len(rows) == PAGE_SIZE
+        assert manager.saved == []
+
+    def test_follows_offset_pagination_until_short_page(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        pages = {0: (_full_page(0), False), PAGE_SIZE: ([{"id": 999}], False)}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert len(rows) == PAGE_SIZE + 1
+        # State is saved after the first full page (offset advances to PAGE_SIZE), then we stop.
+        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+
+    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager(SimpleCastResumeConfig(offset=PAGE_SIZE))
+        # Offset 0 must never be fetched on resume.
+        pages = {PAGE_SIZE: ([{"id": 5}], False)}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert rows == [{"id": 5}]
+
+    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: ([], False)})
+        assert rows == []
+        assert manager.saved == []
+
+
+class TestFetchPage:
+    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.ok = status_code < 400
+        response.json.return_value = body if body is not None else _envelope([], total=1, current=1)
+        response.text = ""
+        response.raise_for_status.side_effect = (
+            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        return session
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(SimpleCastRetryableError):
+            _fetch_page_unwrapped(session, "/podcasts", 0, PAGE_SIZE, MagicMock())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(requests.HTTPError):
+            _fetch_page_unwrapped(session, "/podcasts", 0, PAGE_SIZE, MagicMock())
+
+    def test_success_returns_collection_and_not_last(self) -> None:
+        body = _envelope([{"id": 1}], total=3, current=1)
+        session = self._session_returning(200, body)
+        items, is_last = _fetch_page_unwrapped(session, "/podcasts", 0, PAGE_SIZE, MagicMock())
+        assert items == [{"id": 1}]
+        assert is_last is False
+
+    def test_success_marks_last_page_when_current_reaches_total(self) -> None:
+        body = _envelope([{"id": 1}], total=2, current=2)
+        session = self._session_returning(200, body)
+        items, is_last = _fetch_page_unwrapped(session, "/podcasts", 0, PAGE_SIZE, MagicMock())
+        assert items == [{"id": 1}]
+        assert is_last is True
+
+    @parameterized.expand(
+        [("bare_list", [{"id": 1}]), ("missing_collection", {"pages": {}}), ("error", {"error": "no"})]
+    )
+    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
+        session = self._session_returning(200, body)
+        with pytest.raises(SimpleCastRetryableError):
+            _fetch_page_unwrapped(session, "/podcasts", 0, PAGE_SIZE, MagicMock())
+
+    def test_request_uses_limit_and_offset_params(self) -> None:
+        session = self._session_returning(200, _envelope([], total=1, current=1))
+        _fetch_page_unwrapped(session, "/podcasts", 200, PAGE_SIZE, MagicMock())
+        _, kwargs = session.get.call_args
+        assert kwargs["params"] == {"limit": PAGE_SIZE, "offset": 200}
+
+
+class TestCheckAccess:
+    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
+        session = MagicMock()
+        if isinstance(response, Exception):
+            session.get.side_effect = response
+        else:
+            session.get.return_value = response
+        monkeypatch.setattr(simplecast, "make_tracked_session", lambda **kwargs: session)
+        return session
+
+    @pytest.mark.parametrize(
+        "status, ok, expected_status, expected_message",
+        [
+            (200, True, 200, None),
+            (401, False, 401, None),
+            (403, False, 403, None),
+            (500, False, 500, "Simplecast returned HTTP 500"),
+        ],
+    )
+    def test_status_mapping(
+        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = ok
+        self._patch_session(monkeypatch, response)
+        assert check_access("sc-token") == (expected_status, expected_message)
+
+    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
+        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
+        status, message = check_access("sc-token")
+        assert status == 0
+        assert message is not None and "boom" in message
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid Simplecast API token"),
+            (403, False, "Invalid Simplecast API token"),
+            (500, False, "Simplecast returned HTTP 500"),
+        ],
+    )
+    def test_validate_credentials(
+        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = status < 400
+        self._patch_session(monkeypatch, response)
+        assert validate_credentials("sc-token") == (expected_valid, expected_message)
+
+
+class TestSimpleCastSourceResponse:
+    @parameterized.expand([(e,) for e in ENDPOINTS])
+    def test_source_response_shape(self, endpoint: str) -> None:
+        response = simplecast_source(
+            api_key="sc-token",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=MagicMock(),
+        )
+        assert response.name == endpoint
+        assert response.primary_keys == ["id"]
+        # No stable creation timestamp is guaranteed across every object, so we don't partition.
+        assert response.partition_mode is None
+
+    def test_every_endpoint_uses_id_primary_key(self) -> None:
+        assert all(config.primary_keys == ["id"] for config in SIMPLECAST_ENDPOINTS.values())
+        assert set(SIMPLECAST_ENDPOINTS) == set(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
@@ -173,17 +173,22 @@ class TestCheckAccess:
         monkeypatch.setattr(simplecast, "make_tracked_session", lambda **kwargs: session)
         return session
 
-    @pytest.mark.parametrize(
-        "status, ok, expected_status, expected_message",
+    @parameterized.expand(
         [
-            (200, True, 200, None),
-            (401, False, 401, None),
-            (403, False, 403, None),
-            (500, False, 500, "Simplecast returned HTTP 500"),
-        ],
+            ("ok", 200, True, 200, None),
+            ("unauthorized", 401, False, 401, None),
+            ("forbidden", 403, False, 403, None),
+            ("server_error", 500, False, 500, "Simplecast returned HTTP 500"),
+        ]
     )
     def test_status_mapping(
-        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
+        self,
+        _name: str,
+        status: int,
+        ok: bool,
+        expected_status: int,
+        expected_message: str | None,
+        monkeypatch: Any,
     ) -> None:
         response = MagicMock()
         response.status_code = status
@@ -197,17 +202,16 @@ class TestCheckAccess:
         assert status == 0
         assert message is not None and "boom" in message
 
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
+    @parameterized.expand(
         [
-            (200, True, None),
-            (401, False, "Invalid Simplecast API token"),
-            (403, False, "Invalid Simplecast API token"),
-            (500, False, "Simplecast returned HTTP 500"),
-        ],
+            ("ok", 200, True, None),
+            ("unauthorized", 401, False, "Invalid Simplecast API token"),
+            ("forbidden", 403, False, "Invalid Simplecast API token"),
+            ("server_error", 500, False, "Simplecast returned HTTP 500"),
+        ]
     )
     def test_validate_credentials(
-        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
+        self, _name: str, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
     ) -> None:
         response = MagicMock()
         response.status_code = status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast.py
@@ -173,22 +173,19 @@ class TestCheckAccess:
         monkeypatch.setattr(simplecast, "make_tracked_session", lambda **kwargs: session)
         return session
 
-    @parameterized.expand(
+    # These cases use the pytest `monkeypatch` fixture, which parameterized.expand cannot inject
+    # (same limitation as async tests), so pytest.mark.parametrize is required here.
+    @pytest.mark.parametrize(
+        "status, ok, expected_status, expected_message",
         [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Simplecast returned HTTP 500"),
-        ]
+            (200, True, 200, None),
+            (401, False, 401, None),
+            (403, False, 403, None),
+            (500, False, 500, "Simplecast returned HTTP 500"),
+        ],
     )
     def test_status_mapping(
-        self,
-        _name: str,
-        status: int,
-        ok: bool,
-        expected_status: int,
-        expected_message: str | None,
-        monkeypatch: Any,
+        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
     ) -> None:
         response = MagicMock()
         response.status_code = status
@@ -202,16 +199,18 @@ class TestCheckAccess:
         assert status == 0
         assert message is not None and "boom" in message
 
-    @parameterized.expand(
+    # Uses the `monkeypatch` fixture, so pytest.mark.parametrize is required (see note above).
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
         [
-            ("ok", 200, True, None),
-            ("unauthorized", 401, False, "Invalid Simplecast API token"),
-            ("forbidden", 403, False, "Invalid Simplecast API token"),
-            ("server_error", 500, False, "Simplecast returned HTTP 500"),
-        ]
+            (200, True, None),
+            (401, False, "Invalid Simplecast API token"),
+            (403, False, "Invalid Simplecast API token"),
+            (500, False, "Simplecast returned HTTP 500"),
+        ],
     )
     def test_validate_credentials(
-        self, _name: str, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
+        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
     ) -> None:
         response = MagicMock()
         response.status_code = status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast_source.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+from parameterized import parameterized
+
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -69,55 +71,42 @@ class TestSimpleCastSource:
         assert {t["name"] for t in tables} == set(ENDPOINTS)
         assert all("Full refresh" in t["sync_methods"] for t in tables)
 
-    @pytest.mark.parametrize(
-        "observed_error",
+    @parameterized.expand(
         [
-            "401 Client Error: Unauthorized for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
-            "403 Client Error: Forbidden for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
-        ],
+            (
+                "unauthorized",
+                "401 Client Error: Unauthorized for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
+            ),
+            (
+                "forbidden",
+                "403 Client Error: Forbidden for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
+            ),
+        ]
     )
-    def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
+    def test_non_retryable_errors_match_auth_failures(self, _name: str, observed_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "unrelated_error",
+    @parameterized.expand(
         [
-            "500 Server Error: Internal Server Error for url: https://api.simplecast.com/podcasts",
-            "429 Client Error: Too Many Requests for url: https://api.simplecast.com/podcasts",
-        ],
+            ("server_error", "500 Server Error: Internal Server Error for url: https://api.simplecast.com/podcasts"),
+            ("rate_limited", "429 Client Error: Too Many Requests for url: https://api.simplecast.com/podcasts"),
+        ]
     )
-    def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
+    def test_non_retryable_errors_ignore_transient(self, _name: str, unrelated_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert not any(key in unrelated_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
-        [
-            (200, True, None),
-            (401, False, "Invalid Simplecast API token"),
-            (403, False, "Invalid Simplecast API token"),
-            (500, False, "Simplecast returned HTTP 500"),
-            (0, False, "Could not connect to Simplecast: boom"),
-        ],
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.source._validate_credentials"
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.source.check_access")
-    def test_validate_credentials(
-        self,
-        mock_check: mock.MagicMock,
-        status: int,
-        expected_valid: bool,
-        expected_message: str | None,
-    ) -> None:
-        message = (
-            "Simplecast returned HTTP 500"
-            if status == 500
-            else ("Could not connect to Simplecast: boom" if status == 0 else None)
-        )
-        mock_check.return_value = (status, message)
-        is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
-        assert is_valid is expected_valid
-        assert returned == expected_message
+    def test_validate_credentials_delegates_to_shared_helper(self, mock_validate: mock.MagicMock) -> None:
+        # The method is a thin wrapper: it must pass the token through and return the helper's result
+        # unchanged. The status->message mapping itself is covered in test_simplecast.py.
+        mock_validate.return_value = (False, "Invalid Simplecast API token")
+        result = self.source.validate_credentials(self.config, self.team_id)
+        mock_validate.assert_called_once_with("sc-token")
+        assert result == (False, "Invalid Simplecast API token")
 
     def test_get_resumable_source_manager_binds_resume_config(self) -> None:
         manager = self.source.get_resumable_source_manager(mock.MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/simplecast/tests/test_simplecast_source.py
@@ -1,0 +1,145 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SimpleCastSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.simplecast import (
+    SimpleCastResumeConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.source import SimpleCastSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestSimpleCastSource:
+    def setup_method(self) -> None:
+        self.source = SimpleCastSource()
+        self.team_id = 123
+        self.config = SimpleCastSourceConfig(api_key="sc-token")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.SIMPLECAST
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+        assert config.name.value == "SimpleCast"
+        assert config.label == "SimpleCast"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        # A finished source is visible — it must not carry the scaffolding flag.
+        assert not config.unreleasedSource
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/simplecast"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_key"]
+
+    def test_api_key_field_is_secret_password(self) -> None:
+        config = self.source.get_source_config
+        field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_key")
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.secret is True
+        assert field.required is True
+
+    def test_no_connection_host_fields(self) -> None:
+        # The only field is the secret API token; the base URL is hardcoded, so there is no non-secret
+        # field an editor could retarget to reuse a preserved token against another account.
+        assert self.source.connection_host_fields == []
+
+    def test_lists_tables_without_credentials(self) -> None:
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_get_schemas_covers_all_endpoints_as_full_refresh(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        assert all(s.supports_incremental is False for s in schemas)
+        assert all(s.supports_append is False for s in schemas)
+        assert all(s.incremental_fields == [] for s in schemas)
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["podcasts"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "podcasts"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self) -> None:
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_documented_tables_render_for_public_docs(self) -> None:
+        tables = self.source.get_documented_tables()
+        assert {t["name"] for t in tables} == set(ENDPOINTS)
+        assert all("Full refresh" in t["sync_methods"] for t in tables)
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
+            "403 Client Error: Forbidden for url: https://api.simplecast.com/podcasts?limit=100&offset=0",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "unrelated_error",
+        [
+            "500 Server Error: Internal Server Error for url: https://api.simplecast.com/podcasts",
+            "429 Client Error: Too Many Requests for url: https://api.simplecast.com/podcasts",
+        ],
+    )
+    def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert not any(key in unrelated_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid Simplecast API token"),
+            (403, False, "Invalid Simplecast API token"),
+            (500, False, "Simplecast returned HTTP 500"),
+            (0, False, "Could not connect to Simplecast: boom"),
+        ],
+    )
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.source.check_access")
+    def test_validate_credentials(
+        self,
+        mock_check: mock.MagicMock,
+        status: int,
+        expected_valid: bool,
+        expected_message: str | None,
+    ) -> None:
+        message = (
+            "Simplecast returned HTTP 500"
+            if status == 500
+            else ("Could not connect to Simplecast: boom" if status == 0 else None)
+        )
+        mock_check.return_value = (status, message)
+        is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
+        assert is_valid is expected_valid
+        assert returned == expected_message
+
+    def test_get_resumable_source_manager_binds_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is SimpleCastResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.simplecast.source.simplecast_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "podcasts"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source.assert_called_once()
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["api_key"] == "sc-token"
+        assert kwargs["endpoint"] == "podcasts"
+        assert kwargs["resumable_source_manager"] is manager
+
+    def test_source_for_pipeline_rejects_unknown_schema(self) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "not_a_table"
+        with pytest.raises(ValueError, match="Unknown Simplecast schema 'not_a_table'"):
+            self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)


### PR DESCRIPTION
## Problem

Simplecast was a scaffolded Data warehouse source (registered stub, `unreleasedSource=True`, no sync logic), so users couldn't pull their Simplecast data into PostHog.

## Changes

Implements the Simplecast source end to end following the `implementing-warehouse-sources` skill.

- Auth: `Authorization: Bearer`. Base URL `https://api.simplecast.com`.
- Endpoints: `podcasts` (primary key `id`).
- Transport: limit/offset over the `{"collection": [...], "pages": {...}}` envelope, over the tracked HTTP session with secrets redacted, tenacity retries on 429/5xx, and non-retryable mapping for 401/403.

Full refresh only (the skill's guidance: no unverifiable incremental logic). Removes `unreleasedSource` so the connector is visible and connectable, shipping at `releaseStatus=ALPHA`. `SOURCES.md` and the generated source config are updated.

## How did you test this code?

Added transport tests and source-class tests (pagination and termination, resume/cursor state, retryable vs non-retryable status mapping, credential validation, the full-refresh schema list, and argument plumbing). All pass locally.

I (Claude) couldn't run a live sync against Simplecast (no account/API key), so endpoint shapes come from the public API docs rather than a curl smoke test.

Reviewer note: Only `podcasts` is a top-level list; episodes and analytics are per-podcast fan-out and left out of v1.

