### PR TITLE
feat(devex): mechanically validate the permanent-interface marker

### DIFF
--- a/tools/hogli-commands/hogli_commands/product/ast_helpers.py
+++ b/tools/hogli-commands/hogli_commands/product/ast_helpers.py
@@ -20,6 +20,21 @@ def ast_parse_safe(file_path: Path) -> ast.Module | None:
         return None
 
 
+def get_imported_module_names(tree: ast.Module) -> set[str]:
+    """Every dotted module path the tree imports via real import statements.
+
+    'from a.b import c' records both 'a.b' and 'a.b.c' (c may be a submodule); relative
+    imports are skipped — they can't name a path outside the importing package."""
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imported.add(node.module)
+            imported.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return imported
+
+
 def _file_imports_django_models(tree: ast.Module) -> bool:
     """Check whether a file imports from django.db.models (or django.db)."""
     for node in ast.walk(tree):

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -726,6 +726,20 @@ class IsolationChainCheck(ProductCheck):
                 f"would skip the Django suite. Add the matching input(s) ({globs}) to keep the skip sound"
             )
 
+        # Guarding against marker abuse: the permanent-interface marker is only legitimate for
+        # modules core depends on outside the import graph (ClickHouse DDL in a frozen migration or
+        # the schema registry). Without this check the marker is mechanically unrestricted — a
+        # product could mark backend.models/backend.logic permanent, list it in turbo inputs, and
+        # pass the chain. Fires regardless of has_narrowed: the abuse lives in tach.toml itself, not
+        # in turbo config, so it must block even before the product narrows.
+        if status.unqualified_permanent_exposures:
+            modules = ", ".join(status.unqualified_permanent_exposures)
+            result.issues.append(
+                f"permanent-interface marker covers module(s) {modules}, but they are not imported by any "
+                "frozen ClickHouse migration or the ClickHouse schema registry — so they don't qualify as a "
+                "permanent interface. Route them through the facade instead (or remove the marker)"
+            )
+
         # Note: a product that has the contract-check script *and* deferred
         # presentation-wave ignore_imports entries is hard-blocked by
         # PackageJsonScriptsCheck — the skip can't be enabled until the wave empties them.
@@ -736,11 +750,14 @@ class IsolationChainCheck(ProductCheck):
             # script, and no narrowing). routes_unwatched can co-occur with them (it only needs
             # has_narrowed + a routes module), but turbo.json is still where the routes omission is
             # fixed, so it wins; the co-firing mismatch issues still print in the lint output.
-            result.file = (
-                f"products/{ctx.name}/turbo.json"
-                if needs_turn_on or routes_unwatched
-                else f"products/{ctx.name}/backend/facade/api.py"
-            )
+            # An unqualified permanent exposure is a defect in the tach.toml marker itself, so point
+            # there; it takes precedence because it's the most fundamental of these issues.
+            if status.unqualified_permanent_exposures:
+                result.file = "tach.toml"
+            elif needs_turn_on or routes_unwatched:
+                result.file = f"products/{ctx.name}/turbo.json"
+            else:
+                result.file = f"products/{ctx.name}/backend/facade/api.py"
         if result.issues:
             result.lines = [f"✗ {len(result.issues)} issue(s)"] + [f"  → {i}" for i in result.issues]
         elif result.warnings:

--- a/tools/hogli-commands/hogli_commands/product/isolation.py
+++ b/tools/hogli-commands/hogli_commands/product/isolation.py
@@ -27,7 +27,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-from .ast_helpers import has_any_function_defs
+from .ast_helpers import ast_parse_safe, get_imported_module_names, has_any_function_defs
 from .paths import REPO_ROOT, TACH_TOML, get_tach_block
 
 # ---------------------------------------------------------------------------
