### PR TITLE
feat(data-modeling): add cross-team fleet endpoints to internal ops API

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -547,9 +547,9 @@ urlpatterns = [
         "api/internal/data_modeling_ops/endpoints/<str:endpoint_id>",
         csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoint_detail"})),
     ),
-    # Cross-team (fleet) routes for the modeling-ops admin app. Same OIDC auth as the
-    # team-scoped routes; the api/internal/data_modeling_ops prefix must be 403'd by
-    # Contour at the edge before these deploy.
+    # Fleet views for the same app: aggregates and cross-team searches that answer a
+    # question about the estate rather than about one entity. Same namespace and OIDC
+    # auth as the routes above.
     path(
         "api/internal/data_modeling_ops/teams",
         csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_teams"})),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -47,11 +47,14 @@ from posthog.temporal.codec_server import decode_payloads
 
 from products.ai_observability.backend.api.personal_spend import PersonalSpendEUProxyViewSet
 from products.cdp.backend.api import hog_function_template
-from products.data_modeling.backend.facade.internal_ops import InternalDataModelingOpsViewSet
+from products.data_modeling.backend.facade.internal_ops import (
+    InternalDataModelingOpsFleetViewSet,
+    InternalDataModelingOpsViewSet,
+)
 from products.data_warehouse.backend.presentation.views.public_source_configs import PublicSourceConfigViewSet
 from products.demo.backend.facade.api import demo_route
 from products.early_access_features.backend.api import early_access_features
-from products.endpoints.backend.facade.internal_ops import InternalEndpointsOpsViewSet
+from products.endpoints.backend.facade.internal_ops import InternalEndpointsOpsFleetViewSet, InternalEndpointsOpsViewSet
 from products.legal_documents.backend.presentation.webhook import legal_document_pandadoc_webhook
 from products.messaging.backend.api.customerio_webhook import CustomerIOWebhookView
 from products.messaging.backend.api.push_subscriptions import push_subscriptions
@@ -543,6 +546,33 @@ urlpatterns = [
     path(
         "api/internal/data_modeling_ops/endpoints/<str:endpoint_id>",
         csrf_exempt(InternalEndpointsOpsViewSet.as_view({"get": "internal_endpoint_detail"})),
+    ),
+    # Cross-team (fleet) routes for the modeling-ops admin app. Same OIDC auth as the
+    # team-scoped routes; the api/internal/data_modeling_ops prefix must be 403'd by
+    # Contour at the edge before these deploy.
+    path(
+        "api/internal/data_modeling_ops/teams",
+        csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_teams"})),
+    ),
+    path(
+        "api/internal/data_modeling_ops/migration_matrix",
+        csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_migration_matrix"})),
+    ),
+    path(
+        "api/internal/data_modeling_ops/orphans",
+        csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_orphans"})),
+    ),
+    path(
+        "api/internal/data_modeling_ops/failing_schedules",
+        csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_failing_schedules"})),
+    ),
+    path(
+        "api/internal/data_modeling_ops/duplicates",
+        csrf_exempt(InternalDataModelingOpsFleetViewSet.as_view({"get": "internal_duplicates"})),
+    ),
+    path(
+        "api/internal/data_modeling_ops/resolve",
+        csrf_exempt(InternalEndpointsOpsFleetViewSet.as_view({"get": "internal_resolve"})),
     ),
     # Test setup endpoint (only available in TEST mode)
     path("api/setup_test/<str:test_name>/", csrf_exempt(playwright_setup.setup_test)),

--- a/products/data_modeling/backend/facade/fleet_ops.py
+++ b/products/data_modeling/backend/facade/fleet_ops.py
@@ -1,0 +1,35 @@
+"""Facade over logic/fleet_ops.py and the fleet slice of logic/schedule_truth.py for the
+data_modeling_ops cross-team internal API. Consumed by this product's presentation layer
+and the endpoints product's internal ops views."""
+
+from products.data_modeling.backend.logic.fleet_ops import (
+    FAILING_SAVED_QUERY_CAP,
+    classify_migration,
+    dag_ids_by_team,
+    failing_saved_query_rows,
+    find_duplicate_backing_tables,
+    find_multi_dag_saved_queries,
+    find_orphaned_schedules,
+    find_unscheduled_entities,
+    group_failing_by_schedule,
+    modeling_team_ids,
+    resolve_entity,
+    team_activity_rows,
+)
+from products.data_modeling.backend.logic.schedule_truth import list_data_modeling_schedules
+
+__all__ = [
+    "FAILING_SAVED_QUERY_CAP",
+    "classify_migration",
+    "dag_ids_by_team",
+    "failing_saved_query_rows",
+    "find_duplicate_backing_tables",
+    "find_multi_dag_saved_queries",
+    "find_orphaned_schedules",
+    "find_unscheduled_entities",
+    "group_failing_by_schedule",
+    "list_data_modeling_schedules",
+    "modeling_team_ids",
+    "resolve_entity",
+    "team_activity_rows",
+]

--- a/products/data_modeling/backend/facade/internal_ops.py
+++ b/products/data_modeling/backend/facade/internal_ops.py
@@ -10,6 +10,8 @@ from products.data_modeling.backend.presentation.internal_auth import (
     DataModelingOpsAuthenticationMixin,
     DataModelingOpsOIDCAuthentication,
 )
+from products.data_modeling.backend.presentation.internal_fleet_views import InternalDataModelingOpsFleetViewSet
+from products.data_modeling.backend.presentation.internal_serializers import InternalResolveMatchSerializer
 from products.data_modeling.backend.presentation.internal_views import (
     InternalDataModelingOpsViewSet,
     scoped_to_team,
@@ -19,7 +21,9 @@ from products.data_modeling.backend.presentation.internal_views import (
 __all__ = [
     "DataModelingOpsAuthenticationMixin",
     "DataModelingOpsOIDCAuthentication",
+    "InternalDataModelingOpsFleetViewSet",
     "InternalDataModelingOpsViewSet",
     "scoped_to_team",
     "team_id_filter",
+    "InternalResolveMatchSerializer",
 ]

--- a/products/data_modeling/backend/logic/fleet_ops.py
+++ b/products/data_modeling/backend/logic/fleet_ops.py
@@ -1,0 +1,491 @@
+"""Cross-team (fleet) reads for the data_modeling_ops internal API.
+
+Pure DB aggregation — Temporal state comes in as arguments (see logic/schedule_truth.py)
+so each request performs at most one namespace listing. All queries here are genuinely
+cross-team: this backs a staff-only ops surface, not customer requests.
+"""
+
+import uuid
+from typing import Any
+
+from django.db.models import Count, Q
+
+from products.data_modeling.backend.models import DAG, DataModelingJob, DataModelingJobStatus, Node
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+
+# Bound fleet sweeps so one request cannot scan unbounded job history.
+FAILING_SAVED_QUERY_CAP = 500
+UNSCHEDULED_SCAN_CAP = 2000
+FAILING_JOBS_SCAN_CAP = 10_000
+RESOLVE_MATCH_CAP = 50
+
+
+def modeling_team_ids() -> list[int]:
+    """Teams with any data-modeling footprint: a saved query or a DAG."""
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    saved_query_teams = (
+        DataWarehouseSavedQuery.objects.exclude(deleted=True)
+        .exclude(team_id__isnull=True)
+        .values_list("team_id", flat=True)
+        .distinct()
+    )
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    dag_teams = DAG.objects.exclude(team_id__isnull=True).values_list("team_id", flat=True).distinct()
+    return sorted({*saved_query_teams, *dag_teams})
+
+
+def team_activity_rows(team_ids: list[int]) -> dict[int, dict[str, Any]]:
+    """Per-team entity counts for the given teams."""
+    rows: dict[int, dict[str, Any]] = {
+        team_id: {
+            "team_id": team_id,
+            "saved_query_count": 0,
+            "materialized_saved_query_count": 0,
+            "failing_saved_query_count": 0,
+            "saved_queries_with_sync_frequency_count": 0,
+            "endpoint_origin_saved_query_count": 0,
+            "dag_count": 0,
+        }
+        for team_id in team_ids
+    }
+    saved_query_counts = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataWarehouseSavedQuery.objects.filter(team_id__in=team_ids)
+        .exclude(deleted=True)
+        .values("team_id")
+        .annotate(
+            total=Count("id"),
+            materialized=Count("id", filter=Q(is_materialized=True)),
+            failing=Count("id", filter=Q(status=DataWarehouseSavedQuery.Status.FAILED)),
+            with_sync_frequency=Count("id", filter=Q(sync_frequency_interval__isnull=False)),
+            endpoint_origin=Count("id", filter=Q(origin=DataWarehouseSavedQuery.Origin.ENDPOINT)),
+        )
+    )
+    for entry in saved_query_counts:
+        row = rows[entry["team_id"]]
+        row["saved_query_count"] = entry["total"]
+        row["materialized_saved_query_count"] = entry["materialized"]
+        row["failing_saved_query_count"] = entry["failing"]
+        row["saved_queries_with_sync_frequency_count"] = entry["with_sync_frequency"]
+        row["endpoint_origin_saved_query_count"] = entry["endpoint_origin"]
+
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for entry in DAG.objects.filter(team_id__in=team_ids).values("team_id").annotate(total=Count("id")):
+        rows[entry["team_id"]]["dag_count"] = entry["total"]
+    return rows
+
+
+def classify_migration(
+    *,
+    has_dags: bool,
+    v2_flag_enabled: bool,
+    v2_schedule_present: bool,
+    sync_frequencies_remaining: int,
+) -> str:
+    """Label a team's position across the three migration switches (flag A, v2 schedule B,
+    nulled sync_frequency_interval C)."""
+    if not has_dags and not v2_schedule_present:
+        return "no_dags"
+    if v2_schedule_present:
+        if not v2_flag_enabled:
+            return "v2_scheduled_flag_excluded"
+        if sync_frequencies_remaining > 0:
+            return "v2_scheduled_cleanup_pending"
+        return "fully_v2"
+    if not v2_flag_enabled:
+        return "v1_flag_excluded"
+    return "not_migrated"
+
+
+def dag_ids_by_team(team_ids: list[int]) -> dict[int, list[str]]:
+    result: dict[int, list[str]] = {team_id: [] for team_id in team_ids}
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for team_id, dag_id in DAG.objects.filter(team_id__in=team_ids).values_list("team_id", "id"):
+        result[team_id].append(str(dag_id))
+    return result
+
+
+def find_orphaned_schedules(schedules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Schedules whose owning entity no longer exists: v1 schedule id with no live saved
+    query, v2 schedule id with no DAG. The read-only twin of
+    delete_orphaned_saved_query_schedules, plus the execute-dag direction it lacks."""
+    v1_ids = {s["schedule_id"] for s in schedules if s["kind"] == "v1_saved_query"}
+    v2_ids = {s["schedule_id"] for s in schedules if s["kind"] == "v2_dag"}
+
+    live_saved_query_ids = {
+        str(pk)
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        for pk in DataWarehouseSavedQuery.objects.filter(id__in=_valid_uuids(v1_ids))
+        .exclude(deleted=True)
+        .values_list("id", flat=True)
+    }
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    live_dag_ids = {str(pk) for pk in DAG.objects.filter(id__in=_valid_uuids(v2_ids)).values_list("id", flat=True)}
+
+    orphaned = []
+    for schedule in schedules:
+        if schedule["kind"] == "v1_saved_query" and schedule["schedule_id"] not in live_saved_query_ids:
+            orphaned.append(schedule)
+        elif schedule["kind"] == "v2_dag" and schedule["schedule_id"] not in live_dag_ids:
+            orphaned.append(schedule)
+    return orphaned
+
+
+def find_unscheduled_entities(schedules: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """Materialized saved queries with no covering Temporal schedule — neither their own
+    v1 schedule nor a v2 schedule on any DAG they have a node in. The scan is capped at
+    UNSCHEDULED_SCAN_CAP rows; the second return value reports whether it was cut off."""
+    v1_ids = {s["schedule_id"] for s in schedules if s["kind"] == "v1_saved_query"}
+    v2_ids = {s["schedule_id"] for s in schedules if s["kind"] == "v2_dag"}
+
+    materialized = list(
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataWarehouseSavedQuery.objects.filter(is_materialized=True)
+        .exclude(deleted=True)
+        .order_by("team_id", "name")
+        .values("id", "team_id", "name", "is_materialized", "sync_frequency_interval", "last_run_at")[
+            :UNSCHEDULED_SCAN_CAP
+        ]
+    )
+    saved_query_ids = [entry["id"] for entry in materialized]
+    node_dags: dict[uuid.UUID, list[str]] = {}
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for saved_query_id, dag_id in Node.objects.filter(saved_query_id__in=saved_query_ids).values_list(
+        "saved_query_id", "dag_id"
+    ):
+        node_dags.setdefault(saved_query_id, []).append(str(dag_id))
+
+    unscheduled = []
+    for entry in materialized:
+        dag_ids = node_dags.get(entry["id"], [])
+        if str(entry["id"]) in v1_ids or any(dag_id in v2_ids for dag_id in dag_ids):
+            continue
+        unscheduled.append(
+            {
+                "team_id": entry["team_id"],
+                "saved_query_id": str(entry["id"]),
+                "name": entry["name"],
+                "is_materialized": entry["is_materialized"],
+                "sync_frequency_interval": entry["sync_frequency_interval"],
+                "last_run_at": entry["last_run_at"],
+                "dag_ids": dag_ids,
+            }
+        )
+    return unscheduled, len(materialized) == UNSCHEDULED_SCAN_CAP
+
+
+def find_multi_dag_saved_queries() -> list[dict[str, Any]]:
+    """Saved queries with nodes in more than one DAG — double-materialized every cycle."""
+    duplicated = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        Node.objects.filter(saved_query_id__isnull=False)
+        .values("saved_query_id")
+        .annotate(dag_count=Count("dag_id", distinct=True))
+        .filter(dag_count__gt=1)
+    )
+    saved_query_ids = [entry["saved_query_id"] for entry in duplicated]
+    if not saved_query_ids:
+        return []
+
+    dags_by_saved_query: dict[uuid.UUID, list[dict[str, str]]] = {}
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for node in Node.objects.filter(saved_query_id__in=saved_query_ids).select_related("dag").order_by("dag__name"):
+        if node.saved_query_id is None:
+            continue
+        dags_by_saved_query.setdefault(node.saved_query_id, []).append(
+            {"dag_id": str(node.dag_id), "dag_name": node.dag.name}
+        )
+
+    results = []
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for saved_query in DataWarehouseSavedQuery.objects.filter(id__in=saved_query_ids).order_by("team_id", "name"):
+        results.append(
+            {
+                "team_id": saved_query.team_id,
+                "saved_query_id": str(saved_query.id),
+                "name": saved_query.name,
+                "is_materialized": saved_query.is_materialized,
+                "dags": dags_by_saved_query.get(saved_query.id, []),
+            }
+        )
+    return results
+
+
+def find_duplicate_backing_tables() -> list[dict[str, Any]]:
+    """Saved queries with more than one same-named DataWarehouseTable in their team —
+    the orphaned-duplicate-backing-table regression class."""
+    duplicated_names = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataWarehouseTable.objects.exclude(deleted=True)
+        .values("team_id", "name")
+        .annotate(table_count=Count("id"))
+        .filter(table_count__gt=1)
+    )
+    pairs = {(entry["team_id"], entry["name"]) for entry in duplicated_names}
+    if not pairs:
+        return []
+
+    name_filter = Q()
+    for team_id, name in pairs:
+        name_filter |= Q(team_id=team_id, name=name)
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    saved_queries = (
+        DataWarehouseSavedQuery.objects.filter(name_filter).exclude(deleted=True).order_by("team_id", "name")
+    )
+
+    tables_by_pair: dict[tuple[int, str], list[DataWarehouseTable]] = {}
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for table in DataWarehouseTable.objects.filter(name_filter).exclude(deleted=True).order_by("created_at"):
+        tables_by_pair.setdefault((table.team_id, table.name), []).append(table)
+
+    results = []
+    for saved_query in saved_queries:
+        results.append(
+            {
+                "team_id": saved_query.team_id,
+                "saved_query_id": str(saved_query.id),
+                "name": saved_query.name,
+                "linked_table_id": str(saved_query.table_id) if saved_query.table_id else None,
+                "tables": tables_by_pair.get((saved_query.team_id, saved_query.name), []),
+            }
+        )
+    return results
+
+
+def failing_saved_query_rows() -> list[dict[str, Any]]:
+    """Saved queries currently in FAILED status, with per-engine consecutive-failure
+    counts derived from recent job history (jobs are the primary failure signal; the
+    engine split keeps duck-shadow jobs from polluting the serving engine's count)."""
+    failing = list(
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataWarehouseSavedQuery.objects.filter(status=DataWarehouseSavedQuery.Status.FAILED)
+        .exclude(deleted=True)
+        .order_by("team_id", "name")[:FAILING_SAVED_QUERY_CAP]
+    )
+    if not failing:
+        return []
+
+    jobs = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataModelingJob.objects.filter(saved_query_id__in=[saved_query.id for saved_query in failing])
+        .order_by("-created_at")
+        .values("saved_query_id", "engine", "status", "error", "created_at")[:FAILING_JOBS_SCAN_CAP]
+    )
+    # Jobs arrive newest-first; a per-engine streak stops counting at that engine's
+    # first non-FAILED job.
+    consecutive: dict[uuid.UUID, dict[str, int]] = {}
+    streak_open: dict[tuple[uuid.UUID, str], bool] = {}
+    last_failed_at: dict[uuid.UUID, Any] = {}
+    for job in jobs:
+        key = (job["saved_query_id"], job["engine"])
+        if job["status"] == DataModelingJobStatus.FAILED:
+            if streak_open.setdefault(key, True):
+                per_engine = consecutive.setdefault(job["saved_query_id"], {})
+                per_engine[job["engine"]] = per_engine.get(job["engine"], 0) + 1
+            last_failed_at.setdefault(job["saved_query_id"], job["created_at"])
+        elif job["status"] != DataModelingJobStatus.RUNNING:
+            streak_open[key] = False
+
+    node_context: dict[uuid.UUID, list[dict[str, Any]]] = {}
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    for node in Node.objects.filter(saved_query_id__in=[saved_query.id for saved_query in failing]):
+        if node.saved_query_id is None:
+            continue
+        node_context.setdefault(node.saved_query_id, []).append(
+            {
+                "node_id": str(node.id),
+                "dag_id": str(node.dag_id),
+                "suspended": (node.properties or {}).get("system", {}).get("suspended"),
+            }
+        )
+
+    rows = []
+    for saved_query in failing:
+        rows.append(
+            {
+                "team_id": saved_query.team_id,
+                "saved_query_id": str(saved_query.id),
+                "name": saved_query.name,
+                "latest_error": saved_query.latest_error,
+                "last_run_at": saved_query.last_run_at,
+                "last_failed_job_at": last_failed_at.get(saved_query.id),
+                "consecutive_failures_by_engine": consecutive.get(saved_query.id, {}),
+                "nodes": node_context.get(saved_query.id, []),
+            }
+        )
+    return rows
+
+
+def group_failing_by_schedule(rows: list[dict[str, Any]], schedules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group failing saved queries under the Temporal schedule that covers them: their own
+    v1 schedule, a v2 schedule on one of their DAGs, or an 'unscheduled' bucket."""
+    by_id = {s["schedule_id"]: s for s in schedules}
+    groups: dict[tuple[str | None, int | None], dict[str, Any]] = {}
+    for row in rows:
+        schedule = by_id.get(row["saved_query_id"])
+        if schedule is None:
+            for node in row["nodes"]:
+                dag_schedule = by_id.get(node["dag_id"])
+                if dag_schedule is not None and dag_schedule["kind"] == "v2_dag":
+                    schedule = dag_schedule
+                    break
+        schedule_id = schedule["schedule_id"] if schedule else None
+        # Unscheduled rows bucket per team so one group never mixes teams.
+        group = groups.setdefault(
+            (schedule_id, None if schedule_id else row["team_id"]),
+            {
+                "schedule_id": schedule_id,
+                "schedule_kind": schedule["kind"] if schedule else "none",
+                "paused": schedule["paused"] if schedule else None,
+                "team_id": row["team_id"],
+                "affected_saved_queries": [],
+            },
+        )
+        group["affected_saved_queries"].append(row)
+    return sorted(groups.values(), key=lambda group: (group["schedule_id"] is None, str(group["schedule_id"])))
+
+
+def resolve_entity(kind: str, query: str) -> list[dict[str, Any]]:
+    """Typed search across all teams for data_modeling entities. Returns match dicts of
+    {kind, team_id, id, name, detail}; empty when nothing matches."""
+    if kind == "saved_query":
+        return _resolve_saved_query(query)
+    if kind == "dag":
+        return _resolve_dag(query)
+    if kind == "node":
+        return _resolve_node(query)
+    if kind == "job":
+        return _resolve_job(query)
+    if kind == "schedule":
+        return _resolve_saved_query(query) + _resolve_dag(query)
+    if kind == "workflow":
+        return _resolve_workflow(query)
+    if kind == "name":
+        return _resolve_name(query)
+    raise ValueError(f"Unknown kind: {kind}")
+
+
+def _valid_uuids(values: set[str] | list[str]) -> list[str]:
+    valid = []
+    for value in values:
+        try:
+            uuid.UUID(value)
+        except (ValueError, AttributeError, TypeError):
+            continue
+        valid.append(value)
+    return valid
+
+
+def _resolve_saved_query(query: str) -> list[dict[str, Any]]:
+    if not _valid_uuids([query]):
+        return []
+    return [
+        {
+            "kind": "saved_query",
+            "team_id": saved_query.team_id,
+            "id": str(saved_query.id),
+            "name": saved_query.name,
+            "detail": {"deleted": bool(saved_query.deleted), "status": saved_query.status},
+        }
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        for saved_query in DataWarehouseSavedQuery.objects.filter(id=query)
+    ]
+
+
+def _resolve_dag(query: str) -> list[dict[str, Any]]:
+    if not _valid_uuids([query]):
+        return []
+    return [
+        {
+            "kind": "dag",
+            "team_id": dag.team_id,
+            "id": str(dag.id),
+            "name": dag.name,
+            "detail": {},
+        }
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        for dag in DAG.objects.filter(id=query)
+    ]
+
+
+def _resolve_node(query: str) -> list[dict[str, Any]]:
+    if not _valid_uuids([query]):
+        return []
+    return [
+        {
+            "kind": "node",
+            "team_id": node.team_id,
+            "id": str(node.id),
+            "name": node.name,
+            "detail": {
+                "dag_id": str(node.dag_id),
+                "saved_query_id": str(node.saved_query_id) if node.saved_query_id else None,
+            },
+        }
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        for node in Node.objects.filter(id=query)
+    ]
+
+
+def _resolve_job(query: str) -> list[dict[str, Any]]:
+    if not _valid_uuids([query]):
+        return []
+    return [
+        {
+            "kind": "job",
+            "team_id": job.team_id,
+            "id": str(job.id),
+            "name": job.workflow_id or "",
+            "detail": {
+                "saved_query_id": str(job.saved_query_id) if job.saved_query_id else None,
+                "status": job.status,
+                "engine": job.engine,
+            },
+        }
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        for job in DataModelingJob.objects.filter(id=query)
+    ]
+
+
+def _resolve_workflow(query: str) -> list[dict[str, Any]]:
+    jobs = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataModelingJob.objects.filter(Q(workflow_id=query) | Q(parent_workflow_id=query)).order_by("-created_at")[
+            :RESOLVE_MATCH_CAP
+        ]
+    )
+    return [
+        {
+            "kind": "job",
+            "team_id": job.team_id,
+            "id": str(job.id),
+            "name": job.workflow_id or "",
+            "detail": {
+                "saved_query_id": str(job.saved_query_id) if job.saved_query_id else None,
+                "status": job.status,
+                "engine": job.engine,
+            },
+        }
+        for job in jobs
+    ]
+
+
+def _resolve_name(query: str) -> list[dict[str, Any]]:
+    matches = (
+        # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+        DataWarehouseSavedQuery.objects.filter(name__icontains=query)
+        .exclude(deleted=True)
+        .order_by("name")[:RESOLVE_MATCH_CAP]
+    )
+    results = [
+        {
+            "kind": "saved_query",
+            "team_id": saved_query.team_id,
+            "id": str(saved_query.id),
+            "name": saved_query.name,
+            "detail": {"status": saved_query.status, "is_materialized": saved_query.is_materialized},
+        }
+        for saved_query in matches
+    ]
+    return sorted(results, key=lambda match: (match["name"].lower() != query.lower(), match["name"]))

--- a/products/data_modeling/backend/logic/schedule_truth.py
+++ b/products/data_modeling/backend/logic/schedule_truth.py
@@ -93,6 +93,55 @@ def _iso_or_none(value: Any) -> str | None:
     return value.isoformat() if value is not None else None
 
 
+def _listing_search_attributes(listing: Any) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    typed = getattr(getattr(listing, "typed_search_attributes", None), "search_attributes", None) or []
+    for pair in typed:
+        key_name = getattr(getattr(pair, "key", None), "name", None)
+        if key_name:
+            attributes[key_name] = pair.value
+    return attributes
+
+
+@async_to_sync
+async def list_data_modeling_schedules() -> list[dict[str, Any]]:
+    """List every data-modeling Temporal schedule in the namespace, flattened.
+
+    One unscoped listing per call, client-filtered to the two data-modeling workflows —
+    the same sweep the orphan-cleanup management command performs. Search attributes are
+    informational (old schedules predate the backfill); classification is by workflow name.
+    """
+    temporal = await async_connect()
+    schedules: list[dict[str, Any]] = []
+    async for listing in await temporal.list_schedules():
+        action = getattr(getattr(listing, "schedule", None), "action", None)
+        workflow_name = getattr(action, "workflow", None)
+        kind = classify_workflow(workflow_name)
+        if kind == "other":
+            continue
+        state = getattr(getattr(listing, "schedule", None), "state", None)
+        info = getattr(listing, "info", None)
+        next_action_times = getattr(info, "next_action_times", None) or []
+        search_attributes = _listing_search_attributes(listing)
+        try:
+            team_id: int | None = int(search_attributes["PostHogTeamId"])
+        except (KeyError, TypeError, ValueError):
+            team_id = None
+        schedules.append(
+            {
+                "schedule_id": listing.id,
+                "workflow_name": workflow_name,
+                "kind": kind,
+                "paused": getattr(state, "paused", None),
+                "note": getattr(state, "note", None),
+                "next_run_at": _iso_or_none(next_action_times[0]) if next_action_times else None,
+                "team_id": team_id,
+                "search_attributes": search_attributes,
+            }
+        )
+    return schedules
+
+
 @async_to_sync
 async def describe_schedules(schedule_ids: list[str]) -> dict[str, dict[str, Any] | None]:
     """Describe many schedules concurrently; NOT_FOUND maps to None.

--- a/products/data_modeling/backend/presentation/internal_fleet_views.py
+++ b/products/data_modeling/backend/presentation/internal_fleet_views.py
@@ -1,0 +1,216 @@
+"""Cross-team (fleet) read-only internal API for the modeling-ops admin app.
+
+Routes are wired manually in posthog/urls.py under ``api/internal/data_modeling_ops/``.
+Contour must 403 that prefix at the edge before these deploy (charts PR); locally there
+is no Contour so they are directly reachable against ./bin/start. Authenticated with
+OIDC ID tokens — see internal_auth.py.
+"""
+
+from typing import Any
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.documentation import _FallbackSerializer
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models import Team
+
+from products.data_modeling.backend.facade.fleet_ops import (
+    classify_migration,
+    dag_ids_by_team,
+    failing_saved_query_rows,
+    find_duplicate_backing_tables,
+    find_multi_dag_saved_queries,
+    find_orphaned_schedules,
+    find_unscheduled_entities,
+    group_failing_by_schedule,
+    list_data_modeling_schedules,
+    modeling_team_ids,
+    team_activity_rows,
+)
+from products.data_modeling.backend.facade.schedule_truth import SCHEDULE_CANDIDATE_CAP, describe_schedules
+from products.data_modeling.backend.presentation.internal_auth import DataModelingOpsAuthenticationMixin
+from products.data_modeling.backend.presentation.internal_serializers import (
+    InternalDuplicateBackingTableGroupSerializer,
+    InternalFailingScheduleGroupSerializer,
+    InternalFleetTeamSerializer,
+    InternalMigrationMatrixRowSerializer,
+    InternalMultiDagSavedQuerySerializer,
+    InternalOrphanedScheduleSerializer,
+    InternalUnscheduledEntitySerializer,
+)
+from products.data_modeling.backend.presentation.internal_views import _is_v2_backend_enabled_for_team
+
+DEFAULT_PAGE_LIMIT = 50
+MAX_PAGE_LIMIT = 100
+
+
+def _page_params(request: Request) -> tuple[int, int]:
+    try:
+        limit = min(int(request.query_params.get("limit", DEFAULT_PAGE_LIMIT)), MAX_PAGE_LIMIT)
+        offset = max(int(request.query_params.get("offset", 0)), 0)
+    except ValueError:
+        return DEFAULT_PAGE_LIMIT, 0
+    return max(limit, 1), offset
+
+
+def _teams_by_id(team_ids: list[int]) -> dict[int, Team]:
+    return {team.id: team for team in Team.objects.filter(id__in=team_ids)}
+
+
+class InternalDataModelingOpsFleetViewSet(
+    DataModelingOpsAuthenticationMixin, TeamAndOrgViewSetMixin, viewsets.GenericViewSet
+):
+    """Cross-team read-only endpoints for the modeling-ops admin app.
+
+    Authenticated with OIDC ID tokens only (no session/PAT/OAuth fallback); not exposed
+    through Contour ingress.
+    """
+
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+
+    @extend_schema(exclude=True)
+    def internal_teams(self, request: Request, **kwargs: Any) -> Response:
+        limit, offset = _page_params(request)
+        all_team_ids = modeling_team_ids()
+        page_ids = all_team_ids[offset : offset + limit]
+        rows = team_activity_rows(page_ids)
+        teams = _teams_by_id(page_ids)
+        for team_id, row in rows.items():
+            team = teams.get(team_id)
+            row["team_name"] = team.name if team else None
+            row["organization_id"] = str(team.organization_id) if team else None
+        serializer = InternalFleetTeamSerializer([rows[team_id] for team_id in page_ids], many=True)
+        return Response({"results": serializer.data, "count": len(all_team_ids), "limit": limit, "offset": offset})
+
+    @extend_schema(exclude=True)
+    def internal_migration_matrix(self, request: Request, **kwargs: Any) -> Response:
+        limit, offset = _page_params(request)
+        team_ids_param = request.query_params.get("team_ids")
+        if team_ids_param:
+            try:
+                all_team_ids: list[int] = sorted({int(value) for value in team_ids_param.split(",")})
+            except ValueError:
+                return Response({"error": "team_ids must be a comma-separated list of integers"}, status=400)
+        else:
+            all_team_ids = modeling_team_ids()
+        page_ids = all_team_ids[offset : offset + limit]
+
+        rows = team_activity_rows(page_ids)
+        teams = _teams_by_id(page_ids)
+        dag_ids = dag_ids_by_team(page_ids)
+
+        # Describe candidate DAG schedules individually — independent of the
+        # search-attribute backfill state, same trade-off as the team schedules route.
+        all_dag_ids = [dag_id for ids in dag_ids.values() for dag_id in ids]
+        truncated = len(all_dag_ids) > SCHEDULE_CANDIDATE_CAP
+        temporal_error: str | None = None
+        try:
+            descriptions = describe_schedules(all_dag_ids[:SCHEDULE_CANDIDATE_CAP])
+        except Exception as error:
+            # Switches A and C are DB/flag facts; keep them visible and null out B.
+            descriptions = {}
+            temporal_error = str(error)
+        v2_scheduled_dag_ids = {
+            schedule_id for schedule_id, info in descriptions.items() if info is not None and info["kind"] == "v2_dag"
+        }
+
+        results = []
+        for team_id in page_ids:
+            team = teams.get(team_id)
+            switch_a = _is_v2_backend_enabled_for_team(team) if team else False
+            switch_b: bool | None = (
+                None if temporal_error else any(dag_id in v2_scheduled_dag_ids for dag_id in dag_ids[team_id])
+            )
+            switch_c_remaining = rows[team_id]["saved_queries_with_sync_frequency_count"]
+            results.append(
+                {
+                    "team_id": team_id,
+                    "team_name": team.name if team else None,
+                    "switch_a_v2_flag_enabled": switch_a,
+                    "switch_b_v2_schedule_present": switch_b,
+                    "switch_c_sync_frequencies_remaining": switch_c_remaining,
+                    "dag_count": rows[team_id]["dag_count"],
+                    # Without switch B (Temporal down) any label would be a guess.
+                    "classification": (
+                        classify_migration(
+                            has_dags=bool(dag_ids[team_id]),
+                            v2_flag_enabled=switch_a,
+                            v2_schedule_present=switch_b,
+                            sync_frequencies_remaining=switch_c_remaining,
+                        )
+                        if switch_b is not None
+                        else None
+                    ),
+                }
+            )
+        serializer = InternalMigrationMatrixRowSerializer(results, many=True)
+        return Response(
+            {
+                "results": serializer.data,
+                "count": len(all_team_ids),
+                "limit": limit,
+                "offset": offset,
+                "truncated": truncated,
+                "temporal_error": temporal_error,
+            }
+        )
+
+    @extend_schema(exclude=True)
+    def internal_orphans(self, request: Request, **kwargs: Any) -> Response:
+        direction = request.query_params.get("direction", "both")
+        if direction not in ("schedules", "entities", "both"):
+            return Response({"error": "direction must be one of schedules, entities, both"}, status=400)
+
+        try:
+            schedules = list_data_modeling_schedules()
+        except Exception as error:
+            # Orphan detection is meaningless without the Temporal listing.
+            return Response({"error": f"Temporal unreachable: {error}"}, status=503)
+        payload: dict[str, Any] = {"schedule_count": len(schedules)}
+        if direction in ("schedules", "both"):
+            payload["schedules_without_entity"] = InternalOrphanedScheduleSerializer(
+                find_orphaned_schedules(schedules), many=True
+            ).data
+        if direction in ("entities", "both"):
+            unscheduled, scan_capped = find_unscheduled_entities(schedules)
+            payload["entities_without_schedule"] = InternalUnscheduledEntitySerializer(unscheduled, many=True).data
+            payload["unscheduled_scan_capped"] = scan_capped
+        return Response(payload)
+
+    @extend_schema(exclude=True)
+    def internal_failing_schedules(self, request: Request, **kwargs: Any) -> Response:
+        rows = failing_saved_query_rows()
+        temporal_error: str | None = None
+        try:
+            schedules = list_data_modeling_schedules()
+        except Exception as error:
+            # Failure rows come from the DB; degrade to an 'unscheduled' grouping rather
+            # than hiding failing models behind a Temporal outage.
+            schedules = []
+            temporal_error = str(error)
+        groups = group_failing_by_schedule(rows, schedules)
+        serializer = InternalFailingScheduleGroupSerializer(groups, many=True)
+        return Response(
+            {
+                "results": serializer.data,
+                "failing_saved_query_count": len(rows),
+                "temporal_error": temporal_error,
+            }
+        )
+
+    @extend_schema(exclude=True)
+    def internal_duplicates(self, request: Request, **kwargs: Any) -> Response:
+        return Response(
+            {
+                "multi_dag_saved_queries": InternalMultiDagSavedQuerySerializer(
+                    find_multi_dag_saved_queries(), many=True
+                ).data,
+                "duplicate_backing_tables": InternalDuplicateBackingTableGroupSerializer(
+                    find_duplicate_backing_tables(), many=True
+                ).data,
+            }
+        )

--- a/products/data_modeling/backend/presentation/internal_fleet_views.py
+++ b/products/data_modeling/backend/presentation/internal_fleet_views.py
@@ -41,7 +41,7 @@ from products.data_modeling.backend.presentation.internal_serializers import (
     InternalOrphanedScheduleSerializer,
     InternalUnscheduledEntitySerializer,
 )
-from products.data_modeling.backend.presentation.internal_views import _is_v2_backend_enabled_for_team
+from products.data_modeling.backend.presentation.internal_views import _is_v2_backend_enabled
 
 DEFAULT_PAGE_LIMIT = 50
 MAX_PAGE_LIMIT = 100
@@ -121,7 +121,7 @@ class InternalDataModelingOpsFleetViewSet(
         results = []
         for team_id in page_ids:
             team = teams.get(team_id)
-            switch_a = _is_v2_backend_enabled_for_team(team) if team else False
+            switch_a = _is_v2_backend_enabled(team.id, str(team.organization_id)) if team else False
             switch_b: bool | None = (
                 None if temporal_error else any(dag_id in v2_scheduled_dag_ids for dag_id in dag_ids[team_id])
             )

--- a/products/data_modeling/backend/presentation/internal_serializers.py
+++ b/products/data_modeling/backend/presentation/internal_serializers.py
@@ -315,8 +315,10 @@ class InternalMigrationMatrixRowSerializer(serializers.Serializer):
             "v1_flag_excluded",
             "no_dags",
         ],
+        allow_null=True,
         help_text="Derived label across the three switches; v2_scheduled_flag_excluded is the "
-        "'Sync now' storm cohort (scheduled on v2 but excluded from the v2 flag).",
+        "'Sync now' storm cohort (scheduled on v2 but excluded from the v2 flag). Null when "
+        "Temporal was unreachable — switch B is unknown, so no label would be trustworthy.",
     )
 
 

--- a/products/data_modeling/backend/presentation/internal_serializers.py
+++ b/products/data_modeling/backend/presentation/internal_serializers.py
@@ -273,6 +273,157 @@ class InternalEdgeSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class InternalFleetTeamSerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team with data-modeling activity.")
+    team_name = serializers.CharField(allow_null=True, help_text="Team name, null if the team row is gone.")
+    organization_id = serializers.CharField(allow_null=True, help_text="Owning organization id.")
+    saved_query_count = serializers.IntegerField(help_text="Non-deleted saved queries.")
+    materialized_saved_query_count = serializers.IntegerField(help_text="Saved queries that are materialized.")
+    failing_saved_query_count = serializers.IntegerField(help_text="Saved queries whose last run failed.")
+    saved_queries_with_sync_frequency_count = serializers.IntegerField(
+        help_text="Saved queries still carrying a v1 sync_frequency_interval (migration switch C not cleaned)."
+    )
+    endpoint_origin_saved_query_count = serializers.IntegerField(
+        help_text="Saved queries created by endpoint materialization."
+    )
+    dag_count = serializers.IntegerField(help_text="Number of DAGs.")
+
+
+class InternalMigrationMatrixRowSerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team the switch states describe.")
+    team_name = serializers.CharField(allow_null=True, help_text="Team name, null if the team row is gone.")
+    switch_a_v2_flag_enabled = serializers.BooleanField(
+        help_text="Flag data-modeling-backend-v2 for this team. The flag is an exclusion list: "
+        "false means the team is excluded from the v2 backend."
+    )
+    switch_b_v2_schedule_present = serializers.BooleanField(
+        allow_null=True,
+        help_text="Whether any of the team's DAGs has a live v2 execute-dag Temporal schedule; "
+        "null when Temporal was unreachable (see temporal_error).",
+    )
+    switch_c_sync_frequencies_remaining = serializers.IntegerField(
+        help_text="Saved queries still carrying sync_frequency_interval — nonzero after a v2 "
+        "migration means cleanup never finished."
+    )
+    dag_count = serializers.IntegerField(help_text="Number of DAGs.")
+    classification = serializers.ChoiceField(
+        choices=[
+            "fully_v2",
+            "v2_scheduled_flag_excluded",
+            "v2_scheduled_cleanup_pending",
+            "not_migrated",
+            "v1_flag_excluded",
+            "no_dags",
+        ],
+        help_text="Derived label across the three switches; v2_scheduled_flag_excluded is the "
+        "'Sync now' storm cohort (scheduled on v2 but excluded from the v2 flag).",
+    )
+
+
+class InternalOrphanedScheduleSerializer(serializers.Serializer):
+    schedule_id = serializers.CharField(help_text="Temporal schedule id with no live owning entity.")
+    workflow_name = serializers.CharField(allow_null=True, help_text="Workflow the schedule starts.")
+    kind = serializers.ChoiceField(
+        choices=["v1_saved_query", "v2_dag"],
+        help_text="v1_saved_query: schedule id is a deleted saved query; v2_dag: a deleted DAG.",
+    )
+    paused = serializers.BooleanField(allow_null=True, help_text="Whether the schedule is paused.")
+    note = serializers.CharField(allow_null=True, help_text="Operator note on the schedule state, if any.")
+    next_run_at = serializers.CharField(allow_null=True, help_text="Next scheduled action time (ISO), if any.")
+    team_id = serializers.IntegerField(
+        allow_null=True,
+        help_text="Team from the PostHogTeamId search attribute; null on schedules predating the backfill.",
+    )
+
+
+class InternalUnscheduledEntitySerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team owning the unscheduled entity.")
+    saved_query_id = serializers.CharField(help_text="Materialized saved query with no covering schedule.")
+    name = serializers.CharField(help_text="Saved query name.")
+    is_materialized = serializers.BooleanField(help_text="Always true today; kept for future entity kinds.")
+    sync_frequency_interval = serializers.DurationField(
+        allow_null=True, help_text="Residual v1 cadence, if any — a hint the v1 schedule went missing."
+    )
+    last_run_at = serializers.DateTimeField(allow_null=True, help_text="Last recorded run.")
+    dag_ids = serializers.ListField(
+        child=serializers.CharField(), help_text="DAGs this saved query has nodes in (none of them scheduled)."
+    )
+
+
+class InternalFailingSavedQuerySerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team owning the failing saved query.")
+    saved_query_id = serializers.CharField(help_text="Failing saved query id.")
+    name = serializers.CharField(help_text="Saved query name.")
+    latest_error = serializers.CharField(allow_null=True, help_text="Full latest error text, untruncated.")
+    last_run_at = serializers.DateTimeField(allow_null=True, help_text="Last recorded run.")
+    last_failed_job_at = serializers.DateTimeField(
+        allow_null=True, help_text="Creation time of the most recent FAILED job."
+    )
+    consecutive_failures_by_engine = serializers.DictField(
+        child=serializers.IntegerField(),
+        help_text="Consecutive FAILED jobs per engine, newest-first, streak broken by that engine's "
+        "first non-failed job. Engine-split so duck-shadow jobs don't pollute the serving count.",
+    )
+    nodes = serializers.ListField(
+        child=serializers.JSONField(),
+        help_text="Node context: node_id, dag_id, and suspension state from node system properties "
+        "(headroom for the per-node circuit breaker).",
+    )
+
+
+class InternalFailingScheduleGroupSerializer(serializers.Serializer):
+    schedule_id = serializers.CharField(
+        allow_null=True, help_text="Covering Temporal schedule id; null when nothing covers the entities."
+    )
+    schedule_kind = serializers.ChoiceField(
+        choices=["v1_saved_query", "v2_dag", "none"],
+        help_text="Classification of the covering schedule by workflow name.",
+    )
+    paused = serializers.BooleanField(allow_null=True, help_text="Whether the covering schedule is paused.")
+    team_id = serializers.IntegerField(help_text="Team owning the affected entities.")
+    affected_saved_queries = InternalFailingSavedQuerySerializer(
+        many=True, help_text="Failing saved queries hanging off this schedule."
+    )
+
+
+class InternalMultiDagSavedQuerySerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team owning the saved query.")
+    saved_query_id = serializers.CharField(help_text="Saved query with nodes in more than one DAG.")
+    name = serializers.CharField(help_text="Saved query name.")
+    is_materialized = serializers.BooleanField(help_text="Whether the saved query is materialized.")
+    dags = serializers.ListField(
+        child=serializers.JSONField(), help_text="The DAGs it appears in: dag_id + dag_name each."
+    )
+
+
+class InternalDuplicateBackingTableGroupSerializer(serializers.Serializer):
+    team_id = serializers.IntegerField(help_text="Team owning the saved query and tables.")
+    saved_query_id = serializers.CharField(help_text="Saved query whose name matches multiple backing tables.")
+    name = serializers.CharField(help_text="Shared saved query / table name.")
+    linked_table_id = serializers.CharField(
+        allow_null=True, help_text="Table the saved query's table FK points at; the others are orphans."
+    )
+    tables = serializers.SerializerMethodField(help_text="All same-named tables, oldest first, with is_linked.")
+
+    def get_tables(self, group: dict) -> list[dict]:
+        return list(
+            InternalBackingTableSerializer(
+                group["tables"], many=True, context={"linked_table_id": group["linked_table_id"]}
+            ).data
+        )
+
+
+class InternalResolveMatchSerializer(serializers.Serializer):
+    kind = serializers.ChoiceField(
+        choices=["saved_query", "endpoint", "dag", "node", "job"],
+        help_text="Entity kind the match resolved to (schedule/workflow/name queries resolve to these).",
+    )
+    team_id = serializers.IntegerField(allow_null=True, help_text="Owning team.")
+    id = serializers.CharField(help_text="Entity id.")
+    name = serializers.CharField(allow_blank=True, help_text="Entity name, when it has one.")
+    detail = serializers.JSONField(help_text="Kind-specific extras (status, dag_id, saved_query_id, ...).")
+
+
 class InternalTeamOverviewSerializer(serializers.Serializer):
     team_id = serializers.IntegerField(help_text="Team the overview describes.")
     v2_backend_enabled = serializers.BooleanField(

--- a/products/data_modeling/backend/tests/api/test_internal_fleet_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_fleet_ops_api.py
@@ -1,0 +1,265 @@
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Team
+
+from products.data_modeling.backend.logic.fleet_ops import classify_migration
+from products.data_modeling.backend.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Node, NodeType
+from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
+
+FLEET_BASE = "/api/internal/data_modeling_ops"
+VIEWS = "products.data_modeling.backend.presentation.internal_fleet_views"
+
+
+def _schedule(schedule_id: str, kind: str, team_id: int | None = None) -> dict:
+    workflow = "data-modeling-run" if kind == "v1_saved_query" else "data-modeling-execute-dag"
+    return {
+        "schedule_id": schedule_id,
+        "workflow_name": workflow,
+        "kind": kind,
+        "paused": False,
+        "note": None,
+        "next_run_at": None,
+        "team_id": team_id,
+        "search_attributes": {},
+    }
+
+
+class FleetOpsAPITestCase(OidcAuthTestMixin, APIBaseTest):
+    def _get(self, path: str, token: str | None = None):
+        if token is not None:
+            return self.client.get(f"{FLEET_BASE}{path}", HTTP_AUTHORIZATION=f"Bearer {token}")
+        return self.client.get(f"{FLEET_BASE}{path}")
+
+    def _fleet_token(self) -> str:
+        return mint_oidc_token()
+
+
+class TestFleetAuth(FleetOpsAPITestCase):
+    # The client is session-logged-in (APIBaseTest); the no-bearer row proves a regular
+    # logged-in user cannot reach the cross-team routes.
+    @parameterized.expand(
+        [
+            ("session_only_no_bearer", lambda: None),
+            ("expired_token", lambda: mint_oidc_token(expiry_delta=timedelta(minutes=-1))),
+            ("wrong_domain", lambda: mint_oidc_token(email="someone@example.com")),
+        ]
+    )
+    def test_rejects_invalid_tokens(self, _name, token_factory):
+        response = self._get("/teams", token_factory())
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestFleetTeams(FleetOpsAPITestCase):
+    def test_teams_lists_only_modeling_activity_with_counts(self):
+        DAG.objects.create(team=self.team, name="Default")
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="materialized_view",
+            query={"query": "select 1"},
+            is_materialized=True,
+            sync_frequency_interval=timedelta(hours=24),
+        )
+        Team.objects.create(organization=self.organization, name="no modeling here")
+
+        response = self._get("/teams", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual([row["team_id"] for row in data["results"]], [self.team.id])
+        row = data["results"][0]
+        self.assertEqual(row["dag_count"], 1)
+        self.assertEqual(row["saved_query_count"], 1)
+        self.assertEqual(row["materialized_saved_query_count"], 1)
+        self.assertEqual(row["saved_queries_with_sync_frequency_count"], 1)
+        self.assertEqual(data["count"], 1)
+
+
+class TestMigrationMatrix(FleetOpsAPITestCase):
+    @patch(f"{VIEWS}._is_v2_backend_enabled_for_team", return_value=False)
+    @patch(f"{VIEWS}.describe_schedules")
+    def test_matrix_surfaces_v2_scheduled_flag_excluded_cohort(self, mock_describe, _mock_flag):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="my_view",
+            query={"query": "select 1"},
+            sync_frequency_interval=timedelta(hours=24),
+        )
+        mock_describe.return_value = {
+            str(dag.id): {"schedule_id": str(dag.id), "kind": "v2_dag", "exists": True},
+        }
+
+        response = self._get("/migration_matrix", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        row = response.json()["results"][0]
+        self.assertFalse(row["switch_a_v2_flag_enabled"])
+        self.assertTrue(row["switch_b_v2_schedule_present"])
+        self.assertEqual(row["switch_c_sync_frequencies_remaining"], 1)
+        self.assertEqual(row["classification"], "v2_scheduled_flag_excluded")
+
+    @patch(f"{VIEWS}._is_v2_backend_enabled_for_team", return_value=True)
+    @patch(f"{VIEWS}.describe_schedules", side_effect=RuntimeError("temporal down"))
+    def test_matrix_leaves_classification_null_when_temporal_unreachable(self, _mock_describe, _mock_flag):
+        DAG.objects.create(team=self.team, name="Default")
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="my_view", query={"query": "select 1"})
+
+        response = self._get("/migration_matrix", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["temporal_error"], "temporal down")
+        row = data["results"][0]
+        self.assertIsNone(row["switch_b_v2_schedule_present"])
+        self.assertIsNone(row["classification"])
+
+
+class TestClassifyMigration(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (True, True, True, 0, "fully_v2"),
+            (True, False, True, 0, "v2_scheduled_flag_excluded"),
+            (True, True, True, 3, "v2_scheduled_cleanup_pending"),
+            (True, True, False, 2, "not_migrated"),
+            (True, False, False, 2, "v1_flag_excluded"),
+            (False, True, False, 0, "no_dags"),
+        ]
+    )
+    def test_labels(self, has_dags, flag, schedule, remaining, expected):
+        self.assertEqual(
+            classify_migration(
+                has_dags=has_dags,
+                v2_flag_enabled=flag,
+                v2_schedule_present=schedule,
+                sync_frequencies_remaining=remaining,
+            ),
+            expected,
+        )
+
+
+class TestOrphans(FleetOpsAPITestCase):
+    @patch(f"{VIEWS}.list_data_modeling_schedules")
+    def test_reports_both_orphan_directions(self, mock_list):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        covered_by_dag = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="covered_view", query={"query": "select 1"}, is_materialized=True
+        )
+        Node.objects.create(team=self.team, dag=dag, saved_query=covered_by_dag, type=NodeType.MAT_VIEW)
+        unscheduled = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="unscheduled_view", query={"query": "select 1"}, is_materialized=True
+        )
+        deleted = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="deleted_view", query={"query": "select 1"}, deleted=True
+        )
+        mock_list.return_value = [
+            _schedule(str(dag.id), "v2_dag", self.team.id),
+            _schedule(str(deleted.id), "v1_saved_query", self.team.id),
+            _schedule("0197aaaa-0000-0000-0000-000000000000", "v2_dag"),
+        ]
+
+        response = self._get("/orphans", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        orphaned_ids = {entry["schedule_id"] for entry in data["schedules_without_entity"]}
+        self.assertEqual(orphaned_ids, {str(deleted.id), "0197aaaa-0000-0000-0000-000000000000"})
+        unscheduled_ids = {entry["saved_query_id"] for entry in data["entities_without_schedule"]}
+        self.assertEqual(unscheduled_ids, {str(unscheduled.id)})
+
+    @patch(f"{VIEWS}.list_data_modeling_schedules", side_effect=RuntimeError("temporal down"))
+    def test_returns_503_when_temporal_unreachable(self, _mock_list):
+        response = self._get("/orphans", self._fleet_token())
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class TestFailingSchedules(FleetOpsAPITestCase):
+    @patch(f"{VIEWS}.list_data_modeling_schedules")
+    def test_per_engine_streaks_grouped_under_covering_schedule(self, mock_list):
+        dag = DAG.objects.create(team=self.team, name="Default")
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="failing_view",
+            query={"query": "select 1"},
+            status=DataWarehouseSavedQuery.Status.FAILED,
+            latest_error="boom",
+        )
+        Node.objects.create(team=self.team, dag=dag, saved_query=saved_query, type=NodeType.MAT_VIEW)
+        # Oldest to newest: ch FAILED / ch COMPLETED / duck FAILED / ch FAILED / ch FAILED / ch RUNNING.
+        for engine, job_status in [
+            (DataModelingJob.Engine.CLICKHOUSE, DataModelingJob.Status.FAILED),
+            (DataModelingJob.Engine.CLICKHOUSE, DataModelingJob.Status.COMPLETED),
+            (DataModelingJob.Engine.DUCKGRES, DataModelingJob.Status.FAILED),
+            (DataModelingJob.Engine.CLICKHOUSE, DataModelingJob.Status.FAILED),
+            (DataModelingJob.Engine.CLICKHOUSE, DataModelingJob.Status.FAILED),
+            (DataModelingJob.Engine.CLICKHOUSE, DataModelingJob.Status.RUNNING),
+        ]:
+            DataModelingJob.objects.create(team=self.team, saved_query=saved_query, engine=engine, status=job_status)
+        mock_list.return_value = [_schedule(str(dag.id), "v2_dag", self.team.id)]
+
+        response = self._get("/failing_schedules", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["failing_saved_query_count"], 1)
+        group = data["results"][0]
+        self.assertEqual(group["schedule_id"], str(dag.id))
+        self.assertEqual(group["schedule_kind"], "v2_dag")
+        affected = group["affected_saved_queries"][0]
+        self.assertEqual(affected["saved_query_id"], str(saved_query.id))
+        self.assertEqual(affected["latest_error"], "boom")
+        self.assertEqual(affected["consecutive_failures_by_engine"], {"clickhouse": 2, "duckgres": 1})
+
+
+class TestDuplicates(FleetOpsAPITestCase):
+    def test_reports_multi_dag_saved_queries(self):
+        dag_a = DAG.objects.create(team=self.team, name="A")
+        dag_b = DAG.objects.create(team=self.team, name="B")
+        doubled = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="doubled_view", query={"query": "select 1"}, is_materialized=True
+        )
+        single = DataWarehouseSavedQuery.objects.create(team=self.team, name="single_view", query={"query": "select 1"})
+        Node.objects.create(team=self.team, dag=dag_a, saved_query=doubled, type=NodeType.MAT_VIEW)
+        Node.objects.create(team=self.team, dag=dag_b, saved_query=doubled, type=NodeType.MAT_VIEW)
+        Node.objects.create(team=self.team, dag=dag_a, saved_query=single, type=NodeType.VIEW)
+
+        response = self._get("/duplicates", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual([entry["saved_query_id"] for entry in data["multi_dag_saved_queries"]], [str(doubled.id)])
+        self.assertEqual(
+            {dag_entry["dag_name"] for dag_entry in data["multi_dag_saved_queries"][0]["dags"]}, {"A", "B"}
+        )
+
+    def test_reports_duplicate_backing_tables_with_linked_flag(self):
+        from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="my_view", query={"query": "select 1"}
+        )
+        linked = DataWarehouseTable.objects.create(
+            team=self.team, name="my_view", format="Parquet", url_pattern="s3://bucket/linked"
+        )
+        DataWarehouseTable.objects.create(
+            team=self.team, name="my_view", format="Parquet", url_pattern="s3://bucket/orphan"
+        )
+        saved_query.table = linked
+        saved_query.save()
+
+        response = self._get("/duplicates", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        groups = response.json()["duplicate_backing_tables"]
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["saved_query_id"], str(saved_query.id))
+        by_url = {table["url_pattern"]: table for table in groups[0]["tables"]}
+        self.assertTrue(by_url["s3://bucket/linked"]["is_linked"])
+        self.assertFalse(by_url["s3://bucket/orphan"]["is_linked"])

