### PR TITLE
perf(web-experiments): compile XSS validation regexes at module level

### DIFF
--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -22,6 +22,19 @@ from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.web_experiment import WebExperiment
 from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
 
+# XSS vector patterns, paired with the error message shown when one matches:
+# script tags (opening and closing), event handlers (onclick, onerror, etc.),
+# javascript: protocol, data:text/html, iframe/object/embed tags
+_XSS_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"<script[^>]*>", re.IGNORECASE), "contains disallowed <script> tags"),
+    (re.compile(r"</script>", re.IGNORECASE), "contains disallowed </script> tags"),
+    (re.compile(r"\son\w+\s*=", re.IGNORECASE), "contains disallowed event handlers (onclick, onerror, etc.)"),
+    (re.compile(r"javascript\s*:", re.IGNORECASE), "contains disallowed javascript: protocol"),
+    (re.compile(r"data\s*:\s*text/html", re.IGNORECASE), "contains disallowed data:text/html"),
+    (re.compile(r"<iframe[^>]*>", re.IGNORECASE), "contains disallowed <iframe> tags"),
+    (re.compile(r"<(object|embed)[^>]*>", re.IGNORECASE), "contains disallowed <object> or <embed> tags"),
+]
+
 
 def validate_no_xss(content: str, field_name: str) -> None:
     """
@@ -30,32 +43,9 @@ def validate_no_xss(content: str, field_name: str) -> None:
 
     This validation-only approach preserves the original formatting while preventing XSS attacks.
     """
-    # Check for script tags (opening and closing)
-    if re.search(r"<script[^>]*>", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed <script> tags")
-
-    if re.search(r"</script>", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed </script> tags")
-
-    # Check for event handlers (onclick, onerror, onload, onmouseover, etc.)
-    if re.search(r"\son\w+\s*=", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed event handlers (onclick, onerror, etc.)")
-
-    # Check for javascript: protocol in attributes
-    if re.search(r"javascript\s*:", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed javascript: protocol")
-
-    # Check for data: protocol with HTML/script content
-    if re.search(r"data\s*:\s*text/html", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed data:text/html")
-
-    # Check for iframe tags (commonly used for XSS)
-    if re.search(r"<iframe[^>]*>", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed <iframe> tags")
-
-    # Check for object and embed tags
-    if re.search(r"<(object|embed)[^>]*>", content, re.IGNORECASE):
-        raise ValidationError(f"{field_name} contains disallowed <object> or <embed> tags")
+    for pattern, message in _XSS_PATTERNS:
+        if pattern.search(content):
+            raise ValidationError(f"{field_name} {message}")
 
 
 class WebExperimentsAPISerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Problem

`validate_no_xss` in `posthog/api/web_experiment.py` calls `re.search` with seven inline pattern literals on every invocation, and it runs once per `text`/`html` field of every transform on every web experiment create and update. Python's `re` module caches compiled patterns, but each call still pays the cache dispatch, and the idiomatic form is to compile once at import.

## Changes

- Hoisted the seven patterns into a module-level `_XSS_PATTERNS` table of `(compiled pattern, error message)` pairs and made `validate_no_xss` iterate it.
- Matching behavior, check order, and error messages are byte-for-byte identical; this is a pure refactor.

## How did you test this code?

- Ran `posthog/api/test/test_web_experiment.py` locally: 21 passed, including the XSS rejection cases that assert the exact error messages for script tags, event handlers, `javascript:` and `data:text/html` payloads.
- No new tests: the existing suite already pins the observable behavior (which payloads are rejected and with what message), and this change doesn't alter it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of six small improvement PRs from a PostHog Code (Claude Code) session sweeping for safe cleanups. The `/improving-drf-endpoints` skill was invoked earlier in the session before touching API files. A table-driven loop was chosen over seven named constants to keep pattern and message adjacent and the function body short.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
