### PR TITLE
chore(logs): remove the legacy filter bar layout behind logs-facet-rail

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -352,7 +352,6 @@ export const FEATURE_FLAGS = {
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-ai-observability
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
-    LOGS_FACET_RAIL: 'logs-facet-rail', // owner: #team-logs
     LOGS_GROUP_BY: 'logs-group-by', // owner: #team-logs
     LOGS_PATTERNS_VIEW: 'logs-patterns-view', // owner: #team-logs
     LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs

--- a/playwright/e2e/logs/logs.spec.ts
+++ b/playwright/e2e/logs/logs.spec.ts
@@ -38,11 +38,36 @@ test.describe('Logs', () => {
                 })
             )
 
+            // The facet rail populates the Level and Service facets from this endpoint, keyed by the
+            // requested facetField. Return sensible values + non-zero counts for each (a fixed facet
+            // value with a zero count renders disabled and can't be clicked).
+            const facetValuesByField: Record<string, { value: string; count: number }[]> = {
+                service_name: [
+                    { value: 'api-service', count: 42 },
+                    { value: 'web-frontend', count: 17 },
+                ],
+                severity_text: [
+                    { value: 'error', count: 12 },
+                    { value: 'info', count: 8 },
+                ],
+            }
+            await page.route('**/logs/facet_values/', (route) => {
+                const facetField = route.request().postDataJSON()?.query?.facetField
+                const results = facetValuesByField[facetField] ?? []
+                return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ results }) })
+            })
+
+            // Resource-attribute presence probe — return none so only the Level and Service column
+            // facets render, keeping the rail deterministic.
+            await page.route('**/logs/attributes/', (route) =>
+                route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ results: [] }) })
+            )
+
             await page.goto(`/project/${workspace!.team_id}/logs`)
             await page.waitForLoadState('networkidle')
         })
 
