### PR TITLE
feat(experiments/mcp): harden experiment-diagnosis skill with forced-arm and null-metric checks

### DIFF
--- a/products/experiments/skills/diagnosing-experiment-results/SKILL.md
+++ b/products/experiments/skills/diagnosing-experiment-results/SKILL.md
@@ -44,43 +44,43 @@ can be confirmed or ruled out from that data without an interview.
 
 ## Step 2 — Match symptom to diagnostic
 
-| User says...                                                                               | Diagnostic group                               |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| "Smaller variant looks biased" / banner says bias                                          | A — bias & skew                                |
-| "Variant ratio doesn't match my split" / SRM warning                                       | A — bias & skew                                |
-| "Why isn't it 50/50?" / "users in both groups"                                             | A — bias & skew                                |
-| "Users in both control and test" / high `$multiple` %                                      | A — bias & skew                                |
-| Multi-variant exposure on a server-rendered app                                            | A — bias & skew                                |
-| Banner about feature-flag/experiment state mismatch                                        | A — bias & skew                                |
-| "Migrating distinct_id" / "switching from anonymous to user_id" mid-run                    | A — bias & skew                                |
-| Metric count is much smaller than exposures (e.g. 10× or 100× gap)                         | A — bias & skew (route here before D)          |
-| "Experiment shows 0 / not enough data" / empty                                             | B — empty experiment                           |
-| "Variant always undefined / false"                                                         | B — empty experiment                           |
-| "$feature_flag_called fires but no exposures show up"                                      | B — empty experiment                           |
-| "Experiment says running but exposures haven't moved in weeks/months"                      | B — empty experiment                           |
-| "Significance keeps flipping as we run longer"                                             | C — interpretation traps                       |
-| "Significance was declared, then it wasn't significant anymore"                            | C — interpretation traps                       |
-| "30/16 split at 46 exposures, is this broken?"                                             | C — interpretation traps                       |
-| "A/A test is showing significant results"                                                  | C — interpretation traps                       |
-| "Many metrics — some significant, some not"                                                | C — interpretation traps                       |
-| "Bayesian says 96% chance to win — should we ship?"                                        | C — interpretation traps                       |
-| "Confidence intervals overlap — does that mean not significant?"                           | C — interpretation traps                       |
-| "An external tool (significance calculator or AI agent) disagrees with PostHog"            | C — interpretation traps                       |
-| "Should I ship? Primary is up but a secondary is down"                                     | C — interpretation traps                       |
-| "PostHog numbers ≠ my SQL count"                                                           | D — numbers vs SQL                             |
-| "Funnel says X% but my raw event count says Y"                                             | D — numbers vs SQL                             |
-| "Sum of revenue looks wrong" / "breakdown shows 'none'"                                    | D — numbers vs SQL                             |
-| "Recordings panel doesn't match the stats"                                                 | D — numbers vs SQL                             |
-| "I applied a filter but the user count didn't change"                                      | D — numbers vs SQL                             |
-| "I want to slice results by current person properties (as of now, not as of exposure)"     | D — numbers vs SQL                             |
-| "Changed split / rollout / metric / criteria mid-run, now odd"                             | E — mid-run changes                            |
-| "Ended/shipped — flag now flipped to 0/100 unexpectedly"                                   | E — mid-run changes                            |
-| "Long-term metric moves opposite from primary"                                             | E — mid-run changes                            |
-| "Retention metric counts users I didn't expect"                                            | E — mid-run changes                            |
-| "Can't convert the feature flag back to a simple (boolean) flag after the experiment ends" | E — mid-run changes                            |
-| "How do I restart an experiment with new variants?"                                        | E — mid-run changes                            |
-| Metric line is rendered but the result block is empty / no chance-to-win or significance   | E — mid-run changes (E13 legacy methodology)   |
-| "Results won't load" / many metric rows show `data: null` (not a legacy experiment)        | Step 1.5 snapshot — reading metric result rows |
+| User says...                                                                               | Diagnostic group                             |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| "Smaller variant looks biased" / banner says bias                                          | A — bias & skew                              |
+| "Variant ratio doesn't match my split" / SRM warning                                       | A — bias & skew                              |
+| "Why isn't it 50/50?" / "users in both groups"                                             | A — bias & skew                              |
+| "Users in both control and test" / high `$multiple` %                                      | A — bias & skew                              |
+| Multi-variant exposure on a server-rendered app                                            | A — bias & skew                              |
+| Banner about feature-flag/experiment state mismatch                                        | A — bias & skew                              |
+| "Migrating distinct_id" / "switching from anonymous to user_id" mid-run                    | A — bias & skew                              |
+| Metric count is much smaller than exposures (e.g. 10× or 100× gap)                         | A — bias & skew (route here before D)        |
+| "Experiment shows 0 / not enough data" / empty                                             | B — empty experiment                         |
+| "Variant always undefined / false"                                                         | B — empty experiment                         |
+| "$feature_flag_called fires but no exposures show up"                                      | B — empty experiment                         |
+| "Experiment says running but exposures haven't moved in weeks/months"                      | B — empty experiment                         |
+| "Significance keeps flipping as we run longer"                                             | C — interpretation traps                     |
+| "Significance was declared, then it wasn't significant anymore"                            | C — interpretation traps                     |
+| "30/16 split at 46 exposures, is this broken?"                                             | C — interpretation traps                     |
+| "A/A test is showing significant results"                                                  | C — interpretation traps                     |
+| "Many metrics — some significant, some not"                                                | C — interpretation traps                     |
+| "Bayesian says 96% chance to win — should we ship?"                                        | C — interpretation traps                     |
+| "Confidence intervals overlap — does that mean not significant?"                           | C — interpretation traps                     |
+| "An external tool (significance calculator or AI agent) disagrees with PostHog"            | C — interpretation traps                     |
+| "Should I ship? Primary is up but a secondary is down"                                     | C — interpretation traps                     |
+| "PostHog numbers ≠ my SQL count"                                                           | D — numbers vs SQL                           |
+| "Funnel says X% but my raw event count says Y"                                             | D — numbers vs SQL                           |
+| "Sum of revenue looks wrong" / "breakdown shows 'none'"                                    | D — numbers vs SQL                           |
+| "Recordings panel doesn't match the stats"                                                 | D — numbers vs SQL                           |
+| "I applied a filter but the user count didn't change"                                      | D — numbers vs SQL                           |
+| "I want to slice results by current person properties (as of now, not as of exposure)"     | D — numbers vs SQL                           |
+| "Changed split / rollout / metric / criteria mid-run, now odd"                             | E — mid-run changes                          |
+| "Ended/shipped — flag now flipped to 0/100 unexpectedly"                                   | E — mid-run changes                          |
+| "Long-term metric moves opposite from primary"                                             | E — mid-run changes                          |
+| "Retention metric counts users I didn't expect"                                            | E — mid-run changes                          |
+| "Can't convert the feature flag back to a simple (boolean) flag after the experiment ends" | E — mid-run changes                          |
+| "How do I restart an experiment with new variants?"                                        | E — mid-run changes                          |
+| Metric line is rendered but the result block is empty / no chance-to-win or significance   | E — mid-run changes (E13 legacy methodology) |
+| "Results won't load" / many metric rows show `data: null` (not a legacy experiment)        | Step 1.5 — diagnostic snapshot (null rows)   |
 
 If the symptom is unclear, ask one clarifying question before picking. Most diagnostics have different fixes
 — do not guess.

