### PR TITLE
chore(tasks): add shell efficiency instruction to agent prompts

### DIFF
--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -45,6 +45,12 @@ Whenever you mention the pull request in any output, summary, or comment, always
 full URL (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain
 text, so readers can open it directly.
 
+Shell efficiency: optimize for the fewest shell round trips.
+- Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have.
+
 Hard limits: stay strictly within the wizard's changes, plus the changes required to automatically
 configure the environment variables in production, plus the minimal fixes needed for CI to pass.
 When keeping CI green, do not modify unrelated code, add/remove/upgrade dependencies beyond

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -1,4 +1,11 @@
-WIZARD_PR_AGENT_PROMPT = """
+SHELL_EFFICIENCY_INSTRUCTION = """\
+Shell efficiency: optimize for the fewest shell round trips.
+- Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have."""
+
+WIZARD_PR_AGENT_PROMPT = f"""
 PostHog's setup wizard has already run in this repository and integrated PostHog. The working tree
 contains its uncommitted changes (modified source files, an updated package manifest, installed
 dependencies, a `posthog-setup-report.md` summary, and possibly a `.posthog-events.json` plan).
@@ -45,11 +52,7 @@ Whenever you mention the pull request in any output, summary, or comment, always
 full URL (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain
 text, so readers can open it directly.
 
-Shell efficiency: optimize for the fewest shell round trips.
-- Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
-- Emit all independent tool calls in the same response.
-- Read multiple files at once.
-- Never rerun a command solely to reproduce output you already have.
+{SHELL_EFFICIENCY_INSTRUCTION}
 
 Hard limits: stay strictly within the wizard's changes, plus the changes required to automatically
 configure the environment variables in production, plus the minimal fixes needed for CI to pass.

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -11,6 +11,8 @@ from datetime import timedelta
 
 from django.conf import settings
 
+from products.tasks.backend.prompts import SHELL_EFFICIENCY_INSTRUCTION
+
 # Per-task inactivity timeout defaults (production). User-driven runs — explicitly
 # user-created, or with no origin product — get a longer idle grace window since a
 # human may still be in the loop; automated/background runs reclaim the sandbox
@@ -96,7 +98,7 @@ MAX_ACK_RETRIES = 5
 # flush rate-limits retries.
 OUTBOUND_RETRY_BACKOFF = timedelta(seconds=10)
 
-DEFAULT_CI_MESSAGE = """\
+DEFAULT_CI_MESSAGE = f"""\
 You are re-entering this run to address CI feedback on the pull request you opened.
 
 Scope (what to do):
@@ -123,9 +125,5 @@ When you mention the pull request in your summary, always hyperlink it to its fu
 Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain text, so readers
 can open it directly.
 
-Shell efficiency: optimize for the fewest shell round trips.
-- Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
-- Emit all independent tool calls in the same response.
-- Read multiple files at once.
-- Never rerun a command solely to reproduce output you already have.
+{SHELL_EFFICIENCY_INSTRUCTION}
 """.strip()

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -122,4 +122,10 @@ After fixing, commit and push so CI can re-run.
 When you mention the pull request in your summary, always hyperlink it to its full URL (e.g. a
 Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain text, so readers
 can open it directly.
+
+Shell efficiency: optimize for the fewest shell round trips.
+- Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have.
 """.strip()


### PR DESCRIPTION
## Problem

Task agents run shell commands one call at a time, and each tool call re-sends the full conversation context. PostHog/code#3207 benchmarked an instruction that batches related commands: -19% Bash calls, -12% turns, -15% input tokens with no task-success regression. The repo-owned task prompts here don't carry that instruction.

## Changes

Adds the benchmarked shell-efficiency block from PostHog/code#3207 to `WIZARD_PR_AGENT_PROMPT` and `DEFAULT_CI_MESSAGE`: batch related commands with `&&`, emit independent tool calls in one response, read multiple files at once and don't rerun commands for output already seen.

## How did you test this code?

Prompt string change only. I (Claude) ran no tests locally; CI covers the modules importing these constants. The wording itself was benchmarked in PostHog/code#3207 (120 synthetic-task runs plus 36 real-workload runs).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Charles asked to propagate the shell-efficiency instruction from PostHog/code#3207 (where it covers the PostHog Code agent surfaces) to the repo-owned task prompts here, mirroring how the PR-hyperlink instruction landed in #68770. I (Claude Code) authored the change and shipped it as a single GitHub-signed commit via the GraphQL API. No repo skills invoked.
