### PR TITLE
fix(data-warehouse): v3 loader outage hardening — visibility, concurrency, tunables, fail-fast

### DIFF
--- a/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
@@ -178,6 +178,7 @@ class Command(BaseCommand):
             connect_timeout=config.connect_timeout_seconds,
             lease_ttl=config.lease_ttl_seconds,
             recovery_grace=config.recovery_grace_seconds,
+            poll_failure_liveness_threshold=config.poll_failure_liveness_threshold,
         )
 
         health_state = HealthState(timeout_seconds=health_timeout)

--- a/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
@@ -47,6 +47,8 @@ def build_consumer_config(options: dict) -> ConsumerConfig:
         kwargs["lease_ttl_seconds"] = options["lease_ttl"]
     if options.get("recovery_grace") is not None:
         kwargs["recovery_grace_seconds"] = options["recovery_grace"]
+    if options.get("poll_failure_liveness_threshold") is not None:
+        kwargs["poll_failure_liveness_threshold"] = options["poll_failure_liveness_threshold"] or None
     return ConsumerConfig(**kwargs)
 
 
@@ -145,6 +147,16 @@ class Command(BaseCommand):
             type=int,
             default=None,
             help="Seconds an executing batch may go without a heartbeat before the recovery sweep re-queues it",
+        )
+        parser.add_argument(
+            "--poll-failure-liveness-threshold",
+            type=int,
+            default=None,
+            help=(
+                "Stop reporting liveness after this many consecutive failed polls, so a pod that can no "
+                "longer claim work becomes a visible restart instead of a silent zero-throughput loop. "
+                "0 disables the trip"
+            ),
         )
 
     def handle(self, *args, **options):

