### PR TITLE
fix(wizard): make setup wizard authenticate action session-only

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -31,7 +31,6 @@ from posthog.cloud_utils import get_api_host
 from posthog.exceptions_capture import capture_exception
 from posthog.models import User
 from posthog.models.project import Project
-from posthog.permissions import APIScopePermission
 from posthog.rate_limit import (
     SetupWizardAuthenticationRateThrottle,
     SetupWizardCloudRunBurstRateThrottle,
@@ -126,23 +125,11 @@ class SetupWizardCloudRunResponseSerializer(serializers.Serializer):
 
 
 class SetupWizardViewSet(viewsets.ViewSet):
+    # Actions authenticate themselves: initialize is open, data/query use the wizard hash, and the
+    # session-only actions (authenticate, cloud_run) set their own authentication/permission classes.
     permission_classes = ()
     lookup_field = "hash"
     lookup_url_kwarg = "hash"
-
-    def dangerously_get_permissions(self):
-        # API Level permissions are only required during the authentication step.
-        # For all other actions we use a cache key to authenticate.
-        if self.action == "authenticate":
-            return [IsAuthenticated(), APIScopePermission()]
-
-        raise NotImplementedError()
-
-    def dangerously_get_required_scopes(self):
-        if self.action == "authenticate":
-            return ["project:read"]
-
-        return []
 
     @action(methods=["POST"], detail=False, url_path="initialize")
     def initialize(self, request: Request) -> Response:
@@ -361,6 +348,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         methods=["POST"],
         url_path="authenticate",
         detail=False,
+        authentication_classes=[SessionAuthentication],
+        permission_classes=[IsAuthenticated],
         throttle_classes=[SetupWizardAuthenticationRateThrottle],
     )
     def authenticate(self, request, **kwargs):

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
@@ -6,12 +7,14 @@ from unittest.mock import MagicMock, patch
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from rest_framework import status
 
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
 from posthog.models import Organization, PersonalAPIKey, User
+from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 
@@ -445,6 +448,47 @@ class SetupWizardTests(APIBaseTest):
         self.assertEqual(response_data["code"], "permission_denied")
         self.assertEqual(response_data["detail"], "You don't have access to this project.")
         self.assertEqual(response_data["attr"], "projectId")
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    def test_authenticate_rejects_oauth_token(self):
+        # The setup step exchanges the caller's browser session for a project API key, so it is
+        # session-only. A valid OAuth token (project:read, would authenticate on token-accepting
+        # endpoints) must get 401 here and must not mint a project key into the cache.
+        app = OAuthApplication.objects.create(
+            name="Some OAuth App",
+            redirect_uris="https://example.com/callback",
+            organization=self.organization,
+            user=self.user,
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            algorithm="RS256",
+        )
+        OAuthAccessToken.objects.create(
+            user=self.user,
+            application=app,
+            token="pha_test_wizard_oauth_token",
+            scope="project:read",
+            expires=timezone.now() + timedelta(hours=1),
+        )
+        cache_key = f"{SETUP_WIZARD_CACHE_PREFIX}valid_hash"
+        cache.set(cache_key, {}, SETUP_WIZARD_CACHE_TIMEOUT)
+        self.client.logout()
+
+        response = self.client.post(
+            "/api/wizard/authenticate",
+            data={"hash": "valid_hash", "projectId": self.team.id},
+            format="json",
+            headers={"authorization": "Bearer pha_test_wizard_oauth_token"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertNotIn("project_api_key", cache.get(cache_key))
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
## Problem

The setup wizard's `authenticate` action is the step that exchanges a logged-in user's browser session for a project API key (stashed in the wizard cache). It was relying on `dangerously_get_permissions` / `dangerously_get_required_scopes` to enforce `IsAuthenticated` + a `project:read` scope, but `SetupWizardViewSet` subclasses a plain DRF `ViewSet` (not the PostHog viewset mixin that calls those hooks), so those methods were never invoked. In practice the action fell through to the default `SessionAuthentication` plus the project-visibility check, and the intended permission guard was dead, misleading code.

The endpoint still failed closed (a non-session request was treated as anonymous and rejected by the access check), so this is a hardening + clarity fix rather than an exploitable bypass. Raised while reviewing a report that flagged the wizard viewset's permission handling.

## Changes

- Declare the auth guard explicitly on the `authenticate` action (`authentication_classes=[SessionAuthentication]`, `permission_classes=[IsAuthenticated]`), mirroring the existing `cloud_run` action so a non-session token now gets a proper 401.
- Remove the dead `dangerously_get_permissions` / `dangerously_get_required_scopes` methods and the now-unused `APIScopePermission` import.
- Add a test that a valid OAuth bearer token is rejected with 401 and does not write a project API key into the cache.

## How did you test this code?

Added `test_authenticate_rejects_oauth_token`: mints a valid OAuth access token (with `project:read`), logs out the session, posts to `/api/wizard/authenticate` with the bearer token, and asserts 401 plus that no `project_api_key` lands in the cache. This guards the regression where the setup step starts honoring a non-session token and becomes a way to mint project keys without a browser session — no existing test covered the non-session path (the existing `authenticate` tests all run as a logged-in session, and `test_rejects_personal_api_key_auth` covers the separate `cloud_run` action).

The DB-backed test wasn't run locally (no Postgres in the sandbox); it will run in CI. Ran `ruff check` / `ruff format` and `py_compile` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0ABCF3JEN6/p1783307765936749?thread_ts=1783307765.936749&cid=C0ABCF3JEN6). The ask was to verify whether the wizard setup endpoint accepts OAuth tokens (it should be session-only) and to add a test proving it. Investigation found the endpoint is session-only in effect, but the permission code meant to enforce that was never wired because the viewset subclasses a plain DRF `ViewSet`. Chose to make the guard explicit (matching the sibling `cloud_run` action) rather than leave the misleading dead code, and added the requested regression test.

Skills invoked: `/writing-tests`, `/improving-drf-endpoints`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ABCF3JEN6/p1783307765936749?thread_ts=1783307765.936749&cid=C0ABCF3JEN6)*
