### PR TITLE
fix(data-imports): treat unparseable source config as non-retryable in import

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -217,7 +217,15 @@ async def import_data_activity_sync(inputs: ImportDataActivityInputs) -> Pipelin
             )
 
             new_source = SourceRegistry.get_source(source_type)
-            config = new_source.parse_config(model.pipeline.job_inputs)
+
+            try:
+                config = new_source.parse_config(model.pipeline.job_inputs)
+            except Exception as e:
+                # A stored config that can't be parsed (corrupt or double-encoded `job_inputs`)
+                # fails identically on every attempt — there is nothing to retry. Treat it as
+                # non-retryable so the job gives up cleanly instead of crash-looping and spamming
+                # error tracking. Mirrors the skip in `sync_new_schemas_activity`.
+                await handle_non_retryable_error(job_inputs, str(e), logger, e)
 
             resumable_source_manager: ResumableSourceManager | None = None
             try:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -111,6 +111,25 @@ async def test_retryable_setup_error_is_reraised():
     handle_mock.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_unparseable_config_routes_through_handler():
+    # A corrupt / double-encoded stored config makes parse_config raise deterministically before
+    # source setup. It must be treated as non-retryable instead of crash-looping on every attempt.
+    error = ValueError("invalid literal for int() with base 10: 'not-an-int'")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.parse_config.side_effect = error
+    source.get_non_retryable_errors.return_value = {}
+
+    with _patched_activity(source) as handle_mock:
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await import_data_activity_sync(_inputs())
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args.args[3] is error
+    source.source_for_pipeline.assert_not_called()
+
+
 def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -> mock.MagicMock:
     schema = mock.MagicMock()
     schema.should_use_incremental_field = True


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ValueError: invalid literal for int() with base 10: '<encrypted>'` coming out of the data warehouse import pipeline ([issue](https://us.posthog.com/project/2/error_tracking/019f3b45-8b8c-7f83-9e13-1c3e93c39cca)). The stored source config came back with values that were still encrypted ciphertext rather than plaintext, so building the typed config crashed when it tried to coerce the `port` value to an `int` inside `to_config`.

Two sibling issues share this exact root cause and fired together in one burst:

- The schema-discovery path (`sync_new_schemas_activity`). This is **already handled on master** by #65703, which wraps `parse_config` in a try/except and skips discovery quietly.
- The per-schema import path (`import_data_activity_sync`), which was **not** handled. Here `parse_config` is called outside the activity's error-handling `try/except`, so an unparseable config raised a raw `ValueError` that Temporal retried on every attempt, crash-looping and spamming error tracking rather than failing cleanly.

Note: #65703's own comment claims "the per-schema sync path surfaces and disables the source on the same config" but that was not actually true, because the import path's `parse_config` sat outside the handler. This PR makes that claim hold.

This is a fixable-bug case, not a `NonRetryableErrors` string match: the failure is a deterministic parse crash of our own config code, not a credential/upstream error keyed off a message substring.

## Changes

Wrap the `parse_config` call in `import_data_activity_sync` in a try/except and route any failure through `handle_non_retryable_error`. A config that can't be parsed fails identically on every attempt, so there is nothing to retry. The job now gives up after the standard non-retryable attempt budget instead of retrying to the activity's max and reporting the raw exception each time.

Scoped deliberately: I left the shared `config.py` parser untouched (the maintainer's #68826 is already hardening `from_dict` for a related but different double-encoding shape, where the whole config comes back as a JSON string). Fixing this at the caller mirrors how #65703 fixed the discovery caller, and avoids stepping on that in-flight work.

## How did you test this code?

I (Claude) added a regression test and ran it locally.

- `test_unparseable_config_routes_through_handler` in `test_import_data_sync.py`: stubs `parse_config` to raise a `ValueError` and asserts the activity routes it through `handle_non_retryable_error` (with the original error) and never reaches source setup. This is the regression no existing test caught: the prior tests only covered errors raised during `source_for_pipeline` (setup phase), not parse-time failures.
- Ran the full `test_import_data_sync.py` (5 passed) and `test_sync_new_schemas.py` (3 passed) suites, plus `ruff check` / `ruff format --check` on the changed files.

I did not run the pipeline end to end against a live source.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue with Claude Code (PostHog MCP error-tracking tools for the stack trace and to find the sibling issue, `gh` for PR de-duplication).

Key decisions:
- Confirmed the assigned discovery-path issue is already handled on master (#65703), so re-fixing it would be a no-op. Instead fixed the still-live sibling issue on the import path, same root cause, higher volume.
- Checked the maintainer's open PRs. #68826 addresses a different manifestation (`from_dict` receiving a JSON string, recovered via `json.loads`); it does not prevent this crash, where `from_dict` receives a dict whose values are ciphertext. So this is not a duplicate. Left #68826 untouched and kept this change out of `config.py` to avoid conflict.
- Chose `handle_non_retryable_error` over an immediate hard-fail to stay consistent with how the import activity already handles deterministic setup errors.

Invoked the `/writing-tests` skill before adding the test.
