### PR TITLE
fix(signals): mark auto-started implementation task as internal

### DIFF
--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -230,7 +230,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                     const [scoutResult, signalResult] = await Promise.allSettled([
                         api.signalScout.runs.list({ limit: SCOUT_RUNS_LIMIT }),
                         // `internal: 'all'` so the pipeline's runs (research and implementation, both
-                        // created internal) are included — they're hidden from the default task list.
+                        // created internal) are included. They're hidden from the default task list.
                         api.tasks.list({
                             origin_product: OriginProduct.SIGNAL_REPORT,
                             internal: 'all',

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -229,8 +229,8 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 loadRuns: async (_payload: void, breakpoint) => {
                     const [scoutResult, signalResult] = await Promise.allSettled([
                         api.signalScout.runs.list({ limit: SCOUT_RUNS_LIMIT }),
-                        // `internal: 'all'` so the pipeline's research runs (created internal) are included,
-                        // not just the non-internal implementation/PR runs.
+                        // `internal: 'all'` so the pipeline's runs (research and implementation, both
+                        // created internal) are included — they're hidden from the default task list.
                         api.tasks.list({
                             origin_product: OriginProduct.SIGNAL_REPORT,
                             internal: 'all',

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -148,11 +148,7 @@ def _create_implementation_task_if_absent(
             posthog_mcp_scopes="full",
             interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
             ai_stage="implementation",
-            # Keep pipeline-spawned implementation runs out of the default task list — the report
-            # detail surfaces them by id (via task_run artefacts) and shows the draft PR there, so
-            # listing them alongside user-created tasks is just noise. `internal` gates default list
-            # visibility only, not access: retrieve-by-id, PR-url lookup, notifications, and the
-            # `internal=all` Runs tab are all unaffected.
+            # Internal so the run stays out of the default task list; the report surfaces it by id.
             internal=True,
         )
         if created.latest_run is None:

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -148,6 +148,12 @@ def _create_implementation_task_if_absent(
             posthog_mcp_scopes="full",
             interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
             ai_stage="implementation",
+            # Keep pipeline-spawned implementation runs out of the default task list — the report
+            # detail surfaces them by id (via task_run artefacts) and shows the draft PR there, so
+            # listing them alongside user-created tasks is just noise. `internal` gates default list
+            # visibility only, not access: retrieve-by-id, PR-url lookup, notifications, and the
+            # `internal=all` Runs tab are all unaffected.
+            internal=True,
         )
         if created.latest_run is None:
             raise RuntimeError(f"Task {created.task_id} auto-started without producing a TaskRun")

--- a/products/signals/backend/test/test_auto_start.py
+++ b/products/signals/backend/test/test_auto_start.py
@@ -159,6 +159,8 @@ def test_create_implementation_task_if_absent_is_idempotent(organization, team):
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["origin_product"] == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
     assert call_kwargs["ai_stage"] == "implementation"
+    # Pipeline-spawned implementation runs are internal so they stay out of the default task list.
+    assert call_kwargs["internal"] is True
     # The gate the second evaluation observed is the legacy SignalReportTask implementation link,
     # written in the same transaction as the task; the task_run artefact is the work-log entry
     # alongside.

--- a/products/signals/backend/test/test_auto_start.py
+++ b/products/signals/backend/test/test_auto_start.py
@@ -159,7 +159,6 @@ def test_create_implementation_task_if_absent_is_idempotent(organization, team):
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["origin_product"] == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
     assert call_kwargs["ai_stage"] == "implementation"
-    # Pipeline-spawned implementation runs are internal so they stay out of the default task list.
     assert call_kwargs["internal"] is True
     # The gate the second evaluation observed is the legacy SignalReportTask implementation link,
     # written in the same transaction as the task; the task_run artefact is the work-log entry


### PR DESCRIPTION
## Problem

Signal-report "implementation" runs (the pipeline auto-starts these to open a draft PR from a report) were showing up in the PostHog code task list alongside user-created tasks. Every other signal task in the pipeline (research, scout runs) is already created `internal=True`, so the implementation task was the lone one leaking into the list. Back when the task list was the primary surface this was intended, but the report detail now surfaces these runs and their PR directly, so listing them again is just noise. Raised in a Slack thread.

## Changes

- `products/signals/backend/auto_start.py`: pass `internal=True` when auto-creating the implementation task, so it stays out of the default task list.
- Updated the inbox Runs-tab comment (`inboxSceneLogic.ts`) since both research and implementation runs are now internal (that loader already passes `internal: 'all'`, so nothing functionally changes there).
- Added one assertion to the existing `test_auto_start` kwargs check.

`internal` gates default list visibility only, not access. I traced every consumer of this task to confirm nothing breaks:

- **Report → task/PR linkage** (web, desktop, mobile): resolved from the report's `task_run` artefacts and fetched by id (`get_task` / retrieve-by-id ignores `internal`); the report's `implementation_pr_url` comes from `TaskRun` rows, not the internal-filtered list. Unaffected.
- **Idempotency gate** (prevents duplicate implementation tasks): reads the `SignalReportTask` / `SignalReportArtefact` relationship tables directly, neither of which has an `internal` column. No duplicate-creation risk.
- **Inbox Runs tab**: already queries with `internal: 'all'`, so implementation runs still appear.
- **Notifications, Temporal workflow, webhooks, analytics capture, LLM-gateway product tagging** (keyed on `origin_product`, not `internal`): all unaffected.
- **PostHog/code app**: default list already excludes internal server-side; every report surface reaches its tasks by id. No regression (verified against the repo).

One minor, self-correcting cosmetic note: right after creation the desktop app optimistically seeds the new task into origin-less list caches, so it may flash in the sidebar until the next 60s poll, then drops out — the intended decluttering. The `repositories` picker also only draws from non-internal tasks, so a repo used solely by signal implementation tasks would not appear there (repos are otherwise sourced from the GitHub integration).

## How did you test this code?

Added an `internal is True` assertion to the existing `create_and_run_task` kwargs check in `test_auto_start.py` — guards the exact regression this PR fixes (someone dropping the flag re-floods the task list); no existing test covered it. I could not run the DB-backed suite in this environment (no Postgres reachable), but confirmed both changed Python files parse, pass `ruff check`, and are `ruff format`-clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- no user-facing docs affected -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Work was scoped by fanning out read-only exploration agents to (1) locate the implementation-task creation site, (2) enumerate every reference to and side effect of the `Task.internal` flag, (3) verify the signals report UI/backend linkage, and (4) clone and inspect the PostHog/code app's task-list consumption. The change itself is a single `internal=True` kwarg. Invoked the `/writing-tests` skill before adding the test assertion.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783363907930559?thread_ts=1783363907.930559&cid=C09SK2PAGKF)*
