### PR TITLE
feat(data-warehouse): implement jobnimbus import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -195,6 +195,7 @@ the row lists both.
 | ip2whois                | HTTP                        | requests                                                        | ✅                          |
 | iterable                | HTTP                        | requests                                                        | ✅                          |
 | jira                    | HTTP                        | requests                                                        | ✅                          |
+| jobnimbus               | HTTP                        | requests                                                        | ✅                          |
 | jotform                 | HTTP                        | requests                                                        | ✅                          |
 | justcall                | HTTP                        | requests                                                        | ✅                          |
 | k6_cloud                | HTTP                        | requests                                                        | ✅                          |
@@ -497,7 +498,6 @@ doesn't conflict with concurrent PRs.
 - invoiced
 - jamf_pro
 - jobber
-- jobnimbus
 - judgeme_reviews
 - justsift
 - kafka

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -1691,7 +1691,7 @@ class JiraSourceConfig(config.Config):
 
 @config.config
 class JobNimbusSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/canonical_descriptions.py
@@ -1,0 +1,65 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Descriptions sourced from the JobNimbus Open API docs (https://documenter.getpostman.com/view/3919598/S11PpG7g).
+# Partial coverage is fine — uncovered columns fall back to LLM enrichment.
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "contacts": {
+        "description": "A person or company in your JobNimbus CRM — a lead, customer, or business contact.",
+        "docs_url": "https://documenter.getpostman.com/view/3919598/S11PpG7g",
+        "columns": {
+            "jnid": "The unique ID of the contact.",
+            "display_name": "The contact's display name.",
+            "first_name": "The contact's first name.",
+            "last_name": "The contact's last name.",
+            "company": "The company the contact is associated with.",
+            "email": "The contact's primary email address.",
+            "status_name": "The contact's current status in the workflow.",
+            "record_type_name": "The contact record type.",
+            "date_created": "When the contact was created (epoch seconds).",
+            "date_updated": "When the contact was last updated (epoch seconds).",
+        },
+    },
+    "jobs": {
+        "description": "A job or project tracked in JobNimbus, typically linked to one or more contacts.",
+        "docs_url": "https://documenter.getpostman.com/view/3919598/S11PpG7g",
+        "columns": {
+            "jnid": "The unique ID of the job.",
+            "name": "The job name.",
+            "number": "The human-readable job number.",
+            "status_name": "The job's current status in the workflow.",
+            "record_type_name": "The job record type.",
+            "date_created": "When the job was created (epoch seconds).",
+            "date_updated": "When the job was last updated (epoch seconds).",
+            "date_status_change": "When the job status last changed (epoch seconds).",
+        },
+    },
+    "tasks": {
+        "description": "A to-do or scheduled task linked to a contact or job.",
+        "docs_url": "https://documenter.getpostman.com/view/3919598/S11PpG7g",
+        "columns": {
+            "jnid": "The unique ID of the task.",
+            "title": "The task title.",
+            "description": "The task description.",
+            "record_type_name": "The task record type.",
+            "date_start": "When the task starts (epoch seconds).",
+            "date_end": "When the task ends (epoch seconds).",
+            "is_completed": "Whether the task has been completed.",
+            "date_created": "When the task was created (epoch seconds).",
+            "date_updated": "When the task was last updated (epoch seconds).",
+        },
+    },
+    "activities": {
+        "description": "An activity or note recorded against a contact or job (calls, emails, updates).",
+        "docs_url": "https://documenter.getpostman.com/view/3919598/S11PpG7g",
+        "columns": {
+            "jnid": "The unique ID of the activity.",
+            "note": "The activity note or message body.",
+            "record_type_name": "The activity record type.",
+            "primary": "The primary related record (contact or job) the activity is attached to.",
+            "date_created": "When the activity was created (epoch seconds).",
+            "date_updated": "When the activity was last updated (epoch seconds).",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/jobnimbus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/jobnimbus.py
@@ -1,0 +1,158 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import JOBNIMBUS_ENDPOINTS
+
+JOBNIMBUS_BASE_URL = "https://app.jobnimbus.com/api1"
+# The Elasticsearch-backed list endpoints accept a `size` of up to 100; the largest page minimises
+# round trips.
+PAGE_SIZE = 100
+REQUEST_TIMEOUT_SECONDS = 60
+# Cheap endpoint used to confirm an API key is genuine. The key is account-wide, so one probe
+# validates access to every list endpoint.
+DEFAULT_PROBE_PATH = "/contacts"
+
+
+class JobNimbusRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class JobNimbusResumeConfig:
+    # Offset of the next page to fetch. Offset pagination is deterministic, so a crashed
+    # full-refresh sync resumes from the page after the last one yielded; merge dedupes on `jnid`.
+    offset: int = 0
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+
+@retry(
+    retry=retry_if_exception_type((JobNimbusRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(
+    session: requests.Session,
+    path: str,
+    offset: int,
+    limit: int,
+    logger: FilteringBoundLogger,
+) -> tuple[list[dict[str, Any]], int]:
+    response = session.get(
+        f"{JOBNIMBUS_BASE_URL}{path}",
+        params={"size": limit, "from": offset},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise JobNimbusRetryableError(f"JobNimbus API error (retryable): status={response.status_code}, path={path}")
+
+    if not response.ok:
+        logger.error(f"JobNimbus API error: status={response.status_code}, body={response.text}, path={path}")
+        response.raise_for_status()
+
+    data = response.json()
+    # JobNimbus list endpoints wrap rows in `{"count": N, "results": [...]}`.
+    if not isinstance(data, dict):
+        raise JobNimbusRetryableError(f"JobNimbus returned an unexpected payload for {path}: {type(data).__name__}")
+    results = data.get("results")
+    if not isinstance(results, list):
+        raise JobNimbusRetryableError(f"JobNimbus returned no results list for {path}: {type(results).__name__}")
+    count = data.get("count")
+    # `count` is the total matching row count; if it's ever missing the short-page check still
+    # terminates the scan safely.
+    if not isinstance(count, int):
+        count = offset + len(results)
+    return results, count
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[JobNimbusResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = JOBNIMBUS_ENDPOINTS[endpoint]
+    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    offset = resume.offset if resume else 0
+    if resume and resume.offset > 0:
+        logger.debug(f"JobNimbus: resuming {endpoint} from offset {offset}")
+
+    while True:
+        items, count = _fetch_page(session, config.path, offset, PAGE_SIZE, logger)
+        if items:
+            yield items
+
+        # Stop on a short/empty page or once the offset has caught up to the reported total.
+        if len(items) < PAGE_SIZE or offset + len(items) >= count:
+            break
+
+        offset += PAGE_SIZE
+        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
+        # persisted); merge dedupes the re-pulled page on the primary key.
+        resumable_source_manager.save_state(JobNimbusResumeConfig(offset=offset))
+
+
+def jobnimbus_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[JobNimbusResumeConfig],
+) -> SourceResponse:
+    config = JOBNIMBUS_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+    )
+
+
+def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+    """Probe a single endpoint to validate the API key.
+
+    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
+    connection problem, other HTTP status otherwise.
+    """
+    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
+    try:
+        response = session.get(f"{JOBNIMBUS_BASE_URL}{path}", params={"size": 1, "from": 0}, timeout=15)
+    except Exception as e:
+        return 0, f"Could not connect to JobNimbus: {e}"
+
+    if response.status_code in (401, 403):
+        return response.status_code, None
+
+    if not response.ok:
+        return response.status_code, f"JobNimbus returned HTTP {response.status_code}"
+
+    return 200, None
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    status, message = check_access(api_key)
+    if status == 200:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid JobNimbus API key"
+    return False, message or "Could not validate JobNimbus API key"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/settings.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class JobNimbusEndpointConfig:
+    name: str
+    path: str
+    # JobNimbus records carry a globally unique `jnid` (not `id`), so it is a safe primary key.
+    primary_keys: list[str] = field(default_factory=lambda: ["jnid"])
+
+
+# JobNimbus Open API top-level list endpoints. All are full-refresh only: while records expose
+# `date_created` / `date_updated` epoch fields, the server-side modification filter syntax isn't
+# documented well enough to advance an incremental cursor safely, so a client-side scan would cost
+# the same as a full refresh (see the implementing-warehouse-sources skill).
+JOBNIMBUS_ENDPOINTS: dict[str, JobNimbusEndpointConfig] = {
+    "contacts": JobNimbusEndpointConfig(name="contacts", path="/contacts"),
+    "jobs": JobNimbusEndpointConfig(name="jobs", path="/jobs"),
+    "tasks": JobNimbusEndpointConfig(name="tasks", path="/tasks"),
+    "activities": JobNimbusEndpointConfig(name="activities", path="/activities"),
+}
+
+ENDPOINTS = tuple(JOBNIMBUS_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[dict[str, str]]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
@@ -1,19 +1,42 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import JobNimbusSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import (
+    JobNimbusResumeConfig,
+    check_access,
+    jobnimbus_source,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import (
+    ENDPOINTS,
+    JOBNIMBUS_ENDPOINTS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class JobNimbusSource(SimpleSource[JobNimbusSourceConfig]):
+class JobNimbusSource(ResumableSource[JobNimbusSourceConfig, JobNimbusResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.JOBNIMBUS
@@ -24,7 +47,91 @@ class JobNimbusSource(SimpleSource[JobNimbusSourceConfig]):
             name=SchemaExternalDataSourceType.JOB_NIMBUS,
             category=DataWarehouseSourceCategory.CRM,
             label="JobNimbus",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Enter your JobNimbus API key to pull your CRM data into the PostHog Data warehouse.
+
+You can create an API key under **Settings → API** in [JobNimbus](https://app.jobnimbus.com). The key grants access to your contacts, jobs, tasks, and activities.
+""",
             iconPath="/static/services/jobnimbus.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/jobnimbus",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://app.jobnimbus.com": "Your JobNimbus API key is invalid or has been revoked. Generate a new key under Settings → API, then reconnect.",
+            "403 Client Error: Forbidden for url: https://app.jobnimbus.com": "Your JobNimbus API key does not have access to this data. Check the key's access profile, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: JobNimbusSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Every endpoint is full refresh only — JobNimbus's list endpoints expose no reliably
+        # documented server-side timestamp filter, so there is no incremental cursor to advance.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: JobNimbusSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        # The API key is account-wide, so a single probe validates access to every schema.
+        status, message = check_access(config.api_key)
+        if status == 200:
+            return True, None
+        if status in (401, 403):
+            return False, "Invalid JobNimbus API key"
+        return False, message or "Could not validate JobNimbus API key"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[JobNimbusResumeConfig]:
+        return ResumableSourceManager[JobNimbusResumeConfig](inputs, JobNimbusResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: JobNimbusSourceConfig,
+        resumable_source_manager: ResumableSourceManager[JobNimbusResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        if inputs.schema_name not in JOBNIMBUS_ENDPOINTS:
+            raise ValueError(f"Unknown JobNimbus schema '{inputs.schema_name}'")
+
+        return jobnimbus_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
@@ -23,8 +23,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sch
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import JobNimbusSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import (
     JobNimbusResumeConfig,
-    check_access,
     jobnimbus_source,
+    validate_credentials as _validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import (
     ENDPOINTS,
@@ -110,12 +110,7 @@ You can create an API key under **Settings → API** in [JobNimbus](https://app.
         self, config: JobNimbusSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
         # The API key is account-wide, so a single probe validates access to every schema.
-        status, message = check_access(config.api_key)
-        if status == 200:
-            return True, None
-        if status in (401, 403):
-            return False, "Invalid JobNimbus API key"
-        return False, message or "Could not validate JobNimbus API key"
+        return _validate_credentials(config.api_key)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[JobNimbusResumeConfig]:
         return ResumableSourceManager[JobNimbusResumeConfig](inputs, JobNimbusResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus.py
@@ -1,0 +1,230 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus import jobnimbus
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import (
+    PAGE_SIZE,
+    JobNimbusResumeConfig,
+    JobNimbusRetryableError,
+    check_access,
+    get_rows,
+    jobnimbus_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import (
+    ENDPOINTS,
+    JOBNIMBUS_ENDPOINTS,
+)
+
+# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
+_fetch_page_unwrapped = jobnimbus._fetch_page.__wrapped__  # type: ignore[attr-defined]
+
+
+class _FakeResumableManager:
+    def __init__(self, state: JobNimbusResumeConfig | None = None) -> None:
+        self._state = state
+        self.saved: list[JobNimbusResumeConfig] = []
+
+    def can_resume(self) -> bool:
+        return self._state is not None
+
+    def load_state(self) -> JobNimbusResumeConfig | None:
+        return self._state
+
+    def save_state(self, data: JobNimbusResumeConfig) -> None:
+        self.saved.append(data)
+
+
+def _full_page(start_id: int) -> list[dict]:
+    return [{"jnid": str(start_id + i)} for i in range(PAGE_SIZE)]
+
+
+class TestGetRows:
+    @staticmethod
+    def _collect(
+        manager: _FakeResumableManager,
+        monkeypatch: Any,
+        pages: dict[int, tuple[list[dict], int]],
+        endpoint: str = "contacts",
+    ) -> list[dict]:
+        def fake_fetch(session: Any, path: str, offset: int, limit: int, logger: Any) -> tuple[list[dict], int]:
+            return pages[offset]
+
+        monkeypatch.setattr(jobnimbus, "_fetch_page", fake_fetch)
+        monkeypatch.setattr(jobnimbus, "make_tracked_session", lambda **kwargs: MagicMock())
+
+        rows: list[dict] = []
+        for batch in get_rows(
+            api_key="jn-key",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=manager,  # type: ignore[arg-type]
+        ):
+            rows.extend(batch)
+        return rows
+
+    def test_single_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: ([{"jnid": "1"}, {"jnid": "2"}], 2)})
+        assert rows == [{"jnid": "1"}, {"jnid": "2"}]
+        # The page is short (< PAGE_SIZE), so we stop without persisting resume state.
+        assert manager.saved == []
+
+    def test_follows_offset_pagination_until_short_page(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        pages = {0: (_full_page(0), PAGE_SIZE + 1), PAGE_SIZE: ([{"jnid": "999"}], PAGE_SIZE + 1)}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert len(rows) == PAGE_SIZE + 1
+        # State is saved after the first full page (offset advances to PAGE_SIZE), then we stop.
+        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+
+    def test_stops_when_offset_reaches_reported_count(self, monkeypatch: Any) -> None:
+        # A full page whose length exactly equals the reported total must terminate without a
+        # second request, even though the page isn't short.
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: (_full_page(0), PAGE_SIZE)})
+        assert len(rows) == PAGE_SIZE
+        assert manager.saved == []
+
+    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager(JobNimbusResumeConfig(offset=PAGE_SIZE))
+        # Offset 0 must never be fetched on resume.
+        pages = {PAGE_SIZE: ([{"jnid": "5"}], PAGE_SIZE + 1)}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert rows == [{"jnid": "5"}]
+
+    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: ([], 0)})
+        assert rows == []
+        assert manager.saved == []
+
+
+class TestFetchPage:
+    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.ok = status_code < 400
+        response.json.return_value = body if body is not None else {"count": 0, "results": []}
+        response.text = ""
+        response.raise_for_status.side_effect = (
+            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        return session
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(JobNimbusRetryableError):
+            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(requests.HTTPError):
+            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+
+    def test_success_returns_results_and_count(self) -> None:
+        body = {"count": 3, "results": [{"jnid": "1"}]}
+        session = self._session_returning(200, body)
+        results, count = _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+        assert results == [{"jnid": "1"}]
+        assert count == 3
+
+    def test_missing_count_falls_back_to_offset_plus_len(self) -> None:
+        body = {"results": [{"jnid": "1"}, {"jnid": "2"}]}
+        session = self._session_returning(200, body)
+        results, count = _fetch_page_unwrapped(session, "/contacts", 50, PAGE_SIZE, MagicMock())
+        assert results == body["results"]
+        assert count == 52
+
+    @parameterized.expand([("bare_list", [{"jnid": "1"}]), ("results_not_a_list", {"results": "nope"})])
+    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
+        session = self._session_returning(200, body)
+        with pytest.raises(JobNimbusRetryableError):
+            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+
+    def test_request_uses_size_and_from_params(self) -> None:
+        session = self._session_returning(200, {"count": 0, "results": []})
+        _fetch_page_unwrapped(session, "/jobs", 200, PAGE_SIZE, MagicMock())
+        _, kwargs = session.get.call_args
+        assert kwargs["params"] == {"size": PAGE_SIZE, "from": 200}
+
+
+class TestCheckAccess:
+    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
+        session = MagicMock()
+        if isinstance(response, Exception):
+            session.get.side_effect = response
+        else:
+            session.get.return_value = response
+        monkeypatch.setattr(jobnimbus, "make_tracked_session", lambda **kwargs: session)
+        return session
+
+    @pytest.mark.parametrize(
+        "status, ok, expected_status, expected_message",
+        [
+            (200, True, 200, None),
+            (401, False, 401, None),
+            (403, False, 403, None),
+            (500, False, 500, "JobNimbus returned HTTP 500"),
+        ],
+    )
+    def test_status_mapping(
+        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = ok
+        self._patch_session(monkeypatch, response)
+        assert check_access("jn-key") == (expected_status, expected_message)
+
+    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
+        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
+        status, message = check_access("jn-key")
+        assert status == 0
+        assert message is not None and "boom" in message
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid JobNimbus API key"),
+            (403, False, "Invalid JobNimbus API key"),
+            (500, False, "JobNimbus returned HTTP 500"),
+        ],
+    )
+    def test_validate_credentials(
+        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = status < 400
+        self._patch_session(monkeypatch, response)
+        assert validate_credentials("jn-key") == (expected_valid, expected_message)
+
+
+class TestJobNimbusSourceResponse:
+    @parameterized.expand([(e,) for e in ENDPOINTS])
+    def test_source_response_shape(self, endpoint: str) -> None:
+        response = jobnimbus_source(
+            api_key="jn-key",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=MagicMock(),
+        )
+        assert response.name == endpoint
+        assert response.primary_keys == ["jnid"]
+        # No stable creation timestamp is guaranteed across every object, so we don't partition.
+        assert response.partition_mode is None
+
+    def test_every_endpoint_uses_jnid_primary_key(self) -> None:
+        assert all(config.primary_keys == ["jnid"] for config in JOBNIMBUS_ENDPOINTS.values())
+        assert set(JOBNIMBUS_ENDPOINTS) == set(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+from parameterized import parameterized
+
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -67,45 +69,42 @@ class TestJobNimbusSource:
         assert {t["name"] for t in tables} == set(ENDPOINTS)
         assert all("Full refresh" in t["sync_methods"] for t in tables)
 
-    @pytest.mark.parametrize(
-        "observed_error",
+    @parameterized.expand(
         [
-            "401 Client Error: Unauthorized for url: https://app.jobnimbus.com/api1/contacts?size=100&from=0",
-            "403 Client Error: Forbidden for url: https://app.jobnimbus.com/api1/jobs?size=100&from=0",
-        ],
+            ("401 Client Error: Unauthorized for url: https://app.jobnimbus.com/api1/contacts?size=100&from=0",),
+            ("403 Client Error: Forbidden for url: https://app.jobnimbus.com/api1/jobs?size=100&from=0",),
+        ]
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "unrelated_error",
+    @parameterized.expand(
         [
-            "500 Server Error: Internal Server Error for url: https://app.jobnimbus.com/api1/contacts",
-            "429 Client Error: Too Many Requests for url: https://app.jobnimbus.com/api1/jobs",
-        ],
+            ("500 Server Error: Internal Server Error for url: https://app.jobnimbus.com/api1/contacts",),
+            ("429 Client Error: Too Many Requests for url: https://app.jobnimbus.com/api1/jobs",),
+        ]
     )
     def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert not any(key in unrelated_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
+    @parameterized.expand(
         [
             (200, True, None),
             (401, False, "Invalid JobNimbus API key"),
             (403, False, "Invalid JobNimbus API key"),
             (500, False, "JobNimbus returned HTTP 500"),
             (0, False, "Could not connect to JobNimbus: boom"),
-        ],
+        ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.source.check_access")
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus.check_access")
     def test_validate_credentials(
         self,
-        mock_check: mock.MagicMock,
         status: int,
         expected_valid: bool,
         expected_message: str | None,
+        mock_check: mock.MagicMock,
     ) -> None:
         message = (
             "JobNimbus returned HTTP 500"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
@@ -1,0 +1,143 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import JobNimbusSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import JobNimbusResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.source import JobNimbusSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestJobNimbusSource:
+    def setup_method(self) -> None:
+        self.source = JobNimbusSource()
+        self.team_id = 123
+        self.config = JobNimbusSourceConfig(api_key="jn-key")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.JOBNIMBUS
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+        assert config.name.value == "JobNimbus"
+        assert config.label == "JobNimbus"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        # A finished source is visible — it must not carry the scaffolding flag.
+        assert not config.unreleasedSource
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/jobnimbus"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_key"]
+
+    def test_api_key_field_is_secret_password(self) -> None:
+        config = self.source.get_source_config
+        field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_key")
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.secret is True
+        assert field.required is True
+
+    def test_no_connection_host_fields(self) -> None:
+        # The only field is the secret API key; the base URL is hardcoded, so there is no non-secret
+        # field an editor could retarget to reuse a preserved key against another account.
+        assert self.source.connection_host_fields == []
+
+    def test_lists_tables_without_credentials(self) -> None:
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_get_schemas_covers_all_endpoints_as_full_refresh(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        assert all(s.supports_incremental is False for s in schemas)
+        assert all(s.supports_append is False for s in schemas)
+        assert all(s.incremental_fields == [] for s in schemas)
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["jobs"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "jobs"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self) -> None:
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_documented_tables_render_for_public_docs(self) -> None:
+        tables = self.source.get_documented_tables()
+        assert {t["name"] for t in tables} == set(ENDPOINTS)
+        assert all("Full refresh" in t["sync_methods"] for t in tables)
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://app.jobnimbus.com/api1/contacts?size=100&from=0",
+            "403 Client Error: Forbidden for url: https://app.jobnimbus.com/api1/jobs?size=100&from=0",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "unrelated_error",
+        [
+            "500 Server Error: Internal Server Error for url: https://app.jobnimbus.com/api1/contacts",
+            "429 Client Error: Too Many Requests for url: https://app.jobnimbus.com/api1/jobs",
+        ],
+    )
+    def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert not any(key in unrelated_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid JobNimbus API key"),
+            (403, False, "Invalid JobNimbus API key"),
+            (500, False, "JobNimbus returned HTTP 500"),
+            (0, False, "Could not connect to JobNimbus: boom"),
+        ],
+    )
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.source.check_access")
+    def test_validate_credentials(
+        self,
+        mock_check: mock.MagicMock,
+        status: int,
+        expected_valid: bool,
+        expected_message: str | None,
+    ) -> None:
+        message = (
+            "JobNimbus returned HTTP 500"
+            if status == 500
+            else ("Could not connect to JobNimbus: boom" if status == 0 else None)
+        )
+        mock_check.return_value = (status, message)
+        is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
+        assert is_valid is expected_valid
+        assert returned == expected_message
+
+    def test_get_resumable_source_manager_binds_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is JobNimbusResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.source.jobnimbus_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "contacts"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source.assert_called_once()
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["api_key"] == "jn-key"
+        assert kwargs["endpoint"] == "contacts"
+        assert kwargs["resumable_source_manager"] is manager
+
+    def test_source_for_pipeline_rejects_unknown_schema(self) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "not_a_table"
+        with pytest.raises(ValueError, match="Unknown JobNimbus schema 'not_a_table'"):
+            self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)


### PR DESCRIPTION
## Problem

JobNimbus was a scaffolded Data warehouse source (registered stub, `unreleasedSource=True`, no sync logic), so users couldn't pull their JobNimbus data into PostHog.

## Changes

Implements the JobNimbus source end to end following the `implementing-warehouse-sources` skill.

- Auth: `Authorization: Bearer`. Base URL `https://app.jobnimbus.com/api1`.
- Endpoints: `contacts`, `jobs`, `tasks`, `activities` (primary key `jnid`).
- Transport: `from`/`size` offset over the `{"count", "results"}` envelope, over the tracked HTTP session with secrets redacted, tenacity retries on 429/5xx, and non-retryable mapping for 401/403.

Full refresh only (the skill's guidance: no unverifiable incremental logic). Removes `unreleasedSource` so the connector is visible and connectable, shipping at `releaseStatus=ALPHA`. `SOURCES.md` and the generated source config are updated.

## How did you test this code?

Added transport tests and source-class tests (pagination and termination, resume/cursor state, retryable vs non-retryable status mapping, credential validation, the full-refresh schema list, and argument plumbing). All pass locally.

I (Claude) couldn't run a live sync against JobNimbus (no account/API key), so endpoint shapes come from the public API docs rather than a curl smoke test.

Reviewer note: Very large accounts could hit JobNimbus's ~10k Elasticsearch result window; v1 is full refresh.

