### PR TITLE
fix(custom): fail fast when endpoint.incremental omits start_param

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -340,10 +340,11 @@ def _validate_resource_graph(manifest: dict[str, Any]) -> dict[str, Optional[Res
 def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
     """Reject incremental config values that would deterministically crash at sync time.
 
-    The structural schema doesn't model ``endpoint.incremental``, so a hand-authored
-    non-string ``datetime_format``, or an ``endpoint.incremental`` block missing the
-    required ``start_param``, would otherwise only surface mid-sync as a bare
-    ``KeyError`` the REST engine raises from ``setup_incremental_object``.
+    The structural schema doesn't model ``endpoint.incremental``, so hand-authored
+    mistakes here would otherwise only surface mid-sync: a non-string ``datetime_format``
+    as a strftime error (and only from the second sync onward, once a watermark is
+    stored), and a missing ``start_param`` as a bare ``KeyError`` the REST engine raises
+    from ``setup_incremental_object``.
     """
     for resource in manifest.get("resources") or []:
         if not isinstance(resource, dict):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -341,8 +341,9 @@ def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
     """Reject incremental config values that would deterministically crash at sync time.
 
     The structural schema doesn't model ``endpoint.incremental``, so a hand-authored
-    non-string ``datetime_format`` would otherwise only surface mid-sync, and only
-    from the second sync onward (formatting needs a stored watermark).
+    non-string ``datetime_format``, or an ``endpoint.incremental`` block missing the
+    required ``start_param``, would otherwise only surface mid-sync as a bare
+    ``KeyError`` the REST engine raises from ``setup_incremental_object``.
     """
     for resource in manifest.get("resources") or []:
         if not isinstance(resource, dict):
@@ -356,6 +357,12 @@ def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
             raise ManifestValidationError(
                 f"Resource {resource.get('name')!r}: endpoint.incremental.datetime_format must be a string "
                 'strftime pattern (e.g. "%Y-%m-%dT%H:%M:%SZ")'
+            )
+        start_param = incremental.get("start_param")
+        if not isinstance(start_param, str) or not start_param:
+            raise ManifestValidationError(
+                f"Resource {resource.get('name')!r}: endpoint.incremental.start_param is required and must be a "
+                "non-empty string naming the query parameter used to send the cursor value to the API"
             )
 
 
@@ -1021,6 +1028,11 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
                 _strip_engine_unsupported_incremental_keys(chain.child),
             ]
             engine_manifest = cast(RESTAPIConfig, {**manifest, "resources": engine_resources})
+
+            # Backstop for manifests stored before create-time validation covered this: an
+            # endpoint.incremental block missing start_param crashes the engine with a bare,
+            # retryable KeyError. Reject it as a ValueError so it fails fast and non-retryably.
+            _validate_incremental_configs({"resources": engine_resources})
 
             # The engine serializes a datetime watermark via str() (space-separated),
             # which strict APIs reject — format it to the declared wire format first.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -2424,6 +2424,44 @@ class TestCustomSourceIncrementalDatetimeFormat(SimpleTestCase):
         assert child_params.get("since") == "2026-06-08T12:53:34Z"
 
 
+class TestCustomSourceIncrementalStartParam(SimpleTestCase):
+    _OMIT = object()
+
+    def _manifest(self, start_param) -> dict:
+        manifest = _minimal_manifest()
+        incremental: dict = {"cursor_path": "updated_at"}
+        if start_param is not self._OMIT:
+            incremental["start_param"] = start_param
+        manifest["resources"][0]["endpoint"]["incremental"] = incremental
+        return manifest
+
+    @parameterized.expand([("missing", _OMIT), ("empty", ""), ("non_string", 123)])
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.custom.source.rest_api_resources")
+    def test_missing_start_param_raises_non_retryable(self, _name, start_param, mock_resources):
+        mock_resources.return_value = [_fake_resource("users")]
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest(start_param)))
+        inputs = MagicMock(
+            team_id=1,
+            schema_name="users",
+            job_id="job-1",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+        )
+        with self.assertRaises(NonRetryableException) as ctx:
+            source.source_for_pipeline(config, inputs)
+        assert "start_param" in str(ctx.exception)
+        mock_resources.assert_not_called()
+
+    @parameterized.expand([("missing", _OMIT), ("empty", "")])
+    def test_missing_start_param_rejected_at_validation(self, _name, start_param):
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest(start_param)), auth_token="abc")
+        ok, err = source.validate_credentials(config, team_id=999)
+        assert ok is False
+        assert err is not None and "start_param" in err and "'users'" in err
+
+
 def _apikey_manifest() -> dict:
     """A minimal manifest whose auth is an api_key in a query param, so the
     injected secret is registered for value-based redaction."""


