### PR TITLE
fix(flags): make active param filtering case-insensitive

### DIFF
--- a/products/feature_flags/backend/flag_status.py
+++ b/products/feature_flags/backend/flag_status.py
@@ -112,8 +112,8 @@ def filter_flags_by_active_param(queryset: QuerySet, value: str | bool) -> Query
         )
         return queryset.filter(usage_based_stale) | config_based_queryset
 
-    # Handle both string "true"/"false" and boolean True/False
-    is_active = value == "true" or value is True
+    # Handle both string "true"/"false" (any casing) and boolean True/False
+    is_active = str(value).lower() == "true"
     return queryset.filter(active=is_active)
 
 

--- a/products/feature_flags/backend/test/test_flag_status.py
+++ b/products/feature_flags/backend/test/test_flag_status.py
@@ -85,6 +85,10 @@ class TestFilterFlagsByActiveParam(BaseTest):
     def test_filters_stale(self):
         assert self._filter("STALE") == {"stale", "stale-by-usage", "stale-multivariate", "stale-empty-variants"}
 
+    def test_active_param_is_case_insensitive(self):
+        assert self._filter("True") == self._filter("true")
+        assert self._filter("False") == self._filter("false")
+
     def test_accepts_native_booleans(self):
         assert self._filter(True) == {
             "enabled",


### PR DESCRIPTION
## Problem

`filter_flags_by_active_param` in `products/feature_flags/backend/flag_status.py` decides the filter with `value == "true" or value is True`. Only lowercase `"true"` matches, so a client sending `active=True` or `active=TRUE` silently gets the inactive flags instead of the active ones. The sibling `archived` filter on the same endpoint already normalizes with `str(value).lower() == "true"`, so the two params behave inconsistently.

## Changes

- Normalize the `active` param the same way as `archived`: `str(value).lower() == "true"`. Native booleans keep working (`str(True).lower()` is `"true"`), and the `STALE` branch above is untouched.

## How did you test this code?

- Added `test_active_param_is_case_insensitive` to `products/feature_flags/backend/test/test_flag_status.py`, asserting `"True"`/`"False"` filter the same as `"true"`/`"false"`. Before the fix, `"True"` returned the inactive set; no existing test covered non-lowercase input.
- Ran the full `test_flag_status.py` suite locally: 16 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of six small improvement PRs from a PostHog Code (Claude Code) session sweeping for safe bugfixes. Found by an exploration agent comparing query param normalization across the flag filtering code paths. The `/writing-tests` and `/improving-drf-endpoints` skills were invoked during this session before making the change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
