### PR TITLE
fix(data-warehouse): make Snowflake connection errors actionable at setup time

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -43,10 +43,10 @@ _MALFORMED_PEM_MESSAGE = (
 )
 
 SnowflakeErrors = {
-    "No active warehouse selected in the current session": "No warehouse found for selected role",
+    "No active warehouse selected in the current session": "No active warehouse is available for this connection. Check that the configured warehouse exists, is running, and that the connecting role has USAGE on it, then try again.",
     "or attempt to login with another role": "Role specified doesn't exist or is not authorized",
     "Incorrect username or password was specified": "Incorrect username or password was specified",
-    "This session does not have a current database": "Database specified not found",
+    "This session does not have a current database": "No database is available for this connection. Check that the configured database exists and that the connecting role has USAGE on it, then try again.",
     "Verify the account name is correct": "Can't find an account with the specified account ID",
     "Multi-factor authentication is required for this account": "This Snowflake account requires multi-factor authentication enrollment. Connect with a service user that uses key-pair authentication or is exempt from MFA.",
     # Snowflake error 290404: the login-request endpoint 404s because the account identifier doesn't


### PR DESCRIPTION
## Problem

When you connect a Snowflake source and the configured warehouse or database isn't reachable, setup-time credential validation showed a terse message: "No warehouse found for selected role" or "Database specified not found". Replay Vision watched a real onboarding session where a user repeatedly hit "Database specified not found", couldn't work out what to change, and abandoned the connection.

The message is misleading. In Snowflake the object can exist but be invisible to the connecting role when that role lacks `USAGE` on it, so "not found" points people at the wrong fix (the name) instead of the real one (the grant).

## Changes

The sync-time error map (`get_non_retryable_errors`) already maps these exact two Snowflake error strings to much more actionable text that calls out the `USAGE`-grant gotcha. The setup-time map (`SnowflakeErrors`) mapped the same strings to the terse versions, so a user got a worse message during onboarding than they would have during a sync.

Align the two. The setup-time messages now match the sync-time wording, adapted to the pre-sync context ("then try again" rather than "then resync"):

- warehouse: "No active warehouse is available for this connection. Check that the configured warehouse exists, is running, and that the connecting role has USAGE on it, then try again."
- database: "No database is available for this connection. Check that the configured database exists and that the connecting role has USAGE on it, then try again."

Copy-only change. No validation logic or matching behavior changes.

## How did you test this code?

I (Claude) ran `ruff check` and `ruff format --check` on the touched file (both pass) and grepped the repo to confirm nothing asserts on the old message strings. The error-string matching keys are unchanged, so the same conditions map to the same (now clearer) messages.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) authored this while synthesizing friction themes from a batch of Replay Vision session summaries of the data-warehouse new-source onboarding flow. A session showed a user stuck on the terse Snowflake database message. I found the setup-time and sync-time error maps in the same source file disagreed on wording for identical errors, with the sync side already being the good one, so I aligned setup to match. No skills were needed for this copy-only change.
