### PR TITLE
fix(shopify): tolerate a trailing dot in the store subdomain

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -290,6 +290,9 @@ def normalize_store_id(raw: str) -> str:
         store_id = store_id.removeprefix("admin.shopify.com/store/")
     # Drop any path/query/fragment that rode along with a pasted URL.
     store_id = store_id.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    # A trailing dot (FQDN form, e.g. "my-store.myshopify.com.") otherwise defeats the suffix
+    # strip below and leaves a value the subdomain regex rejects.
+    store_id = store_id.rstrip(".")
     # Strip the domain suffix, looping to collapse an accidental double suffix.
     while store_id.endswith(".myshopify.com"):
         store_id = store_id.removesuffix(".myshopify.com")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_store_id.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_store_id.py
@@ -21,6 +21,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.sh
         ("https://admin.shopify.com/store/my-store/products", "my-store"),
         # Accidental double suffix collapses back to the bare subdomain.
         ("my-store.myshopify.com.myshopify.com", "my-store"),
+        # A trailing dot (FQDN form) is tolerated rather than rejected.
+        ("my-store.myshopify.com.", "my-store"),
+        ("https://my-store.myshopify.com./", "my-store"),
         ("store123", "store123"),
     ],
 )


### PR DESCRIPTION
## Problem

`normalize_store_id` reduces whatever the user pastes into the Shopify store id field down to the bare subdomain, since the value is interpolated into `https://{}.myshopify.com/...`. It handles a scheme, a path, and the `.myshopify.com` suffix, but the suffix strip used an exact `endswith(".myshopify.com")` check. A value carrying a trailing dot (valid FQDN form, e.g. `my-store.myshopify.com.`) slips past that check, so the suffix never gets removed and the subdomain regex then rejects the whole thing. The user gets an "invalid store id" error for what is really a well-formed store domain with one stray character.

This was a source-creation failure in the new-source wizard.

## Changes

Strip trailing dots before the suffix-stripping loop, so FQDN-style values normalize to the bare subdomain like every other accepted paste form. One line, plus two parameterized test cases (a bare trailing-dot domain and a URL variant) covering the paths that previously raised.

## How did you test this code?

I (Claude) added the two cases to the existing `test_normalize_store_id_accepts_common_paste_forms` parameterization and ran the Shopify store-id test module locally — all pass. The new cases guard the regression directly: revert the trailing-dot strip and they fail with the same `ValueError` the user hit. Ran `ruff check` and `ruff format` over the touched files (clean). No manual wizard testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code while triaging real Shopify new-source creation failures. The failing value was a store domain with a trailing dot, which I traced to `normalize_store_id`'s exact-match suffix strip. Confirmed the function already intends to accept "whatever the user pasted," so tolerating the trailing dot fits its contract rather than expanding scope. Invoked the `/writing-tests` skill before adding the cases and folded them into the existing parameterized test instead of new test functions.
