### PR TITLE
fix(data-warehouse): show a retry when the inline source picker can't load sources

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -102,7 +102,7 @@ export function NewSourceScene(): JSX.Element {
 // The wizard endpoint failed (a timeout, a 5xx, or a 403 for members without data-source
 // access). Without this the scene keeps rendering a bare skeleton indefinitely, which reads
 // as a permanently stuck loading state.
-function AvailableSourcesError(): JSX.Element {
+export function AvailableSourcesError(): JSX.Element {
     const { load } = useActions(availableSourcesLogic)
 
     return (

--- a/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
+++ b/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
@@ -8,7 +8,7 @@ import { LemonButton, LemonCard, LemonInput, LemonSkeleton } from '@posthog/lemo
 import { ExternalDataSourceType, SourceConfig } from '~/queries/schema/schema-general'
 
 import { availableSourcesLogic } from '../../scenes/NewSourceScene/availableSourcesLogic'
-import { NewSourcesWizard } from '../../scenes/NewSourceScene/NewSourceScene'
+import { AvailableSourcesError, NewSourcesWizard } from '../../scenes/NewSourceScene/NewSourceScene'
 import { sourceWizardLogic } from '../../scenes/NewSourceScene/sourceWizardLogic'
 import { DataWarehouseWizardBlock } from './DataWarehouseWizardBlock'
 import { SourceIcon } from './SourceIcon'
@@ -203,8 +203,12 @@ function InternalInlineSourceSetup({
 export function InlineSourceSetup(props: InlineSourceSetupProps): JSX.Element {
     const { availableSources, availableSourcesLoading } = useValues(availableSourcesLogic)
 
-    if (availableSourcesLoading || availableSources === null) {
+    if (availableSourcesLoading) {
         return <LemonSkeleton />
+    }
+
+    if (availableSources === null) {
+        return <AvailableSourcesError />
     }
 
     return (


### PR DESCRIPTION
## Problem

When you open the inline data-warehouse source picker (the one embedded in onboarding and dashboard flows) and the available-sources request fails, the picker renders a bare loading skeleton forever. There is no error, no retry, nothing actionable. Replay Vision watched a real onboarding session where a user landed on a source-linking screen that never rendered its content and showed only a persistent striped (skeleton) background. They waited, then abandoned onboarding.

The request can fail for ordinary reasons: a timeout, a 5xx, or a 403 for members who don't have data-source access in the project.

## Changes

The full new-source scene already handles this cleanly: once the request resolves to no sources it swaps the skeleton for an error banner with a "Try again" action. The inline picker was still collapsing both the loading and the failed states into a single skeleton branch.

Split them so the inline picker matches the scene:

- skeleton only while the request is in flight
- the existing retriable error banner once it fails

I exported the scene's `AvailableSourcesError` component and reused it, so both entry points share one banner and one retry path.

## How did you test this code?

This mirrors the exact loading/error/retry pattern already present and shipping in `NewSourceScene`. I (Claude) could not run the frontend lint/typecheck tooling in this environment (no `node_modules`), so I verified by inspection that `availableSourcesLogic` is already mounted in the inline picker (it reads `availableSources`/`availableSourcesLoading` from it), so the banner's retry `load()` action resolves. No behavior changes on the success path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) authored this while synthesizing friction themes from a batch of Replay Vision session summaries of the data-warehouse new-source onboarding flow. One session showed a user stuck on a never-resolving skeleton on the source-linking screen. Tracing it, I found `NewSourceScene` already renders a retriable error banner on load failure while `InlineSourceSetup` still fell through to a bare skeleton. The fix reuses the existing component rather than duplicating the banner. No skills were needed for this frontend-only change.