--- a/products/experiments/skills/diagnosing-experiment-results/SKILL.md
+++ b/products/experiments/skills/diagnosing-experiment-results/SKILL.md
@@ -28,8 +28,12 @@ Call `experiment-get` and pull these fields. They are inputs for almost every di
 - `exposure_criteria.exposure_event` — `null` means default `$feature_flag_called`
 - `exposure_criteria.filterTestAccounts` — defaults to `true`
 - `feature_flag.active`, status (`draft` / `running` / `paused` / `stopped`), `start_date`, `end_date`
-- `feature_flag.filters.groups[].variant` — any non-null value is a forced-variant override on the
-  matched cohort (release-condition assignment, not randomized). Surfaces A7 by default.
+- `feature_flag.filters.groups[]` — for each group read `variant`, `properties`, and
+  `rollout_percentage`. Any non-null `variant` is a forced-variant override on the matched cohort
+  (release-condition assignment, not randomized) — surfaces A7. Watch for the severe shape (A7b): a
+  variant-pinned group with broad/empty `properties` at high rollout, or no group left randomized
+  (`variant: null`) / no release path to one arm — that starves the other variant (one arm gets ~0
+  analyzable exposures). See `references/bias-and-skew.md`.
 - `stats_config` — Bayesian (default) or Frequentist
 
 ## Step 1.5 — Pull a diagnostic snapshot (verify before asking)
