### PR TITLE
fix(data-warehouse): sweep orphaned RUNNING job rows after v3 lock acquisition

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
@@ -344,13 +344,15 @@ def _sweep_stale_running_jobs(inputs: AcquireV3LockActivityInputs, token: str, l
     """
     try:
         close_old_connections()
-        # NULL workflow_run_id rows are intentionally not swept (exclude() drops them via
-        # SQL three-valued logic) - without a run id there is no workflow to safely verify.
+        # NULL workflow_run_id rows are intentionally not swept - without a run id there is
+        # no workflow to safely verify, and the queue-DB check would match nothing and
+        # wrongly report the run as inactive.
         stale_jobs = (
             ExternalDataJob.objects.filter(
                 team_id=inputs.team_id,
                 schema_id=inputs.schema_id,
                 status=ExternalDataJob.Status.RUNNING,
+                workflow_run_id__isnull=False,
             )
             .exclude(workflow_run_id=token)
             .order_by("created_at")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
@@ -355,6 +355,7 @@ def _sweep_stale_running_jobs(inputs: AcquireV3LockActivityInputs, token: str, l
                 workflow_run_id__isnull=False,
             )
             .exclude(workflow_run_id=token)
+            .only("id", "status", "workflow_id", "workflow_run_id")
             .order_by("created_at")
         )
         for job in stale_jobs:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
@@ -97,6 +97,9 @@ def acquire_v3_pipeline_lock_activity(inputs: AcquireV3LockActivityInputs) -> Ac
     if not acquired:
         acquired = _take_over_lock_if_holder_finished(inputs, token, logger)
 
+    if acquired:
+        _sweep_stale_running_jobs(inputs, token, logger)
+
     logger.info(
         "v3_pipeline_lock_acquire_result",
         schema_id=str(inputs.schema_id),
@@ -179,16 +182,9 @@ def _describe_holder_workflow(
                 workflow_run_id=holder_run_id,
             )
             .order_by("-created_at")
-            .only("id", "status", "workflow_id")
+            .only("id", "status", "workflow_id", "workflow_run_id")
             .first()
         )
-        if holder_job is None or not holder_job.workflow_id:
-            return WorkflowExecutionStatus.TERMINATED, holder_job
-
-        temporal: Client = sync_connect()
-        handle = temporal.get_workflow_handle(holder_job.workflow_id, run_id=holder_run_id)
-        desc = async_to_sync(handle.describe)()
-        return desc.status, holder_job
     except Exception as e:
         logger.warning(
             "v3_pipeline_lock_describe_failed",
@@ -199,6 +195,40 @@ def _describe_holder_workflow(
         capture_exception(e)
         return None, None
 
+    if holder_job is None:
+        return WorkflowExecutionStatus.TERMINATED, None
+
+    return _describe_job_workflow_status(holder_job, str(inputs.schema_id), logger), holder_job
+
+
+def _describe_job_workflow_status(
+    job: ExternalDataJob,
+    schema_id: str,
+    logger: Any,
+) -> WorkflowExecutionStatus | None:
+    """Describe the Temporal workflow behind a job row; None means ambiguous (fail closed).
+
+    A job row with no workflow_id recorded is treated as terminated: the worker died
+    before recording it, so there is no live workflow to protect.
+    """
+    if not job.workflow_id:
+        return WorkflowExecutionStatus.TERMINATED
+
+    try:
+        temporal: Client = sync_connect()
+        handle = temporal.get_workflow_handle(job.workflow_id, run_id=job.workflow_run_id)
+        desc = async_to_sync(handle.describe)()
+        return desc.status
+    except Exception as e:
+        logger.warning(
+            "v3_pipeline_lock_describe_failed",
+            schema_id=schema_id,
+            holder_run_id=job.workflow_run_id,
+            error=str(e),
+        )
+        capture_exception(e)
+        return None
+
 
 def _take_over_stale_running_job(
     inputs: AcquireV3LockActivityInputs,
@@ -208,13 +238,35 @@ def _take_over_stale_running_job(
     logger: Any,
 ) -> bool:
     """Consult queue DB for a RUNNING job whose workflow is terminal."""
+    if not _finalize_stale_running_job(inputs, holder_job, holder, logger):
+        return False
+
+    logger.warning(
+        "v3_pipeline_lock_taking_over",
+        schema_id=str(inputs.schema_id),
+        holder_token=holder,
+        reason="stale_running_job",
+        holder_job_id=str(holder_job.id),
+    )
+    return _release_and_acquire(inputs, holder, token)
+
+
+def _finalize_stale_running_job(
+    inputs: AcquireV3LockActivityInputs,
+    job: ExternalDataJob,
+    run_id: str,
+    logger: Any,
+) -> bool:
+    """Mark a RUNNING job whose workflow is terminal as FAILED, unless the queue DB shows
+    an actively-consuming run. Returns True if the row was finalized; fails closed on any
+    ambiguity (queue DB unreachable, query error, active non-stale batches)."""
     try:
         conn = psycopg.Connection.connect(WAREHOUSE_SOURCES_DATABASE_URL, autocommit=True)
     except Exception as e:
         logger.warning(
             "v3_pipeline_lock_takeover_ambiguous",
             schema_id=str(inputs.schema_id),
-            holder_token=holder,
+            holder_token=run_id,
             reason="queue_db_connect_failed",
             error=str(e),
         )
@@ -224,14 +276,14 @@ def _take_over_stale_running_job(
     try:
         summary = BatchQueue.get_run_activity_summary(
             conn,
-            job_id=str(holder_job.id),
-            workflow_run_id=holder,
+            job_id=str(job.id),
+            workflow_run_id=run_id,
         )
     except Exception as e:
         logger.warning(
             "v3_pipeline_lock_takeover_ambiguous",
             schema_id=str(inputs.schema_id),
-            holder_token=holder,
+            holder_token=run_id,
             reason="queue_db_query_failed",
             error=str(e),
         )
@@ -245,16 +297,16 @@ def _take_over_stale_running_job(
         logger.info(
             "v3_pipeline_lock_takeover_skipped",
             schema_id=str(inputs.schema_id),
-            holder_token=holder,
+            holder_token=run_id,
             reason="active_consumer",
         )
         return False
 
-    # No batches, all terminal, or stale - mark job FAILED and take over
+    # No batches, all terminal, or stale - mark job FAILED
     takeover_logger = structlog.get_logger(__name__).bind(team_id=inputs.team_id)
     try:
         update_external_job_status(
-            job_id=str(holder_job.id),
+            job_id=str(job.id),
             team_id=inputs.team_id,
             status=ExternalDataJob.Status.FAILED,
             logger=takeover_logger,
@@ -264,22 +316,57 @@ def _take_over_stale_running_job(
         logger.warning(
             "v3_pipeline_lock_takeover_job_fail_error",
             schema_id=str(inputs.schema_id),
-            holder_token=holder,
+            holder_token=run_id,
             error=str(e),
         )
         capture_exception(e)
         return False
 
     logger.warning(
-        "v3_pipeline_lock_taking_over",
+        "v3_pipeline_stale_running_job_finalized",
         schema_id=str(inputs.schema_id),
-        holder_token=holder,
-        reason="stale_running_job",
-        holder_job_id=str(holder_job.id),
+        job_id=str(job.id),
+        run_id=run_id,
         has_batches=summary.has_batches,
         is_stale=summary.is_stale,
     )
-    return _release_and_acquire(inputs, holder, token)
+    return True
+
+
+def _sweep_stale_running_jobs(inputs: AcquireV3LockActivityInputs, token: str, logger: Any) -> None:
+    """Finalize prior RUNNING job rows for this schema whose workflows are dead.
+
+    The lock takeover path only fires when the previous holder still holds the lock. If a
+    run died after its lock was released or expired, the next run acquires the lock cleanly
+    and the dead run's RUNNING job row would otherwise linger forever, which reads as a
+    perpetually-running sync in the UI. Best-effort: runs under the freshly-acquired lock,
+    fails closed per job on any ambiguity, and never blocks the new run.
+    """
+    try:
+        close_old_connections()
+        # NULL workflow_run_id rows are intentionally not swept (exclude() drops them via
+        # SQL three-valued logic) - without a run id there is no workflow to safely verify.
+        stale_jobs = (
+            ExternalDataJob.objects.filter(
+                team_id=inputs.team_id,
+                schema_id=inputs.schema_id,
+                status=ExternalDataJob.Status.RUNNING,
+            )
+            .exclude(workflow_run_id=token)
+            .order_by("created_at")
+        )
+        for job in stale_jobs:
+            status = _describe_job_workflow_status(job, str(inputs.schema_id), logger)
+            if status is None or status == WorkflowExecutionStatus.RUNNING:
+                continue
+            _finalize_stale_running_job(inputs, job, job.workflow_run_id or "", logger)
+    except Exception as e:
+        logger.warning(
+            "v3_pipeline_stale_job_sweep_error",
+            schema_id=str(inputs.schema_id),
+            error=str(e),
+        )
+        capture_exception(e)
 
 
 def _release_and_acquire(inputs: AcquireV3LockActivityInputs, holder: str, token: str) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
@@ -334,7 +334,7 @@ class TestSweepStaleRunningJobs:
 
     @staticmethod
     def _set_stale_jobs(mock_job_model: MagicMock, jobs: list[MagicMock]) -> None:
-        mock_job_model.objects.filter.return_value.exclude.return_value.order_by.return_value = jobs
+        mock_job_model.objects.filter.return_value.exclude.return_value.only.return_value.order_by.return_value = jobs
 
     @pytest.mark.parametrize(
         "workflow_status, summary, expect_finalized",

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
@@ -84,6 +84,7 @@ class TestAcquireV3PipelineLockActivity:
         [True, False],
         ids=["lock_free", "lock_held"],
     )
+    @patch(f"{MODULE}._sweep_stale_running_jobs")
     @patch(f"{MODULE}._take_over_lock_if_holder_finished", return_value=False)
     @patch(f"{MODULE}.acquire_v3_pipeline_lock")
     @patch(f"{MODULE}.activity")
@@ -94,6 +95,7 @@ class TestAcquireV3PipelineLockActivity:
         mock_activity: MagicMock,
         mock_acquire: MagicMock,
         mock_take_over: MagicMock,
+        mock_sweep: MagicMock,
         lock_acquired: bool,
     ) -> None:
         mock_activity.info.return_value.workflow_run_id = WORKFLOW_RUN_ID
@@ -106,9 +108,12 @@ class TestAcquireV3PipelineLockActivity:
         mock_acquire.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), WORKFLOW_RUN_ID)
         if lock_acquired:
             mock_take_over.assert_not_called()
+            mock_sweep.assert_called_once()
         else:
             mock_take_over.assert_called_once()
+            mock_sweep.assert_not_called()
 
+    @patch(f"{MODULE}._sweep_stale_running_jobs")
     @patch(f"{MODULE}._take_over_lock_if_holder_finished", return_value=True)
     @patch(f"{MODULE}.acquire_v3_pipeline_lock", return_value=False)
     @patch(f"{MODULE}.activity")
@@ -119,12 +124,14 @@ class TestAcquireV3PipelineLockActivity:
         mock_activity: MagicMock,
         _mock_acquire: MagicMock,
         _mock_take_over: MagicMock,
+        mock_sweep: MagicMock,
     ) -> None:
         mock_activity.info.return_value.workflow_run_id = WORKFLOW_RUN_ID
 
         result = acquire_v3_pipeline_lock_activity(AcquireV3LockActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID))
 
         assert result.acquired is True
+        mock_sweep.assert_called_once()
 
     @patch(f"{MODULE}.activity")
     @patch(f"{MODULE}.bind_contextvars")
@@ -304,6 +311,122 @@ class TestTakeOverStaleRunningJob:
     ) -> None:
         mock_conn_cls.connect.side_effect = RuntimeError("connection refused")
         assert self._run() is False
+
+
+class TestSweepStaleRunningJobs:
+    STALE_RUN_ID = "stale-run-777"
+
+    def _run_sweep(self) -> None:
+        from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.acquire_v3_lock import (
+            _sweep_stale_running_jobs,
+        )
+
+        inputs = AcquireV3LockActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID)
+        _sweep_stale_running_jobs(inputs, WORKFLOW_RUN_ID, MagicMock())
+
+    def _stale_job(self) -> MagicMock:
+        job = MagicMock()
+        job.id = "job-stale-1"
+        job.status = "Running"
+        job.workflow_id = "workflow-stale-1"
+        job.workflow_run_id = self.STALE_RUN_ID
+        return job
+
+    @staticmethod
+    def _set_stale_jobs(mock_job_model: MagicMock, jobs: list[MagicMock]) -> None:
+        mock_job_model.objects.filter.return_value.exclude.return_value.order_by.return_value = jobs
+
+    @pytest.mark.parametrize(
+        "workflow_status, summary, expect_finalized",
+        [
+            (
+                WorkflowExecutionStatus.COMPLETED,
+                RunActivitySummary(has_batches=False, has_non_terminal=False, is_stale=True),
+                True,
+            ),
+            (
+                WorkflowExecutionStatus.TERMINATED,
+                RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=True),
+                True,
+            ),
+            (
+                WorkflowExecutionStatus.COMPLETED,
+                RunActivitySummary(has_batches=True, has_non_terminal=True, is_stale=False),
+                False,
+            ),
+            (WorkflowExecutionStatus.RUNNING, None, False),
+            (None, None, False),
+        ],
+        ids=[
+            "dead_workflow_no_batches",
+            "dead_workflow_stale_batches",
+            "active_consumer_left_alone",
+            "workflow_still_running_left_alone",
+            "describe_ambiguous_left_alone",
+        ],
+    )
+    @patch(f"{MODULE}.update_external_job_status")
+    @patch(f"{MODULE}.BatchQueue")
+    @patch(f"{MODULE}.psycopg.Connection")
+    @patch(f"{MODULE}._describe_job_workflow_status")
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.close_old_connections")
+    def test_sweep_decision(
+        self,
+        _close: MagicMock,
+        mock_job_model: MagicMock,
+        mock_describe: MagicMock,
+        mock_conn_cls: MagicMock,
+        mock_queue: MagicMock,
+        mock_update: MagicMock,
+        workflow_status: WorkflowExecutionStatus | None,
+        summary: RunActivitySummary | None,
+        expect_finalized: bool,
+    ) -> None:
+        self._set_stale_jobs(mock_job_model, [self._stale_job()])
+        mock_describe.return_value = workflow_status
+        mock_queue.get_run_activity_summary.return_value = summary
+
+        self._run_sweep()
+
+        if expect_finalized:
+            mock_update.assert_called_once()
+            assert mock_update.call_args.kwargs["job_id"] == "job-stale-1"
+        else:
+            mock_update.assert_not_called()
+
+    @patch(f"{MODULE}.update_external_job_status")
+    @patch(f"{MODULE}._describe_job_workflow_status")
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.close_old_connections")
+    def test_no_stale_rows_is_a_noop(
+        self,
+        _close: MagicMock,
+        mock_job_model: MagicMock,
+        mock_describe: MagicMock,
+        mock_update: MagicMock,
+    ) -> None:
+        self._set_stale_jobs(mock_job_model, [])
+
+        self._run_sweep()
+
+        mock_describe.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.close_old_connections")
+    def test_sweep_errors_never_propagate(
+        self,
+        _close: MagicMock,
+        mock_job_model: MagicMock,
+        mock_capture: MagicMock,
+    ) -> None:
+        mock_job_model.objects.filter.side_effect = RuntimeError("db unavailable")
+
+        self._run_sweep()
+
+        mock_capture.assert_called_once()
 
 
 class TestReleaseV3PipelineLockActivity:


### PR DESCRIPTION
## Problem

Support ticket #61822. A customer on project 112509 clicked "Sync now" on a Google Sheets schema. The sync's actual work completed in seconds, but the job row has shown `Running` in the sync history ever since (`finished_at: null`), and nothing (cancel, reload, subsequent syncs) clears it. The schema itself is `Completed` and later scheduled syncs run fine, so the stuck row is purely a dead record, but it reads as a hung multi-hour sync and generates tickets.

Root cause of the cleanup gap: when a v3 sync workflow dies without finalizing its `ExternalDataJob` row, the only cleanup is the lock-takeover path in `acquire_v3_pipeline_lock_activity`, and that path only runs when the next run FAILS to acquire the pipeline lock. If the dead run's lock was already released or expired (which is what happened here), the next run acquires the lock cleanly, the takeover logic never executes, and the stale RUNNING row lingers forever. There is no periodic janitor that would ever revisit it.

Why the worker died post-extraction without finalizing is a separate reliability question not addressed here. This PR closes the cleanup gap that turns that flakiness into permanent customer-visible "Running" rows.

## Changes

- Added `_sweep_stale_running_jobs`, called after any successful v3 lock acquisition (clean or via takeover). It finds prior `ExternalDataJob` rows on the same schema that are `RUNNING` under a different `workflow_run_id`, with no age restriction, so pre-existing orphans get finalized by the first sync after this deploys.
- Each candidate goes through the same fail-closed decision matrix the takeover path already used. Temporal describe must say the workflow is terminal, and the queue DB must show no active non-stale batches, otherwise the row is left alone. Describe errors and queue DB errors also leave the row alone.
- Extracted that decision logic into `_finalize_stale_running_job`, now shared by the takeover path and the sweep, and extracted `_describe_job_workflow_status` for the Temporal describe. The takeover path's behavior is unchanged.
- The sweep is best-effort. It runs while holding the freshly acquired pipeline lock, and any unexpected error is logged and swallowed so it can never block a sync.

One observability note: the `has_batches` / `is_stale` fields moved from the `v3_pipeline_lock_taking_over` log event to a new `v3_pipeline_stale_running_job_finalized` event, which fires for both the takeover path and the sweep. If any dashboard keys on those fields on the old event, it should switch to the new one.

Notes on scope, considered and rejected alternatives:

- A periodic janitor task would also catch schemas that never sync again, but the sweep-on-next-run approach reuses the existing safety machinery, runs under the schema's lock (no new concurrency concerns), and covers the observed failure mode. Can revisit if orphans show up on schemas with no subsequent runs.
- The orphaned rows get marked `Failed` with the existing lock-takeover `latest_error` rather than a new dedicated status, keeping the change small and consistent with what the takeover path already writes. Marking the old job failed also rewrites the schema status, but the sweep runs at the same lifecycle point as the existing takeover (start of a new run, which immediately sets the schema to running), so the behavior is identical to the takeover path today.
- v1/v2 pipelines have no equivalent cleanup either, but they also have no lock-acquisition step to hang the sweep on, and the observed breakage is v3, so they're out of scope here.

## How did you test this code?

- Ran the full unit suite for the module, 26 tests pass: `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py`
- New tests and the regression each catches:
  - `test_sweep_decision` (parameterized, 5 cases): a dead workflow's RUNNING row gets finalized (the bug in this ticket), and the three safety cases (workflow still running, describe ambiguous, active queue consumer) leave the row alone, guarding against the sweep ever killing a live sync.
  - `test_no_stale_rows_is_a_noop`: the common path does no Temporal describes and no writes.
  - `test_sweep_errors_never_propagate`: a sweep bug can't take down lock acquisition for all syncs.
  - Extended the existing activity tests to pin the gating: sweep runs on any successful acquisition and never when acquisition fails.
- Ran the full warehouse e2e suite locally (`products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py`): 185 passed, 1 skipped, 1 fixture-setup error in 35 minutes. The one error was leftover test-DB state from an earlier interrupted run (duplicate team `api_token` at fixture insert, in a `non_dlt` variant that doesn't touch this change); that test passes on rerun in isolation.
- Prod verification after deploy: project 112509 has a live orphaned row from 2026-07-06 (job `019f35a0-52a6-0000-c8e6-63f6e30acb92`) that the first scheduled sync after rollout should finalize, observable via the new `v3_pipeline_stale_running_job_finalized` log event.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal pipeline behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Root cause investigation was done in a prior session against live prod data and handed off; this session verified the claims against master, wrote tests first, then the fix.
- Skills invoked: `/writing-tests`.
- Subagents were used to confirm no existing stale-job janitor exists, that v1/v2 have no equivalent cleanup, and to map the side effects of `update_external_job_status` (notably the unconditional schema status rewrite discussed above). A code-review agent reviewed the diff before commit; its two suggestions (comment on the intentional NULL `workflow_run_id` exclusion, dashboard note for the moved log fields) are incorporated.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


