### PR TITLE
fix(postgres): reject out-of-range SSH tunnel ports at validation

### DIFF
--- a/products/warehouse_sources/backend/models/ssh_tunnel.py
+++ b/products/warehouse_sources/backend/models/ssh_tunnel.py
@@ -169,7 +169,16 @@ class SSHTunnel:
         return False, ""  # type: ignore
 
     def has_valid_port(self) -> tuple[bool, str]:
-        port = int(self.port)
+        try:
+            port = int(self.port)
+        except (TypeError, ValueError):
+            return False, "Port must be a number between 1 and 65535"
+
+        # Out-of-range ports otherwise slip through to sshtunnel, which asserts `0 <= port <= 65535`
+        # and raises a bare AssertionError ("PORT < 0 (...)") that surfaces as error-tracking noise.
+        if port < 1 or port > 65535:
+            return False, "Port must be between 1 and 65535"
+
         if port == 80 or port == 443:
             return False, f"Port {port} is not allowed"
 

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.models.external_data_schema import (
 )
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.oom_event import ExternalDataSchemaOOMEvent
+from products.warehouse_sources.backend.models.ssh_tunnel import SSHTunnel
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.models.util import CLICKHOUSE_HOGQL_MAPPING, clean_type
 from products.warehouse_sources.backend.types import IncrementalFieldType
@@ -611,3 +612,33 @@ class TestStagedIncrementalCursor:
         with patch.object(schema, "save"):
             schema.update_sync_type_config_for_reset_pipeline()
         assert "incremental_staged" not in schema.sync_type_config
+
+
+@pytest.mark.parametrize(
+    "port,expected_valid",
+    [
+        # Out-of-range ports previously slipped through to sshtunnel, which asserted `port >= 0` and
+        # crashed credential validation with a bare AssertionError ("PORT < 0 (...)").
+        (-122, False),
+        (0, False),
+        (70000, False),
+        ("not-a-number", False),
+        (80, False),
+        (443, False),
+        (22, True),
+        (5432, True),
+        (65535, True),
+    ],
+)
+def test_ssh_tunnel_has_valid_port(port: int | str, expected_valid: bool) -> None:
+    tunnel = SSHTunnel(
+        enabled=True,
+        host="ssh.example.com",
+        port=port,
+        auth_type="password",
+        username="user",
+        password="pw",
+        private_key=None,
+        passphrase=None,
+    )
+    assert tunnel.has_valid_port()[0] is expected_valid

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -6,7 +6,10 @@ from posthog.test.base import BaseTest
 from unittest.mock import patch
 
 from django.db.models import Model
+from django.test import SimpleTestCase
 from django.utils import timezone
+
+from parameterized import parameterized
 
 from posthog.models.signals import model_activity_signal
 
@@ -614,31 +617,31 @@ class TestStagedIncrementalCursor:
         assert "incremental_staged" not in schema.sync_type_config
 
 
-@pytest.mark.parametrize(
-    "port,expected_valid",
-    [
-        # Out-of-range ports previously slipped through to sshtunnel, which asserted `port >= 0` and
-        # crashed credential validation with a bare AssertionError ("PORT < 0 (...)").
-        (-122, False),
-        (0, False),
-        (70000, False),
-        ("not-a-number", False),
-        (80, False),
-        (443, False),
-        (22, True),
-        (5432, True),
-        (65535, True),
-    ],
-)
-def test_ssh_tunnel_has_valid_port(port: int | str, expected_valid: bool) -> None:
-    tunnel = SSHTunnel(
-        enabled=True,
-        host="ssh.example.com",
-        port=port,
-        auth_type="password",
-        username="user",
-        password="pw",
-        private_key=None,
-        passphrase=None,
+class TestSSHTunnelPortValidation(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # Out-of-range ports previously slipped through to sshtunnel, which asserted `port >= 0`
+            # and crashed credential validation with a bare AssertionError ("PORT < 0 (...)").
+            ("negative", -122, False),
+            ("zero", 0, False),
+            ("too_large", 70000, False),
+            ("non_numeric", "not-a-number", False),
+            ("http", 80, False),
+            ("https", 443, False),
+            ("ssh", 22, True),
+            ("postgres", 5432, True),
+            ("max_valid", 65535, True),
+        ]
     )
-    assert tunnel.has_valid_port()[0] is expected_valid
+    def test_has_valid_port(self, _name: str, port: int | str, expected_valid: bool) -> None:
+        tunnel = SSHTunnel(
+            enabled=True,
+            host="ssh.example.com",
+            port=port,
+            auth_type="password",
+            username="user",
+            password="pw",
+            private_key=None,
+            passphrase=None,
+        )
+        assert tunnel.has_valid_port()[0] is expected_valid


### PR DESCRIPTION
## Problem

An error-tracking issue fired an `AssertionError: PORT < 0 (...)` from the Postgres source during source setup. A user configured an SSH tunnel with an out-of-range port (a negative value). Our `SSHTunnel.has_valid_port` only rejected ports 80 and 443, so the invalid port passed `ssh_tunnel_is_valid` (the event shows `is_ssh_valid: True`) and slipped through into the `sshtunnel` library, whose `check_port` asserts `port >= 0` and raised a bare `AssertionError`.

That assertion is caught by `validate_credentials`' generic `except Exception` and captured to error tracking as noise, while the user gets a generic "could not connect" message instead of being told their port is invalid.

This is a user-config error, but it happens on the synchronous credential-validation path (the `database_schema` API endpoint), not the Temporal retry path, so `get_non_retryable_errors` does not apply. The right fix is to validate the port range up front.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f3c25-35ff-7ac0-b864-33325f9e83ac

## Changes

`SSHTunnel.has_valid_port` now rejects anything outside the 1-65535 TCP range (and non-numeric values) before the existing 80/443 check. With this:

- `ssh_tunnel_is_valid` returns a clear "Port must be between 1 and 65535" during credential validation, so setup fails cleanly with an actionable message.
- `get_tunnel`'s existing `has_valid_port` guard now also rejects the port before it ever reaches `sshtunnel`, so the assertion can't fire on the sync path either.

No change to retry policy and nothing added to `NonRetryableErrors` (this path isn't retried).

## How did you test this code?

Added a parameterized unit test `test_ssh_tunnel_has_valid_port` at the pure-method layer covering the regression (negative port, plus 0, > 65535, non-numeric) and the existing rejections (80, 443) and valid ports (22, 5432, 65535). It catches the exact regression: an out-of-range SSH tunnel port previously passed validation and crashed with an `AssertionError` instead of being rejected with a message. No existing test exercised `has_valid_port` range handling.

Ran locally (agent-run):
- `pytest products/warehouse_sources/backend/tests/test_models.py::test_ssh_tunnel_has_valid_port` — 9 passed
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py` — 50 passed
- `ruff check` / `ruff format` on both changed files — clean

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking webhook by Claude (Claude Code). I pulled the issue and a representative event via the PostHog error-tracking MCP tools, traced the stack (`validate_credentials` → `get_schemas` → `open_ssh_tunnel` → `SSHTunnel.get_tunnel` → `sshtunnel.check_port`), and confirmed the root cause is `has_valid_port` only checking 80/443.

Decision: fixable bug, not a `NonRetryableErrors` addition, since the crash is on the synchronous validation path rather than the retried Temporal activity. Invoked `/writing-tests` before adding the test and placed it at the cheapest layer (pure dataclass method). Checked open PRs (including the maintainer's) for a duplicate first; none addressed this SSH-tunnel port-range gap.
