### PR TITLE
fix(data-warehouse): patch run_chdb_query in chdb introspection escaping test

### DIFF
--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -484,14 +484,15 @@ class TestTable(BaseTest):
             team=self.team,
         )
 
-        chdb_result = type("R", (), {"__str__": lambda self: chdb_csv})()
         with (
             patch("products.warehouse_sources.backend.models.table.TEST", False),
-            patch("chdb.query", return_value=chdb_result) as chdb_query,
+            patch(
+                "products.warehouse_sources.backend.models.table.run_chdb_query", return_value=chdb_csv
+            ) as chdb_query,
         ):
             getattr(table, method_name)()
 
-        assert chdb_query.called, "chdb.query should have been invoked on the chdb path"
+        assert chdb_query.called, "run_chdb_query should have been invoked on the chdb path"
         rendered_query: str = chdb_query.call_args.args[0]
         assert malicious_secret not in rendered_query, (
             f"Unescaped secret leaked into chdb query, enabling SQL injection: {rendered_query}"


### PR DESCRIPTION
## Problem

`test_chdb_introspection_escapes_single_quotes_in_placeholders` (both parameterized cases) has been failing on master and on every PR merge commit since #68727 landed this morning ([example failure](https://github.com/PostHog/posthog/actions/runs/28854181425/job/85577320785)).
The last 4 completed master Backend CI runs are red on the `data-warehouse (1/2)` product test shard because of it.

#68727 moved chdb execution into a subprocess (`run_chdb_query` spawns `sys.executable -c ...`), so the test's `patch("chdb.query", ...)` no longer intercepts anything.
The test now runs real chdb against `https://example.com/data.parquet`, which fails, then falls into the 5-attempt ClickHouse fallback with exponential backoff and fails there too, ~30s per case.
It slipped through #68727's own CI because the test lives in `products/data_warehouse` while that PR only touched `products/warehouse_sources`, so the narrowed product-test selection didn't run it.

## Changes

Patch `run_chdb_query` at the module under test instead of `chdb.query`, returning the CSV string directly (its actual return type).
The test's purpose is unchanged: it still asserts the rendered chdb query has single quotes escaped so a quote in a credential can't break out of the string literal.

Note: mendral-app opened equivalent draft fixes in #68854 and #68855; whichever of the three lands first, the others should be closed.

## How did you test this code?

- Reproduced the failure locally on master (`Exception: Could not get columns`, 31s)
- After the fix: `hogli test products/data_warehouse/backend/models/test/test_table.py` — all 49 pass in 4.6s, no network or ClickHouse dependency in the escaping tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) diagnosed this from a failing CI run URL using the `/fixing-flaky-tests` skill.
It classified the failure as a deterministic regression rather than a flake by confirming an unbroken failure streak on master's Backend CI and tracing the boundary to #68727's subprocess change via `git log -S`.
It reproduced the failure locally before changing anything and validated the fix against the full test file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
