### PR TITLE
feat(mcp): gate activity-log tools on audit_logs entitlement

### DIFF
--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -18,6 +18,7 @@ tools:
     advanced-activity-logs-filters:
         operation: advanced_activity_logs_available_filters_retrieve
         enabled: true
+        feature_entitlement: audit_logs
         scopes:
             - activity_log:read
         annotations:
@@ -32,6 +33,7 @@ tools:
     advanced-activity-logs-list:
         operation: advanced_activity_logs_list
         enabled: true
+        feature_entitlement: audit_logs
         scopes:
             - activity_log:read
         annotations:

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -18,7 +18,6 @@ tools:
     advanced-activity-logs-filters:
         operation: advanced_activity_logs_available_filters_retrieve
         enabled: true
-        feature_entitlement: audit_logs
         scopes:
             - activity_log:read
         annotations:
@@ -29,11 +28,11 @@ tools:
         description: >
             Get the available filter options for activity logs — scopes, activity types, and users that have logged
             activity. Useful for building filter UIs or understanding what kinds of activity are tracked.
+        feature_entitlement: audit_logs
         url_prefix: /activity
     advanced-activity-logs-list:
         operation: advanced_activity_logs_list
         enabled: true
-        feature_entitlement: audit_logs
         scopes:
             - activity_log:read
         annotations:
@@ -50,6 +49,7 @@ tools:
         param_overrides:
             page_size:
                 default: 10
