### PR TITLE
feat(cohorts): allow negative-only cohort criteria

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/types.ts
+++ b/frontend/src/scenes/cohorts/CohortFilters/types.ts
@@ -138,7 +138,7 @@ export type CohortFieldProps =
     | CohortRelativeAndExactTimeFieldProps
 
 export enum CohortClientErrors {
-    NegationCriteriaMissingOther = 'Negation criteria can only be used when matching all criteria (AND), and must be accompanied by at least one positive matching criteria.',
+    NegationCriteriaRequiresAnd = 'Negation criteria can only be used when matching all criteria (AND).',
     NegationCriteriaCancel = 'These criteria cancel each other out, and would result in no matching persons.',
     PeriodTimeMismatch = 'The lower bound period value must not be greater than the upper bound value.',
     SequentialTimeMismatch = 'The lower bound period sequential time value must not be greater than the upper bound time value.',

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -247,7 +247,7 @@ describe('cohortEditLogic', () => {
             expect(api.update).toHaveBeenCalledTimes(0)
         })
 
-        describe('negation errors', () => {
+        describe('negation validation', () => {
             it('do not save on OR operator', async () => {
                 await initCohortLogic({ id: 1 })
                 await expectLogic(logic, async () => {
@@ -294,10 +294,10 @@ describe('cohortEditLogic', () => {
                                 properties: {
                                     values: [
                                         {
-                                            id: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND), and must be accompanied by at least one positive matching criteria.",
+                                            id: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND).",
                                             values: [
                                                 {
-                                                    value: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND), and must be accompanied by at least one positive matching criteria.",
+                                                    value: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND).",
                                                 },
                                                 {},
                                             ],
@@ -310,7 +310,7 @@ describe('cohortEditLogic', () => {
                 expect(api.update).toHaveBeenCalledTimes(0)
             })
 
-            it('do not save on less than one positive matching criteria', async () => {
+            it('saves a cohort with only negative matching criteria', async () => {
                 await initCohortLogic({ id: 1 })
                 await expectLogic(logic, async () => {
                     logic.actions.setCohort({
@@ -341,26 +341,11 @@ describe('cohortEditLogic', () => {
                     })
                     logic.actions.submitCohort()
                 })
-                    .toDispatchActions(['setCohort', 'submitCohort', 'submitCohortFailure'])
+                    .toDispatchActions(['setCohort', 'submitCohort', 'submitCohortSuccess', 'saveCohortSuccess'])
                     .toMatchValues({
-                        cohortErrors: partial({
-                            filters: {
-                                properties: {
-                                    values: [
-                                        {
-                                            id: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND), and must be accompanied by at least one positive matching criteria.",
-                                            values: [
-                                                {
-                                                    value: "'Did not complete event' is a negative cohort criteria. Negation criteria can only be used when matching all criteria (AND), and must be accompanied by at least one positive matching criteria.",
-                                                },
-                                            ],
-                                        },
-                                    ],
-                                },
-                            },
-                        }),
+                        cohortErrors: {},
                     })
-                expect(api.update).toHaveBeenCalledTimes(0)
+                expect(api.update).toHaveBeenCalledTimes(1)
             })
 
             it('do not save on criteria cancelling each other out', async () => {

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -196,12 +196,7 @@ export function validateGroup(
     const negatedCriteria = criteria.filter((c) => !!c.negation)
     const negatedCriteriaIndices = new Set(negatedCriteria.map((c) => c.index))
 
-    if (
-        // Negation criteria can only be used when matching ALL criteria
-        (group.type !== FilterLogicalOperator.And && negatedCriteria.length > 0) ||
-        // Negation criteria has at least one positive matching criteria
-        (group.type === FilterLogicalOperator.And && negatedCriteria.length === criteria.length)
-    ) {
+    if (group.type !== FilterLogicalOperator.And && negatedCriteria.length > 0) {
         const errorMsg = `${negatedCriteria
             .map((c) => {
                 const behavioralFilterType = criteriaToBehavioralFilterType(c)
@@ -211,7 +206,7 @@ export function validateGroup(
                 return `'${BEHAVIORAL_TYPE_TO_LABEL[behavioralFilterType]?.label ?? behavioralFilterType}'`
             })
             .join(', ')} ${negatedCriteria.length > 1 ? 'are' : 'is a'} negative cohort criteria. ${
-            CohortClientErrors.NegationCriteriaMissingOther
+            CohortClientErrors.NegationCriteriaRequiresAnd
         }`
         return {
             id: errorMsg,

--- a/posthog/hogql/functions/cohort.py
+++ b/posthog/hogql/functions/cohort.py
@@ -95,7 +95,12 @@ def inline_cohort_query(
 
         context.team = Team.objects.get(id=context.team_id)
 
-    return HogQLCohortQuery(cohort=cohort, team=context.team).get_query()
+    cohort_query = HogQLCohortQuery(cohort=cohort, team=context.team)
+    inline_query = cohort_query.get_query()
+    if cohort_query.is_top_level_negated:
+        return None
+
+    return inline_query
 
 
 def cohort_subquery(cohort_id, is_static, version: Optional[int] = None) -> ast.Expr:

--- a/posthog/hogql/functions/test/test_cohort.py
+++ b/posthog/hogql/functions/test/test_cohort.py
@@ -12,8 +12,10 @@ from parameterized import parameterized
 from posthog.schema import HogQLQueryModifiers, InCohortVia, InlineCohortCalculation, PersonsArgMaxVersion
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
-from posthog.hogql.parser import parse_expr
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_response_in_tests
 
@@ -271,6 +273,43 @@ class TestInlineCohortSubquery(BaseTest):
                 pretty=False,
             )
         self.assertEqual(len(response.results), 1)
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_inline_cohort_auto_mode_skips_top_level_negated_cohort(self, _mock_feature_enabled) -> None:
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "test_prop",
+                            "value": "excluded",
+                            "type": "person",
+                            "negation": True,
+                        }
+                    ]
+                }
+            ],
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            team=self.team,
+            enable_select_queries=True,
+            modifiers=HogQLQueryModifiers(
+                inCohortVia=InCohortVia.SUBQUERY,
+                inlineCohortCalculation=InlineCohortCalculation.AUTO,
+            ),
+        )
+
+        query, _ = prepare_and_print_ast(
+            parse_select(f"SELECT event FROM events WHERE person_id IN cohort({cohort.pk})"),
+            context,
+            "clickhouse",
+            pretty=True,
+        )
+
+        self.assertIn("cohortpeople.cohort_id", query)
+        self.assertNotIn("\nEXCEPT\n", query)
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -230,6 +230,7 @@ class HogQLCohortQuery:
         cohort: Optional[Cohort] = None,
         team: Optional[Team] = None,
     ):
+        self.is_top_level_negated = False
         if cohort is not None:
             self.hogql_context = HogQLContext(team_id=cohort.team.pk, enable_select_queries=True)
             self.team = team or cohort.team
@@ -649,6 +650,7 @@ class HogQLCohortQuery:
         )
 
     def _get_conditions(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        self.is_top_level_negated = False
         Condition = namedtuple("Condition", ["query", "negation"])
         should_combine_person_properties_and = self._should_combine_person_properties_and()
         should_combine_person_properties_or = self._should_combine_person_properties_or()
@@ -745,8 +747,7 @@ class HogQLCohortQuery:
                     parent_condition_negated = True
                     children = [Condition(query, not negation) for query, negation in children]
 
-            # Sort positive queries first so mixed groups start from matches and subtract exclusions.
-            # Fully negated groups are combined here, then wrapped by the parent condition.
+            # Sort the positive queries first, then subtract the negative queries.
             children.sort(key=lambda query: query[1])  # False before True
             return Condition(
                 ast.SelectSetQuery(
@@ -768,6 +769,7 @@ class HogQLCohortQuery:
 
         condition = build_conditions(self.property_groups)
         if condition.negation:
+            self.is_top_level_negated = True
             return ast.SelectSetQuery(
                 initial_select_query=self.get_all_persons_condition(),
                 subsequent_select_queries=[SelectSetNode(select_query=condition.query, set_operator="EXCEPT")],

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -576,6 +576,9 @@ class HogQLCohortQuery:
             ),
         )
 
+    def get_all_persons_condition(self) -> ast.SelectQuery:
+        return cast(ast.SelectQuery, parse_select("SELECT id FROM persons"))
+
     def _get_condition_for_property(self, prop: Property) -> ast.SelectQuery | ast.SelectSetQuery:
         if prop.type == "behavioral":
             if prop.value == "performed_event":
@@ -742,8 +745,8 @@ class HogQLCohortQuery:
                     parent_condition_negated = True
                     children = [Condition(query, not negation) for query, negation in children]
 
-            # Negation criteria must be accompanied by at least one positive matching criteria.
-            # Sort the positive queries first, then subtract the negative queries.
+            # Sort positive queries first so mixed groups start from matches and subtract exclusions.
+            # Fully negated groups are combined here, then wrapped by the parent condition.
             children.sort(key=lambda query: query[1])  # False before True
             return Condition(
                 ast.SelectSetQuery(
@@ -765,7 +768,10 @@ class HogQLCohortQuery:
 
         condition = build_conditions(self.property_groups)
         if condition.negation:
-            raise ValidationError("Top level condition cannot be negated", str(self.property_groups))
+            return ast.SelectSetQuery(
+                initial_select_query=self.get_all_persons_condition(),
+                subsequent_select_queries=[SelectSetNode(select_query=condition.query, set_operator="EXCEPT")],
+            )
         return condition.query
 
 

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -231,6 +231,93 @@ class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
         # Should use EXCEPT because one property is negated
         self.assertIn("EXCEPT", query_str)
 
+    @parameterized.expand(
+        [
+            (
+                "and_two_negated_criteria",
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": "spam",
+                                    "negation": True,
+                                    "operator": "icontains",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "name",
+                                    "type": "person",
+                                    "value": "bot",
+                                    "negation": True,
+                                    "operator": "icontains",
+                                }
+                            ],
+                        },
+                    ],
+                },
+                "union distinct",
+                1,
+            ),
+            (
+                "or_mixed_negated_and_positive",
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": "spam",
+                                    "negation": True,
+                                    "operator": "icontains",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "plan",
+                                    "type": "person",
+                                    "value": "pro",
+                                    "negation": False,
+                                    "operator": "exact",
+                                }
+                            ],
+                        },
+                    ],
+                },
+                "except",
+                2,
+            ),
+        ]
+    )
+    def test_top_level_negation_bubbles_to_all_persons_except(
+        self, _name: str, cohort_filters: dict[str, object], expected_inner_operator: str, minimum_except_count: int
+    ) -> None:
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name=f"Test top-level negation {_name}",
+            filters={"properties": cohort_filters},
+        )
+
+        query_str = HogQLCohortQuery(cohort=cohort).query_str("clickhouse").lower()
+
+        self.assertIn("limit 50000\nexcept\n", query_str)
+        self.assertIn(expected_inner_operator, query_str)
+        self.assertGreaterEqual(query_str.count("except"), minimum_except_count)
+
     def test_negative_only_behavioral_cohort_membership_end_to_end(self) -> None:
         now = dt.datetime(2025, 1, 15, tzinfo=ZoneInfo("UTC"))
         with freeze_time(now):

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_person, flush_persons_and_events
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
 from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
@@ -230,6 +230,65 @@ class TestHogQLCohortQuery(ClickhouseTestMixin, APIBaseTest):
 
         # Should use EXCEPT because one property is negated
         self.assertIn("EXCEPT", query_str)
+
+    def test_negative_only_behavioral_cohort_membership_end_to_end(self) -> None:
+        now = dt.datetime(2025, 1, 15, tzinfo=ZoneInfo("UTC"))
+        with freeze_time(now):
+            purchased_person = _create_person(
+                team=self.team,
+                distinct_ids=["purchased"],
+                properties={"email": "purchased@example.com"},
+                immediate=True,
+            )
+            not_purchased_person = _create_person(
+                team=self.team,
+                distinct_ids=["not_purchased"],
+                properties={"email": "not-purchased@example.com"},
+                immediate=True,
+            )
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id="purchased",
+                timestamp=now,
+            )
+            flush_persons_and_events()
+
+            cohort = Cohort.objects.create(
+                team=self.team,
+                name="Did not purchase",
+                filters={
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "purchase",
+                                        "type": "behavioral",
+                                        "value": "performed_event",
+                                        "negation": True,
+                                        "event_type": "events",
+                                        "time_value": 30,
+                                        "time_interval": "day",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            )
+            cohort.calculate_people_ch(pending_version=0)
+
+        rows = sync_execute(
+            "SELECT person_id FROM cohortpeople WHERE cohort_id = %(cohort_id)s AND team_id = %(team_id)s "
+            "GROUP BY person_id, cohort_id, team_id, version HAVING sum(sign) > 0",
+            {"cohort_id": cohort.pk, "team_id": self.team.pk},
+        )
+        member_ids = {str(row[0]) for row in rows}
+        self.assertIn(str(not_purchased_person.uuid), member_ids)
+        self.assertNotIn(str(purchased_person.uuid), member_ids)
 
     @patch("posthoganalytics.feature_enabled", return_value=True)
     def test_multiple_person_properties_or_optimization(self, mock_feature_enabled: MagicMock) -> None:


### PR DESCRIPTION
## Problem

Users could not create cohorts based entirely on something a person did not do, such as users who did not purchase in the last 30 days. The cohort editor required at least one positive criterion, which forced users to add an unrelated inclusive condition just to express a valid negative-only audience.

Closes #68782

## Changes

- Remove the requirement that negated cohort criteria must be paired with at least one positive criterion.
  - Keep the existing AND-only validation for negated criteria, so OR-group behavior is unchanged.
- Update HogQL cohort calculation to handle top-level negation by evaluating all persons and subtracting the matching negative condition.
- Add regression coverage for both the editor save path and backend cohort membership calculation.

## How did you test this code?

New/updated tests:
- `hogli test frontend/src/scenes/cohorts/cohortEditLogic.test.ts frontend/src/scenes/cohorts/cohortUtils.test.tsx`
- `hogli test posthog/hogql_queries/test/test_hogql_cohort_query.py::TestHogQLCohortQuery::test_negative_only_behavioral_cohort_membership_end_to_end`

Additionally, I tested this locally with dummy data:
<img width="1033" height="1229" alt="image" src="https://github.com/user-attachments/assets/6348a0d8-bf64-46cc-9c9e-f26732ee5ac2" />

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.