### PR TITLE
fix(property-vals): bound aggregation buffers and seen cache by bytes

### DIFF
--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -1,24 +1,38 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use crate::types::TupleKey;
 
 pub struct Aggregator {
     counts: HashMap<TupleKey, u64>,
+    approx_bytes: usize,
 }
 
 impl Aggregator {
     pub fn new() -> Self {
         Self {
             counts: HashMap::new(),
+            approx_bytes: 0,
         }
     }
 
     pub fn add(&mut self, tuple: TupleKey, count: u64) {
-        *self.counts.entry(tuple).or_insert(0) += count;
+        let tuple_bytes = tuple.approx_bytes();
+        match self.counts.entry(tuple) {
+            Entry::Occupied(mut entry) => *entry.get_mut() += count,
+            Entry::Vacant(entry) => {
+                self.approx_bytes += tuple_bytes;
+                entry.insert(count);
+            }
+        }
     }
 
     pub fn len(&self) -> usize {
         self.counts.len()
+    }
+
+    pub fn approx_bytes(&self) -> usize {
+        self.approx_bytes
     }
 
     pub fn is_empty(&self) -> bool {
@@ -26,6 +40,7 @@ impl Aggregator {
     }
 
     pub fn drain(&mut self) -> HashMap<TupleKey, u64> {
+        self.approx_bytes = 0;
         std::mem::take(&mut self.counts)
     }
 }
@@ -98,5 +113,24 @@ mod tests {
 
         let second = agg.drain();
         assert!(second.is_empty());
+    }
+
+    #[test]
+    fn approx_bytes_counts_distinct_keys_only() {
+        let mut agg = Aggregator::new();
+        assert_eq!(agg.approx_bytes(), 0);
+
+        agg.add(tuple(2, "$browser", "Chrome"), 1);
+        let one_key = agg.approx_bytes();
+        assert_eq!(one_key, tuple(2, "$browser", "Chrome").approx_bytes());
+
+        agg.add(tuple(2, "$browser", "Chrome"), 5);
+        assert_eq!(agg.approx_bytes(), one_key);
+
+        agg.add(tuple(2, "$browser", "Firefox"), 1);
+        assert!(agg.approx_bytes() > one_key);
+
+        agg.drain();
+        assert_eq!(agg.approx_bytes(), 0);
     }
 }

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -44,8 +44,8 @@ pub struct Config {
     #[envconfig(default = "30")]
     pub flush_interval_secs: u64,
 
-    #[envconfig(default = "500000")]
-    pub max_buffered_tuples: usize,
+    #[envconfig(default = "268435456")]
+    pub max_buffered_bytes: usize,
 
     #[envconfig(default = "0")]
     pub max_values_per_key: usize,
@@ -54,7 +54,7 @@ pub struct Config {
     pub length_caps: LengthCaps,
 
     #[envconfig(default = "0")]
-    pub merger_seen_cache_capacity: usize,
+    pub merger_seen_cache_max_bytes: u64,
 
     #[envconfig(default = "60")]
     pub kafka_produce_timeout_secs: u64,

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -182,7 +182,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "merger",
         ReductionConfig {
             max_values_per_key: shared_config.max_values_per_key,
-            seen_cache_capacity: shared_config.merger_seen_cache_capacity,
+            seen_cache_max_bytes: shared_config.merger_seen_cache_max_bytes,
         },
     ));
     drop(events_handle);

--- a/rust/property-vals-rs/src/seen_cache.rs
+++ b/rust/property-vals-rs/src/seen_cache.rs
@@ -1,4 +1,4 @@
-use quick_cache::{sync, DefaultHashBuilder, Lifecycle, UnitWeighter};
+use quick_cache::{sync, DefaultHashBuilder, Lifecycle, Weighter};
 
 use crate::metrics_consts::{SEEN_CACHE_EVICTED, SEEN_CACHE_HITS, SEEN_CACHE_MISSES};
 use crate::types::TupleKey;
