### PR TITLE
chore(frontend): exclude flaky Combobox.test.tsx from jest

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -296,6 +296,8 @@ const config: Config = {
         '/products/visual_review/cli/',
         '/products/agent_platform/services/',
         '/products/agent_platform/packages/',
+        // Flaky on master and blocking merges — tracked for re-enable.
+        '/lib/components/TaxonomicFilter/menu/Combobox.test.tsx',
     ],
 
     // The regexp pattern or array of patterns that Jest uses to detect test files


### PR DESCRIPTION
## Problem

`Combobox.test.tsx` is failing on master and blocking all merges.

## Changes

Add `frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx` to jest's `testPathIgnorePatterns` to unblock CI. Tracked for re-enable once the flakiness is root-caused.

## How did you test this code?

Ran `npx jest --listTests` locally and confirmed the file is no longer collected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude) added the ignore pattern and verified the exclusion via `jest --listTests`.
- No skills were required for this one-line config change.
