### PR TITLE
chore(aio): rename commit scope convention from llma to aio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 - `feat`: New feature or functionality (touches production code)
 - `fix`: Bug fix (touches production code)
 - `chore`: Non-production changes (docs, tests, config, CI, refactoring agents instructions, etc.)
-- Scope convention: use `llma` for LLM analytics changes (for example, `feat(llma): ...`)
+- Scope convention: use `aio` for AI observability changes (for example, `feat(aio): ...`)
 
 ### Format
 


### PR DESCRIPTION
## Problem

Our team renamed from LLM analytics to AI observability, but the commit scope convention in `AGENTS.md` still tells everyone to use `feat(llma)`.

## Changes

Change to `feat(aio)`

## How did you test this code?

Doc-only change, no code paths affected. No automated tests apply.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. This is the agent-instructions doc itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked PostHog Code (Claude) to find where the `feat(llma)` style came from and update it for the team rename. It traced the only occurrence to the `AGENTS.md` scope convention line (my personal branch-name convention already used the new name), and surfaced that `llma` is far from dead: 2669 commits use the `(llma)` scope and the name is baked into shipped identifiers across ~260 files. On that basis we deliberately scoped this PR to the doc line only.

We initially considered `aiobs`, but I confirmed `aio` with my boss (it already matches a handful of existing commits), so the convention lands on `aio`. This commit is itself the first to use the new `chore(aio)` scope. Skill invoked: `/pr-link`.
