### PR TITLE
fix(sentry): skip tag values pages with unparseable 2xx bodies

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -8,7 +8,7 @@ from urllib.parse import quote, urljoin
 import structlog
 from dateutil import parser as dateutil_parser
 from requests import Request, Response
-from requests.exceptions import HTTPError, RequestException
+from requests.exceptions import HTTPError, JSONDecodeError, RequestException
 from tenacity import RetryCallState, retry, retry_if_exception_type, retry_if_result, stop_after_attempt
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -416,7 +416,22 @@ def _iter_issue_tag_values_rows(
                         )
                         break
                     raise
-                rows = response.json()
+
+                try:
+                    rows = response.json()
+                except JSONDecodeError:
+                    # Sentry occasionally returns a 2xx with an empty/unparseable
+                    # body for a single (issue, tag) values page. Skip this tag's
+                    # remaining values rather than crashing the whole sync — same
+                    # graceful-skip as the persistent 5xx case above.
+                    logger.warning(
+                        "sentry_source.issue_tag_values_invalid_json_skipped",
+                        organization_slug=organization_slug,
+                        issue_id=issue_id,
+                        tag_key=tag_key,
+                        status_code=response.status_code,
+                    )
+                    break
 
                 should_stop = False
                 for row in rows:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from parameterized import parameterized
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, JSONDecodeError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SentrySourceConfig
@@ -555,6 +555,38 @@ class TestSentrySourceValidation:
 
         # The 500 on the "bad tag" values endpoint is skipped; the healthy
         # "browser" tag still yields its values instead of the whole sync crashing.
+        rows = list(cast(Any, resp.items()))
+        assert rows == [{"value": "Chrome", "issue_id": "100", "tag_key": "browser"}]
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_issue_tag_values_skips_tag_on_unparseable_ok_body(self, mock_request) -> None:
+        def side_effect(url, headers=None, params=None, timeout=None):
+            if url.endswith("/organizations/acme/issues/"):
+                return _response([{"id": "100"}])
+            if url.endswith("/organizations/acme/issues/100/tags/"):
+                return _response([{"key": "bad tag"}, {"key": "browser"}])
+            if "tags/bad%20tag/values/" in url:
+                # Sentry returns a 200 with an empty/unparseable body for this tag.
+                bad = _response([])
+                bad.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+                return bad
+            if url.endswith("/organizations/acme/issues/100/tags/browser/values/"):
+                return _response([{"value": "Chrome"}])
+            return _response([])
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        # The unparseable 200 on the "bad tag" values endpoint is skipped; the
+        # healthy "browser" tag still yields its values instead of crashing.
         rows = list(cast(Any, resp.items()))
         assert rows == [{"value": "Chrome", "issue_id": "100", "tag_key": "browser"}]
 


### PR DESCRIPTION
## Problem

The Sentry data-warehouse import can crash with a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` in `_iter_issue_tag_values_rows` (`sentry.py`, at the `response.json()` call in the tag-values loop).

Surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019f37e9-b3da-7f50-be9a-654538e80773

The failure happens after `response.raise_for_status()` has already passed, so it is a 2xx response whose body is empty or otherwise unparseable. Sentry returns this for a single `(issue, tag)` values page. Because the parse was unguarded, one bad page took down the entire `issue_tag_values` sync rather than being contained to that tag.

## Changes

This is a fixable fragility bug, not a user/upstream credential issue, so it belongs in the code rather than `NonRetryableErrors`. The values loop already has an established graceful-skip for the sibling case (a persistent 5xx on the same endpoint skips that tag's remaining values instead of failing the sync). I folded the unparseable-2xx case into that same pattern: catch `JSONDecodeError` around `response.json()`, log a warning with the same context fields, and `break` out of that tag's values pagination. The rest of the sync continues normally.

Scoped strictly to the crashing path. No retry-policy or global behavior changes.

## How did you test this code?

Added `test_issue_tag_values_skips_tag_on_unparseable_ok_body` to `test_sentry.py`. It mocks a values page that returns a 200 whose `.json()` raises `JSONDecodeError`, followed by a healthy tag, and asserts the healthy tag still yields its values instead of the whole sync crashing. No existing test covered a JSON parse failure on a 2xx values response - the nearest one (`test_issue_tag_values_skips_tag_on_persistent_server_error`) exercises the 5xx branch, which is a different code path.

I (Claude) ran the full `test_sentry.py` suite locally (60 passed) plus `ruff check` and `ruff format --check` on both changed files. I did not run a live Sentry import.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) working from an error-tracking inbox report. I confirmed the issue in error tracking (stack frame under the sentry source, `_iter_issue_tag_values_rows`), read the implementation, and judged it a fixable bug rather than an upstream credential error: a 2xx with an empty body is a response shape we should tolerate, not stop retrying over. I chose the existing graceful-skip pattern already used a few lines above for persistent 5xx errors so the fix slots into established behavior rather than introducing a new mechanism. Invoked the `/writing-tests` skill before adding the regression test to apply the value gate.
