### PR TITLE
fix(devex): link master CI alerts to engineering analytics workflow detail

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -32,10 +32,10 @@
 const SLACK_API = 'https://slack.com/api'
 const INCIDENT_EVENT_TYPE = 'master_ci_incident'
 // Per-workflow links point at the engineering analytics workflow-detail page (not GitHub), scoped
-// to master via that product's `?q=` branch filter. Hosted in the team-devex project (project 2)
-// for now: the only project with the PostHog/posthog GitHub source synced. `owner`/`repo` come
-// from the run context; the workflow's GitHub display name is the path key.
-const ENG_ANALYTICS_BASE = 'https://us.posthog.com/project/2/engineering-analytics'
+// to master via that product's `?q=` branch filter. Hosted in the team-devex project (347861) for
+// now, before it moves to its final home; it's the project with the PostHog/posthog GitHub source
+// synced. `owner`/`repo` come from the run context; the workflow's GitHub display name is the path key.
+const ENG_ANALYTICS_BASE = 'https://us.posthog.com/project/347861/engineering-analytics'
 // One page of channel history. #alerts-devex is low-traffic, so the open anchor
 // reliably stays within the newest 100 messages; a busier channel would need paging.
 const HISTORY_LIMIT = 100

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -31,6 +31,11 @@
 
 const SLACK_API = 'https://slack.com/api'
 const INCIDENT_EVENT_TYPE = 'master_ci_incident'
+// Per-workflow links point at the engineering analytics workflow-detail page (not GitHub), scoped
+// to master via that product's `?q=` branch filter. Hosted in the team-devex project (project 2)
+// for now: the only project with the PostHog/posthog GitHub source synced. `owner`/`repo` come
+// from the run context; the workflow's GitHub display name is the path key.
+const ENG_ANALYTICS_BASE = 'https://us.posthog.com/project/2/engineering-analytics'
 // One page of channel history. #alerts-devex is low-traffic, so the open anchor
 // reliably stays within the newest 100 messages; a busier channel would need paging.
 const HISTORY_LIMIT = 100
@@ -292,9 +297,10 @@ function formatDuration(mins) {
 // Slack mrkdwn requires escaping these three in user-supplied text.
 const slackEscape = (text) => String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-// A workflow's run history on master — where you can see all of its runs at a glance.
-function runsUrlFor(owner, repo, workflowFile) {
-    return `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}?query=branch%3Amaster`
+// A workflow's run history on master, in engineering analytics — where you can see all of its
+// runs at a glance. The path key is the workflow's GitHub display name (e.g. "Backend CI").
+function runsUrlFor(owner, repo, workflowName) {
+    return `${ENG_ANALYTICS_BASE}/${owner}/${repo}/actions/workflows/${encodeURIComponent(workflowName)}?q=master`
 }
 
 // Read-boundary normalizer for persisted incident workflows: tolerate an older
@@ -442,7 +448,7 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
             const redForMins = Math.round((now.getTime() - new Date(f.since).getTime()) / 60000)
             return {
                 ...f,
-                runsUrl: runsUrlFor(owner, repo, f.workflow_file),
+                runsUrl: runsUrlFor(owner, repo, f.name),
                 redForMins, // detection: byDuration + open/resolve thresholds
                 displayRedForMins: Math.round((now.getTime() - new Date(f.displaySince).getTime()) / 60000),
                 byCount: f.consecutive_failures >= workflowThreshold,

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -179,7 +179,8 @@ describe('ci-alerts-devex', () => {
             const body = JSON.stringify(anchor.attachments)
             assert.match(body, /Backend CI/)
             assert.match(body, /5 failed runs in a row/)
-            assert.match(body, /actions\/workflows\/ci-backend\.yml\?query=branch/) // per-workflow runs link
+            // per-workflow link → engineering analytics workflow detail, scoped to master
+            assert.match(body, /engineering-analytics\/PostHog\/posthog\/actions\/workflows\/Backend%20CI\?q=master/)
             assert.equal(anchor.metadata.event_type, 'master_ci_incident')
             assert.equal(anchor.metadata.event_payload.status, 'active')
             assert.deepEqual(
@@ -223,7 +224,7 @@ describe('ci-alerts-devex', () => {
         const thread = slack.postMessage.calls[0][0].text
         assert.match(thread, /now also failing/)
         assert.match(thread, /Frontend CI/)
-        assert.match(thread, /actions\/workflows\/ci-frontend\.yml\?query=branch/)
+        assert.match(thread, /engineering-analytics\/PostHog\/posthog\/actions\/workflows\/Frontend%20CI\?q=master/)
     })
 
     it('strikes through the anchor and threads recovery on resolve', async () => {


### PR DESCRIPTION
## Problem

The #alerts-devex master CI incident messages (posted by the DevEx bot) linked each failing workflow straight to GitHub Actions. We now have the engineering analytics product surfacing the same workflow run history with richer context, so the alerts should point there instead.

## Changes

`runsUrlFor` in `.github/scripts/ci-alerts-devex.js` now builds an engineering analytics workflow-detail URL, scoped to master via that product's `?q=` branch filter, instead of a GitHub Actions URL. The path key switched from the workflow file slug (`ci-backend.yml`) to the workflow's GitHub display name (`Backend CI`), which is what the engineering analytics route expects. Links are hosted in the team-devex project (project 2) for now, the only project with the PostHog/posthog GitHub source synced.

The "all failing runs" aggregate link stays on GitHub, since there's no clean engineering analytics equivalent for a failing-only view.

## How did you test this code?

Updated the two URL assertions in `.github/scripts/ci-alerts-devex.test.js` and ran the suite with `node --test .github/scripts/ci-alerts-devex.test.js`: all 38 tests pass. I did not exercise the live Slack posting path.

## Docs update

No docs cover this internal alerting script.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Julian asked (from a Slack thread in #alerts-devex) to make the master CI alerts link to the engineering analytics workflow detail for master. I (Claude, via the PostHog Slack app) traced the alert copy to `.github/scripts/ci-alerts-devex.js`, confirmed the engineering analytics route shape (`/engineering-analytics/:repoOwner/:repoName/actions/workflows/:workflowName`, branch via `?q=`) and that its `workflow_name` is GitHub's display name, and verified via the engineering-analytics MCP tool that project 2 is the project with the PostHog/posthog source connected. I kept the change scoped to the per-workflow links and left the GitHub aggregate link alone.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1783360274484019?thread_ts=1783360274.484019&cid=C0AS64N6DJL)*
