### PR TITLE
perf(sharing): short-circuit whitelabel feature check

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -939,8 +939,9 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 
-        available_features = resource.team.organization.available_product_features or []
-        if "whitelabel" in request.GET and "white_labelling" in [feature["key"] for feature in available_features]:
+        if "whitelabel" in request.GET and resource.team.organization.is_feature_available(
+            AvailableFeature.WHITE_LABELLING
+        ):
             exported_data.update({"whitelabel": True})
 
         if isinstance(resource, SharingConfiguration) and resource.password_required:


### PR DESCRIPTION
## Problem

The shared dashboard/insight view (`SharingViewerData.retrieve`) checks for the whitelabel feature by building a full list of all the org's product feature keys just to test membership:

```python
available_features = resource.team.organization.available_product_features or []
if "whitelabel" in request.GET and "white_labelling" in [feature["key"] for feature in available_features]:
```

This runs on every shared page view, and the same file already uses the idiomatic helper everywhere else.

## Changes

Replace the hand-rolled membership test with `organization.is_feature_available(AvailableFeature.WHITE_LABELLING)`, which short-circuits on the first match and handles the `None` case. Semantics are identical; the password-protected branch a few lines below already does exactly this.

## How did you test this code?

Ran `hogli test posthog/api/test/test_sharing.py`: 71 passed, and the 2 failures (`test_refresh_token_grace_period`, `test_should_not_get_deleted_item`) fail identically on master without this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, no behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude via PostHog Code) found this while sweeping hot endpoints for avoidable list materialization. Invoked the /improving-drf-endpoints skill before editing per repo rules; no schema or serializer changes were needed since this is a method-body-only change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*