### PR TITLE
fix(ci): drop database atomically with FORCE in hogli schema restore

### DIFF
--- a/tools/hogli-commands/hogli_commands/db_schema.py
+++ b/tools/hogli-commands/hogli_commands/db_schema.py
@@ -154,14 +154,7 @@ def _psql_admin(sql: str) -> None:
 
 
 def _recreate_database(target_db: str) -> None:
-    # Terminate any active sessions on target_db first; otherwise DROP DATABASE
-    # fails with "is being accessed by other users" when an idle connection
-    # remains open from an earlier step (e.g. on CI runners).
-    _psql_admin(
-        f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-        f"WHERE datname = '{target_db}' AND pid <> pg_backend_pid();"
-    )
-    _psql_admin(f"DROP DATABASE IF EXISTS {target_db};")
+    _psql_admin(f"DROP DATABASE IF EXISTS {target_db} WITH (FORCE);")
     _psql_admin(f"CREATE DATABASE {target_db};")
 
 

--- a/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_db_schema.py
@@ -240,7 +240,7 @@ def test_restore_schema_dump_recreate_drops_and_creates(tmp_path: Path, monkeypa
 
     db_schema.restore_schema_dump(target_db="test_posthog", recreate=True, schema_path=schema_path)
 
-    assert any("DROP DATABASE IF EXISTS test_posthog;" in command for call in commands for command in call)
+    assert any("DROP DATABASE IF EXISTS test_posthog WITH (FORCE);" in command for call in commands for command in call)
     assert any("CREATE DATABASE test_posthog;" in command for call in commands for command in call)
     assert restored == [(schema_path, "test_posthog")]
     assert defaults == ["test_posthog"]
@@ -267,16 +267,10 @@ def test_restore_schema_dump_recreate_cleans_up_after_failure(tmp_path: Path, mo
         db_schema.restore_schema_dump(target_db="test_posthog", recreate=True, schema_path=schema_path)
 
     admin_sql = [command[-1] for command in commands]
-    terminate_sql = (
-        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-        "WHERE datname = 'test_posthog' AND pid <> pg_backend_pid();"
-    )
     assert admin_sql == [
-        terminate_sql,
-        "DROP DATABASE IF EXISTS test_posthog;",
+        "DROP DATABASE IF EXISTS test_posthog WITH (FORCE);",
         "CREATE DATABASE test_posthog;",
-        terminate_sql,
-        "DROP DATABASE IF EXISTS test_posthog;",
+        "DROP DATABASE IF EXISTS test_posthog WITH (FORCE);",
         "CREATE DATABASE test_posthog;",
     ]
 


### PR DESCRIPTION
## Problem

The "Prime posthog from cached schema" step in MCP CI fails intermittently with:

```
ERROR:  database "posthog" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

3 occurrences in the last ~24h of MCP CI runs ([example](https://github.com/PostHog/posthog/actions/runs/28854162777/job/85576541494)).

`hogli db:restore-test-db` recreates the target DB by running `pg_terminate_backend` and then `DROP DATABASE` as two separate `docker compose exec psql` invocations, several seconds apart in CI.
The dev compose stack includes always-on services (e.g. `feature-flags`) that open persistent connection pools to the `posthog` DB shortly after boot.
When such a connection lands in the terminate-to-drop window, the plain drop fails.
A previous fix (#60608) added the terminate pre-step, which handles pre-existing idle sessions but not this race, and retries wouldn't help because the service reconnects continuously.

## Changes

Replace the terminate + plain drop pair in `_recreate_database` with a single `DROP DATABASE IF EXISTS <db> WITH (FORCE)`.
The PG 13+ FORCE option terminates other sessions while holding the database lock, so there's no window for a new connection to sneak in.
The compose `db` service pins postgres 15.12, so FORCE is always available.

This covers all callers: the MCP CI prime step, ci-backend's test DB restore, and the local `db:restore-schema*` commands.

## How did you test this code?

- `hogli test tools/hogli-commands/hogli_commands/tests/test_db_schema.py` — 29 passed (existing assertions updated to the new SQL)
- Reproduced the race locally against the dev `db` container: opened a persistent session right after the terminate statement, then ran the old sequence 20 times (20/20 failed with the exact CI error) and the FORCE drop 20 times under identical conditions (20/20 passed)
- Ran the real `_recreate_database` code path 5 times against a scratch DB with a racing session, all passed

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) diagnosed and fixed this from a failing CI run URL, using the `/fixing-flaky-tests` skill.
It classified the failure as a setup race rather than a flaky test by reading the job logs, traced the connecting service via the compose files, and measured recurrence across recent MCP CI runs via the GitHub API.
A retry loop was rejected because the racing service reconnects continuously, making the atomic FORCE drop the only reliable option.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
