### PR TITLE
fix(data-imports): stringify mixed list/scalar columns instead of crashing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -131,6 +131,23 @@ def test_table_from_py_list_inconsistent_types_with_str_and_dict():
     )
 
 
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        # bool in one row, list in another: wrapping to a list yields [true]/["x"], whose element
+        # types differ, so an intermediate pyarrow list array would raise "tried to convert to boolean".
+        ([{"column": True}, {"column": ["x"]}], ["[true]", '["x"]']),
+        # dict in one row, list in another: would raise "cannot mix struct and non-struct values".
+        ([{"column": {"a": 1}}, {"column": ["x"]}], ['[{"a":1}]', '["x"]']),
+    ],
+)
+def test_table_from_py_list_list_mixed_with_incompatible_element_types(rows, expected):
+    table = table_from_py_list(rows)
+
+    assert table.equals(pa.table({"column": expected}))
+    assert table.schema.equals(pa.schema([("column", pa.string())]))
+
+
 def test_table_from_py_list_with_lists():
     table = table_from_py_list([{"column": ["hello"]}, {"column": ["hi"]}])
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -1121,14 +1121,20 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
                         field_index, arrow_schema.field(field_index).with_type(overflow_arr.type)
                     )
 
-        # If one type is a list, then make everything into a list
+        # If one type is a list, wrap scalars into single-element lists and JSON-stringify the column.
+        # Element types can differ across rows (e.g. a WordPress field returned as a bool in one row
+        # and an object in another), which no single pyarrow list type can hold, so serialize directly
+        # rather than via an intermediate list array that would raise ArrowInvalid on the mismatch.
         if len(unique_types_in_column) > 1 and list in unique_types_in_column:
-            list_array = pa.array(
-                [s if isinstance(s, list) else [s] for s in _to_list_array(columnar_table_data[field_name])]
+            json_array = pa.array(
+                [
+                    None if s is None else _json_dumps(s if isinstance(s, list) else [s])
+                    for s in _to_list_array(columnar_table_data[field_name])
+                ]
             )
-            columnar_table_data[field_name] = list_array
-            py_type = list
-            unique_types_in_column = {list}
+            columnar_table_data[field_name] = json_array
+            py_type = str
+            unique_types_in_column = {str}
             if arrow_schema:
                 arrow_schema = arrow_schema.set(field_index, arrow_schema.field(field_index).with_type(pa.string()))
 


### PR DESCRIPTION
## Problem

A WordPress data-warehouse import was failing with `ArrowInvalid: Could not convert '<a url>' with type str: tried to convert to boolean` (and a sibling `cannot mix struct and non-struct, non-null values`). Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3bb4-39ce-7c03-a668-9d981a60cba6

The stack originates in the WordPress source (`get_rows` → `batcher.get_table()`) but the actual crash is in the shared data-imports batch converter, `table_from_py_list` → `_process_batch`.

WordPress's REST API returns polymorphic JSON: a field can be a list in one row and a scalar in another (a bool or an object, often from SEO/plugin fields). When a column mixes a `list` with another type, `_process_batch` wraps each scalar into a single-element list and then builds an intermediate pyarrow list array before JSON-stringifying the column. pyarrow cannot infer a single list element type when the wrapped rows differ (for example `[true]` next to `["...url..."]`, or `[{...}]` next to `["...url..."]`), so it raises `ArrowInvalid` and the whole sync dies.

This is a fixable robustness bug in our code, not a user or upstream error. The final representation for these columns was already a JSON string, so the intermediate list array was pointless and was the only thing that could crash.

## Changes

In the "one type is a list" branch of `_process_batch`, serialize the wrapped values straight to JSON strings instead of routing them through an intermediate pyarrow list array. Scalars are still wrapped into single-element lists first, so the output is identical to what the branch already produced for the cases that worked (a string like `"hello"` becomes `'["hello"]'`). Heterogeneous element types across rows no longer raise, since JSON serialization does not care that one row is a bool and another an object.

## How did you test this code?

Automated only. I (Claude) did not run the live import.

- Added a parameterized case to `test_pipeline_utils.py::test_table_from_py_list_list_mixed_with_incompatible_element_types` covering the two crash shapes: a `bool` mixed with a `list`, and a `dict` mixed with a `list`. Neither was covered before. The existing `test_table_from_py_list_inconsistent_list` only mixes `str` and `list`, whose wrapped element types match, so pyarrow's intermediate array happened to succeed and the crash path went untested.
- Confirmed the new test fails on master with the exact production error (`cannot mix struct and non-struct, non-null values` / `tried to convert to boolean`) and passes with the fix.
- Full `test_pipeline_utils.py` suite passes (100 tests), ruff check and format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the WordPress import source. I (Claude) pulled the issue, read the stack end to end, and traced it from the WordPress source into the shared batch converter. The failure is generic to any source that emits polymorphic list/scalar columns, and a per-record WordPress-side fix cannot solve it (the offending field looks like a valid scalar in the row where it is a scalar, so the mismatch is only visible across the whole batch). So the fix lives at the shared layer where the batch is materialized.

Invoked the `/writing-tests` skill before adding the regression test. Considered a broader normalization pass but kept the change scoped to the single crashing branch, preserving the existing JSON-string output for the cases that already worked.
