### PR TITLE
fix(data-imports): recover double-encoded source config strings

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
@@ -1,3 +1,4 @@
+import json
 import types
 import typing
 import reprlib
@@ -583,11 +584,19 @@ def config(
 
     def wrap(cls: type[_T]) -> type[_T]:
         def from_dict(cls, d: dict[str, typing.Any]):
+            if isinstance(d, str):
+                # Stored config (an `EncryptedJSONField`) can come back double-encoded: a JSON
+                # string holding the mapping rather than the mapping itself. Recover by decoding
+                # it once so the sync proceeds instead of crashing.
+                try:
+                    d = json.loads(d)
+                except json.JSONDecodeError:
+                    pass
+
             if not isinstance(d, dict):
-                # Stored config (e.g. an `EncryptedJSONField`) can occasionally come back as a
-                # non-mapping (a double-encoded string). Fail with an actionable message instead
-                # of the opaque `TypeError: string indices must be integers` raised when `to_config`
-                # tries to index into it.
+                # Anything still not a mapping (a non-object JSON value, bytes, ...) can't build a
+                # config. Fail with an actionable message instead of the opaque
+                # `TypeError: string indices must be integers` raised when `to_config` indexes it.
                 raise TypeError(f"Cannot build '{cls.__name__}' from {type(d).__name__}; expected a mapping")
 
             if prefix:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
@@ -73,7 +73,7 @@ class ConfigProtocol(_Dataclass, typing.Protocol):
     """
 
     @classmethod
-    def from_dict(cls: type[_T], d: dict[str, typing.Any]) -> _T: ...
+    def from_dict(cls: type[_T], d: dict[str, typing.Any] | str) -> _T: ...
 
     @classmethod
     def validate_dict(cls: type[_T], d: dict[str, typing.Any]) -> tuple[bool, list[str]]: ...
@@ -106,7 +106,7 @@ class Config(ConfigProtocol):
     """
 
     @classmethod
-    def from_dict(cls: type[_T], d: dict[str, typing.Any]) -> _T:
+    def from_dict(cls: type[_T], d: dict[str, typing.Any] | str) -> _T:
         raise NotImplementedError
 
     @classmethod
@@ -583,7 +583,7 @@ def config(
     """
 
     def wrap(cls: type[_T]) -> type[_T]:
-        def from_dict(cls, d: dict[str, typing.Any]):
+        def from_dict(cls, d: dict[str, typing.Any] | str):
             if isinstance(d, str):
                 # Stored config (an `EncryptedJSONField`) can come back double-encoded: a JSON
                 # string holding the mapping rather than the mapping itself. Recover by decoding

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
@@ -1,3 +1,4 @@
+import json
 import typing
 
 import pytest
@@ -462,14 +463,16 @@ def test_to_config_scalar_under_nested_config_key(
     assert cfg.account_id == expected_account_id
 
 
-@pytest.mark.parametrize("bad_input", ["not a mapping", '{"key_file": {}}', b"bytes", 5, ["a", "b"], None])
+@pytest.mark.parametrize("bad_input", ["not a mapping", '"scalar"', "[1, 2, 3]", b"bytes", 5, ["a", "b"], None])
 def test_from_dict_with_non_mapping_raises_clear_error(bad_input):
     """A non-mapping input must raise an actionable error, not the opaque builtin `TypeError`.
 
     Stored config can come back as a non-mapping (e.g. a double-encoded string from an
     `EncryptedJSONField`). Indexing into it deep inside `to_config` raised
     `TypeError: string indices must be integers`, which is impossible to triage from the
-    source alone. `from_dict` must reject it up front with the config class name in the message.
+    source alone. A string that decodes to a mapping is recovered, but any other shape
+    (unparseable text, or JSON that decodes to a scalar/list) must be rejected up front with
+    the config class name in the message.
     """
 
     @config.config
@@ -484,6 +487,24 @@ def test_from_dict_with_non_mapping_raises_clear_error(bad_input):
 
     with pytest.raises(TypeError, match="Cannot build 'SourceConfig'"):
         SourceConfig.from_dict(bad_input)
+
+
+def test_from_dict_recovers_double_encoded_json_string():
+    """A config stored as a JSON string (double-encoded by `EncryptedJSONField`) must be
+    decoded back into a working config instead of crashing the sync with `Cannot build ...`.
+    """
+
+    @config.config
+    class SourceConfig(config.Config):
+        host: str
+        port: int = 0
+
+    config_dict = {"host": "example", "port": 5432}
+
+    cfg = SourceConfig.from_dict(json.dumps(config_dict))
+
+    assert cfg.host == "example"
+    assert cfg.port == 5432
 
 
 def test_to_config_optional_config_does_not_retain_unparseable_dict():


### PR DESCRIPTION
## Problem

Data-warehouse imports were crashing with a `TypeError` surfaced by error tracking:

`Cannot build 'MySQLSourceConfig' from str; expected a mapping`

The stack trace lands in shared pipeline code (`sources/common/config.py:from_dict`, via `sources/common/base.py:parse_config`), and it repeated across retries without ever succeeding. It couldn't be pinned to one source because it lives in the config layer every source shares.

Root cause: source config is persisted in an `EncryptedJSONField` (`ExternalDataSource.job_inputs`). That field encrypts per-value and serializes with `json.dumps(...)`. When a source's `job_inputs` gets saved as an already-serialized JSON **string** instead of a mapping, it comes back from the DB double-encoded, as a plain JSON string. `Config.from_dict` expected a mapping and raised.

An earlier change had already replaced the opaque `string indices must be integers` with this actionable message, but that only improved triage. The syncs kept failing because nothing recovered the value.

## Changes

`from_dict` now decodes a `str` input once before the mapping check. A JSON string that decodes to an object is recovered into a working config so the sync proceeds. Anything still not a mapping (unparseable text, a JSON scalar or list, bytes) keeps failing with the same actionable, class-named error.

This is scoped to the shared config builder, so it covers every source at once, which matches how the error presented.

## How did you test this code?

Automated, at the same layer as the fix (`sources/common/test/test_config.py`):

- Added `test_from_dict_recovers_double_encoded_json_string` — passes `json.dumps(config_dict)` and asserts the fields come back correct. This is the regression that catches a revert of the recovery path.
- Updated `test_from_dict_with_non_mapping_raises_clear_error` — a JSON-object string is now recovered rather than rejected, so that case is replaced by JSON strings that decode to a scalar and a list, which must still raise.

`hogli test` / pytest: 59 passed. Ran `ruff check` and `ruff format --check` on both files (clean). I did not run the full pipeline end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged an error-tracking issue for the data-imports pipeline and traced it to the shared `EncryptedJSONField` config path. I confirmed the field's behavior empirically by loading the real field in isolation and reproducing both the normal (mapping) and double-encoded (string) read paths, which showed a double-encoded `job_inputs` returns a plain JSON string.

I weighed treating this as non-retryable versus fixing it. It's our own data/serialization shape, not a customer credential or upstream failure, and the string still holds the correct config, so recovering by decoding is the correct fix rather than giving up on the sync. I kept the change narrow: decode-once in the one shared builder, with non-mapping shapes still failing loudly.

Skill invoked: `/writing-tests` (before touching the test file).