--- a/products/data_modeling/backend/tests/api/test_internal_fleet_ops_api.py
+++ b/products/data_modeling/backend/tests/api/test_internal_fleet_ops_api.py
@@ -83,7 +83,7 @@ class TestFleetTeams(FleetOpsAPITestCase):
 
 
 class TestMigrationMatrix(FleetOpsAPITestCase):
-    @patch(f"{VIEWS}._is_v2_backend_enabled_for_team", return_value=False)
+    @patch(f"{VIEWS}._is_v2_backend_enabled", return_value=False)
     @patch(f"{VIEWS}.describe_schedules")
     def test_matrix_surfaces_v2_scheduled_flag_excluded_cohort(self, mock_describe, _mock_flag):
         dag = DAG.objects.create(team=self.team, name="Default")
@@ -106,7 +106,7 @@ class TestMigrationMatrix(FleetOpsAPITestCase):
         self.assertEqual(row["switch_c_sync_frequencies_remaining"], 1)
         self.assertEqual(row["classification"], "v2_scheduled_flag_excluded")
 
-    @patch(f"{VIEWS}._is_v2_backend_enabled_for_team", return_value=True)
+    @patch(f"{VIEWS}._is_v2_backend_enabled", return_value=True)
     @patch(f"{VIEWS}.describe_schedules", side_effect=RuntimeError("temporal down"))
     def test_matrix_leaves_classification_null_when_temporal_unreachable(self, _mock_describe, _mock_flag):
         DAG.objects.create(team=self.team, name="Default")

