### PR TITLE
feat(web-analytics): warm lazy precompute jobs for enrolled teams via cache warming

### DIFF
--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -19,6 +19,7 @@ from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
 from posthog.models.instance_setting import get_instance_setting
 
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_precompute_enabled_for_team
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
 
 STALE_WEB_QUERIES_GAUGE = Gauge(
@@ -51,6 +52,38 @@ def increment_counter(team_id: int, normalized_query_hash: str, is_cached: bool)
 def get_teams_enabled_for_web_analytics_cache_warming() -> list[int]:
     value = get_instance_setting("WEB_ANALYTICS_WARMING_TEAMS_TO_WARM")
     return value if isinstance(value, list) else []
+
+
+# Query kinds that carry the `useWebAnalyticsPrecompute` per-query opt-in.
+LAZY_PRECOMPUTE_QUERY_KINDS = frozenset(
+    {"WebStatsTableQuery", "WebOverviewQuery", "WebGoalsQuery", "WebVitalsPathBreakdownQuery"}
+)
+
+
+def maybe_opt_into_lazy_precompute(team: Team, query_json: dict) -> dict:
+    """Opt an enrolled team's replayed query into the lazy precompute path.
+
+    Replayed queries are the team's real production shapes, which for a
+    restricted-enrolled team carry no per-query opt-in (users only send one via
+    the UI toggle). Without this, warming such a team never computes its lazy
+    jobs — so enrolling a team on `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` plus
+    this warming list is what populates its precompute from real query shapes
+    while its user-facing reads stay on the raw path (their queries still have
+    no opt-in). That combination is how a team is evaluated before its reads
+    are switched over.
+
+    The opt-in changes the runner's cache key, so the warmed Django-cache entry
+    differs from the one raw user reads hit — acceptable: the durable output of
+    warming an enrolled team is the precompute jobs (shared by query shape),
+    not the result-cache row.
+    """
+    if query_json.get("kind") not in LAZY_PRECOMPUTE_QUERY_KINDS:
+        return query_json
+    if query_json.get("useWebAnalyticsPrecompute") is not None:
+        return query_json
+    if not is_precompute_enabled_for_team(team):
+        return query_json
+    return {**query_json, "useWebAnalyticsPrecompute": True}
 
 
 def queries_to_keep_fresh(
@@ -166,6 +199,8 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: dict) -> None:
             team_id = query_info["team_id"]
             query_json = query_info["query_json"]
             normalized_query_hash = query_info["normalized_query_hash"]
+
+            query_json = maybe_opt_into_lazy_precompute(team, query_json)
 
             runner = get_query_runner(
                 query=query_json,

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -1,0 +1,34 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.web_analytics.dags.cache_warming import maybe_opt_into_lazy_precompute
+
+
+class TestMaybeOptIntoLazyPrecompute(BaseTest):
+    def test_enrolled_team_web_query_gets_opt_in(self) -> None:
+        # If this breaks, warming an enrolled-but-restricted team silently stops
+        # computing its lazy jobs — the pre-enrollment evaluation pipeline reads empty.
+        query = {"kind": "WebStatsTableQuery", "properties": []}
+        with self.settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.id]):
+            result = maybe_opt_into_lazy_precompute(self.team, query)
+
+        self.assertIs(result["useWebAnalyticsPrecompute"], True)
+        self.assertNotIn("useWebAnalyticsPrecompute", query)  # input not mutated
+
+    @parameterized.expand(
+        [
+            # Non-web kinds don't carry the field; injecting it would break validation.
+            ("non_web_kind", {"kind": "TrendsQuery"}, True),
+            # Teams outside the enrollment lists must warm exactly what users run.
+            ("not_enrolled", {"kind": "WebStatsTableQuery"}, False),
+            # An explicit user opt-out in the replayed shape is preserved.
+            ("explicit_opt_out", {"kind": "WebStatsTableQuery", "useWebAnalyticsPrecompute": False}, True),
+        ]
+    )
+    def test_leaves_query_untouched(self, _name: str, query: dict, enrolled: bool) -> None:
+        team_ids = [self.team.id] if enrolled else []
+        with self.settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=team_ids):
+            result = maybe_opt_into_lazy_precompute(self.team, query)
+
+        self.assertEqual(result, query)


### PR DESCRIPTION
## Problem

Before switching a new team's reads onto the PATHS lazy precompute — especially a large one — we want production evidence of what its inserts will cost and whether its reads would actually improve. Enrolling a team on `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` alone doesn't produce that evidence: restricted enrollment requires the per-query `useWebAnalyticsPrecompute` opt-in, users only send that via the UI toggle (feature-flag gated), and the hourly cache-warming Dagster job replays the team's real queries **verbatim** — so neither users nor the warmer ever compute the team's lazy jobs.

## Changes

One small change to the existing cache-warming job, reusing the existing knobs — no new settings:

- `maybe_opt_into_lazy_precompute(team, query_json)`: when replaying a query for a team on the existing enrollment lists, and the query kind carries the field (`WebStatsTableQuery`, `WebOverviewQuery`, `WebGoalsQuery`, `WebVitalsPathBreakdownQuery`), inject `useWebAnalyticsPrecompute: true`. Explicit user opt-outs in the replayed shape are preserved; non-enrolled teams warm exactly what their users ran.

This makes the evaluation workflow purely operational: add the team to `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` (charts env) **and** the `WEB_ANALYTICS_WARMING_TEAMS_TO_WARM` instance setting. The hourly warmer then computes the team's lazy jobs from its real query shapes (insert cost lands in `query_log` as `web_stats_*_lazy_insert`), while user-facing reads keep serving raw — their queries carry no opt-in until the toggle flag/defaults change. Switching reads on later is the existing flag/unrestricted-list step.

Note: the injected opt-in changes the runner's cache key, so the warmed Django-cache row differs from the one raw user reads hit. The durable output of warming an enrolled team is the precompute jobs (shared by query shape), not the result-cache row; this is called out in a comment.

## How did you test this code?

Agent-authored (Claude Code); automated tests in `test_cache_warming.py` (4 passing):

- Enrolled team + web query kind gets the opt-in injected (guards silently killing the evaluation pipeline — no jobs would ever compute) without mutating the input dict.
- Parameterized no-op cases: non-web kinds (injecting would break validation), non-enrolled teams (must warm exactly what users ran), and an explicit opt-out in the replayed shape is preserved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal rollout tooling; behavior documented inline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to a per-team cap-impact analysis showing precompute read cost is highly skewed by team path-cardinality profile, so candidates get evaluated from real production shapes before any read cutover. A first revision added a dedicated shadow-mode setting + celery dispatch; reworked per review preference to reuse the existing enrollment list + warming instance setting instead.

Skill invoked: /writing-tests.
