### PR TITLE
feat(billing): MDW grouped billing card, spend-alert gauge and alert-only product support

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -206,7 +206,17 @@ class BillingManager:
                 current_usage = billing_reported_usage + todays_usage
 
             product["current_usage"] = current_usage
-            product["percentage_usage"] = current_usage / usage_limit if usage_limit else 0
+            # The usage_summary limit is the ENFORCEMENT signal — None for alert-only products
+            # (whose limit is an alert threshold) and for every product during a trial. Keep
+            # billing's own percentage_usage only for alert-only products, so their alert banners
+            # and gauges work; zero it otherwise (trials must not surface over-limit UI — nothing
+            # is enforced there).
+            if usage_limit:
+                product["percentage_usage"] = current_usage / usage_limit
+            elif product.get("alert_only"):
+                product["percentage_usage"] = product.get("percentage_usage") or 0
+            else:
+                product["percentage_usage"] = 0
 
         return response
 
@@ -439,6 +449,9 @@ class BillingManager:
                     data["billing_period"]["current_period_end"],
                 ],
             )
+            # Conditionally present — see the NotRequired note on OrganizationUsageInfo.
+            if "managed_warehouse_storage_gb_hours" in usage_summary:
+                usage_info["managed_warehouse_storage_gb_hours"] = usage_summary["managed_warehouse_storage_gb_hours"]
 
             if set_org_usage_summary(organization, new_usage=usage_info):
                 org_modified = True

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -213,7 +213,7 @@ class BillingManager:
             # is enforced there).
             if usage_limit:
                 product["percentage_usage"] = current_usage / usage_limit
-            elif product.get("alert_only"):
+            elif product.get("alert_only") and product.get("subscribed"):
                 product["percentage_usage"] = product.get("percentage_usage") or 0
             else:
                 product["percentage_usage"] = 0

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -87,6 +87,10 @@ class QuotaResource(Enum):
     WORKFLOW_EMAILS = "workflow_emails"
     WORKFLOW_DESTINATIONS = "workflow_destinations_dispatched"
     LOGS_MB_INGESTED = "logs_mb_ingested"
+    # Managed data warehouse storage. Usage and limit both come from the billing sync (not a
+    # ClickHouse query), so todays_usage is always 0. Billing sends a limit only when storage
+    # should be enforced (free tier); paid storage is alert-only and arrives with limit=None.
+    MANAGED_WAREHOUSE_STORAGE = "managed_warehouse_storage_gb_hours"
 
 
 class QuotaLimitingCaches(Enum):
@@ -110,6 +114,7 @@ OVERAGE_BUFFER = {
     QuotaResource.WORKFLOW_EMAILS: 0,
     QuotaResource.WORKFLOW_DESTINATIONS: 0,
     QuotaResource.LOGS_MB_INGESTED: 0,
+    QuotaResource.MANAGED_WAREHOUSE_STORAGE: 0,  # free tier is a hard 100 GB line, no buffer
 }
 
 # These resources are exempt from any grace periods, whether trust-based or never_drop_data
@@ -136,6 +141,9 @@ class UsageCounters(TypedDict):
     workflow_emails: int
     workflow_destinations_dispatched: int
     logs_mb_ingested: int
+    # Storage has no daily ClickHouse delta (it's a billing-computed level), so today's usage is
+    # always 0 here; the billing-synced period usage in organization.usage carries the full signal.
+    managed_warehouse_storage_gb_hours: int
 
 
 # -------------------------------------------------------------------------------------------------
@@ -961,6 +969,8 @@ def update_all_orgs_billing_quotas(
             workflow_emails=all_data["teams_with_workflow_emails_sent_in_period"].get(team.id, 0),
             workflow_destinations_dispatched=all_data["teams_with_workflow_destinations_in_period"].get(team.id, 0),
             logs_mb_ingested=all_data["teams_with_logs_mb_in_period"].get(team.id, 0),
+            # Billing-computed level, no daily ClickHouse delta — see QuotaResource.
+            managed_warehouse_storage_gb_hours=0,
         )
 
         org_id = str(team.organization.id)

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -97,6 +97,17 @@ class TestBillingManager(BaseTest):
                         "percentage_usage": 1.11,
                         "usage_limit": 130200,
                         "alert_only": True,
+                        "subscribed": True,
+                    },
+                    {
+                        # UNSUBSCRIBED alert-only (trial edge: limits nulled for everything) —
+                        # must zero like any other product, not surface billing's >1 percentage
+                        "type": "managed_data_warehouse_endpoints",
+                        "usage_key": "managed_warehouse_endpoints_compute_seconds",
+                        "percentage_usage": 2.2,
+                        "usage_limit": 180000,
+                        "alert_only": True,
+                        "subscribed": False,
                     },
                     {
                         "type": "product_analytics",
@@ -116,6 +127,7 @@ class TestBillingManager(BaseTest):
                 "usage_summary": {
                     # alert-only: no enforcement limit exported
                     "managed_warehouse_storage_gb_hours": {"usage": 144000, "limit": None},
+                    "managed_warehouse_endpoints_compute_seconds": {"usage": 400000, "limit": None},
                     # enforced: recompute from the enforcement limit as before
                     "events": {"usage": 900, "limit": 1000},
                     # standard keys update_org_details requires
@@ -143,6 +155,8 @@ class TestBillingManager(BaseTest):
         assert events["percentage_usage"] == 900 / 1000, "enforced products still recompute from the summary"
         replay = by_type["session_replay"]
         assert replay["percentage_usage"] == 0, "non-alert-only products without an enforcement limit zero out"
+        endpoints = by_type["managed_data_warehouse_endpoints"]
+        assert endpoints["percentage_usage"] == 0, "UNSUBSCRIBED alert-only products zero out too"
 
     @patch(
         "ee.billing.billing_manager.requests.patch",

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -74,6 +74,76 @@ class TestBillingManager(BaseTest):
             "https://billing.posthog.com/api/products-v2", params={"plan": "standard"}, headers={}
         )
 
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_get_billing_percentage_usage_without_enforcement_limit(self, billing_get_mock):
+        organization = self.organization
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7, tzinfo=datetime.UTC),
+        )
+        TEST_clear_instance_license_cache()
+
+        billing_response = {
+            "license": {"type": "scale"},
+            "customer": {
+                "customer_id": "cus_123",
+                "has_active_subscription": True,
+                "products": [
+                    {
+                        "type": "managed_data_warehouse_storage",
+                        "usage_key": "managed_warehouse_storage_gb_hours",
+                        # billing computed this vs the customer's $ alert — must survive
+                        "percentage_usage": 1.11,
+                        "usage_limit": 130200,
+                        "alert_only": True,
+                    },
+                    {
+                        "type": "product_analytics",
+                        "usage_key": "events",
+                        "percentage_usage": 0.5,
+                        "usage_limit": 1000,
+                    },
+                    {
+                        # NOT alert-only: limit=None here means a trial (billing nulls all limits) —
+                        # billing's >1 percentage must be zeroed, or trial orgs get over-limit banners
+                        "type": "session_replay",
+                        "usage_key": "recordings",
+                        "percentage_usage": 2.5,
+                        "usage_limit": 5000,
+                    },
+                ],
+                "usage_summary": {
+                    # alert-only: no enforcement limit exported
+                    "managed_warehouse_storage_gb_hours": {"usage": 144000, "limit": None},
+                    # enforced: recompute from the enforcement limit as before
+                    "events": {"usage": 900, "limit": 1000},
+                    # standard keys update_org_details requires
+                    "exceptions": {"usage": 0, "limit": None},
+                    "recordings": {"usage": 0, "limit": None},
+                    "rows_synced": {"usage": 0, "limit": None},
+                    "feature_flag_requests": {"usage": 0, "limit": None},
+                    "api_queries_read_bytes": {"usage": 0, "limit": None},
+                },
+                "billing_period": {
+                    "current_period_start": "2024-01-01T00:00:00Z",
+                    "current_period_end": "2024-01-31T23:59:59Z",
+                },
+            },
+        }
+        billing_get_mock.return_value = MagicMock(status_code=200, json=MagicMock(return_value=billing_response))
+
+        response = BillingManager(license).get_billing(organization)
+
+        by_type = {p["type"]: p for p in response["products"]}
+        storage = by_type["managed_data_warehouse_storage"]
+        assert storage["percentage_usage"] == 1.11, "billing's percentage must be preserved when limit is None"
+        assert storage["current_usage"] == 144000
+        events = by_type["product_analytics"]
+        assert events["percentage_usage"] == 900 / 1000, "enforced products still recompute from the summary"
+        replay = by_type["session_replay"]
+        assert replay["percentage_usage"] == 0, "non-alert-only products without an enforcement limit zero out"
+
     @patch(
         "ee.billing.billing_manager.requests.patch",
         return_value=MagicMock(status_code=200, json=MagicMock(return_value={"text": "ok"})),

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -892,6 +892,38 @@ class TestQuotaLimiting(BaseTest):
                 "quota_limiting_suspended_until": None,
             }
 