--- a/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py
@@ -22,6 +22,34 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 logger = structlog.get_logger(__name__)
 
 
+def build_consumer_config(options: dict) -> ConsumerConfig:
+    """Translate CLI options into a ConsumerConfig.
+
+    Ceiling flags map 0 to None (disabled); unset flags keep the dataclass defaults.
+    """
+    kwargs: dict = {
+        "database_url": WAREHOUSE_SOURCES_DATABASE_URL,
+        "max_concurrency": options["max_concurrency"],
+        "poll_interval_seconds": options["poll_interval"],
+        "poll_limit": options["poll_limit"],
+        "max_attempts": options["max_attempts"],
+        "health_port": options["health_port"],
+        "health_timeout_seconds": options["health_timeout"],
+        "stuck_batch_timeout_seconds": options["stuck_batch_timeout"] or None,
+    }
+    if options.get("poll_timeout") is not None:
+        kwargs["poll_timeout_seconds"] = options["poll_timeout"] or None
+    if options.get("sweep_timeout") is not None:
+        kwargs["sweep_timeout_seconds"] = options["sweep_timeout"] or None
+    if options.get("connect_timeout") is not None:
+        kwargs["connect_timeout_seconds"] = options["connect_timeout"]
+    if options.get("lease_ttl") is not None:
+        kwargs["lease_ttl_seconds"] = options["lease_ttl"]
+    if options.get("recovery_grace") is not None:
+        kwargs["recovery_grace_seconds"] = options["recovery_grace"]
+    return ConsumerConfig(**kwargs)
+
+
 async def _run_consumer(config: ConsumerConfig, health_reporter) -> None:
     """Configure the Temporal-style produce path then run the consumer.
 
@@ -86,22 +114,44 @@ class Command(BaseCommand):
                 "0 disables the watchdog (default: 7200.0)"
             ),
         )
+        # Omitted flags keep the ConsumerConfig defaults (single source of truth);
+        # exposed so a degraded fleet can be retuned without a code deploy.
+        parser.add_argument(
+            "--poll-timeout",
+            type=float,
+            default=None,
+            help="Seconds before a claim poll is abandoned and retried on a fresh connection. 0 disables the ceiling",
+        )
+        parser.add_argument(
+            "--sweep-timeout",
+            type=float,
+            default=None,
+            help="Seconds before a recovery/reconcile sweep is abandoned. 0 disables the ceiling",
+        )
+        parser.add_argument(
+            "--connect-timeout",
+            type=int,
+            default=None,
+            help="Seconds before a queue-DB connection attempt fails",
+        )
+        parser.add_argument(
+            "--lease-ttl",
+            type=int,
+            default=None,
+            help="Group-lease validity window in seconds (defaults to --recovery-grace)",
+        )
+        parser.add_argument(
+            "--recovery-grace",
+            type=int,
+            default=None,
+            help="Seconds an executing batch may go without a heartbeat before the recovery sweep re-queues it",
+        )
 
     def handle(self, *args, **options):
         health_port = options["health_port"]
         health_timeout = options["health_timeout"]
-        stuck_batch_timeout = options["stuck_batch_timeout"] or None
 
-        config = ConsumerConfig(
-            database_url=WAREHOUSE_SOURCES_DATABASE_URL,
-            max_concurrency=options["max_concurrency"],
-            poll_interval_seconds=options["poll_interval"],
-            poll_limit=options["poll_limit"],
-            max_attempts=options["max_attempts"],
-            health_port=health_port,
-            health_timeout_seconds=health_timeout,
-            stuck_batch_timeout_seconds=stuck_batch_timeout,
-        )
+        config = build_consumer_config(options)
 
         logger.info(
             "warehouse_sources_load_starting",
@@ -110,7 +160,12 @@ class Command(BaseCommand):
             poll_limit=config.poll_limit,
             max_attempts=config.max_attempts,
             health_port=health_port,
-            stuck_batch_timeout=stuck_batch_timeout,
+            stuck_batch_timeout=config.stuck_batch_timeout_seconds,
+            poll_timeout=config.poll_timeout_seconds,
+            sweep_timeout=config.sweep_timeout_seconds,
+            connect_timeout=config.connect_timeout_seconds,
+            lease_ttl=config.lease_ttl_seconds,
+            recovery_grace=config.recovery_grace_seconds,
         )
 
         health_state = HealthState(timeout_seconds=health_timeout)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -81,6 +81,9 @@ class BatchConsumerConfig:
     # has been executing longer than this, so a wedged sink connection turns into
     # a liveness-probe restart instead of an indefinite, invisible stall.
     stuck_batch_timeout_seconds: float | None = None
+    # Withhold liveness after this many consecutive failed polls: a pod that
+    # cannot poll does no work but would otherwise pass liveness forever.
+    poll_failure_liveness_threshold: int | None = 10
 
     def __post_init__(self) -> None:
         if self.recovery_grace_seconds is None:
@@ -235,6 +238,9 @@ class BatchConsumer:
         # batch_id -> monotonic start, for the stuck-batch watchdog.
         self._inflight_started: dict[str, float] = {}
         self._last_stuck_log_monotonic = 0.0
+        # Consecutive failed polls, for the poll-failure liveness trip.
+        self._consecutive_poll_failures = 0
+        self._last_poll_failure_log_monotonic = 0.0
 
     @property
     def _lease_ttl_seconds(self) -> int:
@@ -337,15 +343,19 @@ class BatchConsumer:
                     logger.error(  # noqa: TRY400
                         self._event("poll_timed_out"),
                         timeout_seconds=self._config.poll_timeout_seconds,
+                        consecutive_failures=self._consecutive_poll_failures + 1,
                     )
+                    self._note_poll_failure("timeout", duration=time.monotonic() - poll_start)
                     await self._drop_conn("_poll_conn")
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
                     continue
                 except psycopg.OperationalError as e:
                     logger.exception(self._event("poll_failed_queue_db_unreachable"))
                     capture_exception(e)
+                    self._note_poll_failure("db_unreachable", duration=time.monotonic() - poll_start)
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
                     continue
+                self._consecutive_poll_failures = 0
                 poll_duration = time.monotonic() - poll_start
                 self._metrics.poll_duration_seconds.observe(poll_duration)
                 self._metrics.poll_batches_fetched.observe(len(batches))
@@ -859,15 +869,35 @@ class BatchConsumer:
             limit=self._config.reconcile_limit,
         )
 
+    def _note_poll_failure(self, reason: str, *, duration: float) -> None:
+        """Record a failed poll: the success path never reaches the poll histograms,
+        so without this a fleet whose polls all fail looks healthier than a slow one."""
+        self._consecutive_poll_failures += 1
+        self._metrics.poll_failures_total.labels(reason=reason).inc()
+        self._metrics.poll_duration_seconds.observe(duration)
+
     def _report_health(self) -> None:
-        """Report liveness, unless the stuck-batch watchdog has tripped.
+        """Report liveness, unless the stuck-batch watchdog or the poll-failure trip fired.
 
         Withholding the report makes the health server's timeout fail the liveness
         probe, so Kubernetes restarts the pod and the recovery sweep reassigns the
         wedged batch -- a sync thread blocked on a dead sink connection cannot be
         cancelled from the event loop, so a restart is the only real remedy.
+        Likewise for polling: a pod whose polls all fail does no work but would
+        otherwise report healthy forever.
         """
         if self._health_reporter is None:
