### PR TITLE
fix(tasks): stop Slack relay striking through "approximately" tildes

### DIFF
--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -40,6 +40,18 @@ _RE_LINK_TRAILING_MARKER = re.compile(r"(?<![*_~])(\*+|_+|~+)<([^<>]+?)\1>(?![*_
 # left alone.
 _RE_BARE_URL_IN_EMPHASIS = re.compile(r"(?<![*_~])(\*+|_+|~+)(https?://[^\s<>]+?)\1(?![*_~])")
 
+# A lone ``~`` directly in front of a quantity (``~$36k``, ``~2pm``, ``~10%``) is the agent
+# writing "approximately". In Markdown a single tilde is a literal character, but Slack mrkdwn
+# uses a single tilde as its strikethrough delimiter, so two such approximations on one line
+# pair up and strike through everything between them. The negative lookbehind skips the first
+# ``~`` of a ``~~strikethrough~~`` run (its neighbour is a tilde, not a quantity), and the
+# lookahead leaves paths (``~/dir``) and standalone tildes alone.
+_RE_APPROX_TILDE = re.compile(r"(?<!~)~(?=[$€£¥₹]?\d)")
+
+# Unicode "tilde operator" — visually a tilde, but not the ASCII strikethrough delimiter, so
+# Slack renders it literally.
+_APPROX_TILDE = "∼"
+
 
 class _RelayAlreadyRecorded(Exception):
     """Raised when a relay was already recorded while holding the row lock."""
@@ -52,13 +64,13 @@ def _markdown_to_slack_mrkdwn(text: str) -> str:
     Slack ``mrkdwn`` is rendered in a proportional font — pipe-separated rows do
     not line up. A fenced code block forces monospace and the columns align.
 
-    Misplaced link markers (e.g. ``**<url**>``) and bare URLs wrapped in
-    emphasis (e.g. ``**https://example.com**``) are normalized first so the
-    converter sees well-formed input.
+    Misplaced link markers (e.g. ``**<url**>``), bare URLs wrapped in emphasis
+    (e.g. ``**https://example.com**``), and "approximately" tildes (e.g. ``~$36k``)
+    are normalized first so the converter sees well-formed input.
     """
     if not text:
         return text
-    repaired = _wrap_bare_urls_in_emphasis(_repair_link_trailing_markers(text))
+    repaired = _neutralize_approx_tildes(_wrap_bare_urls_in_emphasis(_repair_link_trailing_markers(text)))
     return _CONVERTER.convert(_tables_to_fenced_code_blocks(repaired))
 
 
@@ -82,6 +94,18 @@ def _wrap_bare_urls_in_emphasis(text: str) -> str:
     are left untouched because the URL group rejects ``<`` and ``[``.
     """
     return _RE_BARE_URL_IN_EMPHASIS.sub(r"\1<\2>\1", text)
+
+
+def _neutralize_approx_tildes(text: str) -> str:
+    """Replace "approximately" tildes in front of a quantity with the tilde operator.
+
+    ``~$36k`` / ``~2pm`` / ``~10%`` becomes ``∼$36k`` / ``∼2pm`` / ``∼10%``. The agent
+    means "approximately", but Slack mrkdwn reads a single ``~`` as a strikethrough
+    delimiter, so two of them on one line strike through the text in between. The tilde
+    operator looks the same and carries no formatting meaning. ``~~strikethrough~~``,
+    paths (``~/dir``), and standalone tildes are left alone.
+    """
+    return _RE_APPROX_TILDE.sub(_APPROX_TILDE, text)
 
 
 def _tables_to_fenced_code_blocks(text: str) -> str:

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -40,17 +40,24 @@ _RE_LINK_TRAILING_MARKER = re.compile(r"(?<![*_~])(\*+|_+|~+)<([^<>]+?)\1>(?![*_
 # left alone.
 _RE_BARE_URL_IN_EMPHASIS = re.compile(r"(?<![*_~])(\*+|_+|~+)(https?://[^\s<>]+?)\1(?![*_~])")
 
-# A lone ``~`` directly in front of a quantity (``~$36k``, ``~2pm``, ``~10%``) is the agent
-# writing "approximately". In Markdown a single tilde is a literal character, but Slack mrkdwn
-# uses a single tilde as its strikethrough delimiter, so two such approximations on one line
-# pair up and strike through everything between them. The negative lookbehind skips the first
-# ``~`` of a ``~~strikethrough~~`` run (its neighbour is a tilde, not a quantity), and the
-# lookahead leaves paths (``~/dir``) and standalone tildes alone.
-_RE_APPROX_TILDE = re.compile(r"(?<!~)~(?=[$€£¥₹]?\d)")
+# A ``~`` on a word boundary directly in front of a quantity (``~$36k``, ``~2pm``, ``~10%``)
+# is the agent writing "approximately". In Markdown a single tilde is a literal character, but
+# Slack mrkdwn uses a single tilde as its strikethrough delimiter, so two such approximations
+# on one line pair up and strike through everything between them. The lookbehind requires a
+# non-word, non-tilde char before the tilde so a git ref (``HEAD~1``), a range (``5~10``), and
+# the first ``~`` of a ``~~strikethrough~~`` run are left alone; the lookahead leaves paths
+# (``~/dir``) and standalone tildes alone.
+_RE_APPROX_TILDE = re.compile(r"(?<![\w~])~(?=[$€£¥₹]?\d)")
 
 # Unicode "tilde operator" — visually a tilde, but not the ASCII strikethrough delimiter, so
 # Slack renders it literally.
 _APPROX_TILDE = "∼"
+
+# Fenced blocks and inline code spans, kept whole so the tilde substitution skips them: inside
+# a code span Slack has no strikethrough semantics anyway, and rewriting ``~`` there would alter
+# literal content (``HEAD~1``, npm ranges like ``~1.2.0``). Triple backticks are matched before
+# the single-backtick form so a fence isn't split at its inner backticks.
+_RE_CODE_SEGMENT = re.compile(r"(```[\s\S]*?```|`[^`\n]*`)")
 
 
 class _RelayAlreadyRecorded(Exception):
@@ -103,9 +110,15 @@ def _neutralize_approx_tildes(text: str) -> str:
     means "approximately", but Slack mrkdwn reads a single ``~`` as a strikethrough
     delimiter, so two of them on one line strike through the text in between. The tilde
     operator looks the same and carries no formatting meaning. ``~~strikethrough~~``,
-    paths (``~/dir``), and standalone tildes are left alone.
+    git refs (``HEAD~1``), paths (``~/dir``), and standalone tildes are left alone, and
+    code spans/fences are skipped so literal code is never rewritten.
     """
-    return _RE_APPROX_TILDE.sub(_APPROX_TILDE, text)
+    # ``re.split`` with a capturing group yields alternating text/code segments; the odd
+    # (code) segments pass through untouched.
+    return "".join(
+        segment if index % 2 else _RE_APPROX_TILDE.sub(_APPROX_TILDE, segment)
+        for index, segment in enumerate(_RE_CODE_SEGMENT.split(text))
+    )
 
 
 def _tables_to_fenced_code_blocks(text: str) -> str:

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -18,6 +18,7 @@ from products.tasks.backend.temporal.slack_relay.activities import (
     SLACK_MESSAGE_TEXT_LIMIT,
     RelaySlackMessageInput,
     _markdown_to_slack_mrkdwn,
+    _neutralize_approx_tildes,
     _repair_link_trailing_markers,
     _split_markdown_for_slack,
     _wrap_bare_urls_in_emphasis,
@@ -153,6 +154,14 @@ class TestMarkdownToSlackMrkdwn(unittest.TestCase):
             ("italic_underscore", "_italic_", "_italic_"),
             ("bold_italic", "***boldit***", "*_boldit_*"),
             ("strikethrough", "~~removed~~", "~removed~"),
+            # "Approximately" tildes in front of a quantity would otherwise pair up as
+            # Slack strikethrough delimiters and strike through the text between them.
+            # The tilde operator (∼) looks the same but carries no formatting meaning.
+            (
+                "approx_tildes_do_not_strike_through",
+                "**~$36.0k**, averaging **~$5.1k/day** by ~2pm",
+                "*∼$36.0k*, averaging *∼$5.1k/day* by ∼2pm",
+            ),
             ("link", "[Click here](https://example.com)", "<https://example.com|Click here>"),
             ("h1", "# Title", "*Title*"),
             ("h3", "### Section", "*Section*"),
@@ -298,6 +307,30 @@ class TestWrapBareUrlsInEmphasis(unittest.TestCase):
     )
     def test_wrap(self, _name, text, expected):
         assert _wrap_bare_urls_in_emphasis(text) == expected
+
+
+class TestNeutralizeApproxTildes(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("dollar", "~$36.0k", "∼$36.0k"),
+            ("bare_number", "~5.1k/day", "∼5.1k/day"),
+            ("time", "roughly ~2pm PT", "roughly ∼2pm PT"),
+            ("percent", "up ~10% MoM", "up ∼10% MoM"),
+            ("euro", "~€40", "∼€40"),
+            ("multiple_on_one_line", "~$5k then ~$9k", "∼$5k then ∼$9k"),
+            # A genuine ``~~strikethrough~~`` run must survive untouched — its tildes are
+            # adjacent to each other, not to a quantity.
+            ("strikethrough_run_preserved", "~~$5 off~~", "~~$5 off~~"),
+            # Paths, standalone tildes, and non-quantity tildes are literal characters that
+            # never form an accidental strikethrough, so they are left alone.
+            ("path_left_alone", "see ~/notes/report.md", "see ~/notes/report.md"),
+            ("tilde_before_letter_left_alone", "~foo", "~foo"),
+            ("tilde_before_space_left_alone", "~ $5", "~ $5"),
+            ("plain_text_unchanged", "no tildes here", "no tildes here"),
+        ]
+    )
+    def test_neutralize(self, _name, text, expected):
+        assert _neutralize_approx_tildes(text) == expected
 
 
 class TestSplitTextForSlack(TestCase):

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -321,12 +321,24 @@ class TestNeutralizeApproxTildes(unittest.TestCase):
             # A genuine ``~~strikethrough~~`` run must survive untouched — its tildes are
             # adjacent to each other, not to a quantity.
             ("strikethrough_run_preserved", "~~$5 off~~", "~~$5 off~~"),
+            # A tilde glued to a preceding word is a git ref or range, not "approximately".
+            ("git_ref_left_alone", "rebase onto HEAD~2", "rebase onto HEAD~2"),
+            ("numeric_range_left_alone", "5~10 items", "5~10 items"),
             # Paths, standalone tildes, and non-quantity tildes are literal characters that
             # never form an accidental strikethrough, so they are left alone.
             ("path_left_alone", "see ~/notes/report.md", "see ~/notes/report.md"),
             ("tilde_before_letter_left_alone", "~foo", "~foo"),
             ("tilde_before_space_left_alone", "~ $5", "~ $5"),
             ("plain_text_unchanged", "no tildes here", "no tildes here"),
+            # Code spans/fences hold literal content Slack never strikes through, so a tilde
+            # there stays ASCII even when it looks like an approximation.
+            ("inline_code_left_alone", "run `git reset HEAD~1` and `~$5`", "run `git reset HEAD~1` and `~$5`"),
+            (
+                "fenced_block_left_alone",
+                "```\ninstall foo@~1.2.0\ncost ~$5\n```",
+                "```\ninstall foo@~1.2.0\ncost ~$5\n```",
+            ),
+            ("approx_outside_code_still_converted", "about ~$5 for `~$9`", "about ∼$5 for `~$9`"),
         ]
     )
     def test_neutralize(self, _name, text, expected):


### PR DESCRIPTION
## Problem

The `posthog_code` Slack agent kept rendering chunks of its own replies with ~~strikethrough~~. The agent writes "approximately" as a lone `~` before a number (`~$36k`, `~2pm`, `~10%`). Markdown treats that as a literal tilde, but Slack mrkdwn reads a single `~` as a strikethrough delimiter, so two of them on one line strike through everything in between.

[Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783370942471969)

Looking forward moving to new slack agent design which supports the markdown :D

## Changes

Added a repair pass in the Slack relay converter that maps the approximately-tilde to the Unicode tilde operator `∼` (looks the same, not a delimiter). Genuine `~~strikethrough~~`, paths like `~/dir`, and standalone tildes are left alone.

## How did you test this code?

Added a regression case at the `_markdown_to_slack_mrkdwn` level plus a focused `TestNeutralizeApproxTildes` unit class. Full slack_relay suite: 72 passed, ruff clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) traced the reported message through the tasks `slack_relay` activity and confirmed the `markdown_to_mrkdwn` library passes lone tildes through untouched. Considered a zero-width-space escape to keep the ASCII `~`, but rejected it since Slack has no escape char and I couldn't verify it against the real renderer. The Unicode `∼` swap is guaranteed correct regardless of Slack's tokenizer. Same latent bug exists in the agent_platform TS and conversations converters, left out of scope.