+    def test_org_quota_limited_until_managed_warehouse_storage(self):
+        # MDW storage rides the same free-tier enforcement as every other product: billing sends the
+        # limit as the free allocation (74,400 GB-hours = 100 GB) for unsubscribed storage, with usage
+        # being the current level projected to GB-hours (level_gb * 744). The quota machinery flags the
+        # org once usage >= limit. Paid storage is alert-only: billing sends limit=None, so it's never
+        # limited via this path.
+        self.organization.customer_trust_scores = zero_trust_scores()
+        previously = list_limited_team_attributes(
+            QuotaResource.MANAGED_WAREHOUSE_STORAGE, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+        )
+        free_allocation = 74_400  # 100 GB * 744 h
+        self.organization.usage = {
+            "events": {"usage": 1, "limit": 100},
+            "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            # ~83 GB level (61,752 GB-hours) — under the 100 GB free tier
+            "managed_warehouse_storage_gb_hours": {"usage": 61_752, "limit": free_allocation},
+        }
+
+        # Under the free tier -> not limited
+        assert org_quota_limited_until(self.organization, QuotaResource.MANAGED_WAREHOUSE_STORAGE, previously) is None
+
+        # >= 100 GB level (77,376 GB-hours) -> limited (no overage buffer for storage)
+        self.organization.usage["managed_warehouse_storage_gb_hours"]["usage"] = 77_376
+        assert org_quota_limited_until(self.organization, QuotaResource.MANAGED_WAREHOUSE_STORAGE, previously) == {
+            "quota_limited_until": 1612137599,
+            "quota_limiting_suspended_until": None,
+        }
+
+        # Paid storage is alert-only (billing sends limit=None) -> never limited via the quota path
+        self.organization.usage["managed_warehouse_storage_gb_hours"]["limit"] = None
+        assert org_quota_limited_until(self.organization, QuotaResource.MANAGED_WAREHOUSE_STORAGE, previously) is None
+
     def test_over_quota_but_not_dropped_org(self):
         self.organization.usage = None
         previously_quota_limited_team_tokens_events = list_limited_team_attributes(
@@ -2240,6 +2272,7 @@ def _full_usage_counters(**overrides: int) -> UsageCounters:
         workflow_emails=0,
         workflow_destinations_dispatched=0,
         logs_mb_ingested=0,
+        managed_warehouse_storage_gb_hours=0,
     )
     base.update(overrides)  # type: ignore[typeddict-item]
     return base

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -56,6 +56,7 @@ export function Billing(): JSX.Element {
         showBillingHero,
         minimumBillingAccessLevel,
         hasSupportAddonPlan,
+        groupedProducts,
     } = useValues(billingLogic)
     const { reportBillingShown } = useActions(billingLogic)
     const { preflight, isCloudOrDev } = useValues(preflightLogic)
@@ -119,7 +120,9 @@ export function Billing(): JSX.Element {
         )
     }
 
-    const products = billing?.products
+    // Card list uses the grouped view (MDW storage nested under compute for one-card display).
+    // billing.products stays flat/truthful for other consumers (e.g. the usage-limit banner).
+    const products = groupedProducts
     const platformAndSupportProduct = products?.find((product) => product.type === ProductKey.PLATFORM_AND_SUPPORT)
 
     return (

--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -38,6 +38,12 @@
         &.BillingGaugeItem--within-usage-limit {
             background: var(--brand-blue);
         }
+
+        // Alert-only products (e.g. storage) are never blocked, so being over the threshold is a
+        // warning, not an error — surface it yellow rather than red.
+        &.BillingGaugeItem--alert-only:not(.BillingGaugeItem--within-usage-limit) {
+            background: var(--warning);
+        }
     }
 
     &.BillingGaugeItem--projected_usage {
@@ -57,6 +63,17 @@
                 var(--data-color-1) 0.5rem,
                 var(--data-color-1-hover) 0.5rem,
                 var(--data-color-1-hover) 1rem
+            );
+        }
+
+        // Alert-only products: warning-striped projection when over, matching the current-usage warning.
+        &.BillingGaugeItem--alert-only:not(.BillingGaugeItem--within-usage-limit) {
+            background: repeating-linear-gradient(
+                -45deg,
+                var(--warning),
+                var(--warning) 0.5rem,
+                var(--warning-dark) 0.5rem,
+                var(--warning-dark) 1rem
             );
         }
     }

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -1,14 +1,31 @@
 import './BillingGauge.scss'
 
 import clsx from 'clsx'
-import { useMemo } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
 
-import { createProductValueFormatter, formatDisplayUsage, hasDisplayFormatting } from './billing-utils'
+import {
+    createProductValueFormatter,
+    formatDisplayUsage,
+    hasDisplayFormatting,
+    isAlertOnlyProduct,
+} from './billing-utils'
 import { BillingGaugeItemType } from './types'
