### PR TITLE
fix(intercom): ride out 429 rate limits on substream fetches

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py
@@ -251,16 +251,75 @@ def _resolve_intercom_url(path_or_url: str) -> str:
     return path_or_url if path_or_url.startswith("http") else f"{INTERCOM_API_BASE}{path_or_url}"
 
 
+def _is_rate_limited(exc: HTTPError) -> bool:
+    """Intercom rate-limits per workspace and returns `429` once the window is
+    exhausted. It's transient — the counter resets on a short rolling window —
+    so retrying after a wait clears it. Match on the status, not the URL."""
+    resp = exc.response
+    return resp is not None and resp.status_code == 429
+
+
+def _rate_limit_backoff_seconds(resp: Response, default: float) -> float:
+    """Honor Intercom's `Retry-After` (seconds) on a 429 when present, else fall
+    back to `default`. Intercom sends `Retry-After` on some 429s and always sends
+    `X-RateLimit-Reset`, but a fixed window-sized fallback rides out the bucket
+    regardless, so we key off the simpler signal."""
+    raw = resp.headers.get("Retry-After")
+    if raw is None:
+        return default
+    try:
+        return max(float(raw), 0.0)
+    except (TypeError, ValueError):
+        return default
+
+
+# Intercom's default limit is 1000 requests/minute, metered in ~10s buckets, so a
+# burst of per-row substream fetches (one GET per company/conversation) can exhaust
+# one bucket and get 429ed. The shared transport retry lists 429 but backs off at
+# most ~2s across its attempts — shorter than the bucket window — so a rate-limited
+# burst surfaces and Temporal re-walks the whole activity. Wait out a bucket inline
+# and retry, capped so sustained pressure still surfaces instead of looping forever.
+_RATE_LIMIT_BACKOFF_SECONDS = 10.0
+_RATE_LIMIT_MAX_RETRIES = 3
+
+
+def _request_with_rate_limit_retry(do_request: Callable[[], Response]) -> dict[str, Any]:
+    """Run an Intercom request, riding out a transient 429 rate limit inline.
+
+    `do_request` performs the call and raises `HTTPError` on a non-2xx. On a 429
+    we back off (honoring `Retry-After` when Intercom sends it) and retry the same
+    request, which is safe: every Intercom call routed through here is a read."""
+    for attempt in range(_RATE_LIMIT_MAX_RETRIES + 1):
+        try:
+            return do_request().json()
+        except HTTPError as exc:
+            resp = exc.response
+            if _is_rate_limited(exc) and resp is not None and attempt < _RATE_LIMIT_MAX_RETRIES:
+                wait = _rate_limit_backoff_seconds(resp, _RATE_LIMIT_BACKOFF_SECONDS)
+                logger.warning("intercom_rate_limited_retry", attempt=attempt + 1, backoff_seconds=wait)
+                time.sleep(wait)
+                continue
+            raise
+    # Unreachable: the final attempt either returns or re-raises above.
+    raise AssertionError("unreachable")
+
+
 def _intercom_get(session: Session, path_or_url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    response = session.get(_resolve_intercom_url(path_or_url), params=params, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    def do() -> Response:
+        response = session.get(_resolve_intercom_url(path_or_url), params=params, timeout=30)
+        response.raise_for_status()
+        return response
+
+    return _request_with_rate_limit_retry(do)
 
 
 def _intercom_post(session: Session, path_or_url: str, body: dict[str, Any]) -> dict[str, Any]:
-    response = session.post(_resolve_intercom_url(path_or_url), json=body, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    def do() -> Response:
+        response = session.post(_resolve_intercom_url(path_or_url), json=body, timeout=30)
+        response.raise_for_status()
+        return response
+
+    return _request_with_rate_limit_retry(do)
 
 
 def _iter_conversations(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -23,10 +23,13 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.intercom.i
     _company_segments_generator,
     _conversation_parts_generator,
     _drain_company_ids,
+    _intercom_get,
+    _is_rate_limited,
     _is_scroll_exists,
     _is_server_error,
     _iter_companies,
     _make_intercom_session,
+    _rate_limit_backoff_seconds,
     get_resource,
     intercom_source,
     validate_credentials,
@@ -578,6 +581,68 @@ class TestCompaniesScrollServerError:
 
         # One open + every continuation attempt (initial + retries) before surfacing.
         assert mock_session.get.call_count == intercom_module._SCROLL_SERVER_ERROR_MAX_RETRIES + 2
+
+
+class TestRateLimitRetry:
+    @pytest.mark.parametrize(
+        "status_code,expected",
+        [
+            (429, True),
+            (400, False),
+            (404, False),
+            (500, False),
+            (200, False),
+        ],
+    )
+    def test_is_rate_limited(self, status_code: int, expected: bool):
+        assert _is_rate_limited(_http_error(None, status_code=status_code, text="boom")) is expected
+
+    def test_backoff_honors_retry_after_header(self):
+        resp = _make_response(None, status_code=429, text="Too Many Requests")
+        resp.headers["Retry-After"] = "7"
+        assert _rate_limit_backoff_seconds(resp, default=10.0) == 7.0
+
+    @pytest.mark.parametrize("raw", [None, "not-a-number"])
+    def test_backoff_falls_back_without_usable_retry_after(self, raw: str | None):
+        resp = _make_response(None, status_code=429, text="Too Many Requests")
+        if raw is not None:
+            resp.headers["Retry-After"] = raw
+        assert _rate_limit_backoff_seconds(resp, default=10.0) == 10.0
+
+    def test_company_segments_retries_rate_limited_segment_fetch(self):
+        # The observed failure: a burst of per-company `/companies/{id}/segments`
+        # fetches trips Intercom's rate limit and 429s. Riding out the window inline
+        # lets the walk continue instead of failing the whole sync. Scroll is drained
+        # first (two GETs), then the segment fetch 429s once and succeeds on retry.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": []}),
+            _make_response(None, status_code=429, text="Too Many Requests"),
+            _make_response({"data": [{"id": "seg1"}]}),
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep") as sleep:
+            segments = list(_company_segments_generator(mock_session))
+
+        assert [s["id"] for s in segments] == ["seg1"]
+        assert segments[0]["company_id"] == "co1"
+        sleep.assert_called_once_with(intercom_module._RATE_LIMIT_BACKOFF_SECONDS)
+
+    def test_intercom_get_reraises_rate_limit_after_max_retries(self):
+        # A persistent 429 must surface after the bounded retries rather than
+        # looping forever, so Temporal can retry the activity.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=429, text="Too Many Requests")
+            for _ in range(intercom_module._RATE_LIMIT_MAX_RETRIES + 1)
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep"):
+            with pytest.raises(HTTPError):
+                _intercom_get(mock_session, "/companies/co1/segments")
+
+        assert mock_session.get.call_count == intercom_module._RATE_LIMIT_MAX_RETRIES + 1
 
 
 class TestSubstreamSessionRetries:


### PR DESCRIPTION
## Problem

The Intercom warehouse source surfaced a real error in error tracking:

```
HTTPError: 429 Client Error: Too Many Requests for url: https://api.intercom.io/companies/<redacted>/segments
```

Origin: `_intercom_get` (`raise_for_status`) called from `_company_segments_generator` in `products/warehouse_sources/backend/temporal/data_imports/sources/intercom/intercom.py`.

The `company_segments` substream walks every company and fires one `GET /companies/{id}/segments` per company, back to back. Intercom meters roughly 1000 requests per minute in ~10 second buckets, so a big workspace exhausts a bucket mid-walk and gets a 429.

The 429 is transient (the bucket resets on a short rolling window), so it should not be treated as non-retryable. The problem is our backoff. The shared transport retry does list 429, but it backs off at most ~2s across its attempts, which is shorter than Intercom's bucket window. When Intercom does not send a `Retry-After` header (it uses `X-RateLimit-Reset` instead), the short backoff never rides out the window, the 429 surfaces, and Temporal re-walks the whole full-refresh activity from scratch.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3b68-52b0-7cc0-b491-b9e882e5e86f

## Changes

Added rate-limit-aware inline retry to the shared `_intercom_get` / `_intercom_post` helpers, mirroring the pattern already in this file for transient 5xx on the companies scroll walk (`_scroll_companies_get`).

On a 429 we wait out a bucket (default 10s, honoring `Retry-After` when Intercom sends it) and retry the same request. Every call routed through these helpers is a read, so retrying is safe. The retry is capped (`_RATE_LIMIT_MAX_RETRIES`) so sustained pressure still surfaces and hands back to Temporal rather than looping forever.

This applies to the custom-walk paths (companies scroll, `conversation_parts` and `company_segments` substreams) that go through these helpers, which is exactly where the observed error fired. I deliberately did not add 429 to `NonRetryableErrors`: permanently stopping on a rate limit is the opposite of the correct response.

## How did you test this code?

I (Claude) added and ran automated tests. I did not do any manual testing against the live Intercom API.

New tests in `test_intercom.py` (`TestRateLimitRetry`):

- `test_is_rate_limited` - the predicate matches 429 only, not other statuses. Catches a regression where the status check is widened or narrowed.
- `test_backoff_honors_retry_after_header` / `test_backoff_falls_back_without_usable_retry_after` - `Retry-After` is honored when a usable value is present and the fixed fallback is used otherwise. Catches a regression in header parsing.
- `test_company_segments_retries_rate_limited_segment_fetch` - the observed failure path: a 429 on a per-company segment fetch is retried inline and the walk completes instead of failing. This is the highest-value case; without the fix it raises.
- `test_intercom_get_reraises_rate_limit_after_max_retries` - a persistent 429 surfaces after the bounded retries rather than looping forever.

Ran the full intercom test dir locally: 114 passed. `ruff check` and `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Skills invoked: `/writing-tests` (to gate the added tests).

Decision path: confirmed the stack genuinely originates in the intercom source (not just serialized log context), read the implementation, and classified the 429 as a transient upstream rate limit. Rejected extending `NonRetryableErrors` (wrong for a rate limit) and rejected widening the global transport retry policy (too broad). Chose an inline retry at the shared request helpers because it matches the file's existing inline-retry style for transient scroll conditions and scopes the change to the 429. Verified no existing open PR (including the maintainer's own) already addresses this.
