### PR TITLE
fix(surveys): end repeating surveys after their final iteration

### DIFF
--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -176,7 +176,7 @@ function SurveyIterationOptions(): JSX.Element {
                                         <div className="text-xs text-muted">
                                             {survey.iteration_count === 1
                                                 ? 'This survey will only be shown once (no repeats).'
-                                                : `This survey will be shown now, then ${survey.iteration_count - 1} more ${pluralize(survey.iteration_count - 1, 'time', 'times', false)} with ${pluralize(survey.iteration_frequency_days, 'day')} between each.`}
+                                                : `This survey runs for ${survey.iteration_count} iterations of ${pluralize(survey.iteration_frequency_days, 'day')} each, counted from the launch date. Each user can respond once per iteration.`}
                                         </div>
                                     )}
                                 </div>

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.test.tsx
@@ -56,6 +56,6 @@ describe('SuccessStep', () => {
             />
         )
 
-        expect(screen.getByText('Up to 2 times, every 90 days')).toBeInTheDocument()
+        expect(screen.getByText('Up to 2 times, every 90 days from launch')).toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/SuccessStep.tsx
@@ -94,7 +94,7 @@ export function SuccessStep({ survey }: SuccessStepProps): JSX.Element {
                                     ? 'Every time a trigger event is captured'
                                     : survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
                                       ? 'Once ever'
-                                      : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days`}
+                                      : `Up to ${survey.iteration_count ?? 10} times, every ${survey.iteration_frequency_days} days from launch`}
                             </dd>
                         </div>
                         {survey.conditions?.seenSurveyWaitPeriodInDays != null && (

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.test.tsx
@@ -96,4 +96,20 @@ describe('WhenStep', () => {
         expect(screen.getByText('Once ever')).toBeInTheDocument()
         expect(screen.queryByText(/the schedule options don't apply/)).not.toBeInTheDocument()
     })
+
+    it('surfaces a non-preset recurring cadence as a custom option instead of falling back to once', async () => {
+        useMocks(
+            surveyMocks({
+                ...createEventTriggeredSurvey(false),
+                conditions: { actions: null, events: null },
+                schedule: SurveySchedule.Recurring,
+                iteration_count: 5,
+                iteration_frequency_days: 45,
+            })
+        )
+        renderWhenStep()
+
+        expect(await screen.findByText('Every 45 days')).toBeInTheDocument()
+        expect(screen.getByText(/times in total/)).toBeInTheDocument()
+    })
 })

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -59,12 +59,25 @@ export function WhenStep(): JSX.Element {
     const delaySeconds = appearance.surveyPopupDelaySeconds ?? 0
     const excludedObjectProperties = useExcludedObjectProperties()
     // Derive frequency strictly from the iteration model — the universal wait-period is a separate
-    // across-surveys gate and must not influence which cadence is highlighted. Default to 'once' so
-    // an unconfigured survey doesn't silently imply a recurring cadence.
+    // across-surveys gate and must not influence which cadence is highlighted.
+    const presetFrequency = FREQUENCY_OPTIONS.find((opt) => opt.days === survey.iteration_frequency_days)?.value
+    // A recurring survey with a non-preset cadence (set in the full editor) must not render as
+    // 'Once ever' — surface it as a custom option instead.
     const frequency =
-        survey.schedule === SurveySchedule.Once
+        survey.schedule === SurveySchedule.Once || !survey.iteration_frequency_days
             ? 'once'
-            : (FREQUENCY_OPTIONS.find((opt) => opt.days === survey.iteration_frequency_days)?.value ?? 'once')
+            : (presetFrequency ?? 'custom')
+    const frequencyOptions =
+        frequency === 'custom'
+            ? [
+                  ...FREQUENCY_OPTIONS,
+                  {
+                      value: 'custom',
+                      days: survey.iteration_frequency_days ?? undefined,
+                      label: `Every ${survey.iteration_frequency_days} days`,
+                  },
+              ]
+            : FREQUENCY_OPTIONS
     const iterationCount = survey.iteration_count ?? DEFAULT_ITERATION_COUNT
     const seenSurveyWaitPeriodInDays = conditions.seenSurveyWaitPeriodInDays ?? null
 
@@ -82,6 +95,10 @@ export function WhenStep(): JSX.Element {
     }
 
     const setFrequency = (value: string): void => {
+        if (value === 'custom') {
+            // Already the active cadence — nothing to change.
+            return
+        }
         const option = FREQUENCY_OPTIONS.find((opt) => opt.value === value)
         if (value === 'once') {
             setSurveyValue('schedule', SurveySchedule.Once)
@@ -281,7 +298,7 @@ export function WhenStep(): JSX.Element {
 
             <WizardSection
                 title="How often should this survey show?"
-                description="How many times the same user can see this survey, and how often."
+                description="How many times this survey repeats, and how often. Repeats count from the launch date, so all users become eligible again at the same time."
                 descriptionClassName="text-sm"
             >
                 {repeatsOnEveryEvent ? (
@@ -297,7 +314,7 @@ export function WhenStep(): JSX.Element {
                         <LemonSegmentedButton
                             value={frequency}
                             onChange={setFrequency}
-                            options={FREQUENCY_OPTIONS.map((opt) => ({
+                            options={frequencyOptions.map((opt) => ({
                                 ...opt,
                                 tooltip:
                                     opt.value === recommendedFrequency.value

--- a/posthog/tasks/test/test_update_survey_iteration.py
+++ b/posthog/tasks/test/test_update_survey_iteration.py
@@ -53,6 +53,15 @@ class TestUpdateSurveyIteration(TestCase, ClickhouseTestMixin):
         self.recurring_survey.refresh_from_db()
         self.assertEqual(self.recurring_survey.current_iteration, 3)
 
+    def test_survey_ends_after_final_iteration(self) -> None:
+        self.recurring_survey.start_date = now() - timedelta(days=self.iteration_frequency_days * 3 + 1)
+        self.recurring_survey.save()
+        self.assertEqual(self.recurring_survey.current_iteration, 1)
+        update_survey_iteration()
+        self.recurring_survey.refresh_from_db()
+        self.assertIsNotNone(self.recurring_survey.end_date)
+        self.assertEqual(self.recurring_survey.current_iteration, 1)
+
     def test_can_guard_for_current_survey_iteration_overflow(self) -> None:
         self.recurring_survey.start_date = now() - timedelta(self.iteration_frequency_days * 3)
         self.recurring_survey.save()

--- a/posthog/tasks/test/test_update_survey_iteration.py
+++ b/posthog/tasks/test/test_update_survey_iteration.py
@@ -62,6 +62,14 @@ class TestUpdateSurveyIteration(TestCase, ClickhouseTestMixin):
         self.assertIsNotNone(self.recurring_survey.end_date)
         self.assertEqual(self.recurring_survey.current_iteration, 1)
 
+    def test_huge_iteration_frequency_does_not_crash_task(self) -> None:
+        self.recurring_survey.iteration_count = 1
+        self.recurring_survey.iteration_frequency_days = 2_147_483_647
+        self.recurring_survey.save()
+        update_survey_iteration()
+        self.recurring_survey.refresh_from_db()
+        self.assertIsNone(self.recurring_survey.end_date)
+
     def test_can_guard_for_current_survey_iteration_overflow(self) -> None:
         self.recurring_survey.start_date = now() - timedelta(self.iteration_frequency_days * 3)
         self.recurring_survey.save()

--- a/posthog/tasks/update_survey_iteration.py
+++ b/posthog/tasks/update_survey_iteration.py
@@ -1,5 +1,7 @@
-from datetime import date
+from datetime import date, timedelta
 from typing import Any
+
+from django.utils import timezone
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.surveys.backend.models import Survey
@@ -10,16 +12,34 @@ def _update_survey_iteration(survey: Survey) -> None:
     if survey.iteration_start_dates is None or survey.end_date is not None:
         return
 
+    if _has_final_iteration_ended(survey):
+        survey.end_date = timezone.now()
+        survey.save(update_fields=["end_date"])
+        return
+
     current_iteration = _get_current_iteration(survey)
     if (
-        current_iteration != survey.current_iteration
+        current_iteration > 0
+        and current_iteration != survey.current_iteration
         and survey.iteration_start_dates is not None
         and 0 < len(survey.iteration_start_dates)
     ):
-        survey.current_iteration = max(_get_current_iteration(survey), 1)
+        survey.current_iteration = current_iteration
         survey.current_iteration_start_date = survey.iteration_start_dates[survey.current_iteration - 1]
         survey.internal_targeting_flag = _get_targeting_flag(survey)
         survey.save(update_fields=["current_iteration", "current_iteration_start_date", "internal_targeting_flag_id"])
+
+
+def _has_final_iteration_ended(survey: Survey) -> bool:
+    if not survey.iteration_start_dates or not survey.iteration_frequency_days:
+        return False
+
+    last_iteration_start = survey.iteration_start_dates[-1]
+    if last_iteration_start is None:
+        return False
+
+    final_iteration_end = last_iteration_start.date() + timedelta(days=survey.iteration_frequency_days)
+    return date.today() > final_iteration_end
 
 
 def _get_targeting_flag(survey: Survey) -> FeatureFlag | Any:

--- a/posthog/tasks/update_survey_iteration.py
+++ b/posthog/tasks/update_survey_iteration.py
@@ -38,7 +38,11 @@ def _has_final_iteration_ended(survey: Survey) -> bool:
     if last_iteration_start is None:
         return False
 
-    final_iteration_end = last_iteration_start.date() + timedelta(days=survey.iteration_frequency_days)
+    try:
+        final_iteration_end = last_iteration_start.date() + timedelta(days=survey.iteration_frequency_days)
+    except OverflowError:
+        # iteration_frequency_days is not capped by the API; a huge value must not crash the task
+        return False
     return date.today() > final_iteration_end
 
 


### PR DESCRIPTION
## Problem

Repeating surveys ("Repeat on a schedule") have three issues that surfaced while auditing the behavior against the docs (context: [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1783335567251989?thread_ts=1783335567.251989&cid=C07QD3LT8U9), docs overhaul in [posthog.com#18200](https://github.com/PostHog/posthog.com/pull/18200)):

1. **A repeating survey never ends.** Once past its final iteration window, `_update_survey_iteration` computed a current iteration of 0 and then did `max(0, 1)`, resetting `current_iteration` back to 1. This re-opened the first iteration's eligibility gate, so users who had responded only in later iterations became eligible *again*, and the survey kept serving indefinitely until manually stopped. "Show up to 3 times" actually meant "show forever".
2. **Product copy promises a per-user cadence the feature doesn't have.** Iterations are calendar windows counted from the survey's launch date and shared by all users, but the wizard said "How many times the same user can see this survey, and how often", and the editor helper said "shown now, then N-1 more times with D days between each".
3. **The wizard misrenders custom cadences.** A recurring survey with a non-preset frequency (say 45 days, set in the full editor) fell back to displaying "Once ever" in the wizard's frequency selector.

## Changes

- `update_survey_iteration` now sets `end_date` once the final iteration window has passed (same approach as the responses-limit auto-stop task), instead of reverting to iteration 1. The iteration-advance branch only runs for a valid current iteration, so the `max(..., 1)` hack is gone.
- Wizard "How often should this survey show?" description, editor helper text, and wizard summary now describe the real model: iterations count from the launch date, each user can respond once per iteration.
- The wizard frequency selector surfaces a non-preset cadence as an extra "Every N days" option instead of falling back to "Once ever". Selecting it is a no-op; picking a preset still switches normally.

Note on rollout: recurring surveys already past their final window (currently stuck serving on the reverted iteration 1) will be ended by the next task run after deploy. That's the intended semantics, but it is a behavior change for those surveys.

## How did you test this code?

- `posthog/tasks/test/test_update_survey_iteration.py` — all pass, including a new `test_survey_ends_after_final_iteration`: catches a regression where a survey past its last window keeps serving (end_date unset) or reverts to iteration 1. No existing test exercised the past-final-window path.
- `WhenStep.test.tsx` — new case asserting a recurring survey with a 45-day cadence renders "Every 45 days" and the repetition count input, instead of "Once ever" (the bug this PR fixes). Existing cases still pass.
- `SuccessStep.test.tsx` — updated copy assertion, passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The user-facing docs for this section are being rewritten in [posthog.com#18200](https://github.com/PostHog/posthog.com/pull/18200), grounded in this behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) directed by Lucas. The agent audited the repeating-survey implementation across the backend task, the survey model, and all five SDKs while rewriting the docs, found these bugs, and Lucas asked for the fixes as this PR. Skills invoked: `/debugging-surveys` (eligibility pipeline + SDK parity grounding) and `/writing-tests` (test gate). A per-user minimum gap across iteration rollovers was considered and deliberately left out — it changes semantics and needs a team decision. The React Native iteration bug (local seen state not iteration-aware) lives in posthog-js and ships separately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*