### PR TITLE
fix(cdp): stub empty person when rerun lookup misses

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -94,20 +94,10 @@ export class CdpCyclotronWorker<
                         ? this.personsManager
                               .getCyclotronPerson(item.teamId, hogFuncState.globals.event.distinct_id, 'distinct_id')
                               .then((person) => {
-                                  // Fall back to an empty-shaped stub when the lookup misses.
-                                  // Happens on the rerun path for cookieless-mode events
-                                  // (`cookieless_*` distinct_ids never persist to
-                                  // `posthog_persondistinctid`) and for reruns where the
-                                  // person has since been deleted. This matches the shape
-                                  // the events pipeline attaches at original ingest time
-                                  // (`{id: '', name, url}`, no `properties`). Leaving
-                                  // `globals.person` as `undefined` would make any input
-                                  // bytecode that dereferences `person.properties.*`
-                                  // (e.g. the Google Ads template's
-                                  // `person.properties.gclid ?? … ?? event.properties.gclid`)
-                                  // halt on the first branch with "Could not execute
-                                  // bytecode" — never reaching the event-level fallback
-                                  // that would otherwise recover the send.
+                                  // Stub when the lookup misses (cookieless events don't persist to
+                                  // posthog_persondistinctid; reruns may race with person deletes).
+                                  // Leaving undefined would halt any bytecode dereferencing
+                                  // person.properties.* with "Could not execute bytecode".
                                   hogFuncState.globals.person = person ?? {
                                       id: '',
                                       name: '',

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -94,8 +94,25 @@ export class CdpCyclotronWorker<
                         ? this.personsManager
                               .getCyclotronPerson(item.teamId, hogFuncState.globals.event.distinct_id, 'distinct_id')
                               .then((person) => {
-                                  if (person) {
-                                      hogFuncState.globals.person = person
+                                  // Fall back to an empty-shaped stub when the lookup misses.
+                                  // Happens on the rerun path for cookieless-mode events
+                                  // (`cookieless_*` distinct_ids never persist to
+                                  // `posthog_persondistinctid`) and for reruns where the
+                                  // person has since been deleted. This matches the shape
+                                  // the events pipeline attaches at original ingest time
+                                  // (`{id: '', name, url}`, no `properties`). Leaving
+                                  // `globals.person` as `undefined` would make any input
+                                  // bytecode that dereferences `person.properties.*`
+                                  // (e.g. the Google Ads template's
+                                  // `person.properties.gclid ?? … ?? event.properties.gclid`)
+                                  // halt on the first branch with "Could not execute
+                                  // bytecode" — never reaching the event-level fallback
+                                  // that would otherwise recover the send.
+                                  hogFuncState.globals.person = person ?? {
+                                      id: '',
+                                      name: '',
+                                      url: '',
+                                      properties: {},
                                   }
                               })
                         : undefined,

--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -377,4 +377,140 @@ describe('CDP hog invocation rerun e2e', () => {
         // ── 6. The hog function's fetch was called twice — once original, once rerun ─
         expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
+
+    it('reruns successfully when person rehydration misses and the input reads person.properties', async () => {
+        // On the rerun path the paginator strips globals.person; the worker
+        // re-hydrates via getCyclotronPerson, which returns null when the
+        // distinct_id has no row in posthog_persondistinctid (cookieless
+        // events by design, deleted persons, etc.). The worker must fall back
+        // to an empty person stub — leaving globals.person as undefined halts
+        // any input bytecode dereferencing `person.properties.*` with "Could
+        // not execute bytecode", before coalesce fallbacks can traverse to an
+        // event-level branch.
+        //
+        // If the worker's null-lookup fallback regresses, this test's rerun
+        // fetch never fires and the count assertion fails.
+
+        // Custom function whose input specifically dereferences
+        // `person.properties.foo` — the shape that crashed pre-fix.
+        const FALLBACK_WEBHOOK_URL = 'https://example.com/person-props-fallback'
+        const gclidLikeHog = `
+        let res := fetch(inputs.url, { 'method': 'POST', 'body': f'foo={inputs.foo}' });
+        print('Fetch response:', res);
+        `
+        const personPropsFn = await _insertHogFunction(hub.postgres, team.id, {
+            type: 'destination',
+            hog: gclidLikeHog,
+            bytecode: await compileHog(gclidLikeHog),
+            inputs_schema: [
+                { key: 'url', type: 'string', label: 'URL', secret: false, required: true },
+                { key: 'foo', type: 'string', label: 'foo', secret: false, required: false },
+            ],
+            inputs: {
+                url: {
+                    value: FALLBACK_WEBHOOK_URL,
+                    bytecode: ['_h', 32, FALLBACK_WEBHOOK_URL],
+                },
+                // Same shape as the Google Ads template: person.properties first,
+                // event.properties as the tail fallback.
+                foo: {
+                    value: '{person.properties.foo ?? event.properties.foo}',
+                    bytecode: await compileHog('return person.properties.foo ?? event.properties.foo'),
+                },
+            },
+            ...HOG_FILTERS_EXAMPLES.no_filters,
+        })
+
+        mockFetch.mockResolvedValue({
+            status: 200,
+            json: () => Promise.resolve({ ok: true }),
+            text: () => Promise.resolve('{"ok":true}'),
+            headers: { 'Content-Type': 'application/json' },
+            dump: () => Promise.resolve(),
+        })
+
+        // Simulate cookieless / missing-person for the rerun: personRepo returns
+        // no rows for any distinct_id, so getCyclotronPerson returns null. The
+        // ORIGINAL invocation doesn't call the repo — events consumer uses the
+        // person we attach to data.person directly — so this only affects the
+        // rerun path's rehydration.
+        const personRepo = cdpDeps.personRepository as jest.Mocked<PersonReadRepository>
+        personRepo.fetchPersonsByDistinctIds.mockResolvedValue([])
+
+        // Original event carries the fallback value on event.properties. The
+        // person we hand-attach here has no `foo`, so even on the original the
+        // coalesce falls through to event.properties.foo — proving the
+        // fallback wiring is real (and letting the rerun's stubbed-empty
+        // person hit the same branch).
+        const cookielessGlobals = createHogExecutionGlobals({
+            project: { id: team.id } as any,
+            event: {
+                uuid: 'aaaa1111-bbbb-2222-cccc-333333333333',
+                event: '$pageview',
+                distinct_id: 'cookieless_stub',
+                properties: { foo: 'from-event' },
+                timestamp: '2026-07-02T09:00:00Z',
+            } as any,
+            person: {
+                id: '',
+                name: 'cookieless_stub',
+                url: 'http://localhost:8000/persons/cookieless_stub',
+                properties: {}, // no `foo` — coalesce must reach event branch
+            },
+        })
+
+        const { invocations } = await eventsConsumer.processBatch([cookielessGlobals])
+        // Both fnFetch (from beforeEach) and personPropsFn match a $pageview — we
+        // care about ours.
+        const personPropsInvocations = invocations.filter((i) => i.functionId === personPropsFn.id)
+        expect(personPropsInvocations).toHaveLength(1)
+
+        await waitForExpect(async () => {
+            const rows = await clickhouse.query<PersistedRow>(
+                `SELECT invocation_id, status FROM hog_invocation_results
+                 WHERE team_id = ${team.id} AND function_id = '${personPropsFn.id}' AND status = 'succeeded'`
+            )
+            expect(rows.length).toBeGreaterThanOrEqual(1)
+        }, 30_000)
+
+        const originalRows = await clickhouse.query<PersistedRow>(
+            `SELECT invocation_id, status FROM hog_invocation_results
+             WHERE team_id = ${team.id} AND function_id = '${personPropsFn.id}' AND status = 'succeeded'`
+        )
+        const originalInvocationId = originalRows[0].invocation_id
+
+        // Trigger the rerun scoped to just this invocation_id.
+        const windowStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+        const windowEnd = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        const rerunJobId = await rerunManager.enqueue(team.id, 'hog_function', personPropsFn.id, {
+            filter: {
+                window_start: windowStart,
+                window_end: windowEnd,
+                status: ['succeeded'],
+                invocation_ids: [originalInvocationId],
+            },
+        })
+
+        rerunWorker = new CdpRerunWorkerConsumer(
+            { ...hub, CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'postgres' },
+            cdpDeps,
+            { hog_function: kafkaQueue, hog_flow: postgresV2Queue }
+        )
+        await rerunWorker.start()
+
+        await waitForExpect(async () => {
+            const res = await nodeAssertPool.query('SELECT status FROM cyclotron_jobs WHERE id = $1', [rerunJobId])
+            expect(res.rows[0]?.status).toBe('completed')
+        }, 30_000)
+
+        // The core assertion: the rerun re-fired the fetch to our specific URL,
+        // with the value coming through the coalesce's event-level fallback.
+        // Pre-fix, the input eval crashed on `undefined.properties` and this
+        // count stayed at 1 (just the original). Post-fix, it's 2 (original +
+        // rerun), and the rerun's body carries `foo=from-event`.
+        const ourCalls = mockFetch.mock.calls.filter(([url]) => String(url).startsWith(FALLBACK_WEBHOOK_URL))
+        expect(ourCalls.length).toBeGreaterThanOrEqual(2)
+        const rerunBody = String((ourCalls[ourCalls.length - 1] as any)[1]?.body ?? '')
+        expect(rerunBody).toContain('foo=from-event')
+    })
 })


### PR DESCRIPTION
## Problem

On the rerun path, the paginator strips `globals.person` from stored invocation globals. The worker re-hydrates via `getCyclotronPerson`, which returns `null` in real cases:

- **Cookieless-mode distinct_ids.** By design, cookieless events never create rows in `posthog_persondistinctid`, so the `posthog_person JOIN posthog_persondistinctid` lookup returns nothing. Live cookieless invocations are unaffected because the ingestion pipeline attaches a minimal `person: {id: '', name: 'cookieless_...', url: ...}` stub to globals before the CDP consumer picks up the event — the rerun path skips that stub construction.
- **Persons deleted between original send and rerun.** GDPR delete / admin action / cascade from team delete.

Previously the worker did:

```typescript
.then((person) => {
    if (person) {
        hogFuncState.globals.person = person
    }
})
```

Leaving `globals.person` as `undefined` when the lookup missed. Any input bytecode that dereferences `person.properties.*` then halts the hog VM with `finished: false`, and `hog-inputs.service.ts` throws `Could not execute bytecode for input field: <key>`.

The Google Ads destination template is a concrete example. Its input mapping is `{person.properties.gclid ?? person.properties.$initial_gclid ?? event.properties.gclid}` — a three-branch coalesce that ends on the event. Pre-fix, cookieless reruns would crash on `undefined.properties` before the coalesce could traverse to the event fallback. The send never re-fires even though the event has everything needed to reconstruct the request.

## Fix

Synthesize a minimal person stub `{id: '', name: '', url: '', properties: {}}` when the lookup returns null. Matches the exact shape the ingestion pipeline attaches at original send time for cookieless events. Any downstream `person.properties.*` access returns null in hog rather than crashing, letting coalesce chains reach event-level fallbacks.

## Risk assessment

- **Live traffic: no change.** The rehydration branch only enters when `!globals.person`, and live invocations always have person populated by the events consumer. Untouched code path.
- **Reruns with a valid person lookup: no change.** The `if (person)` guard was replaced with `person ?? stub`, so a real returned person still wins.
- **Reruns with a null lookup (the target case): behavior changes from crash → proceed with empty stub.**
  - Templates using coalesce fallbacks reach their fallback branches and succeed instead of throwing.
  - Templates that use `person.name` / `person.id` directly would send empty strings instead of crashing. Not a regression — live cookieless traffic already sends with `person = {id: '', name: 'cookieless_...'}` today, so any template that cared about non-empty person data was already broken on live.
- **No shipped template branches on `person == null` or `empty(person)`.** Grepped `nodejs/src/cdp/templates/` — no matches.
- **CH lifecycle row's `person_id` column: unchanged.** `extractTriggerFields` uses `globals.person?.id ?? ''`. Before, `undefined?.id ?? ''` → `''`. After, `{id: ''}.id` → `''`. Same output.

## How did you test this code?

- `pnpm typescript:check` — clean on touched files (unrelated `@posthog/replay-anonymizer` pre-existing failure on master).
- `pnpm lint src/cdp/consumers/cdp-cyclotron-worker.consumer.ts` and `src/cdp/rerun/rerun-e2e.test.ts` — clean.
- Added one e2e test to `nodejs/src/cdp/rerun/rerun-e2e.test.ts`: `reruns successfully when person rehydration misses and the input reads person.properties`. Inserts a hog function with input `person.properties.foo ?? event.properties.foo`, mocks `fetchPersonsByDistinctIds` to return `[]` so rehydration returns null, and asserts the rerun's fetch fires with the event-level fallback value. Pre-fix, input eval halts on `undefined.properties` and the fetch count stays at 1 (just the original). Post-fix, it's 2 and the rerun body contains `foo=from-event`. Guards the null-lookup fallback specifically — the pre-existing rerun-e2e test uses a mock returning a valid person and doesn't exercise this path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 4.7, 1M context). Skills invoked: `/writing-tests` before adding the e2e case — used its value gate to confirm the test catches a specific regression (refactoring the rehydration branch back to `if (person)`) that no existing test covers.

Investigation trail:

1. Failed rerun invocations surfaced `Error building inputs: Error: Could not execute bytecode for input field: gclid` in production logs.
2. Distinct IDs on the failing rows all had the `cookieless_` prefix.
3. Traced `serializeInvocationGlobals` at `hog-invocation-results.service.ts:213-217` stripping person on persist, and `cdp-cyclotron-worker.consumer.ts:91-102` re-hydrating (or not) on rerun dequeue.
4. Confirmed via `hashToDistinctId` in `cookieless-manager.ts:806` that cookieless distinct_ids never persist to `posthog_persondistinctid`.
5. Verified via direct hogvm exec that empty-object person handles `.properties.<x>` gracefully in hog, while undefined halts.