--- a/products/endpoints/backend/facade/internal_ops.py
+++ b/products/endpoints/backend/facade/internal_ops.py
@@ -5,6 +5,9 @@ modules. Only imported by posthog/urls.py (request time), so the DRF dependencie
 off the ``django.setup()`` path.
 """
 
-from products.endpoints.backend.presentation.views.internal_ops import InternalEndpointsOpsViewSet
+from products.endpoints.backend.presentation.views.internal_ops import (
+    InternalEndpointsOpsFleetViewSet,
+    InternalEndpointsOpsViewSet,
+)
 
-__all__ = ["InternalEndpointsOpsViewSet"]
+__all__ = ["InternalEndpointsOpsFleetViewSet", "InternalEndpointsOpsViewSet"]

--- a/products/endpoints/backend/presentation/views/internal_ops.py
+++ b/products/endpoints/backend/presentation/views/internal_ops.py
@@ -5,9 +5,11 @@ the ``api/internal/data_modeling_ops/`` URL prefix and the OIDC auth from the
 data_modeling facade. Wired manually in posthog/urls.py.
 """
 
+import uuid
 from typing import Any
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Q
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import pagination, serializers, viewsets
@@ -17,13 +19,18 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
+from products.data_modeling.backend.facade.fleet_ops import resolve_entity
 from products.data_modeling.backend.facade.internal_ops import (
     DataModelingOpsAuthenticationMixin,
+    InternalResolveMatchSerializer,
     scoped_to_team,
     team_id_filter,
 )
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
 from products.endpoints.backend.facade.models import Endpoint, EndpointVersion