+
+// Where a label sits relative to the bar: which side, and how many rows out from it. depth > 0 means
+// the label was stacked further from the bar to avoid overlapping a closer label on the same side.
+type LabelPlacement = { isTop: boolean; depth: number }
+
+// Fallback label-row height (px) before labels have been measured.
+const FALLBACK_ROW_HEIGHT_PX = 34
+// Minimum horizontal gap (px) two labels must keep on the same row before one is stacked.
+const LABEL_HGAP_PX = 8
+
+const placementsEqual = (a: LabelPlacement[], b: LabelPlacement[]): boolean =>
+    a.length === b.length && a.every((p, i) => p.isTop === b[i].isTop && p.depth === b[i].depth)
 
 /*
  * Billing Gauge Item: Individual bars on the billing gauge.
@@ -17,23 +34,37 @@ type BillingGaugeItemProps = {
     item: BillingGaugeItemType
     maxValue: number
     isWithinUsageLimit: boolean
-    isTop: boolean
+    placement: LabelPlacement
+    rowHeight: number
     product?: BillingProductV2Type | BillingProductV2AddonType
+    valueFormatter?: (value: number | null) => string
 }
 
 const BillingGaugeItem = ({
     item,
     maxValue,
     isWithinUsageLimit,
-    isTop,
+    placement,
+    rowHeight,
     product,
+    valueFormatter,
 }: BillingGaugeItemProps): JSX.Element => {
     const width = `${(item.value / maxValue) * 100}%`
 
-    const formatValue = product ? createProductValueFormatter(product) : (v: number | null) => v?.toLocaleString() ?? ''
+    // An explicit valueFormatter wins (e.g. the combined dollar gauge, whose values aren't in the
+    // product's unit); otherwise format from the product's display config.
+    const formatValue =
+        valueFormatter ??
+        (product ? createProductValueFormatter(product) : (v: number | null) => v?.toLocaleString() ?? '')
     const formattedValue = formatValue(item.value)
-    const tooltipValue =
-        product && hasDisplayFormatting(product) ? formatDisplayUsage(item.value, product) : item.value.toLocaleString()
+    const tooltipValue = valueFormatter
+        ? valueFormatter(item.value)
+        : product && hasDisplayFormatting(product)
+          ? formatDisplayUsage(item.value, product)
+          : item.value.toLocaleString()
+
+    // Push the label away from the bar (up for top labels, down for bottom) when it's been stacked.
+    const offset = placement.depth * rowHeight
 
     return (
         <div
@@ -41,6 +72,7 @@ const BillingGaugeItem = ({
                 `BillingGaugeItem BillingGaugeItem--${item.type}`,
                 {
                     'BillingGaugeItem--within-usage-limit': isWithinUsageLimit,
+                    'BillingGaugeItem--alert-only': product ? isAlertOnlyProduct(product) : false,
                 },
                 'absolute top-0 left-0 bottom-0 h-2'
             )}
@@ -51,8 +83,10 @@ const BillingGaugeItem = ({
             <Tooltip title={item.prefix ? `${item.prefix}${tooltipValue}` : tooltipValue} placement="right">
                 <div
                     className={clsx('BillingGaugeItem__info', {
-                        'BillingGaugeItem__info--bottom': !isTop,
+                        'BillingGaugeItem__info--bottom': !placement.isTop,
                     })}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={offset ? { transform: `translateY(${placement.isTop ? -offset : offset}px)` } : undefined}
                 >
                     <b>{item.text}</b>
                     <div>{item.prefix ? `${item.prefix}${formattedValue}` : formattedValue}</div>
@@ -68,9 +102,11 @@ const BillingGaugeItem = ({
 export type BillingGaugeProps = {
     items: BillingGaugeItemType[]
     product: BillingProductV2Type | BillingProductV2AddonType
+    /** Overrides product-derived formatting — for gauges whose values aren't in the product's unit. */
+    valueFormatter?: (value: number | null) => string
 }
 
-export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element {
+export function BillingGauge({ items, product, valueFormatter }: BillingGaugeProps): JSX.Element {
     const maxValue = useMemo(() => {
         return Math.max(100, ...items.map((item) => item.value)) * 1.3
     }, [items])
@@ -80,16 +116,86 @@ export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element
         return [...items].sort((a, b) => a.value - b.value)
     }, [items])
 
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [placements, setPlacements] = useState<LabelPlacement[]>([])
+    const [rowHeight, setRowHeight] = useState(FALLBACK_ROW_HEIGHT_PX)
+
+    // Call sites often pass a freshly-built items array on every render; keying the layout effect
+    // on the VALUES (not array identity) avoids re-measuring the DOM and reconnecting the
+    // ResizeObserver on unrelated re-renders. The ref keeps the effect reading current items.
+    const sortedItemsRef = useRef(sortedItems)
+    sortedItemsRef.current = sortedItems
+    const itemsKey = sortedItems.map((item) => item.value).join('|')
+
+    // Keep each label on its original side (top/bottom alternating), but when it would overlap a
+    // closer label on that side, stack it one row further out. Measured from the DOM so it adapts to
+    // real label widths and the container's rendered width, and recomputed on resize.
+    useLayoutEffect(() => {
+        const container = containerRef.current
+        if (!container) {
+            return
+        }
+        const recompute = (): void => {
+            const containerWidth = container.offsetWidth
+            if (!containerWidth) {
+                return
+            }
+            // Labels render in sorted order, so the Nth `.BillingGaugeItem__info` maps to sortedItems[N].
+            const labelEls = container.querySelectorAll<HTMLElement>('.BillingGaugeItem__info')
+            const topRowEnds: number[] = []
+            const bottomRowEnds: number[] = []
+            let measuredRowHeight = 0
+            const next = sortedItemsRef.current.map((item, i): LabelPlacement => {
+                const isTop = i % 2 !== 0
+                const labelEl = labelEls[i]
+                const labelWidth = labelEl?.offsetWidth ?? 0
+                measuredRowHeight = Math.max(measuredRowHeight, labelEl?.offsetHeight ?? 0)
+                const left = (item.value / maxValue) * containerWidth
+                const rowEnds = isTop ? topRowEnds : bottomRowEnds
+                let depth = 0
+                while (rowEnds[depth] !== undefined && rowEnds[depth] + LABEL_HGAP_PX > left) {
+                    depth++
+                }
+                rowEnds[depth] = left + labelWidth
+                return { isTop, depth }
+            })
+            setPlacements((prev) => (placementsEqual(prev, next) ? prev : next))
+            if (measuredRowHeight) {
+                const nextRowHeight = measuredRowHeight + 4
+                setRowHeight((prev) => (prev === nextRowHeight ? prev : nextRowHeight))
+            }
+        }
+        recompute()
+        const observer = new ResizeObserver(recompute)
+        observer.observe(container)
+        return () => observer.disconnect()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [itemsKey, maxValue])
+
+    // Reserve vertical room for however many stacked rows we used on each side (base matches `my-16`).
+    const maxTopDepth = placements.reduce((m, p) => (p.isTop ? Math.max(m, p.depth) : m), 0)
+    const maxBottomDepth = placements.reduce((m, p) => (!p.isTop ? Math.max(m, p.depth) : m), 0)
+
     return (
-        <div className="relative h-2 bg-border-light my-16">
+        <div
+            ref={containerRef}
+            className="relative h-2 bg-border-light"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                marginTop: `calc(4rem + ${maxTopDepth * rowHeight}px)`,
+                marginBottom: `calc(4rem + ${maxBottomDepth * rowHeight}px)`,
+            }}
+        >
             {sortedItems.map((item, i) => (
                 <BillingGaugeItem
                     key={i}
                     item={item}
                     maxValue={maxValue}
                     isWithinUsageLimit={isWithinUsageLimit}
-                    isTop={i % 2 !== 0}
+                    placement={placements[i] ?? { isTop: i % 2 !== 0, depth: 0 }}
+                    rowHeight={rowHeight}
                     product={product}
+                    valueFormatter={valueFormatter}
                 />
             ))}
         </div>

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -72,7 +72,9 @@ const BillingGaugeItem = ({
                 `BillingGaugeItem BillingGaugeItem--${item.type}`,
                 {
                     'BillingGaugeItem--within-usage-limit': isWithinUsageLimit,
-                    'BillingGaugeItem--alert-only': product ? isAlertOnlyProduct(product) : false,
+                    'BillingGaugeItem--alert-only': product
+                        ? isAlertOnlyProduct(product) && !!product.subscribed
+                        : false,
                 },
                 'absolute top-0 left-0 bottom-0 h-2'
             )}
