### PR TITLE
chore(test): assert recorder-script sampling against a fixed expected set

### DIFF
--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -107,13 +107,18 @@ class TestSetRecorderScriptCommand(BaseTest):
     def test_samples_the_expected_teams_at_rate_0_5(self):
         # Fixed ids are required: sample_on_property now hashes into 10000 buckets (was 100 before
         # #68598 raised the resolution so sub-1% rates stop truncating to zero). At that finer
-        # resolution a block of consecutive auto-increment ids lands almost all-or-nothing mod 10000,
-        # so the old "roughly 50 of 100 sampled" assertion flipped to 0 or 100 depending on the id
-        # block CI happened to assign. These fixed ids give a stable split, and the expected set below
-        # is derived independently of the command's sampling code: for these 100 ids
-        # simple_hash(id) % 10000 lands under 5000 for ids 9_400_000..9_400_079 and at/above it for
-        # the last 20. Asserting against this precomputed 80/20 split (rather than re-deriving it with
-        # sample_on_property) proves the command samples correctly, not merely that it matches itself.
+        # resolution a block of consecutive ids lands almost all-or-nothing mod 10000. The old test
+        # created its 100 teams with Team.objects.create(), drawing from the Postgres id sequence,
+        # which is not rolled back between tests, so the block's starting id drifted run-to-run. Under
+        # the old %100 every possible block spread ~40-55/100 and passed "roughly 50 sampled"; under
+        # %10000 only a small fraction of blocks land in that range, so the same assertion passed or
+        # failed purely on which id block a run happened to draw (which is why it went green on #68598
+        # and started failing later). These fixed ids remove that dependency and give a stable split,
+        # and the expected set below is derived independently of the command's sampling code: for these
+        # 100 ids simple_hash(id) % 10000 lands under 5000 for ids 9_400_000..9_400_079 and at/above it
+        # for the last 20. Asserting against this precomputed 80/20 split (rather than re-deriving it
+        # with sample_on_property) proves the command samples correctly, not merely that it matches
+        # itself.
         Team.objects.bulk_create(
             [
                 Team(id=9_400_000 + i, organization=self.organization, project=self.project, name=f"Team {i}")

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -105,11 +105,15 @@ class TestSetRecorderScriptCommand(BaseTest):
         assert "Sample rate must be between 0.0 and 1.0" in str(cm.exception)
 
     def test_samples_the_expected_teams_at_rate_0_5(self):
-        # Fixed ids give a deterministic split at rate 0.5. The expected set below is derived
-        # independently of the command's sampling code: for these 100 ids, simple_hash(id) % 10000
-        # lands under 5000 for ids 9_400_000..9_400_079 and at/above it for the last 20. Asserting
-        # against this precomputed 80/20 split (rather than re-deriving it with sample_on_property)
-        # proves the command applies sampling correctly, not merely that it matches itself.
+        # Fixed ids are required: sample_on_property now hashes into 10000 buckets (was 100 before
+        # #68598 raised the resolution so sub-1% rates stop truncating to zero). At that finer
+        # resolution a block of consecutive auto-increment ids lands almost all-or-nothing mod 10000,
+        # so the old "roughly 50 of 100 sampled" assertion flipped to 0 or 100 depending on the id
+        # block CI happened to assign. These fixed ids give a stable split, and the expected set below
+        # is derived independently of the command's sampling code: for these 100 ids
+        # simple_hash(id) % 10000 lands under 5000 for ids 9_400_000..9_400_079 and at/above it for
+        # the last 20. Asserting against this precomputed 80/20 split (rather than re-deriving it with
+        # sample_on_property) proves the command samples correctly, not merely that it matches itself.
         Team.objects.bulk_create(
             [
                 Team(id=9_400_000 + i, organization=self.organization, project=self.project, name=f"Team {i}")

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -132,8 +132,15 @@ class TestSetRecorderScriptCommand(BaseTest):
             "--sample-rate=0.5",
         )
 
+        # Scope to this block's ids: BaseTest's self.team also has no recorder_script and may sample
+        # true at 0.5, so an unscoped query would leak it into updated_ids.
+        created_ids = range(9_400_000, 9_400_100)
         expected_ids = set(range(9_400_000, 9_400_080))
-        updated_ids = set(Team.objects.filter(extra_settings__has_key="recorder_script").values_list("id", flat=True))
+        updated_ids = set(
+            Team.objects.filter(extra_settings__has_key="recorder_script", id__in=created_ids).values_list(
+                "id", flat=True
+            )
+        )
 
         assert updated_ids == expected_ids
 

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -7,7 +7,6 @@ from django.core.management import call_command
 from parameterized import parameterized
 
 from posthog.models import Team
-from posthog.sampling import sample_on_property
 
 
 class TestSetRecorderScriptCommand(BaseTest):
@@ -105,9 +104,12 @@ class TestSetRecorderScriptCommand(BaseTest):
 
         assert "Sample rate must be between 0.0 and 1.0" in str(cm.exception)
 
-    def test_sampling_is_consistent(self):
-        # simple_hash maps consecutive decimal ids into a narrow band mod 10000, so a sequence-assigned
-        # id block usually samples all-or-nothing; fixed ids give a deterministic 80/20 split at rate 0.5.
+    def test_samples_the_expected_teams_at_rate_0_5(self):
+        # Fixed ids give a deterministic split at rate 0.5. The expected set below is derived
+        # independently of the command's sampling code: for these 100 ids, simple_hash(id) % 10000
+        # lands under 5000 for ids 9_400_000..9_400_079 and at/above it for the last 20. Asserting
+        # against this precomputed 80/20 split (rather than re-deriving it with sample_on_property)
+        # proves the command applies sampling correctly, not merely that it matches itself.
         Team.objects.bulk_create(
             [
                 Team(id=9_400_000 + i, organization=self.organization, project=self.project, name=f"Team {i}")
@@ -121,13 +123,10 @@ class TestSetRecorderScriptCommand(BaseTest):
             "--sample-rate=0.5",
         )
 
-        all_ids = set(Team.objects.values_list("id", flat=True))
-        expected_ids = {team_id for team_id in all_ids if sample_on_property(str(team_id), 0.5)}
+        expected_ids = set(range(9_400_000, 9_400_080))
         updated_ids = set(Team.objects.filter(extra_settings__has_key="recorder_script").values_list("id", flat=True))
 
         assert updated_ids == expected_ids
-        # Both sides non-empty proves the command actually filtered rather than updating none or all.
-        assert updated_ids and all_ids - updated_ids
 
     def test_bulk_updates_in_batches(self):
         # Use bulk_create with a shared project to avoid 2500 individual


### PR DESCRIPTION
## Problem

`test_set_recorder_script.py`'s sampling test started failing, and the test itself hadn't meaningfully changed in months. Root cause: **#68598** ("stop truncating sub-1% sampling rates to zero") raised `sample_on_property`'s resolution from `simple_hash(x) % 100 < int(pct*100)` to `% 10000 < round(pct*10000)`. That change is correct and intended — it is *not* a product bug and the command still samples real teams correctly.

The old test created 100 teams with `Team.objects.create()` (drawing sequential ids from the Postgres sequence) and asserted "roughly 50 of 100 sampled" at rate 0.5. Consecutive ids hash into a narrow band, so:
- at the old `% 100` resolution every possible block spread ~40–55/100 → always inside the `30 < updated < 70` assertion (stable for months)
- at the new `% 10000` resolution the same block lands almost all-or-nothing → only ~8% of possible id blocks fall inside `30 < updated < 70`; the rest are 0 or ~100

So we are not masking a regression — the test's statistical assumption only held at the coarser resolution.

### Why didn't the test fail on #68598's own CI?

It did run there (full 24-shard Django suite, all green) — it passed **by luck**. Because the id sequence is not rolled back between tests, the sampled block's starting id drifts run-to-run depending on how many teams earlier tests in the shard created. Under the old formula *any* block passed; under the new formula only ~8% do. #68598's run drew a passing block; subsequent master runs (different test set, different sequence position) drew failing ones. That sequence-dependence is exactly the latent flakiness this PR removes.

A fix already landed on master using fixed ids, but it derived `expected_ids` by calling `sample_on_property` — the same function the command uses — making it a tautology (`sample_on_property(x) == sample_on_property(x)`).

## Changes

Keep the fixed-id approach (stable, non all-or-nothing split, no dependency on the runtime id sequence) but assert against a **precomputed** 80/20 expected set — ids `9_400_000..9_400_079` at rate 0.5 — derived independently of the command's sampling code. This actually catches a broken `sample_on_property` (unlike the tautology) and is deterministic (unlike the old `30 < x < 70`). The test no longer imports `sample_on_property`.

## How did you test this code?

Reproduced the root cause with a standalone reproduction of `simple_hash`/`sample_on_property`: across 200k starting ids, a 100-consecutive block gives ~40–55/100 under `% 100` (always passes) but only ~8% of blocks land in `30 < x < 70` under `% 10000` (~84% go all-or-nothing) — matching the observed flake and the green-on-#68598 / red-later behavior. The expected 80/20 split for the fixed ids was computed the same way before hardcoding it. The Django-backed test could not be executed in the agent environment (no database reachable), so it was not run here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app. First pass addressed Robbie's note that the landed fix tested the sampling function against itself. Follow-up investigation (prompted by Paul asking whether `sample_on_property` was broken, and why CI didn't catch it on the changing PR) traced the failure to #68598's intended resolution bump plus the test's reliance on the non-rolled-back id sequence — confirming the test assumption, not the product code, was the fragile part. Invoked `/writing-tests`. Kept the fixed-id idea, replaced the self-referential expectation with an independently-derived constant set, and documented the root cause and the "why it passed on #68598" mechanism in the test comment.
