### PR TITLE
fix(replay): revive the replay-shared jest suite and run it in CI

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -48,6 +48,9 @@ jobs:
                 ${{ (steps.filter.outputs.frontend_code || 'true') == 'true'
                     && (steps.exclude.outputs.outside_node_product_workspaces || 'true') == 'true'
                     && steps.baseline_push.outputs.result != 'true' }}
+            replay_shared: >-
+                ${{ (steps.filter.outputs.replay_shared || 'true') == 'true'
+                    && steps.baseline_push.outputs.result != 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -122,6 +125,16 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
+                      # The @posthog/replay-shared package's own jest suite (the
+                      # jest-replay-shared job). posthog-js bumps land via the catalog +
+                      # lockfile and have broken it before (rrweb subpath entries switching
+                      # to ESM); its zstd tests need the node:zlib support pinned by .nvmrc.
+                      replay_shared:
+                        - 'common/replay-shared/**'
+                        - pnpm-workspace.yaml
+                        - pnpm-lock.yaml
+                        - .nvmrc
+                        - .github/workflows/ci-frontend.yml
 
             - name: Detect Visual Review baseline-only push
               id: baseline_push
@@ -688,9 +701,36 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 1
 
+    jest-replay-shared:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        needs: changes
+        if: needs.changes.outputs.replay_shared == 'true'
+        name: Jest test (replay-shared)
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            # Full workspace install: the suite's jsdom test environment resolves
+            # through the workspace root, not the package's own dependencies, so a
+            # filtered install can't run it.
+            - name: Install pnpm dependencies
+              uses: ./.github/actions/pnpm-install
+
+            - name: Test with Jest
+              run: pnpm --filter=@posthog/replay-shared test
+
     calculate-running-time:
         name: Calculate running time
-        needs: [jest, frontend-typescript-checks, frontend-format, frontend-bundle-size, frontend_tests, changes]
+        needs:
+            [
+                jest,
+                jest-replay-shared,
+                frontend-typescript-checks,
+                frontend-format,
+                frontend-bundle-size,
+                frontend_tests,
+                changes,
+            ]
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)
@@ -732,7 +772,7 @@ jobs:
                   runner: 'github'
 
     frontend_tests:
-        needs: [jest, frontend-format, frontend-bundle-size, frontend-typescript-checks]
+        needs: [jest, jest-replay-shared, frontend-format, frontend-bundle-size, frontend-typescript-checks]
         name: Frontend Tests Pass
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -746,6 +786,11 @@ jobs:
                     exit 1
                   fi
                   echo "Frontend jest tests passed."
+                  if [[ "${{ needs.jest-replay-shared.result }}" != "success" && "${{ needs.jest-replay-shared.result }}" != "skipped" ]]; then
+                    echo "Replay shared jest tests failed."
+                    exit 1
+                  fi
+                  echo "Replay shared jest tests passed."
                   if [[ "${{ needs.frontend-format.result }}" != "success" && "${{ needs.frontend-format.result }}" != "skipped" ]]; then
                     echo "Frontend linting failed."
                     exit 1

--- a/common/replay-shared/jest.config.js
+++ b/common/replay-shared/jest.config.js
@@ -1,7 +1,9 @@
 module.exports = {
     transform: {
-        '^.+\\.ts$': ['@swc/jest'],
+        '^.+\\.[cm]?[jt]s$': ['@swc/jest'],
     },
+    // posthog-js's rrweb subpath entries are shipped as ESM; let them through to the transform.
+    transformIgnorePatterns: ['node_modules/(?!.*posthog-js/dist/rrweb)'],
     testEnvironment: 'node',
     clearMocks: true,
     testMatch: ['<rootDir>/src/**/*.test.ts'],

--- a/common/replay-shared/src/rrweb-plugins/rrweb-plugins.test.ts
+++ b/common/replay-shared/src/rrweb-plugins/rrweb-plugins.test.ts
@@ -60,6 +60,10 @@ jest.mock('hls.js', () => ({ __esModule: true, default: mockHlsClass }))
 describe('HLSPlayerPlugin', () => {
     let plugin: ReturnType<typeof createHLSPlayerPlugin>
 
+    // `onBuild` fires `import('hls.js').then(...)` without awaiting it; drain the microtask
+    // queue so the handler has run before asserting.
+    const delay = (ms = 0): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
     beforeEach(() => {
         jest.clearAllMocks()
         mockHlsClass.isSupported.mockReturnValue(true)
@@ -83,6 +87,7 @@ describe('HLSPlayerPlugin', () => {
         video.setAttribute('hls-src', 'https://example.com/stream.m3u8')
 
         await plugin.onBuild?.(video, { id: 1, replayer: null as any })
+        await delay()
 
         expect(mockHlsClass).toHaveBeenCalled()
         expect(mockHlsInstance.loadSource).toHaveBeenCalledWith('https://example.com/stream.m3u8')
@@ -97,6 +102,7 @@ describe('HLSPlayerPlugin', () => {
         video.canPlayType = jest.fn(() => 'maybe') as any
 
         await plugin.onBuild?.(video, { id: 1, replayer: null as any })
+        await delay()
 
         expect(mockHlsInstance.loadSource).not.toHaveBeenCalled()
         expect(video.src).toContain('https://example.com/stream.m3u8')


### PR DESCRIPTION
## Problem

`common/replay-shared` has a jest suite, but no CI job runs it: the only `turbo run test` invocations in `.github/workflows/` filter to `@posthog/frontend` and `@posthog/nodejs`. Predictably, it rotted. On master today, 5 of the package's 6 suites fail to load with `SyntaxError: Unexpected token 'export'` because posthog-js now ships its rrweb subpath entries (`posthog-js/rrweb-types` etc.) as ESM, which the package's jest transform config predates. This surfaced while adding decode tests in #68545, which is stacked on this PR.

## Changes

- `common/replay-shared/jest.config.js`: extend the transform match to `.js`/`.mjs`/`.cjs` and let posthog-js's rrweb dist files through `transformIgnorePatterns`, using the same ignore-pattern idiom as `frontend/jest.config.ts`. This is what un-breaks suite loading.
- `rrweb-plugins.test.ts`: reviving the suite exposed two genuinely racy HLS plugin tests. The plugin's `onBuild` fires `import('hls.js').then(...)` without awaiting it, and the tests asserted after only one microtask. They now drain the timer queue via a small `delay(ms = 0)` helper before asserting.
- `ci-frontend.yml`: a new `jest-replay-shared` job in Frontend CI running the package's suite, gated on a new `replay_shared` paths filter in the existing `changes` job and wired into the `Frontend Tests Pass` aggregate (skipped counts as success, matching the other jobs). The filter covers the package plus the exact surface that broke it before, since posthog-js bumps land via the workspace catalog and lockfile (`pnpm-workspace.yaml`, `pnpm-lock.yaml`), and the zstd tests arriving in #68545 depend on the `node:zlib` support pinned by `.nvmrc`. The install is a full workspace install because the suite's jsdom test environment resolves through the workspace root, not the package's own dependencies.

## How did you test this code?

Red/green locally, all through the package's public `pnpm test` entry point:

- On master's config, 5 of 6 suites fail to load with the ESM `SyntaxError` (0 tests execute in those suites).
- With only the config fix applied, exactly the two HLS tests fail (`dynamically imports hls.js and attaches...` and `falls back to native HLS...`), confirming the race fix is load-bearing and not a drive-by.
- With both fixes: 6/6 suites, 53/53 tests, 2/2 snapshots pass in ~0.7s.

The job validates itself on this PR: the branch touches `common/replay-shared/**` and `ci-frontend.yml`, both in the `replay_shared` filter, so `Jest test (replay-shared)` runs here. An earlier revision of this PR shipped the job as a standalone workflow and its run passed; this revision folds the same job into Frontend CI.

No new tests were added; the two changed HLS tests catch the same regressions they always aimed at (hls.js attach wiring and the native-HLS fallback), now without depending on scheduler luck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: no user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Code). Split out of #68545 at Robbie's direction after we noticed that PR was carrying test-infra fixes unrelated to its feature. While isolating them, I (Claude) found the root cause of the rot: nothing runs this package's tests in CI, so the suite broke silently when posthog-js went ESM.

Decisions along the way: the job first shipped as its own `ci-replay-shared.yml` workflow (and passed on this PR); Robbie preferred folding it into an existing workflow, so it moved into `ci-frontend.yml` as a filter-gated job, which also gets it under the required `Frontend Tests Pass` aggregate rather than being informational-only. Full `pnpm install` over a filtered one because `jest-environment-jsdom` is not declared by the package and resolves via the workspace root, and declaring it would touch the lockfile, which is currently blocked by an unrelated pnpm `trustPolicy` false positive on npm's 2023 semver backports (reported to devex separately).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
