### PR TITLE
feat(engineering-analytics): make the workflow header chip a switcher dropdown

### DIFF
--- a/products/engineering_analytics/frontend/components/ScopeBar.tsx
+++ b/products/engineering_analytics/frontend/components/ScopeBar.tsx
@@ -3,17 +3,20 @@
 // one page carries to the next.
 
 import { useActions, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 import { Fragment, ReactNode, useState } from 'react'
 
 import { IconX } from '@posthog/icons'
-import { LemonButton, LemonDropdown, LemonInput, LemonSelect, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonDropdown, LemonInput, LemonSelect, Link, Spinner } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { cn } from 'lib/utils/css-classes'
 import { dateMapping } from 'lib/utils/dateFilters'
+import { urls } from 'scenes/urls'
 
 import { SHARED_DEFAULT_DATE_FROM, engineeringAnalyticsFiltersLogic } from '../scenes/engineeringAnalyticsFiltersLogic'
 import { engineeringAnalyticsLogic } from '../scenes/engineeringAnalyticsLogic'
+import { workflowSwitcherLogic } from '../scenes/workflowSwitcherLogic'
 
 // The endpoints require a window start (no "all time") — relative windows + Custom only.
 export const SCOPE_DATE_OPTIONS = dateMapping.filter(({ key }) =>
@@ -31,6 +34,8 @@ export const SCOPE_DATE_OPTIONS = dateMapping.filter(({ key }) =>
 export interface ScopeCrumb {
     label: string
     to?: string
+    /** Custom chip rendering (e.g. the workflow switcher); overrides `to`. `label` stays the key. */
+    node?: ReactNode
 }
 
 export interface LensChip {
@@ -81,6 +86,102 @@ export function RepoScopeChip({ label, to }: { label: string; to: string }): JSX
                 <strong className="font-semibold text-primary">{label}</strong>
             </span>
         </Link>
+    )
+}
+
+/** Workflow crumb that doubles as a switcher: a searchable dropdown of the repo's workflows, loaded
+ *  lazily on first open, navigating to the picked workflow's page. */
+export function WorkflowScopeChip({
+    repoOwner,
+    repoName,
+    workflowName,
+    sourceId,
+}: {
+    repoOwner: string
+    repoName: string
+    workflowName: string
+    sourceId: string | null
+}): JSX.Element {
+    const logic = workflowSwitcherLogic({ repoOwner, repoName, sourceId })
+    const { workflowNames, workflowNamesLoading } = useValues(logic)
+    const { ensureWorkflowsLoaded } = useActions(logic)
+    const [visible, setVisible] = useState(false)
+    const [search, setSearch] = useState('')
+
+    const searchTerm = search.trim().toLowerCase()
+    const options = (workflowNames ?? []).filter((name) => !searchTerm || name.toLowerCase().includes(searchTerm))
+
+    const selectWorkflow = (name: string): void => {
+        setVisible(false)
+        setSearch('')
+        if (name !== workflowName) {
+            router.actions.push(
+                combineUrl(
+                    urls.engineeringAnalyticsWorkflowRuns(repoOwner, repoName, name),
+                    sourceId ? { source: sourceId } : {}
+                ).url
+            )
+        }
+    }
+
+    return (
+        <LemonDropdown
+            visible={visible}
+            onVisibilityChange={(next) => {
+                setVisible(next)
+                if (next) {
+                    ensureWorkflowsLoaded()
+                } else {
+                    setSearch('')
+                }
+            }}
+            closeOnClickInside={false}
+            overlay={
+                <div className="flex w-72 flex-col gap-1 p-1">
+                    <LemonInput
+                        type="search"
+                        size="small"
+                        placeholder="Search workflows…"
+                        value={search}
+                        onChange={setSearch}
+                        autoFocus
+                        data-attr="engineering-analytics-workflow-switcher-search"
+                    />
+                    <div className="max-h-80 overflow-y-auto">
+                        {workflowNamesLoading ? (
+                            <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-secondary">
+                                <Spinner /> Loading workflows…
+                            </div>
+                        ) : options.length > 0 ? (
+                            options.map((name) => (
+                                <LemonButton
+                                    key={name}
+                                    size="small"
+                                    fullWidth
+                                    active={name === workflowName}
+                                    onClick={() => selectWorkflow(name)}
+                                >
+                                    <span className="truncate">{name}</span>
+                                </LemonButton>
+                            ))
+                        ) : (
+                            <div className="px-2 py-1.5 text-xs text-secondary">
+                                {searchTerm ? 'No workflows match.' : 'No workflows in the window.'}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            }
+        >
+            <span
+                className={cn(CHIP_CLASS, 'cursor-pointer')}
+                title="Switch to another workflow in this repository"
+                data-attr="engineering-analytics-workflow-switcher"
+            >
+                <strong className="font-semibold text-primary">{workflowName}</strong>
+                <span className="text-[8px] text-tertiary">▼</span>
+            </span>
+        </LemonDropdown>
     )
 }
 
@@ -181,7 +282,9 @@ export function ScopeBar({
             {crumbs.map((crumb) => (
                 <Fragment key={crumb.label}>
                     <span className="text-xs text-tertiary">›</span>
-                    {crumb.to ? (
+                    {crumb.node ? (
+                        crumb.node
+                    ) : crumb.to ? (
                         <Link to={crumb.to} className="text-[13px] font-medium">
                             {crumb.label}
                         </Link>

--- a/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
@@ -22,7 +22,7 @@ import { JobAggregatesTable } from '../components/JobAggregatesTable'
 import { MetricTile } from '../components/MetricTile'
 import { RunActivityChart } from '../components/RunActivityChart'
 import { RunConclusionTag } from '../components/runTables'
-import { RepoScopeChip, ScopeBar } from '../components/ScopeBar'
+import { RepoScopeChip, ScopeBar, WorkflowScopeChip } from '../components/ScopeBar'
 import { Section, SectionNav } from '../components/Section'
 import { ShareRow } from '../components/ShareRow'
 import type { WorkflowRunnerCostApi } from '../generated/api.schemas'
@@ -287,7 +287,19 @@ export function WorkflowRunsScene(): JSX.Element {
                         to={combineUrl(urls.engineeringAnalytics(), sourceId ? { source: sourceId } : {}).url}
                     />
                 }
-                crumbs={[{ label: workflowName }]}
+                crumbs={[
+                    {
+                        label: workflowName,
+                        node: (
+                            <WorkflowScopeChip
+                                repoOwner={repoOwner}
+                                repoName={repoName}
+                                workflowName={workflowName}
+                                sourceId={sourceId}
+                            />
+                        ),
+                    },
+                ]}
                 showBranch
             />
             <EntityHeader

--- a/products/engineering_analytics/frontend/scenes/workflowSwitcherLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowSwitcherLogic.test.ts
@@ -1,0 +1,59 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { ApiConfig } from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { engineeringAnalyticsWorkflowHealth } from '../generated/api'
+import type { WorkflowHealthItemApi } from '../generated/api.schemas'
+import { workflowSwitcherLogic } from './workflowSwitcherLogic'
+
+jest.mock('../generated/api', () => ({
+    engineeringAnalyticsWorkflowHealth: jest.fn(),
+}))
+
+const mockWorkflowHealth = engineeringAnalyticsWorkflowHealth as jest.MockedFunction<
+    typeof engineeringAnalyticsWorkflowHealth
+>
+
+function healthItem(owner: string, name: string, workflowName: string): WorkflowHealthItemApi {
+    return {
+        repo: { provider: 'github', owner, name },
+        workflow_name: workflowName,
+    } as WorkflowHealthItemApi
+}
+
+describe('workflowSwitcherLogic', () => {
+    let logic: ReturnType<typeof workflowSwitcherLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        ApiConfig.setCurrentProjectId(1)
+        jest.clearAllMocks()
+        mockWorkflowHealth.mockResolvedValue([
+            healthItem('PostHog', 'posthog', 'Frontend CI'),
+            healthItem('PostHog', 'posthog', 'Backend CI'),
+            healthItem('PostHog', 'posthog.com', 'Deploy'),
+        ])
+        logic = workflowSwitcherLogic({ repoOwner: 'PostHog', repoName: 'posthog', sourceId: null })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('loads lazily on first open only, keeping just the workflows of the scoped repo', async () => {
+        // Mounting alone must not fetch — detail pages shouldn't pay for the list until the dropdown opens.
+        expect(mockWorkflowHealth).not.toHaveBeenCalled()
+
+        logic.actions.ensureWorkflowsLoaded()
+        await expectLogic(logic).toDispatchActions(['loadWorkflowNamesSuccess'])
+        expect(logic.values.workflowNames).toEqual(['Frontend CI', 'Backend CI'])
+
+        // Re-opening the dropdown reuses the loaded list.
+        logic.actions.ensureWorkflowsLoaded()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(mockWorkflowHealth).toHaveBeenCalledTimes(1)
+    })
+})

--- a/products/engineering_analytics/frontend/scenes/workflowSwitcherLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowSwitcherLogic.ts
@@ -1,0 +1,61 @@
+// Backs the workflow chip's switcher dropdown: the repo's workflow names, loaded lazily on first open
+// so detail pages don't pay for the list until the user reaches for it.
+
+import { actions, connect, kea, key, listeners, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { ApiConfig } from 'lib/api'
+
+import { engineeringAnalyticsWorkflowHealth } from '../generated/api'
+import { engineeringAnalyticsFiltersLogic } from './engineeringAnalyticsFiltersLogic'
+import type { workflowSwitcherLogicType } from './workflowSwitcherLogicType'
+
+export interface WorkflowSwitcherLogicProps {
+    repoOwner: string
+    repoName: string
+    sourceId: string | null
+}
+
+export const workflowSwitcherLogic = kea<workflowSwitcherLogicType>([
+    path(['products', 'engineering_analytics', 'frontend', 'scenes', 'workflowSwitcherLogic']),
+    props({} as WorkflowSwitcherLogicProps),
+    key(({ repoOwner, repoName, sourceId }) => `${repoOwner}/${repoName}:${sourceId ?? ''}`),
+
+    connect(() => ({
+        values: [engineeringAnalyticsFiltersLogic, ['dateFrom', 'dateTo', 'appliedBranch']],
+    })),
+
+    actions({
+        // Fired when the dropdown opens; loads once per mount instead of on every page view.
+        ensureWorkflowsLoaded: true,
+    }),
+
+    loaders(({ props, values }) => ({
+        // null = never loaded, so an empty result isn't refetched on every open.
+        workflowNames: [
+            null as string[] | null,
+            {
+                loadWorkflowNames: async (): Promise<string[]> => {
+                    const items = await engineeringAnalyticsWorkflowHealth(String(ApiConfig.getCurrentProjectId()), {
+                        date_from: values.dateFrom ?? undefined,
+                        date_to: values.dateTo ?? undefined,
+                        branch: values.appliedBranch || undefined,
+                        source_id: props.sourceId ?? undefined,
+                    })
+                    // Server order (top workflows by run count) — the most active ones surface first.
+                    return items
+                        .filter((it) => it.repo.owner === props.repoOwner && it.repo.name === props.repoName)
+                        .map((it) => it.workflow_name)
+                },
+            },
+        ],
+    })),
+
+    listeners(({ actions, values }) => ({
+        ensureWorkflowsLoaded: () => {
+            if (values.workflowNames === null && !values.workflowNamesLoading) {
+                actions.loadWorkflowNames()
+            }
+        },
+    })),
+])


### PR DESCRIPTION
## Problem

On the engineering analytics workflow page, the scope bar's hierarchy chips read repo › workflow (e.g. `PostHog/posthog › Frontend CI`), but the workflow chip was static text. To look at a different workflow you had to navigate back to the workflows list and drill in again.

## Changes

- The workflow chip in the scope bar is now a dropdown: a searchable list of the repo's workflows that navigates to the picked workflow's page, preserving the `?source=` scope.
- The list is backed by a new `workflowSwitcherLogic`, loaded lazily on the first open so the workflow page doesn't pay for the list until you reach for it. It uses the existing `workflow_health` endpoint with the shared date/branch scope, so the options match what the workflows tab shows.
- `ScopeBar` crumbs accept an optional custom `node`, which the workflow page uses for the switcher. Other pill usages checked and left alone: the repo chip already links back to the hub (or is a source picker on multi-source teams), the branch chip is already a picker, the run detail page's workflow crumb stays a plain link since there it navigates up one level.

## How did you test this code?

- Added `workflowSwitcherLogic.test.ts` covering the regression no existing test catches: the list must not fetch on mount (lazy load on first dropdown open only) and must filter to the scoped repo when the source syncs multiple repos.
- Ran the whole `products/engineering_analytics` jest suite (7 suites, 116 tests, all green), the full frontend TypeScript check, and oxlint/oxfmt on the changed files.
- No manual browser testing was done (no running dev stack in this environment).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code task session). Skills invoked: `/adopting-generated-api-types`, `/writing-tests`.

Direction was to review the header pills on the engineering analytics pages and make the static workflow chip (e.g. "Frontend CI") an actual switcher. I surveyed all `ScopeBar` usages first; only the workflow page's chip was dead text, so the change is scoped to that. Considered mounting the hub's `engineeringAnalyticsLogic` for the list, but its `afterMount` fires four loaders, so a small dedicated keyed logic with lazy loading was chosen instead. The dropdown follows the existing `BranchScopeChip` pattern (LemonDropdown + LemonInput) to stay consistent within the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)