+        feature_entitlement: audit_logs
         url_prefix: /activity
         response:
             include:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -246,7 +246,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "audit_logs"
     },
     "advanced-activity-logs-list": {
         "description": "List activity log entries — who changed what and when (feature flag changes, dashboard edits, experiment launches, insight edits, etc.), with field-level diffs. Filter by scope, activity type, user, item, date range, and free-text search. Use this to audit a specific resource's history or to see what changed recently across the project.",
@@ -260,7 +261,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "audit_logs"
     },
     "agent-applications-create": {
         "description": "Create a new agent. Requires `name` + `slug` (unique within the team). The fresh application has no revisions; create a draft via `agent-applications-revisions-create`, populate its bundle, then freeze + promote. Playbook: read the `authoring-new-agents` playbook via `agent-resolve-resource` for the end-to-end authoring flow.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -246,7 +246,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "audit_logs"
     },
     "advanced-activity-logs-list": {
         "description": "List activity log entries — who changed what and when (feature flag changes, dashboard edits, experiment launches, insight edits, etc.), with field-level diffs. Filter by scope, activity type, user, item, date range, and free-text search. Use this to audit a specific resource's history or to see what changed recently across the project.",
@@ -260,7 +261,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "audit_logs"
     },
     "agent-applications-create": {
         "description": "Create a new agent. Requires `name` + `slug` (unique within the team). The fresh application has no revisions; create a draft via `agent-applications-revisions-create`, populate its bundle, then freeze + promote. Playbook: read the `authoring-new-agents` playbook via `agent-resolve-resource` for the end-to-end authoring flow.",

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -1732,6 +1732,7 @@ function generateDefinitionsJson(
             // Per-tool feature_flag wins; otherwise inherit the category-level
             // gate (lets one line gate a whole not-yet-GA product).
             const featureFlag = toolConfig.feature_flag ?? category.feature_flag
+            const featureEntitlement = toolConfig.feature_entitlement ?? category.feature_entitlement
             const featureFlagBehavior = toolConfig.feature_flag_behavior ?? category.feature_flag_behavior
             const featureFlagVariant = toolConfig.feature_flag_variant ?? category.feature_flag_variant
 
@@ -1759,6 +1760,7 @@ function generateDefinitionsJson(
                     },
                     ...(toolConfig.requires_ai_consent ? { requires_ai_consent: true } : {}),
                     ...(featureFlag ? { feature_flag: featureFlag } : {}),
+                    ...(featureEntitlement ? { feature_entitlement: featureEntitlement } : {}),
                     ...(featureFlagBehavior ? { feature_flag_behavior: featureFlagBehavior } : {}),
                     ...(featureFlagVariant ? { feature_flag_variant: featureFlagVariant } : {}),
                     ...(toolConfig.system_prompt_hint ? { system_prompt_hint: toolConfig.system_prompt_hint } : {}),
@@ -1782,6 +1784,7 @@ function generateDefinitionsJson(
                     },
                     ...(toolConfig.requires_ai_consent ? { requires_ai_consent: true } : {}),
                     ...(featureFlag ? { feature_flag: featureFlag } : {}),
+                    ...(featureEntitlement ? { feature_entitlement: featureEntitlement } : {}),
                     ...(featureFlagBehavior ? { feature_flag_behavior: featureFlagBehavior } : {}),
                     ...(featureFlagVariant ? { feature_flag_variant: featureFlagVariant } : {}),
                     ...(toolConfig.system_prompt_hint ? { system_prompt_hint: toolConfig.system_prompt_hint } : {}),
@@ -1802,6 +1805,7 @@ function generateDefinitionsJson(
                     },
                     ...(toolConfig.requires_ai_consent ? { requires_ai_consent: true } : {}),
                     ...(featureFlag ? { feature_flag: featureFlag } : {}),
+                    ...(featureEntitlement ? { feature_entitlement: featureEntitlement } : {}),
                     ...(featureFlagBehavior ? { feature_flag_behavior: featureFlagBehavior } : {}),
                     ...(featureFlagVariant ? { feature_flag_variant: featureFlagVariant } : {}),
                     ...(toolConfig.system_prompt_hint ? { system_prompt_hint: toolConfig.system_prompt_hint } : {}),
@@ -1824,6 +1828,9 @@ function generateDefinitionsJson(
                     readOnlyHint: wrapperConfig.annotations.readOnly,
                 },
                 ...(wrapperConfig.feature_flag ? { feature_flag: wrapperConfig.feature_flag } : {}),
+                ...(wrapperConfig.feature_entitlement
+                    ? { feature_entitlement: wrapperConfig.feature_entitlement }
+                    : {}),
                 ...(wrapperConfig.feature_flag_behavior
                     ? { feature_flag_behavior: wrapperConfig.feature_flag_behavior }
                     : {}),
@@ -2002,6 +2009,7 @@ function generateQueryWrapperDefinitionsJson(
                 readOnlyHint: toolConfig.annotations.readOnly,
             },
             ...(toolConfig.feature_flag ? { feature_flag: toolConfig.feature_flag } : {}),
+            ...(toolConfig.feature_entitlement ? { feature_entitlement: toolConfig.feature_entitlement } : {}),
             ...(toolConfig.feature_flag_behavior ? { feature_flag_behavior: toolConfig.feature_flag_behavior } : {}),
             ...(toolConfig.feature_flag_variant ? { feature_flag_variant: toolConfig.feature_flag_variant } : {}),
             ...(toolConfig.system_prompt_hint ? { system_prompt_hint: toolConfig.system_prompt_hint } : {}),

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -155,6 +155,7 @@ export const ToolConfigSchema = z
          * the tool when the flag is on (useful for sunsetting old tools).
          */
         feature_flag: z.string().optional(),
+        feature_entitlement: z.string().optional(),
         /**
          * Controls how `feature_flag` gates the tool:
          * - `'enable'` (default): tool is shown only when the flag is on.
@@ -461,6 +462,7 @@ export const QueryWrapperToolConfigSchema = z
          * See ToolConfigSchema.feature_flag for full documentation.
          */
         feature_flag: z.string().optional(),
+        feature_entitlement: z.string().optional(),
         /**
          * Controls how `feature_flag` gates the tool:
          * - `'enable'` (default): tool is shown only when the flag is on.
@@ -512,6 +514,7 @@ export const CategoryConfigSchema = z
          * from the standard MCP surface in one place. See ToolConfigSchema.feature_flag.
          */
         feature_flag: z.string().optional(),
+        feature_entitlement: z.string().optional(),
         feature_flag_behavior: z.enum(['enable', 'disable']).optional(),
         feature_flag_variant: z.string().optional(),
         tools: z.record(

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -1,7 +1,7 @@
 import type { GroupType } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import { MCPClientProfile } from '@/lib/client-detection'
-import { isLocalApi } from '@/lib/constants'
+import { isCloudApi, isLocalApi } from '@/lib/constants'
 import { buildMCPAnalyticsGroups } from '@/lib/posthog/analytics'
 import {
     type EvaluatedFlags,
@@ -179,6 +179,8 @@ export class RequestStateResolver {
         const apiKeyScopes = _apiKey?.scopes ?? []
         const apiKeyScopedTeams = _apiKey?.scoped_teams ?? []
         const aiConsentGiven = await context.stateManager.getAiConsentGiven()
+        const availableFeatures = await context.stateManager.getAvailableFeatures()
+        const isCloud = isCloudApi()
 
         const excludeTools: string[] = []
         if (projectId) {
@@ -195,6 +197,8 @@ export class RequestStateResolver {
             featureFlags: toolFeatureFlags,
             scopedTeams: apiKeyScopedTeams,
             aiConsentGiven: aiConsentGiven ?? undefined,
+            availableFeatures,
+            isCloud,
         }
         const allTools = this.catalog.getFilteredTools({ ...filterOptions, scopes: apiKeyScopes })
         // Scope-gated hints are only consumed by the exec `search` command, which

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -441,4 +441,37 @@ export class StateManager {
             return undefined
         }
     }
+
+    async getAvailableFeatures(): Promise<string[] | undefined> {
+        const extractKeys = (features: unknown): string[] | undefined => {
+            if (!Array.isArray(features)) {
+                return undefined
+            }
+            return features.map((f) => (f as { key?: string }).key).filter((k): k is string => typeof k === 'string')
+        }
+
+        try {
+            const org = await this.getCachedOrFetchOrg()
+            if (org) {
+                const keys = extractKeys((org as { available_product_features?: unknown }).available_product_features)
+                if (keys !== undefined) {
+                    return keys
+                }
+            }
+
+            // Team-scoped tokens can't fetch `/api/organizations/{id}/`. Fall back
+            // to the org embedded in `/api/users/@me/` (exempt from team scoping),
+            // but only when it matches the active project's owning org — mirrors
+            // getAiConsentGiven.
+            const [user, project] = await Promise.all([this.getCachedOrFetchUser(), this.getCachedOrFetchProject()])
+            if (user?.organization && project?.organization === user.organization.id) {
+                return extractKeys(
+                    (user.organization as { available_product_features?: unknown }).available_product_features
+                )
+            }
+            return undefined
+        } catch {
+            return undefined
+        }
+    }
 }

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -465,9 +465,7 @@ export class StateManager {
             // getAiConsentGiven.
             const [user, project] = await Promise.all([this.getCachedOrFetchUser(), this.getCachedOrFetchProject()])
             if (user?.organization && project?.organization === user.organization.id) {
-                return extractKeys(
-                    (user.organization as { available_product_features?: unknown }).available_product_features
-                )
+                return extractKeys(user.organization.available_product_features)
             }
             return undefined
         } catch {

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -16,6 +16,13 @@ import type { CachedOrg, CachedProject, CachedUser, State } from '@/tools/types'
 
 const CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
 
+// Entitlement-related fields shared by both org shapes we read from — the
+// standalone org endpoint and the org embedded in `/api/users/@me/`.
+type OrgEntitlementFields = {
+    is_ai_data_processing_approved?: boolean | null
+    available_product_features?: Array<{ key: string }> | null
+}
+
 export class StateManager {
     private _cache: ScopedCache<State>
     private _api: ApiClient
@@ -415,26 +422,27 @@ export class StateManager {
         }
     }
 
-    async getAiConsentGiven(): Promise<boolean | undefined> {
+    /**
+     * Resolve a field from the active organization, failing closed to `undefined`.
+     *
+     * Tries `/api/organizations/{id}/` first. Team-scoped tokens (e.g. sandbox
+     * OAuth tokens) can never fetch that endpoint — see the guard in
+     * getCachedOrFetchOrg — so fall back to the org embedded in
+     * `/api/users/@me/` (exempt from team scoping). That embedded org is the
+     * user's *current* org, which isn't necessarily the one owning the scoped
+     * project, so only trust it when it matches the active project's owning org.
+     * Any failure resolves to `undefined` so callers keep failing closed.
+     */
+    private async getOrgField<T>(extract: (org: OrgEntitlementFields) => T): Promise<T | undefined> {
         try {
             const org = await this.getCachedOrFetchOrg()
             if (org) {
-                const consent = (org as { is_ai_data_processing_approved?: boolean | null })
-                    .is_ai_data_processing_approved
-                return !!consent
+                return extract(org as OrgEntitlementFields)
             }
 
-            // Team-scoped tokens (e.g. sandbox OAuth tokens) can never fetch
-            // `/api/organizations/{id}/` — see the guard in getCachedOrFetchOrg.
-            // But `/api/users/@me/` is exempt from team scoping and embeds the
-            // full org serializer (including the consent flag) for the user's
-            // *current* org. That org isn't necessarily the one owning the
-            // scoped project, so only trust the flag when it matches the active
-            // project's owning org; otherwise stay undefined so callers keep
-            // failing closed.
             const [user, project] = await Promise.all([this.getCachedOrFetchUser(), this.getCachedOrFetchProject()])
             if (user?.organization && project?.organization === user.organization.id) {
-                return !!user.organization.is_ai_data_processing_approved
+                return extract(user.organization)
             }
             return undefined
         } catch {
@@ -442,34 +450,21 @@ export class StateManager {
         }
     }
 
+    async getAiConsentGiven(): Promise<boolean | undefined> {
+        return this.getOrgField((org) => !!org.is_ai_data_processing_approved)
+    }
+
     async getAvailableFeatures(): Promise<string[] | undefined> {
-        const extractKeys = (features: unknown): string[] | undefined => {
+        // A fetched org resolves to its entitlement keys, treating both `null`
+        // and a missing field as "no features" (`[]`) rather than falling
+        // through — the fallback only exists for tokens that can't fetch the org
+        // at all, where getCachedOrFetchOrg returns undefined.
+        return this.getOrgField((org) => {
+            const features = org.available_product_features
             if (!Array.isArray(features)) {
-                return undefined
+                return []
             }
-            return features.map((f) => (f as { key?: string }).key).filter((k): k is string => typeof k === 'string')
-        }
-
-        try {
-            const org = await this.getCachedOrFetchOrg()
-            if (org) {
-                const keys = extractKeys((org as { available_product_features?: unknown }).available_product_features)
-                if (keys !== undefined) {
-                    return keys
-                }
-            }
-
-            // Team-scoped tokens can't fetch `/api/organizations/{id}/`. Fall back
-            // to the org embedded in `/api/users/@me/` (exempt from team scoping),
-            // but only when it matches the active project's owning org — mirrors
-            // getAiConsentGiven.
-            const [user, project] = await Promise.all([this.getCachedOrFetchUser(), this.getCachedOrFetchProject()])
-            if (user?.organization && project?.organization === user.organization.id) {
-                return extractKeys(user.organization.available_product_features)
-            }
-            return undefined
-        } catch {
-            return undefined
-        }
+            return features.map((f) => f.key).filter((k): k is string => typeof k === 'string')
+        })
     }
 }

--- a/services/mcp/src/schema/api.ts
+++ b/services/mcp/src/schema/api.ts
@@ -26,6 +26,7 @@ export interface ApiUser {
         // current org, so the consent flag is always present on the wire; it is
         // optional here because some tests construct partial users.
         is_ai_data_processing_approved?: boolean | null
+        available_product_features?: Array<{ key: string }> | null
     } | null
 }
 

--- a/services/mcp/src/schema/api.ts
+++ b/services/mcp/src/schema/api.ts
@@ -26,6 +26,9 @@ export interface ApiUser {
         // current org, so the consent flag is always present on the wire; it is
         // optional here because some tests construct partial users.
         is_ai_data_processing_approved?: boolean | null
+        // `/api/users/@me/` embeds the full OrganizationSerializer, so the org's
+        // plan entitlements ride along too; used by the fallback path when a
+        // team-scoped token can't fetch the org directly.
         available_product_features?: Array<{ key: string }> | null
     } | null
 }

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -22,6 +22,13 @@ export const ToolDefinitionSchema = z
         feature_flag_behavior: z.enum(['enable', 'disable']).optional(),
         /** Variant of `feature_flag` to match exactly. Requires `feature_flag` to be set. */
         feature_flag_variant: z.string().optional(),
+        /**
+         * AvailableFeature the org's plan must include for this tool to be
+         * advertised (e.g. `'audit_logs'`), matching the backend's
+         * `premium_feature_on_cloud`. Best-effort — the backend
+         * `PremiumFeaturePermission` stays authoritative; the gate is fail-open.
+         */
+        feature_entitlement: z.string().optional(),
         /** One-line selection hint surfaced in the system prompt's query tool catalog. */
         system_prompt_hint: z.string().optional(),
         /**
@@ -128,6 +135,10 @@ export interface ToolFilterOptions {
      * need `organization:*` scopes — they'd fail anyway.
      */
     scopedTeams?: number[] | undefined
+    /** Org's plan entitlements (`available_product_features` keys). Undefined when unresolved. */
+    availableFeatures?: string[] | undefined
+    /** Whether the API this MCP talks to is PostHog Cloud. Off-cloud is never entitlement-gated. */
+    isCloud?: boolean | undefined
 }
 
 /**
@@ -174,8 +185,36 @@ export function toolPassesFlagGate(definition: ToolDefinition, featureFlags: Eva
     return (definition.feature_flag_behavior ?? 'enable') === 'enable' ? isOn : !isOn
 }
 
+/**
+ * Predicate: is a tool's `feature_entitlement` satisfied for this org? Fail-open,
+ * mirroring the backend `premium_feature_on_cloud` semantics:
+ *
+ *   no feature_entitlement          → pass (ungated)
+ *   isCloud === false (self-hosted) → pass (backend never gates off-cloud)
+ *   availableFeatures unknown       → pass (couldn't resolve; backend authoritative)
+ *   feature ∈ availableFeatures     → pass
+ *   otherwise (cloud + absent)      → hide
+ */
+export function toolPassesEntitlementGate(
+    definition: ToolDefinition,
+    availableFeatures?: string[],
+    isCloud?: boolean
+): boolean {
+    if (!definition.feature_entitlement) {
+        return true
+    }
+    if (isCloud === false) {
+        return true
+    }
+    if (availableFeatures === undefined) {
+        return true
+    }
+    return availableFeatures.includes(definition.feature_entitlement)
+}
+
 export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
-    const { features, tools, readOnly, aiConsentGiven, featureFlags, scopedTeams } = options || {}
+    const { features, tools, readOnly, aiConsentGiven, featureFlags, scopedTeams, availableFeatures, isCloud } =
+        options || {}
     const toolDefinitions = getToolDefinitions()
 
     let entries = Object.entries(toolDefinitions)
@@ -215,6 +254,9 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
 
     // Filter by feature flags — see {@link toolPassesFlagGate} for the predicate.
     entries = entries.filter(([_, definition]) => toolPassesFlagGate(definition, featureFlags))
+
+    // Filter by billing entitlement — see {@link toolPassesEntitlementGate}.
+    entries = entries.filter(([_, definition]) => toolPassesEntitlementGate(definition, availableFeatures, isCloud))
 
     // Hide tools that need org-level access when the session's token is
     // project-scoped - the backend would 403 them

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -57,6 +57,7 @@ vi.mock('@/hono/request-context', () => {
                         getAiConsentGiven: vi.fn(async () => undefined),
                         getOrFetchGroupTypes: vi.fn(async () => undefined),
                         getEnvironmentPrompt: vi.fn(async () => undefined),
+                        getAvailableFeatures: vi.fn(async () => undefined),
                     },
                 })),
                 safelyGetAnalyticsContext: vi.fn(async () => undefined),

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -632,6 +632,82 @@ describe('StateManager', () => {
         })
     })
 
