### PR TITLE
fix(data-warehouse): use timezone-aware timestamps in soft_delete

### DIFF
--- a/products/data_tools/backend/models/join.py
+++ b/products/data_tools/backend/models/join.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from typing import cast
 from warnings import warn
 
 from django.db import models
+from django.utils import timezone
 
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDTModel
 
@@ -48,5 +48,5 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDTModel, DeletedMetaFields):
 
     def soft_delete(self):
         self.deleted = True
-        self.deleted_at = datetime.now()
+        self.deleted_at = timezone.now()
         self.save()

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -591,7 +591,7 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
 
     def soft_delete(self):
         self.deleted = True
-        self.deleted_at = datetime.now()
+        self.deleted_at = timezone.now()
         self.save()
 
     def delete_table(self):

--- a/products/warehouse_sources/backend/models/external_data_source.py
+++ b/products/warehouse_sources/backend/models/external_data_source.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 from uuid import UUID
 
 from django.db import models
+from django.utils import timezone
 
 import structlog
 
@@ -128,7 +128,7 @@ class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
 
     def soft_delete(self):
         self.deleted = True
-        self.deleted_at = datetime.now()
+        self.deleted_at = timezone.now()
         self.save()
 
         # Lazy import to avoid circular: SourceRegistry → helpers.py → this module.

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -2,13 +2,13 @@ import csv
 import sys
 import time
 import subprocess
-from datetime import datetime
 from io import StringIO
 from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, cast
 from uuid import UUID
 
 from django.db import models
 from django.db.models import Q
+from django.utils import timezone
 
 import structlog
 from clickhouse_driver.errors import ServerException as ClickHouseServerException
@@ -223,7 +223,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             join.soft_delete()
 
         self.deleted = True
-        self.deleted_at = datetime.now()
+        self.deleted_at = timezone.now()
         self.save()
 
     def table_name_without_prefix(self) -> str:


### PR DESCRIPTION
## Problem

Four `soft_delete()` methods set `deleted_at = datetime.now()`, a timezone-naive local-time value. With Django's `USE_TZ=True` this emits a `RuntimeWarning` on every soft delete and stores local server time instead of UTC, so deletion timestamps are wrong on any non-UTC host. Other models in the repo already do this correctly with `timezone.now()`.

## Changes

Replace `datetime.now()` with `django.utils.timezone.now()` in:

- `products/data_tools/backend/models/join.py` (DataWarehouseJoin)
- `products/warehouse_sources/backend/models/external_data_source.py`
- `products/warehouse_sources/backend/models/external_data_schema.py`
- `products/warehouse_sources/backend/models/table.py`

Removed the now-unused `datetime` imports.

## How did you test this code?

Ran `hogli test products/warehouse_sources/backend/tests/test_models.py` (77 passed). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude via PostHog Code) found these while sweeping for naive-datetime bugs. The fix follows the `timezone.now()` pattern used by equivalent `soft_delete` implementations elsewhere in the repo (e.g. products/tasks, products/endpoints). No skills invoked beyond standard lint/test tooling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*