+            return
+        threshold = self._config.poll_failure_liveness_threshold
+        if threshold is not None and self._consecutive_poll_failures >= threshold:
+            now = time.monotonic()
+            if now - self._last_poll_failure_log_monotonic > 60:
+                self._last_poll_failure_log_monotonic = now
+                logger.error(
+                    self._event("poll_failure_liveness_tripped"),
+                    consecutive_failures=self._consecutive_poll_failures,
+                    threshold=threshold,
+                )
             return
         timeout = self._config.stuck_batch_timeout_seconds
         if timeout is not None and self._inflight_started:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -200,6 +200,12 @@ class BatchConsumerAdapter(Protocol):
         batch: PendingBatch,
     ) -> bool: ...
 
+    def is_retryable_error(self, err: Exception) -> bool:
+        """Whether a processing error can plausibly succeed on retry — deterministic
+        data/config errors fail identically every attempt, so retrying only delays
+        the run's terminal state."""
+        ...
+
     async def after_batch_processed(
         self,
         conn: psycopg.AsyncConnection[Any],
@@ -772,7 +778,18 @@ class BatchConsumer:
         status_conn: psycopg.AsyncConnection[Any],
     ) -> None:
         """Write the retry/terminal state after a processing error."""
-        if attempt >= self._config.max_attempts:
+        if not self._adapter.is_retryable_error(err):
+            # Deterministic failure: retrying repeats the same outcome. The raw
+            # message is the customer-visible latest_error, so keep it unwrapped.
+            logger.exception(
+                self._event("batch_failed_non_retryable"),
+                batch_id=batch.id,
+                run_uuid=batch.run_uuid,
+                attempt=attempt,
+            )
+            capture_exception(err)
+            await self._fail_run(batch, reason=str(err), conn=lock_conn)
+        elif attempt >= self._config.max_attempts:
             logger.exception(
                 self._event("batch_failed_no_retries_left"),
                 batch_id=batch.id,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -377,6 +377,10 @@ class DuckgresBatchConsumerAdapter:
         if not batch.is_final_batch:
             await DuckgresBatchQueue.mark_applied(conn, batch=batch)
 
+    def is_retryable_error(self, err: Exception) -> bool:
+        # No known deterministic duckgres failure signatures yet; retry everything.
+        return True
+
 
 class DuckgresBatchConsumer(SharedBatchConsumer):
     """The shared engine plus the sink's lease-safety overrides, kept out of the

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -55,6 +55,15 @@ ConsumerConfig = BatchConsumerConfig
 # timeout so a degraded probe can't starve the reconcile sweep it rides on.
 FRESHNESS_PROBE_TIMEOUT_SECONDS = 30.0
 
+# Errors that fail identically on every attempt. Substring-matched because they
+# surface as generic exceptions; keep entries specific so transients can't match.
+NON_RETRYABLE_ERROR_PATTERNS: tuple[str, ...] = (
+    # delta-rs decimal precision overflow — the batch's data cannot fit the column
+    "is too large to store in a Decimal128",
+    # schema configured as incremental without a primary key — config error
+    "Primary key required for incremental syncs",
+)
+
 
 class DeltaBatchConsumerAdapter:
     log_prefix: str = ""
@@ -302,6 +311,10 @@ class DeltaBatchConsumerAdapter:
         batch: PendingBatch,
     ) -> bool:
         return True
+
+    def is_retryable_error(self, err: Exception) -> bool:
+        message = str(err)
+        return not any(pattern in message for pattern in NON_RETRYABLE_ERROR_PATTERNS)
 
     async def after_batch_processed(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -7,6 +7,7 @@ polling, retry, and recovery mechanics to the v3 batch consumer engine.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -33,6 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _group_by_key,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
+    FRESHNESS_WINDOW_SECONDS,
     BatchQueue,
     PendingBatch,
 )
@@ -48,6 +50,10 @@ from products.warehouse_sources_queue.backend.models import SourceBatchStatus
 logger = structlog.get_logger(__name__)
 
 ConsumerConfig = BatchConsumerConfig
+
+# Ceiling for the queue-freshness probe, deliberately far below the sweep
+# timeout so a degraded probe can't starve the reconcile sweep it rides on.
+FRESHNESS_PROBE_TIMEOUT_SECONDS = 30.0
 
 
 class DeltaBatchConsumerAdapter:
@@ -267,11 +273,22 @@ class DeltaBatchConsumerAdapter:
 
         This is the loader's data-freshness signal: it rises whenever loading
         stalls, no matter why — the alert on it fires even when every other
-        health signal looks green. Failures are swallowed-with-capture so a
-        broken probe can't take the reconcile sweep down with it.
+        health signal looks green. The probe has its own timeout so it cannot
+        eat the reconcile sweep's budget; on timeout the gauge saturates, since
+        a queue DB too degraded to measure freshness must read as stale. Other
+        failures are swallowed-with-capture so a broken probe can't take the
+        sweep down.
         """
         try:
-            age = await BatchQueue.get_oldest_unclaimed_batch_age_seconds(conn)
+            async with asyncio.timeout(FRESHNESS_PROBE_TIMEOUT_SECONDS):
+                age = await BatchQueue.get_oldest_unclaimed_batch_age_seconds(conn)
+        except TimeoutError:
+            logger.error(  # noqa: TRY400 — designed degraded path, traceback is noise
+                "queue_freshness_probe_timed_out",
+                timeout_seconds=FRESHNESS_PROBE_TIMEOUT_SECONDS,
+            )
+            OLDEST_UNCLAIMED_BATCH_SECONDS.set(FRESHNESS_WINDOW_SECONDS)
+            return
         except Exception as e:
             logger.exception("queue_freshness_probe_failed")
             capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -49,7 +49,8 @@ TAKEOVER_STALE_THRESHOLD_SECONDS = 6 * 60 * 60
 # Lookback for the queue-freshness probe. Bounds both the probe's cost and the
 # reported age: an unclaimed batch older than this saturates the gauge at the
 # window, which is already far past any sane alert threshold.
-FRESHNESS_WINDOW = "48 hours"
+FRESHNESS_WINDOW_SECONDS = 48 * 60 * 60
+FRESHNESS_WINDOW = f"{FRESHNESS_WINDOW_SECONDS} seconds"
 
 
 def pending_batch_select_columns(status_alias: str) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/load.py
@@ -25,4 +25,6 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 
 async def process_batch(batch: PendingBatch) -> None:
     """Load a single batch into Delta Lake, reusing the existing processor."""
-    await sync_to_async(process_message)(batch.to_export_signal())
+    # thread_sensitive=False: the default single-thread executor would cap the pod's
+    # real parallelism at 1; process_message is self-contained, so cross-thread is safe.
+    await sync_to_async(process_message, thread_sensitive=False)(batch.to_export_signal())

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/metrics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/metrics.py
@@ -38,6 +38,14 @@ POLL_DURATION_SECONDS = Histogram(
     buckets=POLL_DURATION_BUCKETS,
 )
 
+# Failed polls never reach the histograms above, so a fleet whose polls all
+# time out looks better on those — this counter is the alertable signal.
+POLL_FAILURES_TOTAL = Counter(
+    "warehouse_pg_consumer_poll_failures_total",
+    "Poll cycles that failed before returning batches",
+    labelnames=["reason"],
+)
+
 POLL_BATCHES_FETCHED = Histogram(
     "warehouse_pg_consumer_poll_batches_fetched",
     "Number of batches returned per poll cycle",
@@ -90,6 +98,7 @@ class ConsumerMetrics:
     runs_failed_total: Counter
     poll_duration_seconds: Histogram
     poll_batches_fetched: Histogram
+    poll_failures_total: Counter
     active_groups: Gauge
     recovery_sweeps_total: Counter
 
@@ -101,6 +110,7 @@ DELTA_CONSUMER_METRICS = ConsumerMetrics(
     runs_failed_total=RUNS_FAILED_TOTAL,
     poll_duration_seconds=POLL_DURATION_SECONDS,
     poll_batches_fetched=POLL_BATCHES_FETCHED,
+    poll_failures_total=POLL_FAILURES_TOTAL,
     active_groups=ACTIVE_GROUPS,
     recovery_sweeps_total=RECOVERY_SWEEPS_TOTAL,
 )
@@ -145,6 +155,11 @@ def make_consumer_metrics(prefix: str) -> ConsumerMetrics:
             f"{p}_poll_batches_fetched",
             "Number of batches returned per poll cycle",
             buckets=(0, 1, 5, 10, 25, 50, 100, 250, 500),
+        ),
+        poll_failures_total=Counter(
+            f"{p}_poll_failures_total",
+            "Poll cycles that failed before returning batches",
+            labelnames=["reason"],
         ),
         active_groups=Gauge(
             f"{p}_active_groups",

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _group_by_key,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
+    FRESHNESS_WINDOW_SECONDS,
     FailedRunRef,
     PendingBatch,
 )
@@ -528,6 +529,69 @@ class TestQueueOperationTimeouts:
             await asyncio.wait_for(run_task, timeout=5.0)
 
 
+class TestPollFailureLiveness:
+    def test_withholds_liveness_after_threshold_consecutive_failures(self):
+        # Without the trip, a pod whose every poll fails passes liveness forever.
+        calls: list[int] = []
+        consumer = _make_consumer(poll_failure_liveness_threshold=2)
+        consumer._health_reporter = lambda: calls.append(1)
+
+        consumer._report_health()
+        consumer._note_poll_failure("timeout", duration=1.0)
+        consumer._report_health()
+        assert len(calls) == 2  # one failure is below the threshold
+
+        consumer._note_poll_failure("timeout", duration=1.0)
+        consumer._report_health()
+        consumer._report_health()
+        assert len(calls) == 2  # tripped: heartbeat and poll-loop reports both withhold
+
+    @pytest.mark.asyncio
+    async def test_successful_poll_resets_the_failure_count(self):
+        # Only consecutive failures may trip the probe; without the reset a pod
+        # restarts after N failures spread across weeks of healthy operation.
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+            poll_timeout_seconds=0.05,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        succeeded = asyncio.Event()
+        fetch_calls = 0
+
+        async def fetch(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls <= 2:
+                await asyncio.sleep(3600)  # times out
+            succeeded.set()
+            return []
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=fetch,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            await asyncio.wait_for(succeeded.wait(), timeout=2.0)
+            assert consumer._consecutive_poll_failures == 0
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+
 class TestFailRun:
     @pytest.mark.asyncio
     async def test_does_not_raise_when_job_status_update_fails(self):
@@ -605,6 +669,36 @@ class TestReconcileFailedRuns:
             ):
                 await consumer._reconcile_failed_runs()
         assert OLDEST_UNCLAIMED_BATCH_SECONDS._value.get() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_hung_freshness_probe_saturates_gauge_and_reconcile_still_runs(self):
+        # A queue DB too degraded to measure freshness must read as stale, not
+        # pin the last good value — and the probe must not eat the sweep's budget.
+        consumer = _make_consumer()
+
+        async def hung_probe(*args: Any, **kwargs: Any) -> float:
+            await asyncio.sleep(3600)
+            return 0.0
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.FRESHNESS_PROBE_TIMEOUT_SECONDS",
+                0.05,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_oldest_unclaimed_batch_age_seconds",
+                side_effect=hung_probe,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_failed_runs",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_failed_runs,
+        ):
+            await asyncio.wait_for(consumer._reconcile_failed_runs(), timeout=2.0)
+
+        assert OLDEST_UNCLAIMED_BATCH_SECONDS._value.get() == FRESHNESS_WINDOW_SECONDS
+        mock_failed_runs.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_marks_non_terminal_run_failed(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -137,6 +137,35 @@ class TestProcessSingle:
 
         assert states == [SourceBatchStatus.State.EXECUTING, SourceBatchStatus.State.WAITING_RETRY]
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "20009.59457503306999908717 is too large to store in a Decimal128 of precision 24.",
+            "Primary key required for incremental syncs",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_non_retryable_error_fails_run_on_first_attempt(self, message: str):
+        # Deterministic data/config errors fail identically every attempt;
+        # retrying them wastes all attempts on every scheduled run.
+        consumer = _make_consumer(max_attempts=3)
+        batch = _make_batch(latest_attempt=0)
+        consumer._process_batch = AsyncMock(side_effect=ValueError(message))
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
+                new_callable=AsyncMock,
+            ) as mock_status,
+            patch.object(consumer, "_fail_run", new_callable=AsyncMock) as mock_fail,
+        ):
+            await consumer._process_single(batch)
+
+        mock_fail.assert_called_once()
+        assert mock_fail.call_args[1]["reason"] == message  # customer-visible error stays actionable
+        states = [call[1]["job_state"] for call in mock_status.call_args_list]
+        assert SourceBatchStatus.State.WAITING_RETRY not in states
+
     @pytest.mark.asyncio
     async def test_max_attempts_exceeded_fails_run(self):
         consumer = _make_consumer(max_attempts=3)

