### PR TITLE
feat(tracing): restructure scene to logs-viewer layout

### DIFF
--- a/products/tracing/frontend/TracingDisplayBar.tsx
+++ b/products/tracing/frontend/TracingDisplayBar.tsx
@@ -1,0 +1,109 @@
+import { useActions, useValues } from 'kea'
+
+import { IconChevronLeft, IconChevronRight, IconList, IconListTree } from '@posthog/icons'
+import { LemonButton, LemonSegmentedButton, LemonSwitch } from '@posthog/lemon-ui'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import { tracingConfigLogic } from './tracingConfigLogic'
+import { tracingFiltersLogic, type TracingViewMode } from './tracingFiltersLogic'
+import { tracingSceneLogic } from './tracingSceneLogic'
+
+/**
+ * The bar above the results, mirroring logs' LogsDisplayBar, grouped by scope:
+ *
+ *  - persistent-left "frame": controls that apply to the whole results region — the facet
+ *    rail toggle, the Traces ⇄ Operations view switch, and the matching-count indicator.
+ *  - contextual-right: traces-view-only controls (Traces ⇄ Spans granularity, Compare),
+ *    hidden entirely on the Operations view where neither applies.
+ */
+export function TracingDisplayBar(): JSX.Element {
+    const { activeTracingTab, totalMatchingFilters, filters } = useValues(tracingSceneLogic())
+    const { setActiveTracingTab } = useActions(tracingSceneLogic())
+    const { setViewMode, setCompareMode } = useActions(tracingFiltersLogic())
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { facetRailCollapsed } = useValues(tracingConfigLogic)
+    const { setFacetRailCollapsed } = useActions(tracingConfigLogic)
+
+    const facetRailEnabled = !!featureFlags[FEATURE_FLAGS.TRACING_FACET_RAIL]
+    const operationsViewEnabled = !!featureFlags[FEATURE_FLAGS.TRACING_OPERATIONS_VIEW]
+    const inTracesView = !operationsViewEnabled || activeTracingTab !== 'operations'
+    const showCount = inTracesView && !filters.compareMode && totalMatchingFilters > 0
+
+    return (
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
+                {facetRailEnabled && (
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
+                        onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
+                        aria-label={facetRailCollapsed ? 'Show facets' : 'Hide facets'}
+                        tooltip={facetRailCollapsed ? 'Show facets' : 'Hide facets'}
+                        data-attr="tracing-facet-rail-toggle"
+                    />
+                )}
+                {operationsViewEnabled && (
+                    <LemonSegmentedButton<'traces' | 'operations'>
+                        size="small"
+                        value={activeTracingTab}
+                        onChange={setActiveTracingTab}
+                        options={[
+                            { value: 'traces', label: 'Traces', 'data-attr': 'tracing-display-tab-traces' },
+                            {
+                                value: 'operations',
+                                label: 'Operations',
+                                'data-attr': 'tracing-display-tab-operations',
+                            },
+                        ]}
+                    />
+                )}
+                {/* No loading guard: keep the last (view-mode-independent) count visible across reloads,
+                    so a Traces/Spans switch doesn't flicker the label out and back in. */}
+                {showCount && (
+                    <span className="text-muted text-xs">
+                        {humanFriendlyNumber(totalMatchingFilters)} {filters.viewMode === 'spans' ? 'spans' : 'traces'}{' '}
+                        matching filters
+                    </span>
+                )}
+            </div>
+            {inTracesView && (
+                <div className="flex items-center gap-1.5 flex-wrap">
+                    {!filters.compareMode && (
+                        <LemonSegmentedButton<TracingViewMode>
+                            size="small"
+                            value={filters.viewMode}
+                            onChange={setViewMode}
+                            options={[
+                                {
+                                    value: 'traces',
+                                    label: 'Traces',
+                                    icon: <IconListTree />,
+                                    tooltip: 'Group matching spans by trace — one row per trace (its root span)',
+                                    'data-attr': 'tracing-view-mode-traces',
+                                },
+                                {
+                                    value: 'spans',
+                                    label: 'Spans',
+                                    icon: <IconList />,
+                                    tooltip: 'Show every matching span individually, including child spans',
+                                    'data-attr': 'tracing-view-mode-spans',
+                                },
+                            ]}
+                        />
+                    )}
+                    <LemonSwitch
+                        label="Compare"
+                        checked={filters.compareMode}
+                        onChange={setCompareMode}
+                        bordered
+                        size="small"
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/tracing/frontend/TracingFilterBar.tsx
+++ b/products/tracing/frontend/TracingFilterBar.tsx
@@ -1,16 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useRef, useState } from 'react'
 
-import { IconChevronDown, IconChevronLeft, IconChevronRight, IconList, IconListTree, IconRefresh } from '@posthog/icons'
-import {
-    LemonButton,
-    LemonCheckbox,
-    LemonDropdown,
-    LemonInput,
-    LemonSegmentedButton,
-    LemonSwitch,
-    LemonTag,
-} from '@posthog/lemon-ui'
+import { IconChevronDown, IconRefresh } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonDropdown, LemonInput, LemonTag } from '@posthog/lemon-ui'
 
 import { DateRangePickerWithZoom } from 'lib/components/DateFilter/DateRangePicker'
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
@@ -21,7 +13,6 @@ import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
 import { DateRange } from '~/queries/schema/schema-general'
@@ -34,9 +25,8 @@ import {
 } from '~/types'
 
 import { SavedViewsButton } from './savedViews/SavedViewsButton'
-import { tracingConfigLogic } from './tracingConfigLogic'
 import { tracingDataLogic } from './tracingDataLogic'
-import { tracingFiltersLogic, type TracingViewMode } from './tracingFiltersLogic'
+import { tracingFiltersLogic } from './tracingFiltersLogic'
 import { tracingServiceFilterLogic, TracingServiceFilterLogicProps } from './tracingServiceFilterLogic'
 
 const taxonomicFilterLogicKey = 'tracing'
@@ -50,29 +40,14 @@ export function TracingFilterBar(): JSX.Element {
     const { spansLoading } = useValues(tracingDataLogic())
     const { runQuery } = useActions(tracingDataLogic())
     const { filters, utcDateRange, timezone } = useValues(tracingFiltersLogic())
-    const { setDateRange, setTimezone, setServiceNames, setFilterGroup, setViewMode, setCompareMode } =
-        useActions(tracingFiltersLogic())
-    const { dateRange, serviceNames, filterGroup, viewMode, compareMode } = filters
-    const showFacetRail = useFeatureFlag('TRACING_FACET_RAIL')
-    const { facetRailCollapsed } = useValues(tracingConfigLogic)
-    const { setFacetRailCollapsed } = useActions(tracingConfigLogic)
+    const { setDateRange, setTimezone, setServiceNames, setFilterGroup } = useActions(tracingFiltersLogic())
+    const { dateRange, serviceNames, filterGroup } = filters
 
     return (
         <TracingFilterGroup filterGroup={filterGroup} onFilterGroupChange={setFilterGroup}>
             <div className="flex flex-col gap-2 w-full">
                 <div className="flex gap-2 flex-wrap w-full justify-between">
                     <div className="flex shrink-0 flex-1 gap-1.5">
-                        {showFacetRail && !compareMode && (
-                            <LemonButton
-                                size="small"
-                                type="secondary"
-                                icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
-                                onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
-                                aria-label={facetRailCollapsed ? 'Show facets' : 'Hide facets'}
-                                tooltip={facetRailCollapsed ? 'Show facets' : 'Hide facets'}
-                                data-attr="tracing-facet-rail-toggle"
-                            />
-                        )}
                         <TracingServiceFilter
                             value={serviceNames}
                             onChange={setServiceNames}
@@ -89,36 +64,6 @@ export function TracingFilterBar(): JSX.Element {
                             setDateRange={setDateRange}
                             timezone={timezone}
                             onTimezoneChange={setTimezone}
-                        />
-                        {!compareMode && (
-                            <LemonSegmentedButton<TracingViewMode>
-                                size="small"
-                                value={viewMode}
-                                onChange={setViewMode}
-                                options={[
-                                    {
-                                        value: 'traces',
-                                        label: 'Traces',
-                                        icon: <IconListTree />,
-                                        tooltip: 'Group matching spans by trace — one row per trace (its root span)',
-                                        'data-attr': 'tracing-view-mode-traces',
-                                    },
-                                    {
-                                        value: 'spans',
-                                        label: 'Spans',
-                                        icon: <IconList />,
-                                        tooltip: 'Show every matching span individually, including child spans',
-                                        'data-attr': 'tracing-view-mode-spans',
-                                    },
-                                ]}
-                            />
-                        )}
-                        <LemonSwitch
-                            label="Compare"
-                            checked={compareMode}
-                            onChange={setCompareMode}
-                            bordered
-                            size="small"
                         />
                         <LemonButton
                             size="small"

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -2,13 +2,12 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { LemonBanner, LemonButton, LemonModal, LemonTabs, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconFeedback } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
-import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -27,6 +26,7 @@ import { TraceCompareFlame } from './TraceCompareFlame'
 import { TraceCompareTable } from './TraceCompareTable'
 import { tracingConfigLogic } from './tracingConfigLogic'
 import { tracingDataLogic } from './tracingDataLogic'
+import { TracingDisplayBar } from './TracingDisplayBar'
 import { TracingFilterBar } from './TracingFilterBar'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
 import { tracingSceneLogic } from './tracingSceneLogic'
@@ -61,7 +61,6 @@ function TracingSceneContents(): JSX.Element {
         selectedTraceTs,
         sparklineData,
         sparklineLoading,
-        totalMatchingFilters,
         openTraceSpans,
         isLoadingFullTrace,
         canLoadMoreTraceSpans,
@@ -95,7 +94,6 @@ function TracingSceneContents(): JSX.Element {
         loadMoreTraceSpans,
         setVisibleRowRange,
         setSort,
-        setActiveTracingTab,
     } = useActions(tracingSceneLogic())
     const { addProductIntent } = useActions(teamLogic)
     const { facetRailCollapsed } = useValues(tracingConfigLogic)
@@ -173,6 +171,8 @@ function TracingSceneContents(): JSX.Element {
                 Tracing is in alpha. Expect bugs, missing features, and breaking changes.
             </LemonBanner>
             <TracingSetupPrompt>
+                <TracingFilterBar />
+                <SceneDivider />
                 <TracingSparkline
                     sparklineData={sparklineData}
                     sparklineLoading={sparklineLoading || (isDurationMode && durationHistogramLoading)}
@@ -183,84 +183,63 @@ function TracingSceneContents(): JSX.Element {
                     durationHistogram={isDurationMode ? durationHistogramData : null}
                     visibleRowDurationRange={visibleRowDurationRange}
                 />
-                <SceneDivider />
-                <TracingFilterBar />
-                {operationsViewEnabled && (
-                    <LemonTabs
-                        activeKey={activeTracingTab}
-                        onChange={(key) => setActiveTracingTab(key as 'traces' | 'operations')}
-                        tabs={[
-                            { key: 'traces', label: 'Traces' },
-                            { key: 'operations', label: 'Operations' },
-                        ]}
-                    />
-                )}
-                {operationsViewEnabled && activeTracingTab === 'operations' ? (
-                    <OperationsTable
-                        rows={aggregation.current}
-                        loading={aggregationLoading}
-                        windowMs={operationsWindowMs}
-                        onRowClick={(row) => router.actions.push(urls.tracingOperation(row.service_name, row.name))}
-                    />
-                ) : (
-                    <div className="flex flex-row gap-2 flex-1 min-h-0">
-                        {facetRailEnabled && !compareMode && !facetRailCollapsed && <FacetRail />}
-                        <div className="flex flex-col gap-y-4 flex-1 min-w-0 min-h-0">
-                            {/* No loading guard: keep the last (view-mode-independent) count visible across reloads,
-                            so a Traces/Spans switch doesn't flicker the label out and back in. */}
-                            {!compareMode && totalMatchingFilters > 0 && (
-                                <div className="text-xs text-muted px-1">
-                                    {humanFriendlyNumber(totalMatchingFilters)}{' '}
-                                    {filters.viewMode === 'spans' ? 'spans' : 'traces'} matching filters
-                                </div>
-                            )}
-                            {compareMode ? (
-                                <TraceCompareTable
-                                    current={aggregation.current}
-                                    previous={aggregation.previous}
-                                    loading={aggregationLoading}
-                                    onRowClick={(row) => openCompareFlame(row.name, row.service_name)}
-                                />
-                            ) : (
-                                <VirtualizedSpanList
-                                    dataSource={listRows}
-                                    loading={spansLoading}
-                                    hasMoreToLoad={hasMoreToLoad}
-                                    onLoadMore={fetchNextPage}
-                                    onVisibleRowRangeChange={setVisibleRowRange}
-                                    orderBy={filters.orderBy}
-                                    orderDirection={filters.orderDirection}
-                                    onSort={(column) =>
-                                        // Click an active column to flip direction; a new column starts at DESC.
-                                        setSort(
-                                            column,
-                                            column === filters.orderBy && filters.orderDirection === 'DESC'
-                                                ? 'ASC'
-                                                : 'DESC'
-                                        )
-                                    }
-                                    emptyState={
-                                        <div className="flex flex-col items-center gap-1">
-                                            <span>No spans found</span>
-                                            <Link to={TRACING_DOCS_URL} onClick={onDocsLinkClick} target="_blank">
-                                                Learn how to send traces
-                                            </Link>
-                                        </div>
-                                    }
-                                    onRowClick={(span: Span) => {
-                                        // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
-                                        // element; react-modal then scrolls it back into view when restoring focus
-                                        // on close. Blur so the restore target is <body>, which doesn't scroll.
-                                        ;(document.activeElement as HTMLElement | null)?.blur?.()
-                                        // Anchor the waterfall on the clicked span — in Spans mode this is often a
-                                        // child span, so without spanId the drawer would open unfocused at the root.
-                                        openTrace(span.trace_id, { spanId: span.span_id, ts: span.timestamp })
-                                    }}
-                                />
-                            )}
-                        </div>
+                <div className="flex flex-row gap-2 flex-1 min-h-0">
+                    {facetRailEnabled && !facetRailCollapsed && <FacetRail />}
+                    <div className="flex flex-col gap-2 flex-1 min-w-0 min-h-0">
+                        <TracingDisplayBar />
+                        {operationsViewEnabled && activeTracingTab === 'operations' ? (
+                            <OperationsTable
+                                rows={aggregation.current}
+                                loading={aggregationLoading}
+                                windowMs={operationsWindowMs}
+                                onRowClick={(row) =>
+                                    router.actions.push(urls.tracingOperation(row.service_name, row.name))
+                                }
+                            />
+                        ) : compareMode ? (
+                            <TraceCompareTable
+                                current={aggregation.current}
+                                previous={aggregation.previous}
+                                loading={aggregationLoading}
+                                onRowClick={(row) => openCompareFlame(row.name, row.service_name)}
+                            />
+                        ) : (
+                            <VirtualizedSpanList
+                                dataSource={listRows}
+                                loading={spansLoading}
+                                hasMoreToLoad={hasMoreToLoad}
+                                onLoadMore={fetchNextPage}
+                                onVisibleRowRangeChange={setVisibleRowRange}
+                                orderBy={filters.orderBy}
+                                orderDirection={filters.orderDirection}
+                                onSort={(column) =>
+                                    // Click an active column to flip direction; a new column starts at DESC.
+                                    setSort(
+                                        column,
+                                        column === filters.orderBy && filters.orderDirection === 'DESC' ? 'ASC' : 'DESC'
+                                    )
+                                }
+                                emptyState={
+                                    <div className="flex flex-col items-center gap-1">
+                                        <span>No spans found</span>
+                                        <Link to={TRACING_DOCS_URL} onClick={onDocsLinkClick} target="_blank">
+                                            Learn how to send traces
+                                        </Link>
+                                    </div>
+                                }
+                                onRowClick={(span: Span) => {
+                                    // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
+                                    // element; react-modal then scrolls it back into view when restoring focus
+                                    // on close. Blur so the restore target is <body>, which doesn't scroll.
+                                    ;(document.activeElement as HTMLElement | null)?.blur?.()
+                                    // Anchor the waterfall on the clicked span — in Spans mode this is often a
+                                    // child span, so without spanId the drawer would open unfocused at the root.
+                                    openTrace(span.trace_id, { spanId: span.span_id, ts: span.timestamp })
+                                }}
+                            />
+                        )}
                     </div>
-                )}
+                </div>
             </TracingSetupPrompt>
             <TraceDrawer
                 isOpen={isTraceOpen}


### PR DESCRIPTION
## Problem

The tracing scene's controls are scattered. The sparkline sits above the filters, the Traces/Operations switch is a full-width tab row, and the facet rail toggle (from the previous PR in this stack) lives in the filter bar away from the content it controls.

The logs viewer already settled a good frame for this kind of scene: query bar at the top, sparkline under it, then a results region with the facet rail on the left and a compact display bar above the table. This PR adopts that frame for tracing.

Stacked on #68597 (facet rail shell).

## Changes

- `TracingFilterBar` moves above the sparkline, so the query controls come first like logs' query bar.
- New `TracingDisplayBar` mirroring logs' `LogsDisplayBar`. It holds the facet rail toggle (moved out of the filter bar), a `LemonSegmentedButton` for Traces/Operations replacing the `LemonTabs` row (still gated by the operations view flag), and the "N traces/spans matching filters" count.
- The results region is now one frame for all views. The facet rail (flag-gated) sits on the left, and the display bar plus the active view (span list, operations table, or compare table) fill the right.

Two behavior notes for review. The rail now renders beside the operations and compare views too, not just the span list, since facet filters apply to those queries as well. And the Traces/Spans segmented button plus the Compare switch moved from the filter bar to the right side of the display bar, hidden on the Operations view where neither applies.

## How did you test this code?

- Ran the tracing jest suites (`tracingDataLogic.test.ts`, `tracingFiltersLogic.test.ts`), 26 tests pass.
- oxlint and oxfmt clean on the three changed files.
- No new tests: this is a layout rearrangement of existing components with no new logic. The display bar reads and writes existing `tracingSceneLogic` / `tracingConfigLogic` state that is already covered where it matters.
- I did not manually verify the rendered layout in a browser. The three result views all self-size with the same `flex flex-col flex-1 min-h-0` root, which is what the new frame requires, but the flex sizing deserves a visual once-over before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, in-app layout change for an alpha product.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed the layout (segmented button instead of tabs, logs-viewer frame), Claude (PostHog Code) implemented it. It checked that `OperationsTable`, `TraceCompareTable`, and `VirtualizedSpanList` all have self-sizing flex roots before putting them in the fixed-height frame.

Decisions: the display bar is a plain component rather than a new logic since all state it touches already lives in `tracingSceneLogic` and `tracingConfigLogic`. The rail toggle moved out of the filter bar so view controls sit next to the content they affect, matching logs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

