### PR TITLE
chore(tests): speed up backend python test runs

### DIFF
--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -29,6 +29,10 @@ from products.warehouse_sources.backend.facade.types import ExternalDataSourceTy
 
 class TestMetadata(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
+    # No test here writes per-team ClickHouse data, so the per-test team isolation
+    # that ClickhouseTestMixin defaults to (CLASS_DATA_LEVEL_SETUP = False) only adds
+    # ~100ms of org/team/user creation to every test.
+    CLASS_DATA_LEVEL_SETUP = True
 
     def _expr(self, query: str, table: str = "events", debug=True) -> HogQLMetadataResponse:
         return get_hogql_metadata(

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1,5 +1,5 @@
 from datetime import UTC, date, datetime
-from typing import Any, Optional, cast
+from typing import Any, ClassVar, Optional, cast
 from uuid import UUID
 
 import pytest
@@ -30,6 +30,7 @@ from posthog.hogql.database.models import (
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
 from posthog.hogql.errors import QueryError
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast, print_prepared_ast
 from posthog.hogql.resolver import ResolutionError, resolve_types
@@ -56,8 +57,20 @@ class TestResolver(BaseTest):
             "hogql",
         )[0]
 
+    # _fetch_sources hits Postgres a dozen times and its inputs never change within this class
+    # (fixed team, no warehouse objects), so cache the fetched sources per effective modifiers —
+    # the only input that varies (via @override_settings). Building the Database stays per-test
+    # because several tests mutate their instance's tables.
+    _sources_cache: ClassVar[dict[str, Any]] = {}
+
     def setUp(self):
-        self.database = Database.create_for(team=self.team)
+        modifiers = create_default_modifiers_for_team(self.team)
+        cache_key = modifiers.model_dump_json()
+        sources = TestResolver._sources_cache.get(cache_key)
+        if sources is None:
+            sources = Database._fetch_sources(team=self.team, modifiers=modifiers)
+            TestResolver._sources_cache[cache_key] = sources
+        self.database = Database._build_from_sources(sources)
         self.context = HogQLContext(database=self.database, team_id=self.team.pk, enable_select_queries=True)
 
     @pytest.mark.usefixtures("unittest_snapshot")

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -1,5 +1,5 @@
+import sys
 import time
-import inspect
 import dataclasses
 from collections.abc import Callable
 from datetime import timedelta
@@ -94,18 +94,22 @@ def _detect_impersonation_for_login(user, request):
         hasattr(request, "session") and request.session and la_settings.USER_SESSION_FLAG in request.session
     )
 
-    for frame in inspect.stack():
-        if "loginas" in frame.filename:
+    # Walk raw frames instead of inspect.stack(): the latter resolves source context for
+    # every frame (linecache + sys.modules scans), which costs ~200ms per login.
+    frame = sys._getframe().f_back
+    while frame is not None:
+        if "loginas" in frame.f_code.co_filename:
             try:
-                if "original_user_pk" in frame.frame.f_locals:
+                if "original_user_pk" in frame.f_locals:
                     User = get_user_model()
-                    original_user_pk = frame.frame.f_locals["original_user_pk"]
+                    original_user_pk = frame.f_locals["original_user_pk"]
                     admin_user = User.objects.get(pk=original_user_pk)
                     return True, admin_user, str(user.id), "impersonation"
             except Exception:
                 pass
 
             return True, user, str(user.id), "impersonation"
+        frame = frame.f_back
 
     if has_impersonation_session:
         try:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -344,6 +344,12 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "posthog.auth.ZxcvbnValidator"},
 ]
 
+if TEST:
+    # PBKDF2 is deliberately slow (~150ms per hash), which adds up because every
+    # per-test user creation hashes a password. MD5 keeps the same hasher API with
+    # none of the cost. Never used outside tests.
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 PASSWORD_RESET_TIMEOUT = 86_400  # 1 day
 
 ####

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,9 @@ DJANGO_SETTINGS_MODULE = posthog.settings
 # --pytest-durations=0 disables the pytest-durations plugin by default; CI shard steps re-enable it explicitly
 # -p no:tach disables tach's pytest plugin: without --tach it builds the full import graph (~5-10s
 # per invocation) only to print a "could be skipped" hint. Opt back in with: pytest -p tach --tach
