### PR TITLE
fix(ci): block fork PRs from rust image build

### DIFF
--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -142,11 +142,17 @@ jobs:
 
             - name: Retrieve sccache configuration
               id: sccache
+              env:
+                  IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
               run: |
+                  echo "cache-key-prefix=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_OUTPUT"
+                  if [ "$IS_FORK_PR" = "true" ]; then
+                      echo "Fork PR — skipping sccache credentials (build runs without remote cache)"
+                      exit 0
+                  fi
                   echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
                   echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
                   echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
-                  echo "cache-key-prefix=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_OUTPUT"
 
             - name: Build and push image
               id: docker_build

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -39,7 +39,10 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 10
         # Skip on workflow_dispatch — always build everything (escape hatch)
-        if: github.event_name != 'workflow_dispatch'
+        if: >-
+            github.event_name != 'workflow_dispatch' &&
+            (github.event_name != 'pull_request' ||
+             github.event.pull_request.head.repo.full_name == github.repository)
         permissions:
             contents: read
         outputs:
@@ -77,6 +80,8 @@ jobs:
         # Run unless affected explicitly found zero images ('none') or failed.
         if: |
             always() && !cancelled() &&
+            (github.event_name != 'pull_request' ||
+             github.event.pull_request.head.repo.full_name == github.repository) &&
             needs.affected.result != 'failure' &&
             needs.affected.outputs.image-filter != 'none'
         uses: ./.github/workflows/_rust-build-images.yml


### PR DESCRIPTION
## Problem

`rust-docker-build.yml` builds Rust container images on `pull_request` events but has no fork-origin check, so it runs on untrusted PR code. During the build, the reusable `_rust-build-images.yml` workflow passes the sccache WebDAV endpoint and token into the Docker build as BuildKit secrets to speed up compilation.

## Changes

- Gate the `affected` job on `github.event.pull_request.head.repo.full_name == github.repository` (keeping the `workflow_dispatch` escape hatch intact).
- Gate the `build-images` job on the same condition. This is required, not redundant: `build-images` uses `always()`, so skipping only `affected` would still let it run for a fork (`result == 'skipped' != 'failure'`, empty `image-filter != 'none'`) and build every image with the secrets attached.

## How did you test this code?

No automated tests exist for these workflows. I validated the YAML parses and that the `if` expressions and the reusable-workflow step resolve as intended by parsing the files with PyYAML and tracing every trigger scenario (push, workflow_dispatch, internal PR, fork PR) against both job conditions. `hogli ci:preflight --strict` passes with 0 failures (workflow-lint clean on the 2 changed files). I did not exercise the live workflow against a real fork PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.
