### PR TITLE
fix(stamphog): sticky comment lookup broken by --slurp with --jq

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -135,7 +135,7 @@ jobs:
                     # so pipe to standalone jq. The || guard keeps a transient
                     # lookup failure from aborting the step before the label strip
                     # below (it degrades to posting a fresh comment instead).
-                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp 2>/dev/null \
+                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp \
                       | jq "[.[][] | select(.user.login == \"$BOT_LOGIN\" and (.body | startswith(\"$MARKER\")))][0] // empty" \
                       || echo "")
                     COMMENT_ID=""

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -130,12 +130,13 @@ jobs:
                     # Author + leading-marker filter: on a public repo anyone can
                     # post a comment containing the marker; without the filter the
                     # bot would PATCH (clobber) a third-party comment. Slurp so the
-                    # jq runs once over all pages — per-page --jq could emit one
-                    # object per page. The || guard keeps a transient lookup
-                    # failure from aborting the step before the label strip below
-                    # (it degrades to posting a fresh comment instead).
-                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp \
-                      --jq "[.[][] | select(.user.login == \"$BOT_LOGIN\" and (.body | startswith(\"$MARKER\")))][0] // empty" \
+                    # jq runs once over all pages (per-page filtering could emit
+                    # one object per page); gh rejects --slurp combined with --jq,
+                    # so pipe to standalone jq. The || guard keeps a transient
+                    # lookup failure from aborting the step before the label strip
+                    # below (it degrades to posting a fresh comment instead).
+                    EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp 2>/dev/null \
+                      | jq "[.[][] | select(.user.login == \"$BOT_LOGIN\" and (.body | startswith(\"$MARKER\")))][0] // empty" \
                       || echo "")
                     COMMENT_ID=""
                     EXISTING_BODY=""


### PR DESCRIPTION
## Problem

Testing stamphog 2.0.0b1 on a live PR surfaced a silent failure in the review workflow's post step. `gh api` rejects `--slurp` combined with `--jq` (`the --slurp option is not supported with --jq or --template`), and the `|| echo` guard swallowed the error. Result: the existing-sticky-comment lookup always returned empty, so every non-approve run posts a fresh comment instead of updating the one in place. That's exactly the refusal pileup the sticky mechanism was built to prevent.

Found in [this run](https://github.com/PostHog/posthog/actions/runs/28857612756/job/85587966202) (the error is visible in the Post review step output).

## Changes

Pipe the slurped pages to standalone `jq` instead of using `--jq`. A lookup failure still degrades to posting a fresh comment before the label strip, same as before.

## How did you test this code?

Ran the fixed command against a PR that has a real sticky comment (found it, correct comment id) and against a nonexistent PR (degrades to empty, fresh-comment path). No automated test: this is workflow bash, and the surrounding step already fails toward the safe path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, driven by @webjunkie while analyzing the linked CI run with the gh-logs skill. The same log check confirmed a second suspected issue (verdict comment missing the gate table) was already fixed on master and only affected PRs with a pre-merge base.

https://claude.ai/code/session_01PYFqkDL2Mf7BdV1JFY4hHC