### PR TITLE
fix(mysql): stop reporting best-effort row-size probe failures as noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -33,6 +33,11 @@ from pymysql.constants import FIELD_TYPE
 from pymysql.cursors import Cursor, SSCursor
 from structlog.types import FilteringBoundLogger
 
+# Module-level error-capture seam. This module's best-effort probes (get_rows_to_sync,
+# explain_query, fetch_average_row_size) deliberately do NOT report handled failures here;
+# their guard tests patch `mysql.capture_exception` to enforce that.
+from posthog.exceptions_capture import capture_exception  # noqa: F401
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     SourceInputs,
     SourceResponse,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -1087,8 +1087,8 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
             # Row-size sampling is a best-effort probe: on any failure the caller falls back to the
             # default chunk size and the sync proceeds. A genuine problem (missing table, revoked
             # permission) resurfaces in the real extraction query and is classified through the normal
-            # retryable/non-retryable path, while a transient connection drop here — e.g. pymysql's
-            # `InterfaceError(0, '')` when the socket was already closed — stays retryable there too.
+            # retryable/non-retryable path, while a transient connection drop here (e.g. pymysql's
+            # `InterfaceError(0, '')` when the socket was already closed) stays retryable there too.
             # Capturing it would only flood error tracking with handled duplicates, so log at debug and
             # fall back. Mirrors `get_partition_settings` and the Redshift source's `fetch_average_row_size`.
             logger.debug(f"fetch_average_row_size: Error: {e}.", exc_info=e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -33,8 +33,6 @@ from pymysql.constants import FIELD_TYPE
 from pymysql.cursors import Cursor, SSCursor
 from structlog.types import FilteringBoundLogger
 
-from posthog.exceptions_capture import capture_exception
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     SourceInputs,
     SourceResponse,
@@ -1086,8 +1084,14 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
             row_size_bytes = max(row[0] or 0, 1)
             return int(row_size_bytes)
         except Exception as e:
+            # Row-size sampling is a best-effort probe: on any failure the caller falls back to the
+            # default chunk size and the sync proceeds. A genuine problem (missing table, revoked
+            # permission) resurfaces in the real extraction query and is classified through the normal
+            # retryable/non-retryable path, while a transient connection drop here — e.g. pymysql's
+            # `InterfaceError(0, '')` when the socket was already closed — stays retryable there too.
+            # Capturing it would only flood error tracking with handled duplicates, so log at debug and
+            # fall back. Mirrors `get_partition_settings` and the Redshift source's `fetch_average_row_size`.
             logger.debug(f"fetch_average_row_size: Error: {e}.", exc_info=e)
-            capture_exception(e)
             return None
 
     def find_index_for_cursor(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -528,20 +528,23 @@ class TestFetchAverageRowSize:
         # The unquotable column is neither quoted nor spliced in raw.
         assert "Ach:CompanyId" not in sql
 
-    @pytest.mark.parametrize(
-        "exc",
-        [
-            RuntimeError("boom"),
-            # pymysql raises InterfaceError(0, "") when the connection socket was already closed:
-            # a transient drop. Row-size sampling is best-effort, so it's swallowed and the caller
-            # falls back to the default chunk size rather than surfacing error-tracking noise.
-            pymysql.err.InterfaceError(0, ""),
-        ],
-    )
-    def test_returns_none_on_exception(self, exc, impl, cursor, logger):
-        cursor.execute.side_effect = exc
+    def test_returns_none_on_exception(self, impl, cursor, logger):
+        cursor.execute.side_effect = RuntimeError("boom")
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result is None
+
+    def test_does_not_capture_handled_probe_failures(self, impl, cursor, logger, mocker):
+        # Row-size sampling is best-effort: on failure the caller falls back to the default chunk
+        # size, so handled failures must not flood error tracking. pymysql raises InterfaceError(0, "")
+        # when the connection socket was already closed (a transient drop). Mirrors the get_rows_to_sync
+        # and explain_query probe guards.
+        cursor.execute.side_effect = pymysql.err.InterfaceError(0, "")
+        capture = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.capture_exception"
+        )
+
+        assert impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger) is None
+        capture.assert_not_called()
 
 
 def _show_index_rows(*triples: tuple[str, str, int]) -> list[tuple]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -528,8 +528,18 @@ class TestFetchAverageRowSize:
         # The unquotable column is neither quoted nor spliced in raw.
         assert "Ach:CompanyId" not in sql
 