+    describe('getAvailableFeatures', () => {
+        it('returns available_product_features keys from the fetched org when the org is resolvable', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue({
+                id: 'org-1',
+                name: 'Org 1',
+                available_product_features: [{ key: 'audit_logs' }, { key: 'sso' }],
+            } as any)
+            const userSpy = vi.spyOn(stateManager, 'getCachedOrFetchUser')
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toEqual(['audit_logs', 'sso'])
+            expect(userSpy).not.toHaveBeenCalled()
+        })
+
+        it('returns an empty array (not undefined) when the org has no entitled features', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue({
+                id: 'org-1',
+                name: 'Org 1',
+                available_product_features: [],
+            } as any)
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toEqual([])
+        })
+
+        it('falls back to users/@me features when the org is unreachable and the current org owns the active project', async () => {
+            // Team-scoped tokens (e.g. sandbox OAuth tokens) can never fetch
+            // `/api/organizations/{id}/`, so getCachedOrFetchOrg yields undefined.
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({
+                ...mockUser,
+                organization: {
+                    id: 'org-1',
+                    name: 'Org 1',
+                    available_product_features: [{ key: 'audit_logs' }],
+                },
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                organization: 'org-1',
+            } as any)
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toEqual(['audit_logs'])
+        })
+
+        it('returns undefined when the org has no readable entitlements and no fallback applies', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({
+                ...mockUser,
+                organization: { id: 'org-other', name: 'Other Org' },
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                organization: 'org-1',
+            } as any)
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toBeUndefined()
+        })
+
+        it('returns undefined (fail open) when the fallback fetches throw', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockRejectedValue(new Error('boom'))
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue(undefined)
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toBeUndefined()
+        })
+    })
+
     describe('getProjectId', () => {
         it('should return cached projectId if available', async () => {
             await cache.set('projectId', 'cached-project-id')

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -653,10 +653,12 @@ describe('StateManager', () => {
                 name: 'Org 1',
                 available_product_features: [],
             } as any)
+            const userSpy = vi.spyOn(stateManager, 'getCachedOrFetchUser')
 
             const result = await stateManager.getAvailableFeatures()
 
             expect(result).toEqual([])
+            expect(userSpy).not.toHaveBeenCalled()
         })
 
         it('falls back to users/@me features when the org is unreachable and the current org owns the active project', async () => {

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -661,6 +661,20 @@ describe('StateManager', () => {
             expect(userSpy).not.toHaveBeenCalled()
         })
 
+        it('treats a null available_product_features from the fetched org as no features, not a fallback trigger', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue({
+                id: 'org-1',
+                name: 'Org 1',
+                available_product_features: null,
+            } as any)
+            const userSpy = vi.spyOn(stateManager, 'getCachedOrFetchUser')
+
+            const result = await stateManager.getAvailableFeatures()
+
+            expect(result).toEqual([])
+            expect(userSpy).not.toHaveBeenCalled()
+        })
+
         it('falls back to users/@me features when the org is unreachable and the current org owns the active project', async () => {
             // Team-scoped tokens (e.g. sandbox OAuth tokens) can never fetch
             // `/api/organizations/{id}/`, so getCachedOrFetchOrg yields undefined.

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -908,3 +908,22 @@ describe('toolPassesEntitlementGate', () => {
         expect(toolPassesEntitlementGate(gated, undefined, true)).toBe(true)
     })
 })
+
+describe('Tool Filtering - Entitlements (activity log family)', () => {
+    // Guards the full YAML -> generated definitions -> getToolsForFeatures wire-up:
+    // a predicate-only test wouldn't catch the entitlement missing from the
+    // generated JSON for these specific tools.
+    it('hides audit-log tools for a cloud org without audit_logs, shows them with it', () => {
+        const withoutAudit = getToolsForFeatures({ availableFeatures: [], isCloud: true })
+        expect(withoutAudit).not.toContain('advanced-activity-logs-list')
+        expect(withoutAudit).not.toContain('advanced-activity-logs-filters')
+
+        const withAudit = getToolsForFeatures({ availableFeatures: ['audit_logs'], isCloud: true })
+        expect(withAudit).toContain('advanced-activity-logs-list')
+        expect(withAudit).toContain('advanced-activity-logs-filters')
+
+        // Fail-open: unresolved entitlements still advertise.
+        const unknown = getToolsForFeatures({ isCloud: true })
+        expect(unknown).toContain('advanced-activity-logs-list')
+    })
+})

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -10,6 +10,7 @@ import {
     getRequiredFeatureFlags,
     getToolsForFeatures,
     type ToolDefinition,
+    toolPassesEntitlementGate,
     toolPassesFlagGate,
 } from '@/tools/toolDefinitions'
 import type { Context } from '@/tools/types'
@@ -878,5 +879,32 @@ describe('Tool Filtering - Feature Flags', () => {
             expect(toolsOff).toContain('old-tool-v1')
             expect(toolsOff).toContain('unrelated-tool')
         })
+    })
+})
+
+describe('toolPassesEntitlementGate', () => {
+    const gated = { feature_entitlement: 'audit_logs' } as ToolDefinition
+    const ungated = {} as ToolDefinition
+
+    it('passes tools with no feature_entitlement regardless of features', () => {
+        expect(toolPassesEntitlementGate(ungated, [], true)).toBe(true)
+        expect(toolPassesEntitlementGate(ungated, undefined, true)).toBe(true)
+    })
+
+    it('passes when the org has the entitlement on cloud', () => {
+        expect(toolPassesEntitlementGate(gated, ['audit_logs', 'sso'], true)).toBe(true)
+    })
+
+    it('hides when cloud org positively lacks the entitlement', () => {
+        expect(toolPassesEntitlementGate(gated, ['sso'], true)).toBe(false)
+        expect(toolPassesEntitlementGate(gated, [], true)).toBe(false)
+    })
+
+    it('fails open on self-hosted (isCloud false)', () => {
+        expect(toolPassesEntitlementGate(gated, [], false)).toBe(true)
+    })
+
+    it('fails open when entitlements are unknown', () => {
+        expect(toolPassesEntitlementGate(gated, undefined, true)).toBe(true)
     })
 })


