### PR TITLE
docs: guide agents on stacked-PR push hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Each PR push fans out to ~40 workflow runs. Restacking force-pushes every branch
 
 - Keep stacks shallow; merge the base before extending.
 - Restack only when you need to — avoid rebasing the whole stack on master repeatedly.
-- When a restack must push many branches, stagger them instead of force-pushing all at once.
+- If you must push many branches, stagger them so each batch lands outside the 10-second dispatch window rather than force-pushing all at once.
 
 #### Pre-push checks — ci:preflight
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,11 +80,14 @@ Pushes still trigger CI, which burns runner credits, so batch related commits an
 
 #### Stacked PRs
 
-Each PR push fans out to ~40 workflow runs. Restacking force-pushes every branch at once, so a deep stack can create hundreds of runs in one 10-second window and blow past GitHub's per-repo dispatch cap (500 workflow runs / 10s); the overflow fails as `startup_failure`, taking unrelated runs in the same window down with it. Draft status does not help: runs are dispatched before draft/skip logic applies.
+Restacking force-pushes every branch, and each push triggers a full CI fan-out.
+Pushing a deep stack at once can exceed GitHub's per-repo dispatch cap (500 workflow runs / 10s).
+The overflow fails as `startup_failure` and takes unrelated runs in the same window down too.
+Draft status doesn't help, since runs are dispatched before draft/skip logic applies.
 
 - Keep stacks shallow; merge the base before extending.
-- Restack only when you need to — avoid rebasing the whole stack on master repeatedly.
-- If you must push many branches, stagger them so each batch lands outside the 10-second dispatch window rather than force-pushing all at once.
+- Restack only when you need to, rather than rebasing the whole stack on master repeatedly.
+- When a restack must push many branches, stagger them instead of force-pushing all at once.
 
 #### Pre-push checks — ci:preflight
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Pushes still trigger CI, which burns runner credits, so batch related commits an
 
 #### Stacked PRs
 
-Restacking force-pushes every branch, and each push triggers a full CI fan-out. Pushing a deep stack at once can exceed GitHub's per-repo dispatch cap (500 workflow runs / 10s); the overflow fails as `startup_failure`, taking unrelated runs in the same window down too. Draft status doesn't help — runs dispatch before draft/skip logic applies.
+Each PR push fans out to ~40 workflow runs. Restacking force-pushes every branch at once, so a deep stack can create hundreds of runs in one 10-second window and blow past GitHub's per-repo dispatch cap (500 workflow runs / 10s); the overflow fails as `startup_failure`, taking unrelated runs in the same window down with it. Draft status does not help: runs are dispatched before draft/skip logic applies.
 
 - Keep stacks shallow; merge the base before extending.
 - Restack only when you need to — avoid rebasing the whole stack on master repeatedly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ NEVER share sensitive information in a PR description. Users may share sensitive
 Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
 Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 
+#### Stacked PRs
+
+Restacking force-pushes every branch, and each push triggers a full CI fan-out. Pushing a deep stack at once can exceed GitHub's per-repo dispatch cap (500 workflow runs / 10s); the overflow fails as `startup_failure`, taking unrelated runs in the same window down too. Draft status doesn't help — runs dispatch before draft/skip logic applies.
+
+- Keep stacks shallow; merge the base before extending.
+- Restack only when you need to — avoid rebasing the whole stack on master repeatedly.
+- When a restack must push many branches, stagger them instead of force-pushing all at once.
+
 #### Pre-push checks — ci:preflight
 
 A pre-push hook runs `hogli ci:preflight --strict`, failing the push on deterministic CI breakage reachable from your diff (lint, lockfiles, migration conflicts). Never bypass it (`--no-verify`).


### PR DESCRIPTION
## Problem

- A deep stack restacked and force-pushed at once created enough workflow runs in one 10-second window to exceed GitHub's per-repo dispatch cap (500 runs / 10s).
- Overflow fails as `startup_failure` and takes unrelated PRs' runs in the same window down too. Draft status doesn't help — runs dispatch before draft/skip logic applies.

## Changes

- Add a short "Stacked PRs" note to `AGENTS.md` under Pushing to remote: keep stacks shallow, restack only when needed, stagger many pushes.

## How did you test this code?

- Docs-only. `AGENTS.md`/`CLAUDE.md` symlink check and markdown format ran via lint-staged on commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Root-caused a `startup_failure` burst to whole-stack force-push exceeding the 500-runs/10s dispatch limit; this codifies the push-side mitigation.
