### PR TITLE
feat(llm-gateway): add ci product for e2e test runs

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -13,6 +13,7 @@ logger = structlog.get_logger(__name__)
 
 Product = Literal[
     "llm_gateway",
+    "ci",
     "posthog_code",
     "background_agents",
     "slack_app",

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -213,6 +213,7 @@ OAuth access is permitted only for products with an explicit `allowed_applicatio
 | Product              | Auth            | Models                     | Notes                           |
 | -------------------- | --------------- | -------------------------- | ------------------------------- |
 | `llm_gateway`        | API key only    | All                        | Default when no product in path |
+| `ci`                 | API key only    | All                        | CI / e2e test runs              |
 | `posthog_code`       | OAuth only      | Restricted set             | Desktop coding agent            |
 | `background_agents`  | OAuth only      | Restricted set             | Cloud background agents         |
 | `wizard`             | API key + OAuth | All                        | Max AI assistant                |

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -26,6 +26,7 @@ DEFAULT_USER_COST_LIMIT = UserCostLimit(
 
 DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "llm_gateway": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
+    "ci": ProductCostLimit(limit_usd=1000.0, window_seconds=2592000),  # $1000 / 30 days
     "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
     "posthog_code": ProductCostLimit(limit_usd=5000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -65,6 +65,14 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_models=None,
         allow_api_keys=True,
     ),
+    # CI / end-to-end test runs (e.g. posthog/code agent e2e tests). Authenticates with a
+    # personal API key, allows all models, and keeps CI traffic attributed to its own
+    # ai_product rather than the catch-all llm_gateway bucket.
+    "ci": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=None,
+        allow_api_keys=True,
+    ),
     "posthog_code": ProductConfig(
         allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=_POSTHOG_CODE_AGENT_MODELS | BEDROCK_MODELS,

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -43,6 +43,9 @@ class TestCheckProductAccess:
             ("llm_gateway", "personal_api_key", None, "claude-3-opus", True, None),
             ("llm_gateway", "oauth_access_token", "any-app-id", "gpt-4o", False, "not authorized"),
             ("llm_gateway", "personal_api_key", None, None, True, None),
+            # ci allows API keys with any model (used by e2e test runs); OAuth rejected (no app IDs)
+            ("ci", "personal_api_key", None, "claude-3-opus", True, None),
+            ("ci", "oauth_access_token", "any-app-id", "gpt-4o", False, "not authorized"),
             # posthog_code requires OAuth with valid app ID
             ("posthog_code", "personal_api_key", None, None, False, "requires OAuth"),
             ("posthog_code", "oauth_access_token", "invalid-app-id", None, False, "not authorized"),


### PR DESCRIPTION
## Problem

The posthog/code agent e2e tests route through the llm-gateway's catch-all `llm_gateway` product. That works, but it lumps CI traffic in with everything else that falls through to the default bucket, so you can't cleanly filter e2e spend/usage by `ai_product`.

## Changes

Add a dedicated `ci` product to the gateway registry. It mirrors `llm_gateway` (personal API key auth, all models allowed, no OAuth apps), so the e2e suite keeps authenticating with a personal API key exactly as before, but its traffic is now attributed to its own `ai_product` instead of the catch-all.

- New `ci` entry in `services/llm-gateway/src/llm_gateway/products/config.py`
- Added `ci` to the `Product` literal in `posthog/llm/gateway_client.py`
- One parametrized access-check case (guards that `ci` keeps accepting API keys and rejects OAuth)
- README product table updated

The companion change that switches the e2e suite to `/ci` lives in a posthog/code PR.

## How did you test this code?

Ran the gateway product-config suite locally: `uv run pytest tests/test_product_config.py` (184 passed). No manual testing beyond that.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Josh asked (over Slack) for a `ci` gateway product to use in the posthog/code agent e2e tests in place of `llm_gateway`, with API-key auth allowed. I (the PostHog Slack app, running Claude) added the product config, kept it minimal by mirroring the existing `llm_gateway` config rather than restricting models, and invoked the `/writing-tests` skill before adding the single parametrized access-check case. The e2e-side switch is a separate posthog/code PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1783369326757809)*
