### PR TITLE
chore(product-analytics): cover the remaining insight chart components

### DIFF
--- a/frontend/src/test/insight-testing/README.md
+++ b/frontend/src/test/insight-testing/README.md
@@ -2,6 +2,15 @@
 
 A test wrapper for rendering insight components (or any component that depends on insight infrastructure) with mocked data and a chart inspection API.
 
+## What belongs in a harness test
+
+Chart coverage is layered; a rendered harness test is the most expensive layer (~100ms per mount), so it only earns its place for what the cheaper layers can't see:
+
+- **Storybook snapshot stories** own render smoke and visual states. Don't write "renders without crashing" tests — add a story instead.
+- **quill-charts' own suite** owns chart mechanics (legend toggling, tooltip pinning, goal lines, value labels, axes). Don't re-test library behavior here.
+- **Transforms/adapter unit tests** own the case matrix for pure logic (series construction, formatters, click-handler payloads) at ~1ms per case.
+- **Harness tests** (this wrapper) own interaction and data wiring only: the right values reach the tooltip, clicks open the persons modal with the right actors, empty-state guards fire — one wiring test per chart-specific feature, not one per data variation.
+
 ## Quick start
 
 ```tsx

--- a/frontend/src/test/insight-testing/index.ts
+++ b/frontend/src/test/insight-testing/index.ts
@@ -6,6 +6,7 @@ export { createInsightTooltipAccessor } from './tooltip-helpers'
 export type { InsightTooltipAccessor } from './tooltip-helpers'
 export {
     buildFunnelsQuery,
+    buildRetentionQuery,
     buildStickinessQuery,
     buildTrendsQuery,
     renderInsight,

--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -6,6 +6,10 @@ import {
     actionDefinitions,
     eventDefinitions as defaultEventDefs,
     type FunnelStepData,
+    type FunnelStepFixture,
+    funnelSteps,
+    type FunnelTimeToConvertFixture,
+    funnelTimeToConvertBins,
     funnelTrendsSteps,
     lookupActors,
     lookupCompareSeries,
@@ -14,6 +18,8 @@ import {
     personProperties,
     propertyDefinitions as defaultPropDefs,
     propertyValues as defaultPropValues,
+    type RetentionResultFixture,
+    retentionResults,
     sessionPropertyDefinitions,
     type SeriesData,
 } from './test-data'
@@ -30,6 +36,9 @@ export interface QueryBody {
         formulas?: string[]
         formulaNodes?: unknown[]
     }
+    funnelsFilter?: {
+        funnelVizType?: string
+    }
     [key: string]: unknown
 }
 
@@ -39,16 +48,22 @@ function hasFormula(query: QueryBody): boolean {
 }
 
 interface FunnelsQueryResponseLike {
-    results: FunnelStepData[]
+    results: FunnelStepData[] | FunnelStepFixture[] | FunnelStepFixture[][] | FunnelTimeToConvertFixture
 }
+
+interface RetentionQueryResponseLike {
+    results: RetentionResultFixture[]
+}
+
+type InsightMockResponse =
+    | TrendsQueryResponse
+    | ActorsQueryResponse
+    | FunnelsQueryResponseLike
+    | RetentionQueryResponseLike
 
 export interface MockResponse {
     match: (query: QueryBody) => boolean
-    response:
-        | TrendsQueryResponse
-        | ActorsQueryResponse
-        | FunnelsQueryResponseLike
-        | ((query: QueryBody) => TrendsQueryResponse | ActorsQueryResponse | FunnelsQueryResponseLike)
+    response: InsightMockResponse | ((query: QueryBody) => InsightMockResponse)
 }
 
 /** Build an ActorsQueryResponse shaped like the server response, with one row
@@ -156,7 +171,7 @@ function resolveActors(query: QueryBody): Array<{ email: string }> {
 }
 
 /** Funnels in trends-viz mode return a flat `FunnelStep[]` — one entry per series, or per breakdown value. */
-function buildFunnelsResponse(query: QueryBody): FunnelsQueryResponseLike {
+function buildFunnelTrendsResponse(query: QueryBody): FunnelsQueryResponseLike {
     const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown
     const isCompare = !!(query as { compareFilter?: { compare?: boolean } }).compareFilter?.compare
     if (isCompare && breakdownProp && funnelTrendsSteps.compareByBreakdown[breakdownProp]) {
@@ -166,6 +181,28 @@ function buildFunnelsResponse(query: QueryBody): FunnelsQueryResponseLike {
         return { results: funnelTrendsSteps.byBreakdown[breakdownProp] }
     }
     return { results: [funnelTrendsSteps.default] }
+}
+
+/** Steps-viz funnels return a flat `FunnelStep[]`, or `FunnelStep[][]` (one funnel per breakdown value). */
+function buildFunnelStepsResponse(query: QueryBody): FunnelsQueryResponseLike {
+    const breakdownProp = query.breakdownFilter?.breakdowns?.[0]?.property ?? query.breakdownFilter?.breakdown
+    if (breakdownProp && funnelSteps.byBreakdown[breakdownProp]) {
+        return { results: funnelSteps.byBreakdown[breakdownProp] }
+    }
+    return { results: funnelSteps.default }
+}
+
+/** Routes a FunnelsQuery to the fixture matching its viz type. The backend defaults an
+ *  absent `funnelVizType` to steps, so the mock does too. */
+function buildFunnelsResponse(query: QueryBody): FunnelsQueryResponseLike {
+    const vizType = query.funnelsFilter?.funnelVizType
+    if (vizType === 'trends') {
+        return buildFunnelTrendsResponse(query)
+    }
+    if (vizType === 'time_to_convert') {
+        return { results: funnelTimeToConvertBins }
+    }
+    return buildFunnelStepsResponse(query)
 }
 
 interface FunnelsActorsQueryShape {
@@ -250,6 +287,10 @@ export function setupInsightMocks({
         {
             match: (query) => query.kind === NodeKind.FunnelsQuery,
             response: (query) => buildFunnelsResponse(query),
+        },
+        {
+            match: (query) => query.kind === NodeKind.RetentionQuery,
+            response: { results: retentionResults },
         },
         // Must precede the generic ActorsQuery matcher so funnel actor queries route to lookupFunnelActors.
         {

--- a/frontend/src/test/insight-testing/render-insight.tsx
+++ b/frontend/src/test/insight-testing/render-insight.tsx
@@ -5,9 +5,16 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { actionsModel } from '~/models/actionsModel'
 import { groupsModel } from '~/models/groupsModel'
-import { FunnelsQuery, InsightVizNode, NodeKind, StickinessQuery, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    FunnelsQuery,
+    InsightVizNode,
+    NodeKind,
+    RetentionQuery,
+    StickinessQuery,
+    TrendsQuery,
+} from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { FunnelVizType } from '~/types'
+import { FunnelVizType, RetentionPeriod } from '~/types'
 
 import { initKeaTests } from '../init'
 import { resetCapturedCharts } from './chartjs-mock'
@@ -16,7 +23,7 @@ import { setupInsightMocks, type SetupMocksOptions } from './mocks'
 export const INSIGHT_TEST_KEY = 'test-harness'
 export const INSIGHT_TEST_ID = `new-AdHoc.InsightViz.${INSIGHT_TEST_KEY}`
 
-export type InsightQuery = TrendsQuery | FunnelsQuery | StickinessQuery
+export type InsightQuery = TrendsQuery | FunnelsQuery | StickinessQuery | RetentionQuery
 
 export function buildTrendsQuery(overrides?: Partial<TrendsQuery>): TrendsQuery {
     return {
@@ -46,6 +53,21 @@ export function buildFunnelsQuery(overrides?: Partial<FunnelsQuery>): FunnelsQue
         funnelsFilter: {
             funnelVizType: FunnelVizType.Trends,
             ...overrides?.funnelsFilter,
+        },
+    }
+}
+
+export function buildRetentionQuery(overrides?: Partial<RetentionQuery>): RetentionQuery {
+    return {
+        kind: NodeKind.RetentionQuery,
+        ...overrides,
+        retentionFilter: {
+            period: RetentionPeriod.Day,
+            totalIntervals: 3,
+            targetEntity: { id: '$pageview', name: '$pageview', type: 'events' },
+            returningEntity: { id: '$pageview', name: '$pageview', type: 'events' },
+            retentionType: 'retention_first_time',
+            ...overrides?.retentionFilter,
         },
     }
 }

--- a/frontend/src/test/insight-testing/test-data.ts
+++ b/frontend/src/test/insight-testing/test-data.ts
@@ -368,6 +368,104 @@ export const funnelTrendsSteps = {
     } as Record<string, FunnelStepData[]>,
 }
 
+// Steps-viz funnel response shape: a flat FunnelStep[] (or FunnelStep[][] with a breakdown),
+// one entry per step with the absolute converted count.
+export interface FunnelStepFixture {
+    action_id: string
+    name: string
+    custom_name: string | null
+    order: number
+    count: number
+    type: 'events'
+    average_conversion_time: number | null
+    median_conversion_time: number | null
+    breakdown?: string[]
+    breakdown_value?: string[]
+}
+
+function buildFunnelStep(
+    name: string,
+    order: number,
+    count: number,
+    breakdownValue?: string,
+    conversionTime?: number
+): FunnelStepFixture {
+    return {
+        action_id: name,
+        name,
+        custom_name: null,
+        order,
+        count,
+        type: 'events',
+        average_conversion_time: conversionTime ?? null,
+        median_conversion_time: conversionTime ?? null,
+        ...(breakdownValue ? { breakdown: [breakdownValue], breakdown_value: [breakdownValue] } : {}),
+    }
+}
+
+export const funnelSteps = {
+    // 100 hedgehogs viewed → 60 napped → 30 snored.
+    default: [
+        buildFunnelStep('$pageview', 0, 100),
+        buildFunnelStep('Napped', 1, 60),
+        buildFunnelStep('Snored', 2, 30),
+    ] satisfies FunnelStepFixture[],
+    byBreakdown: {
+        hedgehog: [
+            [
+                buildFunnelStep('$pageview', 0, 70, 'Spike'),
+                buildFunnelStep('Napped', 1, 42, 'Spike'),
+                buildFunnelStep('Snored', 2, 21, 'Spike'),
+            ],
+            [
+                buildFunnelStep('$pageview', 0, 30, 'Bramble'),
+                buildFunnelStep('Napped', 1, 18, 'Bramble'),
+                buildFunnelStep('Snored', 2, 9, 'Bramble'),
+            ],
+        ] satisfies FunnelStepFixture[][],
+    } as Record<string, FunnelStepFixture[][]>,
+}
+
+// Time-to-convert funnel response shape: histogram bins of [seconds, converted count]
+// plus the overall average. Counts sum to 20 → bar labels 20% / 50% / 20% / 10%.
+export interface FunnelTimeToConvertFixture {
+    bins: [number, number][]
+    average_conversion_time: number
+}
+
+export const funnelTimeToConvertBins = {
+    bins: [
+        [0, 4],
+        [120, 10],
+        [240, 4],
+        [360, 2],
+    ],
+    average_conversion_time: 138,
+} satisfies FunnelTimeToConvertFixture
+
+// Retention response shape: one row per cohort with the cohort start `date` and the
+// absolute retained `count` per interval. The frontend derives percentages from
+// interval 0: Jun 10 → 100/60/30%, Jun 11 → 100/40/10%.
+export interface RetentionResultFixture {
+    date: string
+    label: string
+    values: { count: number }[]
+    breakdown_value?: string | number | null
+}
+
+export const retentionResults: RetentionResultFixture[] = [
+    {
+        date: '2024-06-10T00:00:00Z',
+        label: 'Day 0',
+        values: [{ count: 100 }, { count: 60 }, { count: 30 }],
+    },
+    {
+        date: '2024-06-11T00:00:00Z',
+        label: 'Day 1',
+        values: [{ count: 50 }, { count: 20 }, { count: 5 }],
+    },
+]
+
 // Keyed by breakdown value (or '__none__'), then by calendar date.
 const funnelActorsByBreakdownDay: Record<string, Record<string, ActorFixture[]>> = {
     __none__: {

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.test.tsx
@@ -1,0 +1,163 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, fireEvent, screen, waitFor, within } from '@testing-library/react'
+
+import { clickAtIndex, setupJsdom } from '@posthog/quill-charts/testing'
+
+import { FunnelLayout } from 'lib/constants'
+
+import { FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
+import {
+    buildActorsResponse,
+    buildFunnelsQuery,
+    type MockResponse,
+    personsModal,
+    renderInsight,
+} from '~/test/insight-testing'
+import { FunnelVizType } from '~/types'
+
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
+
+let cleanupJsdom: () => void
+
+// No setupSyncRaf here: the stacked bars' hover-fade animation re-requests a frame until time
+// advances, so a synchronous RAF mock recurses forever and crashes the chart on hover.
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+})
+
+afterEach(() => {
+    personsModal.cleanupAll()
+    cleanupJsdom()
+    cleanup()
+})
+
+interface StepsActorsSource {
+    kind?: string
+    funnelStep?: number
+    funnelStepBreakdown?: unknown
+}
+
+// The harness's default funnel actors mock keys off funnelTrendsEntrancePeriodStart; steps-viz
+// actor queries carry funnelStep/funnelStepBreakdown instead, so echo those into the actor email
+// to prove the click scoped the query correctly.
+const stepsFunnelActorsEcho: MockResponse = {
+    match: (query) => {
+        const source = (query as { source?: StepsActorsSource }).source
+        return (
+            query.kind === NodeKind.ActorsQuery &&
+            source?.kind === NodeKind.FunnelsActorsQuery &&
+            source.funnelStep != null
+        )
+    },
+    response: (query) => {
+        const source = (query as { source?: StepsActorsSource }).source!
+        const breakdown = Array.isArray(source.funnelStepBreakdown)
+            ? source.funnelStepBreakdown.join('+')
+            : source.funnelStepBreakdown
+        return buildActorsResponse([
+            { email: `step${source.funnelStep}${breakdown == null ? '' : `-${breakdown}`}@example.com` },
+        ])
+    },
+}
+
+function horizontalFunnelQuery(overrides: Partial<FunnelsQuery> = {}): FunnelsQuery {
+    return buildFunnelsQuery({
+        series: [
+            { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+            { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+            { kind: NodeKind.EventsNode, event: 'Snored', name: 'Snored' },
+        ],
+        ...overrides,
+        funnelsFilter: {
+            funnelVizType: FunnelVizType.Steps,
+            layout: FunnelLayout.horizontal,
+            ...overrides.funnelsFilter,
+        },
+    })
+}
+
+async function findStepCanvases(container: HTMLElement, count: number): Promise<HTMLCanvasElement[]> {
+    return await waitFor(() => {
+        const canvases = Array.from(container.querySelectorAll<HTMLCanvasElement>('canvas[aria-label]'))
+        expect(canvases).toHaveLength(count)
+        return canvases
+    })
+}
+
+describe('FunnelBarHorizontalChart', () => {
+    it('renders for layout=horizontal with one bar per step and the counts and percentages in each step row', async () => {
+        renderInsight({ query: horizontalFunnelQuery() })
+
+        const container = await screen.findByTestId('funnel-bar-horizontal')
+        expect(screen.queryByTestId('funnel-steps-bar-chart')).not.toBeInTheDocument()
+
+        await findStepCanvases(container, 3)
+
+        // Canned steps: $pageview 100 → Napped 60 (60%) → Snored 30 (30%).
+        expect(container.textContent).toMatch(/100\spersons/)
+        expect(container.textContent).toMatch(/60\spersons\s\(60%\) completed step/)
+        expect(container.textContent).toMatch(/40\spersons\s\(40%\) dropped off/)
+    })
+
+    it('stacks one segment per breakdown value plus the drop-off filler in each step bar', async () => {
+        renderInsight({
+            query: horizontalFunnelQuery({ breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' } }),
+        })
+
+        const container = await screen.findByTestId('funnel-bar-horizontal')
+        const canvases = await findStepCanvases(container, 3)
+
+        // Spike + Bramble segments + the filler series on every step.
+        expect(canvases.map((canvas) => canvas.getAttribute('aria-label'))).toEqual(
+            Array(3).fill('Chart with 3 data series')
+        )
+    })
+
+    it.each([
+        {
+            kind: 'converted',
+            buttonText: /^60\spersons$/,
+            title: /Completed step 2/,
+            actor: 'step2@example.com',
+        },
+        {
+            kind: 'dropped off',
+            buttonText: /^40\spersons$/,
+            title: /Dropped off at step 2/,
+            actor: 'step-2@example.com',
+        },
+    ])('opens the $kind persons modal from the step footer inspect button', async ({ buttonText, title, actor }) => {
+        renderInsight({
+            query: horizontalFunnelQuery(),
+            mocks: { additionalMockResponses: [stepsFunnelActorsEcho] },
+        })
+
+        const container = await screen.findByTestId('funnel-bar-horizontal')
+        fireEvent.click(within(container).getByText(buttonText))
+
+        await waitFor(() => {
+            expect(personsModal.actorNames()).toEqual([actor])
+        })
+        expect(personsModal.title()).toMatch(title)
+    })
+
+    it('clicking a breakdown segment opens the persons modal scoped to that breakdown value', async () => {
+        renderInsight({
+            query: horizontalFunnelQuery({ breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' } }),
+            mocks: { additionalMockResponses: [stepsFunnelActorsEcho] },
+        })
+
+        const container = await screen.findByTestId('funnel-bar-horizontal')
+        const canvases = await findStepCanvases(container, 3)
+
+        // Click near the left edge of step 2's bar — inside the Spike segment (42% of the width).
+        await clickAtIndex(canvases[1].parentElement!, 0, 1)
+
+        await waitFor(() => {
+            expect(personsModal.actorNames()).toEqual(['step2-Spike@example.com'])
+        })
+        expect(personsModal.title()).toMatch(/Spike/)
+    })
+})

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.test.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, screen, waitFor } from '@testing-library/react'
+
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
+import {
+    buildFunnelsQuery,
+    getHogChart,
+    type MockResponse,
+    type QueryBody,
+    renderInsight,
+} from '~/test/insight-testing'
+import { type FunnelTimeToConvertFixture, funnelTimeToConvertBins } from '~/test/insight-testing/test-data'
+import { FunnelVizType } from '~/types'
+
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+const timeToConvertQuery = (extra: Partial<FunnelsQuery> = {}): FunnelsQuery =>
+    buildFunnelsQuery({ ...extra, funnelsFilter: { funnelVizType: FunnelVizType.TimeToConvert } })
+
+const isTimeToConvertQuery = (query: QueryBody): boolean =>
+    query.kind === NodeKind.FunnelsQuery && query.funnelsFilter?.funnelVizType === 'time_to_convert'
+
+type TimeToConvertResults =
+    | (FunnelTimeToConvertFixture & { median_conversion_time?: number })
+    | (FunnelTimeToConvertFixture & { compare_label: string })[]
+
+function mockTimeToConvertResults(results: TimeToConvertResults): MockResponse {
+    return { match: isTimeToConvertQuery, response: { results } as MockResponse['response'] }
+}
+
+describe('FunnelHistogramChart', () => {
+    it('renders one bar per time-to-convert bin, labelled with each bin share of conversions', async () => {
+        renderInsight({ query: timeToConvertQuery() })
+
+        await screen.findByLabelText(/chart with 1 data series/i)
+
+        // Canned bins hold 4/10/4/2 of 20 conversions → 20% / 50% / 20% / 10%.
+        await waitFor(() => {
+            expect(
+                getHogChart()
+                    .valueLabels()
+                    .map((label) => label.text)
+            ).toEqual(['20.0%', '50.0%', '20.0%', '10.0%'])
+        })
+    })
+
+    it('shows the median time to convert from the response in the canvas label', async () => {
+        renderInsight({
+            query: timeToConvertQuery(),
+            mocks: {
+                additionalMockResponses: [
+                    mockTimeToConvertResults({ ...funnelTimeToConvertBins, median_conversion_time: 138 }),
+                ],
+            },
+        })
+
+        await screen.findByLabelText(/chart with 1 data series/i)
+        expect(screen.getByText('Median time to convert')).toBeInTheDocument()
+        expect(screen.getByText('2m 18s')).toBeInTheDocument()
+    })
+
+    it('renders the empty state instead of a chart when the response has fewer than two bins', async () => {
+        renderInsight({
+            query: timeToConvertQuery(),
+            mocks: {
+                additionalMockResponses: [mockTimeToConvertResults({ bins: [[0, 4]], average_conversion_time: 0 })],
+            },
+        })
+
+        await screen.findByTestId('insight-empty-state')
+        expect(screen.queryByLabelText(/chart with/i)).not.toBeInTheDocument()
+    })
+
+    it('splits a compare response into current and previous series and drops the per-bin labels', async () => {
+        renderInsight({
+            query: timeToConvertQuery({ compareFilter: { compare: true } }),
+            mocks: {
+                additionalMockResponses: [
+                    mockTimeToConvertResults([
+                        { ...funnelTimeToConvertBins, compare_label: 'current' },
+                        {
+                            bins: [
+                                [0, 2],
+                                [120, 5],
+                                [240, 2],
+                                [360, 1],
+                            ],
+                            average_conversion_time: 150,
+                            compare_label: 'previous',
+                        },
+                    ]),
+                ],
+            },
+        })
+
+        await screen.findByLabelText(/chart with 2 data series/i)
+        expect(getHogChart().valueLabels()).toHaveLength(0)
+    })
+})

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.test.tsx
@@ -1,0 +1,151 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, fireEvent, screen, waitFor } from '@testing-library/react'
+
+import { setupJsdom } from '@posthog/quill-charts/testing'
+
+import { FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
+import {
+    buildActorsResponse,
+    buildFunnelsQuery,
+    chart,
+    type MockResponse,
+    personsModal,
+    renderInsight,
+} from '~/test/insight-testing'
+import { FunnelVizType } from '~/types'
+
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
+
+let cleanupJsdom: () => void
+
+// No setupSyncRaf here: the bars' hover-fade animation re-requests a frame until time advances,
+// so a synchronous RAF mock recurses until the stack overflows and crashes the chart on hover.
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+})
+
+afterEach(() => {
+    personsModal.cleanupAll()
+    cleanupJsdom()
+    cleanup()
+})
+
+interface StepsActorsSource {
+    kind?: string
+    funnelStep?: number
+    funnelStepBreakdown?: unknown
+}
+
+// The harness's default funnel actors mock keys off funnelTrendsEntrancePeriodStart; steps-viz
+// actor queries carry funnelStep/funnelStepBreakdown instead, so echo those into the actor email
+// to prove the click scoped the query correctly.
+const stepsFunnelActorsEcho: MockResponse = {
+    match: (query) => {
+        const source = (query as { source?: StepsActorsSource }).source
+        return (
+            query.kind === NodeKind.ActorsQuery &&
+            source?.kind === NodeKind.FunnelsActorsQuery &&
+            source.funnelStep != null
+        )
+    },
+    response: (query) => {
+        const source = (query as { source?: StepsActorsSource }).source!
+        const breakdown = Array.isArray(source.funnelStepBreakdown)
+            ? source.funnelStepBreakdown.join('+')
+            : source.funnelStepBreakdown
+        return buildActorsResponse([
+            { email: `step${source.funnelStep}${breakdown == null ? '' : `-${breakdown}`}@example.com` },
+        ])
+    },
+}
+
+function stepsFunnelQuery(overrides: Partial<FunnelsQuery> = {}): FunnelsQuery {
+    return buildFunnelsQuery({
+        series: [
+            { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+            { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+            { kind: NodeKind.EventsNode, event: 'Snored', name: 'Snored' },
+        ],
+        ...overrides,
+        funnelsFilter: { funnelVizType: FunnelVizType.Steps, ...overrides.funnelsFilter },
+    })
+}
+
+const hedgehogBreakdown = { breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' as const } }
+
+describe('FunnelStepsBarChart', () => {
+    it('renders a bar per step with the canned counts and conversion percentages in the step legends', async () => {
+        renderInsight({ query: stepsFunnelQuery() })
+
+        await screen.findByTestId('funnel-steps-bar-chart')
+        await screen.findByLabelText(/chart with 1 data series/i)
+
+        // Canned steps: $pageview 100 → Napped 60 (60%) → Snored 30 (30%).
+        const legends = screen.getAllByTestId('funnel-step-legend')
+        expect(legends).toHaveLength(3)
+        expect(legends[0].textContent).toContain('100')
+        expect(legends[1].textContent).toContain('60%')
+        expect(legends[2].textContent).toContain('30%')
+    })
+
+    it('renders one canvas series per breakdown value, with legend counts summed across values', async () => {
+        renderInsight({ query: stepsFunnelQuery(hedgehogBreakdown) })
+
+        await screen.findByTestId('funnel-steps-bar-chart')
+        // Canned breakdown: Spike 70/42/21 + Bramble 30/18/9, plus the prepended Baseline series.
+        await screen.findByLabelText(/chart with 3 data series/i)
+
+        const legends = screen.getAllByTestId('funnel-step-legend')
+        expect(legends).toHaveLength(3)
+        expect(legends[0].textContent).toMatch(/100\spersons/)
+        expect(legends[1].textContent).toMatch(/60\spersons/)
+    })
+
+    it('opens the persons modal for the clicked step, converted actors scoped via funnelStep', async () => {
+        renderInsight({
+            query: stepsFunnelQuery(),
+            mocks: { additionalMockResponses: [stepsFunnelActorsEcho] },
+        })
+
+        await screen.findByLabelText(/chart with 1 data series/i)
+        await chart.clickAtIndex(1, 3)
+
+        await waitFor(() => {
+            expect(personsModal.actorNames()).toEqual(['step2@example.com'])
+        })
+        expect(personsModal.title()).toMatch(/Completed step 2/)
+    })
+
+    it('scopes the persons modal to the clicked breakdown value via funnelStepBreakdown', async () => {
+        renderInsight({
+            query: stepsFunnelQuery(hedgehogBreakdown),
+            mocks: { additionalMockResponses: [stepsFunnelActorsEcho] },
+        })
+
+        await screen.findByLabelText(/chart with 3 data series/i)
+        await chart.clickAtIndex(1, 3)
+
+        await waitFor(() => {
+            expect(personsModal.actorNames()).toEqual(['step2-Spike@example.com'])
+        })
+        expect(personsModal.title()).toMatch(/Spike/)
+    })
+
+    it('opens the drop-off persons modal (negative funnelStep) from the legend inspect button', async () => {
+        renderInsight({
+            query: stepsFunnelQuery(),
+            mocks: { additionalMockResponses: [stepsFunnelActorsEcho] },
+        })
+
+        await screen.findByLabelText(/chart with 1 data series/i)
+        const droppedOffButtons = screen.getAllByTestId('funnel-inspect-dropped-off')
+        fireEvent.click(droppedOffButtons[0])
+
+        await waitFor(() => {
+            expect(personsModal.actorNames()).toEqual(['step-2@example.com'])
+        })
+        expect(personsModal.title()).toMatch(/Dropped off at step 2/)
+    })
+})

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, screen } from '@testing-library/react'
+
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { buildRetentionQuery, chart, renderInsight } from '~/test/insight-testing'
+import { ChartDisplayType } from '~/types'
+
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+const retentionBarQuery = (): ReturnType<typeof buildRetentionQuery> =>
+    buildRetentionQuery({ retentionFilter: { display: ChartDisplayType.ActionsBar } })
+
+describe('RetentionBarChart', () => {
+    it('renders the bar variant for the ActionsBar display with the same derived percentages', async () => {
+        renderInsight({ query: retentionBarQuery() })
+
+        await screen.findByLabelText(/chart with 2 data series/i)
+
+        // Grouped bars tooltip only the hovered band slot; the band-1 center lands on the
+        // second cohort's bar: Jun 11 Day 1 retention is 20/50 → 40%.
+        const tooltip = await chart.hoverTooltip(1, 3)
+        expect(tooltip.title()).toContain('Day 1')
+        expect(tooltip.row('Tue, Jun 11')).toMatch(/\b40(\.0+)?%/)
+    })
+
+    it('clicking a pinned tooltip row opens the retention modal for that cohort', async () => {
+        renderInsight({ query: retentionBarQuery() })
+
+        await screen.findByLabelText(/chart with 2 data series/i)
+
+        // First click pins the tooltip (narrowed to the hovered Jun 11 bar), a row click drills down.
+        await chart.clickAtIndex(1, 3)
+        await chart.clickTooltipRow(/Tue, Jun 11/)
+
+        expect(await screen.findByText('Tue, Jun 11 Cohort')).toBeInTheDocument()
+    })
+})

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -94,14 +94,14 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
             if (shouldShowMeanPerBreakdown) {
                 return
             }
-            const rowIndex = isIntervalView
-                ? datum.dataIndex
-                : (series[datum.datasetIndex]?.meta?.rowIndex ?? datum.datasetIndex)
+            // The bar tooltip is narrowed to the hovered bar, so datum.datasetIndex is positional
+            // within the narrowed rows — datum.order carries the narrow-proof cohort row index.
+            const rowIndex = isIntervalView ? datum.dataIndex : datum.order
             if (rowIndex !== undefined) {
                 openModal(rowIndex)
             }
         },
-        [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
+        [shouldShowMeanPerBreakdown, isIntervalView, openModal]
     )
 
     const renderTooltip = useCallback(

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, screen } from '@testing-library/react'
+
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { buildRetentionQuery, chart, renderInsight } from '~/test/insight-testing'
+
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+describe('RetentionLineChart', () => {
+    it('renders one line per cohort with retention percentages derived from the canned counts', async () => {
+        renderInsight({ query: buildRetentionQuery() })
+
+        // Two canned cohorts (Jun 10 and Jun 11) become two chart series.
+        await screen.findByLabelText(/chart with 2 data series/i)
+
+        // Day 1 retention: Jun 10 cohort 60/100 → 60%, Jun 11 cohort 20/50 → 40%.
+        const tooltip = await chart.hoverTooltip(1, 3)
+        expect(tooltip.title()).toContain('Day 1')
+        expect(tooltip.row('Mon, Jun 10')).toMatch(/\b60(\.0+)?%/)
+        expect(tooltip.row('Tue, Jun 11')).toMatch(/\b40(\.0+)?%/)
+    })
+
+    it('recomputes percentages against the prior interval when retentionReference is "previous"', async () => {
+        renderInsight({
+            query: buildRetentionQuery({ retentionFilter: { retentionReference: 'previous' } }),
+        })
+
+        await screen.findByLabelText(/chart with 2 data series/i)
+
+        // Day 2 vs Day 1: Jun 10 cohort 30/60 → 50%, Jun 11 cohort 5/20 → 25%
+        // (vs 30% and 10% against the Day 0 baseline).
+        const tooltip = await chart.hoverTooltip(2, 3)
+        expect(tooltip.title()).toContain('Day 2')
+        expect(tooltip.row('Mon, Jun 10')).toMatch(/\b50(\.0+)?%/)
+        expect(tooltip.row('Tue, Jun 11')).toMatch(/\b25(\.0+)?%/)
+    })
+
+    it('clicking a pinned tooltip row opens the retention modal for that cohort', async () => {
+        renderInsight({ query: buildRetentionQuery() })
+
+        await screen.findByLabelText(/chart with 2 data series/i)
+
+        // Multi-series pinnable chart: first click pins the tooltip, a row click drills down.
+        await chart.clickAtIndex(1, 3)
+        await chart.clickTooltipRow(/Tue, Jun 11/)
+
+        expect(await screen.findByText('Tue, Jun 11 Cohort')).toBeInTheDocument()
+    })
+})

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -97,14 +97,14 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
                 return
             }
             // In interval view each x-position is a different cohort, otherwise each series is.
-            const rowIndex = isIntervalView
-                ? datum.dataIndex
-                : (series[datum.datasetIndex]?.meta?.rowIndex ?? datum.datasetIndex)
+            // datum.order carries the cohort row index and survives tooltip narrowing, unlike
+            // the positional datum.datasetIndex.
+            const rowIndex = isIntervalView ? datum.dataIndex : datum.order
             if (rowIndex !== undefined) {
                 openModal(rowIndex)
             }
         },
-        [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
+        [shouldShowMeanPerBreakdown, isIntervalView, openModal]
     )
 
     const renderTooltip = useCallback(

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
@@ -140,6 +140,7 @@ describe('retentionChartTransforms', () => {
             )
             expect(series[0].meta).toEqual({
                 rowIndex: 2,
+                order: 2,
                 breakdown_value: 'Chrome',
                 days: ['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'],
                 cohortLabel: '2024-01-03',

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
@@ -32,6 +32,9 @@ export type RetentionTrendSeriesEntry = RetentionResultLike & { label?: string }
 export interface RetentionSeriesMeta {
     /** Original row index from the unfiltered results — drives modal opens in non-interval view. */
     rowIndex: number
+    /** Same as rowIndex; read by InsightSeriesTooltip (meta.order ?? idx), where the narrowed
+     *  grouped-bar row list makes the positional idx fallback point at the wrong cohort. */
+    order: number
     breakdown_value?: string | number | null
     days?: string[]
     cohortLabel?: string
@@ -68,6 +71,7 @@ export function buildRetentionSeries(
             data: s.data,
             meta: {
                 rowIndex,
+                order: rowIndex,
                 breakdown_value: s.breakdown_value,
                 days: s.days,
                 cohortLabel: s.label,

--- a/products/product_analytics/frontend/insights/trends/TrendsBarValueChart/trendsBarValueChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarValueChart/trendsBarValueChartTransforms.test.ts
@@ -1,0 +1,30 @@
+import { buildTrendsBarValueSeries } from './trendsBarValueChartTransforms'
+
+describe('buildTrendsBarValueSeries', () => {
+    it('collapses items into one series with per-bar colors by index and labels passed through', () => {
+        const series = buildTrendsBarValueSeries(
+            [
+                { label: 'Chrome', value: 30 },
+                { label: 'Safari', value: 12 },
+            ],
+            { getColor: (i) => `color-${i}` }
+        )
+
+        expect(series).toHaveLength(1)
+        expect(series[0].data).toEqual([30, 12])
+        expect(series[0].bars).toEqual([
+            { color: 'color-0', label: 'Chrome' },
+            { color: 'color-1', label: 'Safari' },
+        ])
+    })
+
+    it.each([null, undefined, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+        'replaces non-finite value %p with 0',
+        (badValue) => {
+            const series = buildTrendsBarValueSeries([{ label: 'Chrome', value: badValue }], {
+                getColor: () => '#000',
+            })
+            expect(series[0].data).toEqual([0])
+        }
+    )
+})

--- a/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.test.tsx
@@ -1,0 +1,122 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, configure, screen, waitFor } from '@testing-library/react'
+
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { NodeKind, ResultCustomizationBy } from '~/queries/schema/schema-general'
+import { buildTrendsQuery, getHogChart, renderInsight } from '~/test/insight-testing'
+import { ChartDisplayType } from '~/types'
+
+configure({ asyncUtilTimeout: 3000 })
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+const slopeQuery = (extra?: Parameters<typeof buildTrendsQuery>[0]): ReturnType<typeof buildTrendsQuery> =>
+    buildTrendsQuery({ trendsFilter: { display: ChartDisplayType.SlopeGraph }, ...extra })
+
+const slopeResult = (label: string, data: number[], order: number = 0): Record<string, unknown> => ({
+    action: { id: `$${label.toLowerCase()}`, type: 'events', name: label, order },
+    label,
+    count: data.reduce((a, b) => a + b, 0),
+    data,
+    labels: data.map((_, i) => `Day ${i + 1}`),
+    days: data.map((_, i) => `2024-06-0${i + 1}`),
+})
+
+const mockResults = (results: Record<string, unknown>[]): Parameters<typeof renderInsight>[0]['mocks'] => ({
+    additionalMockResponses: [{ match: (q) => q.kind === NodeKind.TrendsQuery, response: { results } as never }],
+})
+
+describe('TrendsSlopeChart', () => {
+    it('drops single-point series and renders only slopeable ones', async () => {
+        renderInsight({
+            query: slopeQuery(),
+            mocks: mockResults([slopeResult('Pageview', [10, 90]), slopeResult('Napped', [5], 1)]),
+        })
+
+        await waitFor(
+            () => {
+                expect(screen.getByLabelText(/chart with 1 data series/i)).toBeInTheDocument()
+            },
+            { timeout: 5000 }
+        )
+        const labels = getHogChart().slopeValueLabels()
+        expect(labels.map((l) => ({ side: l.side, text: l.text }))).toEqual([
+            { side: 'start', text: '10' },
+            { side: 'end', text: '90' },
+        ])
+    })
+
+    it('renders InsightEmptyState when no series has two points', async () => {
+        renderInsight({
+            query: slopeQuery(),
+            mocks: mockResults([slopeResult('Pageview', [5])]),
+        })
+
+        await waitFor(
+            () => {
+                expect(screen.getByTestId('insight-empty-state')).toBeInTheDocument()
+            },
+            { timeout: 5000 }
+        )
+        expect(screen.queryByLabelText(/chart with/i)).not.toBeInTheDocument()
+    })
+
+    it('drops series hidden via result customizations', async () => {
+        renderInsight({
+            query: slopeQuery({
+                series: [
+                    { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+                    { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
+                ],
+                trendsFilter: {
+                    display: ChartDisplayType.SlopeGraph,
+                    resultCustomizationBy: ResultCustomizationBy.Position,
+                    resultCustomizations: {
+                        1: { assignmentBy: ResultCustomizationBy.Position, hidden: true },
+                    },
+                },
+            }),
+        })
+
+        await waitFor(
+            () => {
+                expect(screen.getByLabelText(/chart with 1 data series/i)).toBeInTheDocument()
+            },
+            { timeout: 5000 }
+        )
+    })
+
+    it('formats slope value labels with the insight aggregation axis format', async () => {
+        renderInsight({
+            query: slopeQuery({
+                trendsFilter: { display: ChartDisplayType.SlopeGraph, aggregationAxisFormat: 'percentage' },
+            }),
+        })
+
+        await waitFor(
+            () => {
+                expect(screen.getByLabelText(/chart with 1 data series/i)).toBeInTheDocument()
+            },
+            { timeout: 5000 }
+        )
+        // Canned Pageview data runs 45 → 95; the slope shows first and last values.
+        const texts = getHogChart()
+            .slopeValueLabels()
+            .map((l) => l.text)
+        expect(texts).toEqual(expect.arrayContaining(['45%', '95%']))
+    })
+})


### PR DESCRIPTION
## Problem

Follow-up to #68776. Seven insight chart components had no rendered test coverage: RetentionLineChart, RetentionBarChart, FunnelStepsBarChart, FunnelBarHorizontalChart, FunnelHistogramChart, TrendsSlopeChart, and the trendsBarValueChartTransforms module had no test at all. The insight test harness couldn't drive them: it had no RetentionQuery support and its FunnelsQuery mock only produced trends-viz responses.

While writing the retention bar chart click test, we found a real bug: clicking a pinned tooltip row on the grouped retention bar chart opened the wrong cohort's modal.

## Changes

- **fix(retention)**: quill's grouped-bar tooltip narrows `seriesData` to the hovered bar, so the positional `datum.datasetIndex` always resolved to the first cohort on pinned-tooltip row clicks. Both retention charts now resolve the cohort via `datum.order`, and `buildRetentionSeries` populates `meta.order` so the flag-on quill tooltip path (which falls back to the narrowed index) resolves correctly too. The new RetentionBarChart test locks this in.
- Harness: `buildRetentionQuery` + a canned retention response; the FunnelsQuery mock now routes on `funnelVizType` (trends / steps / time_to_convert, absent defaults to steps matching the backend).
- Seven lean suites (24 new rendered tests + 6 transforms tests total), scoped by the coverage-layer rule now documented in the harness README: Storybook snapshot stories own render smoke and visual states, quill-charts' own suite owns chart mechanics, transforms tests own the pure case matrix, and these harness tests only assert interaction and data wiring (tooltip values, persons/retention modal click routing including funnel drop-off and breakdown scoping, empty-state guards).
- The two funnel steps suites deliberately skip `setupSyncRaf`: the hover-fade animation re-requests frames until wall time advances, so a synchronous RAF mock recurses to stack overflow (noted in-file).

## How did you test this code?

I'm an agent; all testing was automated, no manual testing was done.

- Full `products/product_analytics/frontend/insights` run on this branch (rebased on master including #68561): 38 suites, 570 tests, all passing.
- Other harness consumers unaffected: TaxonomicBreakdownFilter, ActionFilterRow, InsightSelector, SqlLineGraph/SqlBarGraph — 127 tests passing.
- The funnel suites were run repeatedly (8x combined, 3x full-pattern) to validate the sync-RAF fix against the intermittent stack overflow it addresses.
- Each new test names the regression it catches (per-test rationale in the suite files' structure); none duplicate the existing transforms matrices, quill-charts' own tests, or the snapshot stories.
- The retention fix is proven by a test that failed against the previous behavior (modal opened "Mon, Jun 10 Cohort" when "Tue, Jun 11" was clicked) and passes after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Harness README updated with the coverage-layer rule and the new query builders in the same PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Claude Fable 5), directed by @sampennington, continuing the session that produced #68776. One agent extended the harness and proved each new mode with exemplar tests; parallel agents then wrote the suites against the verified fixture shapes.
- Skills invoked: /writing-tests (every test gated on naming a regression nothing else catches).
- Judgment calls: the retention `meta.order` fix was applied to both tooltip paths (legacy and flag-on quill) rather than only the one the tests exercise; funnel steps suites use `setupJsdom` without sync RAF (documented in-file) — they assert DOM, not painted canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)