### PR TITLE
fix(google_sheets): retry read timeouts and connection resets inline

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, TypeVar
 from django.conf import settings
 
 import gspread
+import requests
 from cachetools import Cache, TTLCache, cached
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2 import service_account
@@ -119,8 +120,14 @@ def _retry_on_transient_api_error(execute: Callable[[], T]) -> T:
     while True:
         try:
             return execute()
-        except gspread.exceptions.APIError as e:
-            if not _is_retryable_api_error(e) or attempts >= max_attempts:
+        except (gspread.exceptions.APIError, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            # A dropped connection or read timeout is raised by `requests` before gspread can wrap
+            # it in an APIError, so the status-code check never sees it, and the tracked adapter's
+            # transport retries are already spent by the time it reaches us. It's a transient
+            # network blip, so retry inline like a 5xx; APIErrors still gate on their status. Once
+            # the budget is spent, let it bubble so Temporal retries the activity.
+            is_retryable = _is_retryable_api_error(e) if isinstance(e, gspread.exceptions.APIError) else True
+            if not is_retryable or attempts >= max_attempts:
                 raise
 
             jitter = random.uniform(-jitter_in_seconds, jitter_in_seconds)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -5,6 +5,7 @@ import pytest
 from unittest import mock
 
 import gspread
+import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GoogleSheetsSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets import (
@@ -317,6 +318,48 @@ def test_retry_on_transient_api_error_does_not_retry_non_transient():
             _retry_on_transient_api_error(fn)
 
         assert fn.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        requests.exceptions.ConnectionError("Connection aborted."),
+        requests.exceptions.ReadTimeout("Read timed out. (read timeout=120.0)"),
+        requests.exceptions.ConnectTimeout("Connection timed out."),
+    ],
+)
+def test_retry_on_transient_api_error_retries_network_error_then_succeeds(error):
+    """A dropped connection or read timeout is raised by `requests` before gspread wraps it in an
+    APIError, so the status-code path never sees it. It's a transient blip and must be retried
+    inline rather than failing the read on the first occurrence."""
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.time"
+    ):
+        fn = mock.MagicMock(side_effect=[error, error, "ok"])
+
+        assert _retry_on_transient_api_error(fn) == "ok"
+        assert fn.call_count == 3
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        requests.exceptions.ConnectionError("Connection aborted."),
+        requests.exceptions.ReadTimeout("Read timed out. (read timeout=120.0)"),
+    ],
+)
+def test_retry_on_transient_api_error_bubbles_network_error_after_max_retries(error):
+    """A persistent network error exhausts the inline budget and re-raises so it stays retryable
+    at the activity level (Temporal), rather than being swallowed."""
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.time"
+    ):
+        fn = mock.MagicMock(side_effect=error)
+
+        with pytest.raises(type(error)):
+            _retry_on_transient_api_error(fn)
+
+        assert fn.call_count == 10
 
 
 def test_google_sheets_source_retries_transient_error_on_data_reads():


### PR DESCRIPTION
## Problem

Google Sheets imports intermittently fail with `TimeoutError: The read operation timed out` (surfaced by error tracking as [issue 019f384f](https://us.posthog.com/project/2/error_tracking/019f384f-097d-7ff2-92ce-7c8533f5b5ce)).

The Sheets API stalls partway through a `get_all_records` read, the socket read hits its 120s timeout, and the whole import activity dies. The error tracking event shows the chain `ReadTimeoutError` → `MaxRetryError` → `requests.ConnectionError` landing in `get_rows` at `google_sheets.py`. It's a transient network blip, not a config or credential problem, so it should recover on retry.

Two things line up to let it through:

- The stall is raised by `requests` as a `ConnectionError` (or `Timeout`) before gspread ever builds an `APIError`. The inline retry loop `_retry_on_transient_api_error` only caught `gspread.exceptions.APIError`, so a network-level exception bubbled straight past it.
- The tracked HTTP adapter's `Retry` policy does retry the read (it's a GET), but its retries share the same 120s read timeout and short backoff, so a brief server-side slowdown exhausts them all in one go and re-raises.

So a single slow response kills the activity.

## Changes

Catch `requests.ConnectionError` and `requests.Timeout` inside `_retry_on_transient_api_error` and retry them inline with the same linear backoff already used for transient 5xx/429 responses. `APIError`s still gate on their status code via `_is_retryable_api_error`; network exceptions are always transient, so they always retry until the budget (`max_attempts`) is spent, at which point the real error re-raises so Temporal retries the activity.

The error stays retryable. It is deliberately not added to `NonRetryableErrors`, since a read timeout is transient and recovers on its own.

This mirrors the pattern just landed for the sibling source in #68691 (`fix(google_search_console): retry connection resets inline`), which handled the same class of pre-response network exception escaping an inline retry loop.

## How did you test this code?

Added two parameterized tests to `test_google_sheets.py`, alongside the existing transient-API-error retry tests:

- `test_retry_on_transient_api_error_retries_network_error_then_succeeds` - a `ConnectionError` / `ReadTimeout` / `ConnectTimeout` twice then a success returns the value, and the callable is invoked three times. Catches the regression where dropping the new `except` branch fails the read on the first blip instead of retrying.
- `test_retry_on_transient_api_error_bubbles_network_error_after_max_retries` - a persistent network error exhausts the inline budget and re-raises the original exception (retryable at the activity level) after `max_attempts` attempts.

No existing test covered a network-level exception raised before an `APIError`, so this is genuinely new coverage rather than a variation of the response-based cases.

I (Claude) ran the source's full test file locally: `46 passed`. `ruff check` and `ruff format --check` are clean. I did not run the import against live Google Sheets.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing or documented-workflow change - internal retry behavior only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above by Claude. I confirmed the failure originates in the `google_sheets` source (the stack contains `google_sheets.py` `get_rows` → `_retry_on_transient_api_error` → gspread `get_all_records`), classified it as a transient infrastructure error (a read timeout to `sheets.googleapis.com`) rather than a user/upstream error, and so kept it retryable instead of extending `NonRetryableErrors`. I checked open PRs and found the maintainer had just fixed the identical class of bug for `google_search_console` (#68691); I followed that same inline-retry pattern here. Invoked the `/writing-tests` skill before adding the regression tests.
