### PR TITLE
fix(cdp): use UTC timestamp for internal events

### DIFF
--- a/posthog/cdp/internal_events.py
+++ b/posthog/cdp/internal_events.py
@@ -1,6 +1,6 @@
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 import structlog
@@ -54,7 +54,7 @@ def create_internal_event(
     if data.event.uuid is None:
         data.event.uuid = str(uuid.uuid4())
     if data.event.timestamp is None:
-        data.event.timestamp = datetime.now().isoformat()
+        data.event.timestamp = datetime.now(UTC).isoformat()
 
     return data
 


### PR DESCRIPTION
## Problem

`create_internal_event` in `posthog/cdp/internal_events.py` stamps events with `datetime.now().isoformat()`, which is a timezone-naive local-time string with no offset suffix. The Node.js CDP consumer parses it with Luxon's `DateTime.fromISO`, which interprets suffix-less strings as local server time. On any non-UTC host the timestamp is wrong, and it's inconsistent with the rest of the codebase, which uses timezone-aware UTC timestamps for Kafka events.

## Changes

Use `datetime.now(UTC).isoformat()` so the timestamp carries an explicit `+00:00` offset, matching the pattern used elsewhere (e.g. `posthog/tasks/tasks.py`).

## How did you test this code?

Ran `hogli test posthog/api/test/test_comments.py` (65 passed), which exercises `produce_internal_event` end to end. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude via PostHog Code) found this while sweeping for timezone-handling bugs. The fix mirrors the UTC-aware pattern already used by other Kafka event producers in the repo. No skills invoked beyond standard lint/test tooling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*