### PR TITLE
fix(session-replay): sort session timestamps chronologically

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -91,8 +91,10 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                     const startTime = performance.now()
                     const sessionIds = sessions.map((x) => x.id)
 
-                    const oldestTimestamp = sessions.map((x) => x.start_time).sort()[0]
-                    const newestTimestamp = sessions.map((x) => x.end_time).sort()[sessions.length - 1]
+                    const chronological = (a: string, b: string): number =>
+                        new Date(a).getTime() - new Date(b).getTime()
+                    const oldestTimestamp = sessions.map((x) => x.start_time).sort(chronological)[0]
+                    const newestTimestamp = sessions.map((x) => x.end_time).sort(chronological)[sessions.length - 1]
 
                     const extraSessionProperties = values.extraSessionProperties
                     let response


### PR DESCRIPTION
## Problem

`sessionRecordingsListPropertiesLogic` computes the oldest and newest timestamps for a batch of recordings with a bare `Array.sort()` on ISO timestamp strings. Lexicographic order only matches chronological order when every string uses the same offset suffix format. ISO strings can carry `+00:00`, `Z`, or no suffix, and those sort differently as text (`+` sorts before digits, `Z` after). A wrong min/max narrows the timestamp range passed to the HogQL properties query, which can silently drop properties for sessions at the boundary of the batch.

## Changes

Sort with a date-value comparator (`new Date(a).getTime() - new Date(b).getTime()`) instead of the default lexicographic sort.

## How did you test this code?

`pnpm --filter=@posthog/frontend typescript:check` passes with no new errors (the two pre-existing WorkflowsScene errors exist on master). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude via PostHog Code) found this while sweeping the frontend for lexicographic sorts over non-string semantics. Kept the fix minimal, a local comparator in the same loader. No skills invoked beyond standard lint/typecheck tooling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*