### PR DESCRIPTION
## Problem

Activity-log MCP tools are advertised to every org, but the underlying API is plan-gated behind `AUDIT_LOGS`, so orgs without that entitlement get a 402 on every call.
A large share of `activity-log-list` calls fail this way today.

## Changes

- Add a reusable `feature_entitlement` gate for MCP tools, mirroring the existing feature-flag gate
- Resolve an org's plan entitlements at request time from data the server already fetches, no extra API call
- Hide entitlement-gated tools from unentitled cloud orgs; fail open on self-hosted or when entitlements can't be resolved
- Gate the activity-log tool family on the `AUDIT_LOGS` entitlement
- Keep the backend permission authoritative, so the gate only trims advertising noise

> [!IMPORTANT]
> Follow-up: the activity-log tool family will be deduped and cleaned up in a separate PR.

## How did you test this code?

- Added unit tests for the gate predicate, entitlement resolution, and end-to-end tool filtering, covering the fail-open paths. Full MCP unit and hono suites pass.
- The one generated definitions file was applied by hand because local codegen needs the backend, and CI's OpenAPI build re-verifies it.
- Agent-authored (agent-assisted, human-directed); only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected; the gate is transparent to end users.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code) did the implementation.

- Started from an investigation of a high 402 rate on the activity-log MCP tools and traced it to plan-gating (`AUDIT_LOGS` via the premium-feature permission), not a handler bug or an observability gap.
- Chose a reusable entitlement gate that mirrors the existing feature-flag gate over a one-off fix, because the whole activity-log tool family shares the same gating.
- Fail-open was deliberate: the gate is advertising noise-reduction and the backend permission stays authoritative, so self-hosted, impersonation, and unresolved-entitlement cases advertise rather than hide.
- Skills invoked: brainstorming, writing-plans, subagent-driven-development (a fresh implementer plus reviewer per task), and creating-pull-requests. No DRF or migration skills were needed since this stays in the MCP layer and touches no serializers, viewsets, or migrations.