@@ -125,7 +127,9 @@ export function BillingGauge({ items, product, valueFormatter }: BillingGaugePro
     // ResizeObserver on unrelated re-renders. The ref keeps the effect reading current items.
     const sortedItemsRef = useRef(sortedItems)
     sortedItemsRef.current = sortedItems
-    const itemsKey = sortedItems.map((item) => item.value).join('|')
+    const itemsKey = sortedItems
+        .map((item) => `${item.value}:${typeof item.text === 'string' ? item.text : item.type}`)
+        .join('|')
 
     // Keep each label on its original side (top/bottom alternating), but when it would overlap a
     // closer label on that side, stack it one row further out. Measured from the DOM so it adapts to

--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -6,13 +6,28 @@ import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { capitalizeFirstLetter } from 'lib/utils/strings'
 
 import { BillingProductV2Type } from '~/types'
 
+import { isAlertOnlyProduct } from './billing-utils'
 import { billingLogic } from './billingLogic'
 import { billingProductLogic } from './billingProductLogic'
 
-export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
+export const BillingLimit = ({
+    product,
+    // alertOnly renders the same control but as an *alert threshold* rather than an enforced
+    // billing limit. Used for Managed data warehouse storage: storage is never hard-capped on
+    // paid plans — crossing the value only triggers an in-app banner + email.
+    alertOnly = false,
+    // Scopes an enforced limit to one part of a multi-part product (e.g. "compute" on the Managed
+    // data warehouse card, where the limit caps compute only — storage is a separate alert-only line).
+    scopeName,
+}: {
+    product: BillingProductV2Type
+    alertOnly?: boolean
+    scopeName?: string
+}): JSX.Element | null => {
     const limitInputRef = useRef<HTMLInputElement | null>(null)
     const { billing, billingLoading } = useValues(billingLogic)
     const { isEditingBillingLimit, customLimitUsd, hasCustomLimitSet, currentAndUpgradePlans, billingLimitNextPeriod } =
@@ -22,6 +37,27 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
 
     const initialBillingLimit = currentAndUpgradePlans?.currentPlan?.initial_billing_limit
     const usingInitialBillingLimit = customLimitUsd === initialBillingLimit
+
+    // Alert-only products (never hard-capped, e.g. MDW storage) — true whether rendered nested
+    // under compute (the grouped MDW card) or as their own top-level card. Detect via the product
+    // itself instead of relying on the caller passing `alertOnly`, so a consumer that renders the
+    // flat `billing.products` list can't surface enforced-limit copy for an alert-only product.
+    const isAlertOnly = alertOnly || isAlertOnlyProduct(product)
+
+    // Copy differs for alert-only (storage) vs enforced (everything else). When `scopeName` is set,
+    // the enforced-limit copy names that scope (e.g. "Compute billing limit", "set for compute") so
+    // it's clear the limit applies only to that part of the product.
+    const productLabel = scopeName ?? product?.name?.toLowerCase()
+    const heading = isAlertOnly
+        ? 'Storage usage alert'
+        : scopeName
+          ? `${capitalizeFirstLetter(scopeName)} billing limit`
+          : 'Billing limit'
+    const noun = isAlertOnly ? 'usage alert' : 'billing limit'
+    const setLabel = isAlertOnly ? 'Set an alert' : 'Set a billing limit'
+    const enforcedTooltip = isAlertOnly
+        ? "We'll email you and show an in-app banner when your storage spend reaches this amount. Storage is never blocked — you keep your data."
+        : 'Set a billing limit to control your recurring costs. Some features may stop working and data may be dropped if your usage exceeds your limit.'
 
     if (billing?.billing_period?.interval !== 'month' || !product.subscribed || product.inclusion_only) {
         return null
@@ -33,7 +69,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                 className="border-t border-primary px-8 py-4"
                 data-attr={`billing-limit-input-wrapper-${product.type}`}
             >
-                <h4>Billing limit</h4>
+                <h4>{heading}</h4>
                 <div className="flex flex-col xl:flex-row w-full items-stretch xl:items-center justify-start xl:justify-between gap-2">
                     <div className="flex items-center gap-1">
                         {!isEditingBillingLimit ? (
@@ -51,13 +87,23 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                                 </span>
                                             </Tooltip>
                                         ) : (
-                                            <Tooltip title="Set a billing limit to control your recurring costs. Some features may stop working and data may be dropped if your usage exceeds your limit.">
+                                            <Tooltip title={enforcedTooltip}>
                                                 <span
                                                     className="text-sm"
                                                     data-attr={`billing-limit-set-${product.type}`}
                                                 >
-                                                    You have a <b>${customLimitUsd?.toLocaleString()}</b> billing limit
-                                                    set for {product?.name?.toLowerCase()}.
+                                                    {isAlertOnly ? (
+                                                        <>
+                                                            We'll alert you when storage spend reaches{' '}
+                                                            <b>${customLimitUsd?.toLocaleString()}</b> — storage is
+                                                            never blocked.
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            You have a <b>${customLimitUsd?.toLocaleString()}</b>{' '}
+                                                            billing limit set for {productLabel}.
+                                                        </>
+                                                    )}
                                                 </span>
                                             </Tooltip>
                                         )}
@@ -67,20 +113,20 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                             status="danger"
                                             size="small"
                                         >
-                                            Edit limit
+                                            {isAlertOnly ? 'Edit alert' : 'Edit limit'}
                                         </LemonButton>
                                     </>
                                 ) : (
                                     <>
                                         <span className="text-sm" data-attr={`billing-limit-not-set-${product.type}`}>
-                                            You do not have a billing limit set for {product?.name?.toLowerCase()}.
+                                            You do not have a {noun} set for {productLabel}.
                                         </span>
                                         <LemonButton
                                             onClick={() => setIsEditingBillingLimit(true)}
                                             status="danger"
                                             size="small"
                                         >
-                                            Set a billing limit
+                                            {setLabel}
                                         </LemonButton>
                                     </>
                                 )}
@@ -131,13 +177,13 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                         status="danger"
                                         size="small"
                                         data-attr={`remove-billing-limit-${product.type}`}
-                                        tooltip="Remove billing limit"
+                                        tooltip={isAlertOnly ? 'Remove alert' : 'Remove billing limit'}
                                         onClick={() => {
                                             setBillingLimitInput(null)
                                             submitBillingLimitInput()
                                         }}
                                     >
-                                        Remove limit
+                                        {isAlertOnly ? 'Remove alert' : 'Remove limit'}
                                     </LemonButton>
                                 ) : null}
                             </div>

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -21,9 +21,11 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { BillingProductV2AddonType, BillingProductV2Type, BillingTierType } from '~/types'
 
 import {
+    HOURS_PER_MONTH,
     createGaugeItems,
     createProductValueFormatter,
     getProductUnitLabel,
+    getSyntheticStorageAddon,
     isProductVariantPrimary,
 } from './billing-utils'
 import { BillingGauge } from './BillingGauge'
