### PR TITLE
fix(onboarding): skip team-scoped tasks call in shared views

### DIFF
--- a/frontend/src/scenes/onboarding/shared/setupWizardStatusLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/setupWizardStatusLogic.ts
@@ -11,6 +11,8 @@ import {
 } from 'scenes/onboarding/self-driving/sdks/OnboardingInstallStep/installationProgressLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { isSharedView } from '~/exporter/exporterViewLogic'
+
 import { tasksList, tasksRunsList } from 'products/tasks/frontend/generated/api'
 import type { TaskRunDetailDTOApi } from 'products/tasks/frontend/generated/api.schemas'
 
@@ -121,6 +123,11 @@ export const setupWizardStatusLogic = kea<setupWizardStatusLogicType>([
             null as DiscoveredSetupRun | null,
             {
                 loadDiscoveredRun: async (): Promise<DiscoveredSetupRun | null> => {
+                    // The onboarding wizard is meaningless to a logged-out viewer, and the tasks API
+                    // it hits is team-scoped, so it 403s in a shared/exported view. Skip it entirely.
+                    if (isSharedView()) {
+                        return null
+                    }
                     // Mounted before the team loaded: the currentTeamId subscription below retries
                     if (values.currentTeamId === null) {
                         return null


### PR DESCRIPTION
## Problem

The Playwright test `shared-insight-unauthenticated.spec.ts` is flaky. It asserts that a logged-out `/shared/{token}` insight view makes no team-scoped `/api/projects/{team}/...` calls, and it intermittently fails on a leaked `GET /api/projects/{team}/tasks/?origin_product=onboarding` returning 403.

Root cause: `setupWizardStatusLogic` fires that team-scoped tasks call on mount to discover the onboarding wizard's setup run. It's mounted by the insights `SampleDataState` empty-state, which also renders inside the exporter (shared) view when the exported insight has no data. A logged-out viewer has no access to that endpoint, so it 403s. The flakiness is just timing: the leak resolves asynchronously, so whether its 403 was recorded before the test's final assertion varied run to run.

The onboarding wizard is meaningless to a logged-out viewer, so it shouldn't be reaching for its data at all in a shared view.

## Changes

Gate `loadDiscoveredRun` in `setupWizardStatusLogic` on the existing `isSharedView()` helper (`~/exporter/exporterViewLogic`) and return early in shared/exported views. This stops the team-scoped tasks call from firing there, from any surface that mounts the logic.

## How did you test this code?

I (Claude, via the PostHog Slack app) traced the leak from the CI job logs to the exact API call and the logic that fires it. The existing `shared-insight-unauthenticated.spec.ts` is the regression guard: it records every `/api/*` response ≥400 in the logged-out context and fails on any team-scoped leak, so with the call gated out there is nothing to record. I did not run the full Playwright E2E stack locally, and lint/typecheck binaries weren't available in this environment. The import path (`~/exporter/exporterViewLogic`) is already used elsewhere in the app, and the change is a single guard plus import.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie asked me (the PostHog Slack app, running Claude) to fix a flaky Playwright test from a CI job and open a draft PR. I invoked the `/fixing-flaky-tests` skill. The linked job was on an unrelated PR (a LemonTree unit-test fix), so this leak is a pre-existing flake that surfaced there rather than anything that PR introduced, which is why this is a separate PR.

I classified the failure as a real team-scoped API leak (the test failed all four attempts in that run, and the underlying leak is timing-dependent), then traced it: `SampleDataState` → `setupWizardStatusLogic.loadDiscoveredRun` → `tasksList(..., { origin_product: 'onboarding' })`. I chose to gate at the logic level rather than the component level so the guard covers every surface that mounts the logic in shared mode, using the purpose-built `isSharedView()` helper already used for exactly this class of shared-view gating. I considered adding a kea unit test but the logic connects several other logics with their own async work, so a new unit test risked introducing a fresh flake; the existing E2E already guards the regression.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1783341940347619?thread_ts=1783341940.347619&cid=C09ADEV3AJD)*