@@ -40,42 +44,43 @@ can be confirmed or ruled out from that data without an interview.
 
 ## Step 2 — Match symptom to diagnostic
 
-| User says...                                                                               | Diagnostic group                             |
-| ------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| "Smaller variant looks biased" / banner says bias                                          | A — bias & skew                              |
-| "Variant ratio doesn't match my split" / SRM warning                                       | A — bias & skew                              |
-| "Why isn't it 50/50?" / "users in both groups"                                             | A — bias & skew                              |
-| "Users in both control and test" / high `$multiple` %                                      | A — bias & skew                              |
-| Multi-variant exposure on a server-rendered app                                            | A — bias & skew                              |
-| Banner about feature-flag/experiment state mismatch                                        | A — bias & skew                              |
-| "Migrating distinct_id" / "switching from anonymous to user_id" mid-run                    | A — bias & skew                              |
-| Metric count is much smaller than exposures (e.g. 10× or 100× gap)                         | A — bias & skew (route here before D)        |
-| "Experiment shows 0 / not enough data" / empty                                             | B — empty experiment                         |
-| "Variant always undefined / false"                                                         | B — empty experiment                         |
-| "$feature_flag_called fires but no exposures show up"                                      | B — empty experiment                         |
-| "Experiment says running but exposures haven't moved in weeks/months"                      | B — empty experiment                         |
-| "Significance keeps flipping as we run longer"                                             | C — interpretation traps                     |
-| "Significance was declared, then it wasn't significant anymore"                            | C — interpretation traps                     |
-| "30/16 split at 46 exposures, is this broken?"                                             | C — interpretation traps                     |
-| "A/A test is showing significant results"                                                  | C — interpretation traps                     |
-| "Many metrics — some significant, some not"                                                | C — interpretation traps                     |
-| "Bayesian says 96% chance to win — should we ship?"                                        | C — interpretation traps                     |
-| "Confidence intervals overlap — does that mean not significant?"                           | C — interpretation traps                     |
-| "An external tool (significance calculator or AI agent) disagrees with PostHog"            | C — interpretation traps                     |
-| "Should I ship? Primary is up but a secondary is down"                                     | C — interpretation traps                     |
-| "PostHog numbers ≠ my SQL count"                                                           | D — numbers vs SQL                           |
-| "Funnel says X% but my raw event count says Y"                                             | D — numbers vs SQL                           |
-| "Sum of revenue looks wrong" / "breakdown shows 'none'"                                    | D — numbers vs SQL                           |
-| "Recordings panel doesn't match the stats"                                                 | D — numbers vs SQL                           |
-| "I applied a filter but the user count didn't change"                                      | D — numbers vs SQL                           |
-| "I want to slice results by current person properties (as of now, not as of exposure)"     | D — numbers vs SQL                           |
-| "Changed split / rollout / metric / criteria mid-run, now odd"                             | E — mid-run changes                          |
-| "Ended/shipped — flag now flipped to 0/100 unexpectedly"                                   | E — mid-run changes                          |
-| "Long-term metric moves opposite from primary"                                             | E — mid-run changes                          |
-| "Retention metric counts users I didn't expect"                                            | E — mid-run changes                          |
-| "Can't convert the feature flag back to a simple (boolean) flag after the experiment ends" | E — mid-run changes                          |
-| "How do I restart an experiment with new variants?"                                        | E — mid-run changes                          |
-| Metric line is rendered but the result block is empty / no chance-to-win or significance   | E — mid-run changes (E13 legacy methodology) |
+| User says...                                                                               | Diagnostic group                               |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| "Smaller variant looks biased" / banner says bias                                          | A — bias & skew                                |
+| "Variant ratio doesn't match my split" / SRM warning                                       | A — bias & skew                                |
+| "Why isn't it 50/50?" / "users in both groups"                                             | A — bias & skew                                |
+| "Users in both control and test" / high `$multiple` %                                      | A — bias & skew                                |
+| Multi-variant exposure on a server-rendered app                                            | A — bias & skew                                |
+| Banner about feature-flag/experiment state mismatch                                        | A — bias & skew                                |
+| "Migrating distinct_id" / "switching from anonymous to user_id" mid-run                    | A — bias & skew                                |
+| Metric count is much smaller than exposures (e.g. 10× or 100× gap)                         | A — bias & skew (route here before D)          |
+| "Experiment shows 0 / not enough data" / empty                                             | B — empty experiment                           |
+| "Variant always undefined / false"                                                         | B — empty experiment                           |
+| "$feature_flag_called fires but no exposures show up"                                      | B — empty experiment                           |
+| "Experiment says running but exposures haven't moved in weeks/months"                      | B — empty experiment                           |
+| "Significance keeps flipping as we run longer"                                             | C — interpretation traps                       |
+| "Significance was declared, then it wasn't significant anymore"                            | C — interpretation traps                       |
+| "30/16 split at 46 exposures, is this broken?"                                             | C — interpretation traps                       |
+| "A/A test is showing significant results"                                                  | C — interpretation traps                       |
+| "Many metrics — some significant, some not"                                                | C — interpretation traps                       |
+| "Bayesian says 96% chance to win — should we ship?"                                        | C — interpretation traps                       |
+| "Confidence intervals overlap — does that mean not significant?"                           | C — interpretation traps                       |
+| "An external tool (significance calculator or AI agent) disagrees with PostHog"            | C — interpretation traps                       |
+| "Should I ship? Primary is up but a secondary is down"                                     | C — interpretation traps                       |
+| "PostHog numbers ≠ my SQL count"                                                           | D — numbers vs SQL                             |
+| "Funnel says X% but my raw event count says Y"                                             | D — numbers vs SQL                             |
+| "Sum of revenue looks wrong" / "breakdown shows 'none'"                                    | D — numbers vs SQL                             |
+| "Recordings panel doesn't match the stats"                                                 | D — numbers vs SQL                             |
+| "I applied a filter but the user count didn't change"                                      | D — numbers vs SQL                             |
+| "I want to slice results by current person properties (as of now, not as of exposure)"     | D — numbers vs SQL                             |
+| "Changed split / rollout / metric / criteria mid-run, now odd"                             | E — mid-run changes                            |
+| "Ended/shipped — flag now flipped to 0/100 unexpectedly"                                   | E — mid-run changes                            |
+| "Long-term metric moves opposite from primary"                                             | E — mid-run changes                            |
+| "Retention metric counts users I didn't expect"                                            | E — mid-run changes                            |
+| "Can't convert the feature flag back to a simple (boolean) flag after the experiment ends" | E — mid-run changes                            |
+| "How do I restart an experiment with new variants?"                                        | E — mid-run changes                            |
+| Metric line is rendered but the result block is empty / no chance-to-win or significance   | E — mid-run changes (E13 legacy methodology)   |
+| "Results won't load" / many metric rows show `data: null` (not a legacy experiment)        | Step 1.5 snapshot — reading metric result rows |
 
 If the symptom is unclear, ask one clarifying question before picking. Most diagnostics have different fixes
 — do not guess.