--- a/products/warehouse_sources/backend/tests/management/test_run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/tests/management/test_run_warehouse_sources_load.py
@@ -20,6 +20,7 @@ class TestBuildConsumerConfig:
         assert config.connect_timeout_seconds == 10
         assert config.recovery_grace_seconds == 300
         assert config.lease_ttl_seconds == config.recovery_grace_seconds
+        assert config.poll_failure_liveness_threshold == 10
 
     @parameterized.expand(
         [
@@ -30,6 +31,8 @@ class TestBuildConsumerConfig:
             (["--connect-timeout", "30"], "connect_timeout_seconds", 30),
             (["--lease-ttl", "600"], "lease_ttl_seconds", 600),
             (["--recovery-grace", "900"], "recovery_grace_seconds", 900),
+            (["--poll-failure-liveness-threshold", "5"], "poll_failure_liveness_threshold", 5),
+            (["--poll-failure-liveness-threshold", "0"], "poll_failure_liveness_threshold", None),
         ]
     )
     def test_flag_overrides_reach_the_config(self, argv: list[str], field: str, expected):

--- a/products/warehouse_sources/backend/tests/management/test_run_warehouse_sources_load.py
+++ b/products/warehouse_sources/backend/tests/management/test_run_warehouse_sources_load.py
@@ -1,0 +1,43 @@
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.management.commands.run_warehouse_sources_load import (
+    Command,
+    build_consumer_config,
+)
+
+
+def _parse_options(argv: list[str]) -> dict:
+    parser = Command().create_parser("manage.py", "run_warehouse_sources_load")
+    return vars(parser.parse_args(argv))
+
+
+class TestBuildConsumerConfig:
+    def test_defaults_come_from_the_config_dataclass(self):
+        config = build_consumer_config(_parse_options([]))
+
+        assert config.poll_timeout_seconds == 180.0
+        assert config.sweep_timeout_seconds == 300.0
+        assert config.connect_timeout_seconds == 10
+        assert config.recovery_grace_seconds == 300
+        assert config.lease_ttl_seconds == config.recovery_grace_seconds
+
+    @parameterized.expand(
+        [
+            (["--poll-timeout", "600"], "poll_timeout_seconds", 600.0),
+            (["--poll-timeout", "0"], "poll_timeout_seconds", None),
+            (["--sweep-timeout", "900"], "sweep_timeout_seconds", 900.0),
+            (["--sweep-timeout", "0"], "sweep_timeout_seconds", None),
+            (["--connect-timeout", "30"], "connect_timeout_seconds", 30),
+            (["--lease-ttl", "600"], "lease_ttl_seconds", 600),
+            (["--recovery-grace", "900"], "recovery_grace_seconds", 900),
+        ]
+    )
+    def test_flag_overrides_reach_the_config(self, argv: list[str], field: str, expected):
+        config = build_consumer_config(_parse_options(argv))
+
+        assert getattr(config, field) == expected
+
+    def test_lease_ttl_follows_recovery_grace_when_not_set(self):
+        config = build_consumer_config(_parse_options(["--recovery-grace", "900"]))
+
+        assert config.lease_ttl_seconds == 900