-    def test_returns_none_on_exception(self, impl, cursor, logger):
-        cursor.execute.side_effect = RuntimeError("boom")
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("boom"),
+            # pymysql raises InterfaceError(0, "") when the connection socket was already closed —
+            # a transient drop. Row-size sampling is best-effort, so it's swallowed and the caller
+            # falls back to the default chunk size rather than surfacing error-tracking noise.
+            pymysql.err.InterfaceError(0, ""),
+        ],
+    )
+    def test_returns_none_on_exception(self, exc, impl, cursor, logger):
+        cursor.execute.side_effect = exc
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result is None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -532,7 +532,7 @@ class TestFetchAverageRowSize:
         "exc",
         [
             RuntimeError("boom"),
-            # pymysql raises InterfaceError(0, "") when the connection socket was already closed —
+            # pymysql raises InterfaceError(0, "") when the connection socket was already closed:
             # a transient drop. Row-size sampling is best-effort, so it's swallowed and the caller
             # falls back to the default chunk size rather than surfacing error-tracking noise.
             pymysql.err.InterfaceError(0, ""),


### PR DESCRIPTION
## Problem

Error tracking flagged a fresh `InterfaceError: (0, '')` from `pymysql.err` in the MySQL import source, raised inside `fetch_average_row_size` ([issue](https://us.posthog.com/project/2/error_tracking/019f3ab7-1970-7291-9c84-3203f0cca52c)).

`fetch_average_row_size` is a best-effort probe. It samples row width to pick a `fetchmany` chunk size, and on any failure the caller just falls back to the default chunk size and the sync proceeds. The problem is it called `capture_exception` on every failure, so benign, already-handled failures showed up as error-tracking issues.

`InterfaceError(0, '')` is pymysql's signature for a connection whose socket was already closed (it raises this from `_execute_command` when `self._sock is None`). That is a transient drop, not a bug in our SQL or a user config error. If the connection really is dead, the real extraction query fails right after and gets classified through the normal retryable path anyway. Reporting it from the probe just adds noise.

## Changes

`fetch_average_row_size` now logs at debug and falls back instead of calling `capture_exception`. This matches the two existing precedents in the same area:

- `get_partition_settings` (the sibling best-effort sizing helper in the shared SQL base) already does exactly this, with a comment spelling out the reasoning.
- The Redshift source's `fetch_average_row_size` already dropped its `capture_exception` for the same "expected, non-actionable noise" reason.

This is not a `NonRetryableErrors` change. The exception never reaches the retry classifier (the probe swallows it internally and returns `None`), and it is transient, so it correctly stays retryable where it actually matters.

## How did you test this code?

Parameterized the existing `TestFetchAverageRowSize::test_returns_none_on_exception` to add the real `pymysql.err.InterfaceError(0, "")` signature alongside the generic error, locking in that this transient drop is swallowed and the probe falls back rather than propagating. Ran `TestFetchAverageRowSize` locally (9 passed) and `ruff check` on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue in error tracking (single occurrence, one affected team, stack frame at `mysql.py:1035` in `fetch_average_row_size`), read the implementation and its callers, and compared against the Postgres/MSSQL/Redshift siblings.

Decision path: this is not a credentials/config/upstream error, so `NonRetryableErrors` is the wrong tool (and the exception is already swallowed before any retry classification runs). It is also not a transient error that needs retry/backoff tuning, because the probe already degrades gracefully. The only defect is that a handled best-effort failure was being reported as error-tracking noise, so the fix is to stop capturing it, consistent with the `get_partition_settings` and Redshift precedents. Left the MSSQL sibling untouched to keep the change scoped.