+
+RESOLVE_KINDS = ("saved_query", "endpoint", "dag", "node", "job", "schedule", "workflow", "name")
+RESOLVE_MATCH_CAP = 50
 
 
 class InternalEndpointVersionSerializer(serializers.ModelSerializer):
@@ -169,3 +176,62 @@ class InternalEndpointsOpsViewSet(DataModelingOpsAuthenticationMixin, TeamAndOrg
                 ).data,
             }
         )
+
+
+def _endpoint_matches(query: str, *, include_partial: bool) -> list[dict]:
+    """Endpoints matching an id or name, across all teams."""
+    filters = Q(name__iexact=query)
+    if include_partial:
+        filters |= Q(name__icontains=query)
+    try:
+        uuid.UUID(query)
+        filters |= Q(id=query)
+    except ValueError:
+        pass
+    # nosemgrep: idor-lookup-without-team (staff-only fleet endpoint aggregates all teams)
+    endpoints = Endpoint.objects.filter(filters).exclude(deleted=True).order_by("name")[:RESOLVE_MATCH_CAP]
+    matches = [
+        {
+            "kind": "endpoint",
+            "team_id": endpoint.team_id,
+            "id": str(endpoint.id),
+            "name": endpoint.name,
+            "detail": {"is_active": endpoint.is_active, "current_version": endpoint.current_version},
+        }
+        for endpoint in endpoints
+    ]
+    return sorted(matches, key=lambda match: (match["name"].lower() != query.lower(), match["name"]))
+
+
+class InternalEndpointsOpsFleetViewSet(
+    DataModelingOpsAuthenticationMixin, TeamAndOrgViewSetMixin, viewsets.GenericViewSet
+):
+    """Cross-team typed search for the modeling-ops admin app.
+
+    Hosted in the endpoints product because resolution spans endpoints AND data_modeling
+    entities, and only this product may import both (tach: endpoints -> data_modeling).
+    """
+
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+
+    @extend_schema(exclude=True)
+    def internal_resolve(self, request: Request, **kwargs: Any) -> Response:
+        kind = request.query_params.get("kind", "")
+        query = (request.query_params.get("q") or "").strip()
+        if kind not in RESOLVE_KINDS:
+            return Response({"error": f"kind must be one of {', '.join(RESOLVE_KINDS)}"}, status=400)
+        if not query:
+            return Response({"error": "q is required"}, status=400)
+
+        if kind == "endpoint":
+            matches = _endpoint_matches(query, include_partial=True)
+        elif kind == "name":
+            combined = resolve_entity("name", query) + _endpoint_matches(query, include_partial=True)
+            matches = sorted(
+                combined, key=lambda match: (match["name"].lower() != query.lower(), match["name"], match["kind"])
+            )[:RESOLVE_MATCH_CAP]
+        else:
+            matches = resolve_entity(kind, query)
+
+        return Response({"kind": kind, "q": query, "matches": InternalResolveMatchSerializer(matches, many=True).data})

