### PR TITLE
fix(data-imports): raise a clear error when source config is still encrypted

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
@@ -121,6 +121,30 @@ def _noop_convert(x: typing.Any) -> typing.Any:
     return x
 
 
+# Fernet tokens always start with this marker (version byte 0x80 + timestamp, base64-encoded).
+# A stored config value that still carries it never got decrypted upstream.
+_ENCRYPTED_SECRET_PREFIX = "gAAAAA"
+
+
+class UndecryptedConfigError(ValueError):
+    """Raised when a config value reaches conversion still Fernet-encrypted.
+
+    Upstream decryption of the stored job inputs failed (e.g. the key that wrote them is no
+    longer in the keychain), so the raw token would otherwise crash the field converter with an
+    opaque, secret-leaking error such as ``invalid literal for int() with base 10: 'gAAAAA...'``.
+    """
+
+
+def _convert_value(
+    convert: typing.Callable[[typing.Any], typing.Any], value: typing.Any, field_name: str
+) -> typing.Any:
+    if isinstance(value, str) and value.startswith(_ENCRYPTED_SECRET_PREFIX):
+        raise UndecryptedConfigError(
+            f"Config field '{field_name}' is still encrypted; the stored credentials could not be decrypted"
+        )
+    return convert(value)
+
+
 @dataclasses.dataclass
 class MetaConfig:
     """Class used to store metadata used for config."""
@@ -258,7 +282,7 @@ def to_config(
                     except KeyError:
                         continue
                     else:
-                        inputs[field.name] = convert(value)
+                        inputs[field.name] = _convert_value(convert, value, field.name)
                         break
 
                 field_type_meta: MetaConfig | None = _try_get_meta(config_type)
@@ -302,7 +326,7 @@ def to_config(
             except KeyError:
                 continue
             else:
-                inputs[field.name] = convert(value)
+                inputs[field.name] = _convert_value(convert, value, field.name)
 
     return config_cls(**inputs)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
@@ -97,6 +97,37 @@ def test_optional_int_converter_handles_numeric_via_from_dict(value, expected):
     assert cfg.port == expected
 
 
+# A representative Fernet token, as it appears when `job_inputs` decryption fails upstream and the
+# raw ciphertext flows into config parsing. Not a real credential.
+_UNDECRYPTED_TOKEN = (
+    "gAAAAABqTJ0OKLTREfglaXr0DZrJ4eYT7GVcKeA0avLvEzY7k3ll0JuD8VpL--DGJ9Dbt9y3KwyAolvAXit1ceqyuOzwyjTqlg=="
+)
+
+
+@pytest.mark.parametrize(
+    "config_dict",
+    [
+        # The reported crash: an int-converted `port` that never got decrypted would raise the
+        # opaque `invalid literal for int() with base 10: 'gAAAAA...'`.
+        {"host": "db.example.com", "port": _UNDECRYPTED_TOKEN},
+        # A plain string field left encrypted must also fail here, not pass ciphertext downstream.
+        {"host": _UNDECRYPTED_TOKEN, "port": "5432"},
+    ],
+)
+def test_from_dict_raises_clear_error_on_undecrypted_secret(config_dict):
+    """Still-encrypted job inputs must fail with a clear error that does not echo the token."""
+
+    @config.config
+    class TestConfig(config.Config):
+        host: str
+        port: int = config.value(converter=int)
+
+    with pytest.raises(config.UndecryptedConfigError) as exc_info:
+        TestConfig.from_dict(config_dict)
+
+    assert _UNDECRYPTED_TOKEN not in str(exc_info.value)
+
+
 def test_nested_to_config_with_flat_dict():
     """Test `config.to_config` with a nested set of classes.
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a data-import crash coming from the shared config parser:

```
ValueError: invalid literal for int() with base 10: 'gAAAAA...'
```

The `gAAAAA...` value is a Fernet token, so the config value was still encrypted when it reached the field converter. `EncryptedJSONField.to_python` catches `InvalidToken` and silently returns the still-encrypted dict, so when decryption of a source's stored `job_inputs` fails (for example the key that wrote them is no longer in the keychain), every value stays ciphertext. The `int` converter on a SQL source's `port` field then blows up with a message that leaks the raw token and gives no clue about what actually went wrong. It affects any source with a converted field (SQL sources have an int `port`).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3b45-8c3e-7ce0-afd8-e38e3075b438

## Changes

I (Claude) added a guard in the shared `to_config` parser. When a config value reaches conversion still carrying the Fernet marker, it raises a clear `UndecryptedConfigError` that names the field and does not echo the ciphertext, instead of the opaque `int()` crash. The check runs at both leaf-scalar conversion sites, so a still-encrypted string field (host, user, ...) also fails loudly here rather than passing ciphertext down to the driver.

Decision: this is a fixable-fragility bug, not a user or upstream error. It is not a revoked credential, a 401/403, or a transient network blip. It is our own decryption path returning ciphertext and our parser crashing opaquely on it. I deliberately kept it retryable rather than adding it to `NonRetryableErrors` — a decryption failure can be a deployment or key-config issue on our side, and marking it non-retryable would disable a customer's sync in that case. The improvement here is a clear, non-leaking error at a single well-defined failure point.

This is distinct from #68826 (recover double-encoded config strings), which handles `from_dict` receiving a whole JSON string. Here `d` is already a proper dict; the problem is the leaf values inside it are still encrypted.

## How did you test this code?

Added a parameterized regression test in `test_config.py` covering both an int-converted `port` (the exact reported crash) and a plain string field left encrypted, asserting `UndecryptedConfigError` is raised and the token is not echoed in the message. I could not run the repo's pytest (no test env in this sandbox), so I verified the parser logic by loading `config.py` in isolation and exercising both failure cases plus a normal-values sanity parse. `ruff check` and `ruff format --check` pass on both files.

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue and full stack trace via the PostHog error-tracking MCP tools, traced the failure from `import_data_activity_sync` through `parse_config` into `to_config`, and confirmed via the stack-frame locals that `d` was a dict of Fernet tokens (decryption had failed upstream, not a double-encoding). Invoked the `/writing-tests` skill before adding the regression test. Considered and rejected `NonRetryableErrors` for the reason given above. Checked open PRs (including the maintainer's) for duplicates and confirmed #68826 addresses a different root cause.
