### PR TITLE
chore(hogli): frame ci:preflight advisories as owned CI failures

### DIFF
--- a/.agents/skills/running-ci-preflight/SKILL.md
+++ b/.agents/skills/running-ci-preflight/SKILL.md
@@ -26,12 +26,12 @@ hogli ci:preflight --fix
 1. Run with `--fix` — it formats, lints, and auto-fixes what is safe.
 2. Read each line: `✓ pass`, `✗ fail`, `→ advisory` (do it yourself), `· skipped` (capability absent).
 3. Resolve every `✗ fail` — these are what `--fix` could not (real lint error, broken lockfile, migration conflict). These block the push.
-4. Act on every `→ advisory` — e.g. `openapi` advisory → run `hogli build:openapi` and commit the drift; `staleness` advisory → `git merge origin/master`. Advisories never block, but ignoring them ships the failure to CI.
+4. Act on every `→ advisory` — e.g. `openapi` advisory → run `hogli build:openapi` and commit the drift; `staleness` advisory → `git merge origin/master`. Advisories never block, but ignoring them ships the failure to CI. **Resolve them before pushing, including drift you didn't introduce — you own the branch state you push.**
 5. Re-run until clean, then push.
 
 ## Notes
 
-- **Strict = failures only.** `--strict` (what the hook runs) exits non-zero only on `✗ fail` — advisories are unverifiable-locally classes, so they warn without blocking. A clean exit means "nothing left to fix", not "CI will pass" — CI stays the authoritative gate.
+- **Strict = failures only.** `--strict` (what the hook runs) exits non-zero only on `✗ fail` — advisories are unverifiable-locally classes, so they warn without blocking. A clean exit means "nothing left to fix", not "CI will pass" — CI stays the authoritative gate. Non-blocking is a mechanism limit, not permission to skip.
 - **Staleness is risk-based.** It fires when merging master _now_ would actually break something — textual merge conflicts (computed via `git merge-tree`, working tree untouched), migrations added on both sides, generated-file inputs changed on both sides, or CI workflows changed on master — plus a behind/age backstop, aggressive by default (5 commits / 2 days; env-tunable via `HOGLI_PREFLIGHT_STALE_COMMITS`/`HOGLI_PREFLIGHT_STALE_DAYS`) so we over-warn to start and tune down from telemetry. Merge master in when it fires. Advisory only, never auto-merged.
 - **`· skipped (needs stack/node)`** is expected on a bare checkout or sandbox. Start the stack with `hogli start` to run those, or let CI cover them. No hooks in your environment (no `node_modules`)? Run the loop yourself before pushing.
 - **Flags.** `--against <ref>` diffs against an explicit base; `--json` emits a machine-readable summary.

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -187,7 +187,8 @@ def _run_diff_check(chk: DiffCheck, do_fix: bool) -> tuple[Status, str]:
     elif chk.verify is None:
         # Guidance-only (no runnable local check, or its fix needs an absent capability):
         # advise regardless, so the hint still shows on a bare checkout — even with --fix.
-        return "advisory", f"run `{' '.join(chk.fix or [])}` and commit drift"
+        # Ownership framing lives once in the advisory footer, not per check.
+        return "advisory", f"run `{' '.join(chk.fix or [])}` and commit before pushing"
     elif unmet:
         return "skipped", f"needs {', '.join(unmet)}"
     else:
@@ -474,6 +475,13 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
         click.echo(
             f"  summary {json.dumps({k: summary[k] for k in ('changed_files', 'triggered', 'failures', 'mode')})}"
         )
+        if advisories:
+            # Non-blocking, so agents skip these as pre-existing. Restate ownership.
+            click.secho(
+                f"\n  {advisories} advisory(ies) are unpushed CI failures — resolve before pushing, "
+                "including drift you didn't introduce. You own the branch state you push.",
+                fg="yellow",
+            )
         click.echo()
 
     _emit_telemetry(summary)

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -77,7 +77,7 @@ class TestStrictAndFixContracts:
     ) -> None:
         result = runner.invoke(cli, ["ci:preflight", "--fix"])
         assert result.exit_code == 0
-        assert "run `hogli build:openapi` and commit drift" in result.output
+        assert "run `hogli build:openapi` and commit before pushing" in result.output
 
 
 class TestStalenessRisks:


### PR DESCRIPTION
## Problem

`ci:preflight` reports drift like out-of-date OpenAPI types as a `→ advisory`. Advisories don't block the push, and agents keep rationalizing them away — "neither of my commits touches a serializer, so this is pre-existing drift, not my problem" — then push a branch that goes red in CI. The mechanism is fine; the framing let agents opt out of drift they didn't personally introduce.

## Changes

Reframe advisories around ownership of the branch's pushable state, not authorship of the drift:

- New yellow footer when any advisory fires: `N advisory(ies) are unpushed CI failures — resolve before pushing, including drift you didn't introduce. You own the branch state you push.`
- Per-check advisory detail trimmed to just the action (`run \`hogli build:openapi\` and commit before pushing`) so the ownership message lives in exactly one place (the footer), applying generically to every advisory rather than being special-cased per check.
- `running-ci-preflight` skill: step 4 and the "strict = failures only" note now state that non-blocking is a mechanism limit, not permission to skip.

No behavior change to what blocks a push (`--strict` still exits non-zero only on `✗ fail`). This is wording and one generic footer.

## How did you test this code?

The reworded advisory string broke an existing assertion in `test_ci_preflight.py` (`test_fix_without_stack_still_advises_openapi`); updated it to match and confirmed the hogli-commands suite passes. `ruff check` / `ruff format --check` pass, and the pre-push `ci:preflight --strict` hook ran green.


## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl directed this after an agent in a fresh session waved off an OpenAPI-drift advisory as "not my commit." Authored by me (Claude).

- Skills invoked: `/simplify` (caught that the ownership clause was duplicated across the per-check detail and the new footer — collapsed it to the footer only, which is also the right altitude since it covers all advisories generically).
- Considered but rejected: making OpenAPI drift a hard blocking failure when the stack is up. Stronger, but slower and risks false positives from regeneration nondeterminism — out of scope for a framing fix.
- The footer counts `DiffCheck` advisories (currently just `openapi`), not the separately-computed `staleness` advisory, which already prints its own remediation.

