### PR TITLE
fix(replay): make set_recorder_script sampling test deterministic

### DIFF
--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -7,7 +7,6 @@ from django.core.management import call_command
 from parameterized import parameterized
 
 from posthog.models import Team
-from posthog.sampling import sample_on_property
 
 
 class TestSetRecorderScriptCommand(BaseTest):
@@ -106,7 +105,15 @@ class TestSetRecorderScriptCommand(BaseTest):
         assert "Sample rate must be between 0.0 and 1.0" in str(cm.exception)
 
     def test_sampling_is_consistent(self):
-        teams = [Team.objects.create(organization=self.organization, name=f"Team {i}") for i in range(100)]
+        # Pin the team IDs the command samples on. Relying on auto-increment IDs makes this flaky:
+        # the sampling hash clumps across consecutive IDs and the starting ID drifts between CI runs
+        # (the DB is reused), so a run of 100 IDs is almost always nearly-all or nearly-none sampled.
+        # These IDs are spread across the hash space so exactly half fall under a 0.5 rate; the golden
+        # values below are precomputed offline from the sampling hash, not re-derived from it at runtime.
+        base, step = 10_000_000, 100_003
+        team_ids = [base + i * step for i in range(100)]
+        for team_id in team_ids:
+            Team.objects.create(id=team_id, organization=self.organization, name=f"Team {team_id}")
 
         call_command(
             "set_recorder_script",
@@ -114,19 +121,15 @@ class TestSetRecorderScriptCommand(BaseTest):
             "--sample-rate=0.5",
         )
 
-        # The command must update exactly the teams that sample_on_property selects for this rate.
-        # Deriving the expected set from the same function keeps the test deterministic regardless of
-        # which auto-increment IDs the teams happen to receive (a fixed statistical band flakes because
-        # the hash clumps across consecutive IDs and the starting ID drifts between CI runs).
-        expected_ids = {team.id for team in teams if sample_on_property(str(team.id), 0.5)}
-        team_ids = [team.id for team in teams]
         updated_ids = set(
             Team.objects.filter(id__in=team_ids, extra_settings__has_key="recorder_script").values_list(
                 "id", flat=True
             )
         )
 
-        assert updated_ids == expected_ids
+        assert len(updated_ids) == 50
+        assert 10_700_021 in updated_ids  # hashes below the 0.5 threshold
+        assert 10_100_003 not in updated_ids  # hashes above the 0.5 threshold
 
     def test_bulk_updates_in_batches(self):
         # Use bulk_create with a shared project to avoid 2500 individual

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -7,6 +7,7 @@ from django.core.management import call_command
 from parameterized import parameterized
 
 from posthog.models import Team
+from posthog.sampling import sample_on_property
 
 
 class TestSetRecorderScriptCommand(BaseTest):
@@ -105,9 +106,7 @@ class TestSetRecorderScriptCommand(BaseTest):
         assert "Sample rate must be between 0.0 and 1.0" in str(cm.exception)
 
     def test_sampling_is_consistent(self):
-        teams = []
-        for i in range(100):
-            teams.append(Team.objects.create(organization=self.organization, name=f"Team {i}"))
+        teams = [Team.objects.create(organization=self.organization, name=f"Team {i}") for i in range(100)]
 
         call_command(
             "set_recorder_script",
@@ -115,9 +114,19 @@ class TestSetRecorderScriptCommand(BaseTest):
             "--sample-rate=0.5",
         )
 
-        updated_teams = Team.objects.filter(extra_settings__has_key="recorder_script").count()
+        # The command must update exactly the teams that sample_on_property selects for this rate.
+        # Deriving the expected set from the same function keeps the test deterministic regardless of
+        # which auto-increment IDs the teams happen to receive (a fixed statistical band flakes because
+        # the hash clumps across consecutive IDs and the starting ID drifts between CI runs).
+        expected_ids = {team.id for team in teams if sample_on_property(str(team.id), 0.5)}
+        team_ids = [team.id for team in teams]
+        updated_ids = set(
+            Team.objects.filter(id__in=team_ids, extra_settings__has_key="recorder_script").values_list(
+                "id", flat=True
+            )
+        )
 
-        assert 30 < updated_teams < 70, f"Expected roughly 50 teams updated, got {updated_teams}"
+        assert updated_ids == expected_ids
 
     def test_bulk_updates_in_batches(self):
         # Use bulk_create with a shared project to avoid 2500 individual


### PR DESCRIPTION
## Problem

`test_set_recorder_script.py::TestSetRecorderScriptCommand::test_sampling_is_consistent` is flaky ([example CI failure](https://github.com/PostHog/posthog/actions/runs/28796679501/job/85405281936?pr=68226): `AssertionError: Expected roughly 50 teams updated, got 20`). It surfaces on unrelated PRs' CI runs.

The test created 100 teams, ran the command at `--sample-rate=0.5`, and asserted a fixed statistical band `30 < updated < 70`. The command samples deterministically via `sample_on_property(str(team.id), rate)`, whose hash (`simple_hash`) clumps heavily across consecutive integer ID strings. Team IDs are consecutive auto-increment values whose starting point drifts run-to-run (the DB is reused across the suite), so a 100-wide window of IDs is almost always nearly all-sampled or nearly none-sampled — only a small minority of starting positions land in a "roughly half" window. The test passed by luck when it did.

## Changes

Pin the team IDs the command samples on instead of leaving them to auto-increment. The test creates 100 teams with a fixed set of IDs spread across the sampling hash space so that exactly half fall under the 0.5 rate, then asserts precomputed golden values: exactly 50 updated, one known-sampled ID present, one known-unsampled ID absent. Those golden values are computed offline from the sampling hash and written as literals, so the test does not re-derive its expectation from the same function under test (not circular) and does not depend on where the ID sequence happens to sit (not up to chance). It still verifies the command's real contract — update exactly the teams the sampling function selects — and the in/out membership checks guard against an inverted condition or sampling on the wrong property. The all-teams path at rate 1.0 remains covered by `test_sets_recorder_script_for_all_teams`.

## How did you test this code?

The Python suite can't run in this environment (no DB/deps), so validation is analytical. A standalone reproduction of the command's selection logic over the pinned ID set confirms the golden values (count 50, `10_700_021` sampled, `10_100_003` not sampled). Team creation with explicit IDs is supported by `TeamManager.create()` and already used elsewhere in the test suite. CI on this PR provides the empirical confirmation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from the linked CI failure and invoked the `/fixing-flaky-tests` skill. Root-caused the flake to `simple_hash` clumping over consecutive team IDs combined with a drifting auto-increment start; quantified it (over 90% of 100-wide ID windows fall outside the old band, and even 1000-wide windows swing 11–79% at some magnitudes, so simply enlarging the sample was rejected as still fragile).

The first iteration derived the expected set from the same `sample_on_property` the command calls; on review feedback that this was circular, it was reworked to pin the team IDs and assert precomputed golden literals instead — deterministic and independent of the function under test. Confirmed explicit-ID Team creation is safe (`TeamManager.create()` auto-creates the coupled `Project` with the same ID) before relying on it.
