### PR TITLE
fix(postgres): retry connection-limit refusals during schema discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -322,13 +322,16 @@ def _is_connection_dropped_error(error: BaseException) -> bool:
 
 
 def _is_connection_limit_error(error: BaseException) -> bool:
-    """True if the source refused a new connection because it's at a connection limit.
+    """True if the source refused a connection because it's at a connection limit.
 
-    Distinct from `_is_connection_dropped_error`: the connection was never established, so this is
-    only meaningful on the connect path (`_connect_with_dropped_retry`), not for mid-stream fetch
-    failures on an already-open connection.
+    Usually a connect-time refusal (`psycopg.OperationalError`), but a pooler that caches an
+    upstream login failure instead reveals the limit on the first query as a `ProtocolViolation`
+    ("server login has been failing, cached error: remaining connection slots are reserved ..."),
+    so match that type too. Distinct from `_is_connection_dropped_error` — the backend connection
+    was never usable — but the same transient capacity class: a slot frees the moment another
+    connection closes, so it stays retryable and is never a `NonRetryableError`.
     """
-    if not isinstance(error, psycopg.OperationalError):
+    if not isinstance(error, psycopg.OperationalError | psycopg.errors.ProtocolViolation):
         return False
     message = " ".join(str(arg) for arg in error.args).lower()
     return any(substring in message for substring in _CONNECTION_LIMIT_ERROR_SUBSTRINGS)
@@ -353,6 +356,20 @@ def _is_dropped_or_connect_timeout(error: BaseException) -> bool:
         or _is_connection_limit_error(error)
         or isinstance(error, psycopg.errors.ConnectionTimeout)
     )
+
+
+def _is_dropped_or_connection_limit(error: BaseException) -> bool:
+    """Transient conditions the background schema-discovery retry recovers from in process.
+
+    A mid-stream drop (`_is_connection_dropped_error`) or a connection-limit refusal
+    (`_is_connection_limit_error`). Both are transient — a slot frees as connections close, and a
+    pooler-cached login failure clears once the upstream has capacity — so discovery retries them on
+    a fresh connection instead of failing the activity and surfacing captured error-tracking noise.
+    Unlike the read/sync connect path (`_is_dropped_or_connect_timeout`), a connect-time *timeout* is
+    deliberately excluded: during discovery a timeout usually means a now-unreachable host, which
+    should fail fast rather than burn the retry budget.
+    """
+    return _is_connection_dropped_error(error) or _is_connection_limit_error(error)
 
 
 def _raise_if_setup_connection_broken(connection: psycopg.Connection) -> None:
@@ -1194,7 +1211,15 @@ def _schemas_from_conn(
             cursor.execute(
                 sql.SQL("SET statement_timeout = {timeout}").format(timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS))
             )
-        except psycopg.Error:
+        except psycopg.Error as e:
+            # A dropped or connection-limit-refused upstream fails on this first query too — a pooler
+            # surfacing "remaining connection slots are reserved ..." on the first statement. Rolling
+            # that back raises a misleading "the connection is lost" that buries the real cause, so
+            # re-raise the true error and let the discovery retry recover on a fresh connection. A
+            # live engine that merely rejects the SET (e.g. DuckDB) is not a drop/limit: clear the
+            # aborted transaction and fall back to the default timeout.
+            if _is_connection_dropped_error(e) or _is_connection_limit_error(e):
+                raise
             connection.rollback()
 
         discovered_tables, _qualify_with_schema = _get_discovered_tables(cursor, schema, names)
@@ -1284,9 +1309,11 @@ def get_schemas(
     # either on connect or on the first discovery query (e.g. `SELECT version()` in
     # `_is_duckdb_connection`). Retry the whole connect-and-discover cycle on a fresh connection so
     # the retry spans both — otherwise the blip fails the discovery activity and surfaces as
-    # captured error-tracking noise even though the next attempt would succeed. Permanent errors
-    # (auth failures, SSL-required) re-raise immediately because `_is_connection_dropped_error` only
-    # matches transient drops.
+    # captured error-tracking noise even though the next attempt would succeed. Connection-limit
+    # refusals ("remaining connection slots are reserved", "sorry, too many clients already") are
+    # retried the same way — the customer's database is momentarily out of slots and frees one as
+    # connections close. Permanent errors (auth failures, SSL-required) re-raise immediately because
+    # `_is_dropped_or_connection_limit` matches only transient drops and connection-limit refusals.
     def _connect_and_discover() -> dict[str, PostgresDiscoveredSchema]:
         connection = _connect_to_postgres(
             host=host, port=port, database=database, user=user, password=password, require_ssl=require_ssl
@@ -1297,7 +1324,10 @@ def get_schemas(
             connection.close()
 
     return _retry_on_connection_dropped(
-        _connect_and_discover, structlog.get_logger(), max_attempts=_MAX_SETUP_CONNECTION_DROPPED_RETRIES
+        _connect_and_discover,
+        structlog.get_logger(),
+        max_attempts=_MAX_SETUP_CONNECTION_DROPPED_RETRIES,
+        is_retryable=_is_dropped_or_connection_limit,
     )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -347,9 +347,10 @@ def _is_dropped_or_connect_timeout(error: BaseException) -> bool:
     the reconnect just needs retrying. Connection-limit refusals ("sorry, too many clients already",
     etc.) are likewise transient — a slot frees the moment another connection closes. Used by the
     read/sync connect retry (`_connect_with_dropped_retry`) and the `offset_chunking` reconnect. The
-    user-facing validation path (`get_schemas`, via `_retry_on_connection_dropped` directly)
-    deliberately keeps failing fast on the same connect-time conditions, where a timeout usually means
-    an unreachable host / unconfigured firewall (see `PostgresErrors` and `get_non_retryable_errors`).
+    schema-discovery path retries drops and connection-limit refusals too (via
+    `_is_dropped_or_connection_limit`) but deliberately keeps failing fast on connect-time *timeouts*,
+    where a timeout usually means an unreachable host / unconfigured firewall (see `PostgresErrors`
+    and `get_non_retryable_errors`).
     """
     return (
         _is_connection_dropped_error(error)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1233,6 +1233,13 @@ class TestIsConnectionLimitError:
                 'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
                 "FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15"
             ),
