### PR TITLE
perf(api): use exists() instead of count() for existence checks

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -66,7 +66,7 @@ class PremiumMultiorganizationPermission(permissions.BasePermission):
                 user.organization is None
                 or not user.organization.is_feature_available(AvailableFeature.ORGANIZATIONS_PROJECTS)
             )
-            and user.organizations.count() >= 1
+            and user.organizations.exists()
         ):
             return False
         return True

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1866,7 +1866,7 @@ class PremiumMultiProjectPermission(BasePermission):
 
         if request.data.get("is_demo"):
             # If we're requesting to make a demo project but the org already has a demo project
-            if organization.teams.filter(is_demo=True).count() > 0:
+            if organization.teams.filter(is_demo=True).exists():
                 return False
 
         current_non_demo_project_count = organization.teams.exclude(is_demo=True).distinct("project_id").count()

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -2464,7 +2464,7 @@ class PremiumMultiEnvironmentPermission(BasePermission):
 
         if request.data.get("is_demo"):
             # Allow one demo team per organization
-            if project.organization.teams.filter(is_demo=True).count() > 0:
+            if project.organization.teams.filter(is_demo=True).exists():
                 return False
             return True
 

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -225,7 +225,7 @@ class RemoteConfig(UUIDTModel):
         config = {
             "token": team.api_token,
             "supportedCompression": ["gzip", "gzip-js"],
-            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True).count() > 0,
+            "hasFeatureFlags": FeatureFlag.objects.filter(team=team, active=True).exists(),
             "captureDeadClicks": bool(team.capture_dead_clicks),
             "capturePerformance": (
                 {

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -279,7 +279,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
             except FeatureFlag.DoesNotExist:
                 raise serializers.ValidationError("Feature Flag with this ID does not exist")
 
-            if feature_flag.features.count() > 0:
+            if feature_flag.features.exists():
                 raise serializers.ValidationError(
                     f"Linked feature flag {feature_flag.key} already has a feature attached to it."
                 )

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1776,7 +1776,7 @@ class FeatureFlagSerializer(
 
         if "deleted" in validated_data and validated_data["deleted"] is True:
             # Check for linked early access features
-            if instance.features.count() > 0:
+            if instance.features.exists():
                 raise exceptions.ValidationError(
                     "Cannot delete a feature flag that is in use with early access features. Please delete the early access feature before deleting the flag."
                 )


### PR DESCRIPTION
## Problem

Six spots on request-serving paths run `SELECT COUNT(*)` when they only need to know whether any row exists. `count()` scans and aggregates all matching rows, while `exists()` compiles to `SELECT 1 ... LIMIT 1` and stops at the first match. On tables like `posthog_featureflag` the difference is real, and one of these (`hasFeatureFlags` in remote config) runs on every config rebuild.

## Changes

Same one-line pattern in six places, no behavior change:

- `posthog/models/remote_config.py` - `hasFeatureFlags` in `build_config()`
- `posthog/api/organization.py` - `user.organizations.count() >= 1` in the create permission check
- `posthog/api/team.py` - demo-team check on environment create
- `posthog/api/project.py` - demo-team check on project create
- `products/feature_flags/backend/api/feature_flag.py` - linked early access features guard on flag delete
- `products/early_access_features/backend/api.py` - linked features guard on early access feature create

## How did you test this code?

- Ran the suites covering all six paths locally: `posthog/models/test/test_remote_config.py`, `posthog/api/test/test_organization.py`, and `products/early_access_features/backend/test/test_early_access_feature.py` - 165 passed, 36 snapshots passed.
- No new tests: the change is semantically identical (`exists()` is true iff `count() > 0`) and the existing suites already assert the guarded behaviors (permission denials, delete rejection with linked features, `hasFeatureFlags` in config output).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of six small improvement PRs from a PostHog Code (Claude Code) session sweeping for safe perf wins. An exploration agent grepped for `count() > 0` / `count() >= 1` patterns and filtered to hot paths where the count value itself is unused (spots that genuinely need the count, like the passkey first-key check, were left alone). The `/improving-drf-endpoints` skill was invoked before touching the API files.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
