### PR TITLE
fix(signals): filter suggested reviewers by repo access, not posthog org

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -41,6 +41,10 @@ github_cache_access_counter = Counter(
 # Repository cache: 1-hour staleness window.
 GITHUB_REPOSITORY_CACHE_TTL_SECONDS = 60 * 60
 
+# Repository collaborator cache: 1-hour window. Access changes rarely and reviewer resolution
+# is not a hot read path, so an hour balances API spend against dropping departed collaborators.
+GITHUB_COLLABORATOR_CACHE_TTL_SECONDS = 60 * 60
+
 # Branch cache: 10-minute staleness, 24-hour eviction timeout.
 GITHUB_BRANCH_CACHE_TTL_SECONDS = 60 * 10
 GITHUB_BRANCH_CACHE_TIMEOUT_SECONDS = 60 * 60 * 24
@@ -453,6 +457,44 @@ class GitHubIntegrationBase:
         if not isinstance(name, str):
             raise ValueError(f"GitHub integration account name is not a string: {name}")
         return name
+
+    def is_repository_collaborator(self, repository: str, login: str) -> bool | None:
+        """Whether ``login`` currently has access to ``repository`` (is a collaborator).
+
+        ``GET /repos/{owner}/{repo}/collaborators/{username}`` returns 204 for a collaborator
+        and 404 for a non-collaborator. Returns ``None`` when the answer is unknown — missing
+        permission (403), a rate limit, or a transport error — so callers can fail open rather
+        than drop someone on an ambiguous signal. Cached per (installation, repo, login) since
+        access changes rarely and the same login recurs across a report's commits.
+        """
+        if not repository or not login:
+            return None
+
+        cache_key = f"github_integration:repo_collaborator:{self.integration.id}:{repository.lower()}:{login.lower()}"
+        cached = cache.get(cache_key)
+        if isinstance(cached, bool):
+            return cached
+
+        try:
+            response = self._installation_authenticated_get(
+                f"https://api.github.com/repos/{repository}/collaborators/{login}",
+                endpoint="/repos/{owner}/{repo}/collaborators/{username}",
+            )
+        except GitHubRateLimitError:
+            return None
+
+        if response is None:
+            return None
+        if response.status_code == 204:
+            is_collaborator = True
+        elif response.status_code == 404:
+            is_collaborator = False
+        else:
+            # 403 (missing permission) or anything unexpected — unknown, so fail open.
+            return None
+
+        cache.set(cache_key, is_collaborator, timeout=GITHUB_COLLABORATOR_CACHE_TTL_SECONDS)
+        return is_collaborator
 
     def list_teams(self, *, search: str = "", limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], bool]:
         """List GitHub teams for the integration account organization with bounded API calls."""

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1024,6 +1024,48 @@ class TestGitHubIntegrationModel(BaseTest):
         with patch.object(github, "_installation_authenticated_get", return_value=None):
             assert github.get_open_pr_base_for_head("PostHog/posthog", "posthog-code/fix") is None
 
