### PR TITLE
fix(postgres): keep foreign-server connection failures retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/exceptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/exceptions.py
@@ -28,3 +28,17 @@ class PostHogDatabaseConnectionError(Exception):
     "Name or service not known"), and must stay retryable rather than be misclassified as
     non-retryable and stop a healthy sync.
     """
+
+
+class ForeignServerUnreachableError(Exception):
+    """Raised when a setup query touched a postgres_fdw foreign table whose foreign server failed.
+
+    postgres_fdw/dblink report a failure to connect to a *foreign* server with SQLSTATE 08001
+    (`SqlclientUnableToEstablishSqlconnection`), embedding the downstream libpq error verbatim —
+    e.g. "... failed: Connection refused". That English wording collides with the connect-time
+    substrings in `PostgresSource.get_non_retryable_errors` (which target the *direct* connection to
+    the customer's database), so a foreign server that's briefly down (failover, restart) would be
+    misclassified as a permanent misconfiguration and stop a healthy sync. The server-side sibling of
+    `PostHogDatabaseConnectionError`: its message intentionally avoids those substrings so a transient
+    foreign-server outage stays retryable.
+    """

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -5,6 +5,7 @@ from django.db import OperationalError as DjangoOperationalError
 
 import structlog
 from psycopg import OperationalError
+from psycopg.errors import SqlclientUnableToEstablishSqlconnection
 from sshtunnel import BaseSSHTunnelForwarderError
 
 if TYPE_CHECKING:
@@ -139,6 +140,15 @@ RLS_WARNING_MESSAGE = (
     "Row-level security is active on this table for the sync role, so PostHog can only read "
     "rows the policy permits, and cannot detect how many rows are hidden. "
     "Granting the sync role BYPASSRLS will silence the check."
+)
+
+# Stable, classifiable message for a postgres_fdw foreign-server connection failure surfaced during
+# setup. Kept clear of the connect-time substrings in `get_non_retryable_errors` so the condition
+# stays retryable — see `ForeignServerUnreachableError`.
+_FOREIGN_SERVER_UNREACHABLE_ERROR = (
+    "A table selected for sync is a postgres_fdw foreign table and PostHog could not connect to the "
+    "foreign server it points at. This is usually a transient outage of that downstream server; if it "
+    "persists, check that the foreign server is running and reachable from your source database."
 )
 
 
@@ -939,6 +949,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
         from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.exceptions import (
             CDCHandledExternally,
+            ForeignServerUnreachableError,
             PostHogDatabaseConnectionError,
         )
 
@@ -982,31 +993,40 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         # Prefer the per-row `schema_metadata.source_schema` so multi-schema warehouse sources work
         # without needing to encode the schema in `config.schema`. Falls back to `config.schema` for
         # legacy single-schema warehouse sources whose rows haven't been reconciled yet.
-        response = postgres_source(
-            tunnel=ssh_tunnel,
-            user=config.user,
-            password=config.password,
-            database=config.database,
-            sslmode="prefer",
-            schema=source_schema or config.schema or "public",
-            table_names=[source_table_name or inputs.schema_name],
-            should_use_incremental_field=inputs.should_use_incremental_field,
-            logger=inputs.logger,
-            incremental_field=inputs.incremental_field,
-            incremental_field_type=inputs.incremental_field_type,
-            db_incremental_field_last_value=inputs.db_incremental_field_last_value,
-            chunk_size_override=schema.chunk_size_override,
-            team_id=inputs.team_id,
-            require_ssl=require_ssl,
-            is_initial_sync=not schema.initial_sync_complete,
-            enabled_columns=inputs.enabled_columns,
-            row_filters=inputs.row_filters,
-            # xmin state is read straight off the schema here (the generic `SourceInputs` stays
-            # Postgres-agnostic). xmin rides the normal full per-schema path — no CDC dispatch.
-            is_xmin=schema.is_xmin,
-            xmin_last_value=schema.xmin_last_value,
-            xmin_num_wraparound=schema.xmin_num_wraparound,
-        )
+        try:
+            response = postgres_source(
+                tunnel=ssh_tunnel,
+                user=config.user,
+                password=config.password,
+                database=config.database,
+                sslmode="prefer",
+                schema=source_schema or config.schema or "public",
+                table_names=[source_table_name or inputs.schema_name],
+                should_use_incremental_field=inputs.should_use_incremental_field,
+                logger=inputs.logger,
+                incremental_field=inputs.incremental_field,
+                incremental_field_type=inputs.incremental_field_type,
+                db_incremental_field_last_value=inputs.db_incremental_field_last_value,
+                chunk_size_override=schema.chunk_size_override,
+                team_id=inputs.team_id,
+                require_ssl=require_ssl,
+                is_initial_sync=not schema.initial_sync_complete,
+                enabled_columns=inputs.enabled_columns,
+                row_filters=inputs.row_filters,
+                # xmin state is read straight off the schema here (the generic `SourceInputs` stays
+                # Postgres-agnostic). xmin rides the normal full per-schema path — no CDC dispatch.
+                is_xmin=schema.is_xmin,
+                xmin_last_value=schema.xmin_last_value,
+                xmin_num_wraparound=schema.xmin_num_wraparound,
+            )
+        except SqlclientUnableToEstablishSqlconnection as e:
+            # A setup query (e.g. the duplicate-PK probe) touched a postgres_fdw foreign table and the
+            # foreign server it points at refused/failed the connection (SQLSTATE 08001). libpq embeds
+            # the downstream error verbatim (e.g. "... Connection refused"), which would otherwise
+            # collide with the connect-time non-retryable rules meant for the direct connection and
+            # permanently disable the sync on a transient foreign-server blip. Re-raise clear of those
+            # substrings so it stays retryable.
+            raise ForeignServerUnreachableError(_FOREIGN_SERVER_UNREACHABLE_ERROR) from e
         # `SourceResponse.name` must match `DataWarehouseTable.url_pattern` (both derived from the
         # storage key when present, otherwise the row name) so HogQL reads from where we wrote.
         storage_schema_name = schema.resolved_s3_folder_name or inputs.schema_name

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -33,6 +33,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
     ValidatedRowFilter,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.exceptions import (
+    ForeignServerUnreachableError,
     PostHogDatabaseConnectionError,
     XminUnsupportedError,
 )
@@ -283,6 +284,58 @@ class TestPostgresSourceMetadataConnectionErrors:
         error_msg = str(exc_info.value)
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"A PostHog-side DB connection failure must stay retryable: {error_msg}"
+
+
+class TestPostgresSourceForeignServerConnectionError:
+    def test_foreign_server_connection_failure_stays_retryable(self):
+        # A setup query touched a postgres_fdw foreign table and the foreign server it points at
+        # refused the connection (SQLSTATE 08001). libpq embeds "... Connection refused" verbatim,
+        # which would collide with the connect-time "Connection refused" non-retryable rule meant for
+        # the direct connection — so a transient foreign-server outage must be re-raised clear of that
+        # substring to stay retryable instead of disabling a healthy sync.
+        source = PostgresSource()
+        schema_model = mock.MagicMock()
+        schema_model.is_cdc = False
+        schema_model.cdc_mode = None
+        schema_model.schema_metadata = {"source_schema": "public", "source_table_name": "orders"}
+        schema_model.initial_sync_complete = True
+
+        inputs = mock.MagicMock(
+            schema_id="00000000-0000-0000-0000-000000000000",
+            schema_name="orders",
+            team_id=1,
+        )
+        config = mock.MagicMock(user="u", password="p", database="db", schema="public")
+
+        fdw_error = psycopg.errors.SqlclientUnableToEstablishSqlconnection(
+            'could not connect to server "some_fdw_server"\n'
+            'DETAIL:  connection to server at "10.0.0.5", port 5432 failed: Connection refused\n'
+            "\tIs the server running on that host and accepting TCP/IP connections?"
+        )
+
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.models.external_data_schema.ExternalDataSchema.objects"
+            ) as objects_mock,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.postgres_source",
+                side_effect=fdw_error,
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.source_requires_ssl",
+                return_value=False,
+            ),
+            mock.patch.object(source, "make_ssh_tunnel_func", return_value=lambda: None),
+        ):
+            objects_mock.select_related.return_value.get.return_value = schema_model
+            with pytest.raises(ForeignServerUnreachableError) as exc_info:
+                source.source_for_pipeline(config, inputs)
+
+        error_msg = str(exc_info.value)
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"A foreign-server connection failure must stay retryable: {error_msg}"
+        assert "Connection refused" not in error_msg
 
 
 class TestPostgresSourceNonRetryableErrors:


### PR DESCRIPTION
## Problem

Error tracking surfaced a stream of `SqlclientUnableToEstablishSqlconnection` exceptions from the Postgres import source ([issue](https://us.posthog.com/project/2/error_tracking/019f3a38-cca3-7290-a129-dd8212b98293)), raised in `_has_duplicate_primary_keys` at `postgres.py:2062` and propagating out of `source_for_pipeline`. The message is a postgres_fdw foreign-server connection failure: `could not connect to server "..." DETAIL: connection to server at "..." port 5432 failed: Connection refused`.

When a table selected for sync is a `postgres_fdw` foreign table, a setup query (the duplicate-PK probe is the first one to touch the table's data) makes the source database connect to the downstream foreign server. If that server is unreachable, Postgres returns SQLSTATE 08001 (`SqlclientUnableToEstablishSqlconnection`) with the downstream libpq error embedded verbatim, including the English `Connection refused`.

That collides with the connect-time `"Connection refused"` rule in `get_non_retryable_errors`, which is meant for the direct connection to the customer's database (a wrong host/port they typed into the form). So a foreign server that is briefly down (failover, restart) gets misclassified as a permanent misconfiguration, and the pipeline disables a healthy sync after a few attempts. The observed occurrences were a tight cluster (a handful of hits inside a ~16-second window, then silence) which is the signature of a transient downstream blip that recovered, exactly the case that should have been retried.

This is the server-side sibling of the case `PostHogDatabaseConnectionError` already guards against: an error whose string collides with the non-retryable substrings and would wrongly stop a healthy sync.

## Changes

Translate the foreign-server failure at the same layer as the existing `PostHogDatabaseConnectionError` handling. `source_for_pipeline` now catches `SqlclientUnableToEstablishSqlconnection` from the `postgres_source(...)` setup call and re-raises it as a new `ForeignServerUnreachableError` with a stable message that stays clear of the connect-time non-retryable substrings, so the condition stays retryable.

SQLSTATE 08001 (`SqlclientUnableToEstablishSqlconnection`) is only produced server-side by `postgres_fdw`/`dblink` when reaching a foreign server. A client-side failure to reach the customer's own database is a plain `OperationalError` with no SQLSTATE, so this catch is specific to the foreign-table case and does not change how direct-connection failures are classified.

No change to the global retry policy, and no change to the direct-connection `"Connection refused"` behavior.

## How did you test this code?

I (Claude) added `TestPostgresSourceForeignServerConnectionError::test_foreign_server_connection_failure_stays_retryable`, which drives `source_for_pipeline` with `postgres_source` raising the exact 08001 "Connection refused" foreign-server error and asserts it re-raises `ForeignServerUnreachableError` with a message that no longer matches `get_non_retryable_errors` (i.e. stays retryable) and does not leak the raw `Connection refused` wording. This is the regression the change fixes and no existing test covered it (`TestPostgresSourceMetadataConnectionErrors` covers only the PostHog-side DB failure).

Ran locally with pytest: the new test plus the existing connection-error tests pass. Three `@pytest.mark.django_db` tests in the same file error in this sandbox because it has no live Postgres (DNS resolution fails); they are unrelated to this change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (`claude-opus-4-8`) via the PostHog error-tracking MCP tools. I confirmed the issue, pulled the stack trace and event samples, and traced the failure from `source_for_pipeline` → `postgres_source` → `_has_duplicate_primary_keys`. Invoked the `/writing-tests` skill before adding the test.

Decision: this is a fixable classification bug, not a new NonRetryableErrors entry. A dict entry can't express "Connection refused except when it comes from a foreign server" (substring matching, no negative match), and the same error can arrive as the transient FDW "too many connections" flavor which the code already keeps retryable. Wrapping at `source_for_pipeline` mirrors the existing `PostHogDatabaseConnectionError` precedent and stays clear of the maintainer's in-flight work on `_has_duplicate_primary_keys` (#68707).