--- a/products/experiments/skills/diagnosing-experiment-results/references/bias-and-skew.md
+++ b/products/experiments/skills/diagnosing-experiment-results/references/bias-and-skew.md
@@ -27,7 +27,7 @@ problem (A3/A4), not a query-scope problem.
 - A4 — Bootstrap × `/decide` variant disagreement
 - A5 — Flag/experiment state inconsistency
 - A6 — Mid-run flag edits that rebucket already-exposed users
-- A7 — Non-randomized assignment via release conditions
+- A7 — Non-randomized assignment via release conditions (incl. forced-group arm starvation)
 - A8 — Migrating the `distinct_id` strategy during a running experiment
 
 ## A1 — Multi-variant exclusion bias on uneven split [HIGH]
@@ -391,6 +391,67 @@ comparisons caveats from `references/interpretation.md`). If the override exists
 release group, or delete the group entirely. On a young experiment with little accumulated data,
 reset + relaunch after the edit; on an experiment with significant clean data from before the
 issue was noticed, treat the post-launch window as contaminated and consider end + relaunch.
+
+### A7b — A forced-variant group starves the other arm [HIGH]
+
+The cohort-vs-cohort case above invalidates significance but still collects both variants. A worse
+shape is a forced-variant release group whose `properties` are broad (or empty) at high rollout: it
+captures most or all of the population, so the _other_ variant receives almost no analyzable
+exposures. Two shapes observed in practice:
+
+- **Unconditional catch-all forcing one variant.** A release group with **empty `properties[]`**
+  (matches everyone) and a pinned `variant` at `rollout_percentage: 100`. Every user who doesn't match
+  an earlier, narrower group falls through to it and is forced to that variant; the randomized
+  `multivariate` split never applies. Observed magnitude: one arm ≈ 5.2M persons vs the other ≈ 500
+  (the residual on the starved arm being leftovers from earlier flag versions).
+- **"All new users" cohort forcing one variant, with no control path.** A release group like
+  `created_at_unix >= <ts>` → `variant: test` at 100%, where **no release group leaves `variant: null`
+  and no group forces the other variant**. Every new account is forced to `test`; the `control` arm
+  stops receiving new assignments and starves over time. Observed: control collapsed from a balanced
+  ~15k/month to ~2/month within weeks of the forced group being added, while test scaled into the
+  millions.
+
+**Detect (config-only, from `experiment-get`).** Enumerate `feature_flag.filters.groups[]` and for each
+read `variant`, `properties` (an empty array = catch-all matching everyone), and `rollout_percentage`.
+Red flags, any of:
+
+- a group with `variant` set **and** broad/empty `properties` at high `rollout_percentage`;
+- **no** group with `variant: null` — i.e. nothing is randomized at all;
+- every variant-pinned group forces the **same** variant — i.e. there is no release path to the other arm.
+
+**Confirm from exposures, and use the trend to read intent.** Run the Step 1.5 exposure-shape query —
+the starved arm shows up immediately as one variant's persons being orders of magnitude below the
+other. Then add a monthly breakdown (`toStartOfMonth(timestamp)`); the shape tells you what happened
+and is worth pulling _before_ you characterize it:
+
+- **Ran balanced, then one arm collapses** — both arms roughly even for a period, then one variant's
+  new assignments drop toward ~0 from a specific date. The experiment ran as a real A/B and was then
+  **rolled out** via the flag. The balanced window is the valid result.
+- **One arm never received meaningful traffic** — the minority variant is ≈ internal pins / a trickle
+  from the start, never a real share (e.g. one arm in the hundreds while the other is in the millions).
+  It was served one variant from the start; it likely never ran as a randomized A/B at all.
+
+This is distinct from the diagnostic-snapshot "plateau" (where the _application_ stopped firing the
+flag) — here the app still fires; the flag _config_ forces the variant, so the cause is visible in
+`feature_flag.filters.groups[]`, not just the event stream.
+
+**Calibrate before reporting — this usually mirrors a rollout, not a bug.** A broad set forcing a
+variant at 100% is most often a **deliberate rollout** done through the flag instead of the experiment
+UI (or a default being forced), with the experiment left in `running` status — not an accident. Two
+things sharpen the read:
+
+- **Which variant is forced.** Forcing `test` (the new behaviour) = the new feature was rolled out to
+  everyone. Forcing `control` (the status quo) = the _default_ was served to everyone, i.e. the feature
+  was effectively **not** shipped — worth surfacing as a question, since it's easy to pin the wrong
+  variant ("did you intend users to get the new experience, or the status quo?").
+- **The exposure trend above** — ran-then-rolled-out vs never-randomized.
+
+Whatever the intent, while the flag forces a variant the experiment **cannot produce a valid
+control-vs-test readout**, and its results page should not be read as an A/B. Recommend **concluding the
+experiment** (read any pre-rollout balanced window as the result); if it was genuinely accidental,
+removing the forced-variant group(s) and resetting restores randomization. Surface the finding and
+confirm intent rather than asserting the experiment is "broken" (consistent with Step 4's
+don't-assume-intent guidance in `SKILL.md`).
 
 ## A8 — Migrating the `distinct_id` strategy during a running experiment [HIGH]
 

--- a/products/experiments/skills/diagnosing-experiment-results/references/diagnostic-snapshot.md
+++ b/products/experiments/skills/diagnosing-experiment-results/references/diagnostic-snapshot.md
@@ -77,6 +77,41 @@ response. PostHog's experiment query filters these out via `in(properties.$featu
 not bias signals; don't pull them into the variant-balance discussion. The exception is when _every_
 exposure is `None`/`false` — that's a B-series symptom, not an A-series one.
 
+## Reading metric result rows (`data: null`)
+
+Powers any diagnostic that reads `experiment-results-get`, and the "results won't load" complaint.
+
+Each row in `metrics.primary.results` / `metrics.secondary.results` is kept positionally even when its
+query produced no output; a failed or not-yet-computed row has `data: null`. **A single cached snapshot
+showing `data: null` rows is not, by itself, evidence that metric queries are failing.** PostHog
+precomputes experiment results on a schedule (gated behind a minimum runtime — see B0 in
+`empty-experiment.md`); until precompute lands, recently launched or recently edited experiments return
+`data: null` placeholders that fill in on their own. Transient query load (e.g. rate-limiting at the
+moment you pulled the snapshot) produces the same shape.
+
+**Disambiguate transient from a real failure before reporting it:**
+
+- **Re-pull** `experiment-results-get` (cached) a while later — if the previously-null rows now carry
+  data, they were transient, not failing.
+- **Force one recompute** with `experiment-results-get { refresh: true }` — this triggers an on-demand
+  compute of every metric. If it returns the rows populated (no `data: null`), the backend compute path
+  is healthy and the earlier nulls were transient. If a row stays `null` after a successful
+  force-refresh, that metric genuinely fails to compute — then inspect its definition (e.g. a `mean`
+  metric over a property that doesn't exist, a baseline of zero, or a malformed funnel).
+
+Two cautions:
+
+- **Don't conflate the _count_ of null rows with severity.** Experiments with very large metric sets
+  (dozens of secondary metrics) show the most warming placeholders simply because there's more to
+  precompute — alarming on first pull, but it clears. Verify persistence per the steps above before
+  reporting "many metrics failing"; jumping straight to "prune metrics / overloaded refresh" from one
+  snapshot is a known false positive.
+- **Backend results health ≠ the user's in-app loading experience.** `experiment-results-get` computing
+  cleanly (even on force-refresh) does not prove the results _page_ loads for the user — a browser
+  rendering many metrics on demand can still time out client-side. If the complaint is "results won't
+  load" but the API computes fine, the issue is front-end / on-demand-render, not the metric queries;
+  don't report it as a query failure.
+
 ## Recent flag mutations
 
 Powers A6, E7; E5 lives on the experiment, not the flag.

--- a/products/experiments/skills/diagnosing-experiment-results/references/mid-run-changes.md
+++ b/products/experiments/skills/diagnosing-experiment-results/references/mid-run-changes.md
@@ -243,6 +243,12 @@ case is that the metric line is rendered but the per-variant result block is emp
 is non-zero, but the entry under `results[]` has no `chance_to_win`, no `credible_interval`, no
 `significant`, no `step_counts`. Exposures are fully populated; only the metric output is missing.
 
+Don't confuse this with a `data: null` row on a **non-legacy** experiment — that's usually transient
+(precompute not yet landed, or load at snapshot time) and resolves on re-pull / force-refresh. See
+"Reading metric result rows (`data: null`)" in `diagnostic-snapshot.md` to disambiguate before
+concluding anything. The legacy fingerprint here is specifically an experiment with `is_legacy: true`
+whose result block stays empty even after a force-refresh.
+
 **Verify directly** (no interview needed). In `experiment-get`'s response:
 
 - `metrics[].kind == "ExperimentFunnelsQuery"` or `"ExperimentTrendsQuery"` (not `"ExperimentMetric"`)


### PR DESCRIPTION
## Problem

The `diagnosing-experiment-results` skill has two spots where it draws the wrong conclusion:

1. It reads a forced-variant rollout as a "broken / biased" experiment.
When a broad release group pins everyone to one variant, the other arm starves of exposures, but the skill couldn't tell "ran as a real A/B then got rolled out" from "never randomized," and asserted breakage instead of confirming intent.
2. It reads transient `data: null` metric rows as failing queries.
Recently launched or edited experiments, and large metric sets, show null placeholders until precompute lands, and the skill had no step to verify persistence first.

Both are false positives that make the assistant sound confidently wrong. This PR teaches it to verify against the flag config and a forced recompute before characterizing results.

## Changes

- **`references/bias-and-skew.md`**: new diagnostic **A7b, "a forced-variant group starves the other arm"** - detect from `feature_flag.filters.groups[]`, confirm from the exposure trend, then read intent (which variant is forced, ran-then-rolled-out vs never-randomized) and recommend concluding the experiment over asserting it is broken.
- **`references/diagnostic-snapshot.md`**: new **"Reading metric result rows (`data: null`)"** - re-pull and force `refresh: true` to separate transient placeholders from a real compute failure.
- **`references/mid-run-changes.md`**: cross-reference so the legacy empty-result case (E13) isn't confused with a transient null row.
- **`SKILL.md`**: Step 1 reads `variant`, `properties`, and `rollout_percentage` per group and points at A7b; dispatch routes "results won't load / `data: null`" to the snapshot section.

## How did you test this code?

Skill-content change with no code paths, so no automated tests apply. I (the agent) did not run the skill's eval suite

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code) made the edits to the `diagnosing-experiment-results` skill.
Both diagnostics came from correcting an over-eager first read: a flag config first called "broken" was really a rollout run through the flag with the experiment still running, and a snapshot of null rows recomputed cleanly on force-refresh. That's why A7b emphasizes confirming intent, and the null-row guidance leads with re-pull / refresh before reporting failure.
