### PR TITLE
fix(postgres): propagate permission-denied from the duplicate-PK probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2065,6 +2065,12 @@ def _has_duplicate_primary_keys(
         return row is not None
     except psycopg.errors.QueryCanceled:
         raise
+    except psycopg.errors.InsufficientPrivilege:
+        # The sync role can't SELECT this table (SQLSTATE 42501, "permission denied for table").
+        # Swallowing it as "no duplicate keys" would be a false negative, and the extraction that
+        # follows fails on the same denial — already surfaced as non-retryable with an actionable
+        # message via `get_non_retryable_errors`. Propagate rather than capture it as noise.
+        raise
     except psycopg.OperationalError:
         # A connection-level failure here (e.g. a foreign-data-wrapper server refusing a new
         # connection with "too many connections") means the probe never ran — swallowing it as

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4937,6 +4937,19 @@ class TestHasDuplicatePrimaryKeys:
         assert result is False
         mock_capture.assert_called_once()
 
+    def test_reraises_permission_denied_without_capturing(self):
+        logger = structlog.get_logger()
+        cursor = MagicMock()
+        # The sync role lacks SELECT on the table (SQLSTATE 42501). This is already non-retryable
+        # via get_non_retryable_errors, so the probe must propagate it, not capture it as noise.
+        cursor.execute.side_effect = psycopg.errors.InsufficientPrivilege("permission denied for table orders")
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
+        ) as mock_capture:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
+        mock_capture.assert_not_called()
+
 
 class TestIsReadReplica:
     @pytest.mark.django_db

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -18,6 +18,7 @@ from django.db import (
 import psycopg
 import pyarrow as pa
 import structlog
+from parameterized import parameterized
 from psycopg import sql
 
 import products.warehouse_sources.backend.temporal.data_imports.sources.postgres.partitioned_tables as partitioned_tables_pkg
@@ -4908,21 +4909,39 @@ class TestHasDuplicatePrimaryKeys:
             result = _has_duplicate_primary_keys(cast(Any, dj_cursor), "public", "test_dup_table", ["id"], logger)
             assert result is True
 
-    def test_reraises_connection_errors_without_capturing(self):
+    @parameterized.expand(
+        [
+            # postgres_fdw surfaces a saturated foreign server while executing the probe query: the
+            # remote connection couldn't be established, so the probe never ran. Transient, stays
+            # retryable — re-raised as its OperationalError base.
+            (
+                "connection_error",
+                psycopg.errors.SqlclientUnableToEstablishSqlconnection(
+                    'could not connect to server "posthog_fdw_payment"\n'
+                    'DETAIL:  connection to server at "10.0.0.1", port 5432 failed: '
+                    'FATAL:  too many connections for role "posthog_fdw_reader"'
+                ),
+                psycopg.OperationalError,
+            ),
+            # The sync role lacks SELECT on the table (SQLSTATE 42501). Already non-retryable via
+            # get_non_retryable_errors, so the probe must propagate it rather than capture it.
+            (
+                "permission_denied",
+                psycopg.errors.InsufficientPrivilege("permission denied for table orders"),
+                psycopg.errors.InsufficientPrivilege,
+            ),
+        ]
+    )
+    def test_reraises_without_capturing(self, _name, side_effect, expected_exception):
+        # A probe failure that means the query never ran, or that is already non-retryable, must
+        # propagate — not be swallowed as "no duplicate keys" and captured as error-tracking noise.
         logger = structlog.get_logger()
         cursor = MagicMock()
-        # postgres_fdw surfaces a saturated foreign server while executing the probe query: the
-        # remote connection couldn't be established, so the probe never ran. This must propagate
-        # (transient, stays retryable), not be swallowed as "no duplicate keys" + captured as noise.
-        cursor.execute.side_effect = psycopg.errors.SqlclientUnableToEstablishSqlconnection(
-            'could not connect to server "posthog_fdw_payment"\n'
-            'DETAIL:  connection to server at "10.0.0.1", port 5432 failed: '
-            'FATAL:  too many connections for role "posthog_fdw_reader"'
-        )
+        cursor.execute.side_effect = side_effect
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
         ) as mock_capture:
