### PR TITLE
perf(activity-log): remove per-item bookmark query in my_notifications

### DIFF
--- a/posthog/api/my_notifications.py
+++ b/posthog/api/my_notifications.py
@@ -35,15 +35,12 @@ class MyNotificationsSerializer(serializers.ModelSerializer):
         if "user" not in self.context:
             return False
 
-        user_bookmark: Optional[NotificationViewed] = NotificationViewed.objects.filter(
-            user=self.context["user"]
-        ).first()
+        bookmark_date: Optional[datetime] = self.context.get("last_read_date")
 
-        if user_bookmark is None:
+        if bookmark_date is None:
             return True
         else:
             # API call from browser only includes milliseconds but python datetime in created_at includes microseconds
-            bookmark_date = user_bookmark.last_viewed_activity_date
             return bookmark_date < obj.created_at.replace(microsecond=obj.created_at.microsecond // 1000 * 1000)
 
 
@@ -252,7 +249,9 @@ class MyNotificationsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             page_of_data = other_peoples_changes[:10]
 
         with timer("serialize"):
-            serialized_data = MyNotificationsSerializer(instance=page_of_data, many=True, context={"user": user}).data
+            serialized_data = MyNotificationsSerializer(
+                instance=page_of_data, many=True, context={"user": user, "last_read_date": last_read_date}
+            ).data
 
         response = Response(
             status=status.HTTP_200_OK,

--- a/posthog/api/test/test_my_notifications.py
+++ b/posthog/api/test/test_my_notifications.py
@@ -300,7 +300,7 @@ class TestMyNotifications(APIBaseTest, QueryMatchingTest):
                 user=user, defaults={"last_viewed_activity_date": f"2023-0{i}-17T04:36:50Z"}
             )
 
-            with self.assertNumQueries(FuzzyInt(43, 43)):
+            with self.assertNumQueries(FuzzyInt(33, 33)):
                 self.client.get(f"/api/projects/{self.team.id}/my_notifications")
 
     def test_microsecond_precision_mismatch(self):


### PR DESCRIPTION
## Problem

`MyNotificationsSerializer.get_unread` runs `NotificationViewed.objects.filter(user=...).first()` once per serialized activity item, up to 10 times per request. It's the exact same query every time, and the list view already runs it once to build the `last_read` response field. A classic N+1.

## Changes

- The list view now passes the already-fetched `last_read_date` into the serializer context, and `get_unread` reads it from there instead of hitting the database.
- Semantics are unchanged: no bookmark row means `last_read_date` is `None`, which keeps returning `unread=True`.

## How did you test this code?

- The existing query-count guard `test_notifications_viewed_n_plus_1` pins the endpoint's query count; it dropped from 43 to 33 queries (the 10 duplicates removed), and I updated the pinned count. That test now guards against reintroducing the per-item query.
- Ran `posthog/api/test/test_my_notifications.py` locally: 5 passed, including the microsecond-precision unread assertions which cover the `get_unread` comparison behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of six small improvement PRs from a PostHog Code (Claude Code) session sweeping the codebase for safe fixes. Found by an exploration agent looking for `SerializerMethodField`s that query per object. The `/improving-drf-endpoints` skill was invoked before editing the serializer. No new tests were added since the existing query-count guard already catches this regression class.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