@@ -18,7 +18,18 @@ impl Lifecycle<TupleKey, ()> for EvictingLifecycle {
     }
 }
 
-type Inner = sync::Cache<TupleKey, (), UnitWeighter, DefaultHashBuilder, EvictingLifecycle>;
+#[derive(Clone)]
+struct TupleKeyWeighter;
+
+impl Weighter<TupleKey, ()> for TupleKeyWeighter {
+    fn weight(&self, key: &TupleKey, _val: &()) -> u64 {
+        key.approx_bytes() as u64
+    }
+}
+
+const ESTIMATED_ENTRY_BYTES: u64 = 256;
+
+type Inner = sync::Cache<TupleKey, (), TupleKeyWeighter, DefaultHashBuilder, EvictingLifecycle>;
 
 pub struct SeenCache {
     cache: Inner,
@@ -26,11 +37,11 @@ pub struct SeenCache {
 }
 
 impl SeenCache {
-    pub fn new(capacity: usize, worker: &'static str) -> Self {
+    pub fn new(max_bytes: u64, worker: &'static str) -> Self {
         let cache = sync::Cache::with(
-            capacity,
-            capacity as u64,
-            UnitWeighter,
+            (max_bytes / ESTIMATED_ENTRY_BYTES).max(1) as usize,
+            max_bytes,
+            TupleKeyWeighter,
             DefaultHashBuilder::default(),
             EvictingLifecycle { worker },
         );
@@ -49,5 +60,37 @@ impl SeenCache {
 
     pub fn insert(&self, key: &TupleKey) {
         self.cache.insert(key.clone(), ());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PropertyType;
+
+    fn tuple(value: String) -> TupleKey {
+        TupleKey {
+            team_id: 2,
+            property_type: PropertyType::Event,
+            property_key: "$current_url".to_string(),
+            property_value: value,
+        }
+    }
+
+    #[test]
+    fn byte_budget_bounds_retention_not_entry_count() {
+        let entry_bytes = tuple("x".repeat(1000)).approx_bytes() as u64;
+        let cache = SeenCache::new(entry_bytes * 100, "test");
+
+        let keys: Vec<TupleKey> = (0..1000).map(|i| tuple(format!("{i:0>1000}"))).collect();
+        for key in &keys {
+            cache.insert(key);
+        }
+
+        let retained = keys.iter().filter(|k| cache.seen(k)).count();
+        assert!(
+            retained <= 100,
+            "byte budget of 100 entries retained {retained}"
+        );
     }
 }

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -47,6 +47,12 @@ pub struct TupleKey {
     pub property_value: String,
 }
 
+impl TupleKey {
+    pub fn approx_bytes(&self) -> usize {
+        std::mem::size_of::<Self>() + self.property_key.len() + self.property_value.len()
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum PropertyType {
     Event,

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -15,7 +15,7 @@ use crate::types::{IngestableEvent, PropertyType, TupleKey};
 #[derive(Clone, Copy, Default)]
 pub struct ReductionConfig {
     pub max_values_per_key: usize,
-    pub seen_cache_capacity: usize,
+    pub seen_cache_max_bytes: u64,
 }
 
 /// One worker loop. Each pod runs one worker per input topic.
@@ -41,8 +41,8 @@ pub async fn worker_loop<E, P, F>(
     let _guard = handle.process_scope();
 
     let mut aggregator = Aggregator::new();
-    let seen_cache = (reduction.seen_cache_capacity > 0)
-        .then(|| SeenCache::new(reduction.seen_cache_capacity, worker));
+    let seen_cache = (reduction.seen_cache_max_bytes > 0)
+        .then(|| SeenCache::new(reduction.seen_cache_max_bytes, worker));
     // One Offset handle per partition: the latest message we've consumed.
     // On successful flush we call .store() on each, which advances the
     // consumer's stored offset; auto-commit ships it to the broker.
@@ -84,7 +84,7 @@ pub async fn worker_loop<E, P, F>(
 
                         pending_offsets.insert(offset.partition(), offset);
 
-                        if aggregator.len() >= config.max_buffered_tuples {
+                        if aggregator.approx_bytes() >= config.max_buffered_bytes {
                             flush(
                                 &mut aggregator,
                                 &mut pending_offsets,
@@ -506,7 +506,7 @@ mod tests {
 
     #[tokio::test]
     async fn seen_cache_suppresses_already_emitted_tuples() {
-        let cache = SeenCache::new(1000, "test");
+        let cache = SeenCache::new(100 << 20, "test");
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new();
 
@@ -548,7 +548,7 @@ mod tests {
 
     #[tokio::test]
     async fn seen_cache_reemits_after_produce_failure() {
-        let cache = SeenCache::new(1000, "test");
+        let cache = SeenCache::new(100 << 20, "test");
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new().fail_on(1);
 
@@ -586,7 +586,7 @@ mod tests {
 
     #[tokio::test]
     async fn seen_cache_emits_new_values_and_suppresses_repeats() {
-        let cache = SeenCache::new(1000, "test");
+        let cache = SeenCache::new(100 << 20, "test");
         let mut pending: HashMap<i32, Offset> = HashMap::new();
         let producer = MockProducer::new();
 


### PR DESCRIPTION
## Problem

property-vals-rs pods get OOM-killed under bursts. Both of the service's big in-memory structures are bounded by entry count while `property_value` strings range from 1 byte to the 10KB length cap, so the pod's memory footprint depends on the value-size mix of incoming traffic:

- the merger seen cache (`quick_cache` with `UnitWeighter`) holds up to `MERGER_SEEN_CACHE_CAPACITY` entries regardless of how large the cached tuples are
- the aggregation buffer flushes on `max_buffered_tuples` and a timer, so a catch-up burst of large values grows the map far past its intended footprint before either trigger fires

## Changes

Replaces the count bounds with byte bounds rather than adding a second knob:

- `TupleKey::approx_bytes()` as the shared size estimate (struct size + key/value string lengths)
- seen cache: entries weighed by bytes; `MERGER_SEEN_CACHE_CAPACITY` (entries) is replaced by `MERGER_SEEN_CACHE_MAX_BYTES` (0 = disabled, matching the old capacity-0 default)
- aggregator: tracks approximate bytes of distinct keys; `MAX_BUFFERED_TUPLES` is replaced by `MAX_BUFFERED_BYTES` (default 256MiB, roughly what 1M tuples occupy at prod's average value size), same `backpressure` flush reason

Deploy note: the charts env needs `MERGER_SEEN_CACHE_MAX_BYTES` (for example 3221225472 = 3GiB, what today's 10M entries occupy) set before this image rolls out, otherwise the merger dedup cache is disabled until it lands. The old vars become no-ops and can be removed from charts afterwards. I'll stack that charts change once this is approved.

## How did you test this code?

Automated only, no manual testing:

- `cargo test -p property-vals-rs` (63 passed)
- new `aggregator::approx_bytes_counts_distinct_keys_only`: catches byte accounting drifting from distinct-key reality (double-counting duplicate adds, or not resetting on drain)
- new `seen_cache::byte_budget_bounds_retention_not_entry_count`: catches the cache regressing to unit weighting (an entry-count budget would retain 10x more bytes than the byte budget allows)
- `cargo clippy -p property-vals-rs -- -D warnings` and `cargo fmt --check` clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a session driven by the assignee, following a Grafana investigation of pod OOM kills in both regions (steady state ~5GiB against a 6GiB limit, restart bursts during catch-up). The companion config change (excluding unique-per-event property keys in prod-eu) shipped separately in the charts repo.

Decisions made along the way: the first draft added byte bounds alongside the count bounds; per the assignee's direction it now replaces them, so each structure has a single byte knob. The seen-cache test asserts only the byte upper bound because retention below budget is quick_cache admission-policy behavior, not our contract. `Aggregator::len()` stays as a test accessor; only the bounding mechanism changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9GooaTfSnqhurXSS5TCsS
