### PR TITLE
chore(devex): ban new /api/environments url-path registrations

### DIFF
--- a/.semgrep/rules/devex/no-environments-url-path.py
+++ b/.semgrep/rules/devex/no-environments-url-path.py
@@ -1,0 +1,29 @@
+# Test cases for no-environments-url-path.
+# ruff: noqa
+
+from django.urls import include, path, re_path
+
+
+def view(*args, **kwargs):
+    pass
+
+
+urlpatterns = [
+    # ruleid: no-environments-url-path
+    path("api/environments/<int:team_id>/thing/", view),
+    # ruleid: no-environments-url-path
+    path("api/environments/<int:team_id>/thing", view),
+    # ruleid: no-environments-url-path
+    re_path(r"^api/environments/(?P<team_id>[0-9]+)/thing/$", view),
+    # ruleid: no-environments-url-path
+    path(
+        "api/environments/<int:parent_lookup_team_id>/thing/",
+        include("products.thing.urls"),
+    ),
+    # ok: no-environments-url-path
+    path("api/projects/<int:team_id>/thing/", view),
+    # ok: no-environments-url-path
+    path("api/environments_lookalike/<int:team_id>/thing/", view),
+    # ok: no-environments-url-path
+    path("api/unsubscribe", view),
+]

--- a/.semgrep/rules/devex/no-environments-url-path.py
+++ b/.semgrep/rules/devex/no-environments-url-path.py
@@ -14,7 +14,11 @@ urlpatterns = [
     # ruleid: no-environments-url-path
     path("api/environments/<int:team_id>/thing", view),
     # ruleid: no-environments-url-path
+    path('api/environments/<int:team_id>/thing/', view),
+    # ruleid: no-environments-url-path
     re_path(r"^api/environments/(?P<team_id>[0-9]+)/thing/$", view),
+    # ruleid: no-environments-url-path
+    re_path(r"api/environments/(?P<team_id>[0-9]+)/thing/$", view),
     # ruleid: no-environments-url-path
     path(
         "api/environments/<int:parent_lookup_team_id>/thing/",

--- a/.semgrep/rules/devex/no-environments-url-path.yaml
+++ b/.semgrep/rules/devex/no-environments-url-path.yaml
@@ -1,0 +1,37 @@
+rules:
+    - id: no-environments-url-path
+      message: |
+          Hand-written `path("api/environments/...")` route. `/api/projects/` is the
+          canonical prefix; `/api/environments/` is only a back-compat alias for clients
+          that integrated against it before the project↔environment split was rolled back.
+
+          Register the endpoint under `/api/projects/` instead:
+
+              path("api/projects/<int:team_id>/my_thing/", my_view),
+
+          `EnvironmentsRewriteMiddleware` already serves `/api/environments/*` transparently
+          by rewriting to the matching `/api/projects/*` route, so an env-only path means the
+          project path is never generated and consumers get pinned to the deprecated surface.
+          (This is the manual-`path()` sibling of `no-environments-router-register`, which
+          bans the DRF-router equivalent.)
+
+          If a route genuinely must stay env-only (e.g. a third party posts to a fixed env
+          URL), add `# nosemgrep: no-environments-url-path -- <reason>` on the line.
+      severity: ERROR
+      languages: [python]
+      paths:
+          include:
+              - 'posthog/**/*.py'
+              - 'ee/**/*.py'
+              - 'products/**/*.py'
+      patterns:
+          - pattern-either:
+                - pattern: path($ROUTE, ...)
+                - pattern: re_path($ROUTE, ...)
+          - metavariable-regex:
+                metavariable: $ROUTE
+                regex: '^r?["'']\^?api/environments/'
+      metadata:
+          category: best-practice
+          subcategory:
+              - audit

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -351,8 +351,11 @@ urlpatterns = [
     # ee
     *ee_urlpatterns,
     # api
+    # nosemgrep: no-environments-url-path -- defunct query-progress stub, pending removal
     path("api/environments/<int:team_id>/progress/", progress),
+    # nosemgrep: no-environments-url-path -- defunct query-progress stub, pending removal
     path("api/environments/<int:team_id>/query/<str:query_uuid>/progress/", progress),
+    # nosemgrep: no-environments-url-path -- defunct query-progress stub, pending removal
     path("api/environments/<int:team_id>/query/<str:query_uuid>/progress", progress),
     path("api/unsubscribe", unsubscribe.unsubscribe),
     path("api/alerts/github", github.SecretAlert.as_view()),
@@ -368,6 +371,7 @@ urlpatterns = [
     ),
     # Dual-served on both prefixes while the Customer.io dispatcher is repointed from the
     # legacy /api/environments/ URL to the canonical /api/projects/ one.
+    # nosemgrep: no-environments-url-path -- customerio posts to this fixed env URL; dispatcher migrating to projects
     path("api/environments/<int:team_id>/messaging/customerio/webhook/", csrf_exempt(CustomerIOWebhookView.as_view())),
     path("api/projects/<int:team_id>/messaging/customerio/webhook/", csrf_exempt(CustomerIOWebhookView.as_view())),
     path(
@@ -383,6 +387,7 @@ urlpatterns = [
     path("api/sdk_health/", sdk_health),
     path("api/conversations/", include("products.conversations.backend.api.urls")),
     path("api/customer_analytics/", include("products.customer_analytics.backend.presentation.views.urls")),
+    # nosemgrep: no-environments-url-path -- legacy dual-route env alias, pending env-prefix retirement
     path(
         "api/environments/<int:parent_lookup_team_id>/mcp_analytics/",
         include("products.mcp_analytics.backend.presentation.urls"),
@@ -391,6 +396,7 @@ urlpatterns = [
         "api/projects/<int:parent_lookup_team_id>/mcp_analytics/",
         include("products.mcp_analytics.backend.presentation.urls"),
     ),
+    # nosemgrep: no-environments-url-path -- legacy dual-route env alias, pending env-prefix retirement
     path(
         "api/environments/<int:parent_lookup_team_id>/property_access_controls/",
         include("products.access_control.backend.presentation.urls"),


### PR DESCRIPTION
## Problem

The existing `no-environments-router-register` rule only bans DRF-router env registrations in `posthog/api/__init__.py`. Hand-written `path("api/environments/…")` entries in `urls.py` — how the remaining env-only routes actually got in — aren't caught by anything.

## Changes

- Add a semgrep ERROR rule flagging `path()`/`re_path()` routes on the `/api/environments/` prefix; new endpoints must register under `/api/projects/`
- Grandfather the six existing entries with reasoned `# nosemgrep` comments (defunct progress stubs, the Customer.io webhook, two dual-route aliases)
- Ship a `--test` fixture covering the flagged and allowed shapes

## How did you test this code?

- Ran the rule locally: 0 findings across backend after grandfathering, and `semgrep --test` passes for the new fixture
- Agent-authored; only the automated checks above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?