@@ -46,6 +48,17 @@ export const getTierDescription = (
 ): string => {
     const formatValue = createProductValueFormatter(product)
     const unitLabel = getProductUnitLabel(product)
+
+    // Storage's free tier is a LEVEL ("up to 100 GB at any moment"), so phrase the free ($0) row in
+    // GB (= GB-hours / 744) to match the public pricing page — paid rows below stay in GB-hours.
+    if (
+        product.type === 'managed_data_warehouse_storage' &&
+        i === 0 &&
+        tiers[i].up_to &&
+        parseFloat(tiers[i].unit_amount_usd || '0') === 0
+    ) {
+        return `Up to ${Math.round((tiers[i].up_to || 0) / HOURS_PER_MONTH).toLocaleString()} GB`
+    }
 
     return i === 0
         ? tiers[i].up_to
@@ -228,11 +241,15 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                     {/* Combined monetary gauge for product variants - only show for subscribed users */}
                     {isProductWithVariants && product.subscribed && (
                         <div className="mt-6 mb-4 ml-2">
-                            <div className="grid grid-cols-[1fr_130px_100px] gap-4 items-center">
+                            <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_130px_100px] md:gap-4 items-center">
                                 <div>
                                     <BillingGauge
                                         items={combinedMonetaryGaugeItems}
-                                        product={{ ...product, unit: '$' }}
+                                        product={product}
+                                        // Gauge values are dollars, not usage units — bypass the
+                                        // product's unit-display config entirely (items carry the '$'
+                                        // prefix).
+                                        valueFormatter={(value) => (value ?? 0).toFixed(2)}
                                     />
                                 </div>
                                 <Tooltip
@@ -256,8 +273,10 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                         billing?.discount_percent ? ', discounts on your account,' : ''
                                     } and the remaining time left in this billing period. This number updates once daily.${
                                         combinedMonetaryData.billingLimit &&
-                                        combinedMonetaryData.projectedTotal >= combinedMonetaryData.billingLimit
-                                            ? ` This value is capped at your current billing limit, we will never charge you more than your billing limit.`
+                                        combinedMonetaryData.cappableProjectedTotal >= combinedMonetaryData.billingLimit
+                                            ? combinedMonetaryData.hasUncappedStorage
+                                                ? ` Compute is capped at your billing limit; storage is billed separately and is never blocked.`
+                                                : ` This value is capped at your current billing limit, we will never charge you more than your billing limit.`
                                             : ''
                                     }`}
                                 >
@@ -576,7 +595,25 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                 {/* Billing limit */}
                 {!isTemporaryFreeProduct && (
                     <div className={isProductWithVariants ? 'mt-8' : ''}>
-                        <BillingLimit product={product} />
+                        {/* Managed data warehouse: the enforced limit caps compute only, so scope the
+                            copy to "compute" to make that explicit. Storage is the alert-only line below. */}
+                        <BillingLimit
+                            product={product}
+                            scopeName={product.type === 'managed_data_warehouse' ? 'compute' : undefined}
+                        />
+                        {/* Managed data warehouse: compute (this product) gets the enforced billing
+                            limit above; storage is a separate billing product nested here for
+                            display, surfaced as an alert-only threshold (never hard-capped). */}
+                        {product.type === 'managed_data_warehouse' &&
+                            (() => {
+                                const storageProduct = getSyntheticStorageAddon(product)
+                                return storageProduct ? (
+                                    <BillingLimit
+                                        product={storageProduct as unknown as BillingProductV2Type}
+                                        alertOnly
+                                    />
+                                ) : null
+                            })()}
                     </div>
                 )}
 

--- a/frontend/src/scenes/billing/BillingProductPricingTable.tsx
+++ b/frontend/src/scenes/billing/BillingProductPricingTable.tsx
@@ -14,6 +14,7 @@ import {
     createProductValueFormatter,
     formatWithDecimals,
     hasDisplayFormatting,
+    HOURS_PER_MONTH,
     isProductVariantPrimary,
 } from './billing-utils'
 import { billingLogic } from './billingLogic'
@@ -45,6 +46,13 @@ export const BillingProductPricingTable = ({
         prod: BillingProductV2Type | BillingProductV2AddonType
     ): string => {
         const price = parseFloat(unitAmountUsd || '0')
+        // Storage bills per GB-hour, but that $ is tiny — show the readable $/GB-month equivalent
+        // (× 744 h/mo), labeled inline since the volume column header is in GB-hours. Padded to a
+        // fixed 4 dp (e.g. $0.0400) to match the public pricing table's formatting. Other
+        // display-divisor products render their converted rate unrounded here.
+        if (prod.type === 'managed_data_warehouse_storage') {
+            return `$${(Math.round(price * HOURS_PER_MONTH * 1e4) / 1e4).toFixed(4)}/GB-month`
+        }
         const adjusted = hasDisplayFormatting(prod) && prod.display_divisor ? price * prod.display_divisor : price
         return `$${formatWithDecimals(adjusted)}`
     }
@@ -250,6 +258,12 @@ export const BillingProductPricingTable = ({
                             rowExpandable: (row) => !!row.subrows?.rows?.length,
                         }}
                     />
+                    {product.type === 'managed_data_warehouse_storage' && (
+                        <LemonBanner type="info" className="text-sm pt-2 mt-2">
+                            Storage is billed per GB-hour. 744 GB-hours ≈ 1 GB held for a full month, so the 100 GB free
+                            tier = 74,400 GB-hours.
+                        </LemonBanner>
+                    )}
                     <LemonBanner type="warning" className="text-sm pt-2 mt-2">
                         Tier breakdowns are updated once daily and may differ from the gauge above.
                     </LemonBanner>

--- a/frontend/src/scenes/billing/billing-utils.test.ts
+++ b/frontend/src/scenes/billing/billing-utils.test.ts
@@ -1,0 +1,106 @@
+import { BillingProductV2Type } from '~/types'
+
+import {
+    HOURS_PER_MONTH,
+    calculateFreeTier,
+    createGaugeItems,
+    getSyntheticStorageAddon,
+    isAlertOnlyProduct,
+} from './billing-utils'
+import { BillingGaugeItemKind } from './types'
+
+const product = (overrides: Partial<BillingProductV2Type> = {}): BillingProductV2Type =>
+    ({
+        type: 'mobile_replay',
+        subscribed: false,
+        tiers: null,
+        free_allocation: null,
+        current_usage: 0,
+        projected_usage: 0,
+        usage_limit: null,
+        percentage_usage: 0,
+        addons: [],
+        ...overrides,
+    }) as unknown as BillingProductV2Type
+
+const markerOf = (items: ReturnType<typeof createGaugeItems>): { text: string | JSX.Element; value: number } | null =>
+    items.find((i) => i.type === BillingGaugeItemKind.BillingLimit) ?? null
+
+describe('isAlertOnlyProduct', () => {
+    it('prefers the billing API flag over the type fallback', () => {
+        expect(isAlertOnlyProduct({ type: 'some_future_product', alert_only: true })).toBe(true)
+        // API can explicitly override the hardcoded fallback list
+        expect(isAlertOnlyProduct({ type: 'managed_data_warehouse_storage', alert_only: false })).toBe(false)
+    })
+
+    it('falls back to the type list when the API does not send the flag', () => {
+        expect(isAlertOnlyProduct({ type: 'managed_data_warehouse_storage' })).toBe(true)
+        expect(isAlertOnlyProduct({ type: 'mobile_replay' })).toBe(false)
+    })
+})
+
+describe('createGaugeItems billing-limit marker', () => {
+    it('does NOT leak a marker onto non-alert-only secondary variants from their usage_limit', () => {
+        // Unsubscribed addons carry usage_limit = free_allocation — a marker defaulted from
+        // usage_limit would show a spurious "Billing limit" on mobile replay et al.
+        const items = createGaugeItems(product({ type: 'mobile_replay', usage_limit: 2500 }))
+        expect(markerOf(items)).toBeNull()
+    })
+
+    it('shows a "Spend alert" marker for SUBSCRIBED alert-only products from their usage_limit', () => {
+        const items = createGaugeItems(
+            product({ type: 'managed_data_warehouse_storage', alert_only: true, subscribed: true, usage_limit: 130200 })
+        )
+        expect(markerOf(items)).toMatchObject({ text: 'Spend alert', value: 130200 })
+    })
+
+    it('does NOT show the alert marker for UNSUBSCRIBED alert-only products (usage_limit is the free allocation)', () => {
+        const items = createGaugeItems(
+            product({ type: 'managed_data_warehouse_storage', alert_only: true, subscribed: false, usage_limit: 74400 })
+        )
+        expect(markerOf(items)).toBeNull()
+    })
+
+    it('still shows an explicit "Billing limit" marker when the caller passes one', () => {
+        const items = createGaugeItems(product({ type: 'mobile_replay' }), { billingLimitAsUsage: 5000 })
+        expect(markerOf(items)).toMatchObject({ text: 'Billing limit', value: 5000 })
+    })
+
+    it('suppresses the marker for 100%-discount orgs when billing is provided', () => {
+        const items = createGaugeItems(product({ type: 'mobile_replay' }), {
+            billingLimitAsUsage: 5000,
+            billing: { discount_percent: 100 } as any,
+        })
+        expect(markerOf(items)).toBeNull()
+    })
+
+    it('labels the storage free tier as a GB level (GB-hours / HOURS_PER_MONTH)', () => {
+        const items = createGaugeItems(
+            product({
+                type: 'managed_data_warehouse_storage',
+                subscribed: true,
+                tiers: [{ unit_amount_usd: '0', up_to: 100 * HOURS_PER_MONTH } as any],
+            })
+        )
+        const freeTier = items.find((i) => i.type === BillingGaugeItemKind.FreeTier)
+        expect(freeTier).toMatchObject({ text: 'Free tier limit (100 GB)', value: 74400 })
+    })
+})
+
+describe('calculateFreeTier', () => {
+    it('uses the free tier boundary when subscribed, free_allocation otherwise', () => {
+        expect(
+            calculateFreeTier(product({ subscribed: true, tiers: [{ unit_amount_usd: '0', up_to: 74400 } as any] }))
+        ).toBe(74400)
+        expect(calculateFreeTier(product({ subscribed: false, free_allocation: 1000 }))).toBe(1000)
+    })
+})
+
+describe('getSyntheticStorageAddon', () => {
+    it('finds the display-nested storage product and nothing else', () => {
+        const storage = { type: 'managed_data_warehouse_storage' }
+        const withStorage = product({ addons: [{ type: 'mobile_replay' }, storage] as any })
+        expect(getSyntheticStorageAddon(withStorage)).toBe(storage)
+        expect(getSyntheticStorageAddon(product({ addons: [{ type: 'mobile_replay' }] as any }))).toBeUndefined()
+    })
+})

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -18,10 +18,40 @@ import type { BillingFilters, BillingSeriesForCsv, BillingUsageInteractionProps,
 import { BillingGaugeItemKind, BillingGaugeItemType } from './types'
 
 export const isProductVariantPrimary = (productType: string): boolean =>
-    ['session_replay', 'realtime_destinations', 'data_warehouse', 'workflows_emails'].includes(productType)
+    [
+        'session_replay',
+        'realtime_destinations',
+        'data_warehouse',
+        'workflows_emails',
+        'managed_data_warehouse',
+    ].includes(productType)
 
 export const isProductVariantSecondary = (productType: string): boolean =>
-    ['mobile_replay', 'batch_exports', 'data_warehouse_historical', 'workflows_destinations'].includes(productType)
+    [
+        'mobile_replay',
+        'batch_exports',
+        'data_warehouse_historical',
+        'workflows_destinations',
+        'managed_data_warehouse_storage',
+    ].includes(productType)
+
+// Hours in the longest (31-day) month — converts MDW storage's billed GB-hours to the "N GB held
+// all month" framing used in labels (100 GB free tier = 74,400 GB-hours).
+export const HOURS_PER_MONTH = 744
+
+// MDW storage is a top-level billing product nested under compute's addons for DISPLAY only (see
+// billingLogic.groupedProducts). Unlike real addons its spend is NOT folded into the parent's
+// amounts — use this helper so consumers can't miss that special-casing.
+export const getSyntheticStorageAddon = (product: BillingProductV2Type): BillingProductV2AddonType | undefined =>
+    product.addons?.find((addon) => addon.type === 'managed_data_warehouse_storage')
+
+// Products whose billing limit is an ALERT threshold only — usage is never hard-capped (e.g. MDW
+// storage, which is billed on what you keep). Their gauge shows the limit as a "Spend alert" marker
+// and turns warning-yellow rather than danger-red when exceeded, since nothing is actually blocked.
+// Prefers the billing API's `alert_only` flag (product config); the type list is a fallback for
+// responses that predate the flag.
+export const isAlertOnlyProduct = (product: { type: string; alert_only?: boolean | null }): boolean =>
+    product.alert_only ?? ['managed_data_warehouse_storage'].includes(product.type)
 
 export const calculateFreeTier = (product: BillingProductV2Type | BillingProductV2AddonType): number => {
     // If subscribed and has tiers, check if the first tier is free
@@ -43,24 +73,36 @@ export const createGaugeItems = (
     } = {}
 ): BillingGaugeItemType[] => {
     const freeTier = calculateFreeTier(product)
+    // Alert-only products (e.g. MDW storage) are rendered as secondary variants via
+    // createGaugeItems() without options, so default their marker from the product's own
+    // usage_limit. SUBSCRIBED only: for unsubscribed products usage_limit is the free allocation,
+    // which would duplicate the free-tier marker under a wrong "Spend alert" label. Everything
+    // else keeps the old behavior (marker only when the caller passes billingLimitAsUsage) —
+    // otherwise every secondary variant with a populated usage_limit (mobile_replay et al.)
+    // would sprout a spurious 'Billing limit' marker.
+    const billingLimitAsUsage =
+        options.billingLimitAsUsage ??
+        (isAlertOnlyProduct(product) && product.subscribed ? product.usage_limit || 0 : 0)
 
     return [
-        // Billing limit (only for main products, excl. product variants setup)
-        options.billingLimitAsUsage &&
-        options.billing?.discount_percent !== 100 &&
-        !isProductVariantPrimary(product.type)
+        // Billing limit / spend alert (only for main products, excl. product variants setup)
+        billingLimitAsUsage && options.billing?.discount_percent !== 100 && !isProductVariantPrimary(product.type)
             ? {
                   type: BillingGaugeItemKind.BillingLimit,
-                  text: 'Billing limit',
-                  value: options.billingLimitAsUsage || 0,
+                  text: isAlertOnlyProduct(product) ? 'Spend alert' : 'Billing limit',
+                  value: billingLimitAsUsage,
               }
             : undefined,
 
-        // Free tier
+        // Free tier. Storage's free tier is a LEVEL, so surface the "100 GB" framing in the label
+        // (the value stays in GB-hours — the gauge's current/projected markers share that axis).
         freeTier
             ? {
                   type: BillingGaugeItemKind.FreeTier,
-                  text: 'Free tier limit',
+                  text:
+                      product.type === 'managed_data_warehouse_storage'
+                          ? `Free tier limit (${Math.round(freeTier / HOURS_PER_MONTH).toLocaleString()} GB)`
+                          : 'Free tier limit',
                   value: freeTier,
               }
             : undefined,

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -35,6 +35,7 @@ import {
     buildUsageLimitExceededMessage,
     canAccessBilling as canAccessBillingUtil,
     getMinimumBillingAccessLevel,
+    isAlertOnlyProduct,
 } from './billing-utils'
 import type { billingLogicType } from './billingLogicType'
 import { DEFAULT_ESTIMATED_MONTHLY_CREDIT_AMOUNT_USD } from './CreditCTAHero'
@@ -198,6 +199,8 @@ export const billingLogic = kea<billingLogicType>([
             ['resetDismissKey as resetUsageLimitExceededKey'],
             lemonBannerLogic({ dismissKey: 'usage-limit-approaching' }),
             ['resetDismissKey as resetUsageLimitApproachingKey'],
+            lemonBannerLogic({ dismissKey: 'usage-limit-storage-alert' }),
+            ['resetDismissKey as resetStorageAlertKey'],
         ],
     })),
     reducers({
@@ -517,6 +520,31 @@ export const billingLogic = kea<billingLogicType>([
         ],
     })),
     selectors({
+        // Products with Managed Data Warehouse presented as ONE card: storage nested under
+        // compute's addons, its standalone entry dropped. Presentation-only — `billing.products`
+        // stays truthful (both top-level) so other consumers (e.g. the usage-limit banner) can
+        // treat storage as its own product. Card consumers should read this selector.
+        groupedProducts: [
+            (s) => [s.billing],
+            (billing: BillingType | null): BillingProductV2Type[] => {
+                const products = billing?.products
+                if (!products) {
+                    return []
+                }
+                const compute = products.find((p) => p.type === 'managed_data_warehouse')
+                const storage = products.find((p) => p.type === 'managed_data_warehouse_storage')
+                if (!compute || !storage) {
+                    return products
+                }
+                const groupedCompute: BillingProductV2Type = {
+                    ...compute,
+                    addons: [...(compute.addons || []), storage as unknown as BillingProductV2AddonType],
+                }
+                return products
+                    .filter((p) => p.type !== 'managed_data_warehouse_storage')
+                    .map((p) => (p.type === 'managed_data_warehouse' ? groupedCompute : p))
+            },
+        ],
         minimumBillingAccessLevel: [
             (s) => [s.featureFlags],
             (featureFlags): OrganizationMembershipLevel =>
@@ -879,6 +907,12 @@ export const billingLogic = kea<billingLogicType>([
                     if (x.percentage_usage <= 1 || !x.usage_key) {
                         return false
                     }
+                    // Paid alert-only products are never hard-capped — they get their own alert
+                    // banner below. Free-tier storage is enforced (level-based via the quota signal,
+                    // folded into percentage_usage), so it falls through like any free-tier product.
+                    if (isAlertOnlyProduct(x) && x.subscribed) {
+                        return false
+                    }
                     const hideProductFlag = `billing_hide_product_${x.type}`
                     if (values.featureFlags[hideProductFlag as FeatureFlagKey] === true) {
                         return false
@@ -923,6 +957,10 @@ export const billingLogic = kea<billingLogicType>([
                     if (x.percentage_usage <= ALLOCATION_THRESHOLD_ALERT || x.percentage_usage > 1) {
                         return false
                     }
+                    // Same rule as the exceeded filter above: alert-only handled separately.
+                    if (isAlertOnlyProduct(x) && x.subscribed) {
+                        return false
+                    }
                     const hideProductFlag = `billing_hide_product_${x.type}`
                     if (values.featureFlags[hideProductFlag as FeatureFlagKey] === true) {
                         return false
@@ -965,7 +1003,55 @@ export const billingLogic = kea<billingLogicType>([
                 return
             }
 
+            // MDW storage is alert-only (never hard-capped) for paid customers. Surface a dedicated,
+            // lower-priority alert banner — only when no real limit banner above has claimed the slot
+            // — with wording that makes clear nothing is blocked. Gated to subscribed storage: a free
+            // customer's percentage_usage is cumulative-GB-hours / free_allocation (so it can exceed 1
+            // when they pass the free tier), and showing them "storage is never blocked" would be the
+            // wrong message — their free-tier overage is handled by the quota signal, not this alert.
+            const storageAlert = values.billing.products?.find((x: BillingProductV2Type) => {
+                if (!isAlertOnlyProduct(x) || !x.subscribed || !x.usage_key || x.percentage_usage <= 1) {
+                    return false
+                }
+                return !isBillingAlertDismissed(
+                    values.currentOrganizationId,
+                    x.type,
+                    billingPeriodEnd,
+                    '-storage-alert'
+                )
+            })
+
+            if (storageAlert) {
+                // Limits can be keyed by product type OR usage_key (mirrors billingProductLogic.customLimitUsd).
+                const limitUsd =
+                    values.billing.custom_limits_usd?.[storageAlert.type] ??
+                    (storageAlert.usage_key ? values.billing.custom_limits_usd?.[storageAlert.usage_key] : undefined)
+                actions.setBillingAlert({
+                    // `warning` (amber), not `info` (neutral surface color) — a crossed spend threshold
+                    // should stand out. It's not an `error`: storage is never blocked (message says so).
+                    status: 'warning',
+                    title: 'Storage usage alert',
+                    message: `You've passed your storage usage alert${
+                        limitUsd ? ` of $${limitUsd}` : ''
+                    }. Storage is never blocked — you keep your data.`,
+                    // Own dismissKey so dismissing this never suppresses the real approaching-limit banner.
+                    dismissKey: 'usage-limit-storage-alert',
+                    onClose: () => {
+                        const periodEnd = values.billing?.billing_period?.current_period_end?.format('YYYY-MM-DD')
+                        storeBillingAlertDismissal(
+                            values.currentOrganizationId,
+                            storageAlert.type,
+                            periodEnd,
+                            '-storage-alert'
+                        )
+                        actions.setBillingAlert(null)
+                    },
+                })
+                return
+            }
+
             actions.resetUsageLimitApproachingKey()
+            actions.resetStorageAlertKey()
         },
         setCreditFormValue: ({ name, value }) => {
             if (name === 'creditInput' || (name as FieldNamePath)?.[0] === 'creditInput') {

--- a/frontend/src/scenes/billing/billingProductLogic.test.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.test.ts
@@ -1,0 +1,75 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { billingLogic } from 'scenes/billing/billingLogic'
+import { billingProductLogic } from 'scenes/billing/billingProductLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { BillingProductV2Type } from '~/types'
+
+const product = (overrides: Partial<BillingProductV2Type>): BillingProductV2Type =>
+    ({
+        type: 'product_analytics',
+        subscribed: true,
+        addons: [],
+        plans: [],
+        tiers: null,
+        current_usage: 0,
+        usage_limit: null,
+        percentage_usage: 0,
+        ...overrides,
+    }) as unknown as BillingProductV2Type
+
+describe('billingProductLogic billing limit submit', () => {
+    let dialogSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        initKeaTests()
+        useMocks({ get: { '/api/billing': () => [200, {}] }, patch: { '/api/billing': () => [200, {}] } })
+        billingLogic.mount()
+        dialogSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        dialogSpy.mockRestore()
+    })
+
+    it('alert-only products skip the enforced-limit warning dialogs entirely', async () => {
+        // An alert below current/projected spend is the NORMAL way to use an alert — the
+        // "data will be dropped" / "limit will be set to current usage" dialogs describe
+        // enforcement that never happens for alert-only products.
+        const storage = product({
+            type: 'managed_data_warehouse_storage',
+            alert_only: true,
+            current_amount_usd: '3.74',
+            projected_amount_usd: '27.00',
+        })
+        const logic = billingProductLogic({ product: storage })
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.setBillingLimitInput(2)
+            logic.actions.submitBillingLimitInput()
+        }).toDispatchActions(['updateBillingLimits'])
+
+        expect(dialogSpy).not.toHaveBeenCalled()
+    })
+
+    it('enforced products still get the warning dialog when the limit is below current spend', async () => {
+        const analytics = product({
+            type: 'product_analytics',
+            current_amount_usd: '700.00',
+            projected_amount_usd: '900.00',
+        })
+        const logic = billingProductLogic({ product: analytics })
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.setBillingLimitInput(100)
+            logic.actions.submitBillingLimitInput()
+        }).toFinishAllListeners()
+
+        expect(dialogSpy).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -22,6 +22,7 @@ import {
 } from '~/types'
 
 import {
+    isAlertOnlyProduct,
     calculateFreeTier,
     createGaugeItems,
     getSyntheticStorageAddon,
@@ -571,8 +572,6 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     cappableProjectedTotal: mainProjected * discountMultiplier,
                     hasUncappedStorage: !!storageAddon && storageProjected > 0,
                     discountPercent,
-                    rawCurrentTotal: rawCurrentTotal.toString(),
-                    rawProjectedTotal: rawProjectedTotal.toString(),
                 }
             },
         ],
@@ -840,7 +839,11 @@ export const billingProductLogic = kea<billingProductLogicType>([
                         : 'Please enter a whole number',
             }),
             submit: async ({ input }) => {
-                if (props.product.current_amount_usd && input < props.product.current_amount_usd) {
+                // Alert-only products (e.g. MDW storage) are never enforced: setting an alert below
+                // current or projected spend is the normal use, and the enforced-limit warnings
+                // below ("data being dropped", "limit set to current usage") would be false.
+                const enforced = !isAlertOnlyProduct(props.product)
+                if (enforced && props.product.current_amount_usd && input < props.product.current_amount_usd) {
                     LemonDialog.open({
                         maxWidth: '600px',
                         title: 'Billing limit warning',
@@ -861,7 +864,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     return
                 }
 
-                if (props.product.projected_amount_usd && input < props.product.projected_amount_usd) {
+                if (enforced && props.product.projected_amount_usd && input < props.product.projected_amount_usd) {
                     LemonDialog.open({
                         maxWidth: '600px',
                         title: 'Billing limit warning',

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -21,7 +21,13 @@ import {
     SurveyEventName,
 } from '~/types'
 
-import { calculateFreeTier, createGaugeItems, isAddonVisible, isProductVariantPrimary } from './billing-utils'
+import {
+    calculateFreeTier,
+    createGaugeItems,
+    getSyntheticStorageAddon,
+    isAddonVisible,
+    isProductVariantPrimary,
+} from './billing-utils'
 import { billingLogic } from './billingLogic'
 import type { billingProductLogicType } from './billingProductLogicType'
 import { DATA_PIPELINES_CUTOFF_DATE } from './constants'
@@ -456,12 +462,27 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 }
 
                 const mainProduct = product as BillingProductV2Type
+
+                // MDW compute is hard-capped by its billing limit, and its only "addon" — storage — is a
+                // synthetic top-level product nested under compute for display (see `groupedProducts`),
+                // not folded into compute's `projected_amount_usd`. So the compute row must show the
+                // CAPPED projection to match the combined gauge (which uses `projected_amount_usd_with_limit`)
+                // and the amount actually billed. Storage (alert-only, uncapped) is its own variant row.
+                const hasSyntheticStorageAddon = !!getSyntheticStorageAddon(mainProduct)
+                if (hasSyntheticStorageAddon) {
+                    return parseFloat(
+                        mainProduct.projected_amount_usd_with_limit || mainProduct.projected_amount_usd || '0'
+                    ).toFixed(2)
+                }
+
                 const totalProjected = parseFloat(mainProduct.projected_amount_usd || '0')
 
                 if (!mainProduct.addons?.length) {
                     return totalProjected.toFixed(2)
                 }
 
+                // Real addons (e.g. mobile replay) ARE folded into the primary's `projected_amount_usd`,
+                // so subtract them to get the primary's own projected spend.
                 const addonProjected = mainProduct.addons.reduce(
                     (sum: number, addon: BillingProductV2AddonType) =>
                         sum + parseFloat(addon.projected_amount_usd || '0'),
@@ -489,6 +510,8 @@ export const billingProductLogic = kea<billingProductLogicType>([
                     session_replay: 'Web session replay',
                     data_warehouse: 'Synced rows',
                     data_warehouse_historical: 'Free historical synced rows',
+                    managed_data_warehouse: 'Compute',
+                    managed_data_warehouse_storage: 'Storage',
                 }
 
                 const mainProduct = product as BillingProductV2Type
@@ -522,13 +545,34 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 const discountPercent = billing?.discount_percent || 0
                 const discountMultiplier = 1 - discountPercent / 100
 
+                // Storage is a synthetic addon (a separate top-level product nested under compute for
+                // display — see `groupedProducts`), so its spend is NOT folded into compute's
+                // `*_amount_usd`. Add it back here so the card headline reflects compute + storage and
+                // reconciles with the per-variant breakdown below it. Real addons are already included.
+                const storageAddon = getSyntheticStorageAddon(mainProduct) as BillingProductV2Type | undefined
+                const storageCurrent = parseFloat(storageAddon?.current_amount_usd || '0')
+                // Storage is alert-only: its limit is an alert threshold, never a cap. Use the UNCAPPED
+                // projection — `projected_amount_usd_with_limit` clamps to the alert value (e.g. $3), which
+                // would push the projected total below current spend and not reconcile with the storage row
+                // below (which already shows the uncapped `projected_amount_usd`).
+                const storageProjected = parseFloat(storageAddon?.projected_amount_usd || '0')
+
+                const mainProjected = parseFloat(mainProduct.projected_amount_usd_with_limit || '0')
+                const rawCurrentTotal = parseFloat(mainProduct.current_amount_usd || '0') + storageCurrent
+                const rawProjectedTotal = mainProjected + storageProjected
+
                 return {
-                    currentTotal: parseFloat(mainProduct.current_amount_usd || '0') * discountMultiplier,
-                    projectedTotal: parseFloat(mainProduct.projected_amount_usd_with_limit || '0') * discountMultiplier,
+                    currentTotal: rawCurrentTotal * discountMultiplier,
+                    projectedTotal: rawProjectedTotal * discountMultiplier,
                     billingLimit: limit,
+                    // The billing limit caps only the main product (compute); storage is alert-only and
+                    // billed on top. Expose the cappable portion + a flag so the gauge/tooltip don't
+                    // claim the combined total is capped when storage is what pushes it over the limit.
+                    cappableProjectedTotal: mainProjected * discountMultiplier,
+                    hasUncappedStorage: !!storageAddon && storageProjected > 0,
                     discountPercent,
-                    rawCurrentTotal: mainProduct.current_amount_usd || '0',
-                    rawProjectedTotal: mainProduct.projected_amount_usd_with_limit || '0',
+                    rawCurrentTotal: rawCurrentTotal.toString(),
+                    rawProjectedTotal: rawProjectedTotal.toString(),
                 }
             },
         ],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2219,6 +2219,8 @@ export interface BillingProductV2Type {
     current_amount_usd_before_addons: string | null
     current_amount_usd: string | null
     usage_limit: number | null
+    // The billing limit is an ALERT threshold only (never caps usage/billing) — e.g. MDW storage.
+    alert_only?: boolean
     has_exceeded_limit: boolean
     unit: string | null
     // Display formatting fields - for human-friendly display of usage values
@@ -2275,6 +2277,8 @@ export interface BillingProductV2AddonType {
         | 'has_parent_subscription'
         | null
     usage_limit?: number | null
+    // The billing limit is an ALERT threshold only (never caps usage/billing) — e.g. MDW storage.
+    alert_only?: boolean
     trial?: BillingTrialType | null
     legacy_product?: boolean | null
 }

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -1,7 +1,7 @@
 import sys
 from datetime import datetime, timedelta
 from functools import cache as functools_cache
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, Union
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
@@ -58,6 +58,10 @@ class OrganizationUsageInfo(TypedDict):
     workflow_emails: OrganizationUsageResource | None
     workflow_destinations_dispatched: OrganizationUsageResource | None
     logs_mb_ingested: OrganizationUsageResource | None
+    # NotRequired: billing only sends storage usage for MDW orgs, so it's added to organization.usage
+    # only for them — non-MDW orgs never gain an empty storage key (which would spuriously flip
+    # set_org_usage_summary's has_changed on the first sync and trigger a needless quota re-eval).
+    managed_warehouse_storage_gb_hours: NotRequired[OrganizationUsageResource | None]
     period: list[str] | None
 
 


### PR DESCRIPTION
In-app billing UI + quota wiring for the managed data warehouse family: grouped compute+storage card with a combined dollar gauge, 'Spend alert' marker and amber over-alert state for alert-only products (storage is never blocked), storage usage-alert banner, and MDW usage-key quota wiring. Includes a proxy fix keeping billing's percentage_usage for alert-only products.

**Merge after** PostHog/billing#2019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hSheSykRTkTsD9rz1pvfv