### PR TITLE
fix(data-warehouse): keep incremental cursor config when switching to webhook sync

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_schema.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_schema.py
@@ -697,9 +697,16 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                         or payload.get("incremental_field_last_value") is None
                     )
 
-            if "incremental_field" in data:
+            # Webhook schemas derive their incremental field from the source, so a null here is the
+            # client's "not applicable", not an intentional clear. Writing it would wipe the cursor
+            # config a previous append/incremental sync built up, turning the webhook initial sync
+            # into an unbounded full-history scan with no durable watermark progress.
+            is_webhook_target = resulting_sync_type == ExternalDataSchema.SyncType.WEBHOOK
+            if "incremental_field" in data and not (is_webhook_target and incremental_field is None):
                 payload["incremental_field"] = incremental_field
-            if "incremental_field_type" in data:
+            if "incremental_field_type" in data and not (
+                is_webhook_target and data.get("incremental_field_type") is None
+            ):
                 payload["incremental_field_type"] = data.get("incremental_field_type")
 
             # Lookback only applies to incremental — merge-by-PK makes re-reading the overlap window

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -1414,6 +1414,7 @@ class TestExternalDataSchema(APIBaseTest):
                 "incremental_field": "created",
                 "incremental_field_type": "integer",
                 "incremental_field_last_value": 1000,
+                "incremental_field_earliest_value": 500,
             },
             table=table,
         )
@@ -1437,9 +1438,12 @@ class TestExternalDataSchema(APIBaseTest):
                 return_value=mock_hog_fn_result,
             ),
         ):
+            # The frontend sends null incremental fields alongside the switch — they must not
+            # wipe the cursor config, or the webhook initial sync degrades to an unbounded
+            # full-history scan with no durable watermark progress.
             response = self.client.patch(
                 f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"sync_type": "webhook"},
+                data={"sync_type": "webhook", "incremental_field": None, "incremental_field_type": None},
             )
 
             assert response.status_code == 200
@@ -1452,6 +1456,7 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("incremental_field") == "created"
             assert schema.sync_type_config.get("incremental_field_type") == "integer"
             assert schema.sync_type_config.get("incremental_field_last_value") == 1000
+            assert schema.sync_type_config.get("incremental_field_earliest_value") == 500
 
     def test_update_schema_change_sync_type_incremental_field(self):
         source = ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

Switching a warehouse schema's sync type to webhook silently destroys its incremental cursor configuration. The frontend sends `incremental_field: null` and `incremental_field_type: null` alongside the switch (webhook has no incremental-field picker), and the schema serializer writes those nulls into `sync_type_config` verbatim.

That wipe breaks the webhook initial sync in two compounding ways:

1. With a null field type, the stored watermarks process to `None`, so the source falls back to an unbounded full-history scan instead of bounded `created[gt]`/`created[lt]` windowed queries.
2. Without an `incremental_field`, the per-batch watermark persistence never runs, so a failed job loses all scan progress (the Redis resume state is scoped to a single job).

On accounts with a large history the initial sync then never completes within one job's retry budget, `initial_sync_complete` never flips true, webhook ingestion never activates, and the schema fails every scheduled run with `activity Heartbeat timeout`. Observed in production on a Stripe `Invoice` schema that went append → webhook.

## Changes

In `ExternalDataSchemaSerializer.update`, ignore incoming null `incremental_field` / `incremental_field_type` when the resulting sync type is webhook. Webhook schemas derive their incremental field from the source (for example Stripe's `APPEND_ONLY_INCREMENTAL_FIELDS`), so a null there is the client's "not applicable", not an intentional clear. Explicit non-null values still apply, and incremental/append/CDC behavior is unchanged.

No schema shape change, no migration, no frontend change.

## How did you test this code?

Extended the existing `test_update_schema_to_webhook_does_not_reset_pipeline` (append and incremental variants) to send the nulls the frontend actually sends, and to assert the cursor keys survive, including `incremental_field_earliest_value`. This catches the exact regression: before the fix both variants fail with the config wiped, after the fix they pass. Verified by stashing the serializer change and re-running.

Also ran the full `products/data_warehouse/backend/tests/api/test_external_data_schema.py` suite (126 passed) and `hogli ci:preflight --fix`.

I did not manually test the UI flow.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the null-handling of this internal transition; sync type docs remain accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). The bug was found during a production investigation of a Stripe schema stuck in a heartbeat-timeout loop: Grafana Loki run logs showed the live `sync_type_config` with `incremental_field: None` after a sync-type switch, which traced back to the serializer writing request nulls verbatim.
- Skills invoked: `/improving-drf-endpoints` before editing the serializer, `/writing-tests` before touching the test file, plus the warehouse sync diagnosis skills during the investigation.
- Decisions: chose to guard only the webhook target rather than ignoring nulls for all sync types, since explicit nulls may be meaningful for incremental/append; extended the existing parameterized switch-to-webhook test instead of adding a new one, since it exercised the same path minus the null payload.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