+            # A pooler (PgBouncer-style) that caches an upstream login failure reveals the limit on
+            # the first query as a ProtocolViolation, not an OperationalError — it must still be
+            # recognised so the discovery retry recovers instead of surfacing it as captured noise.
+            psycopg.errors.ProtocolViolation(
+                "server login has been failing, cached error: remaining connection slots are "
+                "reserved for roles with the SUPERUSER attribute (server_login_retry)"
+            ),
         ],
     )
     def test_connection_limit_errors_are_detected(self, error):
@@ -2857,6 +2864,82 @@ class TestPostgresSchemaDiscovery:
         assert connect_mock.call_count == 2
         assert set(schemas.keys()) == {"public.users"}
         dropped_connection.close.assert_called_once()
+        good_connection.close.assert_called_once()
+
+    def test_get_schemas_retries_pooler_connection_limit_on_discovery_query(self):
+        # A pooler can accept the connect and then reveal, on the first discovery query, that the
+        # customer database is out of connection slots — caching the upstream login failure as a
+        # ProtocolViolation ("server login has been failing, cached error: remaining connection slots
+        # are reserved ..."). It's a transient capacity condition (a slot frees as connections close),
+        # so discovery must retry on a fresh connection. Before the fix the SET-timeout `except` rolled
+        # the refused connection back — raising a misleading "the connection is lost" — and the
+        # discovery retry didn't cover connection-limit refusals, so it surfaced as captured noise.
+        refusal = psycopg.errors.ProtocolViolation(
+            "server login has been failing, cached error: remaining connection slots are reserved "
+            "for roles with the SUPERUSER attribute (server_login_retry)"
+        )
+        refused_connection = self._drop_on_execute_connection(refusal)
+        good_connection = self._mock_connection(
+            [("public", "users")],
+            [("public", "users", "id", "integer", "NO", 1)],
+        )
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            side_effect=[refused_connection, good_connection],
+        ) as connect_mock:
+            with mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"
+            ):
+                schemas = get_schemas(
+                    host="localhost",
+                    port=5432,
+                    database="postgres",
+                    user="postgres",
+                    password="postgres",
+                    schema="",
+                )
+
+        assert connect_mock.call_count == 2
+        assert set(schemas.keys()) == {"public.users"}
+        refused_connection.close.assert_called_once()
+        good_connection.close.assert_called_once()
+        # The refused connection was never rolled back — that's what masked the real cause before.
+        refused_connection.rollback.assert_not_called()
+
+    def test_get_schemas_retries_connection_limit_refused_on_connect(self):
+        # The customer database can refuse the discovery connect outright once it's out of slots
+        # ("remaining connection slots are reserved for roles with the SUPERUSER attribute"). It's the
+        # same transient capacity class as a dropped connection, so discovery must retry on a fresh
+        # connect rather than fail the activity on the first blip — before the fix the discovery retry
+        # only covered drops, so a connection-limit refusal escaped on the first attempt.
+        refusal = psycopg.OperationalError(
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            "FATAL:  remaining connection slots are reserved for roles with the SUPERUSER attribute"
+        )
+        good_connection = self._mock_connection(
+            [("public", "users")],
+            [("public", "users", "id", "integer", "NO", 1)],
+        )
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            side_effect=[refusal, good_connection],
+        ) as connect_mock:
+            with mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"
+            ):
+                schemas = get_schemas(
+                    host="localhost",
+                    port=5432,
+                    database="postgres",
+                    user="postgres",
+                    password="postgres",
+                    schema="",
+                )
+
+        assert connect_mock.call_count == 2
+        assert set(schemas.keys()) == {"public.users"}
         good_connection.close.assert_called_once()
 
     def test_get_schemas_does_not_retry_non_drop_error_during_discovery_query(self):


