### PR TITLE
fix(csp): stop truncating sub-1% sampling rates to zero

### DIFF
--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -631,14 +631,14 @@ class TestCSPModule(TestCase):
         """
 
         # Test specific URL+time combinations with known expected outcomes
-        # These were determined by calculating hash(url + "-" + timestamp) % 100
+        # These were determined by calculating hash(url + "-" + timestamp) % 10000
         deterministic_test_cases = [
-            # URL, time_string, expected_result_at_50_percent, hash_mod_100
-            ("https://example.com/other", "2023-01-01 12:00:00", True, 8),  # 8 < 50 = True
-            ("https://example.com/other", "2023-01-01 12:01:00", False, 99),  # 99 >= 50 = False
-            ("https://test.com/page", "2023-01-01 12:03:00", False, 52),  # 52 >= 50 = False
-            ("https://test.com/page", "2023-01-01 12:04:00", True, 43),  # 43 < 50 = True
-            ("https://test.com/page", "2023-01-01 12:09:00", False, 98),  # 98 >= 50 = False
+            # URL, time_string, expected_result_at_50_percent, hash_mod_10000
+            ("https://example.com/other", "2023-01-01 12:00:00", True, 1608),  # 1608 < 5000 = True
+            ("https://example.com/other", "2023-01-01 12:08:00", False, 9936),  # 9936 >= 5000 = False
+            ("https://example.com/other", "2023-01-01 12:09:00", False, 9727),  # 9727 >= 5000 = False
+            ("https://test.com/page", "2023-01-01 12:03:00", True, 2352),  # 2352 < 5000 = True
+            ("https://test.com/page", "2023-01-01 12:04:00", True, 2143),  # 2143 < 5000 = True
         ]
 
         for url, time_string, expected_result, expected_hash_mod in deterministic_test_cases:
@@ -646,15 +646,15 @@ class TestCSPModule(TestCase):
                 properties = {"document_url": url, "effective_directive": "script-src"}
                 result = sample_csp_report(properties, 0.5)
                 assert result == expected_result, (
-                    f"Expected {expected_result} for {url} at {time_string} (hash%100={expected_hash_mod}), got {result}"
+                    f"Expected {expected_result} for {url} at {time_string} (hash%10000={expected_hash_mod}), got {result}"
                 )
 
         # Demonstrate the key improvement: same URL gets different sampling decisions across time
-        url = "https://test.com/page"
+        url = "https://example.com/other"
         time_sampling_pairs = [
-            ("2023-01-01 12:03:00", False),  # hash%100=52 >= 50
-            ("2023-01-01 12:04:00", True),  # hash%100=43 < 50
-            ("2023-01-01 12:09:00", False),  # hash%100=98 >= 50
+            ("2023-01-01 12:03:00", True),  # hash%10000=981 < 5000
+            ("2023-01-01 12:08:00", False),  # hash%10000=9936 >= 5000
+            ("2023-01-01 12:09:00", False),  # hash%10000=9727 >= 5000
         ]
 
         sampled_in_results = []

--- a/posthog/sampling.py
+++ b/posthog/sampling.py
@@ -75,4 +75,5 @@ def sample_on_property(prop: str, percent: float) -> bool:
         return True
 
     percent = clamp_to_range(percent, 0, 1, "Sampling rate")
-    return simple_hash(prop) % 100 < int(percent * 100)
+    # 4-decimal-place resolution so sub-1% rates don't truncate to zero
+    return simple_hash(prop) % 10000 < round(percent * 10000)

--- a/posthog/test/test_sampling.py
+++ b/posthog/test/test_sampling.py
@@ -28,6 +28,11 @@ class TestSampling(TestCase):
         # The same string should have the same sampling decision at the same rate
         assert sample_on_property(test_string, 0.1) is result_at_10_percent
 
+    def test_sample_on_property_sub_one_percent_rate(self):
+        # sub-1% rates used to truncate to 0% and sample nothing
+        sampled = sum(1 for i in range(10_000) if sample_on_property(f"example.com:script-src-{i}", 0.005))
+        assert 0 < sampled < 200
+
     def test_clamp_to_range(self):
         assert clamp_to_range(5, 0, 10) == 5
         assert clamp_to_range(-5, 0, 10) == 0


### PR DESCRIPTION
## Problem

`sample_on_property` in `posthog/sampling.py` decides sampling with `simple_hash(prop) % 100 < int(percent * 100)`. For any rate below 1% (say a CSP reporting `sample_rate` of 0.005), `int(percent * 100)` truncates to 0, so the comparison is always false and nothing is ingested. A team configuring a sub-1% CSP sample rate silently gets 0% instead of the rate they asked for.

## Changes

- Raise the sampling resolution to 4 decimal places: `simple_hash(prop) % 10000 < round(percent * 10000)`. Rates down to 0.01% now sample the configured fraction; whole-percent rates keep the same statistical behavior.
- Updated the deterministic expectations in `test_csp.py::test_same_url_different_sampling_across_time_windows`, which hardcoded `hash % 100` bucket values.

One behavior note: for a given rate, the specific keys that fall inside the sample change (the bucketing changed). CSP sampling keys include a per-minute timestamp so there is no cross-time stickiness to preserve, and the only other caller (`set_recorder_script` management command) is a manually run rollout tool.

## How did you test this code?

- Added `test_sample_on_property_sub_one_percent_rate` to `posthog/test/test_sampling.py`: asserts a 0.5% rate over 10k deterministic keys samples a nonzero, roughly correct fraction. This is the regression guard, before the fix it samples exactly zero, and no existing test exercised a sub-1% rate.
- Ran `posthog/test/test_sampling.py` (4 passed) and `posthog/api/test/test_csp.py` (24 passed) locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is one of six small improvement PRs from a PostHog Code (Claude Code) session sweeping the codebase for safe bugfixes and cleanups. The bug was found by an exploration agent grepping for int-truncation patterns and verified by reading the call sites. The `/writing-tests` skill was invoked before adding the test. Considered keeping 100 buckets and comparing against the float rate instead, but that still misrepresents sub-1% rates (rounds them up to 1%), so higher resolution was chosen.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