### PR DESCRIPTION
## Problem

The v3 warehouse loader spent ~46 hours at zero throughput last weekend: every poll timed out against the queue DB, yet all 25 pods reported healthy the whole time, the poll dashboards looked *better* than normal (failed polls never reach the duration histograms), and un-wedging the fleet required a code deploy because the poll timeout is not tunable at runtime. Two adjacent chronic issues surfaced in the same investigation: the pod-level Delta load path is serialized through one thread regardless of `max_concurrency`, and deterministic per-schema errors (Decimal128 precision overflow, incremental sync without a primary key) burn all retry attempts on every scheduled run, forever.

This PR is the set of small, high-leverage fixes from that investigation — one commit per fix.

## Changes

**1. `feat(data-warehouse): expose v3 loader timeout and lease knobs as CLI flags`**
`--poll-timeout`, `--sweep-timeout`, `--connect-timeout`, `--lease-ttl`, `--recovery-grace` on `run_warehouse_sources_load`. Omitted flags leave the `ConsumerConfig` dataclass defaults untouched (single source of truth); `0` disables the ceiling flags, matching `--stuck-batch-timeout`. Config building is extracted into `build_consumer_config` so the flag-to-config plumbing is testable.

**2. `fix(data-warehouse): stop serializing all delta loads through one thread`**
`sync_to_async` defaults to `thread_sensitive=True`, funneling every batch on a pod through asgiref's process-global single-thread executor — and since claimed groups are marked executing with fresh leases while they wait, per-pod serialization becomes fleet-wide starvation. Ports the duckgres sink's `thread_sensitive=False` fix (`process_message` is self-contained: opens with `close_old_connections`, own connections/clients; concurrency stays bounded by `max_concurrency`).