@@ -323,46 +323,42 @@ def uncovered_permanent_modules(product_dir: Path, permanent_modules: frozenset[
 # ---------------------------------------------------------------------------
 
 
+# Products whose permanent-interface marker is justified by a coupling channel other than
+# ClickHouse DDL, so the DDL-qualification rule below doesn't apply. warehouse_sources: core's
+# HogQL direct-SQL adapters and system tables reach source internals through the facade's lazy
+# (PEP 562) re-exports; the exposed set is pinned by the product's own guard test
+# (test_ci_core_coupled_sources.py) and stays watched via the turbo-input rule above. Extending
+# this set requires a devex-reviewed change here — which is the point.
+_QUALIFICATION_EXEMPT_PRODUCTS: frozenset[str] = frozenset({"products.warehouse_sources"})
+
+
 @functools.cache
-def _clickhouse_ddl_corpus(repo_root: Path) -> str:
-    """Concatenated source of everything that consumes a permanent DDL interface outside the
+def _clickhouse_ddl_imports(repo_root: Path) -> frozenset[str]:
+    """Dotted module paths imported by the consumers of a permanent DDL interface outside the
     import-reroute path: the frozen ClickHouse migrations and the schema registry.
 
-    Cached per repo_root — product:lint runs the qualification check once per product, and re-reading
-    ~250 migration files each time would dominate the lint. The corpus is stable within one process.
+    Extracted from real import statements via AST (get_imported_module_names), so a module path
+    that only appears in a comment, docstring, or string literal can't qualify a marker.
+
+    Cached per repo_root — product:lint runs the qualification check once per product, and
+    re-parsing ~250 migration files each time would dominate the lint.
     """
     migrations_dir = repo_root / "posthog" / "clickhouse" / "migrations"
     schema_file = repo_root / "posthog" / "clickhouse" / "schema.py"
-    parts: list[str] = []
-    if migrations_dir.is_dir():
-        for path in sorted(migrations_dir.glob("*.py")):
-            parts.append(path.read_text())
+    files = sorted(migrations_dir.glob("*.py")) if migrations_dir.is_dir() else []
     if schema_file.exists():
-        parts.append(schema_file.read_text())
-    return "\n".join(parts)
+        files.append(schema_file)
+    imported: set[str] = set()
+    for path in files:
+        tree = ast_parse_safe(path)
+        if tree is not None:
+            imported.update(get_imported_module_names(tree))
+    return frozenset(imported)
 
 
-def _module_is_referenced(corpus: str, full_dotted_path: str) -> bool:
-    """True if the corpus imports full_dotted_path (e.g. 'products.error_tracking.backend.sql').
-
-    Matches both import spellings: the full dotted path appearing verbatim
-    ('from products.x.backend.sql import Y', 'import products.x.backend.sql', or a submodule
-    'products.x.backend.sql.foo') and the leaf form ('from products.x.backend import sql').
-
-    The trailing '(?![A-Za-z0-9_])' is a word boundary that also permits a following '.' submodule,
-    so 'backend.sql' matches 'backend.sql.foo' but not a distinct 'backend.sql_extra'.
-
-    The leaf alternatives are bounded (no newline outside parens, closing paren inside them) so an
-    unrelated occurrence of the leaf name on a later corpus line can't qualify the module.
-    """
-    parent, _, leaf = full_dotted_path.rpartition(".")
-    leaf_word = r"\b" + re.escape(leaf) + r"\b"
-    from_parent = r"from\s+" + re.escape(parent) + r"\s+import"
-    pattern = (
-        re.escape(full_dotted_path) + r"(?![A-Za-z0-9_])"
-        r"|" + from_parent + r"[^\n(]*" + leaf_word + r"|" + from_parent + r"\s*\([^)]*" + leaf_word
-    )
-    return re.search(pattern, corpus) is not None
+def _module_is_imported(imported: frozenset[str], full_dotted_path: str) -> bool:
+    """True if the module itself or any of its submodules is imported."""
+    return any(imp == full_dotted_path or imp.startswith(full_dotted_path + ".") for imp in imported)
 
 
 def unqualified_permanent_modules(
@@ -373,15 +369,15 @@ def unqualified_permanent_modules(
     The permanent-interface marker is only legitimate for modules core depends on outside the
     import graph — ClickHouse DDL imported by a frozen migration or the schema registry. This is
     the mechanical guard against abusing it: a module (e.g. 'backend.sql') qualifies only if its
-    full dotted path (e.g. 'products.error_tracking.backend.sql') is referenced by one of those
-    consumers. Any marked module with no such reference is returned, and IsolationChainCheck turns
+    full dotted path (e.g. 'products.error_tracking.backend.sql') is imported by one of those
+    consumers. Any marked module with no such import is returned, and IsolationChainCheck turns
     a non-empty result into a blocking issue — the marker can't be used to smuggle 'backend.models'
     or 'backend.logic' past the isolation seal.
     """
-    if not permanent_modules:
+    if not permanent_modules or module_path in _QUALIFICATION_EXEMPT_PRODUCTS:
         return set()
-    corpus = _clickhouse_ddl_corpus(repo_root)
-    return {root for root in permanent_modules if not _module_is_referenced(corpus, f"{module_path}.{root}")}
+    imported = _clickhouse_ddl_imports(repo_root)
+    return {root for root in permanent_modules if not _module_is_imported(imported, f"{module_path}.{root}")}
 
 
 def routes_in_turbo_inputs(product_dir: Path) -> bool:

--- a/tools/hogli-commands/hogli_commands/product/isolation.py
+++ b/tools/hogli-commands/hogli_commands/product/isolation.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 import json
 import tomllib
+import functools
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -317,6 +318,72 @@ def uncovered_permanent_modules(product_dir: Path, permanent_modules: frozenset[
     return {m for m in permanent_modules if not any(i.startswith(_module_input_prefixes(m)) for i in inputs)}
 
 
+# ---------------------------------------------------------------------------
+# Permanent-interface qualification — the marker can only cover genuinely irreducible DDL
+# ---------------------------------------------------------------------------
+
+
+@functools.cache
+def _clickhouse_ddl_corpus(repo_root: Path) -> str:
+    """Concatenated source of everything that consumes a permanent DDL interface outside the
+    import-reroute path: the frozen ClickHouse migrations and the schema registry.
+
+    Cached per repo_root — product:lint runs the qualification check once per product, and re-reading
+    ~250 migration files each time would dominate the lint. The corpus is stable within one process.
+    """
+    migrations_dir = repo_root / "posthog" / "clickhouse" / "migrations"
+    schema_file = repo_root / "posthog" / "clickhouse" / "schema.py"
+    parts: list[str] = []
+    if migrations_dir.is_dir():
+        for path in sorted(migrations_dir.glob("*.py")):
+            parts.append(path.read_text())
+    if schema_file.exists():
+        parts.append(schema_file.read_text())
+    return "\n".join(parts)
+
+
+def _module_is_referenced(corpus: str, full_dotted_path: str) -> bool:
+    """True if the corpus imports full_dotted_path (e.g. 'products.error_tracking.backend.sql').
+
+    Matches both import spellings: the full dotted path appearing verbatim
+    ('from products.x.backend.sql import Y', 'import products.x.backend.sql', or a submodule
+    'products.x.backend.sql.foo') and the leaf form ('from products.x.backend import sql').
+
+    The trailing '(?![A-Za-z0-9_])' is a word boundary that also permits a following '.' submodule,
+    so 'backend.sql' matches 'backend.sql.foo' but not a distinct 'backend.sql_extra'.
+
+    The leaf alternatives are bounded (no newline outside parens, closing paren inside them) so an
+    unrelated occurrence of the leaf name on a later corpus line can't qualify the module.
+    """
+    parent, _, leaf = full_dotted_path.rpartition(".")
+    leaf_word = r"\b" + re.escape(leaf) + r"\b"
+    from_parent = r"from\s+" + re.escape(parent) + r"\s+import"
+    pattern = (
+        re.escape(full_dotted_path) + r"(?![A-Za-z0-9_])"
+        r"|" + from_parent + r"[^\n(]*" + leaf_word + r"|" + from_parent + r"\s*\([^)]*" + leaf_word
+    )
+    return re.search(pattern, corpus) is not None
+
+
+def unqualified_permanent_modules(
+    module_path: str, permanent_modules: frozenset[str], *, repo_root: Path = REPO_ROOT
+) -> set[str]:
+    """Permanently-exposed module roots that don't actually qualify as an irreducible interface.
+
+    The permanent-interface marker is only legitimate for modules core depends on outside the
+    import graph — ClickHouse DDL imported by a frozen migration or the schema registry. This is
+    the mechanical guard against abusing it: a module (e.g. 'backend.sql') qualifies only if its
+    full dotted path (e.g. 'products.error_tracking.backend.sql') is referenced by one of those
+    consumers. Any marked module with no such reference is returned, and IsolationChainCheck turns
+    a non-empty result into a blocking issue — the marker can't be used to smuggle 'backend.models'
+    or 'backend.logic' past the isolation seal.
+    """
+    if not permanent_modules:
+        return set()
+    corpus = _clickhouse_ddl_corpus(repo_root)
+    return {root for root in permanent_modules if not _module_is_referenced(corpus, f"{module_path}.{root}")}
+
+
 def routes_in_turbo_inputs(product_dir: Path) -> bool:
     """True if contract-check inputs watch the routes module specifically — backend/routes.py or a
     backend/routes/ package. Anchored and negation-aware, so a glob that merely contains 'routes',
@@ -349,6 +416,10 @@ class IsolationStatus:
     # in its contract-check inputs — uncovered_permanent_exposures lists any that don't.
     permanent_exposures: tuple[str, ...] = ()
     uncovered_permanent_exposures: tuple[str, ...] = ()
+    # Marked permanent modules that aren't imported by any frozen ClickHouse migration or the
+    # schema registry — so they don't qualify as irreducible interfaces and the marker is being
+    # abused to keep an internal (models/logic) walled off. IsolationChainCheck blocks on these.
+    unqualified_permanent_exposures: tuple[str, ...] = ()
 
     @property
     def deferred_count(self) -> int:
@@ -387,12 +458,15 @@ def compute_isolation_status(
     is_isolated: bool | None = None,
     tach_content: str | None = None,
     pyproject_text: str | None = None,
+    repo_root: Path | None = None,
 ) -> IsolationStatus:
     """Compute the full isolation seal status for one product."""
     if is_isolated is None:
         is_isolated = is_isolated_product(backend_dir)
     if tach_content is None:
         tach_content = TACH_TOML.read_text() if TACH_TOML.exists() else ""
+    if repo_root is None:
+        repo_root = REPO_ROOT
     module_path = f"products.{name}"
     permanent_modules = frozenset(permanent_interface_modules(tach_content, module_path))
     return IsolationStatus(
@@ -406,4 +480,7 @@ def compute_isolation_status(
         has_narrowed_turbo=has_narrowed_turbo_inputs(product_dir, permanent_modules),
         permanent_exposures=tuple(sorted(permanent_modules)),
         uncovered_permanent_exposures=tuple(sorted(uncovered_permanent_modules(product_dir, permanent_modules))),
+        unqualified_permanent_exposures=tuple(
+            sorted(unqualified_permanent_modules(module_path, permanent_modules, repo_root=repo_root))
+        ),
     )

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -30,6 +30,7 @@ from hogli_commands.product.isolation import (
     permanent_interface_modules,
     routes_in_turbo_inputs,
     uncovered_permanent_modules,
+    unqualified_permanent_modules,
 )
 
 # ---------------------------------------------------------------------------
@@ -783,6 +784,53 @@ class TestPermanentInterface:
             )
         )
         assert uncovered_permanent_modules(tmp_path, frozenset({"backend.sql", "backend.embedding"})) == set()
+
+
+def _make_ddl_repo(tmp_path: Path, *, migration_body: str = "", schema_body: str = "") -> Path:
+    migrations = tmp_path / "posthog" / "clickhouse" / "migrations"
+    migrations.mkdir(parents=True)
+    (migrations / "0001_x.py").write_text(migration_body)
+    (tmp_path / "posthog" / "clickhouse" / "schema.py").write_text(schema_body)
+    return tmp_path
+
+
+class TestPermanentInterfaceQualification:
+    @pytest.mark.parametrize(
+        "migration_body, schema_body, marked, expected",
+        [
+            # DDL module imported by a frozen migration qualifies.
+            ("from products.foo.backend.sql import CREATE_X", "", {"backend.sql"}, set()),
+            # A reference from the schema registry alone qualifies too.
+            ("", "from products.foo.backend.sql import CREATE_X", {"backend.sql"}, set()),
+            # A submodule import still counts as a reference to the root.
+            ("from products.foo.backend.sql.tables import CREATE_X", "", {"backend.sql"}, set()),
+            # The abuse case: an internal marked permanent with no DDL consumer is flagged.
+            ("", "", {"backend.models"}, {"backend.models"}),
+            # Word boundary: backend.sql_extra must not qualify backend.sql.
+            ("from products.foo.backend.sql_extra import CREATE_X", "", {"backend.sql"}, {"backend.sql"}),
+            # Leaf import form counts as a reference.
+            ("from products.foo.backend import sql", "", {"backend.sql"}, set()),
+            # An unrelated leaf-name token on a later line must not qualify the module.
+            ("from products.foo.backend import models\nsql = 1", "", {"backend.sql"}, {"backend.sql"}),
+        ],
+    )
+    def test_qualification(
+        self, tmp_path: Path, migration_body: str, schema_body: str, marked: set[str], expected: set[str]
+    ) -> None:
+        repo_root = _make_ddl_repo(tmp_path, migration_body=migration_body, schema_body=schema_body)
+        assert unqualified_permanent_modules("products.foo", frozenset(marked), repo_root=repo_root) == expected
+
+    def test_unqualified_exposure_blocks_isolation_chain(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A marked module that no migration/schema-registry imports must hard-block, and the issue
+        # must point at tach.toml where the bogus marker lives.
+        _seal_externally(monkeypatch)
+        import hogli_commands.product.isolation as isolation_module
+
+        monkeypatch.setattr(isolation_module, "permanent_interface_modules", lambda *_a, **_k: {"backend.models"})
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        result = chain_check.run(ctx)
+        assert any("don't qualify as a permanent interface" in i for i in result.issues)
+        assert result.file == "tach.toml"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -812,6 +812,10 @@ class TestPermanentInterfaceQualification:
             ("from products.foo.backend import sql", "", {"backend.sql"}, set()),
             # An unrelated leaf-name token on a later line must not qualify the module.
             ("from products.foo.backend import models\nsql = 1", "", {"backend.sql"}, {"backend.sql"}),
+            # A path mentioned only in a comment must not qualify — imports come from the AST.
+            ("# depends on products.foo.backend.models\nimport datetime", "", {"backend.models"}, {"backend.models"}),
+            # Same for a string literal (e.g. DDL text or a log message naming the module).
+            ('TABLE_SQL = "see products.foo.backend.models"', "", {"backend.models"}, {"backend.models"}),
         ],
     )
     def test_qualification(
@@ -820,6 +824,17 @@ class TestPermanentInterfaceQualification:
         repo_root = _make_ddl_repo(tmp_path, migration_body=migration_body, schema_body=schema_body)
         assert unqualified_permanent_modules("products.foo", frozenset(marked), repo_root=repo_root) == expected
 
+    def test_exempt_product_skips_qualification(self, tmp_path: Path) -> None:
+        # warehouse_sources' marker is justified by a non-DDL channel; dropping the exemption
+        # would turn product:lint --all red for it.
+        repo_root = _make_ddl_repo(tmp_path)
+        assert (
+            unqualified_permanent_modules(
+                "products.warehouse_sources", frozenset({"backend.models"}), repo_root=repo_root
+            )
+            == set()
+        )
+
     def test_unqualified_exposure_blocks_isolation_chain(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # A marked module that no migration/schema-registry imports must hard-block, and the issue
         # must point at tach.toml where the bogus marker lives.
@@ -827,6 +842,8 @@ class TestPermanentInterfaceQualification:
         import hogli_commands.product.isolation as isolation_module
 
         monkeypatch.setattr(isolation_module, "permanent_interface_modules", lambda *_a, **_k: {"backend.models"})
+        # Controlled corpus — don't let the assertion depend on the real repo's migrations.
+        monkeypatch.setattr(isolation_module, "_clickhouse_ddl_imports", lambda _root: frozenset())
         ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
         result = chain_check.run(ctx)
         assert any("don't qualify as a permanent interface" in i for i in result.issues)


### PR DESCRIPTION
## Problem

Follow-up to #65456. The `# isolation:permanent-interface` marker introduced there is mechanically unrestricted: nothing stops a product from marking a `backend.models.*` or `backend.logic.*` tach block permanent, listing the module in its turbo inputs, and passing `IsolationChainCheck`. The "declared irreducible base layer" is one comment line away from "the models I didn't want to migrate" — only advisory text in the isolation skill guards it.

## Changes

Validate the marker against the deterministic signal that defines irreducibility: every module exposed under a marked block must be imported by a frozen ClickHouse migration (`posthog/clickhouse/migrations/*.py`) and/or the ClickHouse schema registry (`posthog/clickhouse/schema.py`). A marked module with neither import now fails `IsolationChainCheck` with a blocking issue pointing at `tach.toml`, telling the product to route the module through the facade or drop the marker.

Qualification reads real import statements via AST (per review — a module path mentioned in a comment or string literal can't qualify), parsed once per process. `warehouse_sources` carries the one existing marker justified by a non-DDL channel (HogQL direct-SQL adapters reaching source internals through lazy facade re-exports, pinned by its own guard test), so it sits in an explicit exemption set in the tool — extending that set requires a devex-reviewed change here.

error_tracking's three DDL modules are all pinned by real migrations, so the check passes there unchanged.

## How did you test this code?

Agent-authored; automated checks only:

- `tools/hogli-commands` test suite passes. New tests catch: a marked DDL module with a migration or schema-registry import passing; the abuse case (marked `backend.models` with no import) hard-blocking with the issue pointed at tach.toml; submodule and leaf import forms qualifying; comment/string mentions and lookalike module names staying flagged; the warehouse_sources exemption holding.
- `hogli product:lint error_tracking` and `hogli product:lint warehouse_sources` both pass; the qualification issue reproduced on warehouse_sources before the exemption.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @webjunkie. Skills invoked: `/isolating-product-facade-contracts` (defines the marker semantics this enforces).

Decisions: the qualification signal is deliberately narrow — an import from a frozen ClickHouse migration or the schema registry, nothing else — because that is the exact coupling that cannot be rerouted through a facade. Markers justified by other channels don't get a general escape hatch; they go into a reviewed exemption set in the tool. The blocking issue fires regardless of turbo narrowing, since the abuse lives in tach.toml itself.

https://claude.ai/code/session_01PYFqkDL2Mf7BdV1JFY4hHC
