### PR TITLE
[prototype] indeterminate state variants for LemonSwitch

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -46,7 +46,8 @@ const VARIANTS: {
     {
         key: 'C',
         name: 'Half fill',
-        description: 'Handle stretches over the left half on a gray-to-accent gradient track. Literally half on.',
+        description:
+            'Handle stretches over the left half on a track split by a 30° sloped divider, gray left and orange/red right.',
         Component: VariantCHalfFill,
     },
     {
@@ -66,7 +67,7 @@ const VARIANTS: {
         key: 'G',
         name: 'Centered half-width handle with dash',
         description:
-            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph on a gray-to-accent gradient track.',
+            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph on the sloped gray/orange split track.',
         Component: VariantGCenteredHandleDash,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -1,0 +1,92 @@
+/**
+ * PROTOTYPE — throwaway stories for LemonSwitchIndeterminate.prototype.tsx.
+ * Run with `pnpm storybook`, open "Lemon UI/Lemon Switch/Indeterminate Prototype".
+ * Delete together with the prototype file once a variant wins.
+ */
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import {
+    PrototypeSwitchProps,
+    PrototypeToggleValue,
+    VariantACenteredHandle,
+    VariantBDashInHandle,
+    VariantCHalfFill,
+} from './LemonSwitchIndeterminate.prototype'
+
+const meta: Meta = {
+    title: 'Lemon UI/Lemon Switch/Indeterminate Prototype',
+    tags: ['test-skip'],
+}
+export default meta
+
+const VARIANTS: {
+    key: string
+    name: string
+    description: string
+    Component: (props: PrototypeSwitchProps) => JSX.Element
+}[] = [
+    {
+        key: 'A',
+        name: 'Centered handle',
+        description: 'Handle parks mid-track on a neutral track. Position alone signals "mixed".',
+        Component: VariantACenteredHandle,
+    },
+    {
+        key: 'B',
+        name: 'Dash in handle',
+        description:
+            'Track filled like "checked", handle carries a minus glyph — borrowed from indeterminate checkboxes.',
+        Component: VariantBDashInHandle,
+    },
+    {
+        key: 'C',
+        name: 'Half fill',
+        description: 'Handle stretches over the left half, right half shows accent. Literally half on.',
+        Component: VariantCHalfFill,
+    },
+]
+
+function VariantRow({ variant }: { variant: (typeof VARIANTS)[number] }): JSX.Element {
+    const [value, setValue] = useState<PrototypeToggleValue>('indeterminate')
+    const { Component } = variant
+    return (
+        <div className="flex flex-col gap-2 p-4 border rounded bg-surface-primary">
+            <div className="flex items-center justify-between">
+                <div>
+                    <div className="font-semibold">
+                        {variant.key} — {variant.name}
+                    </div>
+                    <div className="text-secondary text-xs">{variant.description}</div>
+                </div>
+                <LemonButton size="xsmall" type="secondary" onClick={() => setValue('indeterminate')}>
+                    Reset to indeterminate
+                </LemonButton>
+            </div>
+            <div className="flex items-center gap-8">
+                <Component label="Interactive (click me)" value={value} onChange={setValue} />
+            </div>
+            <div className="flex items-center gap-8 text-xs text-secondary">
+                <Component label="Unchecked" value={false} onChange={() => {}} />
+                <Component label="Indeterminate" value="indeterminate" onChange={() => {}} />
+                <Component label="Checked" value={true} onChange={() => {}} />
+            </div>
+        </div>
+    )
+}
+
+export const AllVariants: StoryObj = {
+    render: () => (
+        <div className="flex flex-col gap-4 max-w-160">
+            <p className="text-sm text-secondary m-0">
+                Prototype: three treatments for an indeterminate LemonSwitch state. Clicking an indeterminate switch
+                resolves it to checked; after that it toggles normally.
+            </p>
+            {VARIANTS.map((variant) => (
+                <VariantRow key={variant.key} variant={variant} />
+            ))}
+        </div>
+    ),
+}

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -17,6 +17,7 @@ import {
     VariantDFullWidthHandleDash,
     VariantENoHandleDash,
     VariantFNoHandleDashFillGray,
+    VariantGCenteredHandleDash,
 } from './LemonSwitchIndeterminate.prototype'
 
 const meta: Meta = {
@@ -67,6 +68,12 @@ const VARIANTS: {
         name: 'Dash on track, no handle (fill gray)',
         description: 'Like E, but the track keeps the regular unchecked switch fill gray instead of the border gray.',
         Component: VariantFNoHandleDashFillGray,
+    },
+    {
+        key: 'G',
+        name: 'Centered handle with dash',
+        description: 'A + B combined: handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
+        Component: VariantGCenteredHandleDash,
     },
 ]
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -46,7 +46,7 @@ const VARIANTS: {
     {
         key: 'C',
         name: 'Half fill',
-        description: 'Handle stretches over the left half, right half shows accent. Literally half on.',
+        description: 'Handle stretches over the left half on a gray-to-accent gradient track. Literally half on.',
         Component: VariantCHalfFill,
     },
     {
@@ -60,7 +60,7 @@ const VARIANTS: {
         key: 'G',
         name: 'Centered half-width handle with dash',
         description:
-            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph, gray left half and accent right half showing on the track.',
+            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph on a gray-to-accent gradient track.',
         Component: VariantGCenteredHandleDash,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -56,7 +56,7 @@ const VARIANTS: {
         key: 'G',
         name: 'Centered half-width handle with dash',
         description:
-            'A + B + C combined: half-width handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
+            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph, gray left half and accent right half showing on the track.',
         Component: VariantGCenteredHandleDash,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -59,7 +59,7 @@ const VARIANTS: {
     {
         key: 'I',
         name: 'Centered handle with dash (neutral track)',
-        description: 'Like A — centered handle on a neutral track — but the handle carries the minus glyph.',
+        description: 'Like A — centered handle on a neutral track — but the handle carries a gray minus glyph.',
         Component: VariantICenteredHandleDashNeutral,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -6,6 +6,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
+import { IconGear } from '@posthog/icons'
+
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
 import {
@@ -118,11 +120,51 @@ export const AllVariants: StoryObj = {
     render: () => (
         <div className="flex flex-col gap-4 max-w-160">
             <p className="text-sm text-secondary m-0">
-                Prototype: three treatments for an indeterminate LemonSwitch state. Clicking an indeterminate switch
-                resolves it to checked; after that it toggles normally.
+                Prototype: treatments for an indeterminate LemonSwitch state. Clicking an indeterminate switch resolves
+                it to checked; after that it toggles normally.
             </p>
             {VARIANTS.map((variant) => (
                 <VariantRow key={variant.key} variant={variant} />
+            ))}
+        </div>
+    ),
+}
+
+// Mirrors TestAccountFilterSwitch (lib/components/TestAccountFiltersSwitch.tsx): a bordered,
+// full-width switch with the "Filter out internal and test users" label and gear button.
+function TestAccountFilterContextRow({ variant }: { variant: (typeof VARIANTS)[number] }): JSX.Element {
+    const [value, setValue] = useState<PrototypeToggleValue>('indeterminate')
+    const { Component } = variant
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="text-xs text-secondary">
+                {variant.key} — {variant.name}
+            </div>
+            <Component
+                value={value}
+                onChange={setValue}
+                bordered
+                fullWidth
+                label={
+                    <div className="flex items-center">
+                        <span>Filter out internal and test users</span>
+                        <LemonButton icon={<IconGear />} size="small" noPadding className="ml-1" />
+                    </div>
+                }
+            />
+        </div>
+    )
+}
+
+export const InTestAccountFilterContext: StoryObj = {
+    render: () => (
+        <div className="flex flex-col gap-3 w-120">
+            <p className="text-sm text-secondary m-0">
+                Each variant rendered the way the test account filter shows a switch (bordered, full width, label +
+                gear). Click to resolve indeterminate to checked.
+            </p>
+            {VARIANTS.map((variant) => (
+                <TestAccountFilterContextRow key={variant.key} variant={variant} />
             ))}
         </div>
     ),

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -58,7 +58,7 @@ const VARIANTS: {
     {
         key: 'E',
         name: 'Dash on track, no handle',
-        description: 'No handle at all — the filled track shows a centered dash. Most minimal treatment.',
+        description: 'No handle at all — a gray (border-colored) track shows a centered dash. Most minimal treatment.',
         Component: VariantENoHandleDash,
     },
 ]

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -14,6 +14,8 @@ import {
     VariantACenteredHandle,
     VariantBDashInHandle,
     VariantCHalfFill,
+    VariantDFullWidthHandleDash,
+    VariantENoHandleDash,
 } from './LemonSwitchIndeterminate.prototype'
 
 const meta: Meta = {
@@ -46,6 +48,18 @@ const VARIANTS: {
         name: 'Half fill',
         description: 'Handle stretches over the left half, right half shows accent. Literally half on.',
         Component: VariantCHalfFill,
+    },
+    {
+        key: 'D',
+        name: 'Full-width handle with dash',
+        description: 'Handle stretches across the entire track and carries the minus glyph. No position to misread.',
+        Component: VariantDFullWidthHandleDash,
+    },
+    {
+        key: 'E',
+        name: 'Dash on track, no handle',
+        description: 'No handle at all — the filled track shows a centered dash. Most minimal treatment.',
+        Component: VariantENoHandleDash,
     },
 ]
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -16,6 +16,7 @@ import {
     VariantCHalfFill,
     VariantDFullWidthHandleDash,
     VariantENoHandleDash,
+    VariantFNoHandleDashFillGray,
 } from './LemonSwitchIndeterminate.prototype'
 
 const meta: Meta = {
@@ -60,6 +61,12 @@ const VARIANTS: {
         name: 'Dash on track, no handle',
         description: 'No handle at all — a gray (border-colored) track shows a centered dash. Most minimal treatment.',
         Component: VariantENoHandleDash,
+    },
+    {
+        key: 'F',
+        name: 'Dash on track, no handle (fill gray)',
+        description: 'Like E, but the track keeps the regular unchecked switch fill gray instead of the border gray.',
+        Component: VariantFNoHandleDashFillGray,
     },
 ]
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { IconGear } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Link } from 'lib/lemon-ui/Link'
 
 import {
     PrototypeSwitchProps,
@@ -100,9 +101,11 @@ function VariantRow({ variant }: { variant: (typeof VARIANTS)[number] }): JSX.El
                     </div>
                     <div className="text-secondary text-xs">{variant.description}</div>
                 </div>
-                <LemonButton size="xsmall" type="secondary" onClick={() => setValue('indeterminate')}>
-                    Reset to indeterminate
-                </LemonButton>
+                {value !== 'indeterminate' && (
+                    <Link className="text-xs" onClick={() => setValue('indeterminate')}>
+                        Reset to indeterminate
+                    </Link>
+                )}
             </div>
             <div className="flex items-center gap-8">
                 <Component label="Interactive (click me)" value={value} onChange={setValue} />
@@ -137,8 +140,15 @@ function TestAccountFilterContextRow({ variant }: { variant: (typeof VARIANTS)[n
     const { Component } = variant
     return (
         <div className="flex flex-col gap-1">
-            <div className="text-xs text-secondary">
-                {variant.key} — {variant.name}
+            <div className="flex items-center justify-between text-xs text-secondary">
+                <span>
+                    {variant.key} — {variant.name}
+                </span>
+                {value !== 'indeterminate' && (
+                    <Link className="text-xs" onClick={() => setValue('indeterminate')}>
+                        Reset to indeterminate
+                    </Link>
+                )}
             </div>
             <Component
                 value={value}

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta = {
 }
 export default meta
 
+// Ordered by mechanism: handle-only treatments, then dash-in-handle, then dash-without-handle.
 const VARIANTS: {
     key: string
     name: string
@@ -39,6 +40,12 @@ const VARIANTS: {
         Component: VariantACenteredHandle,
     },
     {
+        key: 'C',
+        name: 'Half fill',
+        description: 'Handle stretches over the left half, right half shows accent. Literally half on.',
+        Component: VariantCHalfFill,
+    },
+    {
         key: 'B',
         name: 'Dash in handle',
         description:
@@ -46,10 +53,10 @@ const VARIANTS: {
         Component: VariantBDashInHandle,
     },
     {
-        key: 'C',
-        name: 'Half fill',
-        description: 'Handle stretches over the left half, right half shows accent. Literally half on.',
-        Component: VariantCHalfFill,
+        key: 'G',
+        name: 'Centered handle with dash',
+        description: 'A + B combined: handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
+        Component: VariantGCenteredHandleDash,
     },
     {
         key: 'D',
@@ -68,12 +75,6 @@ const VARIANTS: {
         name: 'Dash on track, no handle (fill gray)',
         description: 'Like E, but the track keeps the regular unchecked switch fill gray instead of the border gray.',
         Component: VariantFNoHandleDashFillGray,
-    },
-    {
-        key: 'G',
-        name: 'Centered handle with dash',
-        description: 'A + B combined: handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
-        Component: VariantGCenteredHandleDash,
     },
 ]
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -22,6 +22,7 @@ import {
     VariantFNoHandleDashFillGray,
     VariantGCenteredHandleDash,
     VariantHFullWidthHandleDashAccent,
+    VariantICenteredHandleDashNeutral,
 } from './LemonSwitchIndeterminate.prototype'
 
 const meta: Meta = {
@@ -55,6 +56,12 @@ const VARIANTS: {
         description:
             'Track filled like "checked", handle carries a minus glyph — borrowed from indeterminate checkboxes.',
         Component: VariantBDashInHandle,
+    },
+    {
+        key: 'I',
+        name: 'Centered handle with dash (neutral track)',
+        description: 'Like A — centered handle on a neutral track — but the handle carries the minus glyph.',
+        Component: VariantICenteredHandleDashNeutral,
     },
     {
         key: 'G',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -47,7 +47,7 @@ const VARIANTS: {
         key: 'C',
         name: 'Half fill',
         description:
-            'Handle stretches over the left half on a track split by a 30° sloped divider, gray left and orange/red right.',
+            'Handle stretches over the left half on a track split by a 30° sloped divider, gray left and accent right (same fill as B).',
         Component: VariantCHalfFill,
     },
     {
@@ -67,7 +67,7 @@ const VARIANTS: {
         key: 'G',
         name: 'Centered half-width handle with dash',
         description:
-            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph on the sloped gray/orange split track.',
+            'A + B + C combined: half-width handle parks mid-track carrying the minus glyph on the sloped gray/accent split track.',
         Component: VariantGCenteredHandleDash,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -18,6 +18,7 @@ import {
     VariantENoHandleDash,
     VariantFNoHandleDashFillGray,
     VariantGCenteredHandleDash,
+    VariantHFullWidthHandleDashAccent,
 } from './LemonSwitchIndeterminate.prototype'
 
 const meta: Meta = {
@@ -64,6 +65,12 @@ const VARIANTS: {
         name: 'Full-width handle with dash',
         description: 'Handle stretches across the entire track and carries the minus glyph. No position to misread.',
         Component: VariantDFullWidthHandleDash,
+    },
+    {
+        key: 'H',
+        name: 'Full-width handle with dash (accent)',
+        description: 'Like D, but the full-width handle is filled with the active accent blue and the dash is white.',
+        Component: VariantHFullWidthHandleDashAccent,
     },
     {
         key: 'E',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -54,8 +54,9 @@ const VARIANTS: {
     },
     {
         key: 'G',
-        name: 'Centered handle with dash',
-        description: 'A + B combined: handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
+        name: 'Centered half-width handle with dash',
+        description:
+            'A + B + C combined: half-width handle parks mid-track and carries the minus glyph on a "checked"-filled track.',
         Component: VariantGCenteredHandleDash,
     },
     {

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.stories.tsx
@@ -9,7 +9,6 @@ import { useState } from 'react'
 import { IconGear } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { Link } from 'lib/lemon-ui/Link'
 
 import {
     PrototypeSwitchProps,
@@ -101,21 +100,19 @@ function VariantRow({ variant }: { variant: (typeof VARIANTS)[number] }): JSX.El
     const { Component } = variant
     return (
         <div className="flex flex-col gap-2 p-4 border rounded bg-surface-primary">
-            <div className="flex items-center justify-between">
-                <div>
-                    <div className="font-semibold">
-                        {variant.key} — {variant.name}
-                    </div>
-                    <div className="text-secondary text-xs">{variant.description}</div>
+            <div>
+                <div className="font-semibold">
+                    {variant.key} — {variant.name}
                 </div>
-                {value !== 'indeterminate' && (
-                    <Link className="text-xs" onClick={() => setValue('indeterminate')}>
-                        Reset to indeterminate
-                    </Link>
-                )}
+                <div className="text-secondary text-xs">{variant.description}</div>
             </div>
             <div className="flex items-center gap-8">
-                <Component label="Interactive (click me)" value={value} onChange={setValue} />
+                <Component
+                    label="Interactive (click me)"
+                    value={value}
+                    onChange={setValue}
+                    onReset={() => setValue('indeterminate')}
+                />
             </div>
             <div className="flex items-center gap-8 text-xs text-secondary">
                 <Component label="Unchecked" value={false} onChange={() => {}} />
@@ -147,19 +144,13 @@ function TestAccountFilterContextRow({ variant }: { variant: (typeof VARIANTS)[n
     const { Component } = variant
     return (
         <div className="flex flex-col gap-1">
-            <div className="flex items-center justify-between text-xs text-secondary">
-                <span>
-                    {variant.key} — {variant.name}
-                </span>
-                {value !== 'indeterminate' && (
-                    <Link className="text-xs" onClick={() => setValue('indeterminate')}>
-                        Reset to indeterminate
-                    </Link>
-                )}
+            <div className="text-xs text-secondary">
+                {variant.key} — {variant.name}
             </div>
             <Component
                 value={value}
                 onChange={setValue}
+                onReset={() => setValue('indeterminate')}
                 bordered
                 fullWidth
                 label={

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -19,8 +19,8 @@
  *       width and sits on a gray-to-accent gradient track (C), carrying the minus glyph (B).
  *   H — Same as D, but the full-width handle is filled with the active accent blue and the
  *       dash is white.
- *   I — Same as A (centered handle on a neutral track), but the handle carries the minus
- *       glyph.
+ *   I — Same as A (centered handle on a neutral track), but the handle carries a gray
+ *       minus glyph.
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -106,13 +106,13 @@ export function VariantACenteredHandle(props: PrototypeSwitchProps): JSX.Element
     return <SwitchShell {...props} handleStyle={{ transform: CENTERED_TRANSLATE }} />
 }
 
-/** I — like A, but the centered handle carries the minus glyph. */
+/** I — like A, but the centered handle carries a gray minus glyph. */
 export function VariantICenteredHandleDashNeutral(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             handleStyle={{ transform: CENTERED_TRANSLATE }}
-            handleContent={<Dash color="var(--color-accent)" width="55%" />}
+            handleContent={<Dash color="var(--color-text-secondary)" width="55%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -9,6 +9,10 @@
  *       (icon communicates, borrowed from indeterminate checkboxes).
  *   C — Half fill: the handle stretches over the left half while the right half of the
  *       track shows accent color (fill amount communicates, "literally half way").
+ *   D — Full-width handle with dash: the handle stretches across the entire track and
+ *       carries the minus glyph (icon communicates, no position to misread).
+ *   E — Dash on track, no handle: the handle disappears entirely; the filled track shows
+ *       a centered dash (most minimal, reads like a "blocked/mixed" badge).
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -35,6 +39,7 @@ interface ShellProps extends PrototypeSwitchProps {
     trackStyle?: React.CSSProperties
     handleStyle?: React.CSSProperties
     handleContent?: JSX.Element
+    trackContent?: JSX.Element
 }
 
 function SwitchShell({
@@ -45,6 +50,7 @@ function SwitchShell({
     trackStyle,
     handleStyle,
     handleContent,
+    trackContent,
 }: ShellProps): JSX.Element {
     const indeterminate = value === 'indeterminate'
     return (
@@ -65,6 +71,7 @@ function SwitchShell({
                 <div className="LemonSwitch__handle" style={indeterminate ? handleStyle : undefined}>
                     {indeterminate ? handleContent : null}
                 </div>
+                {indeterminate ? trackContent : null}
             </button>
         </div>
     )
@@ -85,17 +92,21 @@ export function VariantBDashInHandle(props: PrototypeSwitchProps): JSX.Element {
                 transform:
                     'translateX(calc(var(--lemon-switch-width) - var(--lemon-switch-handle-width) - 2 * var(--lemon-switch-handle-gutter)))',
             }}
-            handleContent={
-                <span
-                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-                    style={{
-                        width: '55%',
-                        height: '2px',
-                        borderRadius: '1px',
-                        backgroundColor: 'var(--color-accent)',
-                    }}
-                />
-            }
+            handleContent={<Dash color="var(--color-accent)" width="55%" />}
+        />
+    )
+}
+
+function Dash({ color, width }: { color: string; width: string }): JSX.Element {
+    return (
+        <span
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+            style={{
+                width,
+                height: '2px',
+                borderRadius: '1px',
+                backgroundColor: color,
+            }}
         />
     )
 }
@@ -112,6 +123,33 @@ export function VariantCHalfFill(props: PrototypeSwitchProps): JSX.Element {
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
                 transform: 'none',
             }}
+        />
+    )
+}
+
+/** D — handle stretches across the entire track and carries the minus glyph. */
+export function VariantDFullWidthHandleDash(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            handleStyle={{
+                width: 'calc(var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter))',
+                transform: 'none',
+            }}
+            handleContent={<Dash color="var(--color-accent)" width="35%" />}
+        />
+    )
+}
+
+/** E — no handle at all: the filled track itself shows a centered dash. */
+export function VariantENoHandleDash(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            handleStyle={{ visibility: 'hidden' }}
+            trackContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -7,8 +7,8 @@
  *   A — Centered handle: the handle parks mid-track on a neutral track (position communicates).
  *   B — Dash in handle: track is filled like "checked", the handle carries a minus glyph
  *       (icon communicates, borrowed from indeterminate checkboxes).
- *   C — Half fill: the handle stretches over the left half while the track fades from
- *       gray to accent in a gradient (fill amount communicates, "literally half way").
+ *   C — Half fill: the handle stretches over the left half while the track splits along a
+ *       30° sloped divider, gray left and danger orange/red right (fill amount communicates).
  *   D — Full-width handle with dash: the handle stretches across the entire track and
  *       carries the minus glyph (icon communicates, no position to misread).
  *   E — Dash on track, no handle: the handle disappears entirely; a gray (border-colored)
@@ -16,7 +16,7 @@
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
  *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
- *       width and sits on a gray-to-accent gradient track (C), carrying the minus glyph (B).
+ *       width and sits on the sloped gray/danger split track (C), carrying the minus glyph (B).
  *   H — Same as D, but the full-width handle is filled with the active accent blue and the
  *       dash is white.
  *   I — Same as A (centered handle on a neutral track), but the handle carries a gray
@@ -146,13 +146,13 @@ function Dash({ color, width }: { color: string; width: string }): JSX.Element {
     )
 }
 
-/** C — handle stretches over the left half on a gray-to-accent gradient track: half on. */
+/** C — handle stretches over the left half on a sloped gray/danger split track: half on. */
 export function VariantCHalfFill(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(90deg, var(--color-bg-fill-switch), var(--color-accent))',
+                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--danger) 50% 100%)',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
@@ -217,13 +217,13 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
     )
 }
 
-/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a gray-to-accent gradient track. */
+/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a sloped gray/danger split track. */
 export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(90deg, var(--color-bg-fill-switch), var(--color-accent))',
+                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--danger) 50% 100%)',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -15,6 +15,8 @@
  *       track shows a centered dash (most minimal, reads like a "blocked/mixed" badge).
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
+ *   G — A + B combined: the handle parks mid-track (as in A) and carries the minus glyph
+ *       on a "checked"-filled track (as in B).
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -164,6 +166,18 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
             trackStyle={{ backgroundColor: 'var(--color-bg-fill-switch)' }}
             handleStyle={{ visibility: 'hidden' }}
             trackContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
+        />
+    )
+}
+
+/** G — A + B combined: centered handle carrying the minus glyph on a "checked"-filled track. */
+export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            handleStyle={{ transform: CENTERED_TRANSLATE }}
+            handleContent={<Dash color="var(--color-accent)" width="55%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -73,7 +73,7 @@ function SwitchShell({
     // Both only show when the switch manages an override (onReset provided).
     const overrideStatus = onReset ? (
         indeterminate ? (
-            <span className="text-xs italic text-secondary">No override set</span>
+            <span className="text-xs text-tertiary">No override set</span>
         ) : (
             <Link className="text-xs" onClick={onReset}>
                 Unset override

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -31,11 +31,15 @@ import './LemonSwitch.scss'
 
 import clsx from 'clsx'
 
+import { Link } from 'lib/lemon-ui/Link'
+
 export type PrototypeToggleValue = boolean | 'indeterminate'
 
 export interface PrototypeSwitchProps {
     value: PrototypeToggleValue
     onChange: (nextChecked: boolean) => void
+    /** When set, a "reset" link shows next to a resolved (yes/no) switch to go back to indeterminate. */
+    onReset?: () => void
     label?: string | JSX.Element
     size?: 'small' | 'medium'
     bordered?: boolean
@@ -55,6 +59,7 @@ interface ShellProps extends PrototypeSwitchProps {
 function SwitchShell({
     value,
     onChange,
+    onReset,
     label,
     size = 'medium',
     bordered,
@@ -87,6 +92,11 @@ function SwitchShell({
                 </div>
                 {indeterminate ? trackContent : null}
             </button>
+            {onReset && !indeterminate && (
+                <Link className="text-xs" onClick={onReset}>
+                    reset
+                </Link>
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -7,8 +7,8 @@
  *   A — Centered handle: the handle parks mid-track on a neutral track (position communicates).
  *   B — Dash in handle: track is filled like "checked", the handle carries a minus glyph
  *       (icon communicates, borrowed from indeterminate checkboxes).
- *   C — Half fill: the handle stretches over the left half while the right half of the
- *       track shows accent color (fill amount communicates, "literally half way").
+ *   C — Half fill: the handle stretches over the left half while the track fades from
+ *       gray to accent in a gradient (fill amount communicates, "literally half way").
  *   D — Full-width handle with dash: the handle stretches across the entire track and
  *       carries the minus glyph (icon communicates, no position to misread).
  *   E — Dash on track, no handle: the handle disappears entirely; a gray (border-colored)
@@ -16,7 +16,7 @@
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
  *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
- *       width and sits on a half-gray, half-accent track (C), carrying the minus glyph (B).
+ *       width and sits on a gray-to-accent gradient track (C), carrying the minus glyph (B).
  *   H — Same as D, but the full-width handle is filled with the active accent blue and the
  *       dash is white.
  *
@@ -123,13 +123,13 @@ function Dash({ color, width }: { color: string; width: string }): JSX.Element {
     )
 }
 
-/** C — handle stretches over the left half, right half of the track shows accent: half on. */
+/** C — handle stretches over the left half on a gray-to-accent gradient track: half on. */
 export function VariantCHalfFill(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(90deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
+                background: 'linear-gradient(90deg, var(--color-bg-fill-switch), var(--color-accent))',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
@@ -194,13 +194,13 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
     )
 }
 
-/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a half-gray, half-accent track. */
+/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a gray-to-accent gradient track. */
 export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(90deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
+                background: 'linear-gradient(90deg, var(--color-bg-fill-switch), var(--color-accent))',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -38,7 +38,7 @@ export type PrototypeToggleValue = boolean | 'indeterminate'
 export interface PrototypeSwitchProps {
     value: PrototypeToggleValue
     onChange: (nextChecked: boolean) => void
-    /** When set, an "Unset override" link shows next to the label of a resolved (yes/no) switch. */
+    /** When set, the label shows override status: "No override set" while indeterminate, an "Unset override" link once resolved. */
     onReset?: () => void
     label?: string | JSX.Element
     size?: 'small' | 'medium'
@@ -70,12 +70,16 @@ function SwitchShell({
     trackContent,
 }: ShellProps): JSX.Element {
     const indeterminate = value === 'indeterminate'
-    const resetLink =
-        onReset && !indeterminate ? (
+    // Both only show when the switch manages an override (onReset provided).
+    const overrideStatus = onReset ? (
+        indeterminate ? (
+            <span className="text-xs italic text-secondary">No override set</span>
+        ) : (
             <Link className="text-xs" onClick={onReset}>
                 Unset override
             </Link>
-        ) : null
+        )
+    ) : null
     return (
         <div
             className={clsx('LemonSwitch', `LemonSwitch--${size}`, {
@@ -87,10 +91,10 @@ function SwitchShell({
             {label ? (
                 <label className="flex items-center gap-2">
                     {label}
-                    {resetLink}
+                    {overrideStatus}
                 </label>
             ) : (
-                resetLink
+                overrideStatus
             )}
             <button
                 type="button"

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -8,7 +8,7 @@
  *   B — Dash in handle: track is filled like "checked", the handle carries a minus glyph
  *       (icon communicates, borrowed from indeterminate checkboxes).
  *   C — Half fill: the handle stretches over the left half while the track splits along a
- *       30° sloped divider, gray left and danger orange/red right (fill amount communicates).
+ *       30° sloped divider, gray left and accent right (fill amount communicates).
  *   D — Full-width handle with dash: the handle stretches across the entire track and
  *       carries the minus glyph (icon communicates, no position to misread).
  *   E — Dash on track, no handle: the handle disappears entirely; a gray (border-colored)
@@ -16,7 +16,7 @@
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
  *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
- *       width and sits on the sloped gray/danger split track (C), carrying the minus glyph (B).
+ *       width and sits on the sloped gray/accent split track (C), carrying the minus glyph (B).
  *   H — Same as D, but the full-width handle is filled with the active accent blue and the
  *       dash is white.
  *   I — Same as A (centered handle on a neutral track), but the handle carries a gray
@@ -154,13 +154,13 @@ function Dash({ color, width }: { color: string; width: string }): JSX.Element {
     )
 }
 
-/** C — handle stretches over the left half on a sloped gray/danger split track: half on. */
+/** C — handle stretches over the left half on a sloped gray/accent split track: half on. */
 export function VariantCHalfFill(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--danger) 50% 100%)',
+                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
@@ -225,13 +225,13 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
     )
 }
 
-/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a sloped gray/danger split track. */
+/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a sloped gray/accent split track. */
 export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{
-                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--danger) 50% 100%)',
+                background: 'linear-gradient(120deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
             }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -15,8 +15,8 @@
  *       track shows a centered dash (most minimal, reads like a "blocked/mixed" badge).
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
- *   G — A + B combined: the handle parks mid-track (as in A) and carries the minus glyph
- *       on a "checked"-filled track (as in B).
+ *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
+ *       width (C), and carries the minus glyph on a "checked"-filled track (B).
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -170,14 +170,17 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
     )
 }
 
-/** G — A + B combined: centered handle carrying the minus glyph on a "checked"-filled track. */
+/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a "checked"-filled track. */
 export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
             trackStyle={{ backgroundColor: 'var(--color-accent)' }}
-            handleStyle={{ transform: CENTERED_TRANSLATE }}
-            handleContent={<Dash color="var(--color-accent)" width="55%" />}
+            handleStyle={{
+                width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
+                transform: 'translateX(calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 4))',
+            }}
+            handleContent={<Dash color="var(--color-accent)" width="40%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -17,6 +17,8 @@
  *       the border gray.
  *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
  *       width and sits on a half-gray, half-accent track (C), carrying the minus glyph (B).
+ *   H — Same as D, but the full-width handle is filled with the active accent blue and the
+ *       dash is white.
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -142,6 +144,22 @@ export function VariantDFullWidthHandleDash(props: PrototypeSwitchProps): JSX.El
                 transform: 'none',
             }}
             handleContent={<Dash color="var(--color-accent)" width="35%" />}
+        />
+    )
+}
+
+/** H — like D, but the full-width handle is filled with the active accent blue and the dash is white. */
+export function VariantHFullWidthHandleDashAccent(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            handleStyle={{
+                width: 'calc(var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter))',
+                transform: 'none',
+                backgroundColor: 'var(--color-accent)',
+            }}
+            handleContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -1,0 +1,117 @@
+/**
+ * PROTOTYPE — throwaway code, do not use in production.
+ *
+ * Question: what should an indeterminate ("mixed") state look like on LemonSwitch?
+ * Plan: three structurally different treatments, side by side in one Storybook story
+ * ("Lemon UI/Lemon Switch/Indeterminate Prototype", run with `pnpm storybook`):
+ *   A — Centered handle: the handle parks mid-track on a neutral track (position communicates).
+ *   B — Dash in handle: track is filled like "checked", the handle carries a minus glyph
+ *       (icon communicates, borrowed from indeterminate checkboxes).
+ *   C — Half fill: the handle stretches over the left half while the right half of the
+ *       track shows accent color (fill amount communicates, "literally half way").
+ *
+ * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
+ *
+ * Verdict: TBD — once a variant wins, fold it into LemonSwitch proper and delete this file
+ * and its stories file.
+ */
+import './LemonSwitch.scss'
+
+import clsx from 'clsx'
+
+export type PrototypeToggleValue = boolean | 'indeterminate'
+
+export interface PrototypeSwitchProps {
+    value: PrototypeToggleValue
+    onChange: (nextChecked: boolean) => void
+    label?: string
+    size?: 'small' | 'medium'
+}
+
+const CENTERED_TRANSLATE =
+    'translateX(calc((var(--lemon-switch-width) - var(--lemon-switch-handle-width) - 2 * var(--lemon-switch-handle-gutter)) / 2))'
+
+interface ShellProps extends PrototypeSwitchProps {
+    trackStyle?: React.CSSProperties
+    handleStyle?: React.CSSProperties
+    handleContent?: JSX.Element
+}
+
+function SwitchShell({
+    value,
+    onChange,
+    label,
+    size = 'medium',
+    trackStyle,
+    handleStyle,
+    handleContent,
+}: ShellProps): JSX.Element {
+    const indeterminate = value === 'indeterminate'
+    return (
+        <div
+            className={clsx('LemonSwitch', `LemonSwitch--${size}`, {
+                'LemonSwitch--checked': value === true,
+            })}
+        >
+            {label && <label>{label}</label>}
+            <button
+                type="button"
+                role="switch"
+                aria-checked={indeterminate ? 'mixed' : value === true}
+                className="LemonSwitch__button"
+                style={indeterminate ? trackStyle : undefined}
+                onClick={() => onChange(value !== true)}
+            >
+                <div className="LemonSwitch__handle" style={indeterminate ? handleStyle : undefined}>
+                    {indeterminate ? handleContent : null}
+                </div>
+            </button>
+        </div>
+    )
+}
+
+/** A — handle parked mid-track, track stays neutral: position alone signals "mixed". */
+export function VariantACenteredHandle(props: PrototypeSwitchProps): JSX.Element {
+    return <SwitchShell {...props} handleStyle={{ transform: CENTERED_TRANSLATE }} />
+}
+
+/** B — track filled like "checked", handle at the checked side carrying a minus glyph. */
+export function VariantBDashInHandle(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            handleStyle={{
+                transform:
+                    'translateX(calc(var(--lemon-switch-width) - var(--lemon-switch-handle-width) - 2 * var(--lemon-switch-handle-gutter)))',
+            }}
+            handleContent={
+                <span
+                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+                    style={{
+                        width: '55%',
+                        height: '2px',
+                        borderRadius: '1px',
+                        backgroundColor: 'var(--color-accent)',
+                    }}
+                />
+            }
+        />
+    )
+}
+
+/** C — handle stretches over the left half, right half of the track shows accent: half on. */
+export function VariantCHalfFill(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{
+                background: 'linear-gradient(90deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
+            }}
+            handleStyle={{
+                width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
+                transform: 'none',
+            }}
+        />
+    )
+}

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -237,7 +237,7 @@ export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Ele
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
                 transform: 'translateX(calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 4))',
             }}
-            handleContent={<Dash color="var(--color-accent)" width="40%" />}
+            handleContent={<Dash color="var(--color-accent)" width="55%" />}
         />
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -34,8 +34,10 @@ export type PrototypeToggleValue = boolean | 'indeterminate'
 export interface PrototypeSwitchProps {
     value: PrototypeToggleValue
     onChange: (nextChecked: boolean) => void
-    label?: string
+    label?: string | JSX.Element
     size?: 'small' | 'medium'
+    bordered?: boolean
+    fullWidth?: boolean
 }
 
 const CENTERED_TRANSLATE =
@@ -53,6 +55,8 @@ function SwitchShell({
     onChange,
     label,
     size = 'medium',
+    bordered,
+    fullWidth,
     trackStyle,
     handleStyle,
     handleContent,
@@ -63,6 +67,8 @@ function SwitchShell({
         <div
             className={clsx('LemonSwitch', `LemonSwitch--${size}`, {
                 'LemonSwitch--checked': value === true,
+                'LemonSwitch--bordered': bordered,
+                'LemonSwitch--full-width': fullWidth,
             })}
         >
             {label && <label>{label}</label>}

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -38,7 +38,7 @@ export type PrototypeToggleValue = boolean | 'indeterminate'
 export interface PrototypeSwitchProps {
     value: PrototypeToggleValue
     onChange: (nextChecked: boolean) => void
-    /** When set, a "reset" link shows next to a resolved (yes/no) switch to go back to indeterminate. */
+    /** When set, an "Unset override" link shows next to the label of a resolved (yes/no) switch. */
     onReset?: () => void
     label?: string | JSX.Element
     size?: 'small' | 'medium'
@@ -70,6 +70,12 @@ function SwitchShell({
     trackContent,
 }: ShellProps): JSX.Element {
     const indeterminate = value === 'indeterminate'
+    const resetLink =
+        onReset && !indeterminate ? (
+            <Link className="text-xs uppercase" onClick={onReset}>
+                Unset override
+            </Link>
+        ) : null
     return (
         <div
             className={clsx('LemonSwitch', `LemonSwitch--${size}`, {
@@ -78,7 +84,14 @@ function SwitchShell({
                 'LemonSwitch--full-width': fullWidth,
             })}
         >
-            {label && <label>{label}</label>}
+            {label ? (
+                <label className="flex items-center gap-2">
+                    {label}
+                    {resetLink}
+                </label>
+            ) : (
+                resetLink
+            )}
             <button
                 type="button"
                 role="switch"
@@ -92,11 +105,6 @@ function SwitchShell({
                 </div>
                 {indeterminate ? trackContent : null}
             </button>
-            {onReset && !indeterminate && (
-                <Link className="text-xs" onClick={onReset}>
-                    reset
-                </Link>
-            )}
         </div>
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -72,7 +72,7 @@ function SwitchShell({
     const indeterminate = value === 'indeterminate'
     const resetLink =
         onReset && !indeterminate ? (
-            <Link className="text-xs uppercase" onClick={onReset}>
+            <Link className="text-xs" onClick={onReset}>
                 Unset override
             </Link>
         ) : null

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -11,8 +11,8 @@
  *       track shows accent color (fill amount communicates, "literally half way").
  *   D — Full-width handle with dash: the handle stretches across the entire track and
  *       carries the minus glyph (icon communicates, no position to misread).
- *   E — Dash on track, no handle: the handle disappears entirely; the filled track shows
- *       a centered dash (most minimal, reads like a "blocked/mixed" badge).
+ *   E — Dash on track, no handle: the handle disappears entirely; a gray (border-colored)
+ *       track shows a centered dash (most minimal, reads like a "blocked/mixed" badge).
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -142,12 +142,12 @@ export function VariantDFullWidthHandleDash(props: PrototypeSwitchProps): JSX.El
     )
 }
 
-/** E — no handle at all: the filled track itself shows a centered dash. */
+/** E — no handle at all: a gray (border-colored) track shows a centered dash. */
 export function VariantENoHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
-            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            trackStyle={{ backgroundColor: 'var(--color-border-primary)' }}
             handleStyle={{ visibility: 'hidden' }}
             trackContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
         />

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -19,6 +19,8 @@
  *       width and sits on a gray-to-accent gradient track (C), carrying the minus glyph (B).
  *   H — Same as D, but the full-width handle is filled with the active accent blue and the
  *       dash is white.
+ *   I — Same as A (centered handle on a neutral track), but the handle carries the minus
+ *       glyph.
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -92,6 +94,17 @@ function SwitchShell({
 /** A — handle parked mid-track, track stays neutral: position alone signals "mixed". */
 export function VariantACenteredHandle(props: PrototypeSwitchProps): JSX.Element {
     return <SwitchShell {...props} handleStyle={{ transform: CENTERED_TRANSLATE }} />
+}
+
+/** I — like A, but the centered handle carries the minus glyph. */
+export function VariantICenteredHandleDashNeutral(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            handleStyle={{ transform: CENTERED_TRANSLATE }}
+            handleContent={<Dash color="var(--color-accent)" width="55%" />}
+        />
+    )
 }
 
 /** B — track filled like "checked", handle at the checked side carrying a minus glyph. */

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -16,7 +16,7 @@
  *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
  *       the border gray.
  *   G — A + B + C combined: the handle parks mid-track (A), stretches to half the track
- *       width (C), and carries the minus glyph on a "checked"-filled track (B).
+ *       width and sits on a half-gray, half-accent track (C), carrying the minus glyph (B).
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -170,12 +170,14 @@ export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.E
     )
 }
 
-/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a "checked"-filled track. */
+/** G — A + B + C combined: centered half-width handle carrying the minus glyph on a half-gray, half-accent track. */
 export function VariantGCenteredHandleDash(props: PrototypeSwitchProps): JSX.Element {
     return (
         <SwitchShell
             {...props}
-            trackStyle={{ backgroundColor: 'var(--color-accent)' }}
+            trackStyle={{
+                background: 'linear-gradient(90deg, var(--color-bg-fill-switch) 0 50%, var(--color-accent) 50% 100%)',
+            }}
             handleStyle={{
                 width: 'calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)',
                 transform: 'translateX(calc((var(--lemon-switch-width) - 2 * var(--lemon-switch-handle-gutter)) / 4))',

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitchIndeterminate.prototype.tsx
@@ -13,6 +13,8 @@
  *       carries the minus glyph (icon communicates, no position to misread).
  *   E — Dash on track, no handle: the handle disappears entirely; a gray (border-colored)
  *       track shows a centered dash (most minimal, reads like a "blocked/mixed" badge).
+ *   F — Same as E, but the track keeps the regular unchecked switch fill gray instead of
+ *       the border gray.
  *
  * Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
  *
@@ -148,6 +150,18 @@ export function VariantENoHandleDash(props: PrototypeSwitchProps): JSX.Element {
         <SwitchShell
             {...props}
             trackStyle={{ backgroundColor: 'var(--color-border-primary)' }}
+            handleStyle={{ visibility: 'hidden' }}
+            trackContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
+        />
+    )
+}
+
+/** F — like E, but the track keeps the regular unchecked switch fill gray. */
+export function VariantFNoHandleDashFillGray(props: PrototypeSwitchProps): JSX.Element {
+    return (
+        <SwitchShell
+            {...props}
+            trackStyle={{ backgroundColor: 'var(--color-bg-fill-switch)' }}
             handleStyle={{ visibility: 'hidden' }}
             trackContent={<Dash color="var(--color-bg-surface-primary)" width="35%" />}
         />


### PR DESCRIPTION
## Problem

LemonSwitch only knows checked and unchecked.
For "some but not all children enabled" situations (bulk toggles, nested settings) we want an indeterminate state, but it's not obvious what that should look like on a switch (unlike a checkbox, where the dash is a convention).

## Changes

Throwaway UI prototype, not production code.
Adds five structurally different indeterminate treatments next to the real component, viewable side by side in Storybook (`pnpm storybook` → Lemon UI/Lemon Switch/Indeterminate Prototype):

- **A — Centered handle**: handle parks mid-track on a neutral track. Position alone signals "mixed".
- **B — Dash in handle**: track filled like "checked", handle carries a minus glyph, borrowed from indeterminate checkboxes.
- **C — Half fill**: handle stretches over the left half, right half of the track shows accent. Literally half on.
- **D — Full-width handle with dash**: handle stretches across the entire track and carries the minus glyph. No position to misread.
- **E — Dash on track, no handle**: no handle at all, the filled track shows a centered dash. Most minimal treatment.

Each variant is interactive (starts indeterminate, click resolves to checked, then toggles normally) with a static unchecked/indeterminate/checked comparison row.
The story is tagged `test-skip` so it stays out of CI visual snapshots, and `LemonSwitch` itself is untouched.

Once a variant wins, the plan is to fold it into `LemonSwitch` proper (as a real `checked: boolean | 'indeterminate'` or similar API, written properly with tests) and delete both prototype files.

## How did you test this code?

Ran oxlint and the full frontend TypeScript check locally, both clean for these files.
No automated tests on purpose, this is a throwaway prototype and the story is excluded from visual regression.
I have not yet visually flipped through the variants in Storybook.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, prototype only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) via the `prototype` skill (UI branch: several structurally different variants of one design question).
Decisions: used Storybook as the host instead of a `?variant=` app route since it's the repo's existing convention for viewing component states, and rendered all variants on one story page because side-by-side comparison beats switching for a 28px control.
Variants D and E were added on reviewer direction after seeing the first three.
Variant styling is done with inline overrides on top of the existing `LemonSwitch.scss` class structure so the production component stays untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*