### PR TITLE
feat(workflows): emit $workflows_email_unsubscribed engagement event

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -511,13 +511,18 @@ def report_workflows_email_unsubscribed(team_id: int, identifier: str, category_
         team = Team.objects.get(id=team_id)
         if not team.workflows_config.capture_workflows_engagement_events:
             return
+    except Exception as e:
+        capture_exception(e)
+        return
 
-        for category_id in category_ids:
-            properties: dict[str, Any] = {
-                "$email": identifier,
-                "category": category_id,
-                "source": source,
-            }
+    # Each category is independently best-effort: one failed capture must not skip the rest
+    for category_id in category_ids:
+        properties: dict[str, Any] = {
+            "$email": identifier,
+            "category": category_id,
+            "source": source,
+        }
+        try:
             result = capture_internal(
                 token=team.api_token,
                 event_name="$workflows_email_unsubscribed",
@@ -532,8 +537,8 @@ def report_workflows_email_unsubscribed(team_id: int, identifier: str, category_
                     category=category_id,
                     error=result.error,
                 )
-    except Exception as e:
-        capture_exception(e)
+        except Exception as e:
+            capture_exception(e)
 
 
 @csrf_exempt

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -579,6 +579,8 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
         request.GET.get("one_click_unsubscribe") == "1" or request.POST.get("one_click_unsubscribe") == "1"
     )
     if is_one_click_unsubscribe:
+        was_fully_opted_out = recipient.get_preference(ALL_MESSAGE_PREFERENCE_CATEGORY_ID) == PreferenceStatus.OPTED_OUT
+
         # If one-click unsubscribe, set all preferences to opted out
         preferences_dict = {str(cat.id): PreferenceStatus.OPTED_OUT.value for cat in categories}
 
@@ -590,7 +592,9 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
 
         sync_preferences_to_customerio(team_id, identifier, preferences_dict)
 
-        report_workflows_email_unsubscribed(team_id, identifier, [ALL_MESSAGE_PREFERENCE_CATEGORY_ID], "one_click")
+        # Only a genuine transition emits, so token replays and scanner prefetches don't inflate events
+        if not was_fully_opted_out:
+            report_workflows_email_unsubscribed(team_id, identifier, [ALL_MESSAGE_PREFERENCE_CATEGORY_ID], "one_click")
 
         if request.method == "POST":
             return HttpResponse(status=200)

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from functools import wraps
 from html import escape
-from typing import Union
+from typing import Any, Union
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from django.apps import apps
@@ -25,13 +25,14 @@ from django.views.decorators.http import require_http_methods
 import structlog
 from opentelemetry import trace
 
+from posthog.api.capture import capture_internal
 from posthog.auth import AUTH_BRAND_COOKIE, apply_auth_brand_cookie, normalize_auth_brand
 from posthog.cloud_utils import is_cloud
 from posthog.email import is_email_available
 from posthog.exceptions_capture import capture_exception
 from posthog.health import is_clickhouse_connected, is_kafka_connected
 from posthog.helpers.dev_login import is_dev_login_allowed
-from posthog.models import Organization, User
+from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.integration import SlackIntegration
 from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token
@@ -497,6 +498,44 @@ def api_key_search_view(request: HttpRequest):
     return render(request, template_name="api_key_search/values.html", context=context, status=200)
 
 
+def report_workflows_email_unsubscribed(team_id: int, identifier: str, category_ids: list[str], source: str) -> None:
+    """
+    Emit $workflows_email_unsubscribed engagement events into the customer's project.
+
+    Mirrors the plugin-server's $workflows_email_* engagement events (email-tracking.service.ts),
+    gated on the same capture_workflows_engagement_events team flag. The unsubscribe token only
+    carries team_id + identifier, so this event is email-level: distinct_id is the recipient's
+    email, and no workflow/action id is available. Best-effort — never fails the unsubscribe flow.
+    """
+    try:
+        team = Team.objects.get(id=team_id)
+        if not team.workflows_config.capture_workflows_engagement_events:
+            return
+
+        for category_id in category_ids:
+            properties: dict[str, Any] = {
+                "$email": identifier,
+                "category": category_id,
+                "source": source,
+            }
+            result = capture_internal(
+                token=team.api_token,
+                event_name="$workflows_email_unsubscribed",
+                event_source="workflows_unsubscribe",
+                distinct_id=identifier,
+                properties=properties,
+            )
+            if not result.succeeded():
+                logger.error(
+                    "workflows_email_unsubscribed_capture_failed",
+                    team_id=team_id,
+                    category=category_id,
+                    error=result.error,
+                )
+    except Exception as e:
+        capture_exception(e)
+
+
 @csrf_exempt
 @require_http_methods(["GET", "POST"])
 def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
@@ -532,6 +571,8 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
         recipient.save(update_fields=["preferences"])
 
         sync_preferences_to_customerio(team_id, identifier, preferences_dict)
+
+        report_workflows_email_unsubscribed(team_id, identifier, [ALL_MESSAGE_PREFERENCE_CATEGORY_ID], "one_click")
 
         if request.method == "POST":
             return HttpResponse(status=200)
@@ -601,6 +642,7 @@ def update_preferences(request: HttpRequest) -> JsonResponse:
         recipient = MessageRecipientPreference(team_id=team_id, identifier=identifier)
 
     try:
+        prior_preferences = dict(recipient.preferences or {})
         preferences = request.POST.getlist("preferences[]")
         # Convert to dict of category_id: status
         preferences_dict = {}
@@ -627,6 +669,16 @@ def update_preferences(request: HttpRequest) -> JsonResponse:
         recipient.save()
 
         sync_preferences_to_customerio(team_id, identifier, preferences_dict)
+
+        # Only genuine opt-out transitions count, so repeated saves don't double-emit
+        newly_opted_out = [
+            category_id
+            for category_id, status in preferences_dict.items()
+            if status == PreferenceStatus.OPTED_OUT.value
+            and prior_preferences.get(category_id) != PreferenceStatus.OPTED_OUT.value
+        ]
+        if newly_opted_out:
+            report_workflows_email_unsubscribed(team_id, identifier, newly_opted_out, "preferences_page")
 
         return JsonResponse({"success": True})
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -511,12 +511,25 @@ def report_workflows_email_unsubscribed(team_id: int, identifier: str, category_
         team = Team.objects.get(id=team_id)
         if not team.workflows_config.capture_workflows_engagement_events:
             return
+
+        # The form POST accepts arbitrary category id strings; only emit for the team's real
+        # categories (or "$all") so a token bearer can't inject junk property values
+        known_category_ids: set[str] = set()
+        if any(category_id != ALL_MESSAGE_PREFERENCE_CATEGORY_ID for category_id in category_ids):
+            known_category_ids = {
+                str(category_id)
+                for category_id in MessageCategory.objects.filter(team_id=team_id, deleted=False).values_list(
+                    "id", flat=True
+                )
+            }
     except Exception as e:
         capture_exception(e)
         return
 
     # Each category is independently best-effort: one failed capture must not skip the rest
     for category_id in category_ids:
+        if category_id != ALL_MESSAGE_PREFERENCE_CATEGORY_ID and category_id not in known_category_ids:
+            continue
         properties: dict[str, Any] = {
             "$email": identifier,
             "category": category_id,

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -254,13 +254,13 @@ class TestMessagePreferencesViews(BaseTest):
     @patch("posthog.views.capture_internal")
     @patch("posthog.views.validate_messaging_preferences_token")
     def test_no_unsubscribed_event_when_flag_off(
-        self, save_point, mock_validate_messaging_preferences_token, mock_capture_internal
+        self, code_path, mock_validate_messaging_preferences_token, mock_capture_internal
     ):
         mock_validate_messaging_preferences_token.return_value = mock_response(
             200, {"valid": True, "team_id": self.team.id, "identifier": self.recipient.identifier}
         )
 
-        if save_point == "one_click":
+        if code_path == "one_click":
             response = self.client.get(
                 reverse("message_preferences", kwargs={"token": self.token}),
                 {"one_click_unsubscribe": "1"},

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -223,6 +223,15 @@ class TestMessagePreferencesViews(BaseTest):
             },
         )
 
+        # A replay (scanner prefetch, reused token) is not a transition and must not emit again
+        mock_capture_internal.reset_mock()
+        response = self.client.get(
+            reverse("message_preferences", kwargs={"token": self.token}),
+            {"one_click_unsubscribe": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_capture_internal.assert_not_called()
+
     @patch("posthog.views.capture_internal")
     @patch("posthog.views.validate_messaging_preferences_token")
     def test_update_preferences_emits_only_for_newly_opted_out(

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -229,7 +229,8 @@ class TestMessagePreferencesViews(BaseTest):
         self, mock_validate_messaging_preferences_token, mock_capture_internal
     ):
         self._enable_engagement_events()
-        # category is already opted out, so only category2 and $all are genuine transitions
+        # category is already opted out, so only category2 and $all are genuine transitions;
+        # the bogus id must be dropped because it isn't one of the team's categories
         self.recipient.preferences = {
             str(self.category.id): PreferenceStatus.OPTED_OUT.value,
             str(self.category2.id): PreferenceStatus.OPTED_IN.value,
@@ -239,7 +240,14 @@ class TestMessagePreferencesViews(BaseTest):
             200, {"valid": True, "team_id": self.team.id, "identifier": self.recipient.identifier}
         )
 
-        data = {"token": self.token, "preferences[]": [f"{self.category.id}:false", f"{self.category2.id}:false"]}
+        data = {
+            "token": self.token,
+            "preferences[]": [
+                f"{self.category.id}:false",
+                f"{self.category2.id}:false",
+                "not-a-real-category:false",
+            ],
+        }
         response = self.client.post(reverse("message_preferences_update"), data)
 
         self.assertEqual(response.status_code, 200)

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -190,6 +190,90 @@ class TestMessagePreferencesViews(BaseTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.content), {"error": "Preference values must be 'true' or 'false'"})
 
+    def _enable_engagement_events(self):
+        config = self.team.workflows_config
+        config.capture_workflows_engagement_events = True
+        config.save()
+
+    @patch("posthog.views.capture_internal")
+    @patch("posthog.views.validate_messaging_preferences_token")
+    def test_one_click_unsubscribe_emits_unsubscribed_event(
+        self, mock_validate_messaging_preferences_token, mock_capture_internal
+    ):
+        self._enable_engagement_events()
+        mock_validate_messaging_preferences_token.return_value = mock_response(
+            200, {"valid": True, "team_id": self.team.id, "identifier": self.recipient.identifier}
+        )
+
+        response = self.client.get(
+            reverse("message_preferences", kwargs={"token": self.token}),
+            {"one_click_unsubscribe": "1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture_internal.assert_called_once_with(
+            token=self.team.api_token,
+            event_name="$workflows_email_unsubscribed",
+            event_source="workflows_unsubscribe",
+            distinct_id=self.recipient.identifier,
+            properties={
+                "$email": self.recipient.identifier,
+                "category": ALL_MESSAGE_PREFERENCE_CATEGORY_ID,
+                "source": "one_click",
+            },
+        )
+
+    @patch("posthog.views.capture_internal")
+    @patch("posthog.views.validate_messaging_preferences_token")
+    def test_update_preferences_emits_only_for_newly_opted_out(
+        self, mock_validate_messaging_preferences_token, mock_capture_internal
+    ):
+        self._enable_engagement_events()
+        # category is already opted out, so only category2 and $all are genuine transitions
+        self.recipient.preferences = {
+            str(self.category.id): PreferenceStatus.OPTED_OUT.value,
+            str(self.category2.id): PreferenceStatus.OPTED_IN.value,
+        }
+        self.recipient.save()
+        mock_validate_messaging_preferences_token.return_value = mock_response(
+            200, {"valid": True, "team_id": self.team.id, "identifier": self.recipient.identifier}
+        )
+
+        data = {"token": self.token, "preferences[]": [f"{self.category.id}:false", f"{self.category2.id}:false"]}
+        response = self.client.post(reverse("message_preferences_update"), data)
+
+        self.assertEqual(response.status_code, 200)
+        emitted_categories = [call.kwargs["properties"]["category"] for call in mock_capture_internal.call_args_list]
+        self.assertEqual(
+            sorted(emitted_categories), sorted([str(self.category2.id), ALL_MESSAGE_PREFERENCE_CATEGORY_ID])
+        )
+        for call in mock_capture_internal.call_args_list:
+            self.assertEqual(call.kwargs["properties"]["source"], "preferences_page")
+
+    @parameterized.expand(["one_click", "preferences_form"])
+    @patch("posthog.views.capture_internal")
+    @patch("posthog.views.validate_messaging_preferences_token")
+    def test_no_unsubscribed_event_when_flag_off(
+        self, save_point, mock_validate_messaging_preferences_token, mock_capture_internal
+    ):
+        mock_validate_messaging_preferences_token.return_value = mock_response(
+            200, {"valid": True, "team_id": self.team.id, "identifier": self.recipient.identifier}
+        )
+
+        if save_point == "one_click":
+            response = self.client.get(
+                reverse("message_preferences", kwargs={"token": self.token}),
+                {"one_click_unsubscribe": "1"},
+            )
+        else:
+            response = self.client.post(
+                reverse("message_preferences_update"),
+                {"token": self.token, "preferences[]": [f"{self.category.id}:false"]},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture_internal.assert_not_called()
+
 
 class TestMessagePreferencesAPIViewSet(APIBaseTest):
     def setUp(self):


### PR DESCRIPTION
## Problem

PostHog already emits `$workflows_email_sent` / `_delivered` / `_opened` / `_link_clicked` / `_bounced` / `_blocked` engagement events into the customer's project (from the plugin-server, gated on the `capture_workflows_engagement_events` team flag), but there is no unsubscribe event.
Customers who want to manage suppression lists in PostHog need unsubscribes captured as events too.
Unsubscribes don't flow through the plugin-server tracking path, they're recorded in Django by the messaging preferences pages.

## Changes

- New `report_workflows_email_unsubscribed()` helper in `posthog/views.py` that emits `$workflows_email_unsubscribed` into the customer's project via `capture_internal`, gated on the same `capture_workflows_engagement_events` team flag as the other engagement events. Best-effort, so a capture failure never breaks the unsubscribe flow, and each category's capture is independently best-effort.
- Wired into both save points, both transition-only so replays and repeated saves never double-count:
  - One-click unsubscribe in `preferences_page` emits a single event with `category: "$all"` and `source: "one_click"`, only when the recipient wasn't already fully opted out (token replays and mail-scanner prefetches don't emit).
  - The preferences form in `update_preferences` compares prior vs new preferences and emits one event per category that genuinely transitioned to opted out (including `$all` when it gets added), with `source: "preferences_page"`.
- Emitted categories are validated against the team's known (non-deleted) message categories (or `$all`), so arbitrary category ids posted to the form can't inject junk property values.
- Properties: `$email` (recipient identifier), `category` (category id, or `$all`), `source`.

Two semantics caveats worth knowing as a reviewer:

- The unsubscribe token only carries `team_id` + identifier, so this event is email-level, not per-send. `distinct_id` is the recipient's email address, which may differ from the tracked distinct_id on opens/clicks, and there is no `$workflow_id` / `$workflow_action_id`.
- Like the other engagement events, this is a billable event, off by default (the team flag defaults to false).

<img width="1845" height="784" alt="Screenshot 2026-07-07 at 11 38 12" src="https://github.com/user-attachments/assets/f493196f-faf2-4729-b84b-8262c0459380"/>

## How did you test this code?

Added three tests to `products/messaging/backend/api/test/test_message_preferences.py`, each catching a regression no existing test covers:

- `test_one_click_unsubscribe_emits_unsubscribed_event`: catches dropped wiring or a changed payload (event name, token, distinct_id, properties) on the one-click path, and asserts a replayed one-click hit does not emit again.
- `test_update_preferences_emits_only_for_newly_opted_out`: catches double-counting (an already-opted-out category must not re-emit) and category injection (an unknown category id posted to the form must not emit).
- `test_no_unsubscribed_event_when_flag_off` (parameterized over both save points): catches removal of the flag gate, which would silently start billing every customer for these events.

The agent environment had no Postgres, so these tests ran in CI (green on the current head). `ruff check` and `ruff format` pass on the diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` currently describe the workflows engagement events, so there was nothing to update in-repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (session: https://claude.ai/code/session_01RnhhvYkU7qeoe2UmYeAnby) from a task spec, with daniel.m directing.
Skills invoked: `/writing-tests` (test gate) and `/setup-web-tests` (environment setup attempt).
Key decisions: reused the plugin-server's flag gating and property naming conventions from `email-tracking.service.ts`; emitted per-category events on the form path with a prior-vs-new transition check rather than emitting on every save; verified the new module-level `posthog.api.capture` import is cheap and cycle-free (the `posthog.api` package init is a lazy shim) before adding it to `views.py`, which loads at startup.
Review-driven changes: per Greptile, made each category's capture independently best-effort; per Veria/Hex security review and DRI confirmation, switched one-click from always-emit to transition-only and added category-id validation against the team's real categories.