**3. `feat(data-warehouse): make v3 loader poll failures visible and trip liveness`**
- New `warehouse_pg_consumer_poll_failures_total{reason}` counter + failed polls now observe `poll_duration_seconds` too.
- Poll-failure liveness trip: after N consecutive failed polls (default 10, `--poll-failure-liveness-threshold`, 0 disables) the consumer withholds health reports the same way the stuck-batch watchdog does — a silent zero-throughput loop becomes a visible crashloop.
- The queue-freshness probe gets its own 30s ceiling and saturates `warehouse_pg_queue_oldest_unclaimed_batch_seconds` at the probe window on timeout, instead of eating the reconcile sweep's budget and pinning a stale value — a queue DB too degraded to measure freshness now reads as stale, not healthy.

**4. `fix(data-warehouse): fail deterministic v3 load errors fast instead of retrying`**
The engine asks the adapter whether an error is retryable. The delta adapter matches a curated list of known-deterministic signatures (delta-rs Decimal128 overflow, `Primary key required for incremental syncs`) and fails the run immediately with the raw error as the customer-visible `latest_error`; unmatched errors keep the existing retry behavior. Duckgres retries everything, as before.

## How did you test this code?

Automated tests only (no manual prod testing):

- `tests/management/test_run_warehouse_sources_load.py` (new): catches a flag that parses but never reaches `ConsumerConfig` — the exact bug class by which the stuck-batch watchdog originally shipped unwired; covers defaults, per-flag overrides, 0-disables mapping, and lease-TTL-follows-grace.
- `test_consumer.py::TestPollFailureLiveness` (new): catches removal of the liveness trip (pod polls failing forever while healthy — the outage mode) and removal of the on-success reset (pod restarting on non-consecutive failures).
- `test_consumer.py::test_hung_freshness_probe_saturates_gauge_and_reconcile_still_runs` (new): catches the probe re-gaining the ability to starve the reconcile sweep, or a timed-out probe leaving the gauge pinned at the last good value.
- `test_consumer.py::test_non_retryable_error_fails_run_on_first_attempt` (new, parameterized): catches deterministic errors regressing to burning all attempts, and the customer-visible reason being wrapped in retry noise.
- Full `postgres_queue/test_consumer.py` + duckgres suites pass (143 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal loader tuning flags; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude) in a session that began as a production investigation of the loader outage using the `investigating-warehouse-sources-load` skill; these four fixes are the "tier 0" subset of a code audit that followed (the deeper structural items — claim-query cost scaling with backlog, Delta commit fencing, a general terminal-state sweep — are deliberately out of scope here).
- Skills invoked: `/writing-tests` before authoring the test additions.
- Decisions: CLI flags use omit-means-dataclass-default rather than duplicating defaults in the parser (drift-proof, and makes the plumbing testable); the non-retryable classifier is adapter-owned with a curated substring list rather than exception-type-based, because the deterministic failures surface as generic exceptions from the delta-rs stack; no test for the `thread_sensitive` change since any assertion on it would be a change-detector on a kwarg.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*