### PR TITLE
feat(dashboards): apply interval and test-account dashboard overrides

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13665,6 +13665,21 @@
                 "explicitDate": {
                     "type": "boolean"
                 },
+                "filterTestAccounts": {
+                    "description": "Tri-state test-account override. Null/absent = inherit; true = force on; false = force off.",
+                    "type": ["boolean", "null"]
+                },
+                "interval": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IntervalType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Time granularity forced onto every insight that supports one. Absent/null = inherit."
+                },
                 "properties": {
                     "anyOf": [
                         {
@@ -43838,6 +43853,19 @@
                 },
                 "explicitDate": {
                     "type": "boolean"
+                },
+                "filterTestAccounts": {
+                    "type": ["boolean", "null"]
+                },
+                "interval": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/IntervalType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "properties": {
                     "anyOf": [

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5039,6 +5039,10 @@ export interface DashboardFilter {
     properties?: AnyPropertyFilter[] | null
     breakdown_filter?: BreakdownFilter | null
     explicitDate?: boolean
+    /** Time granularity forced onto every insight that supports one. Absent/null = inherit. */
+    interval?: IntervalType | null
+    /** Tri-state test-account override. Null/absent = inherit; true = force on; false = force off. */
+    filterTestAccounts?: boolean | null
 }
 
 export interface TileFilters {
@@ -5047,6 +5051,8 @@ export interface TileFilters {
     properties?: AnyPropertyFilter[] | null | undefined
     breakdown_filter?: BreakdownFilter | null | undefined
     explicitDate?: boolean | undefined
+    interval?: IntervalType | null | undefined
+    filterTestAccounts?: boolean | null | undefined
 }
 
 export interface InsightsThresholdBounds {

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1365,6 +1365,21 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             ],
         )
 
+    def test_dashboard_interval_and_test_account_overrides_round_trip(self):
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-24h"}})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"filters": {"date_from": "-24h", "interval": "week", "filterTestAccounts": True}},
+        )
+
+        self.assertEqual(response["filters"]["interval"], "week")
+        self.assertEqual(response["filters"]["filterTestAccounts"], True)
+
+        read_back = self.dashboard_api.get_dashboard(dashboard_id)
+        self.assertEqual(read_back["filters"]["interval"], "week")
+        self.assertEqual(read_back["filters"]["filterTestAccounts"], True)
+
     def test_dashboard_filter_is_applied_even_if_insight_is_created_before_dashboard(self):
         insight_id, _ = self.dashboard_api.create_insight(
             {"filters": {"hello": "test", "date_from": "-7d"}, "name": "some_item"}

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2303,6 +2303,15 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if dashboard_filter.breakdown_filter and not should_ignore_dashboard_breakdown:
             if hasattr(self.query, "breakdownFilter"):  # redundant, but required for mypy
                 self.query.breakdownFilter = dashboard_filter.breakdown_filter
+
+        # Interval and test-account overrides apply only to query types that carry the field.
+        # Types without it (retention, paths) are silently skipped rather than mutated.
+        if dashboard_filter.interval is not None and hasattr(self.query, "interval"):
+            self.query.interval = dashboard_filter.interval
+
+        if dashboard_filter.filterTestAccounts is not None and hasattr(self.query, "filterTestAccounts"):
+            self.query.filterTestAccounts = dashboard_filter.filterTestAccounts
+
         self.__post_init__()
 
 

--- a/posthog/hogql_queries/test/test_dashboard_filters_overrides.py
+++ b/posthog/hogql_queries/test/test_dashboard_filters_overrides.py
@@ -1,0 +1,131 @@
+from collections.abc import Callable
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.schema import (
+    DashboardFilter,
+    EventsNode,
+    FunnelsQuery,
+    IntervalType,
+    LifecycleQuery,
+    PathsFilter,
+    PathsQuery,
+    RetentionFilter,
+    RetentionQuery,
+    StickinessQuery,
+    TrendsQuery,
+)
+
+from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
+from posthog.hogql_queries.insights.lifecycle.lifecycle_query_runner import LifecycleQueryRunner
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
+from posthog.hogql_queries.query_runner import QueryRunner
+from posthog.models import Team
+
+from products.product_analytics.backend.hogql_queries.paths.paths_query_runner import PathsQueryRunner
+from products.product_analytics.backend.hogql_queries.stickiness.stickiness_query_runner import StickinessQueryRunner
+
+_TIME_SERIES = [EventsNode(event="$pageview")]
+
+# Runners whose query model carries an `interval` field.
+INTERVAL_QUERY_RUNNERS: list[tuple[str, Callable[[Team], QueryRunner]]] = [
+    (
+        "trends",
+        lambda team: TrendsQueryRunner(query=TrendsQuery(series=_TIME_SERIES, interval=IntervalType.DAY), team=team),
+    ),
+    (
+        "funnels",
+        lambda team: FunnelsQueryRunner(query=FunnelsQuery(series=_TIME_SERIES), team=team),
+    ),
+    (
+        "stickiness",
+        lambda team: StickinessQueryRunner(
+            query=StickinessQuery(series=_TIME_SERIES, interval=IntervalType.DAY), team=team
+        ),
+    ),
+    (
+        "lifecycle",
+        lambda team: LifecycleQueryRunner(
+            query=LifecycleQuery(series=_TIME_SERIES, interval=IntervalType.DAY), team=team
+        ),
+    ),
+]
+
+# Runners whose query model has no `interval` field.
+NON_INTERVAL_QUERY_RUNNERS: list[tuple[str, Callable[[Team], QueryRunner]]] = [
+    (
+        "retention",
+        lambda team: RetentionQueryRunner(query=RetentionQuery(retentionFilter=RetentionFilter()), team=team),
+    ),
+    (
+        "paths",
+        lambda team: PathsQueryRunner(query=PathsQuery(pathsFilter=PathsFilter()), team=team),
+    ),
+]
+
+# Every supported query type carries a `filterTestAccounts` field.
+ALL_QUERY_RUNNERS = INTERVAL_QUERY_RUNNERS + NON_INTERVAL_QUERY_RUNNERS
+
+
+class TestDashboardFiltersIntervalOverride(BaseTest):
+    def _runner(self, build: Callable[[Team], QueryRunner]) -> QueryRunner:
+        return build(self.team)
+
+    @parameterized.expand(INTERVAL_QUERY_RUNNERS)
+    def test_interval_override_written_onto_interval_supporting_query(self, _name, build):
+        runner = self._runner(build)
+
+        runner.apply_dashboard_filters(DashboardFilter(interval=IntervalType.WEEK))
+
+        assert runner.query.interval == IntervalType.WEEK
+
+    @parameterized.expand(NON_INTERVAL_QUERY_RUNNERS)
+    def test_interval_override_silently_skipped_for_non_interval_query(self, _name, build):
+        runner = self._runner(build)
+
+        runner.apply_dashboard_filters(DashboardFilter(interval=IntervalType.WEEK))
+
+        assert not hasattr(runner.query, "interval")
+
+    @parameterized.expand(INTERVAL_QUERY_RUNNERS)
+    def test_absent_interval_leaves_query_interval_untouched(self, _name, build):
+        runner = self._runner(build)
+        original = runner.query.interval
+
+        runner.apply_dashboard_filters(DashboardFilter())
+
+        assert runner.query.interval == original
+
+
+class TestDashboardFiltersTestAccountsOverride(BaseTest):
+    def _runner(self, build: Callable[[Team], QueryRunner]) -> QueryRunner:
+        return build(self.team)
+
+    @parameterized.expand(ALL_QUERY_RUNNERS)
+    def test_test_accounts_override_forces_on(self, _name, build):
+        runner = self._runner(build)
+
+        runner.apply_dashboard_filters(DashboardFilter(filterTestAccounts=True))
+
+        assert runner.query.filterTestAccounts is True
+
+    @parameterized.expand(ALL_QUERY_RUNNERS)
+    def test_test_accounts_override_forces_off(self, _name, build):
+        runner = self._runner(build)
+        runner.query.filterTestAccounts = True
+
+        runner.apply_dashboard_filters(DashboardFilter(filterTestAccounts=False))
+
+        assert runner.query.filterTestAccounts is False
+
+    @parameterized.expand(ALL_QUERY_RUNNERS)
+    def test_inherit_leaves_query_test_accounts_untouched(self, _name, build):
+        runner = self._runner(build)
+        runner.query.filterTestAccounts = True
+
+        runner.apply_dashboard_filters(DashboardFilter())
+
+        assert runner.query.filterTestAccounts is True

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -13303,6 +13303,14 @@ class DashboardFilter(BaseModel):
     date_from: str | None = None
     date_to: str | None = None
     explicitDate: bool | None = None
+    filterTestAccounts: bool | None = Field(
+        default=None,
+        description=("Tri-state test-account override. Null/absent = inherit; true = force on; false = force off."),
+    )
+    interval: IntervalType | None = Field(
+        default=None,
+        description=("Time granularity forced onto every insight that supports one. Absent/null = inherit."),
+    )
     properties: (
         list[
             EventPropertyFilter
@@ -21303,6 +21311,8 @@ class TileFilters(BaseModel):
     date_from: str | None = None
     date_to: str | None = None
     explicitDate: bool | None = None
+    filterTestAccounts: bool | None = None
+    interval: IntervalType | None = None
     properties: (
         list[
             EventPropertyFilter

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -503,6 +503,17 @@ export interface BreakdownFilterApi {
     breakdowns?: BreakdownApi[] | null
 }
 
+export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
+
+export const IntervalTypeApi = {
+    Second: 'second',
+    Minute: 'minute',
+    Hour: 'hour',
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+} as const
+
 export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
 
 export const PropertyOperatorApi = {
@@ -757,6 +768,10 @@ export interface DashboardFilterApi {
     date_from?: string | null
     date_to?: string | null
     explicitDate?: boolean | null
+    /** Tri-state test-account override. Null/absent = inherit; true = force on; false = force off. */
+    filterTestAccounts?: boolean | null
+    /** Time granularity forced onto every insight that supports one. Absent/null = inherit. */
+    interval?: IntervalTypeApi | null
     properties?:
         | (
               | EventPropertyFilterApi

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14668,6 +14668,10 @@ export namespace Schemas {
       date_from?: string | null;
       date_to?: string | null;
       explicitDate?: boolean | null;
+      /** Tri-state test-account override. Null/absent = inherit; true = force on; false = force off. */
+      filterTestAccounts?: boolean | null;
+      /** Time granularity forced onto every insight that supports one. Absent/null = inherit. */
+      interval?: IntervalType | null;
       properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
     }
 

--- a/services/mcp/src/generated/endpoints/api.ts
+++ b/services/mcp/src/generated/endpoints/api.ts
@@ -375,6 +375,16 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                 date_from: zod.union([zod.string(), zod.null()]).optional(),
                 date_to: zod.union([zod.string(), zod.null()]).optional(),
                 explicitDate: zod.union([zod.boolean(), zod.null()]).optional(),
+                filterTestAccounts: zod
+                    .union([zod.boolean(), zod.null()])
+                    .optional()
+                    .describe(
+                        'Tri-state test-account override. Null/absent = inherit; true = force on; false = force off.'
+                    ),
+                interval: zod
+                    .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
+                    .optional()
+                    .describe('Time granularity forced onto every insight that supports one. Absent/null = inherit.'),
                 properties: zod
                     .union([
                         zod.array(


### PR DESCRIPTION
TL;DR: Backend for interval and test account filter overrides on a dashboard.

## Problem

Dashboard-level filters let a viewer override date range, properties, and breakdown across all insights on a dashboard. Two common needs were unmet:

- **Interval.** No way to change time granularity (hour/day/week/month) across the whole dashboard. You had to open each insight to see every time-series tile at, say, weekly.
- **Test accounts.** No single control to toggle "filter out internal/test traffic" across the dashboard. Each insight carries its own `filterTestAccounts`, so a dashboard mixes filtered and unfiltered tiles.

This PR is the backend half, split out of #68612: the schema fields and the query-runner application. The dashboard UI controls ship separately in #68612, which is stacked on this branch.

## Changes

Two new override dimensions on `DashboardFilter` / `TileFilters`:

- `interval` — optional `IntervalType`. Absent/null means inherit (each insight keeps its own). When set, it's forced onto every insight that supports an interval (trends, funnels, stickiness, lifecycle) and silently skipped for those that don't (retention, paths).
- `filterTestAccounts` — tri-state. Null means inherit, `true` forces on, `false` forces off, across all supporting tiles.

Both are authored in the frontend query schema (`schema-general.ts`) and regenerated into Python — the generated `schema.py` / `schema.json` / OpenAPI types are not hand-edited. Application happens in the query runner's `apply_dashboard_filters`, guarded on the field existing on the query model, so unsupported types are left untouched rather than crashing. Caching differentiates automatically because the cache key derives from the mutated query. Both default to inherit, so existing dashboards are behaviorally unchanged.

## How did you test this code?

Automated tests, carried over from #68612 where I (Claude) ran them green (29 passing):

- **`apply_dashboard_filters` (`posthog/hogql_queries/test/test_dashboard_filters_overrides.py`, new).** Parameterized across all six query types. Catches: an interval override that stops being written onto interval-supporting queries, one that crashes or mutates retention/paths (which have no `interval` field), and a broken test-account tri-state (e.g. `None`/inherit accidentally forcing a value). No existing test exercised these new fields.
- **Dashboard API round-trip (`test_dashboard.py`).** One test that PATCHes `interval` + `filterTestAccounts` into `dashboard.filters` and reads them back. Guards that these specific keys survive the serializer if key-level filter validation is ever added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by Claude (PostHog Code) driven by @thmsobrmlr. This PR was mechanically split out of #68612 on request: the backend + schema changes (schema source, generated artifacts, query-runner mutation, tests) moved here so they can land ahead of the UI. Original work followed a Notion PRD test-first with the `/tdd` and `/writing-tests` skills.

Key decisions:
- Put the mutation in the **base** `QueryRunner.apply_dashboard_filters` with `hasattr` guards rather than per-runner overrides — one place, and unsupported types (retention, paths) fall through untouched.
- The schema source of truth (`schema-general.ts`) and all generated artifacts live in this PR, since `schema.py` is generated from it and CI enforces they stay in sync.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