-            with pytest.raises(psycopg.OperationalError):
+            with pytest.raises(expected_exception):
                 _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
         mock_capture.assert_not_called()
 
@@ -4936,19 +4955,6 @@ class TestHasDuplicatePrimaryKeys:
             result = _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
         assert result is False
         mock_capture.assert_called_once()
-
-    def test_reraises_permission_denied_without_capturing(self):
-        logger = structlog.get_logger()
-        cursor = MagicMock()
-        # The sync role lacks SELECT on the table (SQLSTATE 42501). This is already non-retryable
-        # via get_non_retryable_errors, so the probe must propagate it, not capture it as noise.
-        cursor.execute.side_effect = psycopg.errors.InsufficientPrivilege("permission denied for table orders")
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
-        ) as mock_capture:
-            with pytest.raises(psycopg.errors.InsufficientPrivilege):
-                _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
-        mock_capture.assert_not_called()
 
 
 class TestIsReadReplica:


### PR DESCRIPTION
## Problem

Error tracking surfaced a stream of `InsufficientPrivilege: permission denied for table <name>` exceptions from the Postgres import source, raised in `_has_duplicate_primary_keys` at `postgres.py:2062` ([issue](https://us.posthog.com/project/2/error_tracking/019f3832-09bf-7a31-a59a-af4b89a79697)). The events are marked `handled: true` — they were captured via `capture_exception`, not raised as a failure.

`_has_duplicate_primary_keys` is a best-effort probe run during table setup. When the connecting role lacks `SELECT` on the table (SQLSTATE 42501), the probe query fails. `InsufficientPrivilege` is a `ProgrammingError`, not a `QueryCanceled` or `OperationalError`, so it fell through to the generic `except Exception` handler, which called `capture_exception` and returned `False`.

That's wrong on two counts. Returning "no duplicate keys" off a table we can't read is a false negative, and the permission denial is already handled: `get_non_retryable_errors` matches both `InsufficientPrivilege` and `permission denied for` and stops retrying with an actionable "grant the role SELECT" message. So we were logging the same condition as noise right before the pipeline surfaces it correctly downstream.

## Changes

Re-raise `InsufficientPrivilege` from the probe instead of capturing it, mirroring the existing `QueryCanceled` and `OperationalError` re-raises in the same function (both re-raised because swallowing them would be a false negative). The exception then propagates to the activity's retry path, where the existing non-retryable classification surfaces the actionable message. No change to retry policy, and genuine query-incompatibility errors (e.g. `UndefinedColumn`) still degrade to best-effort as before.

## How did you test this code?

Added `test_reraises_permission_denied_without_capturing`, which asserts the probe propagates `InsufficientPrivilege` and does not call `capture_exception`. It sits alongside the existing `test_reraises_connection_errors_without_capturing` (connection errors) and `test_captures_and_returns_false_on_non_connection_error` (genuine query-incompat still captured), so the three together pin the full classification.

Ran the mock-based tests in `TestHasDuplicatePrimaryKeys` locally — the new test and its two siblings pass. The DB-backed tests in that class need a live Postgres and couldn't run in my sandbox (host doesn't resolve). Ruff check and format are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude. I pulled the issue's stack trace and representative events over MCP, confirmed the failure originates in `_has_duplicate_primary_keys` (not just serialized log context), and traced the call path to confirm a re-raised exception reaches the already-existing non-retryable classification. I considered simply not capturing and returning `False`, but that leaves a false negative and delays the inevitable non-retryable failure — re-raising fails fast with the correct actionable message and matches the function's existing intent. Invoked `/writing-tests` guidance for the regression test.
