### PR TITLE
feat(tasks): add mentions index for thread @-mentions

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -250,6 +250,7 @@ rules:
                               |TaskPresence
                               |TaskRun
                               |TaskThreadMessage
+                              |TaskThreadMessageMention
                               |Channel
                               |EmailChannel
                               |EvaluationReport
@@ -524,6 +525,7 @@ rules:
                         |TaskPresence
                         |TaskRun
                         |TaskThreadMessage
+                        |TaskThreadMessageMention
                         |Channel
                         |EmailChannel
                         |EvaluationReport

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4232,7 +4232,7 @@ def list_mentions(
             task_id=mention.task_id,
             task_title=mention.task.title,
             channel_id=mention.task.channel_id,
-            channel_name=mention.task.channel.name if mention.task.channel_id else None,
+            channel_name=mention.task.channel.name if mention.task.channel else None,
             content=mention.message.content,
             created_at=mention.created_at,
             author=_user_basic_info(mention.message.author if mention.message.author_id else None),

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -26,7 +26,6 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import CharField, Count, Exists, F, Min, OuterRef, Q, QuerySet, Subquery
 from django.db.models.fields.json import KeyTextTransform
-from django.db.models.functions import Lower
 from django.utils import timezone as django_timezone
 
 import posthoganalytics
@@ -38,7 +37,7 @@ from posthog.models.integration import Integration
 from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, is_blocked_sandbox_env_key
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
-from products.tasks.backend.mentions import extract_mention_emails
+from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     Channel,
     CodeInvite,
@@ -4193,14 +4192,8 @@ def _index_thread_message_mentions(message: TaskThreadMessage) -> None:
     Emails resolve case-insensitively, only to members of the team's organization;
     self-mentions are skipped (they are never notifications).
     """
-    emails = extract_mention_emails(message.content)
-    if not emails:
-        return
-    mentioned_user_ids = (
-        User.objects.annotate(_email_lower=Lower("email"))
-        .filter(organizations__team__id=message.team_id, _email_lower__in=list(emails))
-        .values_list("id", flat=True)
-        .distinct()
+    mentioned_user_ids = resolve_mentioned_user_ids(
+        User, message.content, team_id=message.team_id, author_id=message.author_id
     )
     TaskThreadMessageMention.objects.bulk_create(
         [
@@ -4212,7 +4205,6 @@ def _index_thread_message_mentions(message: TaskThreadMessage) -> None:
                 created_at=message.created_at,
             )
             for mentioned_user_id in mentioned_user_ids
-            if mentioned_user_id != message.author_id
         ],
         ignore_conflicts=True,
     )

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import CharField, Count, Exists, F, Min, OuterRef, Q, QuerySet, Subquery
 from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Lower
 from django.utils import timezone as django_timezone
 
 import posthoganalytics
@@ -37,6 +38,7 @@ from posthog.models.integration import Integration
 from products.tasks.backend.constants import RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, is_blocked_sandbox_env_key
 from products.tasks.backend.logic.code_workstreams.default_workflow import build_default_bindings
 from products.tasks.backend.logic.code_workstreams.validation import validate_bindings
+from products.tasks.backend.mentions import extract_mention_emails
 from products.tasks.backend.models import (
     Channel,
     CodeInvite,
@@ -49,6 +51,7 @@ from products.tasks.backend.models import (
     TaskAutomation,
     TaskRun,
     TaskThreadMessage,
+    TaskThreadMessageMention,
 )
 from products.tasks.backend.prompts import WIZARD_PR_AGENT_PROMPT
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
@@ -4175,8 +4178,75 @@ def create_thread_message(
     if _visible_task(task_id, team_id, user_id) is None:
         return None
     message = TaskThreadMessage.objects.create(team_id=team_id, task_id=task_id, author_id=user_id, content=content)
+    try:
+        _index_thread_message_mentions(message)
+    except Exception:
+        # Mentions are best-effort: an indexing failure must never fail message creation.
+        logger.exception("Failed to index thread message mentions", extra={"message_id": str(message.id)})
     # Fresh message: forwarded_by is None (no query) and author lazy-loads once.
     return _thread_message_to_dto(message)
+
+
+def _index_thread_message_mentions(message: TaskThreadMessage) -> None:
+    """Create mention index rows for @[Name](email) tokens in the message content.
+
+    Emails resolve case-insensitively, only to members of the team's organization;
+    self-mentions are skipped (they are never notifications).
+    """
+    emails = extract_mention_emails(message.content)
+    if not emails:
+        return
+    mentioned_user_ids = (
+        User.objects.annotate(_email_lower=Lower("email"))
+        .filter(organizations__team__id=message.team_id, _email_lower__in=list(emails))
+        .values_list("id", flat=True)
+        .distinct()
+    )
+    TaskThreadMessageMention.objects.bulk_create(
+        [
+            TaskThreadMessageMention(
+                team_id=message.team_id,
+                message_id=message.id,
+                task_id=message.task_id,
+                mentioned_user_id=mentioned_user_id,
+                created_at=message.created_at,
+            )
+            for mentioned_user_id in mentioned_user_ids
+            if mentioned_user_id != message.author_id
+        ],
+        ignore_conflicts=True,
+    )
+
+
+def list_mentions(
+    team_id: int, user_id: int | None, *, since: datetime | None = None, limit: int = 100
+) -> list[contracts.TaskMentionDTO]:
+    """Thread-message mentions of the requester across tasks they can see, newest first."""
+    if user_id is None:
+        return []
+    qs = TaskThreadMessageMention.objects.filter(
+        team_id=team_id,
+        mentioned_user_id=user_id,
+        # task__in keeps the visibility rules single-sourced in _visible_task_qs.
+        task__in=_visible_task_qs(team_id, user_id),
+    )
+    if since is not None:
+        qs = qs.filter(created_at__gt=since)
+    mentions = qs.select_related("message__author", "task__channel").order_by("-created_at")[:limit]
+    return [
+        contracts.TaskMentionDTO(
+            id=mention.id,
+            message_id=mention.message_id,
+            task_id=mention.task_id,
+            task_title=mention.task.title,
+            channel_id=mention.task.channel_id,
+            channel_name=mention.task.channel.name if mention.task.channel_id else None,
+            content=mention.message.content,
+            created_at=mention.created_at,
+            author=_user_basic_info(mention.message.author if mention.message.author_id else None),
+        )
+        for mention in mentions
+    ]
 
 
 def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -146,6 +146,21 @@ class TaskThreadMessageDTO:
 
 
 @dataclass(frozen=True)
+class TaskMentionDTO:
+    """One @-mention of the requesting user in a task's thread, for the mentions feed."""
+
+    id: UUID
+    message_id: UUID
+    task_id: UUID
+    task_title: str
+    channel_id: UUID | None
+    channel_name: str | None
+    content: str
+    created_at: datetime
+    author: "TaskUserBasicInfo | None" = None
+
+
+@dataclass(frozen=True)
 class TaskLatestRunSummaryDTO:
     """The latest-run status/environment pair nested in a task summary response."""
 

--- a/products/tasks/backend/mentions.py
+++ b/products/tasks/backend/mentions.py
@@ -34,7 +34,8 @@ def resolve_mentioned_user_ids(user_model: Any, content: str, *, team_id: int, a
         return []
     member_ids = (
         user_model.objects.annotate(_email_lower=Lower("email"))
-        .filter(organizations__team__id=team_id, _email_lower__in=emails)
+        # Organization.members sets related_query_name="organization" (singular) for User filters.
+        .filter(organization__team__id=team_id, _email_lower__in=emails)
         .values_list("id", flat=True)
         .distinct()
     )

--- a/products/tasks/backend/mentions.py
+++ b/products/tasks/backend/mentions.py
@@ -1,4 +1,4 @@
-"""Parsing for @-mention tokens embedded in thread message content.
+"""Parsing and user resolution for @-mention tokens embedded in thread message content.
 
 Mentions are stored inline as ``@[Display Name](email)`` (the canonical format
 shared with PostHog Code clients), so any layer can answer "who does this
@@ -6,6 +6,9 @@ message mention?" from the plain string alone.
 """
 
 import re
+from typing import Any
+
+from django.db.models.functions import Lower
 
 MENTION_TOKEN_PATTERN = re.compile(r"@\[[^\][\n]+\]\(([^\s()]+@[^\s()]+)\)")
 
@@ -13,3 +16,22 @@ MENTION_TOKEN_PATTERN = re.compile(r"@\[[^\][\n]+\]\(([^\s()]+@[^\s()]+)\)")
 def extract_mention_emails(content: str) -> set[str]:
     """Emails mentioned in the content, lowercased and deduped."""
     return {match.group(1).lower() for match in MENTION_TOKEN_PATTERN.finditer(content)}
+
+
+def resolve_mentioned_user_ids(user_model: Any, content: str, *, team_id: int, author_id: int | None) -> list[int]:
+    """Ids of the team's org members mentioned in the content, excluding the author.
+
+    Emails resolve case-insensitively and only to members of the team's organization.
+    ``user_model`` is injected so the backfill migration can pass its historical model
+    and stay filter-identical with the write path.
+    """
+    emails = extract_mention_emails(content)
+    if not emails:
+        return []
+    member_ids = (
+        user_model.objects.annotate(_email_lower=Lower("email"))
+        .filter(organizations__team__id=team_id, _email_lower__in=list(emails))
+        .values_list("id", flat=True)
+        .distinct()
+    )
+    return [user_id for user_id in member_ids if user_id != author_id]

--- a/products/tasks/backend/mentions.py
+++ b/products/tasks/backend/mentions.py
@@ -1,0 +1,15 @@
+"""Parsing for @-mention tokens embedded in thread message content.
+
+Mentions are stored inline as ``@[Display Name](email)`` (the canonical format
+shared with PostHog Code clients), so any layer can answer "who does this
+message mention?" from the plain string alone.
+"""
+
+import re
+
+MENTION_TOKEN_PATTERN = re.compile(r"@\[[^\][\n]+\]\(([^\s()]+@[^\s()]+)\)")
+
+
+def extract_mention_emails(content: str) -> set[str]:
+    """Emails mentioned in the content, lowercased and deduped."""
+    return {match.group(1).lower() for match in MENTION_TOKEN_PATTERN.finditer(content)}

--- a/products/tasks/backend/mentions.py
+++ b/products/tasks/backend/mentions.py
@@ -12,6 +12,10 @@ from django.db.models.functions import Lower
 
 MENTION_TOKEN_PATTERN = re.compile(r"@\[[^\][\n]+\]\(([^\s()]+@[^\s()]+)\)")
 
+# Content length is unbounded, so cap how many distinct emails one message may
+# resolve to keep the lookup's IN list from growing with attacker-sized input.
+MAX_RESOLVED_MENTIONS_PER_MESSAGE = 50
+
 
 def extract_mention_emails(content: str) -> set[str]:
     """Emails mentioned in the content, lowercased and deduped."""
@@ -25,12 +29,12 @@ def resolve_mentioned_user_ids(user_model: Any, content: str, *, team_id: int, a
     ``user_model`` is injected so the backfill migration can pass its historical model
     and stay filter-identical with the write path.
     """
-    emails = extract_mention_emails(content)
+    emails = sorted(extract_mention_emails(content))[:MAX_RESOLVED_MENTIONS_PER_MESSAGE]
     if not emails:
         return []
     member_ids = (
         user_model.objects.annotate(_email_lower=Lower("email"))
-        .filter(organizations__team__id=team_id, _email_lower__in=list(emails))
+        .filter(organizations__team__id=team_id, _email_lower__in=emails)
         .values_list("id", flat=True)
         .distinct()
     )

--- a/products/tasks/backend/migrations/0049_taskthreadmessagemention.py
+++ b/products/tasks/backend/migrations/0049_taskthreadmessagemention.py
@@ -1,0 +1,73 @@
+import uuid
+
+import django.utils.timezone
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("tasks", "0048_task_state"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TaskThreadMessageMention",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "mentioned_user",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "message",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="mentions",
+                        to="tasks.taskthreadmessage",
+                    ),
+                ),
+                (
+                    "task",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="tasks.task",
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_thread_message_mention",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="taskthreadmessagemention",
+            constraint=models.UniqueConstraint(
+                fields=("message", "mentioned_user"), name="task_mention_message_user_unique"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="taskthreadmessagemention",
+            index=models.Index(fields=["team", "mentioned_user", "created_at"], name="task_mention_team_user_created"),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
+++ b/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
@@ -1,7 +1,6 @@
 from django.db import migrations
-from django.db.models.functions import Lower
 
-from products.tasks.backend.mentions import extract_mention_emails
+from products.tasks.backend.mentions import resolve_mentioned_user_ids
 
 BATCH_SIZE = 1000
 
@@ -13,7 +12,7 @@ def backfill_thread_message_mentions(apps, schema_editor):
 
     last_pk = None
     while True:
-        batch_qs = TaskThreadMessage.objects.order_by("pk").select_related("team")
+        batch_qs = TaskThreadMessage.objects.order_by("pk")
         if last_pk is not None:
             batch_qs = batch_qs.filter(pk__gt=last_pk)
         batch = list(batch_qs[:BATCH_SIZE])
@@ -21,28 +20,19 @@ def backfill_thread_message_mentions(apps, schema_editor):
             break
         last_pk = batch[-1].pk
 
-        rows = []
-        for message in batch:
-            emails = extract_mention_emails(message.content)
-            if not emails:
-                continue
-            member_ids = (
-                User.objects.annotate(_email_lower=Lower("email"))
-                .filter(organizations__id=message.team.organization_id, _email_lower__in=list(emails))
-                .values_list("pk", flat=True)
-                .distinct()
+        rows = [
+            TaskThreadMessageMention(
+                team_id=message.team_id,
+                message_id=message.pk,
+                task_id=message.task_id,
+                mentioned_user_id=user_id,
+                created_at=message.created_at,
             )
-            rows.extend(
-                TaskThreadMessageMention(
-                    team_id=message.team_id,
-                    message_id=message.pk,
-                    task_id=message.task_id,
-                    mentioned_user_id=user_id,
-                    created_at=message.created_at,
-                )
-                for user_id in member_ids
-                if user_id != message.author_id
+            for message in batch
+            for user_id in resolve_mentioned_user_ids(
+                User, message.content, team_id=message.team_id, author_id=message.author_id
             )
+        ]
         if rows:
             TaskThreadMessageMention.objects.bulk_create(rows, batch_size=BATCH_SIZE, ignore_conflicts=True)
 

--- a/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
+++ b/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
@@ -38,6 +38,8 @@ def backfill_thread_message_mentions(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    atomic = False  # Batched backfill; each bulk_create commits independently and reruns are idempotent.
+
     dependencies = [
         ("tasks", "0049_taskthreadmessagemention"),
     ]

--- a/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
+++ b/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
@@ -1,0 +1,57 @@
+from django.db import migrations
+from django.db.models.functions import Lower
+
+from products.tasks.backend.mentions import extract_mention_emails
+
+BATCH_SIZE = 1000
+
+
+def backfill_thread_message_mentions(apps, schema_editor):
+    TaskThreadMessage = apps.get_model("tasks", "TaskThreadMessage")
+    TaskThreadMessageMention = apps.get_model("tasks", "TaskThreadMessageMention")
+    User = apps.get_model("posthog", "User")
+
+    last_pk = None
+    while True:
+        batch_qs = TaskThreadMessage.objects.order_by("pk").select_related("team")
+        if last_pk is not None:
+            batch_qs = batch_qs.filter(pk__gt=last_pk)
+        batch = list(batch_qs[:BATCH_SIZE])
+        if not batch:
+            break
+        last_pk = batch[-1].pk
+
+        rows = []
+        for message in batch:
+            emails = extract_mention_emails(message.content)
+            if not emails:
+                continue
+            member_ids = (
+                User.objects.annotate(_email_lower=Lower("email"))
+                .filter(organizations__id=message.team.organization_id, _email_lower__in=list(emails))
+                .values_list("pk", flat=True)
+                .distinct()
+            )
+            rows.extend(
+                TaskThreadMessageMention(
+                    team_id=message.team_id,
+                    message_id=message.pk,
+                    task_id=message.task_id,
+                    mentioned_user_id=user_id,
+                    created_at=message.created_at,
+                )
+                for user_id in member_ids
+                if user_id != message.author_id
+            )
+        if rows:
+            TaskThreadMessageMention.objects.bulk_create(rows, batch_size=BATCH_SIZE, ignore_conflicts=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0049_taskthreadmessagemention"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_thread_message_mentions, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
+++ b/products/tasks/backend/migrations/0050_backfill_thread_message_mentions.py
@@ -38,8 +38,6 @@ def backfill_thread_message_mentions(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    atomic = False  # Batched backfill; each bulk_create commits independently and reruns are idempotent.
-
     dependencies = [
         ("tasks", "0049_taskthreadmessagemention"),
     ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0048_task_state
+0050_backfill_thread_message_mentions

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -773,6 +773,34 @@ class TaskThreadMessage(TeamScopedRootMixin):
         return f"Thread message {self.id} on task {self.task_id}"
 
 
+class TaskThreadMessageMention(TeamScopedRootMixin):
+    """One @-mention of a user inside a thread message, indexed at write time so the
+    mentions feed is a single indexed query instead of a client-side scan of every
+    channel's threads. ``created_at`` is copied from the message so listing never
+    joins for ordering."""
+
+    # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # db_constraint=False on the team/user FKs: adding an FK constraint to those hot tables
+    # locks them and stalls deploys; Django still enforces the relation and on_delete at the
+    # app level (see safe-django-migrations.md).
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    message = models.ForeignKey(TaskThreadMessage, on_delete=models.CASCADE, related_name="mentions")
+    task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name="+")
+    mentioned_user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_thread_message_mention"
+        constraints = [
+            models.UniqueConstraint(fields=["message", "mentioned_user"], name="task_mention_message_user_unique")
+        ]
+        indexes = [models.Index(fields=["team", "mentioned_user", "created_at"], name="task_mention_team_user_created")]
+
+    def __str__(self):
+        return f"Mention of user {self.mentioned_user_id} in message {self.message_id}"
+
+
 class TaskAutomationManager(models.Manager):
     def get_queryset(self):
         return (

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1071,6 +1071,14 @@ class TaskThreadMessageWriteSerializer(serializers.Serializer):
     content = serializers.CharField(help_text="Message text.")
 
 
+class TaskMentionQuerySerializer(serializers.Serializer):
+    """Query parameters for listing mentions."""
+
+    since = serializers.DateTimeField(
+        required=False, help_text="Only return mentions created after this ISO 8601 timestamp."
+    )
+
+
 class TaskMentionSerializer(DataclassSerializer):
     """Response shape for one @-mention of the requester in a task's thread."""
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -21,6 +21,7 @@ from products.tasks.backend.facade.contracts import (
     SandboxEnvironmentDTO,
     TaskAutomationDTO,
     TaskDetailDTO,
+    TaskMentionDTO,
     TaskRunDetailDTO,
     TaskSummaryDTO,
     TaskThreadMessageDTO,
@@ -1068,6 +1069,26 @@ class TaskThreadMessageWriteSerializer(serializers.Serializer):
     """Request body for posting a thread message."""
 
     content = serializers.CharField(help_text="Message text.")
+
+
+class TaskMentionSerializer(DataclassSerializer):
+    """Response shape for one @-mention of the requester in a task's thread."""
+
+    author = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+
+    class Meta:
+        dataclass = TaskMentionDTO
+        fields = [
+            "id",
+            "message_id",
+            "task_id",
+            "task_title",
+            "channel_id",
+            "channel_name",
+            "author",
+            "content",
+            "created_at",
+        ]
 
 
 class TaskRepositoriesResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1077,6 +1077,13 @@ class TaskMentionQuerySerializer(serializers.Serializer):
     since = serializers.DateTimeField(
         required=False, help_text="Only return mentions created after this ISO 8601 timestamp."
     )
+    limit = serializers.IntegerField(
+        required=False,
+        default=100,
+        min_value=1,
+        max_value=500,
+        help_text="Maximum number of mentions to return (newest first).",
+    )
 
 
 class TaskMentionSerializer(DataclassSerializer):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -124,7 +124,8 @@ class TaskMentionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def list(self, request, *args, **kwargs):
         since = request.validated_query_data.get("since")
-        mentions = tasks_facade.list_mentions(self.team_id, self._user_id(), since=since)
+        limit = request.validated_query_data["limit"]
+        mentions = tasks_facade.list_mentions(self.team_id, self._user_id(), since=since, limit=limit)
         return Response(TaskMentionSerializer(mentions, many=True).data)
 
 

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -1,9 +1,6 @@
 from uuid import UUID
 
-from django.utils.dateparse import parse_datetime
-
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -11,6 +8,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from posthog.api.mixins import validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.permissions import APIScopePermission
@@ -19,6 +17,7 @@ from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.presentation.serializers import (
     ChannelSerializer,
     ChannelWriteSerializer,
+    TaskMentionQuerySerializer,
     TaskMentionSerializer,
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
@@ -115,28 +114,16 @@ class TaskMentionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _user_id(self) -> int | None:
         return getattr(self.request.user, "id", None)
 
-    @extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "since",
-                OpenApiTypes.DATETIME,
-                description="Only return mentions created after this ISO 8601 timestamp.",
-            )
-        ],
+    @validated_request(
+        query_serializer=TaskMentionQuerySerializer,
         responses={
             200: OpenApiResponse(response=TaskMentionSerializer(many=True), description="Mentions, newest first"),
-            400: OpenApiResponse(description="Unparseable since timestamp"),
         },
         summary="List mentions of the requester",
         description="Thread messages that @-mention the requester, newest first, restricted to tasks they can see.",
     )
     def list(self, request, *args, **kwargs):
-        since = None
-        since_param = request.query_params.get("since")
-        if since_param:
-            since = parse_datetime(since_param)
-            if since is None:
-                return Response({"detail": "Invalid since timestamp"}, status=status.HTTP_400_BAD_REQUEST)
+        since = request.validated_query_data.get("since")
         mentions = tasks_facade.list_mentions(self.team_id, self._user_id(), since=since)
         return Response(TaskMentionSerializer(mentions, many=True).data)
 

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -1,6 +1,9 @@
 from uuid import UUID
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from django.utils.dateparse import parse_datetime
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -16,6 +19,7 @@ from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.presentation.serializers import (
     ChannelSerializer,
     ChannelWriteSerializer,
+    TaskMentionSerializer,
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
 )
@@ -90,6 +94,51 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if result == "personal":
             raise PermissionDenied("Personal channels cannot be deleted")
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class TaskMentionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    API for the requester's mentions feed — thread messages across the team's tasks
+    that @-mention them, indexed at write time.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    http_method_names = ["get", "head", "options"]
+    serializer_class = TaskMentionSerializer
+
+    def _user_id(self) -> int | None:
+        return getattr(self.request.user, "id", None)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "since",
+                OpenApiTypes.DATETIME,
+                description="Only return mentions created after this ISO 8601 timestamp.",
+            )
+        ],
+        responses={
+            200: OpenApiResponse(response=TaskMentionSerializer(many=True), description="Mentions, newest first"),
+            400: OpenApiResponse(description="Unparseable since timestamp"),
+        },
+        summary="List mentions of the requester",
+        description="Thread messages that @-mention the requester, newest first, restricted to tasks they can see.",
+    )
+    def list(self, request, *args, **kwargs):
+        since = None
+        since_param = request.query_params.get("since")
+        if since_param:
+            since = parse_datetime(since_param)
+            if since is None:
+                return Response({"detail": "Invalid since timestamp"}, status=status.HTTP_400_BAD_REQUEST)
+        mentions = tasks_facade.list_mentions(self.team_id, self._user_id(), since=since)
+        return Response(TaskMentionSerializer(mentions, many=True).data)
 
 
 class TaskThreadMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -13,6 +13,7 @@ def register_routes(routers: RouterRegistry) -> None:
         r"thread_messages", channels.TaskThreadMessageViewSet, "project_task_thread_messages", ["team_id", "task_id"]
     )
     routers.projects.register(r"task_channels", channels.ChannelViewSet, "project_task_channels", ["team_id"])
+    routers.projects.register(r"task_mentions", channels.TaskMentionViewSet, "project_task_mentions", ["team_id"])
     routers.projects.register(r"task_automations", tasks.TaskAutomationViewSet, "project_task_automations", ["team_id"])
     routers.projects.register(
         r"sandbox_environments", tasks.SandboxEnvironmentViewSet, "project_sandbox_environments", ["team_id"]

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -141,7 +141,9 @@ class ChannelsAPITestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class ThreadMessagesAPITestCase(TestCase):
+class ChannelTaskAPITestCase(TestCase):
+    """Shared fixture: an org with two members, a public channel, and a task in it."""
+
     def setUp(self) -> None:
         self.organization = Organization.objects.create(name="Test Org")
         self.team = Team.objects.create(organization=self.organization, name="Growth Team")
@@ -171,6 +173,8 @@ class ThreadMessagesAPITestCase(TestCase):
         self.peer_client = APIClient()
         self.peer_client.force_authenticate(self.peer)
 
+
+class ThreadMessagesAPITestCase(ChannelTaskAPITestCase):
     def _thread_url(self) -> str:
         return f"/api/projects/{self.team.id}/tasks/{self.task.id}/thread_messages/"
 
@@ -234,36 +238,7 @@ class ThreadMessagesAPITestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class TaskMentionsAPITestCase(TestCase):
-    def setUp(self) -> None:
-        self.organization = Organization.objects.create(name="Test Org")
-        self.team = Team.objects.create(organization=self.organization, name="Growth Team")
-        self.author = User.objects.create_user(email="author@example.com", first_name="Ann", password="password")
-        self.peer = User.objects.create_user(email="peer@example.com", first_name="Bob", password="password")
-        for user in (self.author, self.peer):
-            self.organization.members.add(user)
-            OrganizationMembership.objects.filter(user=user, organization=self.organization).update(
-                level=OrganizationMembership.Level.ADMIN
-            )
-
-        # Direct instantiation sidesteps the fail-closed TeamScopedManager so
-        # setUp doesn't need a team_scope wrapper (see test_presence.py).
-        self.channel = Channel(team=self.team, name="growth", created_by=self.author)
-        self.channel.save()
-        self.task = Task.objects.create(
-            team=self.team,
-            created_by=self.author,
-            channel=self.channel,
-            title="A Task",
-            description="d",
-            origin_product=Task.OriginProduct.USER_CREATED,
-        )
-
-        self.author_client = APIClient()
-        self.author_client.force_authenticate(self.author)
-        self.peer_client = APIClient()
-        self.peer_client.force_authenticate(self.peer)
-
+class TaskMentionsAPITestCase(ChannelTaskAPITestCase):
     def _mentions_url(self) -> str:
         return f"/api/projects/{self.team.id}/task_mentions/"
 

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -290,6 +290,9 @@ class TaskMentionsAPITestCase(ChannelTaskAPITestCase):
         ids = [m["message_id"] for m in self.peer_client.get(self._mentions_url()).json()]
         self.assertEqual(ids, [second["id"], first["id"]])
 
+        limited = self.peer_client.get(self._mentions_url(), {"limit": 1}).json()
+        self.assertEqual([m["message_id"] for m in limited], [second["id"]])
+
     def test_unparseable_since_is_a_400(self):
         response = self.peer_client.get(self._mentions_url(), {"since": "not-a-date"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -232,3 +232,122 @@ class ThreadMessagesAPITestCase(TestCase):
         url = f"/api/projects/{self.team.id}/tasks/{private_task.id}/thread_messages/"
         response = self.peer_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class TaskMentionsAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Growth Team")
+        self.author = User.objects.create_user(email="author@example.com", first_name="Ann", password="password")
+        self.peer = User.objects.create_user(email="peer@example.com", first_name="Bob", password="password")
+        for user in (self.author, self.peer):
+            self.organization.members.add(user)
+            OrganizationMembership.objects.filter(user=user, organization=self.organization).update(
+                level=OrganizationMembership.Level.ADMIN
+            )
+
+        # Direct instantiation sidesteps the fail-closed TeamScopedManager so
+        # setUp doesn't need a team_scope wrapper (see test_presence.py).
+        self.channel = Channel(team=self.team, name="growth", created_by=self.author)
+        self.channel.save()
+        self.task = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="A Task",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+        self.author_client = APIClient()
+        self.author_client.force_authenticate(self.author)
+        self.peer_client = APIClient()
+        self.peer_client.force_authenticate(self.peer)
+
+    def _mentions_url(self) -> str:
+        return f"/api/projects/{self.team.id}/task_mentions/"
+
+    def _thread_url(self, task) -> str:
+        return f"/api/projects/{self.team.id}/tasks/{task.id}/thread_messages/"
+
+    def _post_message(self, client, content: str, task=None) -> dict:
+        response = client.post(self._thread_url(task or self.task), {"content": content})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        return response.json()
+
+    def test_mention_appears_in_mentioned_users_feed(self):
+        message = self._post_message(self.author_client, "ping @[Bob](peer@example.com), thoughts?")
+
+        mentions = self.peer_client.get(self._mentions_url()).json()
+        self.assertEqual(len(mentions), 1)
+        self.assertEqual(mentions[0]["message_id"], message["id"])
+        self.assertEqual(mentions[0]["task_id"], str(self.task.id))
+        self.assertEqual(mentions[0]["task_title"], "A Task")
+        self.assertEqual(mentions[0]["channel_id"], str(self.channel.id))
+        self.assertEqual(mentions[0]["channel_name"], "growth")
+        self.assertEqual(mentions[0]["author"]["id"], self.author.id)
+        self.assertEqual(mentions[0]["content"], "ping @[Bob](peer@example.com), thoughts?")
+        # The author wasn't mentioned, so their own feed stays empty.
+        self.assertEqual(self.author_client.get(self._mentions_url()).json(), [])
+
+    def test_mentions_resolve_case_insensitively(self):
+        self._post_message(self.author_client, "cc @[Bob](Peer@Example.COM)")
+        self.assertEqual(len(self.peer_client.get(self._mentions_url()).json()), 1)
+
+    def test_self_mentions_and_non_members_are_not_indexed(self):
+        self._post_message(self.peer_client, "note to self @[Bob](peer@example.com)")
+        self._post_message(self.author_client, "ask @[Sam](sam@other-org.example.com)")
+        self.assertEqual(self.peer_client.get(self._mentions_url()).json(), [])
+        self.assertEqual(self.author_client.get(self._mentions_url()).json(), [])
+
+    def test_since_filters_by_created_at(self):
+        self._post_message(self.author_client, "hey @[Bob](peer@example.com)")
+        created_at = self.peer_client.get(self._mentions_url()).json()[0]["created_at"]
+
+        after = self.peer_client.get(self._mentions_url(), {"since": created_at}).json()
+        self.assertEqual(after, [])
+        before = self.peer_client.get(self._mentions_url(), {"since": "2020-01-01T00:00:00Z"}).json()
+        self.assertEqual(len(before), 1)
+
+    def test_mentions_are_newest_first(self):
+        first = self._post_message(self.author_client, "one @[Bob](peer@example.com)")
+        second = self._post_message(self.author_client, "two @[Bob](peer@example.com)")
+        ids = [m["message_id"] for m in self.peer_client.get(self._mentions_url()).json()]
+        self.assertEqual(ids, [second["id"], first["id"]])
+
+    def test_unparseable_since_is_a_400(self):
+        response = self.peer_client.get(self._mentions_url(), {"since": "not-a-date"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_mention_on_invisible_task_is_hidden(self):
+        private_task = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            title="Private",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        self._post_message(self.author_client, "fyi @[Bob](peer@example.com)", task=private_task)
+        self.assertEqual(self.peer_client.get(self._mentions_url()).json(), [])
+
+    def test_mentions_are_team_scoped(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        other_channel = Channel(team=other_team, name="growth", created_by=self.author)
+        other_channel.save()
+        other_task = Task.objects.create(
+            team=other_team,
+            created_by=self.author,
+            channel=other_channel,
+            title="Elsewhere",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        response = self.author_client.post(
+            f"/api/projects/{other_team.id}/tasks/{other_task.id}/thread_messages/",
+            {"content": "over here @[Bob](peer@example.com)"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        self.assertEqual(self.peer_client.get(self._mentions_url()).json(), [])
+        other_team_mentions = self.peer_client.get(f"/api/projects/{other_team.id}/task_mentions/").json()
+        self.assertEqual(len(other_team_mentions), 1)

--- a/products/tasks/backend/tests/test_mentions.py
+++ b/products/tasks/backend/tests/test_mentions.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.tasks.backend.mentions import extract_mention_emails
+
+
+class ExtractMentionEmailsTest(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("single_mention", "hey @[Ann](ann@example.com), thoughts?", {"ann@example.com"}),
+            (
+                "multiple_mentions",
+                "@[Ann](ann@example.com) and @[Bob Two](bob@example.com)",
+                {"ann@example.com", "bob@example.com"},
+            ),
+            ("lowercased_and_deduped", "@[Ann](Ann@Example.COM) again @[Ann](ann@example.com)", {"ann@example.com"}),
+            ("plain_email_is_not_a_mention", "mail ann@example.com directly", set()),
+            ("invalid_email_in_token", "@[Ann](not-an-email)", set()),
+            ("whitespace_in_email", "@[Ann](ann @example.com)", set()),
+            ("bracket_in_name_breaks_token", "@[An[n](ann@example.com)", set()),
+            ("newline_in_name_breaks_token", "@[An\nn](ann@example.com)", set()),
+            ("empty_content", "", set()),
+        ]
+    )
+    def test_extract_mention_emails(self, _name, content, expected):
+        assert extract_mention_emails(content) == expected

--- a/products/tasks/backend/tests/test_migration_0050.py
+++ b/products/tasks/backend/tests/test_migration_0050.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+class BackfillThreadMessageMentionsMigrationTest(TestMigrations):
+    """0050 indexes mentions already stored inline in existing thread messages. The backfill
+    must mirror write-time extraction: org members only, self-mentions skipped, created_at
+    copied from the message.
+    """
+
+    migrate_from = "0049_taskthreadmessagemention"
+    migrate_to = "0050_backfill_thread_message_mentions"
+
+    @property
+    def app(self) -> str:
+        return "tasks"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Organization = apps.get_model("posthog", "Organization")
+        OrganizationMembership = apps.get_model("posthog", "OrganizationMembership")
+        Project = apps.get_model("posthog", "Project")
+        Team = apps.get_model("posthog", "Team")
+        User = apps.get_model("posthog", "User")
+        Task = apps.get_model("tasks", "Task")
+        TaskThreadMessage = apps.get_model("tasks", "TaskThreadMessage")
+
+        org = Organization.objects.create(name="Org")
+        project = Project.objects.create(id=999_999, organization=org, name="Proj")
+        team = Team.objects.create(organization=org, project=project, name="Team")
+        author = User.objects.create(email="author@example.com", distinct_id="author-distinct")
+        peer = User.objects.create(email="peer@example.com", distinct_id="peer-distinct")
+        for user in (author, peer):
+            OrganizationMembership.objects.create(organization=org, user=user)
+
+        task = Task.objects.create(team=team, title="T", description="d", origin_product="user_created")
+        self.peer_id = peer.id
+        self.mention_message_id = TaskThreadMessage.objects.create(
+            team=team, task=task, author=author, content="hey @[Bob](Peer@Example.com)"
+        ).id
+        # Self-mention and non-member mention must not produce rows.
+        TaskThreadMessage.objects.create(team=team, task=task, author=author, content="me @[Ann](author@example.com)")
+        TaskThreadMessage.objects.create(team=team, task=task, author=author, content="cc @[Sam](sam@elsewhere.com)")
+
+    def test_backfills_org_member_mentions_only(self) -> None:
+        TaskThreadMessage = self.apps.get_model("tasks", "TaskThreadMessage")  # type: ignore[union-attr]
+        TaskThreadMessageMention = self.apps.get_model("tasks", "TaskThreadMessageMention")  # type: ignore[union-attr]
+
+        mentions = list(TaskThreadMessageMention.objects.all())
+        assert len(mentions) == 1
+        assert mentions[0].message_id == self.mention_message_id
+        assert mentions[0].mentioned_user_id == self.peer_id
+        assert mentions[0].created_at == TaskThreadMessage.objects.get(id=self.mention_message_id).created_at

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -339,6 +339,32 @@ export interface PatchedChannelWriteApi {
 }
 
 /**
+ * Response shape for one @-mention of the requester in a task's thread.
+ */
+export interface TaskMentionDTOApi {
+    id: string
+    message_id: string
+    task_id: string
+    task_title: string
+    /** @nullable */
+    channel_id: string | null
+    /** @nullable */
+    channel_name: string | null
+    author?: TaskUserBasicInfoApi | null
+    content: string
+    created_at: string
+}
+
+export interface PaginatedTaskMentionDTOListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TaskMentionDTOApi[]
+}
+
+/**
  * @nullable
  */
 export type TaskDetailDTOApiJsonSchema = { [key: string]: unknown } | null
@@ -2185,6 +2211,23 @@ export type TaskChannelsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+}
+
+export type TaskMentionsListParams = {
+    /**
+     * Maximum number of mentions to return (newest first).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * Only return mentions created after this ISO 8601 timestamp.
+     */
+    since?: string
 }
 
 export type TasksListParams = {

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -17,6 +17,7 @@ import type {
     PaginatedSandboxEnvironmentDTOListApi,
     PaginatedTaskAutomationDTOListApi,
     PaginatedTaskDetailDTOListApi,
+    PaginatedTaskMentionDTOListApi,
     PaginatedTaskRunDetailDTOListApi,
     PaginatedTaskSummaryDTOListApi,
     PaginatedTaskThreadMessageDTOListApi,
@@ -37,6 +38,7 @@ import type {
     TaskAutomationsListParams,
     TaskChannelsListParams,
     TaskDetailDTOApi,
+    TaskMentionsListParams,
     TaskPresenceBeaconRequestApi,
     TaskRepositoriesResponseApi,
     TaskRunAppendLogRequestApi,
@@ -425,6 +427,37 @@ export const taskChannelsDestroy = async (projectId: string, id: string, options
     return apiMutator<void>(getTaskChannelsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getTaskMentionsListUrl = (projectId: string, params?: TaskMentionsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/task_mentions/?${stringifiedParams}`
+        : `/api/projects/${projectId}/task_mentions/`
+}
+
+/**
+ * Thread messages that @-mention the requester, newest first, restricted to tasks they can see.
+ * @summary List mentions of the requester
+ */
+export const taskMentionsList = async (
+    projectId: string,
+    params?: TaskMentionsListParams,
+    options?: RequestInit
+): Promise<PaginatedTaskMentionDTOListApi> => {
+    return apiMutator<PaginatedTaskMentionDTOListApi>(getTaskMentionsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -60,6 +60,9 @@ tools:
     task-channels-partial-update:
         operation: task_channels_partial_update
         enabled: false
+    task-mentions-list:
+        operation: task_mentions_list
+        enabled: false
     tasks-create:
         operation: tasks_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34907,6 +34907,32 @@ export namespace Schemas {
     }
 
     /**
+     * Response shape for one @-mention of the requester in a task's thread.
+     */
+    export interface TaskMentionDTO {
+      id: string;
+      message_id: string;
+      task_id: string;
+      task_title: string;
+      /** @nullable */
+      channel_id: string | null;
+      /** @nullable */
+      channel_name: string | null;
+      author?: TaskUserBasicInfo | null;
+      content: string;
+      created_at: string;
+    }
+
+    export interface PaginatedTaskMentionDTOList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TaskMentionDTO[];
+    }
+
+    /**
      * * `claude` - claude
      * * `codex` - codex
      */
@@ -68229,6 +68255,23 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type TaskMentionsListParams = {
+    /**
+     * Maximum number of mentions to return (newest first).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Only return mentions created after this ISO 8601 timestamp.
+     */
+    since?: string;
     };
 
     export type TasksListParams = {


### PR DESCRIPTION
## Problem

PostHog Code's Activity feed (mentions of you across channel threads) is assembled client-side today: every running client polls each channel's task feed plus each recent task's thread every minute, then scans message content for `@[Name](email)` tokens. That grows with users, channels, and tasks, and it violates the client's own architecture rules. the client half is [PostHog/code#3158](https://github.com/PostHog/code/pull/3158).

## Changes

- New `TaskThreadMessageMention` model (unique on message + user, indexed on team + user + created_at) with a schema migration and a separate batched backfill migration, per safe-migration rules (`db_constraint=False` on the hot-table FKs).
- Write-time indexing in the facade's `create_thread_message`: `@[Name](email)` tokens resolve case-insensitively to members of the team's org only, self-mentions are skipped, and indexing is best-effort so it can never fail message creation. The write path and the backfill share one `resolve_mentioned_user_ids` helper so their scoping can't diverge.
- `GET /api/projects/:team_id/task_mentions/?since=<ISO 8601>`: a GET-only viewset that is a one-line forward to a new `list_mentions` facade function, which reuses the existing task-visibility queryset so mentions on tasks you can't see are never returned. `since` is validated via `@validated_request`.

## How did you test this code?

Automated tests added, each catching a regression no existing test covers:

- `test_mentions.py`: parameterized extraction cases (dedupe, lowercasing, malformed tokens, plain emails not matching).
- `test_channels_api.py`: mention appears only in the mentioned member's feed; case-insensitive resolution; self-mentions and non-org-members not indexed; `since` filtering and 400 on a bad timestamp; newest-first ordering; mentions on invisible (personal-channel) tasks hidden; team scoping.
- `test_migration_0048.py`: backfill indexes org-member mentions only and copies `created_at` from the message.

The agent session had no Postgres available, so `pytest products/tasks` and `hogli build:openapi` could not be executed there; ruff check/format pass on all touched files and the extraction helper was exercised standalone. Please rely on CI for the DB-backed suites, and OpenAPI regeneration may be needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` describe the tasks thread API; the endpoint is annotated for the generated OpenAPI schema.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (Fable 5) via a PostHog Code cloud task, directed by @k11kirky, implementing a pre-written cross-repo plan from the PostHog Code repo.
- Repo skills consulted: `django-migrations` (schema/backfill split, `db_constraint=False` on hot-table FKs), `improving-drf-endpoints` (`@validated_request`, DataclassSerializer conventions), `writing-tests` (parameterized cases, TestCase over TransactionTestCase).
- A follow-up multi-agent `/simplify` review produced the second commit: shared resolver between write path and backfill (they previously used different org-membership join paths), `@validated_request` instead of hand-rolled query-param parsing, and a deduplicated test fixture base class.

---