### PR DESCRIPTION
## Problem

Error tracking flagged a `ProtocolViolation` coming out of the Postgres import source's background schema discovery:

> server login has been failing, cached error: remaining connection slots are reserved for roles with the SUPERUSER attribute

Issue: https://us.posthog.com/project/2/error_tracking/019f372b-2f56-7711-85eb-e265fd3c89cb

The failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py` (`_schemas_from_conn`), reached via `sync_new_schemas_activity` -> `get_schemas`. The root cause is the customer's database being momentarily out of connection slots. A connection pooler in front of it accepts the connect, then reveals the upstream limit on the first query and caches it as a `ProtocolViolation`.

This is a transient capacity condition, not a bug in their config and not something to stop retrying on. The source already has a whole framework for exactly this class (`_CONNECTION_LIMIT_ERROR_SUBSTRINGS`) and deliberately keeps it retryable rather than adding it to `NonRetryableErrors`. Two gaps let it leak out as captured noise anyway:

1. The background discovery retry (`get_schemas`) only recognized connection *drops*, not connection-*limit* refusals. The read/sync path already retries limits; discovery diverged.
2. `_schemas_from_conn` runs `SET statement_timeout` as its first statement and, on any error, calls `connection.rollback()`. On a refused connection that rollback raises the misleading "the connection is lost", burying the real cause. The condition was only ever retried by that accident, and it surfaced with a wrong message.

## Changes

- `_is_connection_limit_error` now also matches the pooler's cached-login-failure form, a `ProtocolViolation` carrying "remaining connection slots are reserved ...", not just an `OperationalError`.
- New `_is_dropped_or_connection_limit` predicate wired into the `get_schemas` retry, so discovery retries connection-limit refusals in process like the read/sync path does. Connect-timeouts are still deliberately excluded from the discovery retry (during discovery a timeout usually means a now-unreachable host, which should fail fast).
- `_schemas_from_conn` no longer rolls a refused connection back. On a drop or limit it re-raises the true error so the discovery retry sees it and recovers on a fresh connection. A live engine that merely rejects the SET (e.g. DuckDB) still rolls back and falls back to the default timeout.

Net effect: transient slot exhaustion is absorbed by the in-process retry instead of failing the discovery activity on the first blip. If a source is genuinely saturated for the whole retry window it still surfaces, now with the accurate "remaining connection slots are reserved" message rather than "the connection is lost".

Nothing is added to `NonRetryableErrors`: doing so would permanently disable syncs on what is a transient condition.

## How did you test this code?

Automated only. I (Claude) ran the mock-based classification and discovery-retry tests in `test_postgres.py` locally: 182 passed. The only failures in this sandbox are pre-existing `@django_db` tests that need a real Postgres (the host doesn't resolve here); they run in CI. Ran `ruff check` and `ruff format --check` on both files, clean.

Added regression tests:

- A `ProtocolViolation` case in `test_connection_limit_errors_are_detected` — catches a revert of the pooler cached-login-failure recognition.
- `test_get_schemas_retries_pooler_connection_limit_on_discovery_query` — the production trace: a limit refusal on the first discovery query is retried on a fresh connection, and the refused connection is never rolled back. Catches a revert of either the `_schemas_from_conn` unmask or the discovery predicate.
- `test_get_schemas_retries_connection_limit_refused_on_connect` — a connect-time limit refusal is retried. Catches the discovery predicate dropping connection-limit.

## Docs update

No user-facing or API change. Nothing to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) from an error-tracking triage. Confirmed the issue and pulled the stack trace via the PostHog error-tracking MCP tools, then traced the failure through the discovery activity into the source. Invoked `/writing-tests` before adding tests to keep them aimed at real regressions.

Decisions worth noting: I rejected adding the message to `NonRetryableErrors` because the source's own design treats connection-limit conditions as transient and retryable, and disabling syncs on a momentary slot shortage would be wrong. I scoped the discovery retry to drops plus limits only, not connect-timeouts, to preserve the existing fail-fast on unreachable hosts. The `_schemas_from_conn` rollback change is the piece that makes the fix relevant to the exact captured trace, which was a limit surfacing on the first query masked as "the connection is lost".