-addopts = -p no:warnings -p no:tach --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
+# -p no:langsmith skips the langsmith pytest plugin (auto-registered by a transitive dependency,
+# ~0.8s of imports per invocation); nothing in this repo uses langsmith's pytest integration
+addopts = -p no:warnings -p no:tach -p no:langsmith --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
 
 markers =
     ee


### PR DESCRIPTION
## Problem

Backend python tests pay avoidable per-test overhead. On a fixed 393-test HogQL workload (`test_resolver` + `test_property` + `test_metadata`) the wall time was ~65s, of which a surprising share was PBKDF2 password hashing, redundant per-test org/team/user creation, repeated identical Postgres reads, and unused pytest plugin imports.

## Changes

Measured on that fixed workload, these changes take it from ~65s to ~46s (~29%). All but the first help the whole suite, not just these files.

- **TEST-only `PASSWORD_HASHERS` = MD5** (`posthog/settings/web.py`): Django's PBKDF2 hasher is deliberately slow (~150ms per hash) and every per-test user creation pays it. The standard Django test override keeps the hasher API identical (`check_password`, login flows) at zero cost. Never active outside `TEST`.
- **`TestMetadata` uses class-level test data**: it inherits per-test org/team/user creation from `ClickhouseTestMixin` (`CLASS_DATA_LEVEL_SETUP = False`), but no test in the file writes per-team ClickHouse data, so that isolation bought nothing (~100ms x 60 tests).
- **`TestResolver` caches `Database._fetch_sources` per effective-modifiers key**: the fetch half of `Database.create_for` runs a dozen Postgres queries whose inputs never change within the class. Keyed on the serialized modifiers so the `PERSON_ON_EVENTS_OVERRIDE` rebuild tests stay correct; `_build_from_sources` still runs per test because several tests mutate their database instance.
- **Disable the langsmith pytest plugin** (`pytest.ini`): auto-registered by a transitive dependency, ~0.8s of imports per pytest invocation, unused in this repo.
- **`fix(activity-log)`: frame walk instead of `inspect.stack()`** in login impersonation detection: `inspect.stack()` resolves source context for every frame (linecache reads + `sys.modules` scans), up to ~200ms per login. This also fires on every `force_login` in every API test. Behavior-identical raw frame walk.

## How did you test this code?

Automated tests only (run locally against Postgres + ClickHouse 26.3.10.60):

- The full workload files: 393 passed, all 24 syrupy snapshots unchanged.
- `posthog/hogql/printer/test/test_printer.py` (837 passed, 1 xfail) and `ee/clickhouse/materialized_columns/test/test_columns.py` (17 passed) - closest coverage for HogQL printing and materialized columns.
- `posthog/api/test/test_authentication.py` (144 passed; `test_login_2fa_enabled` fails identically on unmodified master in my sandbox) and `posthog/api/test/test_activity_log.py` (20 passed) - cover the hasher override and the impersonation frame walk.
- `posthog/api/test/test_signup.py`: 16 failures both with and without these changes (pre-existing sandbox environment issues), 79 passed either way.

No new tests: nothing here changes behavior under test, so a new test would only re-assert what the existing suites already pin.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task) in an iterative measure-change-measure loop against a fixed pytest workload. Skills consulted: `django-startup-time` (read before deciding not to touch setup-path imports).

Tried and rejected along the way, for reviewers' benefit:

- Enabling the in-process `cache_for` layer for materialized-column introspection under TEST (~3.3s win): reverted because `test_caching_and_materializing` explicitly pins stale-until-TTL semantics, and printer tests that call `materialize()` directly mid-test would need invalidation the pinned behavior forbids.
- Caching or deep-copying the whole `Database` object per test class: tests mutate their instances, and `model_copy(deep=True)`/`deepcopy` measured slower than construction.
- Deferring heavy imports off `django.setup()`: real cost (~5.6s per process) but it is an active guarded workstream; nothing safe to grab in one pass.