+    @parameterized.expand(
+        [
+            ("collaborator", 204, True),
+            ("not_a_collaborator", 404, False),
+            ("missing_permission_fails_open", 403, None),
+            ("unexpected_status_fails_open", 500, None),
+        ]
+    )
+    def test_is_repository_collaborator_maps_status(self, _name, status_code, expected):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        mock_response = MagicMock(status_code=status_code)
+        with patch.object(github, "_installation_authenticated_get", return_value=mock_response) as mock_get:
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is expected
+        assert "/repos/PostHog/posthog/collaborators/octocat" in mock_get.call_args.args[0]
+
+    def test_is_repository_collaborator_fails_open_on_rate_limit(self):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        with patch.object(github, "_installation_authenticated_get", side_effect=GitHubRateLimitError("limited")):
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is None
+
+    def test_is_repository_collaborator_caches_definitive_answer(self):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        mock_response = MagicMock(status_code=204)
+        with patch.object(github, "_installation_authenticated_get", return_value=mock_response) as mock_get:
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is True
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is True
+        mock_get.assert_called_once()
+
+    def test_is_repository_collaborator_does_not_cache_unknown(self):
+        # A 403 (missing permission) must be re-checked, so the filter starts working the moment
+        # access is granted rather than being pinned to "unknown" for the cache TTL.
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        mock_response = MagicMock(status_code=403)
+        with patch.object(github, "_installation_authenticated_get", return_value=mock_response) as mock_get:
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is None
+            assert github.is_repository_collaborator("PostHog/posthog", "octocat") is None
+        assert mock_get.call_count == 2
+
     def test_get_diff_truncates_oversized_diff(self):
         from posthog.models.integration import _MAX_DIFF_CHARS
 

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -45,7 +45,10 @@ def enrich_reviewer_dicts_with_org_members(
     """Enrich reviewer dicts (from artefact content) with fresh PostHog user info.
 
     Called at read time so that users who connect their GitHub account after the
-    artefact was created show up properly.
+    artefact was created show up properly. Reviewers are derived from git commit
+    authorship, not the org roster, so an author who has since left the org would
+    otherwise still be suggested. Reviewers whose GitHub login doesn't resolve to a
+    current org member are dropped here rather than emitted with ``user: null``.
     """
     if not reviewer_dicts:
         return reviewer_dicts
@@ -61,6 +64,8 @@ def enrich_reviewer_dicts_with_org_members(
     for r in reviewer_dicts:
         login = r.get("github_login", "")
         user = resolved_map.get(login.lower()) if login else None
+        if user is None:
+            continue
         enriched.append(
             {
                 **r,
@@ -70,9 +75,7 @@ def enrich_reviewer_dicts_with_org_members(
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "email": user.email,
-                }
-                if user
-                else None,
+                },
             }
         )
 

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -45,10 +45,7 @@ def enrich_reviewer_dicts_with_org_members(
     """Enrich reviewer dicts (from artefact content) with fresh PostHog user info.
 
     Called at read time so that users who connect their GitHub account after the
-    artefact was created show up properly. Reviewers are derived from git commit
-    authorship, not the org roster, so an author who has since left the org would
-    otherwise still be suggested. Reviewers whose GitHub login doesn't resolve to a
-    current org member are dropped here rather than emitted with ``user: null``.
+    artefact was created show up properly.
     """
     if not reviewer_dicts:
         return reviewer_dicts
@@ -64,8 +61,6 @@ def enrich_reviewer_dicts_with_org_members(
     for r in reviewer_dicts:
         login = r.get("github_login", "")
         user = resolved_map.get(login.lower()) if login else None
-        if user is None:
-            continue
         enriched.append(
             {
                 **r,
@@ -75,7 +70,9 @@ def enrich_reviewer_dicts_with_org_members(
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "email": user.email,
-                },
+                }
+                if user
+                else None,
             }
         )
 
@@ -174,16 +171,26 @@ def resolve_suggested_reviewers(
             if login not in login_names:
                 login_names[login] = author_info.name
 
-    # Return top reviewers by weighted score
-    return [
-        _ResolvedReviewer(
-            login=login,
-            name=login_names.get(login),
-            commits=login_commits.get(login, []),
-            weight=weight,
+    # Take reviewers by weighted score, but skip anyone who no longer has access to the repo:
+    # authors come from git history, so a past contributor who has since left the GitHub org (or
+    # lost repo access) shouldn't be suggested. Fail open on an unknown access signal (missing
+    # permission, rate limit, error) so we never drop a valid reviewer on ambiguity.
+    reviewers: list[_ResolvedReviewer] = []
+    for login, weight in login_weights.most_common():
+        if len(reviewers) >= MAX_SUGGESTED_REVIEWERS:
+            break
+        if github.is_repository_collaborator(repository, login) is False:
+            logger.info("Skipping suggested reviewer %s without access to %s", login, repository)
+            continue
+        reviewers.append(
+            _ResolvedReviewer(
+                login=login,
+                name=login_names.get(login),
+                commits=login_commits.get(login, []),
+                weight=weight,
+            )
         )
-        for login, weight in login_weights.most_common(MAX_SUGGESTED_REVIEWERS)
-    ]
+    return reviewers
 
 
 @dataclass

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -1,13 +1,18 @@
 import pytest
+from unittest.mock import MagicMock, patch
 
 from social_django.models import UserSocialAuth
 
 from posthog.models import Organization, Team, User
+from posthog.models.github_integration_base import GitHubCommitAuthor
 from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 
-from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
+from products.signals.backend.report_generation.resolve_reviewers import (
+    resolve_org_github_login_to_users,
+    resolve_suggested_reviewers,
+)
 
 
 @pytest.fixture
@@ -106,3 +111,31 @@ def test_skips_users_outside_organization(organization, team):
         assert result == {}
     finally:
         other_org.delete()
+
+
+@pytest.mark.django_db
+def test_resolve_suggested_reviewers_drops_reviewers_without_repo_access(organization, team):
+    # Authors come from git history; a past contributor who lost repo access must not be suggested,
+    # while collaborators and unknown-access authors (fail open) are kept.
+    authors = {
+        "sha_keep": GitHubCommitAuthor(login="keeper", name="Keeper", commit_url="https://gh/c/1"),
+        "sha_drop": GitHubCommitAuthor(login="departed", name="Departed", commit_url="https://gh/c/2"),
+        "sha_unknown": GitHubCommitAuthor(login="mystery", name="Mystery", commit_url="https://gh/c/3"),
+    }
+    collaborator_by_login = {"keeper": True, "departed": False, "mystery": None}
+
+    github = MagicMock()
+    github.get_commit_author_info.side_effect = lambda repository, sha: authors[sha]
+    github.is_repository_collaborator.side_effect = lambda repository, login: collaborator_by_login[login]
+
+    with patch(
+        "products.signals.backend.report_generation.resolve_reviewers.GitHubIntegration.first_for_team_repository",
+        return_value=github,
+    ):
+        result = resolve_suggested_reviewers(
+            team.id,
+            "PostHog/posthog",
+            {"sha_keep": "reason a", "sha_drop": "reason b", "sha_unknown": "reason c"},
+        )
+
+    assert [r.login for r in result] == ["keeper", "mystery"]

--- a/products/signals/backend/test/test_signal_report_artefact_api.py
+++ b/products/signals/backend/test/test_signal_report_artefact_api.py
@@ -124,19 +124,16 @@ class TestSignalReportArtefactViewSet(APIBaseTest):
         assert reviewer["user"]["uuid"] == str(member.uuid)
         assert reviewer["user"]["email"] == "alice@example.com"
 
-    def test_list_drops_reviewers_not_a_current_org_member(self):
-        # Reviewers come from git authorship, so a login that isn't a current org
-        # member (left the org, or never connected GitHub) is dropped, not shown.
+    def test_list_unknown_login_returns_null_user(self):
         report = self._create_report()
         self._create_artefact(report, content=[{"github_login": "nobody"}])
 
         response = self.client.get(self._list_url(str(report.id)))
         assert response.status_code == status.HTTP_200_OK
         rows = response.json()["results"]
-        assert rows[0]["content"] == []
+        assert rows[0]["content"][0]["user"] is None
 
     def test_list_scoped_to_report_and_team(self):
-        self._create_org_member("alice@example.com", github_login="alice")
         report = self._create_report()
         other_report = self._create_report()
         self._create_artefact(report, content=[{"github_login": "alice"}])

--- a/products/signals/backend/test/test_signal_report_artefact_api.py
+++ b/products/signals/backend/test/test_signal_report_artefact_api.py
@@ -124,16 +124,19 @@ class TestSignalReportArtefactViewSet(APIBaseTest):
         assert reviewer["user"]["uuid"] == str(member.uuid)
         assert reviewer["user"]["email"] == "alice@example.com"
 
-    def test_list_unknown_login_returns_null_user(self):
+    def test_list_drops_reviewers_not_a_current_org_member(self):
+        # Reviewers come from git authorship, so a login that isn't a current org
+        # member (left the org, or never connected GitHub) is dropped, not shown.
         report = self._create_report()
         self._create_artefact(report, content=[{"github_login": "nobody"}])
 
         response = self.client.get(self._list_url(str(report.id)))
         assert response.status_code == status.HTTP_200_OK
         rows = response.json()["results"]
-        assert rows[0]["content"][0]["user"] is None
+        assert rows[0]["content"] == []
 
     def test_list_scoped_to_report_and_team(self):
+        self._create_org_member("alice@example.com", github_login="alice")
         report = self._create_report()
         other_report = self._create_report()
         self._create_artefact(report, content=[{"github_login": "alice"}])


### PR DESCRIPTION
## Problem

In the Signals inbox we suggested a reviewer who had left both the PostHog org and the GitHub org. Suggested reviewers are derived from git commit authorship (the GitHub authors of the relevant commits), not from any membership roster, so a past contributor who has since departed or lost repo access could still be surfaced and potentially tagged.

Filtering by PostHog org membership is the wrong proxy: many valid GitHub reviewers aren't in the PostHog org at all (solo / self-serve accounts), so that would drop legitimate reviewers. The precise question is "does this person still have access to the repo" — which maps to GitHub repo-collaborator access.

## Changes

- Add `GitHubIntegrationBase.is_repository_collaborator` — `GET /repos/{owner}/{repo}/collaborators/{username}` (204 = has access, 404 = no access). It only needs the `metadata:read` permission the App already has, so no new App permission or re-consent is required.
- Filter at report-generation time in `resolve_suggested_reviewers`: drop authors who no longer have repo access, keeping the top reviewers among those who do.
- **Fail open** on any ambiguous signal (missing permission, rate limit, transport error) so a valid reviewer is never dropped on uncertainty. Definitive answers are cached per `(installation, repo, login)` for an hour, mirroring the existing GitHub caches; "unknown" is deliberately not cached so the filter starts working the moment access resolves.
- Revert the earlier read-time PostHog-membership drop in `enrich_reviewer_dicts_with_org_members`, so non-PostHog GitHub reviewers still surface (with `user: null`) for a future "invite to PostHog" affordance.

Note: filtering happens at generation time, so already-stored artefacts are corrected when a report is next regenerated, not retroactively.

## How did you test this code?

Added unit tests:
- `test_integration_model.py`: `is_repository_collaborator` maps 204→True / 404→False / 403→None / 5xx→None, fails open on rate limit, caches a definitive answer (single API call on repeat), and does **not** cache an unknown (403 re-checked).
- `test_resolve_reviewers.py`: `resolve_suggested_reviewers` drops a non-collaborator author while keeping a collaborator and an unknown-access author (fail open).

Postgres wasn't reachable in the agent environment, so the DB-backed tests could not be run locally; they'll run in CI. Byte-compiled all changed files and ran ruff check + format (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from a Slack thread about a departed member appearing as a suggested reviewer. Initial approach filtered by PostHog org membership at read time; discussion in-thread reframed the goal as GitHub repo access (many valid reviewers aren't in the PostHog org, and the original complaint was about repo access). Chose the repo-collaborator endpoint over org membership (`/orgs/{org}/members/...`) because the latter needs a `members:read` permission our App manifest doesn't request, whereas collaborator checks work with the existing `metadata:read` and map more precisely to "no longer has access to the repo". Invoked the `/writing-tests` skill before writing tests. All GitHub calls go through the existing egress transport / `api_request` path.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783354684118629?thread_ts=1783354684.118629&cid=C09SK2PAGKF)*