--- a/products/endpoints/backend/tests/test_internal_ops_api.py
+++ b/products/endpoints/backend/tests/test_internal_ops_api.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from rest_framework import status
 
-from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
+from products.data_modeling.backend.facade.models import DAG, DataModelingJob, DataWarehouseSavedQuery
 from products.data_modeling.backend.tests.api.oidc import OidcAuthTestMixin, mint_oidc_token
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 
@@ -65,3 +65,45 @@ class TestInternalEndpointsOpsAPI(OidcAuthTestMixin, APIBaseTest):
         results = response.json()["results"]
         self.assertEqual([e["name"] for e in results], ["a_endpoint", "b_endpoint"])
         self.assertFalse(results[1]["is_active"])
+
+
+class TestInternalResolveAPI(OidcAuthTestMixin, APIBaseTest):
+    def _resolve(self, kind: str, q: str, token: str | None = None):
+        url = f"/api/internal/data_modeling_ops/resolve?kind={kind}&q={q}"
+        if token is not None:
+            return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        return self.client.get(url)
+
+    def _fleet_token(self) -> str:
+        return mint_oidc_token()
+
+    def test_rejects_session_only_request(self):
+        response = self._resolve("name", "anything")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_rejects_unknown_kind(self):
+        response = self._resolve("mystery", "anything", self._fleet_token())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_name_search_merges_saved_queries_and_endpoints_exact_first(self):
+        DataWarehouseSavedQuery.objects.create(team=self.team, name="billing_rollup_daily", query={"query": "select 1"})
+        Endpoint.objects.create(team=self.team, name="billing_rollup", created_by=self.user)
+
+        response = self._resolve("name", "billing_rollup", self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        matches = response.json()["matches"]
+        self.assertEqual(
+            [(m["kind"], m["name"]) for m in matches],
+            [("endpoint", "billing_rollup"), ("saved_query", "billing_rollup_daily")],
+        )
+        self.assertEqual(matches[0]["team_id"], self.team.id)
+
+    def test_schedule_kind_resolves_dag_id_to_owning_dag(self):
+        dag = DAG.objects.create(team=self.team, name="Default")
+
+        response = self._resolve("schedule", str(dag.id), self._fleet_token())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        matches = response.json()["matches"]
+        self.assertEqual([(m["kind"], m["id"]) for m in matches], [("dag", str(dag.id))])


### PR DESCRIPTION
## Problem

Stacked on #68255. The ops app needs fleet views no per-team read can serve: which teams have modeling activity, where each sits in the v1 to v2 scheduling migration, orphaned Temporal schedules in both directions, failing materializations grouped by their covering schedule, duplicate materialization, and a typed search to jump from any identifier in a support ticket to the owning entity.

Third and final API PR.

## Changes

New routes in the same `api/internal/data_modeling_ops/` namespace:

- `teams` — teams with modeling activity plus entity counts, paginated
- `migration_matrix` — per-team switch state: flag A (`data-modeling-backend-v2`), v2 execute-dag schedule presence B from per-DAG Temporal describes (independent of search-attribute backfill), residual `sync_frequency_interval` count C, and a derived classification. `v2_scheduled_flag_excluded` is the half-migrated cohort. Null when Temporal is unreachable, since B is then unknown.
- `orphans` — schedules with no live owning entity (the read-only twin of `delete_orphaned_saved_query_schedules`, plus the execute-dag direction it doesn't cover) and materialized saved queries with no covering schedule
- `failing_schedules` — FAILED saved queries with per-engine consecutive-failure streaks from `DataModelingJob` history, grouped under the covering schedule. Carries node suspension state as headroom for the per-node circuit breaker.
- `duplicates` — saved queries with nodes in more than one DAG, and duplicate same-named backing tables with linked vs orphan flagged
- `resolve` — typed cross-team search (saved_query, endpoint, dag, node, job, schedule, workflow, name). Hosted in the endpoints product because only that import direction may see both Endpoint and data_modeling models.

Temporal degradation is per-route and explicit: `orphans` 503s, `migration_matrix` nulls switch B and the classification, `failing_schedules` falls back to an unscheduled grouping. DB-derived facts stay visible either way.

Auth comes from #68238 downstack. These viewsets just use the same mixin, so the authenticator list is pinned and session, PAT and OAuth can never apply.

## How did you test this code?

106 tests green at this tip across the three internal ops test files.

- fleet auth negatives run on a session-logged-in client, locking in that session auth can't reach the cross-team routes, plus expired and wrong-domain rows against the offline mocked JWKS
- both orphan directions including the covered-via-DAG exclusion, per-engine failure streaks, migration-switch derivation with parameterized classification labels, duplicate detection, resolve merge and kind handling
- one test covers the null classification during a Temporal outage

`tach check` and the import-linter contracts pass. Routes are schema-excluded, so no OpenAPI drift.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8). Skills invoked: `/writing-tests`.

Schedule classification is by workflow name throughout, never by `PostHogDagId`, for the reason spelled out in #68255. Worth checking on review that no new code path reintroduces attribute-based classification.
