### PR TITLE
feat(ingestion): add partition and merge/group counts to tophog metrics

### DIFF
--- a/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
@@ -33,6 +33,17 @@ import {
     PersonsOutput,
 } from './outputs'
 
+// Mirrors the merge condition in PersonMergeService.handleIdentifyOrAlias: an event asks for a person
+// merge when it's $create_alias/$merge_dangerously with an `alias`, or $identify with $anon_distinct_id.
+// Kept in the metrics layer so counting merge-intent events doesn't reach into person processing logic.
+function isMergeIntentEvent(event: PluginEvent): boolean {
+    const properties = event.properties ?? {}
+    if (['$create_alias', '$merge_dangerously'].includes(event.event) && properties['alias']) {
+        return true
+    }
+    return event.event === '$identify' && '$anon_distinct_id' in properties
+}
+
 export interface EventSubpipelineInput {
     message: Message
     event: PluginEvent
@@ -98,7 +109,26 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
                 timer('process_persons_time', (input) => ({
                     team_id: String(input.team.id),
                     distinct_id: input.normalizedEvent.distinct_id,
+                    partition: String(input.message.partition),
                 })),
+                sum(
+                    'merge_events_per_distinct_id',
+                    (input) => ({
+                        team_id: String(input.team.id),
+                        distinct_id: input.normalizedEvent.distinct_id,
+                        partition: String(input.message.partition),
+                    }),
+                    (input) => (isMergeIntentEvent(input.normalizedEvent) ? 1 : 0)
+                ),
+                sum(
+                    'group_identify_events_per_distinct_id',
+                    (input) => ({
+                        team_id: String(input.team.id),
+                        distinct_id: input.normalizedEvent.distinct_id,
+                        partition: String(input.message.partition),
+                    }),
+                    (input) => (input.normalizedEvent.event === '$groupidentify' ? 1 : 0)
+                ),
             ])
         )
         .pipe(createPrepareEventStep())


### PR DESCRIPTION
## Problem

Our TopHog metrics for the analytics ingestion pipeline let us find noisy tenants and distinct IDs, but two gaps made them harder to use:

- `process_persons_time` was keyed by `team_id` + `distinct_id` with no partition, so we couldn't attribute person-processing hotspots to a specific Kafka partition the way the other per-distinct-id metrics already allow.
- We had no visibility into how many merge-triggering events (`$identify` / `$create_alias` / `$merge_dangerously`) or `$groupidentify` events a given distinct ID produces. Those are the events that drive the expensive person and group work, so a per-distinct-id, per-partition count is useful for spotting abusive or misconfigured clients.

## Changes

All in the analytics event subpipeline (`nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts`):

- Add `partition` to the `process_persons_time` TopHog timer key, matching the partition dimension already present on `emitted_events_per_distinct_id`.
- Add `merge_events_per_distinct_id` (sum) counting merge-intent events, keyed by `team_id` + `distinct_id` + `partition`.
- Add `group_identify_events_per_distinct_id` (sum) counting `$groupidentify` events, same key.

"Merge-intent" is classified by a small local predicate `isMergeIntentEvent` that mirrors the exact condition in `PersonMergeService.handleIdentifyOrAlias` (`$create_alias`/`$merge_dangerously` with an `alias`, or `$identify` with `$anon_distinct_id`). It lives in the metrics layer on purpose so counting merges does not reach into or change person processing logic.

## How did you test this code?

I (Claude) ran the TypeScript compiler against the nodejs package — the changed file type-checks clean (the only remaining `tsc` errors are pre-existing `@posthog/hogvm`/`cdp` module-resolution issues unrelated to this diff). Prettier and eslint are clean on the changed file. No automated tests were added: these are declarative TopHog metric definitions, the TopHog framework mechanics are already covered by `framework/tophog` tests, and there is no existing analytics-subpipeline test asserting individual metric keys to extend. I did not run the metrics end-to-end against a live pipeline.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paweł directed this; I (Claude) implemented it. No repo skills were invoked.

Worth flagging for review: I first extracted the merge condition into a shared helper in `PersonMergeService` and had both the metric and `handleIdentifyOrAlias` call it, to guarantee they can't drift. Paweł asked to keep person processing logic untouched, so I reverted that and instead duplicated the condition as a small `isMergeIntentEvent` predicate in the metrics layer with a comment pointing at the source of truth. The tradeoff is that the predicate must be kept in sync by hand if the merge condition ever changes.

The group-identify and merge counts both live in the `process_persons` TopHog wrapper rather than the groups step, because `prepare-event-step` strips `normalizedEvent` from the pipeline input downstream — the process-persons step is the last point where the raw event name, `distinct_id`, and `partition` are all available together.
