### PR TITLE
feat(data-warehouse): implement qualaroo import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -271,6 +271,7 @@ the row lists both.
 | postmark                | HTTP                        | requests                                                        | ✅                          |
 | productboard            | HTTP                        | requests                                                        | ✅                          |
 | pylon                   | HTTP                        | requests                                                        | ✅                          |
+| qualaroo                | HTTP                        | requests                                                        | ✅                          |
 | recurly                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | ramp                    | HTTP                        | requests                                                        | ✅                          |
 | recharge                | HTTP                        | requests                                                        | ✅                          |
@@ -600,7 +601,6 @@ doesn't conflict with concurrent PRs.
 - productive
 - pypi
 - qonto
-- qualaroo
 - qualtrics
 - quickbooks
 - railz

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -2634,7 +2634,8 @@ class QontoSourceConfig(config.Config):
 
 @config.config
 class QualarooSourceConfig(config.Config):
-    pass
+    api_key: str
+    api_secret: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/canonical_descriptions.py
@@ -1,0 +1,22 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Descriptions sourced from the Qualaroo REST Reporting API docs
+# (https://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API).
+# Partial coverage is fine — uncovered columns fall back to LLM enrichment.
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "nudges": {
+        "description": "A Qualaroo nudge (survey) configured in your account.",
+        "docs_url": "https://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API",
+        "columns": {
+            "id": "The unique ID of the nudge (survey).",
+            "name": "The internal name of the nudge.",
+            "alias": "The human-readable alias of the nudge.",
+            "type": "The nudge type (for example, survey or exit).",
+            "status": "The current status of the nudge (for example, active or paused).",
+            "created_at": "When the nudge was created.",
+            "updated_at": "When the nudge was last updated.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/qualaroo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/qualaroo.py
@@ -1,0 +1,164 @@
+import base64
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.settings import QUALAROO_ENDPOINTS
+
+QUALAROO_BASE_URL = "https://api.qualaroo.com/api/v1"
+# The Reporting API caps a page at 500 records; the largest page minimises round trips.
+PAGE_SIZE = 500
+REQUEST_TIMEOUT_SECONDS = 60
+# Cheap endpoint used to confirm the credentials are genuine. The API key/secret pair is
+# account-wide, so one probe validates access to every list endpoint.
+DEFAULT_PROBE_PATH = "/nudges.json"
+
+
+class QualarooRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class QualarooResumeConfig:
+    # Offset of the next page to fetch. Offset pagination is deterministic, so a crashed
+    # full-refresh sync resumes from the page after the last one yielded; merge dedupes on `id`.
+    offset: int = 0
+
+
+def _basic_auth_token(api_key: str, api_secret: str) -> str:
+    # Qualaroo uses HTTP Basic auth with the API key as username and the API secret as password.
+    return base64.b64encode(f"{api_key}:{api_secret}".encode()).decode("ascii")
+
+
+def _headers(api_key: str, api_secret: str) -> dict[str, str]:
+    return {"Authorization": f"Basic {_basic_auth_token(api_key, api_secret)}", "Accept": "application/json"}
+
+
+@retry(
+    retry=retry_if_exception_type((QualarooRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(
+    session: requests.Session,
+    path: str,
+    offset: int,
+    limit: int,
+    logger: FilteringBoundLogger,
+) -> list[dict[str, Any]]:
+    response = session.get(
+        f"{QUALAROO_BASE_URL}{path}",
+        params={"limit": limit, "offset": offset},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise QualarooRetryableError(f"Qualaroo API error (retryable): status={response.status_code}, path={path}")
+
+    if not response.ok:
+        logger.error(f"Qualaroo API error: status={response.status_code}, body={response.text}, path={path}")
+        response.raise_for_status()
+
+    data = response.json()
+    # Qualaroo list endpoints return a bare JSON array of records.
+    if not isinstance(data, list):
+        raise QualarooRetryableError(f"Qualaroo returned an unexpected payload for {path}: {type(data).__name__}")
+    return data
+
+
+def get_rows(
+    api_key: str,
+    api_secret: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[QualarooResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = QUALAROO_ENDPOINTS[endpoint]
+    session = make_tracked_session(
+        headers=_headers(api_key, api_secret),
+        redact_values=(api_key, api_secret, _basic_auth_token(api_key, api_secret)),
+    )
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    offset = resume.offset if resume else 0
+    if resume and resume.offset > 0:
+        logger.debug(f"Qualaroo: resuming {endpoint} from offset {offset}")
+
+    while True:
+        items = _fetch_page(session, config.path, offset, PAGE_SIZE, logger)
+        if items:
+            yield items
+
+        # A short page (or an empty one) means we've reached the end of the collection.
+        if len(items) < PAGE_SIZE:
+            break
+
+        offset += PAGE_SIZE
+        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
+        # persisted); merge dedupes the re-pulled page on the primary key.
+        resumable_source_manager.save_state(QualarooResumeConfig(offset=offset))
+
+
+def qualaroo_source(
+    api_key: str,
+    api_secret: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[QualarooResumeConfig],
+) -> SourceResponse:
+    config = QUALAROO_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            api_secret=api_secret,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+    )
+
+
+def check_access(api_key: str, api_secret: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+    """Probe a single endpoint to validate the credentials.
+
+    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
+    connection problem, other HTTP status otherwise.
+    """
+    session = make_tracked_session(
+        headers=_headers(api_key, api_secret),
+        redact_values=(api_key, api_secret, _basic_auth_token(api_key, api_secret)),
+    )
+    try:
+        response = session.get(f"{QUALAROO_BASE_URL}{path}", params={"limit": 1, "offset": 0}, timeout=15)
+    except Exception as e:
+        return 0, f"Could not connect to Qualaroo: {e}"
+
+    if response.status_code in (401, 403):
+        return response.status_code, None
+
+    if not response.ok:
+        return response.status_code, f"Qualaroo returned HTTP {response.status_code}"
+
+    return 200, None
+
+
+def validate_credentials(api_key: str, api_secret: str) -> tuple[bool, str | None]:
+    status, message = check_access(api_key, api_secret)
+    if status == 200:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Qualaroo API key or secret"
+    return False, message or "Could not validate Qualaroo credentials"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/settings.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class QualarooEndpointConfig:
+    name: str
+    path: str
+    # Qualaroo nudge (survey) IDs are unique within an account, so `id` is a safe primary key.
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+# Qualaroo REST Reporting API top-level list endpoints. Only account-wide lists are exposed here:
+# per-survey responses live at /nudges/{id}/responses.json and require a parent nudge ID, so they
+# are a fan-out stream and are intentionally skipped for now.
+#
+# All endpoints are full-refresh only. The responses endpoint supports server-side start_date/
+# end_date filters, but the nudges list has no reliably ordered timestamp filter, so there is no
+# incremental cursor to advance (see the implementing-warehouse-sources skill).
+QUALAROO_ENDPOINTS: dict[str, QualarooEndpointConfig] = {
+    "nudges": QualarooEndpointConfig(name="nudges", path="/nudges.json"),
+}
+
+ENDPOINTS = tuple(QUALAROO_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[dict[str, str]]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/source.py
@@ -23,8 +23,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sch
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import QualarooSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.qualaroo import (
     QualarooResumeConfig,
-    check_access,
     qualaroo_source,
+    validate_credentials as _validate_qualaroo_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.settings import (
     ENDPOINTS,
@@ -118,12 +118,7 @@ You can find your API key and secret under **Settings → API** in [Qualaroo](ht
         self, config: QualarooSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
         # The key/secret pair is account-wide, so a single probe validates access to every schema.
-        status, message = check_access(config.api_key, config.api_secret)
-        if status == 200:
-            return True, None
-        if status in (401, 403):
-            return False, "Invalid Qualaroo API key or secret"
-        return False, message or "Could not validate Qualaroo credentials"
+        return _validate_qualaroo_credentials(config.api_key, config.api_secret)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[QualarooResumeConfig]:
         return ResumableSourceManager[QualarooResumeConfig](inputs, QualarooResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/source.py
@@ -1,19 +1,42 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import QualarooSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.qualaroo import (
+    QualarooResumeConfig,
+    check_access,
+    qualaroo_source,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.settings import (
+    ENDPOINTS,
+    QUALAROO_ENDPOINTS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class QualarooSource(SimpleSource[QualarooSourceConfig]):
+class QualarooSource(ResumableSource[QualarooSourceConfig, QualarooResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.QUALAROO
@@ -24,7 +47,100 @@ class QualarooSource(SimpleSource[QualarooSourceConfig]):
             name=SchemaExternalDataSourceType.QUALAROO,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="Qualaroo",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Enter your Qualaroo API key and secret to pull your survey (nudge) data into the PostHog Data warehouse.
+
+You can find your API key and secret under **Settings → API** in [Qualaroo](https://app.qualaroo.com/). They authenticate the REST Reporting API with read access to your nudges.
+""",
             iconPath="/static/services/qualaroo.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/qualaroo",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="api_secret",
+                        label="API secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.qualaroo.com": "Your Qualaroo API key or secret is invalid or has been revoked. Generate a new pair under Settings → API, then reconnect.",
+            "403 Client Error: Forbidden for url: https://api.qualaroo.com": "Your Qualaroo credentials do not have access to this data. Check the key's permissions, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: QualarooSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Every endpoint is full refresh only — the nudges list exposes no reliably ordered
+        # server-side timestamp filter, so there is no incremental cursor to advance.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: QualarooSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        # The key/secret pair is account-wide, so a single probe validates access to every schema.
+        status, message = check_access(config.api_key, config.api_secret)
+        if status == 200:
+            return True, None
+        if status in (401, 403):
+            return False, "Invalid Qualaroo API key or secret"
+        return False, message or "Could not validate Qualaroo credentials"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[QualarooResumeConfig]:
+        return ResumableSourceManager[QualarooResumeConfig](inputs, QualarooResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: QualarooSourceConfig,
+        resumable_source_manager: ResumableSourceManager[QualarooResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        if inputs.schema_name not in QUALAROO_ENDPOINTS:
+            raise ValueError(f"Unknown Qualaroo schema '{inputs.schema_name}'")
+
+        return qualaroo_source(
+            api_key=config.api_key,
+            api_secret=config.api_secret,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo.py
@@ -1,0 +1,220 @@
+import base64
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo import qualaroo
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.qualaroo import (
+    PAGE_SIZE,
+    QualarooResumeConfig,
+    QualarooRetryableError,
+    _basic_auth_token,
+    check_access,
+    get_rows,
+    qualaroo_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.settings import (
+    ENDPOINTS,
+    QUALAROO_ENDPOINTS,
+)
+
+# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
+_fetch_page_unwrapped = qualaroo._fetch_page.__wrapped__  # type: ignore[attr-defined]
+
+
+class _FakeResumableManager:
+    def __init__(self, state: QualarooResumeConfig | None = None) -> None:
+        self._state = state
+        self.saved: list[QualarooResumeConfig] = []
+
+    def can_resume(self) -> bool:
+        return self._state is not None
+
+    def load_state(self) -> QualarooResumeConfig | None:
+        return self._state
+
+    def save_state(self, data: QualarooResumeConfig) -> None:
+        self.saved.append(data)
+
+
+def _full_page(start_id: int) -> list[dict]:
+    return [{"id": start_id + i} for i in range(PAGE_SIZE)]
+
+
+class TestBasicAuthToken:
+    def test_encodes_key_and_secret_as_basic_credentials(self) -> None:
+        token = _basic_auth_token("my-key", "my-secret")
+        assert base64.b64decode(token).decode() == "my-key:my-secret"
+
+
+class TestGetRows:
+    @staticmethod
+    def _collect(
+        manager: _FakeResumableManager, monkeypatch: Any, pages: dict[int, list[dict]], endpoint: str = "nudges"
+    ) -> list[dict]:
+        def fake_fetch(session: Any, path: str, offset: int, limit: int, logger: Any) -> list[dict]:
+            return pages[offset]
+
+        monkeypatch.setattr(qualaroo, "_fetch_page", fake_fetch)
+        monkeypatch.setattr(qualaroo, "make_tracked_session", lambda **kwargs: MagicMock())
+
+        rows: list[dict] = []
+        for batch in get_rows(
+            api_key="q-key",
+            api_secret="q-secret",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=manager,  # type: ignore[arg-type]
+        ):
+            rows.extend(batch)
+        return rows
+
+    def test_single_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: [{"id": 1}, {"id": 2}]})
+        assert rows == [{"id": 1}, {"id": 2}]
+        # The page is short (< PAGE_SIZE), so we stop without persisting resume state.
+        assert manager.saved == []
+
+    def test_follows_offset_pagination_until_short_page(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        pages = {0: _full_page(0), PAGE_SIZE: [{"id": 999}]}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert len(rows) == PAGE_SIZE + 1
+        # State is saved after the first full page (offset advances to PAGE_SIZE), then we stop.
+        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+
+    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager(QualarooResumeConfig(offset=PAGE_SIZE))
+        # Offset 0 must never be fetched on resume.
+        pages = {PAGE_SIZE: [{"id": 5}]}
+        rows = self._collect(manager, monkeypatch, pages)
+        assert rows == [{"id": 5}]
+
+    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
+        manager = _FakeResumableManager()
+        rows = self._collect(manager, monkeypatch, {0: []})
+        assert rows == []
+        assert manager.saved == []
+
+
+class TestFetchPage:
+    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.ok = status_code < 400
+        response.json.return_value = body if body is not None else []
+        response.text = ""
+        response.raise_for_status.side_effect = (
+            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        return session
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(QualarooRetryableError):
+            _fetch_page_unwrapped(session, "/nudges.json", 0, PAGE_SIZE, MagicMock())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
+        session = self._session_returning(status)
+        with pytest.raises(requests.HTTPError):
+            _fetch_page_unwrapped(session, "/nudges.json", 0, PAGE_SIZE, MagicMock())
+
+    def test_success_returns_list_body(self) -> None:
+        body = [{"id": 1}]
+        session = self._session_returning(200, body)
+        result = _fetch_page_unwrapped(session, "/nudges.json", 0, PAGE_SIZE, MagicMock())
+        assert result == body
+
+    def test_non_list_body_is_retryable(self) -> None:
+        session = self._session_returning(200, {"error": "nope"})
+        with pytest.raises(QualarooRetryableError):
+            _fetch_page_unwrapped(session, "/nudges.json", 0, PAGE_SIZE, MagicMock())
+
+    def test_request_uses_limit_and_offset_params(self) -> None:
+        session = self._session_returning(200, [])
+        _fetch_page_unwrapped(session, "/nudges.json", 1000, PAGE_SIZE, MagicMock())
+        _, kwargs = session.get.call_args
+        assert kwargs["params"] == {"limit": PAGE_SIZE, "offset": 1000}
+
+
+class TestCheckAccess:
+    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
+        session = MagicMock()
+        if isinstance(response, Exception):
+            session.get.side_effect = response
+        else:
+            session.get.return_value = response
+        monkeypatch.setattr(qualaroo, "make_tracked_session", lambda **kwargs: session)
+        return session
+
+    @pytest.mark.parametrize(
+        "status, ok, expected_status, expected_message",
+        [
+            (200, True, 200, None),
+            (401, False, 401, None),
+            (403, False, 403, None),
+            (500, False, 500, "Qualaroo returned HTTP 500"),
+        ],
+    )
+    def test_status_mapping(
+        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = ok
+        self._patch_session(monkeypatch, response)
+        assert check_access("q-key", "q-secret") == (expected_status, expected_message)
+
+    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
+        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
+        status, message = check_access("q-key", "q-secret")
+        assert status == 0
+        assert message is not None and "boom" in message
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid Qualaroo API key or secret"),
+            (403, False, "Invalid Qualaroo API key or secret"),
+            (500, False, "Qualaroo returned HTTP 500"),
+        ],
+    )
+    def test_validate_credentials(
+        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
+    ) -> None:
+        response = MagicMock()
+        response.status_code = status
+        response.ok = status < 400
+        self._patch_session(monkeypatch, response)
+        assert validate_credentials("q-key", "q-secret") == (expected_valid, expected_message)
+
+
+class TestQualarooSourceResponse:
+    @parameterized.expand([(e,) for e in ENDPOINTS])
+    def test_source_response_shape(self, endpoint: str) -> None:
+        response = qualaroo_source(
+            api_key="q-key",
+            api_secret="q-secret",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=MagicMock(),
+        )
+        assert response.name == endpoint
+        assert response.primary_keys == ["id"]
+        # No stable creation timestamp is guaranteed across every object, so we don't partition.
+        assert response.partition_mode is None
+
+    def test_every_endpoint_uses_id_primary_key(self) -> None:
+        assert all(config.primary_keys == ["id"] for config in QUALAROO_ENDPOINTS.values())
+        assert set(QUALAROO_ENDPOINTS) == set(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo.py
@@ -2,7 +2,7 @@ import base64
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import requests
 from parameterized import parameterized
@@ -148,56 +148,49 @@ class TestFetchPage:
 
 
 class TestCheckAccess:
-    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
+    def _patch_session(self, response: Any) -> Any:
         session = MagicMock()
         if isinstance(response, Exception):
             session.get.side_effect = response
         else:
             session.get.return_value = response
-        monkeypatch.setattr(qualaroo, "make_tracked_session", lambda **kwargs: session)
-        return session
+        return patch.object(qualaroo, "make_tracked_session", lambda **kwargs: session)
 
-    @pytest.mark.parametrize(
-        "status, ok, expected_status, expected_message",
+    @parameterized.expand(
         [
             (200, True, 200, None),
             (401, False, 401, None),
             (403, False, 403, None),
             (500, False, 500, "Qualaroo returned HTTP 500"),
-        ],
+        ]
     )
-    def test_status_mapping(
-        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
-    ) -> None:
+    def test_status_mapping(self, status: int, ok: bool, expected_status: int, expected_message: str | None) -> None:
         response = MagicMock()
         response.status_code = status
         response.ok = ok
-        self._patch_session(monkeypatch, response)
-        assert check_access("q-key", "q-secret") == (expected_status, expected_message)
+        with self._patch_session(response):
+            assert check_access("q-key", "q-secret") == (expected_status, expected_message)
 
-    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
-        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
-        status, message = check_access("q-key", "q-secret")
+    def test_connection_error_maps_to_zero(self) -> None:
+        with self._patch_session(requests.ConnectionError("boom")):
+            status, message = check_access("q-key", "q-secret")
         assert status == 0
         assert message is not None and "boom" in message
 
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
+    @parameterized.expand(
         [
             (200, True, None),
             (401, False, "Invalid Qualaroo API key or secret"),
             (403, False, "Invalid Qualaroo API key or secret"),
             (500, False, "Qualaroo returned HTTP 500"),
-        ],
+        ]
     )
-    def test_validate_credentials(
-        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
-    ) -> None:
+    def test_validate_credentials(self, status: int, expected_valid: bool, expected_message: str | None) -> None:
         response = MagicMock()
         response.status_code = status
         response.ok = status < 400
-        self._patch_session(monkeypatch, response)
-        assert validate_credentials("q-key", "q-secret") == (expected_valid, expected_message)
+        with self._patch_session(response):
+            assert validate_credentials("q-key", "q-secret") == (expected_valid, expected_message)
 
 
 class TestQualarooSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo_source.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+from parameterized import parameterized
+
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -32,7 +34,7 @@ class TestQualarooSource:
         field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
         assert field_names == ["api_key", "api_secret"]
 
-    @pytest.mark.parametrize("field_name", ["api_key", "api_secret"])
+    @parameterized.expand([("api_key",), ("api_secret",)])
     def test_credential_fields_are_secret_passwords(self, field_name: str) -> None:
         config = self.source.get_source_config
         field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == field_name)
@@ -68,55 +70,36 @@ class TestQualarooSource:
         assert {t["name"] for t in tables} == set(ENDPOINTS)
         assert all("Full refresh" in t["sync_methods"] for t in tables)
 
-    @pytest.mark.parametrize(
-        "observed_error",
+    @parameterized.expand(
         [
-            "401 Client Error: Unauthorized for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",
-            "403 Client Error: Forbidden for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",
-        ],
+            ("401 Client Error: Unauthorized for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",),
+            ("403 Client Error: Forbidden for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",),
+        ]
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "unrelated_error",
+    @parameterized.expand(
         [
-            "500 Server Error: Internal Server Error for url: https://api.qualaroo.com/api/v1/nudges.json",
-            "429 Client Error: Too Many Requests for url: https://api.qualaroo.com/api/v1/nudges.json",
-        ],
+            ("500 Server Error: Internal Server Error for url: https://api.qualaroo.com/api/v1/nudges.json",),
+            ("429 Client Error: Too Many Requests for url: https://api.qualaroo.com/api/v1/nudges.json",),
+        ]
     )
     def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
         non_retryable = self.source.get_non_retryable_errors()
         assert not any(key in unrelated_error for key in non_retryable)
 
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
-        [
-            (200, True, None),
-            (401, False, "Invalid Qualaroo API key or secret"),
-            (403, False, "Invalid Qualaroo API key or secret"),
-            (500, False, "Qualaroo returned HTTP 500"),
-            (0, False, "Could not connect to Qualaroo: boom"),
-        ],
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.source._validate_qualaroo_credentials"
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.source.check_access")
-    def test_validate_credentials(
-        self,
-        mock_check: mock.MagicMock,
-        status: int,
-        expected_valid: bool,
-        expected_message: str | None,
-    ) -> None:
-        message = (
-            "Qualaroo returned HTTP 500"
-            if status == 500
-            else ("Could not connect to Qualaroo: boom" if status == 0 else None)
-        )
-        mock_check.return_value = (status, message)
-        is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
-        assert is_valid is expected_valid
-        assert returned == expected_message
+    def test_validate_credentials_delegates_to_qualaroo(self, mock_validate: mock.MagicMock) -> None:
+        # The status-to-result mapping lives in qualaroo.validate_credentials; the source only forwards
+        # the account-wide key/secret and returns the result unchanged.
+        mock_validate.return_value = (False, "Invalid Qualaroo API key or secret")
+        result = self.source.validate_credentials(self.config, self.team_id)
+        mock_validate.assert_called_once_with("q-key", "q-secret")
+        assert result == (False, "Invalid Qualaroo API key or secret")
 
     def test_get_resumable_source_manager_binds_resume_config(self) -> None:
         manager = self.source.get_resumable_source_manager(mock.MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/qualaroo/tests/test_qualaroo_source.py
@@ -1,0 +1,145 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import QualarooSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.qualaroo import QualarooResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.source import QualarooSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestQualarooSource:
+    def setup_method(self) -> None:
+        self.source = QualarooSource()
+        self.team_id = 123
+        self.config = QualarooSourceConfig(api_key="q-key", api_secret="q-secret")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.QUALAROO
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+        assert config.name.value == "Qualaroo"
+        assert config.label == "Qualaroo"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        # A finished source is visible — it must not carry the scaffolding flag.
+        assert not config.unreleasedSource
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/qualaroo"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_key", "api_secret"]
+
+    @pytest.mark.parametrize("field_name", ["api_key", "api_secret"])
+    def test_credential_fields_are_secret_passwords(self, field_name: str) -> None:
+        config = self.source.get_source_config
+        field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == field_name)
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.secret is True
+        assert field.required is True
+
+    def test_no_connection_host_fields(self) -> None:
+        # Both fields are secret credentials; the base URL is hardcoded, so there is no non-secret
+        # field an editor could retarget to reuse a preserved secret against another account.
+        assert self.source.connection_host_fields == []
+
+    def test_lists_tables_without_credentials(self) -> None:
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_get_schemas_covers_all_endpoints_as_full_refresh(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        assert all(s.supports_incremental is False for s in schemas)
+        assert all(s.supports_append is False for s in schemas)
+        assert all(s.incremental_fields == [] for s in schemas)
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["nudges"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "nudges"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self) -> None:
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_documented_tables_render_for_public_docs(self) -> None:
+        tables = self.source.get_documented_tables()
+        assert {t["name"] for t in tables} == set(ENDPOINTS)
+        assert all("Full refresh" in t["sync_methods"] for t in tables)
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",
+            "403 Client Error: Forbidden for url: https://api.qualaroo.com/api/v1/nudges.json?limit=500&offset=0",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "unrelated_error",
+        [
+            "500 Server Error: Internal Server Error for url: https://api.qualaroo.com/api/v1/nudges.json",
+            "429 Client Error: Too Many Requests for url: https://api.qualaroo.com/api/v1/nudges.json",
+        ],
+    )
+    def test_non_retryable_errors_ignore_transient(self, unrelated_error: str) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert not any(key in unrelated_error for key in non_retryable)
+
+    @pytest.mark.parametrize(
+        "status, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid Qualaroo API key or secret"),
+            (403, False, "Invalid Qualaroo API key or secret"),
+            (500, False, "Qualaroo returned HTTP 500"),
+            (0, False, "Could not connect to Qualaroo: boom"),
+        ],
+    )
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.source.check_access")
+    def test_validate_credentials(
+        self,
+        mock_check: mock.MagicMock,
+        status: int,
+        expected_valid: bool,
+        expected_message: str | None,
+    ) -> None:
+        message = (
+            "Qualaroo returned HTTP 500"
+            if status == 500
+            else ("Could not connect to Qualaroo: boom" if status == 0 else None)
+        )
+        mock_check.return_value = (status, message)
+        is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
+        assert is_valid is expected_valid
+        assert returned == expected_message
+
+    def test_get_resumable_source_manager_binds_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is QualarooResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.qualaroo.source.qualaroo_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "nudges"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source.assert_called_once()
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["api_key"] == "q-key"
+        assert kwargs["api_secret"] == "q-secret"
+        assert kwargs["endpoint"] == "nudges"
+        assert kwargs["resumable_source_manager"] is manager
+
+    def test_source_for_pipeline_rejects_unknown_schema(self) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "not_a_table"
+        with pytest.raises(ValueError, match="Unknown Qualaroo schema 'not_a_table'"):
+            self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)


### PR DESCRIPTION
## Problem

Qualaroo was a scaffolded Data warehouse source (registered stub, `unreleasedSource=True`, no sync logic), so users couldn't pull their Qualaroo data into PostHog.

## Changes

Implements the Qualaroo source end to end following the `implementing-warehouse-sources` skill.

- Auth: HTTP Basic (API key + secret, two secret fields). Base URL `https://api.qualaroo.com/api/v1`.
- Endpoints: `nudges` (surveys) (primary key `id`).
- Transport: limit/offset (max 500), over the tracked HTTP session with secrets redacted, tenacity retries on 429/5xx, and non-retryable mapping for 401/403.

Full refresh only (the skill's guidance: no unverifiable incremental logic). Removes `unreleasedSource` so the connector is visible and connectable, shipping at `releaseStatus=ALPHA`. `SOURCES.md` and the generated source config are updated.

## How did you test this code?

Added transport tests and source-class tests (pagination and termination, resume/cursor state, retryable vs non-retryable status mapping, credential validation, the full-refresh schema list, and argument plumbing). All pass locally.

I (Claude) couldn't run a live sync against Qualaroo (no account/API key), so endpoint shapes come from the public API docs rather than a curl smoke test.

Reviewer note: Per-survey responses are a fan-out endpoint and are left out of v1.