-        test('service filter passes serviceNames to API', async ({ page }) => {
+        test('service facet passes serviceNames to API', async ({ page }) => {
             // ARRANGE: Set up request interception that only captures requests with serviceNames
             // This ensures we capture the filter-triggered request, not the initial page load
             const requestPromise = page.waitForRequest((req) => {
@@ -57,10 +82,8 @@ test.describe('Logs', () => {
                 }
             })
 
-            // ACT: Click the service filter and select a value
-            await page.getByTestId('logs-service-filter').click()
-            // Wait for dropdown to be visible, then select first option
-            await page.locator('[data-attr^="logs-service-option-"]').first().click()
+            // ACT: Select a value from the Service facet in the rail
+            await page.locator('[data-attr="logs-facet-service-api-service"]').click()
 
             // Wait for the filter-triggered request
             const request = await requestPromise
@@ -71,7 +94,7 @@ test.describe('Logs', () => {
             expect(body.query.serviceNames.length).toBeGreaterThan(0)
         })
 
-        test('severity filter passes severityLevels to API', async ({ page }) => {
+        test('level facet passes severityLevels to API', async ({ page }) => {
             // ARRANGE: Set up request interception that only captures requests with severityLevels
             // This ensures we capture the filter-triggered request, not the initial page load
             const requestPromise = page.waitForRequest((req) => {
@@ -86,12 +109,8 @@ test.describe('Logs', () => {
                 }
             })
 
-            // ACT: Click the severity filter and select "Error"
-            await page.getByTestId('logs-severity-filter').click()
-            // Select "Error" from the dropdown menu
-            await page.locator('[data-attr="logs-severity-option-error"]').click()
-            // Close the menu by pressing Escape
-            await page.keyboard.press('Escape')
+            // ACT: Select "Error" from the Level facet in the rail
+            await page.locator('[data-attr="logs-facet-level-error"]').click()
 
             // Wait for the filter-triggered request
             const request = await requestPromise

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -12,7 +12,6 @@ import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
 import {
@@ -25,13 +24,8 @@ import {
 
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
-import { LogsFullScreenButton } from 'products/logs/frontend/components/LogsViewer/LogsFullScreenButton'
-import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 
-import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
 import { LogsDateRangePicker } from '../LogsDateRangePicker/LogsDateRangePicker'
-import { ServiceFilter } from '../ServiceFilter'
-import { SeverityLevelsFilter } from '../SeverityLevelsFilter'
 
 const taxonomicFilterLogicKey = 'logs'
 const taxonomicGroupTypes = [
@@ -40,53 +34,8 @@ const taxonomicGroupTypes = [
     TaxonomicFilterGroupType.LogAttributes,
 ]
 
-export const LogsFilterBar = ({
-    showSavedViewsButton = false,
-    showFullScreenButton = false,
-}: {
-    showSavedViewsButton?: boolean
-    showFullScreenButton?: boolean
-}): JSX.Element => {
-    // When the facet rail is on, Level + Service live in the rail instead of this bar.
-    const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
-    const { setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
-    const { filters, utcDateRange, id } = useValues(logsViewerFiltersLogic)
-    const { severityLevels, serviceNames } = filters
-
-    return (
-        <LogsFilterGroup>
-            <div className="flex flex-col gap-2 w-full bg-primary">
-                <div className="flex gap-2 flex-wrap w-full justify-between">
-                    <div className="flex shrink-0 flex-1 gap-1.5">
-                        {!showFacetRail && (
-                            <>
-                                <SeverityLevelsFilter value={severityLevels} onChange={setSeverityLevels} />
-                                <ServiceFilter
-                                    value={serviceNames}
-                                    onChange={setServiceNames}
-                                    dateRange={utcDateRange}
-                                />
-                            </>
-                        )}
-                        <div className="min-w-[300px] max-w-[350px] w-full">
-                            <LogsFilterSearch />
-                        </div>
-                        <FilterHistoryDropdown />
-                        {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
-                    </div>
-                    <div className="flex shrink-0 gap-1.5">
-                        <LogsQueryControls />
-                        {showFullScreenButton && <LogsFullScreenButton id={id} />}
-                    </div>
-                </div>
-                <LogsAppliedFilters />
-            </div>
-        </LogsFilterGroup>
-    )
-}
-
 /**
- * Time range, zoom and refresh — the always-relevant "execute the query" controls shared by both bars.
+ * Time range, zoom and refresh — the always-relevant "execute the query" controls of the query bar.
  * Live tail lives in the results bar instead (LogsViewerToolbar): it's the one streaming control we
  * deliberately place with the Logs-only tools so it hides cleanly with that cluster in Patterns mode,
  * rather than collapsing in this top bar and shifting its layout.

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -86,9 +86,9 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
             pushToHistory,
         }),
 
-        // Mirror of the `pinnedFilters` prop into state so consumers (LogsFilterBar)
-        // can read it via useValues without going through the kea selector input-prop
-        // machinery (which doesn't accept optional props).
+        // Mirror of the `pinnedFilters` prop into state so consumers can read it via
+        // useValues without going through the kea selector input-prop machinery
+        // (which doesn't accept optional props).
         setPinnedFilters: (pinnedFilters: UniversalFiltersGroup | undefined) => ({ pinnedFilters }),
 
         zoomDateRange: (multiplier: number) => ({ multiplier }),

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -14,7 +14,6 @@ import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsVie
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { FacetRail } from 'products/logs/frontend/components/LogsViewer/FacetRail/FacetRail'
-import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
 import { LogsQueryBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar'
 import { logsFilterHistoryLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterHistoryLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
@@ -39,9 +38,6 @@ export interface LogsViewerProps {
     // Filters enforced by the embedding scene. Merged into the user-editable filterGroup
     // and rendered without an X so users can't accidentally drop the scope.
     pinnedFilters?: UniversalFiltersGroup
-    // Hide the filter bar (levels/services/search/date range) entirely. For embeds where the
-    // scope is fixed by `pinnedFilters` and editing filters in place isn't wanted. @default true
-    showFilterBar?: boolean
 }
 
 export function LogsViewer({
@@ -50,7 +46,6 @@ export function LogsViewer({
     showSavedViewsButton = false,
     initialFilters,
     pinnedFilters,
-    showFilterBar = true,
 }: LogsViewerProps): JSX.Element {
     return (
         <BindLogic logic={logsViewerFiltersLogic} props={{ id, initialFilters, pinnedFilters }}>
@@ -63,7 +58,6 @@ export function LogsViewer({
                                     <LogsViewerContent
                                         showFullScreenButton={showFullScreenButton}
                                         showSavedViewsButton={showSavedViewsButton}
-                                        showFilterBar={showFilterBar}
                                     />
                                 </BindLogic>
                             </BindLogic>
@@ -78,11 +72,9 @@ export function LogsViewer({
 function LogsViewerContent({
     showFullScreenButton,
     showSavedViewsButton,
-    showFilterBar,
 }: {
     showFullScreenButton: boolean
     showSavedViewsButton: boolean
-    showFilterBar: boolean
 }): JSX.Element {
     const {
         id,
@@ -122,7 +114,6 @@ function LogsViewerContent({
     } = useValues(logsViewerDataLogic)
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
-    const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
     const showGroupBy = useFeatureFlag('LOGS_GROUP_BY')
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
@@ -309,10 +300,6 @@ function LogsViewerContent({
         </>
     )
 
-    const filterBar = showFilterBar ? (
-        <LogsFilterBar showSavedViewsButton={showSavedViewsButton} showFullScreenButton={showFullScreenButton} />
-    ) : null
-
     const displayBarProps = {
         id,
         totalLogsCount: sparklineLoading ? undefined : totalLogsMatchingFilters,
@@ -378,29 +365,18 @@ function LogsViewerContent({
         </>
     )
 
-    if (showFacetRail) {
-        // Three-tier layout: query bar (ask a question) above the sparkline, the sparkline, then a
-        // row of [facet rail | display bar (operate on the data) + the log lists].
-        return (
-            <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
-                <LogsQueryBar showSavedViewsButton={showSavedViewsButton} showFullScreenButton={showFullScreenButton} />
-                {sparklineSection}
-                <div className="flex flex-row gap-2 flex-1 min-h-0">
-                    {!facetRailCollapsed && <FacetRail id={id} />}
-                    <div className="flex flex-col gap-2 flex-1 min-w-0">
-                        {resultsColumn(<LogsDisplayBar {...displayBarProps} showFacetRailToggle />)}
-                    </div>
-                </div>
-                <LogDetailsModal timezone={timezone} />
-            </div>
-        )
-    }
-
+    // Three-tier layout: query bar (ask a question) above the sparkline, the sparkline, then a
+    // row of [facet rail | display bar (operate on the data) + the log lists].
     return (
         <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
+            <LogsQueryBar showSavedViewsButton={showSavedViewsButton} showFullScreenButton={showFullScreenButton} />
             {sparklineSection}
-            {filterBar}
-            {resultsColumn(<LogsDisplayBar {...displayBarProps} />)}
+            <div className="flex flex-row gap-2 flex-1 min-h-0">
+                {!facetRailCollapsed && <FacetRail id={id} />}
+                <div className="flex flex-col gap-2 flex-1 min-w-0">
+                    {resultsColumn(<LogsDisplayBar {...displayBarProps} showFacetRailToggle />)}
+                </div>
+            </div>
             <LogDetailsModal timezone={timezone} />
         </div>
     )

--- a/products/tracing/frontend/components/TraceDrawer/SpanLogsTab.tsx
+++ b/products/tracing/frontend/components/TraceDrawer/SpanLogsTab.tsx
@@ -14,8 +14,8 @@ import type { Span } from '../../types'
 // Logs correlated to the inspected span (default) or the whole trace, via the embedded LogsViewer
 // pinned to a trace_id/span_id filter. Span scope keeps the tab coherent with the rest of the
 // inspector; the toggle rescues the common case where a span emitted no logs of its own. The
-// viewer's own filter bar is hidden (showFilterBar={false}) — the scope is fixed by the pinned
-// filter, and this toggle is the visible scope control.
+// pinned filter fixes the scope — the viewer's own filters can only narrow within it — and this
+// toggle is the scope control.
 export function SpanLogsTab({ span }: { span: Span }): JSX.Element {
     const [scope, setScope] = useState<TraceLogScope>('span')
 
@@ -68,7 +68,6 @@ export function SpanLogsTab({ span }: { span: Span }): JSX.Element {
                 id={`tracing-logs-${span.trace_id}`}
                 pinnedFilters={pinnedFilters}
                 initialFilters={initialFilters}
-                showFilterBar={false}
                 // Full-screen is off (like PersonLogsTab): the shared modal can't carry pinnedFilters,
                 // so it would open unscoped and clear this viewer's scope. "Open in Logs" preserves
                 // the scope via the URL filterGroup instead.


### PR DESCRIPTION
## Problem

The `logs-facet-rail` flag is at 100% rollout with no conditions, so the pre-rail `LogsFilterBar` layout (dedicated level/service pickers above the log list) is dead code. It only flashed briefly for users whose flags hadn't loaded yet. Keeping two layouts around invites drift, and the goal is for the facet rail to be the single filter surface.

## Changes

- `LogsViewer` always renders the facet-rail layout; the flag check and the legacy return branch are gone.
- Deleted the `LogsFilterBar` component. The shared pieces it exported (`LogsFilterSearch`, `LogsQueryControls`, `LogsAppliedFilters`, `LogsFilterGroup`) stay in the same file - `LogsQueryBar` uses them.
- Removed the `LOGS_FACET_RAIL` constant.
- Removed the `showFilterBar` prop. The rail layout never honored it, so its one consumer (the tracing span drawer) already renders the query bar in production - removing it codifies current behavior. Fixed the stale comment there.
- Kept `SeverityLevelsFilter` and `ServiceFilter`: the logs alert form and the dashboards logs widget still use them as standalone pickers.

No storage or compatibility changes: the rail reads and writes the same `severityLevels`/`serviceNames` filter fields and `log_resource_attribute` filterGroup entries the old bar did, so saved views, alerts, and shared URLs are unaffected.

**Flag deletion must wait until this deploys**: cached old bundles still evaluate `logs-facet-rail`, and deleting the flag early would flip them to the legacy layout. Archive the flag after rollout.

## How did you test this code?

- All 413 logs product jest tests pass, full frontend `typescript:check` passes, zero `LOGS_FACET_RAIL` references remain.
- No new tests: this deletes an unreachable code path and changes no observable behavior for flag-on users (everyone).
- I did not manually verify in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the legacy filter bar.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Follow-up to #68627 (independent - the two PRs touch disjoint files and can merge in either order).
- Verified the flag's 100% rollout via the PostHog MCP before deleting the path, and audited every `LogsViewer` render site to confirm the only `showFilterBar={false}` consumer already gets the rail layout in production.
- Chose to codify current production behavior for the tracing span drawer rather than making `showFilterBar` functional again; if that embed should be chrome-less, that's a product decision for a separate change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
