### PR TITLE
chore(ci): give storybook build headroom over degraded runners

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -165,7 +165,11 @@ jobs:
     build-storybook:
         name: Build Storybook (depot-ubuntu-latest)
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 15
+        # The Vite build normally takes ~3.5 minutes, but a degraded runner can stretch
+        # the memory-heavy bundling phase past 15 minutes — leave headroom so a slow
+        # runner yields a slow-but-green build instead of a cancelled one that hard-fails
+        # the visual-regression gate.
+        timeout-minutes: 30
         needs: changes
         if: needs.changes.outputs.frontend == 'true'
         steps:
@@ -211,26 +215,12 @@ jobs:
                   path: ${{ steps.pnpm-store.outputs.path }}
                   key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-            - name: Restore webpack build cache
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: common/storybook/node_modules/.cache/
-                  key: ${{ runner.os }}-webpack-storybook-${{ hashFiles('pnpm-lock.yaml') }}
-                  restore-keys: ${{ runner.os }}-webpack-storybook-
-
             - name: Build Storybook
               env:
                   NODE_OPTIONS: --max-old-space-size=32768
               run: |
                   bin/turbo --filter=@posthog/storybook prepare
                   pnpm --filter=@posthog/storybook build --test
-
-            - name: Save webpack build cache
-              if: github.ref == 'refs/heads/master'
-              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: common/storybook/node_modules/.cache/
-                  key: ${{ runner.os }}-webpack-storybook-${{ hashFiles('pnpm-lock.yaml') }}
 
             - name: Upload Storybook build artifact
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
## Problem

The `Build Storybook` job's `timeout-minutes: 15` has almost no headroom over its real worst case. The Vite build normally takes ~3.5 minutes, but on 2026-07-07 degraded `depot-ubuntu-latest` runners stretched the memory-heavy rollup bundling phase from ~40 seconds to 12+ minutes, and every affected run — including master's own (run 28856883930) — was killed at the cap. One run was cancelled the very second its artifact upload finished. When the build job is cancelled, the required "Visual regression tests pass" gate hard-fails ("Storybook build did not succeed (result: cancelled) — visual regression is uncovered"), so the whole check goes red for reasons unrelated to the PR being tested.

The job also restores and saves a "webpack build cache" at `common/storybook/node_modules/.cache/`. Storybook builds with Vite (`viteFinal` in `common/storybook/.storybook/main.ts`), whose production build keeps no persistent cache at that path — the cache has been round-tripping ~4KB of nothing (verified in job logs: "Cache Size: ~0 MB (3918 B)") while looking like it provides protection.

## Changes

- Bump `build-storybook`'s `timeout-minutes` from 15 to 30, with a comment explaining the headroom rationale. Runners are billed for time used, not the timeout value, so this costs nothing on healthy runs while turning "slow runner" into a slow-but-green build instead of a cancelled one. Stuck-runner protection remains intact.
- Remove the dead webpack cache restore/save steps.

Both changes are backwards compatible with open PRs that haven't rebased: no new prerequisites are introduced, and removing the cache steps only affects this workflow's own job.

## How did you test this code?

CI on this PR exercises the changed workflow directly (pull_request workflows run the PR's merged version). `hogli ci:preflight --fix` passes, including the workflow-lint check. The diagnosis behind the change comes from comparing job logs across ~10 runs on 2026-07-06/07: identical SHAs building in 3.5 min vs timing out at 15, phase timestamps isolating the slowdown to the post-transform bundling phase, and the cache-restore log lines showing the 4KB payload.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal CI configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude via PostHog Code) diagnosed this while shepherding an unrelated PR whose Storybook check kept failing: ruled out the PR's code (same SHA built fine the previous day), re-run pinning (a fresh run also timed out), and branch state (merging master changed nothing), then found master's own build timing out and the phase-level slowdown in the logs. Considered fixing the cache instead of removing it, but Vite production builds have no on-disk cache to persist, so there is nothing to point the path at; removal is the honest change. Reported the runner degradation itself to the devex team via hogli devex:feedback (two reports with run IDs and phase analysis) — this PR only addresses the blast radius, not the runner issue.