### PR DESCRIPTION
## Problem

A custom (REST) data warehouse source with an `endpoint.incremental` block that is missing `start_param` crashes mid-sync with a bare `KeyError: 'start_param'`. The generic REST engine's `setup_incremental_object` dereferences `incremental_config["start_param"]` to build its cursor parameter, so an incremental block without it always blows up. `KeyError` is retryable, so the import activity retried the same doomed error until its budget was gone rather than failing with anything a user could act on.

`start_param` is the query parameter name the engine uses to send the cursor value to the API, so it is required whenever `endpoint.incremental` is declared. The custom source drives all of its incremental support off `endpoint.incremental` (never a params-style incremental spec), so there is no config shape where the block is present but `start_param` is legitimately absent.

Surfaced by error tracking: [KeyError 'start_param'](https://us.posthog.com/project/2/error_tracking/019f384b-2326-7393-b8ca-805f14469c7a). The failing frame is `setup_incremental_object` reached via `source_for_pipeline` in the custom source.

## Changes

Require a non-empty string `start_param` whenever `endpoint.incremental` is present.

- Extend `_validate_incremental_configs` (the create-time and preview validator) to reject a missing, empty, or non-string `start_param` with a clear `ManifestValidationError`, mirroring the existing `datetime_format` check right next to it.
- Add a sync-time backstop in `source_for_pipeline`: run the same validation against the engine resources before calling `rest_api_resources`. `ManifestValidationError` subclasses `ValueError`, so the existing `except ValueError` there converts it into a `NonRetryableException`. Already-stored manifests now fail fast with a clear message instead of the retryable `KeyError`.

This is scoped to the missing-`start_param` case. Transient and unrelated errors are untouched, and the global retry policy is unchanged.

## How did you test this code?

Added `TestCustomSourceIncrementalStartParam` covering the two paths this fix touches, neither of which any existing test exercised (every incremental fixture already included `start_param`):

- Sync path: a manifest whose incremental block is missing, empty, or a non-string `start_param` raises `NonRetryableException` from `source_for_pipeline` and never reaches the REST engine.
- Create path: the same manifests are rejected by `validate_credentials` with a message naming `start_param` and the resource.

I (Claude) ran the custom source test suite locally with the repo venv pytest. The incremental-focused tests pass (`StartParam`, `DatetimeFormat`, cursor-type). The full file shows 225 passed; the 21 errors are DB-backed OAuth2 tests failing to reach Postgres in this sandbox (no database available), unrelated to this change. `ruff check` and `ruff format` are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error tracking issue above. I (Claude) pulled the stack trace, confirmed the failure originates in the custom source path (`source_for_pipeline` → `rest_api_resources` → `setup_incremental_object`), and traced the `KeyError` to a required-but-unvalidated `start_param`. Classified as a fixable fragility rather than a pure user error: the config is user-authored, but our code crashed with a cryptic retryable error instead of failing fast, so the fix hardens validation on both the create and sync paths.

Considered validating the whole stored manifest at sync, but scoped the backstop to the engine resources (the chosen resource plus its stripped ancestors) so an unrelated resource's incremental config can't fail a sync that never builds it. Invoked the `/writing-tests` skill before adding tests.
