### PR TITLE
feat(insights): reorganized display options with overlays section, submenus, and chart style controls

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -425,6 +425,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION: 'product-analytics-insight-overlays-section', // owner: #team-product-analytics, gates the "Overlays" editor panel section (goal lines, trend lines, alert overlays, annotations, statistical overlays), replacing their Options menu entries
+    PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU: 'product-analytics-insight-style-menu', // owner: #team-product-analytics, gates the "Style" toolbar menu (value labels, legend, number format, axis labels, pie/metric presentation), replacing their Options menu entries
     PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS: 'product-analytics-insights-tooltips', // owner: #team-product-analytics, gates the unified quill DefaultTooltip for trends/retention/stickiness insight charts
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUILL_LEGEND: 'product-analytics-quill-legend', // owner: #team-product-analytics, gates the in-chart quill legend replacing the legacy side InsightLegend

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -424,6 +424,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_FUNNELS_COMPARE: 'product-analytics-funnels-compare', // owner: @thmsobrmlr #team-product-analytics, gates "Compare to previous" toggle on funnel insights
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
+    PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION: 'product-analytics-insight-overlays-section', // owner: #team-product-analytics, gates the "Overlays" editor panel section (goal lines, trend lines, alert overlays, annotations, statistical overlays), replacing their Options menu entries
     PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS: 'product-analytics-insights-tooltips', // owner: #team-product-analytics, gates the unified quill DefaultTooltip for trends/retention/stickiness insight charts
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUILL_LEGEND: 'product-analytics-quill-legend', // owner: #team-product-analytics, gates the in-chart quill legend replacing the legacy side InsightLegend

--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -33,8 +33,7 @@ export interface LemonMenuItemBase extends Pick<
     custom?: boolean
 }
 export interface LemonMenuItemNode extends LemonMenuItemBase {
-    /** The submenu contents — the nested LemonMenu accepts sections too. */
-    items: LemonMenuItems
+    items: (LemonMenuItem | false | null)[]
     placement?: LemonDropdownProps['placement']
     keyboardShortcut?: never
 }

--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -33,7 +33,8 @@ export interface LemonMenuItemBase extends Pick<
     custom?: boolean
 }
 export interface LemonMenuItemNode extends LemonMenuItemBase {
-    items: (LemonMenuItem | false | null)[]
+    /** The submenu contents — the nested LemonMenu accepts sections too. */
+    items: LemonMenuItems
     placement?: LemonDropdownProps['placement']
     keyboardShortcut?: never
 }

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -1,10 +1,10 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { IconInfo } from '@posthog/icons'
-import { LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+import { IconChevronDown, IconChevronRight, IconInfo } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { SmoothingFilter } from 'lib/components/SmoothingFilter/SmoothingFilter'
 import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
@@ -203,7 +203,7 @@ export function MovingAverage(): JSX.Element {
     )
 }
 
-function DecimalPrecision(): JSX.Element {
+export function DecimalPrecision(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
@@ -229,6 +229,35 @@ function DecimalPrecision(): JSX.Element {
             }}
             className="mx-2 mb-1.5"
         />
+    )
+}
+
+/** A menu row that expands its options inline, accordion-style. Nested popovers are awkward to
+ * use inside a menu, so collapsed option groups expand within the same overlay instead. */
+export function CollapsibleOptionsSection({
+    label,
+    dataAttr,
+    children,
+}: {
+    label: string
+    dataAttr?: string
+    children: ReactNode
+}): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <div className="flex flex-col w-full">
+            <LemonButton
+                fullWidth
+                size="small"
+                onClick={() => setExpanded(!expanded)}
+                sideIcon={expanded ? <IconChevronDown /> : <IconChevronRight />}
+                data-attr={dataAttr}
+            >
+                {label}
+            </LemonButton>
+            {expanded && <div className="flex flex-col pl-2 w-full">{children}</div>}
+        </div>
     )
 }
 

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -135,7 +135,7 @@ function PercentStack(): JSX.Element {
     )
 }
 
-export function ConfidenceInterval(): JSX.Element {
+export function ConfidenceInterval({ className = 'pb-2' }: { className?: string } = {}): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
@@ -145,7 +145,7 @@ export function ConfidenceInterval(): JSX.Element {
     return (
         <LemonSwitch
             label="Show confidence intervals"
-            className="pb-2"
+            className={className}
             fullWidth
             checked={showConfidenceIntervals}
             disabledReason={
@@ -166,7 +166,7 @@ export function ConfidenceInterval(): JSX.Element {
     )
 }
 
-export function MovingAverage(): JSX.Element {
+export function MovingAverage({ className = 'pb-2' }: { className?: string } = {}): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
@@ -176,7 +176,7 @@ export function MovingAverage(): JSX.Element {
     return (
         <LemonSwitch
             label="Show moving average"
-            className="pb-2"
+            className={className}
             fullWidth
             checked={showMovingAverage}
             disabledReason={

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -242,7 +242,10 @@ export function CollapsibleOptionsSection({
     const [expanded, setExpanded] = useState(defaultExpanded)
 
     return (
-        <div className="flex flex-col w-full" data-attr={dataAttr}>
+        // The min-width keeps the menu width stable when a section expands. The collapsed content
+        // is not kept mounted: hidden-but-mounted controls inside the popover were prone to stale
+        // paints (not rendering until hovered).
+        <div className="flex flex-col w-full min-w-[18rem]" data-attr={dataAttr}>
             <LemonButton
                 fullWidth
                 size="small"
@@ -252,16 +255,7 @@ export function CollapsibleOptionsSection({
             >
                 {label}
             </LemonButton>
-            {/* Content stays mounted so the menu keeps a constant width — only the height animates
-                (same grid-rows trick as EditorFilterGroupTile) */}
-            <div
-                className="grid transition-all duration-200 ease-in-out"
-                style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
-            >
-                <div className="overflow-hidden">
-                    <div className="flex flex-col pl-2 w-full">{children}</div>
-                </div>
-            </div>
+            {expanded && <div className="flex flex-col pl-2 w-full">{children}</div>}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -11,6 +11,12 @@ import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
 import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
+import {
+    LineShapePicker,
+    LineStylePicker,
+    ShowGridLinesFilter,
+    ShowPointsFilter,
+} from 'scenes/insights/EditorFilters/ChartStyleFilters'
 import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
 import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
 import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
@@ -274,6 +280,10 @@ export const DisplayOptions = {
     HideWeekends: { label: () => <HideWeekendsFilter /> },
     Annotations: { label: () => <ShowAnnotationsFilter /> },
     ResultCustomizationBy: { label: () => <ResultCustomizationByPicker /> },
+    LineShape: { label: () => <LineShapePicker /> },
+    LineStyle: { label: () => <LineStylePicker /> },
+    ShowPoints: { label: () => <ShowPointsFilter /> },
+    GridLines: { label: () => <ShowGridLinesFilter /> },
     Unit: { label: () => <UnitPicker /> },
     Scale: { label: () => <ScalePicker /> },
     ConfidenceInterval: { label: () => <ConfidenceInterval /> },

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -135,7 +135,7 @@ function PercentStack(): JSX.Element {
     )
 }
 
-function ConfidenceInterval(): JSX.Element {
+export function ConfidenceInterval(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
@@ -166,7 +166,7 @@ function ConfidenceInterval(): JSX.Element {
     )
 }
 
-function MovingAverage(): JSX.Element {
+export function MovingAverage(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { IconChevronDown, IconChevronRight, IconInfo } from '@posthog/icons'
@@ -228,6 +228,8 @@ export function DecimalPrecision(): JSX.Element {
 
 /** A menu row that expands its options inline, accordion-style. Nested popovers are awkward to
  * use inside a menu, so collapsed option groups expand within the same overlay instead. */
+const COLLAPSIBLE_TRANSITION_MS = 200
+
 export function CollapsibleOptionsSection({
     label,
     dataAttr,
@@ -240,11 +242,23 @@ export function CollapsibleOptionsSection({
     children: ReactNode
 }): JSX.Element {
     const [expanded, setExpanded] = useState(defaultExpanded)
+    // The content is only in the DOM while the section is (at least partially) open: it mounts as
+    // the expand transition starts and unmounts once the collapse transition ends. Keeping it
+    // permanently mounted-but-hidden made the popover prone to stale paints (controls not
+    // rendering until hovered).
+    const [showContent, setShowContent] = useState(defaultExpanded)
+
+    useEffect(() => {
+        if (expanded) {
+            setShowContent(true)
+        } else {
+            const timeout = setTimeout(() => setShowContent(false), COLLAPSIBLE_TRANSITION_MS)
+            return () => clearTimeout(timeout)
+        }
+    }, [expanded])
 
     return (
-        // The min-width keeps the menu width stable when a section expands. The collapsed content
-        // is not kept mounted: hidden-but-mounted controls inside the popover were prone to stale
-        // paints (not rendering until hovered).
+        // The min-width keeps the menu width stable when a section expands
         <div className="flex flex-col w-full min-w-[18rem]" data-attr={dataAttr}>
             <LemonButton
                 fullWidth
@@ -255,7 +269,14 @@ export function CollapsibleOptionsSection({
             >
                 {label}
             </LemonButton>
-            {expanded && <div className="flex flex-col pl-2 w-full">{children}</div>}
+            <div
+                className="grid transition-all duration-200 ease-in-out"
+                style={{ gridTemplateRows: expanded && showContent ? '1fr' : '0fr' }}
+            >
+                <div className="overflow-hidden">
+                    {showContent && <div className="flex flex-col pt-2 pb-1 pl-2 w-full">{children}</div>}
+                </div>
+            </div>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -11,12 +11,6 @@ import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
 import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
-import {
-    LineShapePicker,
-    LineStylePicker,
-    ShowGridLinesFilter,
-    ShowPointsFilter,
-} from 'scenes/insights/EditorFilters/ChartStyleFilters'
 import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
 import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
 import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
@@ -246,17 +240,26 @@ export function CollapsibleOptionsSection({
     const [expanded, setExpanded] = useState(false)
 
     return (
-        <div className="flex flex-col w-full">
+        <div className="flex flex-col w-full" data-attr={dataAttr}>
             <LemonButton
                 fullWidth
                 size="small"
                 onClick={() => setExpanded(!expanded)}
                 sideIcon={expanded ? <IconChevronDown /> : <IconChevronRight />}
-                data-attr={dataAttr}
+                aria-expanded={expanded}
             >
                 {label}
             </LemonButton>
-            {expanded && <div className="flex flex-col pl-2 w-full">{children}</div>}
+            {/* Content stays mounted so the menu keeps a constant width — only the height animates
+                (same grid-rows trick as EditorFilterGroupTile) */}
+            <div
+                className="grid transition-all duration-200 ease-in-out"
+                style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
+            >
+                <div className="overflow-hidden">
+                    <div className="flex flex-col pl-2 w-full">{children}</div>
+                </div>
+            </div>
         </div>
     )
 }
@@ -309,10 +312,6 @@ export const DisplayOptions = {
     HideWeekends: { label: () => <HideWeekendsFilter /> },
     Annotations: { label: () => <ShowAnnotationsFilter /> },
     ResultCustomizationBy: { label: () => <ResultCustomizationByPicker /> },
-    LineShape: { label: () => <LineShapePicker /> },
-    LineStyle: { label: () => <LineStylePicker /> },
-    ShowPoints: { label: () => <ShowPointsFilter /> },
-    GridLines: { label: () => <ShowGridLinesFilter /> },
     Unit: { label: () => <UnitPicker /> },
     Scale: { label: () => <ScalePicker /> },
     ConfidenceInterval: { label: () => <ConfidenceInterval /> },

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -231,13 +231,15 @@ export function DecimalPrecision(): JSX.Element {
 export function CollapsibleOptionsSection({
     label,
     dataAttr,
+    defaultExpanded = false,
     children,
 }: {
     label: string
     dataAttr?: string
+    defaultExpanded?: boolean
     children: ReactNode
 }): JSX.Element {
-    const [expanded, setExpanded] = useState(false)
+    const [expanded, setExpanded] = useState(defaultExpanded)
 
     return (
         <div className="flex flex-col w-full" data-attr={dataAttr}>

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { IconChevronDown, IconChevronRight, IconInfo } from '@posthog/icons'
@@ -228,8 +228,6 @@ export function DecimalPrecision(): JSX.Element {
 
 /** A menu row that expands its options inline, accordion-style. Nested popovers are awkward to
  * use inside a menu, so collapsed option groups expand within the same overlay instead. */
-const COLLAPSIBLE_TRANSITION_MS = 200
-
 export function CollapsibleOptionsSection({
     label,
     dataAttr,
@@ -242,23 +240,12 @@ export function CollapsibleOptionsSection({
     children: ReactNode
 }): JSX.Element {
     const [expanded, setExpanded] = useState(defaultExpanded)
-    // The content is only in the DOM while the section is (at least partially) open: it mounts as
-    // the expand transition starts and unmounts once the collapse transition ends. Keeping it
-    // permanently mounted-but-hidden made the popover prone to stale paints (controls not
-    // rendering until hovered).
-    const [showContent, setShowContent] = useState(defaultExpanded)
-
-    useEffect(() => {
-        if (expanded) {
-            setShowContent(true)
-        } else {
-            const timeout = setTimeout(() => setShowContent(false), COLLAPSIBLE_TRANSITION_MS)
-            return () => clearTimeout(timeout)
-        }
-    }, [expanded])
 
     return (
-        // The min-width keeps the menu width stable when a section expands
+        // The min-width keeps the menu width stable when a section expands. The entrance animates
+        // opacity/transform only — height-clipping animations (grid-rows with overflow hidden)
+        // left the revealed controls with stale paints inside the popover, not rendering until
+        // hovered.
         <div className="flex flex-col w-full min-w-[18rem]" data-attr={dataAttr}>
             <LemonButton
                 fullWidth
@@ -269,14 +256,9 @@ export function CollapsibleOptionsSection({
             >
                 {label}
             </LemonButton>
-            <div
-                className="grid transition-all duration-200 ease-in-out"
-                style={{ gridTemplateRows: expanded && showContent ? '1fr' : '0fr' }}
-            >
-                <div className="overflow-hidden">
-                    {showContent && <div className="flex flex-col pt-2 pb-1 pl-2 w-full">{children}</div>}
-                </div>
-            </div>
+            {expanded && (
+                <div className="flex flex-col pt-2 pb-1 pl-2 w-full animate-[fade-in_150ms_ease-out]">{children}</div>
+            )}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
@@ -4,6 +4,8 @@ import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BindLogic, Provider } from 'kea'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -130,7 +132,7 @@ describe('EditorFilters', () => {
             name: 'trends',
             query: makeTrendsQuery(),
             expectedPresent: ['Filters'],
-            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types', 'Starts at'],
+            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types', 'Starts at', 'Overlays'],
         },
         {
             name: 'lifecycle',
@@ -213,5 +215,36 @@ describe('EditorFilters', () => {
 
         await userEvent.click(settingsButton)
         expect(settingsButton).toHaveAttribute('title', 'Show less')
+    })
+
+    describe('with the overlays section flag', () => {
+        beforeEach(() => {
+            featureFlagLogic.mount()
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]: true,
+            })
+        })
+
+        it('gathers goal lines and the overlay toggles under one Overlays section for trends', () => {
+            setupAndRender(makeTrendsQuery())
+
+            expect(screen.getByText('Overlays')).toBeInTheDocument()
+            // Moved out of "Advanced options" — must not render in both places
+            expect(screen.getAllByText('Goal lines')).toHaveLength(1)
+            for (const toggle of [
+                'Show trend lines',
+                'Show alert threshold lines',
+                'Show annotations',
+                'Show confidence intervals',
+                'Show moving average',
+            ]) {
+                expect(screen.getByText(toggle)).toBeInTheDocument()
+            }
+        })
+
+        it('hides the Overlays section for paths, which supports no overlays', () => {
+            setupAndRender(makePathsQuery())
+            expect(screen.queryByText('Overlays')).not.toBeInTheDocument()
+        })
     })
 })

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -22,10 +22,6 @@ import { PoeFilter } from 'scenes/insights/EditorFilters/PoeFilter'
 import { RetentionCondition } from 'scenes/insights/EditorFilters/RetentionCondition'
 import { RetentionOptions } from 'scenes/insights/EditorFilters/RetentionOptions'
 import { SamplingDeprecationNotice } from 'scenes/insights/EditorFilters/SamplingDeprecationNotice'
-import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
-import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
-import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
-import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
 import { WebAnalyticsEditorFilters } from 'scenes/insights/EditorFilters/WebAnalyticsEditorFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -51,7 +47,15 @@ import { EditorFiltersShell } from './EditorFiltersShell'
 import { getBreakdownSummary, getFiltersSummary, getSeriesSummary, visibleFilters } from './editorFilterUtils'
 import { GlobalAndOrFilters } from './GlobalAndOrFilters'
 import { LifecycleToggles } from './LifecycleToggles'
-import { ConfidenceIntervalFilter, MovingAverageFilter } from './OverlayFilters'
+import {
+    ConfidenceIntervalFilter,
+    MovingAverageFilter,
+    OverlaysDivider,
+    ShowAlertAnomalyPointsSwitch,
+    ShowAlertThresholdLinesSwitch,
+    ShowAnnotationsSwitch,
+    ShowTrendLinesSwitch,
+} from './OverlayFilters'
 import { TrendsSeries } from './TrendsSeries'
 
 export interface EditorFiltersProps {
@@ -391,12 +395,13 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                     component: GoalLines,
                     show: displayGoalLines,
                 },
-                { key: 'trend-lines', component: ShowTrendLinesFilter, show: displayTrendLines },
-                { key: 'alert-threshold-lines', component: ShowAlertThresholdLinesFilter, show: displayAlertOverlays },
-                { key: 'alert-anomaly-points', component: ShowAlertAnomalyPointsFilter, show: displayAlertOverlays },
+                { key: 'overlays-divider', component: OverlaysDivider, show: displayGoalLines },
+                { key: 'trend-lines', component: ShowTrendLinesSwitch, show: displayTrendLines },
+                { key: 'alert-threshold-lines', component: ShowAlertThresholdLinesSwitch, show: displayAlertOverlays },
+                { key: 'alert-anomaly-points', component: ShowAlertAnomalyPointsSwitch, show: displayAlertOverlays },
                 { key: 'confidence-intervals', component: ConfidenceIntervalFilter, show: displayStatisticalOverlays },
                 { key: 'moving-average', component: MovingAverageFilter, show: displayStatisticalOverlays },
-                { key: 'annotations', component: ShowAnnotationsFilter, show: displayAnnotations },
+                { key: 'annotations', component: ShowAnnotationsSwitch, show: displayAnnotations },
             ]),
         },
         // Hide advanced options for calendar heatmap

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -50,6 +50,7 @@ import { LifecycleToggles } from './LifecycleToggles'
 import {
     AlertOverlaysSwitches,
     ConfidenceIntervalFilter,
+    GoalLinesOverlay,
     MovingAverageFilter,
     OverlaysDivider,
     ShowAnnotationsSwitch,
@@ -382,18 +383,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
             defaultExpanded: false,
             show: overlaysSectionEnabled,
             editorFilters: visibleFilters([
-                {
-                    key: 'goal-lines',
-                    label: 'Goal lines',
-                    tooltip: (
-                        <>
-                            Goal lines can be used to highlight specific goals (Revenue, Signups, etc.) or limits (Web
-                            Vitals, etc.)
-                        </>
-                    ),
-                    component: GoalLines,
-                    show: displayGoalLines,
-                },
+                { key: 'goal-lines', component: GoalLinesOverlay, show: displayGoalLines },
                 { key: 'overlays-divider', component: OverlaysDivider, show: displayGoalLines },
                 { key: 'trend-lines', component: ShowTrendLinesSwitch, show: displayTrendLines },
                 { key: 'alert-overlays', component: AlertOverlaysSwitches, show: displayAlertOverlays },

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -48,11 +48,10 @@ import { getBreakdownSummary, getFiltersSummary, getSeriesSummary, visibleFilter
 import { GlobalAndOrFilters } from './GlobalAndOrFilters'
 import { LifecycleToggles } from './LifecycleToggles'
 import {
+    AlertOverlaysSwitches,
     ConfidenceIntervalFilter,
     MovingAverageFilter,
     OverlaysDivider,
-    ShowAlertAnomalyPointsSwitch,
-    ShowAlertThresholdLinesSwitch,
     ShowAnnotationsSwitch,
     ShowTrendLinesSwitch,
 } from './OverlayFilters'
@@ -397,8 +396,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                 },
                 { key: 'overlays-divider', component: OverlaysDivider, show: displayGoalLines },
                 { key: 'trend-lines', component: ShowTrendLinesSwitch, show: displayTrendLines },
-                { key: 'alert-threshold-lines', component: ShowAlertThresholdLinesSwitch, show: displayAlertOverlays },
-                { key: 'alert-anomaly-points', component: ShowAlertAnomalyPointsSwitch, show: displayAlertOverlays },
+                { key: 'alert-overlays', component: AlertOverlaysSwitches, show: displayAlertOverlays },
                 { key: 'confidence-intervals', component: ConfidenceIntervalFilter, show: displayStatisticalOverlays },
                 { key: 'moving-average', component: MovingAverageFilter, show: displayStatisticalOverlays },
                 { key: 'annotations', component: ShowAnnotationsSwitch, show: displayAnnotations },

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -3,7 +3,8 @@ import { useValues } from 'kea'
 import { IconInfo } from '@posthog/icons'
 import { Link, Tooltip } from '@posthog/lemon-ui'
 
-import { NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
+import { FEATURE_FLAGS, NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { pluralize } from 'lib/utils/strings'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { Attribution } from 'scenes/insights/EditorFilters/AttributionFilter'
@@ -21,6 +22,10 @@ import { PoeFilter } from 'scenes/insights/EditorFilters/PoeFilter'
 import { RetentionCondition } from 'scenes/insights/EditorFilters/RetentionCondition'
 import { RetentionOptions } from 'scenes/insights/EditorFilters/RetentionOptions'
 import { SamplingDeprecationNotice } from 'scenes/insights/EditorFilters/SamplingDeprecationNotice'
+import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
+import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
+import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
+import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
 import { WebAnalyticsEditorFilters } from 'scenes/insights/EditorFilters/WebAnalyticsEditorFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -46,6 +51,7 @@ import { EditorFiltersShell } from './EditorFiltersShell'
 import { getBreakdownSummary, getFiltersSummary, getSeriesSummary, visibleFilters } from './editorFilterUtils'
 import { GlobalAndOrFilters } from './GlobalAndOrFilters'
 import { LifecycleToggles } from './LifecycleToggles'
+import { ConfidenceIntervalFilter, MovingAverageFilter } from './OverlayFilters'
 import { TrendsSeries } from './TrendsSeries'
 
 export interface EditorFiltersProps {
@@ -72,9 +78,11 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         series,
         breakdownFilter,
         properties,
+        isNonTimeSeriesDisplay,
     } = useValues(insightVizDataLogic(insightProps))
 
     const { isStepsFunnel, isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!querySource) {
         return null
@@ -113,6 +121,20 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
             [ChartDisplayType.ActionsLineGraph, ChartDisplayType.ActionsBar].includes(
                 display || ChartDisplayType.ActionsLineGraph
             ))
+
+    const overlaysSectionEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]
+    // Overlay availability mirrors the conditions the Options menu uses for the same toggles
+    // (see useInsightDisplayOptions), so the toggles keep appearing for exactly the same insights.
+    const isContinuousChartDisplay =
+        !isNonTimeSeriesDisplay && display !== ChartDisplayType.Metric && display !== ChartDisplayType.SlopeGraph
+    const displayTrendLines = (isTrends || isRetention || isTrendsFunnel) && isContinuousChartDisplay
+    const displayAlertOverlays = isTrends && isContinuousChartDisplay
+    const displayAnnotations = (isTrends && isContinuousChartDisplay) || isTrendsFunnel
+    const displayStatisticalOverlays =
+        isTrends &&
+        isContinuousChartDisplay &&
+        display !== ChartDisplayType.CalendarHeatmap &&
+        display !== ChartDisplayType.BoxPlot
 
     const seriesSummary = getSeriesSummary(series)
     const filtersSummary = getFiltersSummary(properties)
@@ -349,6 +371,34 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                 },
             ]),
         },
+        // Everything drawn on top of the chart data: reference lines and computed/content overlays.
+        // Gathers the goal lines from "Advanced options" and the overlay toggles from the Options menu
+        // into one place, so e.g. goal lines and alert threshold lines are finally siblings.
+        {
+            title: 'Overlays',
+            defaultExpanded: false,
+            show: overlaysSectionEnabled,
+            editorFilters: visibleFilters([
+                {
+                    key: 'goal-lines',
+                    label: 'Goal lines',
+                    tooltip: (
+                        <>
+                            Goal lines can be used to highlight specific goals (Revenue, Signups, etc.) or limits (Web
+                            Vitals, etc.)
+                        </>
+                    ),
+                    component: GoalLines,
+                    show: displayGoalLines,
+                },
+                { key: 'trend-lines', component: ShowTrendLinesFilter, show: displayTrendLines },
+                { key: 'alert-threshold-lines', component: ShowAlertThresholdLinesFilter, show: displayAlertOverlays },
+                { key: 'alert-anomaly-points', component: ShowAlertAnomalyPointsFilter, show: displayAlertOverlays },
+                { key: 'confidence-intervals', component: ConfidenceIntervalFilter, show: displayStatisticalOverlays },
+                { key: 'moving-average', component: MovingAverageFilter, show: displayStatisticalOverlays },
+                { key: 'annotations', component: ShowAnnotationsFilter, show: displayAnnotations },
+            ]),
+        },
         // Hide advanced options for calendar heatmap
         {
             title: 'Advanced options',
@@ -366,7 +416,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                         </>
                     ),
                     component: GoalLines,
-                    show: displayGoalLines,
+                    show: displayGoalLines && !overlaysSectionEnabled,
                 },
                 { key: 'sampling-deprecation', component: SamplingDeprecationNotice },
             ]),

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -424,22 +424,36 @@ describe('InsightDisplayConfig', () => {
             })
         })
 
-        it('puts display toggles first and drops the low-usage smoothing and color sections', async () => {
+        it('makes Display an auto-open accordion and drops the smoothing and color sections', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
             await openOptionsMenu()
 
+            const displayButton = screen.getByText('Display').closest('button')!
+            expect(displayButton).toHaveAttribute('aria-expanded', 'true')
+            const display = screen.getByTestId('options-display-section')
+            expect(within(display).getByText('Show values on series')).toBeInTheDocument()
+            expect(within(display).getByText('Show legend')).toBeInTheDocument()
+            // Rarely used options leave Display for the Axes accordion
+            expect(within(display).queryByText('Show multiple Y-axes')).not.toBeInTheDocument()
+
             const sectionTitles = getSectionTitles()
-            expect(sectionTitles[0]).toBe('Display')
             expect(sectionTitles).not.toContain('Smoothing')
             expect(sectionTitles).not.toContain('Color customization by')
-
-            const items = getDisplaySectionItems()
-            expect(items).toContain('Show values on series')
-            expect(items).toContain('Show legend')
-            // Rarely used options leave the top level for the accordions
-            expect(items).not.toContain('Show multiple Y-axes')
             expect(screen.getByText('Line style')).toBeInTheDocument()
             expect(screen.getByText('Axes')).toBeInTheDocument()
+        })
+
+        it('keeps an accordion expanded after toggling an option inside it', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await openOptionsMenu()
+
+            const lineStyleButton = screen.getByText('Line style').closest('button')!
+            await userEvent.click(lineStyleButton)
+            expect(lineStyleButton).toHaveAttribute('aria-expanded', 'true')
+
+            await userEvent.click(screen.getByText('Show points'))
+            // The query update must not remount the accordion and reset its expansion state
+            expect(screen.getByText('Line style').closest('button')!).toHaveAttribute('aria-expanded', 'true')
         })
 
         it('nests the unit, scale, and label options under the Axes accordion', async () => {

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -347,6 +347,11 @@ describe('InsightDisplayConfig', () => {
             expect(screen.getByText('Y-axis scale')).toBeInTheDocument()
         })
 
+        it('shows no Style button without the style menu flag', () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            expect(screen.queryByLabelText('Style')).not.toBeInTheDocument()
+        })
+
         it('removes axis label option count after clearing a committed label', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph, { xAxisLabel: 'Signup date' }))
 
@@ -405,6 +410,41 @@ describe('InsightDisplayConfig', () => {
             // The aggregated bar-value layout has no in-chart legend, so it must not get a position select.
             const items = getDisplaySectionItems()
             expect(items.some((item) => item.includes('Bottom'))).toBe(false)
+        })
+    })
+
+    describe('style menu with the style menu flag', () => {
+        beforeEach(() => {
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU]: true,
+            })
+        })
+
+        it('hosts the presentation options in their own Style menu', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await userEvent.click(screen.getAllByLabelText('Style')[0])
+
+            expect(getSectionTitles()).toEqual([
+                'Labels & legend',
+                'Color customization by',
+                'Y-axis unit',
+                'Axis labels',
+            ])
+            expect(screen.getByText('Show values on series')).toBeInTheDocument()
+            expect(screen.getByText('Show legend')).toBeInTheDocument()
+        })
+
+        it('drops the moved presentation options from the Options menu', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await openOptionsMenu()
+
+            expect(getSectionTitles()).toEqual(['Display', 'Y-axis scale', 'Statistical analysis'])
+            const items = getDisplaySectionItems()
+            expect(items).not.toContain('Show values on series')
+            expect(items).not.toContain('Show legend')
+            // Options staying in the menu are unaffected
+            expect(items).toContain('Show multiple Y-axes')
+            expect(items).toContain('Show trend lines')
         })
     })
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -465,6 +465,7 @@ describe('InsightDisplayConfig', () => {
             expect(within(axes).getByText('Y-axis unit')).toBeInTheDocument()
             expect(within(axes).getByText('Y-axis scale')).toBeInTheDocument()
             expect(within(axes).getByText('Show multiple Y-axes')).toBeInTheDocument()
+            expect(within(axes).getByText('Show gridlines')).toBeInTheDocument()
             expect(within(axes).getByText('Axis labels')).toBeInTheDocument()
             // ... and nowhere else in the menu
             expect(screen.getAllByText('Y-axis unit')).toHaveLength(1)

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -424,40 +424,55 @@ describe('InsightDisplayConfig', () => {
             })
         })
 
-        it('keeps frequent options top-level and collapses rare ones into submenu rows', async () => {
+        it('puts display toggles first and drops the low-usage smoothing and color sections', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
             await openOptionsMenu()
+
+            const sectionTitles = getSectionTitles()
+            expect(sectionTitles[0]).toBe('Display')
+            expect(sectionTitles).not.toContain('Smoothing')
+            expect(sectionTitles).not.toContain('Color customization by')
 
             const items = getDisplaySectionItems()
             expect(items).toContain('Show values on series')
             expect(items).toContain('Show legend')
-            // Rarely used options leave the top level for the submenus
+            // Rarely used options leave the top level for the accordions
             expect(items).not.toContain('Show multiple Y-axes')
-            expect(getSectionTitles()).not.toContain('Y-axis scale')
-            expect(getSectionTitles()).not.toContain('Axis labels')
             expect(screen.getByText('Line style')).toBeInTheDocument()
             expect(screen.getByText('Axes')).toBeInTheDocument()
         })
 
-        it('reveals the sub-options when a submenu row is opened', async () => {
+        it('nests the unit, scale, and label options under the Axes accordion', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
             await openOptionsMenu()
 
-            await userEvent.click(screen.getByText('Line style'))
-            expect(await screen.findByText('Line shape')).toBeInTheDocument()
-            expect(screen.getByText('Show points')).toBeInTheDocument()
-
-            await userEvent.click(screen.getByText('Axes'))
-            expect(await screen.findByText('Show multiple Y-axes')).toBeInTheDocument()
-            expect(screen.getByText('Y-axis scale')).toBeInTheDocument()
+            const axes = screen.getByTestId('options-axes-section')
+            expect(within(axes).getByText('Y-axis unit')).toBeInTheDocument()
+            expect(within(axes).getByText('Y-axis scale')).toBeInTheDocument()
+            expect(within(axes).getByText('Show multiple Y-axes')).toBeInTheDocument()
+            expect(within(axes).getByText('Axis labels')).toBeInTheDocument()
+            // ... and nowhere else in the menu
+            expect(screen.getAllByText('Y-axis unit')).toHaveLength(1)
         })
 
-        it('omits the Line style submenu for non-line displays', async () => {
+        it('expands an accordion row in place when clicked', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await openOptionsMenu()
+
+            const lineStyleButton = screen.getByText('Line style').closest('button')!
+            expect(lineStyleButton).toHaveAttribute('aria-expanded', 'false')
+            await userEvent.click(lineStyleButton)
+            expect(lineStyleButton).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByText('Shape')).toBeInTheDocument()
+            expect(screen.getByText('Dash')).toBeInTheDocument()
+        })
+
+        it('omits the Line style accordion for non-line displays', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsBarValue))
             await openOptionsMenu()
 
             expect(screen.queryByText('Line style')).not.toBeInTheDocument()
-            // Axis labels still apply to bar charts, so the Axes submenu stays
+            // Axis labels still apply to bar charts, so the Axes accordion stays
             expect(screen.getByText('Axes')).toBeInTheDocument()
         })
     })

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -407,4 +407,27 @@ describe('InsightDisplayConfig', () => {
             expect(items.some((item) => item.includes('Bottom'))).toBe(false)
         })
     })
+
+    describe('options menu with the overlays section flag', () => {
+        beforeEach(() => {
+            featureFlagLogic.actions.setFeatureFlags([], {
+                [FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]: true,
+            })
+        })
+
+        it('drops the overlay toggles and statistical analysis, which move to the editor panel', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await openOptionsMenu()
+
+            expect(getSectionTitles()).not.toContain('Statistical analysis')
+            const items = getDisplaySectionItems()
+            for (const moved of ['Show trend lines', 'Show alert threshold lines', 'Show annotations']) {
+                expect(items).not.toContain(moved)
+            }
+            // Options staying in the menu are unaffected
+            expect(items).toContain('Show values on series')
+            expect(items).toContain('Show legend')
+            expect(items).toContain('Show multiple Y-axes')
+        })
+    })
 })

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -426,12 +426,23 @@ describe('InsightDisplayConfig', () => {
 
             expect(getSectionTitles()).toEqual([
                 'Labels & legend',
+                'Line style',
                 'Color customization by',
                 'Y-axis unit',
                 'Axis labels',
             ])
             expect(screen.getByText('Show values on series')).toBeInTheDocument()
             expect(screen.getByText('Show legend')).toBeInTheDocument()
+            // The chart style controls, only for line-ish displays
+            expect(screen.getByText('Line shape')).toBeInTheDocument()
+            expect(screen.getByText('Show points')).toBeInTheDocument()
+        })
+
+        it('omits the Line style section for non-line displays', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsBarValue))
+            await userEvent.click(screen.getAllByLabelText('Style')[0])
+
+            expect(getSectionTitles()).not.toContain('Line style')
         })
 
         it('drops the moved presentation options from the Options menu', async () => {

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -347,9 +347,13 @@ describe('InsightDisplayConfig', () => {
             expect(screen.getByText('Y-axis scale')).toBeInTheDocument()
         })
 
-        it('shows no Style button without the style menu flag', () => {
+        it('keeps rarely used options top-level without the style menu flag', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
-            expect(screen.queryByLabelText('Style')).not.toBeInTheDocument()
+            await openOptionsMenu()
+
+            expect(getSectionTitles()).toContain('Y-axis scale')
+            expect(screen.queryByText('Line style')).not.toBeInTheDocument()
+            expect(screen.queryByText('Axes')).not.toBeInTheDocument()
         })
 
         it('removes axis label option count after clearing a committed label', async () => {
@@ -413,49 +417,48 @@ describe('InsightDisplayConfig', () => {
         })
     })
 
-    describe('style menu with the style menu flag', () => {
+    describe('options menu with the style menu flag', () => {
         beforeEach(() => {
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU]: true,
             })
         })
 
-        it('hosts the presentation options in their own Style menu', async () => {
-            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
-            await userEvent.click(screen.getAllByLabelText('Style')[0])
-
-            expect(getSectionTitles()).toEqual([
-                'Labels & legend',
-                'Line style',
-                'Color customization by',
-                'Y-axis unit',
-                'Axis labels',
-            ])
-            expect(screen.getByText('Show values on series')).toBeInTheDocument()
-            expect(screen.getByText('Show legend')).toBeInTheDocument()
-            // The chart style controls, only for line-ish displays
-            expect(screen.getByText('Line shape')).toBeInTheDocument()
-            expect(screen.getByText('Show points')).toBeInTheDocument()
-        })
-
-        it('omits the Line style section for non-line displays', async () => {
-            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsBarValue))
-            await userEvent.click(screen.getAllByLabelText('Style')[0])
-
-            expect(getSectionTitles()).not.toContain('Line style')
-        })
-
-        it('drops the moved presentation options from the Options menu', async () => {
+        it('keeps frequent options top-level and collapses rare ones into submenu rows', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
             await openOptionsMenu()
 
-            expect(getSectionTitles()).toEqual(['Display', 'Y-axis scale', 'Statistical analysis'])
             const items = getDisplaySectionItems()
-            expect(items).not.toContain('Show values on series')
-            expect(items).not.toContain('Show legend')
-            // Options staying in the menu are unaffected
-            expect(items).toContain('Show multiple Y-axes')
-            expect(items).toContain('Show trend lines')
+            expect(items).toContain('Show values on series')
+            expect(items).toContain('Show legend')
+            // Rarely used options leave the top level for the submenus
+            expect(items).not.toContain('Show multiple Y-axes')
+            expect(getSectionTitles()).not.toContain('Y-axis scale')
+            expect(getSectionTitles()).not.toContain('Axis labels')
+            expect(screen.getByText('Line style')).toBeInTheDocument()
+            expect(screen.getByText('Axes')).toBeInTheDocument()
+        })
+
+        it('reveals the sub-options when a submenu row is opened', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
+            await openOptionsMenu()
+
+            await userEvent.click(screen.getByText('Line style'))
+            expect(await screen.findByText('Line shape')).toBeInTheDocument()
+            expect(screen.getByText('Show points')).toBeInTheDocument()
+
+            await userEvent.click(screen.getByText('Axes'))
+            expect(await screen.findByText('Show multiple Y-axes')).toBeInTheDocument()
+            expect(screen.getByText('Y-axis scale')).toBeInTheDocument()
+        })
+
+        it('omits the Line style submenu for non-line displays', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsBarValue))
+            await openOptionsMenu()
+
+            expect(screen.queryByText('Line style')).not.toBeInTheDocument()
+            // Axis labels still apply to bar charts, so the Axes submenu stays
+            expect(screen.getByText('Axes')).toBeInTheDocument()
         })
     })
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -461,6 +461,7 @@ describe('InsightDisplayConfig', () => {
             await openOptionsMenu()
 
             const axes = screen.getByTestId('options-axes-section')
+            await userEvent.click(within(axes).getByText('Axes'))
             expect(within(axes).getByText('Y-axis unit')).toBeInTheDocument()
             expect(within(axes).getByText('Y-axis scale')).toBeInTheDocument()
             expect(within(axes).getByText('Show multiple Y-axes')).toBeInTheDocument()

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { ReactNode } from 'react'
 
-import { IconEllipsis } from '@posthog/icons'
+import { IconEllipsis, IconPalette } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
@@ -72,7 +72,7 @@ export function InsightDisplayConfig(): JSX.Element {
         isLifecycle ||
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
 
-    const { items: advancedOptions, count: advancedOptionsCount } = useInsightDisplayOptions()
+    const { items: advancedOptions, count: advancedOptionsCount, styleItems, styleCount } = useInsightDisplayOptions()
 
     return (
         <div
@@ -120,6 +120,34 @@ export function InsightDisplayConfig(): JSX.Element {
                 )}
             </div>
             <div className="flex items-center gap-x-2">
+                {styleItems.length > 0 && (
+                    <>
+                        <LemonMenu items={styleItems} closeOnClickInside={false} placement="bottom-end">
+                            <LemonButton
+                                size="small"
+                                disabledReason={editingDisabledReason}
+                                aria-label="Style"
+                                className="@max-[780px]:hidden"
+                            >
+                                <span className="font-medium whitespace-nowrap">
+                                    Style
+                                    {styleCount ? (
+                                        <span className="ml-0.5 text-secondary ligatures-none">({styleCount})</span>
+                                    ) : null}
+                                </span>
+                            </LemonButton>
+                        </LemonMenu>
+                        <LemonMenu items={styleItems} closeOnClickInside={false} placement="bottom-end">
+                            <LemonButton
+                                size="small"
+                                disabledReason={editingDisabledReason}
+                                icon={<IconPalette />}
+                                aria-label="Style"
+                                className="hidden @max-[780px]:flex order-[999]"
+                            />
+                        </LemonMenu>
+                    </>
+                )}
                 {advancedOptions.length > 0 && (
                     <>
                         <LemonMenu items={advancedOptions} closeOnClickInside={false} placement="bottom-end">

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { ReactNode } from 'react'
 
-import { IconEllipsis, IconPalette } from '@posthog/icons'
+import { IconEllipsis } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
@@ -72,7 +72,7 @@ export function InsightDisplayConfig(): JSX.Element {
         isLifecycle ||
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
 
-    const { items: advancedOptions, count: advancedOptionsCount, styleItems, styleCount } = useInsightDisplayOptions()
+    const { items: advancedOptions, count: advancedOptionsCount } = useInsightDisplayOptions()
 
     return (
         <div
@@ -120,34 +120,6 @@ export function InsightDisplayConfig(): JSX.Element {
                 )}
             </div>
             <div className="flex items-center gap-x-2">
-                {styleItems.length > 0 && (
-                    <>
-                        <LemonMenu items={styleItems} closeOnClickInside={false} placement="bottom-end">
-                            <LemonButton
-                                size="small"
-                                disabledReason={editingDisabledReason}
-                                aria-label="Style"
-                                className="@max-[780px]:hidden"
-                            >
-                                <span className="font-medium whitespace-nowrap">
-                                    Style
-                                    {styleCount ? (
-                                        <span className="ml-0.5 text-secondary ligatures-none">({styleCount})</span>
-                                    ) : null}
-                                </span>
-                            </LemonButton>
-                        </LemonMenu>
-                        <LemonMenu items={styleItems} closeOnClickInside={false} placement="bottom-end">
-                            <LemonButton
-                                size="small"
-                                disabledReason={editingDisabledReason}
-                                icon={<IconPalette />}
-                                aria-label="Style"
-                                className="hidden @max-[780px]:flex order-[999]"
-                            />
-                        </LemonMenu>
-                    </>
-                )}
                 {advancedOptions.length > 0 && (
                     <>
                         <LemonMenu items={advancedOptions} closeOnClickInside={false} placement="bottom-end">

--- a/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
@@ -1,7 +1,10 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
-import { LemonDivider } from '@posthog/lemon-ui'
+import { IconPlusSmall } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonLabel } from '@posthog/lemon-ui'
 
+import { GoalLinesList } from 'lib/components/GoalLinesList'
+import { goalLinesLogic } from 'scenes/insights/EditorFilters/goalLinesLogic'
 import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
 import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
 import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
@@ -11,7 +14,31 @@ import { ConfidenceLevelInput } from 'scenes/insights/views/LineGraph/Confidence
 import { MovingAverageIntervalsInput } from 'scenes/insights/views/LineGraph/MovingAverageIntervalsInput'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
+import { InsightLogicProps } from '~/types'
+
 import { ConfidenceInterval, MovingAverage } from './DisplayOptions'
+
+// Goal lines with the label and the add button on one row, for the Overlays editor section.
+export function GoalLinesOverlay({ insightProps }: { insightProps: InsightLogicProps }): JSX.Element {
+    const { goalLines } = useValues(goalLinesLogic(insightProps))
+    const { addGoalLine, updateGoalLine, removeGoalLine } = useActions(goalLinesLogic(insightProps))
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+                <LemonLabel info="Goal lines can be used to highlight specific goals (Revenue, Signups, etc.) or limits (Web Vitals, etc.)">
+                    Goal lines
+                </LemonLabel>
+                <LemonButton type="secondary" onClick={addGoalLine} icon={<IconPlusSmall />} size="small">
+                    Add goal line
+                </LemonButton>
+            </div>
+            {goalLines.length > 0 && (
+                <GoalLinesList goalLines={goalLines} removeGoalLine={removeGoalLine} updateGoalLine={updateGoalLine} />
+            )}
+        </div>
+    )
+}
 
 // Panel-flavored (switch) variants of the overlay toggles, for the Overlays editor section.
 // The same components render as checkboxes in the Options menu when the section flag is off.

--- a/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
@@ -19,12 +19,16 @@ export function ShowTrendLinesSwitch(): JSX.Element {
     return <ShowTrendLinesFilter variant="switch" />
 }
 
-export function ShowAlertThresholdLinesSwitch(): JSX.Element | null {
-    return <ShowAlertThresholdLinesFilter variant="switch" />
-}
-
-export function ShowAlertAnomalyPointsSwitch(): JSX.Element | null {
-    return <ShowAlertAnomalyPointsFilter variant="switch" />
+// One editor filter entry for both alert toggles: the anomaly points toggle only renders when the
+// insight has detector alerts, and a null component in its own entry would still take up a slot
+// in the panel's flex gap, leaving a phantom double gap.
+export function AlertOverlaysSwitches(): JSX.Element | null {
+    return (
+        <div className="flex flex-col gap-2">
+            <ShowAlertThresholdLinesFilter variant="switch" />
+            <ShowAlertAnomalyPointsFilter variant="switch" />
+        </div>
+    )
 }
 
 export function ShowAnnotationsSwitch(): JSX.Element | null {
@@ -40,8 +44,8 @@ export function ConfidenceIntervalFilter(): JSX.Element {
     const { showConfidenceIntervals } = useValues(trendsDataLogic(insightProps))
 
     return (
-        <div className="flex flex-col">
-            <ConfidenceInterval />
+        <div className="flex flex-col gap-2">
+            <ConfidenceInterval className="" />
             {showConfidenceIntervals && <ConfidenceLevelInput />}
         </div>
     )
@@ -52,8 +56,8 @@ export function MovingAverageFilter(): JSX.Element {
     const { showMovingAverage } = useValues(trendsDataLogic(insightProps))
 
     return (
-        <div className="flex flex-col">
-            <MovingAverage />
+        <div className="flex flex-col gap-2">
+            <MovingAverage className="" />
             {showMovingAverage && <MovingAverageIntervalsInput />}
         </div>
     )

--- a/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
@@ -1,0 +1,32 @@
+import { useValues } from 'kea'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { ConfidenceLevelInput } from 'scenes/insights/views/LineGraph/ConfidenceLevelInput'
+import { MovingAverageIntervalsInput } from 'scenes/insights/views/LineGraph/MovingAverageIntervalsInput'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { ConfidenceInterval, MovingAverage } from './DisplayOptions'
+
+export function ConfidenceIntervalFilter(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showConfidenceIntervals } = useValues(trendsDataLogic(insightProps))
+
+    return (
+        <div className="flex flex-col">
+            <ConfidenceInterval />
+            {showConfidenceIntervals && <ConfidenceLevelInput />}
+        </div>
+    )
+}
+
+export function MovingAverageFilter(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { showMovingAverage } = useValues(trendsDataLogic(insightProps))
+
+    return (
+        <div className="flex flex-col">
+            <MovingAverage />
+            {showMovingAverage && <MovingAverageIntervalsInput />}
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/OverlayFilters.tsx
@@ -1,11 +1,39 @@
 import { useValues } from 'kea'
 
+import { LemonDivider } from '@posthog/lemon-ui'
+
+import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
+import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
+import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
+import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { ConfidenceLevelInput } from 'scenes/insights/views/LineGraph/ConfidenceLevelInput'
 import { MovingAverageIntervalsInput } from 'scenes/insights/views/LineGraph/MovingAverageIntervalsInput'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
 import { ConfidenceInterval, MovingAverage } from './DisplayOptions'
+
+// Panel-flavored (switch) variants of the overlay toggles, for the Overlays editor section.
+// The same components render as checkboxes in the Options menu when the section flag is off.
+export function ShowTrendLinesSwitch(): JSX.Element {
+    return <ShowTrendLinesFilter variant="switch" />
+}
+
+export function ShowAlertThresholdLinesSwitch(): JSX.Element | null {
+    return <ShowAlertThresholdLinesFilter variant="switch" />
+}
+
+export function ShowAlertAnomalyPointsSwitch(): JSX.Element | null {
+    return <ShowAlertAnomalyPointsFilter variant="switch" />
+}
+
+export function ShowAnnotationsSwitch(): JSX.Element | null {
+    return <ShowAnnotationsFilter variant="switch" />
+}
+
+export function OverlaysDivider(): JSX.Element {
+    return <LemonDivider className="my-0" />
+}
 
 export function ConfidenceIntervalFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { normalizeAxisLabel } from '@posthog/quill-charts'
 
 import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
+import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -192,7 +193,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
 
     const items: LemonMenuItems = []
 
-    if (showSmoothing) {
+    // With the reorganized menu, smoothing and the color-assignment picker are dropped entirely —
+    // usage data shows they barely register (smoothing is set on <1% of saved trends insights).
+    if (showSmoothing && !styleMenuEnabled) {
         items.push({ title: 'Smoothing', items: [DisplayOptions.Smoothing] })
     }
 
@@ -203,7 +206,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         })
     }
 
-    if (supportsResultCustomizationBy) {
+    if (supportsResultCustomizationBy && !styleMenuEnabled) {
         items.push({
             title: (
                 <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
@@ -214,7 +217,8 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         })
     }
 
-    if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
+    const showUnitPicker = !showPercentStackView && isTrends && !isCalendarHeatmap
+    if (showUnitPicker && !styleMenuEnabled) {
         items.push({
             title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
             items: [DisplayOptions.Unit],
@@ -280,18 +284,26 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             })
         }
         const showDecimalPlaces = mightContainFractionalNumbers && isTrends && !isCalendarHeatmap
-        if (showMultipleYAxesConfig || showYAxisScale || showAxisLabelsConfig || showDecimalPlaces) {
+        if (showUnitPicker || showMultipleYAxesConfig || showYAxisScale || showAxisLabelsConfig || showDecimalPlaces) {
             collapsedRows.push({
                 label: function AxesSection() {
                     return (
                         <CollapsibleOptionsSection label="Axes" dataAttr="options-axes-section">
-                            {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
+                            {showUnitPicker && (
+                                <>
+                                    <SectionHeader>
+                                        {axisLabel(display || ChartDisplayType.ActionsLineGraph)}
+                                    </SectionHeader>
+                                    <UnitPicker />
+                                </>
+                            )}
                             {showYAxisScale && (
                                 <>
                                     <SectionHeader>Y-axis scale</SectionHeader>
                                     <ScalePicker />
                                 </>
                             )}
+                            {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
                             {showAxisLabelsConfig && (
                                 <>
                                     <SectionHeader>Axis labels</SectionHeader>
@@ -334,7 +346,8 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         (showLineStyleConfig && chartStyle?.showGrid === false ? 1 : 0)
 
     const optionsCount: number =
-        (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
+        // The smoothing control is dropped from the reorganized menu, so don't badge for it there
+        (showSmoothing && !styleMenuEnabled && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
         (showPercentStackView ? 1 : 0) +
         (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
         (showMultipleYAxes ? 1 : 0) +

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -96,6 +96,10 @@ export function useInsightDisplayOptions(): {
         (!display && isStickiness)
     const isBarDisplay = displayMatches(display, BAR_DISPLAYS)
     const showAxisLabelsConfig = isTrends && (isLineDisplay || isBarDisplay)
+    // The chart style options are only wired into the quill trends line/area charts for now
+    const showLineStyleConfig = isTrends && isLineDisplay
+    const chartStyle = trendsFilter?.chartStyle
+    const defaultCurve = featureFlags[FEATURE_FLAGS.QUILL_CHART_STYLE_REFRESH] ? 'smooth' : 'linear'
     const showFunnelLegendConfig = isTrendsFunnel && hasBreakdownFilter(breakdownFilter)
     const isBoxPlot = display === ChartDisplayType.BoxPlot
     const isCalendarHeatmap = display === ChartDisplayType.CalendarHeatmap
@@ -282,6 +286,17 @@ export function useInsightDisplayOptions(): {
                 items: labelsAndLegendItems,
             })
         }
+        if (showLineStyleConfig) {
+            styleItems.push({
+                title: <SectionHeader dataAttr="style-line-section">Line style</SectionHeader>,
+                items: [
+                    DisplayOptions.LineShape,
+                    DisplayOptions.LineStyle,
+                    DisplayOptions.ShowPoints,
+                    DisplayOptions.GridLines,
+                ],
+            })
+        }
         if (supportsResultCustomizationBy) {
             styleItems.push({
                 title: (
@@ -321,7 +336,11 @@ export function useInsightDisplayOptions(): {
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
         (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
-        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0)
+        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
+        (showLineStyleConfig && chartStyle?.curve && chartStyle.curve !== defaultCurve ? 1 : 0) +
+        (showLineStyleConfig && chartStyle?.lineStyle && chartStyle.lineStyle !== 'solid' ? 1 : 0) +
+        (showLineStyleConfig && chartStyle?.showPoints ? 1 : 0) +
+        (showLineStyleConfig && chartStyle?.showGrid === false ? 1 : 0)
 
     const optionsCount: number =
         (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -36,9 +36,11 @@ import {
     SectionHeader,
 } from './DisplayOptions'
 
-// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
-// active options, badged on the Options button.
-export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+/** Everything the Options menu and its accordion sections need to decide what to show. Shared
+ * between useInsightDisplayOptions and the module-level accordion components below, so those
+ * components keep a stable identity — an inline component recreated per render would remount
+ * (and reset its expansion state) every time the menu re-renders. */
+function useDisplayOptionsState() {
     const { insightProps } = useValues(insightLogic)
     const {
         querySource,
@@ -77,9 +79,8 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     // With the Overlays editor panel section enabled, the overlay toggles (trend lines, alert
     // overlays, annotations, statistical analysis) move there and leave this menu.
     const overlaysSectionEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]
-    // With the style menu flag enabled, rarely used options (axis scale/labels, decimal places,
-    // multiple y-axes) and the chart style controls collapse into "Line style" / "Axes" submenus,
-    // keeping the frequently used options top-level.
+    // With the style menu flag enabled, the menu is reorganized into accordions: Display (auto-open),
+    // Line style (chart style controls), and Axes (unit, scale, labels, decimal places).
     const styleMenuEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
@@ -120,133 +121,313 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const showDisplaySection =
         (isTrends && !isCalendarHeatmap) || isRetention || isTrendsFunnel || isStickiness || isLifecycle
     const showYAxisScale = !hideContinuousChartOptions && isTrends && !isCalendarHeatmap
+    const showUnitPicker = !showPercentStackView && isTrends && !isCalendarHeatmap
+    const showDecimalPlaces = mightContainFractionalNumbers && isTrends && !isCalendarHeatmap
 
-    // The box plot and slope graph only show a couple of options each; everything else falls
-    // through to the full shared list.
-    const getDisplayItems = (): LemonMenuItem[] => {
-        const displayItems: LemonMenuItem[] = []
+    return {
+        display,
+        isTrends,
+        isRetention,
+        isLifecycle,
+        isMetric,
+        isBoxPlot,
+        isSlopeGraph,
+        isCalendarHeatmap,
+        isTrendsFunnel,
+        hideContinuousChartOptions,
+        trendsFilter,
+        chartStyle,
+        defaultCurve,
+        yAxisScaleType,
+        hasLegend,
+        showLegend,
+        supportsValueOnSeries,
+        showPercentStackView,
+        supportsPercentStackView,
+        supportsBarValueStacking,
+        supportsResultCustomizationBy,
+        showMultipleYAxes,
+        showAnnotations,
+        showValuesOnSeries,
+        showPercentagesOnSeries,
+        showConfidenceIntervals,
+        showMovingAverage,
+        hideWeekendsEnabled,
+        overlaysSectionEnabled,
+        styleMenuEnabled,
+        showSmoothing,
+        showMultipleYAxesConfig,
+        showAlertThresholdLinesConfig,
+        showAnnotationsConfig,
+        showAxisLabelsConfig,
+        showLineStyleConfig,
+        showFunnelLegendConfig,
+        useQuillLegendOptions,
+        showDisplaySection,
+        showYAxisScale,
+        showUnitPicker,
+        showDecimalPlaces,
+    }
+}
 
-        if (isBoxPlot) {
-            if (hasLegend) {
-                displayItems.push(DisplayOptions.Legend)
-            }
-            displayItems.push(DisplayOptions.ExcludeOutliers)
-            return displayItems
-        }
+type DisplayOptionsState = ReturnType<typeof useDisplayOptionsState>
 
-        if (isSlopeGraph) {
-            // A slope only shows the first vs last interval of each series — the legend (when there
-            // are multiple series) is the only display option that applies.
-            if (hasLegend) {
-                displayItems.push(DisplayOptions.Legend)
-            }
-            return displayItems
-        }
+// The box plot and slope graph only show a couple of options each; everything else falls
+// through to the full shared list.
+function getDisplayItems(s: DisplayOptionsState): LemonMenuItem[] {
+    const displayItems: LemonMenuItem[] = []
 
-        if (isMetric) {
-            displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
-        }
-        if (isLifecycle) {
-            displayItems.push(DisplayOptions.LifecycleStacking)
-        }
-        if (supportsValueOnSeries) {
-            displayItems.push(DisplayOptions.ValueLabels)
-        }
-        if (isLifecycle) {
-            displayItems.push(DisplayOptions.LifecyclePercentages)
-        }
-        if (supportsPercentStackView) {
-            displayItems.push(DisplayOptions.PercentStack)
-        }
-        if (supportsBarValueStacking) {
-            displayItems.push(DisplayOptions.StackBreakdown)
-        }
-        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions) {
+    if (s.isBoxPlot) {
+        if (s.hasLegend) {
             displayItems.push(DisplayOptions.Legend)
         }
-        if (display === ChartDisplayType.ActionsPie) {
-            displayItems.push(DisplayOptions.PieTotal)
-        }
-        if (showAlertThresholdLinesConfig && !overlaysSectionEnabled) {
-            displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
-        }
-        if (showMultipleYAxesConfig && !styleMenuEnabled) {
-            displayItems.push(DisplayOptions.MultipleYAxes)
-        }
-        if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions && !overlaysSectionEnabled) {
-            displayItems.push(DisplayOptions.TrendLines)
-        }
-        if (isTrendsFunnel && !hideContinuousChartOptions) {
-            displayItems.push(DisplayOptions.HideIncompleteFunnelPeriods)
-        }
-        if (isTrends && !hideContinuousChartOptions && hideWeekendsEnabled) {
-            displayItems.push(DisplayOptions.HideWeekends)
-        }
-        if (showAnnotationsConfig && !overlaysSectionEnabled) {
-            displayItems.push(DisplayOptions.Annotations)
-        }
-        if (useQuillLegendOptions) {
-            displayItems.push(DisplayOptions.LegendOptions)
+        displayItems.push(DisplayOptions.ExcludeOutliers)
+        return displayItems
+    }
+
+    if (s.isSlopeGraph) {
+        // A slope only shows the first vs last interval of each series — the legend (when there
+        // are multiple series) is the only display option that applies.
+        if (s.hasLegend) {
+            displayItems.push(DisplayOptions.Legend)
         }
         return displayItems
     }
 
+    if (s.isMetric) {
+        displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+    }
+    if (s.isLifecycle) {
+        displayItems.push(DisplayOptions.LifecycleStacking)
+    }
+    if (s.supportsValueOnSeries) {
+        displayItems.push(DisplayOptions.ValueLabels)
+    }
+    if (s.isLifecycle) {
+        displayItems.push(DisplayOptions.LifecyclePercentages)
+    }
+    if (s.supportsPercentStackView) {
+        displayItems.push(DisplayOptions.PercentStack)
+    }
+    if (s.supportsBarValueStacking) {
+        displayItems.push(DisplayOptions.StackBreakdown)
+    }
+    if ((s.hasLegend || s.showFunnelLegendConfig) && !s.useQuillLegendOptions) {
+        displayItems.push(DisplayOptions.Legend)
+    }
+    if (s.display === ChartDisplayType.ActionsPie) {
+        displayItems.push(DisplayOptions.PieTotal)
+    }
+    if (s.showAlertThresholdLinesConfig && !s.overlaysSectionEnabled) {
+        displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
+    }
+    if (s.showMultipleYAxesConfig && !s.styleMenuEnabled) {
+        displayItems.push(DisplayOptions.MultipleYAxes)
+    }
+    if (
+        (s.isTrends || s.isRetention || s.isTrendsFunnel) &&
+        !s.hideContinuousChartOptions &&
+        !s.overlaysSectionEnabled
+    ) {
+        displayItems.push(DisplayOptions.TrendLines)
+    }
+    if (s.isTrendsFunnel && !s.hideContinuousChartOptions) {
+        displayItems.push(DisplayOptions.HideIncompleteFunnelPeriods)
+    }
+    if (s.isTrends && !s.hideContinuousChartOptions && s.hideWeekendsEnabled) {
+        displayItems.push(DisplayOptions.HideWeekends)
+    }
+    if (s.showAnnotationsConfig && !s.overlaysSectionEnabled) {
+        displayItems.push(DisplayOptions.Annotations)
+    }
+    if (s.useQuillLegendOptions) {
+        displayItems.push(DisplayOptions.LegendOptions)
+    }
+    return displayItems
+}
+
+// The accordion sections live at module level so their component identity is stable across
+// renders. Defining them inline in the hook would remount them — and reset their expansion
+// state and control internals — on every menu re-render.
+
+function DisplayOptionsAccordion(): JSX.Element {
+    const state = useDisplayOptionsState()
+
+    return (
+        <CollapsibleOptionsSection label="Display" dataAttr="options-display-section" defaultExpanded>
+            {getDisplayItems(state).map((item, index) => {
+                // Registry entries always use component labels
+                const Label = item.label as () => JSX.Element
+                return <Label key={index} />
+            })}
+        </CollapsibleOptionsSection>
+    )
+}
+
+function LineStyleOptionsAccordion(): JSX.Element {
+    return (
+        <CollapsibleOptionsSection label="Line style" dataAttr="options-line-style-section">
+            <LineShapePicker />
+            <LineStylePicker />
+            <ShowPointsFilter />
+            <ShowGridLinesFilter />
+        </CollapsibleOptionsSection>
+    )
+}
+
+function AxesOptionsAccordion(): JSX.Element {
+    const {
+        display,
+        showUnitPicker,
+        showYAxisScale,
+        showMultipleYAxesConfig,
+        showAxisLabelsConfig,
+        showDecimalPlaces,
+    } = useDisplayOptionsState()
+
+    return (
+        <CollapsibleOptionsSection label="Axes" dataAttr="options-axes-section">
+            {showUnitPicker && (
+                <>
+                    <SectionHeader>{axisLabel(display || ChartDisplayType.ActionsLineGraph)}</SectionHeader>
+                    <UnitPicker />
+                </>
+            )}
+            {showYAxisScale && (
+                <>
+                    <SectionHeader>Y-axis scale</SectionHeader>
+                    <ScalePicker />
+                </>
+            )}
+            {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
+            {showAxisLabelsConfig && (
+                <>
+                    <SectionHeader>Axis labels</SectionHeader>
+                    <AxisLabelsFilter />
+                </>
+            )}
+            {showDecimalPlaces && (
+                <>
+                    <SectionHeader>Decimal places</SectionHeader>
+                    <DecimalPrecision />
+                </>
+            )}
+        </CollapsibleOptionsSection>
+    )
+}
+
+// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
+// active options, badged on the Options button.
+export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+    const state = useDisplayOptionsState()
+    const {
+        display,
+        isTrends,
+        isRetention,
+        isLifecycle,
+        isMetric,
+        isBoxPlot,
+        trendsFilter,
+        chartStyle,
+        defaultCurve,
+        yAxisScaleType,
+        hasLegend,
+        showLegend,
+        supportsValueOnSeries,
+        showPercentStackView,
+        supportsResultCustomizationBy,
+        showMultipleYAxes,
+        showAnnotations,
+        showValuesOnSeries,
+        showPercentagesOnSeries,
+        showConfidenceIntervals,
+        showMovingAverage,
+        hideWeekendsEnabled,
+        overlaysSectionEnabled,
+        styleMenuEnabled,
+        showSmoothing,
+        showMultipleYAxesConfig,
+        showAnnotationsConfig,
+        showAxisLabelsConfig,
+        showLineStyleConfig,
+        showFunnelLegendConfig,
+        showDisplaySection,
+        showYAxisScale,
+        showUnitPicker,
+        showDecimalPlaces,
+    } = state
+
     const items: LemonMenuItems = []
 
-    // With the reorganized menu, smoothing and the color-assignment picker are dropped entirely —
-    // usage data shows they barely register (smoothing is set on <1% of saved trends insights).
-    if (showSmoothing && !styleMenuEnabled) {
-        items.push({ title: 'Smoothing', items: [DisplayOptions.Smoothing] })
-    }
-
-    if (showDisplaySection) {
-        items.push({
-            title: <SectionHeader dataAttr="options-display-section">Display</SectionHeader>,
-            items: getDisplayItems(),
-        })
-    }
-
-    if (supportsResultCustomizationBy && !styleMenuEnabled) {
-        items.push({
-            title: (
-                <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
-                    Color customization by
-                </SectionHeader>
-            ),
-            items: [DisplayOptions.ResultCustomizationBy],
-        })
-    }
-
-    const showUnitPicker = !showPercentStackView && isTrends && !isCalendarHeatmap
-    if (showUnitPicker && !styleMenuEnabled) {
-        items.push({
-            title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
-            items: [DisplayOptions.Unit],
-        })
-    }
-
-    if (showYAxisScale && !styleMenuEnabled) {
-        items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
-    }
-
-    if (showYAxisScale && !isBoxPlot && !overlaysSectionEnabled) {
-        const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
-        if (showConfidenceIntervals) {
-            statisticalItems.push(DisplayOptions.ConfidenceLevel)
+    const pushStatisticalSection = (): void => {
+        if (showYAxisScale && !isBoxPlot && !overlaysSectionEnabled) {
+            const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
+            if (showConfidenceIntervals) {
+                statisticalItems.push(DisplayOptions.ConfidenceLevel)
+            }
+            statisticalItems.push(DisplayOptions.MovingAverage)
+            if (showMovingAverage) {
+                statisticalItems.push(DisplayOptions.MovingAverageIntervals)
+            }
+            items.push({ title: 'Statistical analysis', items: statisticalItems })
         }
-        statisticalItems.push(DisplayOptions.MovingAverage)
-        if (showMovingAverage) {
-            statisticalItems.push(DisplayOptions.MovingAverageIntervals)
+    }
+
+    if (styleMenuEnabled) {
+        // Reorganized menu: Display leads and auto-opens, the rarely used options collapse into the
+        // Line style / Axes accordions, and the smoothing and color-assignment sections are dropped
+        // entirely — usage data shows they barely register (smoothing is set on <1% of saved trends
+        // insights).
+        const accordionRows: LemonMenuItem[] = []
+        if (showDisplaySection) {
+            accordionRows.push({ label: DisplayOptionsAccordion })
         }
-        items.push({ title: 'Statistical analysis', items: statisticalItems })
-    }
-
-    if (showAxisLabelsConfig && !styleMenuEnabled) {
-        items.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
-    }
-
-    if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap && !styleMenuEnabled) {
-        items.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        if (showLineStyleConfig) {
+            accordionRows.push({ label: LineStyleOptionsAccordion })
+        }
+        if (showUnitPicker || showYAxisScale || showMultipleYAxesConfig || showAxisLabelsConfig || showDecimalPlaces) {
+            accordionRows.push({ label: AxesOptionsAccordion })
+        }
+        if (accordionRows.length > 0) {
+            items.push({ items: accordionRows })
+        }
+        pushStatisticalSection()
+    } else {
+        if (showSmoothing) {
+            items.push({ title: 'Smoothing', items: [DisplayOptions.Smoothing] })
+        }
+        if (showDisplaySection) {
+            items.push({
+                title: <SectionHeader dataAttr="options-display-section">Display</SectionHeader>,
+                items: getDisplayItems(state),
+            })
+        }
+        if (supportsResultCustomizationBy) {
+            items.push({
+                title: (
+                    <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
+                        Color customization by
+                    </SectionHeader>
+                ),
+                items: [DisplayOptions.ResultCustomizationBy],
+            })
+        }
+        if (showUnitPicker) {
+            items.push({
+                title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
+                items: [DisplayOptions.Unit],
+            })
+        }
+        if (showYAxisScale) {
+            items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
+        }
+        pushStatisticalSection()
+        if (showAxisLabelsConfig) {
+            items.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+        }
+        if (showDecimalPlaces) {
+            items.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        }
     }
 
     if (isRetention) {
@@ -259,71 +440,6 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             ),
             items: [DisplayOptions.RetentionCohortLabelStart],
         })
-    }
-
-    // The Style menu: pure presentation options — none of them change the computed numbers or add
-    // data to the chart. Conditions mirror the ones getDisplayItems/the sections above use, so each
-    // option keeps appearing for exactly the same insights, just in the other menu.
-    // With the reorganized menu, the rarely used options and the chart style controls collapse
-    // into accordion rows that expand inline, keeping the frequently used options scannable at
-    // the top level.
-    if (styleMenuEnabled) {
-        const collapsedRows: LemonMenuItem[] = []
-        if (showLineStyleConfig) {
-            collapsedRows.push({
-                label: function LineStyleSection() {
-                    return (
-                        <CollapsibleOptionsSection label="Line style" dataAttr="options-line-style-section">
-                            <LineShapePicker />
-                            <LineStylePicker />
-                            <ShowPointsFilter />
-                            <ShowGridLinesFilter />
-                        </CollapsibleOptionsSection>
-                    )
-                },
-            })
-        }
-        const showDecimalPlaces = mightContainFractionalNumbers && isTrends && !isCalendarHeatmap
-        if (showUnitPicker || showMultipleYAxesConfig || showYAxisScale || showAxisLabelsConfig || showDecimalPlaces) {
-            collapsedRows.push({
-                label: function AxesSection() {
-                    return (
-                        <CollapsibleOptionsSection label="Axes" dataAttr="options-axes-section">
-                            {showUnitPicker && (
-                                <>
-                                    <SectionHeader>
-                                        {axisLabel(display || ChartDisplayType.ActionsLineGraph)}
-                                    </SectionHeader>
-                                    <UnitPicker />
-                                </>
-                            )}
-                            {showYAxisScale && (
-                                <>
-                                    <SectionHeader>Y-axis scale</SectionHeader>
-                                    <ScalePicker />
-                                </>
-                            )}
-                            {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
-                            {showAxisLabelsConfig && (
-                                <>
-                                    <SectionHeader>Axis labels</SectionHeader>
-                                    <AxisLabelsFilter />
-                                </>
-                            )}
-                            {showDecimalPlaces && (
-                                <>
-                                    <SectionHeader>Decimal places</SectionHeader>
-                                    <DecimalPrecision />
-                                </>
-                            )}
-                        </CollapsibleOptionsSection>
-                    )
-                },
-            })
-        }
-        if (collapsedRows.length > 0) {
-            items.push({ items: collapsedRows })
-        }
     }
 
     const styleCount: number =

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -24,9 +24,14 @@ import {
     SectionHeader,
 } from './DisplayOptions'
 
-// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
-// active options, badged on the Options button.
-export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+// The "Options" (and flag-gated "Style") menus in the insight editor's display config bar. `count`
+// and `styleCount` are the number of non-default active options, badged on the respective buttons.
+export function useInsightDisplayOptions(): {
+    items: LemonMenuItems
+    count: number
+    styleItems: LemonMenuItems
+    styleCount: number
+} {
     const { insightProps } = useValues(insightLogic)
     const {
         querySource,
@@ -65,6 +70,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     // With the Overlays editor panel section enabled, the overlay toggles (trend lines, alert
     // overlays, annotations, statistical analysis) move there and leave this menu.
     const overlaysSectionEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]
+    // With the Style menu enabled, the presentation options (value labels, legend, number format,
+    // axis labels, pie/metric presentation, color assignment) move to their own toolbar menu.
+    const styleMenuEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
     // between them (smoothing, multiple axes, alert/annotation overlays, statistical analysis).
@@ -107,7 +115,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         const displayItems: LemonMenuItem[] = []
 
         if (isBoxPlot) {
-            if (hasLegend) {
+            if (hasLegend && !styleMenuEnabled) {
                 displayItems.push(DisplayOptions.Legend)
             }
             displayItems.push(DisplayOptions.ExcludeOutliers)
@@ -117,22 +125,25 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         if (isSlopeGraph) {
             // A slope only shows the first vs last interval of each series — the legend (when there
             // are multiple series) is the only display option that applies.
-            if (hasLegend) {
+            if (hasLegend && !styleMenuEnabled) {
                 displayItems.push(DisplayOptions.Legend)
             }
             return displayItems
         }
 
         if (isMetric) {
-            displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+            displayItems.push(DisplayOptions.MetricSummary)
+            if (!styleMenuEnabled) {
+                displayItems.push(DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+            }
         }
         if (isLifecycle) {
             displayItems.push(DisplayOptions.LifecycleStacking)
         }
-        if (supportsValueOnSeries) {
+        if (supportsValueOnSeries && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.ValueLabels)
         }
-        if (isLifecycle) {
+        if (isLifecycle && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.LifecyclePercentages)
         }
         if (supportsPercentStackView) {
@@ -141,10 +152,10 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         if (supportsBarValueStacking) {
             displayItems.push(DisplayOptions.StackBreakdown)
         }
-        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions) {
+        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.Legend)
         }
-        if (display === ChartDisplayType.ActionsPie) {
+        if (display === ChartDisplayType.ActionsPie && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.PieTotal)
         }
         if (showAlertThresholdLinesConfig && !overlaysSectionEnabled) {
@@ -165,7 +176,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         if (showAnnotationsConfig && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.Annotations)
         }
-        if (useQuillLegendOptions) {
+        if (useQuillLegendOptions && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.LegendOptions)
         }
         return displayItems
@@ -184,7 +195,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         })
     }
 
-    if (supportsResultCustomizationBy) {
+    if (supportsResultCustomizationBy && !styleMenuEnabled) {
         items.push({
             title: (
                 <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
@@ -195,7 +206,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         })
     }
 
-    if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
+    if (!showPercentStackView && isTrends && !isCalendarHeatmap && !styleMenuEnabled) {
         items.push({
             title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
             items: [DisplayOptions.Unit],
@@ -218,11 +229,11 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         items.push({ title: 'Statistical analysis', items: statisticalItems })
     }
 
-    if (showAxisLabelsConfig) {
+    if (showAxisLabelsConfig && !styleMenuEnabled) {
         items.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
     }
 
-    if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
+    if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap && !styleMenuEnabled) {
         items.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
     }
 
@@ -238,11 +249,68 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         })
     }
 
-    const count: number =
-        (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
+    // The Style menu: pure presentation options — none of them change the computed numbers or add
+    // data to the chart. Conditions mirror the ones getDisplayItems/the sections above use, so each
+    // option keeps appearing for exactly the same insights, just in the other menu.
+    const styleItems: LemonMenuItems = []
+    if (styleMenuEnabled) {
+        const labelsAndLegendItems: LemonMenuItem[] = []
+        if (isMetric) {
+            labelsAndLegendItems.push(DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+        }
+        if (supportsValueOnSeries && !isBoxPlot && !isSlopeGraph) {
+            labelsAndLegendItems.push(DisplayOptions.ValueLabels)
+        }
+        if (isLifecycle) {
+            labelsAndLegendItems.push(DisplayOptions.LifecyclePercentages)
+        }
+        if (isBoxPlot || isSlopeGraph) {
+            if (hasLegend) {
+                labelsAndLegendItems.push(DisplayOptions.Legend)
+            }
+        } else if (useQuillLegendOptions) {
+            labelsAndLegendItems.push(DisplayOptions.LegendOptions)
+        } else if (hasLegend || showFunnelLegendConfig) {
+            labelsAndLegendItems.push(DisplayOptions.Legend)
+        }
+        if (display === ChartDisplayType.ActionsPie) {
+            labelsAndLegendItems.push(DisplayOptions.PieTotal)
+        }
+        if (labelsAndLegendItems.length > 0) {
+            styleItems.push({
+                title: <SectionHeader dataAttr="style-labels-section">Labels & legend</SectionHeader>,
+                items: labelsAndLegendItems,
+            })
+        }
+        if (supportsResultCustomizationBy) {
+            styleItems.push({
+                title: (
+                    <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
+                        Color customization by
+                    </SectionHeader>
+                ),
+                items: [DisplayOptions.ResultCustomizationBy],
+            })
+        }
+        if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
+            styleItems.push({
+                title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
+                items: [DisplayOptions.Unit],
+            })
+        }
+        if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
+            styleItems.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        }
+        if (showAxisLabelsConfig) {
+            styleItems.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+        }
+    }
+
+    // Non-default presentation options — badged on the Style button when it's enabled, otherwise
+    // on the Options button along with everything else.
+    const styleCount: number =
         (supportsValueOnSeries && showValuesOnSeries ? 1 : 0) +
         (isLifecycle && showPercentagesOnSeries ? 1 : 0) +
-        (showPercentStackView ? 1 : 0) +
         (!showPercentStackView &&
         isTrends &&
         trendsFilter?.aggregationAxisFormat &&
@@ -250,15 +318,24 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             ? 1
             : 0) +
         ((hasLegend || showFunnelLegendConfig) && showLegend ? 1 : 0) +
-        (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
+        (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
+        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0)
+
+    const optionsCount: number =
+        (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
+        (showPercentStackView ? 1 : 0) +
+        (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
         (showMultipleYAxes ? 1 : 0) +
         (trendsFilter?.hideWeekends && hideWeekendsEnabled ? 1 : 0) +
         (showAnnotationsConfig && !overlaysSectionEnabled && showAnnotations === false ? 1 : 0) +
-        (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
-        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
         (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)
 
-    return { items, count }
+    return {
+        items,
+        count: optionsCount + (styleMenuEnabled ? 0 : styleCount),
+        styleItems,
+        styleCount: styleMenuEnabled ? styleCount : 0,
+    }
 }

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -62,6 +62,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const { featureFlags } = useValues(featureFlagLogic)
     const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
     const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
+    // With the Overlays editor panel section enabled, the overlay toggles (trend lines, alert
+    // overlays, annotations, statistical analysis) move there and leave this menu.
+    const overlaysSectionEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
     // between them (smoothing, multiple axes, alert/annotation overlays, statistical analysis).
@@ -144,13 +147,13 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         if (display === ChartDisplayType.ActionsPie) {
             displayItems.push(DisplayOptions.PieTotal)
         }
-        if (showAlertThresholdLinesConfig) {
+        if (showAlertThresholdLinesConfig && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
         }
         if (showMultipleYAxesConfig) {
             displayItems.push(DisplayOptions.MultipleYAxes)
         }
-        if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions) {
+        if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.TrendLines)
         }
         if (isTrendsFunnel && !hideContinuousChartOptions) {
@@ -159,7 +162,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         if (isTrends && !hideContinuousChartOptions && hideWeekendsEnabled) {
             displayItems.push(DisplayOptions.HideWeekends)
         }
-        if (showAnnotationsConfig) {
+        if (showAnnotationsConfig && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.Annotations)
         }
         if (useQuillLegendOptions) {
@@ -203,7 +206,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
     }
 
-    if (showYAxisScale && !isBoxPlot) {
+    if (showYAxisScale && !isBoxPlot && !overlaysSectionEnabled) {
         const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
         if (showConfidenceIntervals) {
             statisticalItems.push(DisplayOptions.ConfidenceLevel)
@@ -252,7 +255,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
         (showMultipleYAxes ? 1 : 0) +
         (trendsFilter?.hideWeekends && hideWeekendsEnabled ? 1 : 0) +
-        (showAnnotationsConfig && showAnnotations === false ? 1 : 0) +
+        (showAnnotationsConfig && !overlaysSectionEnabled && showAnnotations === false ? 1 : 0) +
         (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
         (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
         (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -272,7 +272,6 @@ function LineStyleOptionsAccordion(): JSX.Element {
             <LineStylePicker />
             <ShowPointsFilter />
             <GradientFillFilter />
-            <ShowGridLinesFilter />
         </CollapsibleOptionsSection>
     )
 }
@@ -285,6 +284,7 @@ function AxesOptionsAccordion(): JSX.Element {
         showMultipleYAxesConfig,
         showAxisLabelsConfig,
         showDecimalPlaces,
+        showLineStyleConfig,
     } = useDisplayOptionsState()
 
     return (
@@ -302,6 +302,8 @@ function AxesOptionsAccordion(): JSX.Element {
                 </>
             )}
             {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
+            {/* Gridlines are only wired into the quill line/area charts, same as the Line style controls */}
+            {showLineStyleConfig && <ShowGridLinesFilter />}
             {showAxisLabelsConfig && (
                 <>
                     <SectionHeader>Axis labels</SectionHeader>

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 
+import { IconChevronRight } from '@posthog/icons'
 import { normalizeAxisLabel } from '@posthog/quill-charts'
 
 import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
@@ -24,14 +25,9 @@ import {
     SectionHeader,
 } from './DisplayOptions'
 
-// The "Options" (and flag-gated "Style") menus in the insight editor's display config bar. `count`
-// and `styleCount` are the number of non-default active options, badged on the respective buttons.
-export function useInsightDisplayOptions(): {
-    items: LemonMenuItems
-    count: number
-    styleItems: LemonMenuItems
-    styleCount: number
-} {
+// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
+// active options, badged on the Options button.
+export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
     const { insightProps } = useValues(insightLogic)
     const {
         querySource,
@@ -70,8 +66,9 @@ export function useInsightDisplayOptions(): {
     // With the Overlays editor panel section enabled, the overlay toggles (trend lines, alert
     // overlays, annotations, statistical analysis) move there and leave this menu.
     const overlaysSectionEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_OVERLAYS_SECTION]
-    // With the Style menu enabled, the presentation options (value labels, legend, number format,
-    // axis labels, pie/metric presentation, color assignment) move to their own toolbar menu.
+    // With the style menu flag enabled, rarely used options (axis scale/labels, decimal places,
+    // multiple y-axes) and the chart style controls collapse into "Line style" / "Axes" submenus,
+    // keeping the frequently used options top-level.
     const styleMenuEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHT_STYLE_MENU]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
@@ -119,7 +116,7 @@ export function useInsightDisplayOptions(): {
         const displayItems: LemonMenuItem[] = []
 
         if (isBoxPlot) {
-            if (hasLegend && !styleMenuEnabled) {
+            if (hasLegend) {
                 displayItems.push(DisplayOptions.Legend)
             }
             displayItems.push(DisplayOptions.ExcludeOutliers)
@@ -129,25 +126,22 @@ export function useInsightDisplayOptions(): {
         if (isSlopeGraph) {
             // A slope only shows the first vs last interval of each series — the legend (when there
             // are multiple series) is the only display option that applies.
-            if (hasLegend && !styleMenuEnabled) {
+            if (hasLegend) {
                 displayItems.push(DisplayOptions.Legend)
             }
             return displayItems
         }
 
         if (isMetric) {
-            displayItems.push(DisplayOptions.MetricSummary)
-            if (!styleMenuEnabled) {
-                displayItems.push(DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
-            }
+            displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
         }
         if (isLifecycle) {
             displayItems.push(DisplayOptions.LifecycleStacking)
         }
-        if (supportsValueOnSeries && !styleMenuEnabled) {
+        if (supportsValueOnSeries) {
             displayItems.push(DisplayOptions.ValueLabels)
         }
-        if (isLifecycle && !styleMenuEnabled) {
+        if (isLifecycle) {
             displayItems.push(DisplayOptions.LifecyclePercentages)
         }
         if (supportsPercentStackView) {
@@ -156,16 +150,16 @@ export function useInsightDisplayOptions(): {
         if (supportsBarValueStacking) {
             displayItems.push(DisplayOptions.StackBreakdown)
         }
-        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions && !styleMenuEnabled) {
+        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions) {
             displayItems.push(DisplayOptions.Legend)
         }
-        if (display === ChartDisplayType.ActionsPie && !styleMenuEnabled) {
+        if (display === ChartDisplayType.ActionsPie) {
             displayItems.push(DisplayOptions.PieTotal)
         }
         if (showAlertThresholdLinesConfig && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
         }
-        if (showMultipleYAxesConfig) {
+        if (showMultipleYAxesConfig && !styleMenuEnabled) {
             displayItems.push(DisplayOptions.MultipleYAxes)
         }
         if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions && !overlaysSectionEnabled) {
@@ -180,7 +174,7 @@ export function useInsightDisplayOptions(): {
         if (showAnnotationsConfig && !overlaysSectionEnabled) {
             displayItems.push(DisplayOptions.Annotations)
         }
-        if (useQuillLegendOptions && !styleMenuEnabled) {
+        if (useQuillLegendOptions) {
             displayItems.push(DisplayOptions.LegendOptions)
         }
         return displayItems
@@ -199,7 +193,7 @@ export function useInsightDisplayOptions(): {
         })
     }
 
-    if (supportsResultCustomizationBy && !styleMenuEnabled) {
+    if (supportsResultCustomizationBy) {
         items.push({
             title: (
                 <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
@@ -210,14 +204,14 @@ export function useInsightDisplayOptions(): {
         })
     }
 
-    if (!showPercentStackView && isTrends && !isCalendarHeatmap && !styleMenuEnabled) {
+    if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
         items.push({
             title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
             items: [DisplayOptions.Unit],
         })
     }
 
-    if (showYAxisScale) {
+    if (showYAxisScale && !styleMenuEnabled) {
         items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
     }
 
@@ -256,39 +250,16 @@ export function useInsightDisplayOptions(): {
     // The Style menu: pure presentation options — none of them change the computed numbers or add
     // data to the chart. Conditions mirror the ones getDisplayItems/the sections above use, so each
     // option keeps appearing for exactly the same insights, just in the other menu.
-    const styleItems: LemonMenuItems = []
+    // With the reorganized menu, the rarely used options and the chart style controls collapse
+    // into click-to-open submenus so the frequently used options stay scannable at the top level.
     if (styleMenuEnabled) {
-        const labelsAndLegendItems: LemonMenuItem[] = []
-        if (isMetric) {
-            labelsAndLegendItems.push(DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
-        }
-        if (supportsValueOnSeries && !isBoxPlot && !isSlopeGraph) {
-            labelsAndLegendItems.push(DisplayOptions.ValueLabels)
-        }
-        if (isLifecycle) {
-            labelsAndLegendItems.push(DisplayOptions.LifecyclePercentages)
-        }
-        if (isBoxPlot || isSlopeGraph) {
-            if (hasLegend) {
-                labelsAndLegendItems.push(DisplayOptions.Legend)
-            }
-        } else if (useQuillLegendOptions) {
-            labelsAndLegendItems.push(DisplayOptions.LegendOptions)
-        } else if (hasLegend || showFunnelLegendConfig) {
-            labelsAndLegendItems.push(DisplayOptions.Legend)
-        }
-        if (display === ChartDisplayType.ActionsPie) {
-            labelsAndLegendItems.push(DisplayOptions.PieTotal)
-        }
-        if (labelsAndLegendItems.length > 0) {
-            styleItems.push({
-                title: <SectionHeader dataAttr="style-labels-section">Labels & legend</SectionHeader>,
-                items: labelsAndLegendItems,
-            })
-        }
+        const submenuRows: LemonMenuItem[] = []
         if (showLineStyleConfig) {
-            styleItems.push({
-                title: <SectionHeader dataAttr="style-line-section">Line style</SectionHeader>,
+            submenuRows.push({
+                label: 'Line style',
+                sideIcon: <IconChevronRight />,
+                // `custom` keeps the submenu open while toggling the controls inside
+                custom: true,
                 items: [
                     DisplayOptions.LineShape,
                     DisplayOptions.LineStyle,
@@ -297,32 +268,27 @@ export function useInsightDisplayOptions(): {
                 ],
             })
         }
-        if (supportsResultCustomizationBy) {
-            styleItems.push({
-                title: (
-                    <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
-                        Color customization by
-                    </SectionHeader>
-                ),
-                items: [DisplayOptions.ResultCustomizationBy],
-            })
+        const axesItems: LemonMenuItems = []
+        if (showMultipleYAxesConfig) {
+            axesItems.push({ items: [DisplayOptions.MultipleYAxes] })
         }
-        if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
-            styleItems.push({
-                title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
-                items: [DisplayOptions.Unit],
-            })
-        }
-        if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
-            styleItems.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        if (showYAxisScale) {
+            axesItems.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
         }
         if (showAxisLabelsConfig) {
-            styleItems.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+            axesItems.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+        }
+        if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
+            axesItems.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+        }
+        if (axesItems.length > 0) {
+            submenuRows.push({ label: 'Axes', sideIcon: <IconChevronRight />, custom: true, items: axesItems })
+        }
+        if (submenuRows.length > 0) {
+            items.push({ items: submenuRows })
         }
     }
 
-    // Non-default presentation options — badged on the Style button when it's enabled, otherwise
-    // on the Options button along with everything else.
     const styleCount: number =
         (supportsValueOnSeries && showValuesOnSeries ? 1 : 0) +
         (isLifecycle && showPercentagesOnSeries ? 1 : 0) +
@@ -351,10 +317,5 @@ export function useInsightDisplayOptions(): {
         (showAnnotationsConfig && !overlaysSectionEnabled && showAnnotations === false ? 1 : 0) +
         (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)
 
-    return {
-        items,
-        count: optionsCount + (styleMenuEnabled ? 0 : styleCount),
-        styleItems,
-        styleCount: styleMenuEnabled ? styleCount : 0,
-    }
+    return { items, count: optionsCount + styleCount }
 }

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -11,6 +11,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
 import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
 import {
+    GradientFillFilter,
     LineShapePicker,
     LineStylePicker,
     ShowGridLinesFilter,
@@ -270,6 +271,7 @@ function LineStyleOptionsAccordion(): JSX.Element {
             <LineShapePicker />
             <LineStylePicker />
             <ShowPointsFilter />
+            <GradientFillFilter />
             <ShowGridLinesFilter />
         </CollapsibleOptionsSection>
     )
@@ -459,6 +461,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         (showLineStyleConfig && chartStyle?.curve && chartStyle.curve !== defaultCurve ? 1 : 0) +
         (showLineStyleConfig && chartStyle?.lineStyle && chartStyle.lineStyle !== 'solid' ? 1 : 0) +
         (showLineStyleConfig && chartStyle?.showPoints ? 1 : 0) +
+        (showLineStyleConfig && chartStyle?.gradientFill ? 1 : 0) +
         (showLineStyleConfig && chartStyle?.showGrid === false ? 1 : 0)
 
     const optionsCount: number =

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -1,6 +1,5 @@
 import { useValues } from 'kea'
 
-import { IconChevronRight } from '@posthog/icons'
 import { normalizeAxisLabel } from '@posthog/quill-charts'
 
 import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
@@ -9,6 +8,15 @@ import { LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
+import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
+import {
+    LineShapePicker,
+    LineStylePicker,
+    ShowGridLinesFilter,
+    ShowPointsFilter,
+} from 'scenes/insights/EditorFilters/ChartStyleFilters'
+import { ScalePicker } from 'scenes/insights/EditorFilters/ScalePicker'
+import { ShowMultipleYAxesFilter } from 'scenes/insights/EditorFilters/ShowMultipleYAxesFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
@@ -18,6 +26,8 @@ import { ChartDisplayType } from '~/types'
 
 import {
     BAR_DISPLAYS,
+    CollapsibleOptionsSection,
+    DecimalPrecision,
     displayMatches,
     DisplayOptions,
     isDefaultTrendsLineDisplay,
@@ -251,41 +261,56 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     // data to the chart. Conditions mirror the ones getDisplayItems/the sections above use, so each
     // option keeps appearing for exactly the same insights, just in the other menu.
     // With the reorganized menu, the rarely used options and the chart style controls collapse
-    // into click-to-open submenus so the frequently used options stay scannable at the top level.
+    // into accordion rows that expand inline, keeping the frequently used options scannable at
+    // the top level.
     if (styleMenuEnabled) {
-        const submenuRows: LemonMenuItem[] = []
+        const collapsedRows: LemonMenuItem[] = []
         if (showLineStyleConfig) {
-            submenuRows.push({
-                label: 'Line style',
-                sideIcon: <IconChevronRight />,
-                // `custom` keeps the submenu open while toggling the controls inside
-                custom: true,
-                items: [
-                    DisplayOptions.LineShape,
-                    DisplayOptions.LineStyle,
-                    DisplayOptions.ShowPoints,
-                    DisplayOptions.GridLines,
-                ],
+            collapsedRows.push({
+                label: function LineStyleSection() {
+                    return (
+                        <CollapsibleOptionsSection label="Line style" dataAttr="options-line-style-section">
+                            <LineShapePicker />
+                            <LineStylePicker />
+                            <ShowPointsFilter />
+                            <ShowGridLinesFilter />
+                        </CollapsibleOptionsSection>
+                    )
+                },
             })
         }
-        const axesItems: LemonMenuItems = []
-        if (showMultipleYAxesConfig) {
-            axesItems.push({ items: [DisplayOptions.MultipleYAxes] })
+        const showDecimalPlaces = mightContainFractionalNumbers && isTrends && !isCalendarHeatmap
+        if (showMultipleYAxesConfig || showYAxisScale || showAxisLabelsConfig || showDecimalPlaces) {
+            collapsedRows.push({
+                label: function AxesSection() {
+                    return (
+                        <CollapsibleOptionsSection label="Axes" dataAttr="options-axes-section">
+                            {showMultipleYAxesConfig && <ShowMultipleYAxesFilter />}
+                            {showYAxisScale && (
+                                <>
+                                    <SectionHeader>Y-axis scale</SectionHeader>
+                                    <ScalePicker />
+                                </>
+                            )}
+                            {showAxisLabelsConfig && (
+                                <>
+                                    <SectionHeader>Axis labels</SectionHeader>
+                                    <AxisLabelsFilter />
+                                </>
+                            )}
+                            {showDecimalPlaces && (
+                                <>
+                                    <SectionHeader>Decimal places</SectionHeader>
+                                    <DecimalPrecision />
+                                </>
+                            )}
+                        </CollapsibleOptionsSection>
+                    )
+                },
+            })
         }
-        if (showYAxisScale) {
-            axesItems.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
-        }
-        if (showAxisLabelsConfig) {
-            axesItems.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
-        }
-        if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
-            axesItems.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
-        }
-        if (axesItems.length > 0) {
-            submenuRows.push({ label: 'Axes', sideIcon: <IconChevronRight />, custom: true, items: axesItems })
-        }
-        if (submenuRows.length > 0) {
-            items.push({ items: submenuRows })
+        if (collapsedRows.length > 0) {
+            items.push({ items: collapsedRows })
         }
     }
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12837,6 +12837,33 @@
             },
             "type": "object"
         },
+        "ChartStyle": {
+            "additionalProperties": false,
+            "description": "Per-insight chart rendering style. Pure presentation — no field changes the computed values. Every field is optional; unset fields fall through to the app-level chart defaults.",
+            "properties": {
+                "curve": {
+                    "description": "Line interpolation: straight segments or a smoothed curve through the points.",
+                    "enum": ["linear", "smooth"],
+                    "type": "string"
+                },
+                "lineStyle": {
+                    "default": "solid",
+                    "description": "Dash style applied to all line series.",
+                    "enum": ["solid", "dashed", "dotted"],
+                    "type": "string"
+                },
+                "showGrid": {
+                    "description": "Show horizontal gridlines.",
+                    "type": "boolean"
+                },
+                "showPoints": {
+                    "default": false,
+                    "description": "Draw a marker at each data point on line charts.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "ClickhouseQueryProgress": {
             "additionalProperties": false,
             "properties": {
@@ -44832,6 +44859,10 @@
                 },
                 "breakdown_histogram_bin_count": {
                     "type": "number"
+                },
+                "chartStyle": {
+                    "$ref": "#/definitions/ChartStyle",
+                    "description": "Chart rendering style overrides (line shape, dash style, point markers, gridlines)."
                 },
                 "confidenceLevel": {
                     "type": "number"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12846,6 +12846,11 @@
                     "enum": ["linear", "smooth"],
                     "type": "string"
                 },
+                "gradientFill": {
+                    "default": false,
+                    "description": "Fill the area under line series with a vertical gradient of the series color.",
+                    "type": "boolean"
+                },
                 "lineStyle": {
                     "default": "solid",
                     "description": "Dash style applied to all line series.",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1464,6 +1464,9 @@ export interface ChartStyle {
     /** Draw a marker at each data point on line charts.
      * @default false */
     showPoints?: boolean
+    /** Fill the area under line series with a vertical gradient of the series color.
+     * @default false */
+    gradientFill?: boolean
     /** Show horizontal gridlines. */
     showGrid?: boolean
 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1453,6 +1453,21 @@ export type TrendsFormulaNode = {
     custom_name?: string
 }
 
+/** Per-insight chart rendering style. Pure presentation — no field changes the computed values.
+ * Every field is optional; unset fields fall through to the app-level chart defaults. */
+export interface ChartStyle {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: 'linear' | 'smooth'
+    /** Dash style applied to all line series.
+     * @default solid */
+    lineStyle?: 'solid' | 'dashed' | 'dotted'
+    /** Draw a marker at each data point on line charts.
+     * @default false */
+    showPoints?: boolean
+    /** Show horizontal gridlines. */
+    showGrid?: boolean
+}
+
 export type TrendsFilter = {
     /** @default 1 */
     smoothingIntervals?: integer
@@ -1558,6 +1573,8 @@ export type TrendsFilter = {
      * is on; latest compares first→last of the series.
      * @default total */
     metricSummary?: 'total' | 'average' | 'latest'
+    /** Chart rendering style overrides (line shape, dash style, point markers, gridlines). */
+    chartStyle?: ChartStyle
 }
 
 export type CalendarHeatmapFilter = {
@@ -1598,6 +1615,7 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
     'metricLineIncreaseColor',
     'metricLineDecreaseColor',
     'metricSummary',
+    'chartStyle',
 ])
 
 export interface BoxPlotDatum {

--- a/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
@@ -1,0 +1,93 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonCheckbox, LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { useChartStyleRefreshEnabled } from 'lib/charts/hooks'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { ChartStyle } from '~/queries/schema/schema-general'
+
+function useChartStyle(): {
+    chartStyle: ChartStyle
+    updateChartStyle: (patch: Partial<ChartStyle>) => void
+} {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(trendsDataLogic(insightProps))
+    const chartStyle = trendsFilter?.chartStyle ?? {}
+    return {
+        chartStyle,
+        updateChartStyle: (patch) => updateInsightFilter({ chartStyle: { ...chartStyle, ...patch } }),
+    }
+}
+
+export function LineShapePicker(): JSX.Element {
+    const { chartStyle, updateChartStyle } = useChartStyle()
+    const styleRefreshEnabled = useChartStyleRefreshEnabled()
+    // The app-level default curve depends on the chart style refresh rollout
+    const effectiveCurve = chartStyle.curve ?? (styleRefreshEnabled ? 'smooth' : 'linear')
+
+    return (
+        <div className="flex items-center justify-between gap-2 px-2 pb-2 w-full">
+            <span className="font-normal">Line shape</span>
+            <LemonSegmentedButton
+                size="small"
+                value={effectiveCurve}
+                onChange={(value) => updateChartStyle({ curve: value as ChartStyle['curve'] })}
+                options={[
+                    { value: 'linear', label: 'Straight' },
+                    { value: 'smooth', label: 'Smooth' },
+                ]}
+            />
+        </div>
+    )
+}
+
+export function LineStylePicker(): JSX.Element {
+    const { chartStyle, updateChartStyle } = useChartStyle()
+
+    return (
+        <div className="flex items-center justify-between gap-2 px-2 pb-2 w-full">
+            <span className="font-normal">Line style</span>
+            <LemonSegmentedButton
+                size="small"
+                value={chartStyle.lineStyle ?? 'solid'}
+                onChange={(value) => updateChartStyle({ lineStyle: value as ChartStyle['lineStyle'] })}
+                options={[
+                    { value: 'solid', label: 'Solid' },
+                    { value: 'dashed', label: 'Dashed' },
+                    { value: 'dotted', label: 'Dotted' },
+                ]}
+            />
+        </div>
+    )
+}
+
+export function ShowPointsFilter(): JSX.Element {
+    const { chartStyle, updateChartStyle } = useChartStyle()
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            checked={!!chartStyle.showPoints}
+            onChange={(checked) => updateChartStyle({ showPoints: checked })}
+            label={<span className="font-normal">Show points</span>}
+            size="small"
+        />
+    )
+}
+
+export function ShowGridLinesFilter(): JSX.Element {
+    const { chartStyle, updateChartStyle } = useChartStyle()
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            checked={chartStyle.showGrid !== false}
+            onChange={(checked) => updateChartStyle({ showGrid: checked })}
+            label={<span className="font-normal">Show gridlines</span>}
+            size="small"
+        />
+    )
+}

--- a/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
@@ -30,7 +30,7 @@ export function LineShapePicker(): JSX.Element {
 
     return (
         <div className="flex items-center justify-between gap-2 px-2 pb-2 w-full">
-            <span className="font-normal">Line shape</span>
+            <span className="font-normal">Shape</span>
             <LemonSegmentedButton
                 size="small"
                 value={effectiveCurve}
@@ -49,7 +49,7 @@ export function LineStylePicker(): JSX.Element {
 
     return (
         <div className="flex items-center justify-between gap-2 px-2 pb-2 w-full">
-            <span className="font-normal">Line style</span>
+            <span className="font-normal">Dash</span>
             <LemonSegmentedButton
                 size="small"
                 value={chartStyle.lineStyle ?? 'solid'}

--- a/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ChartStyleFilters.tsx
@@ -78,6 +78,20 @@ export function ShowPointsFilter(): JSX.Element {
     )
 }
 
+export function GradientFillFilter(): JSX.Element {
+    const { chartStyle, updateChartStyle } = useChartStyle()
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            checked={!!chartStyle.gradientFill}
+            onChange={(checked) => updateChartStyle({ gradientFill: checked })}
+            label={<span className="font-normal">Gradient fill</span>}
+            size="small"
+        />
+    )
+}
+
 export function ShowGridLinesFilter(): JSX.Element {
     const { chartStyle, updateChartStyle } = useChartStyle()
 

--- a/frontend/src/scenes/insights/EditorFilters/InsightDisplayToggle.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/InsightDisplayToggle.tsx
@@ -19,10 +19,10 @@ export function InsightDisplayToggle({
     variant = 'checkbox',
 }: InsightDisplayToggleProps): JSX.Element {
     if (variant === 'switch') {
+        // No own padding — the editor panel's flex gap provides the spacing between rows
         return (
             <LemonSwitch
                 label={label}
-                className="pb-2"
                 fullWidth
                 checked={checked}
                 onChange={onChange}

--- a/frontend/src/scenes/insights/EditorFilters/InsightDisplayToggle.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/InsightDisplayToggle.tsx
@@ -1,0 +1,43 @@
+import { LemonCheckbox, LemonSwitch } from '@posthog/lemon-ui'
+
+/** How an insight display toggle renders: `checkbox` in the Options menu, `switch` in the editor panel. */
+export type InsightToggleVariant = 'checkbox' | 'switch'
+
+export interface InsightDisplayToggleProps {
+    label: string
+    checked: boolean
+    onChange: (checked: boolean) => void
+    disabledReason?: string
+    variant?: InsightToggleVariant
+}
+
+export function InsightDisplayToggle({
+    label,
+    checked,
+    onChange,
+    disabledReason,
+    variant = 'checkbox',
+}: InsightDisplayToggleProps): JSX.Element {
+    if (variant === 'switch') {
+        return (
+            <LemonSwitch
+                label={label}
+                className="pb-2"
+                fullWidth
+                checked={checked}
+                onChange={onChange}
+                disabledReason={disabledReason}
+            />
+        )
+    }
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            onChange={onChange}
+            checked={checked}
+            disabledReason={disabledReason}
+            label={<span className="font-normal">{label}</span>}
+            size="small"
+        />
+    )
+}

--- a/frontend/src/scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter.tsx
@@ -5,9 +5,28 @@ import { LemonCheckbox } from '@posthog/lemon-ui'
 import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
+import { InsightLogicProps } from '~/types'
+
 export function ShowAlertAnomalyPointsFilter(): JSX.Element | null {
     const { insightProps, insight } = useValues(insightLogic)
-    const logic = insightAlertsLogic({ insightId: insight.id!, insightLogicProps: insightProps })
+
+    // Unsaved insights can't have alerts — mounting insightAlertsLogic without an id would fire a
+    // pointless alerts fetch.
+    if (!insight.id) {
+        return null
+    }
+
+    return <AnomalyPointsToggle insightId={insight.id} insightLogicProps={insightProps} />
+}
+
+function AnomalyPointsToggle({
+    insightId,
+    insightLogicProps,
+}: {
+    insightId: number
+    insightLogicProps: InsightLogicProps
+}): JSX.Element | null {
+    const logic = insightAlertsLogic({ insightId, insightLogicProps })
     const { showAlertAnomalyPointsFlag, hasDetectorAlerts } = useValues(logic)
     const { setShowAlertAnomalyPoints } = useActions(logic)
 

--- a/frontend/src/scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter.tsx
@@ -1,13 +1,17 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox } from '@posthog/lemon-ui'
-
 import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { InsightLogicProps } from '~/types'
 
-export function ShowAlertAnomalyPointsFilter(): JSX.Element | null {
+import { InsightDisplayToggle, InsightToggleVariant } from './InsightDisplayToggle'
+
+export function ShowAlertAnomalyPointsFilter({
+    variant,
+}: {
+    variant?: InsightToggleVariant
+} = {}): JSX.Element | null {
     const { insightProps, insight } = useValues(insightLogic)
 
     // Unsaved insights can't have alerts — mounting insightAlertsLogic without an id would fire a
@@ -16,15 +20,17 @@ export function ShowAlertAnomalyPointsFilter(): JSX.Element | null {
         return null
     }
 
-    return <AnomalyPointsToggle insightId={insight.id} insightLogicProps={insightProps} />
+    return <AnomalyPointsToggle insightId={insight.id} insightLogicProps={insightProps} variant={variant} />
 }
 
 function AnomalyPointsToggle({
     insightId,
     insightLogicProps,
+    variant,
 }: {
     insightId: number
     insightLogicProps: InsightLogicProps
+    variant?: InsightToggleVariant
 }): JSX.Element | null {
     const logic = insightAlertsLogic({ insightId, insightLogicProps })
     const { showAlertAnomalyPointsFlag, hasDetectorAlerts } = useValues(logic)
@@ -35,12 +41,11 @@ function AnomalyPointsToggle({
     }
 
     return (
-        <LemonCheckbox
-            className="p-1 px-2"
+        <InsightDisplayToggle
+            label="Show alert anomaly points"
             onChange={() => setShowAlertAnomalyPoints(!showAlertAnomalyPointsFlag)}
             checked={showAlertAnomalyPointsFlag}
-            label={<span className="font-normal">Show alert anomaly points</span>}
-            size="small"
+            variant={variant}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter.tsx
@@ -1,12 +1,15 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox } from '@posthog/lemon-ui'
-
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { insightVizDataLogic } from '../insightVizDataLogic'
+import { InsightDisplayToggle, InsightToggleVariant } from './InsightDisplayToggle'
 
-export function ShowAlertThresholdLinesFilter(): JSX.Element | null {
+export function ShowAlertThresholdLinesFilter({
+    variant,
+}: {
+    variant?: InsightToggleVariant
+} = {}): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { showAlertThresholdLines } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
@@ -16,12 +19,11 @@ export function ShowAlertThresholdLinesFilter(): JSX.Element | null {
     }
 
     return (
-        <LemonCheckbox
-            className="p-1 px-2"
+        <InsightDisplayToggle
+            label="Show alert threshold lines"
             onChange={toggleShowAlertThresholdLines}
             checked={!!showAlertThresholdLines}
-            label={<span className="font-normal">Show alert threshold lines</span>}
-            size="small"
+            variant={variant}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/ShowAnnotationsFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowAnnotationsFilter.tsx
@@ -1,12 +1,11 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox } from '@posthog/lemon-ui'
-
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { insightVizDataLogic } from '../insightVizDataLogic'
+import { InsightDisplayToggle, InsightToggleVariant } from './InsightDisplayToggle'
 
-export function ShowAnnotationsFilter(): JSX.Element | null {
+export function ShowAnnotationsFilter({ variant }: { variant?: InsightToggleVariant } = {}): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { showAnnotations } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
@@ -14,12 +13,11 @@ export function ShowAnnotationsFilter(): JSX.Element | null {
     const checked = showAnnotations !== false
 
     return (
-        <LemonCheckbox
-            className="p-1 px-2"
+        <InsightDisplayToggle
+            label="Show annotations"
             onChange={(value) => updateInsightFilter({ showAnnotations: value })}
             checked={checked}
-            label={<span className="font-normal">Show annotations</span>}
-            size="small"
+            variant={variant}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/ShowTrendLinesFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowTrendLinesFilter.tsx
@@ -1,7 +1,5 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox } from '@posthog/lemon-ui'
-
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
@@ -9,8 +7,9 @@ import { isFunnelsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils
 import { ChartDisplayType } from '~/types'
 
 import { insightVizDataLogic } from '../insightVizDataLogic'
+import { InsightDisplayToggle, InsightToggleVariant } from './InsightDisplayToggle'
 
-export function ShowTrendLinesFilter(): JSX.Element {
+export function ShowTrendLinesFilter({ variant }: { variant?: InsightToggleVariant } = {}): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter, yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
     const { isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
@@ -55,13 +54,12 @@ export function ShowTrendLinesFilter(): JSX.Element {
     }
 
     return (
-        <LemonCheckbox
-            className="p-1 px-2"
+        <InsightDisplayToggle
+            label="Show trend lines"
             onChange={toggleShowTrendLines}
             checked={!disabledReason && !!showTrendLines}
             disabledReason={disabledReason}
-            label={<span className="font-normal">Show trend lines</span>}
-            size="small"
+            variant={variant}
         />
     )
 }

--- a/frontend/src/scenes/insights/utils/queryUtils.test.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.test.ts
@@ -1,6 +1,7 @@
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, TrendsFilter, TrendsQuery } from '~/queries/schema/schema-general'
 
 import {
+    compareQuery,
     filterVariablesReferencedInQuery,
     hasInvalidRegexFilter,
     isBoxPlotMissingProperty,
@@ -214,5 +215,22 @@ describe('isBoxPlotMissingProperty', () => {
                 { kind: NodeKind.EventsNode, event: '$signup', math_property: 'revenue' },
             ])
         ).toBe(false)
+    })
+})
+
+describe('compareQuery', () => {
+    const makeTrendsQuery = (trendsFilter: TrendsFilter = {}): TrendsQuery => ({
+        kind: NodeKind.TrendsQuery,
+        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+        trendsFilter,
+    })
+
+    it('treats chartStyle changes as visualization-only', () => {
+        const plain = makeTrendsQuery()
+        const styled = makeTrendsQuery({ chartStyle: { curve: 'smooth', lineStyle: 'dashed', showPoints: true } })
+
+        // Style changes must not count as a query change — otherwise every style tweak refetches
+        expect(compareQuery(plain, styled, { ignoreVisualizationOnlyChanges: true })).toBe(true)
+        expect(compareQuery(plain, styled)).toBe(false)
     })
 })

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -266,6 +266,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             breakdownSorting: undefined,
             dataColorTheme: undefined,
             legendPosition: undefined,
+            chartStyle: undefined,
         }
 
         if (isTrendsQuery(cleanedQuery)) {

--- a/packages/quill/packages/charts/src/core/canvas-renderer.test.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.test.ts
@@ -525,7 +525,9 @@ describe('hog-charts canvas-renderer', () => {
                 dimensions.plotTop + dimensions.plotHeight
             )
             expect(gradient.addColorStop).toHaveBeenCalledWith(0, '#22d3ee')
-            expect(gradient.addColorStop).toHaveBeenCalledWith(1, 'transparent')
+            // The bottom stop fades to the series color at zero alpha, not `transparent`
+            // (transparent black), which would grey the midtones
+            expect(gradient.addColorStop).toHaveBeenCalledWith(1, 'rgba(34, 211, 238, 0)')
             expect(recordedFillStyles).toContain(gradient)
         })
 

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -1,6 +1,6 @@
 import { type ScaleLinear, type ScaleLogarithmic } from 'd3-scale'
 
-import { barColorAt, mixColors } from './color-utils'
+import { barColorAt, dimColor, mixColors } from './color-utils'
 import { yTickCountForHeight } from './scales'
 import type {
     BarFillStyle,
@@ -491,7 +491,9 @@ export function drawArea(
     if (useGradient) {
         gradient = ctx.createLinearGradient(0, dimensions.plotTop, 0, baseline)
         gradient.addColorStop(0, series.color)
-        gradient.addColorStop(1, 'transparent')
+        // Fade to the series color at zero alpha — `transparent` is transparent *black*, which
+        // drags the gradient's midtones grey.
+        gradient.addColorStop(1, dimColor(series.color, 0))
     }
 
     for (const { top, bottom } of segments) {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -829,6 +829,10 @@ class ChartStyle(BaseModel):
         default=None,
         description=("Line interpolation: straight segments or a smoothed curve through the points."),
     )
+    gradientFill: bool | None = Field(
+        default=False,
+        description=("Fill the area under line series with a vertical gradient of the series color."),
+    )
     lineStyle: LineStyle | None = Field(default=LineStyle.SOLID, description="Dash style applied to all line series.")
     showGrid: bool | None = Field(default=None, description="Show horizontal gridlines.")
     showPoints: bool | None = Field(default=False, description="Draw a marker at each data point on line charts.")

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -61,6 +61,7 @@ from posthog.schema_enums import (
     CorrelationType as CorrelationType,
     CountPerActorMathType as CountPerActorMathType,
     CurrencyCode as CurrencyCode,
+    Curve as Curve,
     CustomChannelField as CustomChannelField,
     CustomChannelOperator as CustomChannelOperator,
     DatabaseSchemaManagedViewTableKind as DatabaseSchemaManagedViewTableKind,
@@ -141,6 +142,7 @@ from posthog.schema_enums import (
     LegendPosition as LegendPosition,
     LifecycleToggle as LifecycleToggle,
     LimitContext as LimitContext,
+    LineStyle as LineStyle,
     LinkedinAdsDefaultSources as LinkedinAdsDefaultSources,
     LinkedinAdsTableExclusions as LinkedinAdsTableExclusions,
     LinkedinAdsTableKeywords as LinkedinAdsTableKeywords,
@@ -817,6 +819,19 @@ class ChartSettingsFormatting(BaseModel):
     prefix: str | None = None
     style: Style | None = None
     suffix: str | None = None
+
+
+class ChartStyle(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    curve: Curve | None = Field(
+        default=None,
+        description=("Line interpolation: straight segments or a smoothed curve through the points."),
+    )
+    lineStyle: LineStyle | None = Field(default=LineStyle.SOLID, description="Dash style applied to all line series.")
+    showGrid: bool | None = Field(default=None, description="Show horizontal gridlines.")
+    showPoints: bool | None = Field(default=False, description="Draw a marker at each data point on line charts.")
 
 
 class ClientToolResultPayload(BaseModel):
@@ -7290,6 +7305,10 @@ class TrendsFilter(BaseModel):
         ),
     )
     breakdown_histogram_bin_count: float | None = None
+    chartStyle: ChartStyle | None = Field(
+        default=None,
+        description=("Chart rendering style overrides (line shape, dash style, point markers, gridlines)."),
+    )
     confidenceLevel: float | None = None
     decimalPlaces: float | None = Field(
         default=None,

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -589,6 +589,17 @@ class ChartDisplayType(StrEnum):
     SLOPE_GRAPH = "SlopeGraph"
 
 
+class Curve(StrEnum):
+    LINEAR = "linear"
+    SMOOTH = "smooth"
+
+
+class LineStyle(StrEnum):
+    SOLID = "solid"
+    DASHED = "dashed"
+    DOTTED = "dotted"
+
+
 class ColorMode(StrEnum):
     LIGHT = "light"
     DARK = "dark"

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -119,6 +119,7 @@ def to_dict(query: BaseModel) -> dict:
                         "funnelStepReference",
                         "breakdownSorting",
                         "legendPosition",
+                        "chartStyle",
                     ]
                 }
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2126,6 +2126,32 @@ export const AggregationAxisFormatApi = {
     Short: 'short',
 } as const
 
+export type CurveApi = (typeof CurveApi)[keyof typeof CurveApi]
+
+export const CurveApi = {
+    Linear: 'linear',
+    Smooth: 'smooth',
+} as const
+
+export type LineStyleApi = (typeof LineStyleApi)[keyof typeof LineStyleApi]
+
+export const LineStyleApi = {
+    Solid: 'solid',
+    Dashed: 'dashed',
+    Dotted: 'dotted',
+} as const
+
+export interface ChartStyleApi {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: CurveApi | null
+    /** Dash style applied to all line series. */
+    lineStyle?: LineStyleApi | null
+    /** Show horizontal gridlines. */
+    showGrid?: boolean | null
+    /** Draw a marker at each data point on line charts. */
+    showPoints?: boolean | null
+}
+
 export type DetailedResultsAggregationTypeApi =
     (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
 
@@ -2266,6 +2292,8 @@ export interface TrendsFilterApi {
     /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
     aggregationAxisPrefix?: string | null
     breakdown_histogram_bin_count?: number | null
+    /** Chart rendering style overrides (line shape, dash style, point markers, gridlines). */
+    chartStyle?: ChartStyleApi | null
     confidenceLevel?: number | null
     /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
     decimalPlaces?: number | null

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2144,6 +2144,8 @@ export const LineStyleApi = {
 export interface ChartStyleApi {
     /** Line interpolation: straight segments or a smoothed curve through the points. */
     curve?: CurveApi | null
+    /** Fill the area under line series with a vertical gradient of the series color. */
+    gradientFill?: boolean | null
     /** Dash style applied to all line series. */
     lineStyle?: LineStyleApi | null
     /** Show horizontal gridlines. */

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1498,6 +1498,8 @@ export const LineStyleApi = {
 export interface ChartStyleApi {
     /** Line interpolation: straight segments or a smoothed curve through the points. */
     curve?: CurveApi | null
+    /** Fill the area under line series with a vertical gradient of the series color. */
+    gradientFill?: boolean | null
     /** Dash style applied to all line series. */
     lineStyle?: LineStyleApi | null
     /** Show horizontal gridlines. */

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1480,6 +1480,32 @@ export const AggregationAxisFormatApi = {
     Short: 'short',
 } as const
 
+export type CurveApi = (typeof CurveApi)[keyof typeof CurveApi]
+
+export const CurveApi = {
+    Linear: 'linear',
+    Smooth: 'smooth',
+} as const
+
+export type LineStyleApi = (typeof LineStyleApi)[keyof typeof LineStyleApi]
+
+export const LineStyleApi = {
+    Solid: 'solid',
+    Dashed: 'dashed',
+    Dotted: 'dotted',
+} as const
+
+export interface ChartStyleApi {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: CurveApi | null
+    /** Dash style applied to all line series. */
+    lineStyle?: LineStyleApi | null
+    /** Show horizontal gridlines. */
+    showGrid?: boolean | null
+    /** Draw a marker at each data point on line charts. */
+    showPoints?: boolean | null
+}
+
 export type DetailedResultsAggregationTypeApi =
     (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
 
@@ -1620,6 +1646,8 @@ export interface TrendsFilterApi {
     /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
     aggregationAxisPrefix?: string | null
     breakdown_histogram_bin_count?: number | null
+    /** Chart rendering style overrides (line shape, dash style, point markers, gridlines). */
+    chartStyle?: ChartStyleApi | null
     confidenceLevel?: number | null
     /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
     decimalPlaces?: number | null

--- a/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
+++ b/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
@@ -1,0 +1,28 @@
+import type { ChartStyle } from '~/queries/schema/schema-general'
+
+/** Canvas dash patterns for the persisted line styles (px drawn / px gap). */
+export const LINE_STYLE_DASH_PATTERNS: Record<'dashed' | 'dotted', number[]> = {
+    dashed: [8, 4],
+    dotted: [2, 3],
+}
+
+/** Radius used for data-point markers when `chartStyle.showPoints` is on. */
+export const CHART_STYLE_POINT_RADIUS = 3
+
+export function chartStyleCurve(chartStyle: ChartStyle | null | undefined): 'linear' | 'monotone' | undefined {
+    if (!chartStyle?.curve) {
+        return undefined
+    }
+    return chartStyle.curve === 'smooth' ? 'monotone' : 'linear'
+}
+
+export function chartStyleStrokePattern(chartStyle: ChartStyle | null | undefined): number[] | undefined {
+    if (!chartStyle?.lineStyle || chartStyle.lineStyle === 'solid') {
+        return undefined
+    }
+    return LINE_STYLE_DASH_PATTERNS[chartStyle.lineStyle]
+}
+
+export function chartStylePointRadius(chartStyle: ChartStyle | null | undefined): number | undefined {
+    return chartStyle?.showPoints ? CHART_STYLE_POINT_RADIUS : undefined
+}

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -224,6 +224,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 isStickiness,
                 strokePattern: chartStyleStrokePattern(chartStyle),
                 pointRadius: chartStylePointRadius(chartStyle),
+                fillGradient: chartStyle?.gradientFill,
                 getColor: getTrendsColor,
                 // With the quill legend on, hidden series are listed (dimmed) and excluded via
                 // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -25,6 +25,7 @@ import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
 
+import { chartStyleCurve, chartStylePointRadius, chartStyleStrokePattern } from '../../shared/chartStyleAdapter'
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
@@ -99,6 +100,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
 
     const isPercentStackView = !!showPercentStackView && !!supportsPercentStackView
     const resolvedGroupTypeLabel = context?.groupTypeLabel ?? resolveGroupTypeLabel(labelGroupType, aggregationLabel)
+    const chartStyle = trendsFilter?.chartStyle
 
     const labels = currentPeriodResult?.labels ?? []
 
@@ -220,6 +222,8 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 showMultipleYAxes: showMultipleYAxes ?? undefined,
                 incompletenessOffsetFromEnd,
                 isStickiness,
+                strokePattern: chartStyleStrokePattern(chartStyle),
+                pointRadius: chartStylePointRadius(chartStyle),
                 getColor: getTrendsColor,
                 // With the quill legend on, hidden series are listed (dimmed) and excluded via
                 // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.
@@ -233,6 +237,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             showMultipleYAxes,
             incompletenessOffsetFromEnd,
             isStickiness,
+            chartStyle,
             getTrendsColor,
             getTrendsHidden,
             getLabel,
@@ -265,6 +270,8 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 movingAverageIntervals: movingAverageIntervals ?? undefined,
                 showTrendLines: showTrendLines ?? undefined,
                 valueLabels: showValuesOnSeries && valueLabelFormatter ? { formatter: valueLabelFormatter } : false,
+                curve: chartStyleCurve(chartStyle),
+                showGrid: chartStyle?.showGrid,
                 showCrosshair: true,
                 tooltip: TOOLTIP_CONFIG,
                 legend: legendConfig,

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -97,6 +97,25 @@ describe('trendsChartTransforms', () => {
             expect(series.fill).toEqual({})
         })
 
+        it('applies a chart-style stroke pattern, alone and merged with the in-progress tail', () => {
+            const plain = buildMainTrendsSeries(makeResult(), 0, { getColor: () => RED, strokePattern: [8, 4] })
+            expect(plain.stroke).toEqual({ pattern: [8, 4], partial: undefined })
+
+            const withTail = buildMainTrendsSeries(makeResult({ data: [1, 2, 3, 4, 5, 6, 7] }), 0, {
+                getColor: () => RED,
+                strokePattern: [8, 4],
+                incompletenessOffsetFromEnd: -2,
+            })
+            expect(withTail.stroke).toEqual({ pattern: [8, 4], partial: { fromIndex: 5 } })
+        })
+
+        it('draws point markers only when pointRadius is set', () => {
+            expect(buildMainTrendsSeries(makeResult(), 0, { getColor: () => RED }).points).toBeUndefined()
+            expect(buildMainTrendsSeries(makeResult(), 0, { getColor: () => RED, pointRadius: 3 }).points).toEqual({
+                radius: 3,
+            })
+        })
+
         it('marks a series excluded when getHidden returns true', () => {
             const series = buildMainTrendsSeries(makeResult(), 0, {
                 getColor: () => RED,
@@ -424,6 +443,19 @@ describe('trendsChartTransforms', () => {
         it('leaves the x-axis tick formatter unset when xAxisTickFormatter is omitted', () => {
             const config = buildTrendsLineTimeSeriesConfig({ ...baseOpts })
             expect(config.xAxis?.tickFormatter).toBeUndefined()
+        })
+
+        it('passes chart-style curve and grid overrides through, leaving them unset by default', () => {
+            const styled = buildTrendsLineTimeSeriesConfig({ ...baseOpts, curve: 'monotone', showGrid: false })
+            expect(styled.curve).toBe('monotone')
+            expect(styled.showGrid).toBe(false)
+            expect((styled.yAxis as YAxisConfig).showGrid).toBe(false)
+
+            // Unset overrides must stay undefined so the app-level defaults (useChartConfig) apply
+            const unstyled = buildTrendsLineTimeSeriesConfig({ ...baseOpts })
+            expect(unstyled.curve).toBeUndefined()
+            expect(unstyled.showGrid).toBeUndefined()
+            expect((unstyled.yAxis as YAxisConfig).showGrid).toBe(true)
         })
 
         describe('valueLabels', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -116,6 +116,15 @@ describe('trendsChartTransforms', () => {
             })
         })
 
+        it('applies a gradient fill when fillGradient is set, on line and area charts alike', () => {
+            expect(buildMainTrendsSeries(makeResult(), 0, { getColor: () => RED, fillGradient: true }).fill).toEqual({
+                gradient: true,
+            })
+            expect(
+                buildMainTrendsSeries(makeResult(), 0, { getColor: () => RED, isArea: true, fillGradient: true }).fill
+            ).toEqual({ gradient: true })
+        })
+
         it('marks a series excluded when getHidden returns true', () => {
             const series = buildMainTrendsSeries(makeResult(), 0, {
                 getColor: () => RED,

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -34,6 +34,10 @@ export interface BuildTrendsSeriesOpts<R extends TrendsResultLike, M = unknown> 
     // Negative number — index from the end where the in-progress tail begins. Omit to skip.
     incompletenessOffsetFromEnd?: number
     isStickiness?: boolean
+    /** Canvas dash pattern applied to every series' line (per-insight chart style). */
+    strokePattern?: number[]
+    /** Marker radius drawn at each data point (per-insight chart style). Omit for no markers. */
+    pointRadius?: number
     getColor: (r: R, index: number) => string
     getHidden?: (r: R, index: number) => boolean
     buildMeta?: (r: R, index: number) => M
@@ -66,6 +70,13 @@ export function buildMainTrendsSeries<R extends TrendsResultLike, M = unknown>(
     const yAxisId = opts.showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
     const excluded = opts.getHidden ? opts.getHidden(r, index) : false
     const meta: M | undefined = opts.buildMeta ? opts.buildMeta(r, index) : undefined
+    const stroke =
+        dashedFromIndex !== undefined || opts.strokePattern
+            ? {
+                  pattern: opts.strokePattern,
+                  partial: dashedFromIndex !== undefined ? { fromIndex: dashedFromIndex } : undefined,
+              }
+            : undefined
     return {
         key: String(r.id),
         label: opts.getLabel ? opts.getLabel(r) : humanizeSeriesLabel(r.label),
@@ -74,7 +85,8 @@ export function buildMainTrendsSeries<R extends TrendsResultLike, M = unknown>(
         yAxisId,
         meta,
         fill: opts.isArea ? {} : undefined,
-        stroke: dashedFromIndex !== undefined ? { partial: { fromIndex: dashedFromIndex } } : undefined,
+        stroke,
+        points: opts.pointRadius !== undefined ? { radius: opts.pointRadius } : undefined,
         visibility: excluded ? { excluded: true } : undefined,
     }
 }
@@ -201,6 +213,11 @@ export interface BuildTrendsLineTimeSeriesConfigOpts<R extends TrendsResultLike>
 
     valueLabels?: TimeSeriesLineChartConfig['valueLabels']
 
+    /** Line interpolation override (per-insight chart style). Leave undefined for app defaults. */
+    curve?: 'linear' | 'monotone'
+    /** Gridlines override (per-insight chart style). Leave undefined for app defaults. */
+    showGrid?: boolean
+
     showCrosshair?: boolean
     tooltip?: TooltipConfig
     legend?: TimeSeriesLineChartConfig['legend']
@@ -211,7 +228,7 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
 ): TimeSeriesLineChartConfig {
     const yAxis = buildTrendsYAxisConfig(opts.trendsFilter, opts.isPercentStackView, opts.baseCurrency, {
         yAxisScaleType: opts.yAxisScaleType,
-        showGrid: true,
+        showGrid: opts.showGrid ?? true,
     })
     const goalLineConfigs = schemaGoalLinesToConfigs(opts.goalLines)
     const derivedConfigs = buildDerivedConfigs(opts.results, {
@@ -242,6 +259,8 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
         goalLines: goalLineConfigs,
         ...derivedConfigs,
         percentStackView: opts.isPercentStackView,
+        curve: opts.curve,
+        showGrid: opts.showGrid,
         showCrosshair: opts.showCrosshair,
         tooltip: opts.tooltip,
         legend: opts.legend,

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -38,6 +38,8 @@ export interface BuildTrendsSeriesOpts<R extends TrendsResultLike, M = unknown> 
     strokePattern?: number[]
     /** Marker radius drawn at each data point (per-insight chart style). Omit for no markers. */
     pointRadius?: number
+    /** Fill under each series with a vertical gradient of the series color (per-insight chart style). */
+    fillGradient?: boolean
     getColor: (r: R, index: number) => string
     getHidden?: (r: R, index: number) => boolean
     buildMeta?: (r: R, index: number) => M
@@ -84,7 +86,7 @@ export function buildMainTrendsSeries<R extends TrendsResultLike, M = unknown>(
         color: opts.getColor(r, index),
         yAxisId,
         meta,
-        fill: opts.isArea ? {} : undefined,
+        fill: opts.fillGradient ? { gradient: true } : opts.isArea ? {} : undefined,
         stroke,
         points: opts.pointRadius !== undefined ? { radius: opts.pointRadius } : undefined,
         visibility: excluded ? { excluded: true } : undefined,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2347,6 +2347,8 @@ export namespace Schemas {
     export interface ChartStyle {
       /** Line interpolation: straight segments or a smoothed curve through the points. */
       curve?: Curve | null;
+      /** Fill the area under line series with a vertical gradient of the series color. */
+      gradientFill?: boolean | null;
       /** Dash style applied to all line series. */
       lineStyle?: LineStyle | null;
       /** Show horizontal gridlines. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2327,6 +2327,34 @@ export namespace Schemas {
       Short: 'short',
     } as const;
 
+    export type Curve = typeof Curve[keyof typeof Curve];
+
+
+    export const Curve = {
+      Linear: 'linear',
+      Smooth: 'smooth',
+    } as const;
+
+    export type LineStyle = typeof LineStyle[keyof typeof LineStyle];
+
+
+    export const LineStyle = {
+      Solid: 'solid',
+      Dashed: 'dashed',
+      Dotted: 'dotted',
+    } as const;
+
+    export interface ChartStyle {
+      /** Line interpolation: straight segments or a smoothed curve through the points. */
+      curve?: Curve | null;
+      /** Dash style applied to all line series. */
+      lineStyle?: LineStyle | null;
+      /** Show horizontal gridlines. */
+      showGrid?: boolean | null;
+      /** Draw a marker at each data point on line charts. */
+      showPoints?: boolean | null;
+    }
+
     export type DetailedResultsAggregationType = typeof DetailedResultsAggregationType[keyof typeof DetailedResultsAggregationType];
 
 
@@ -2471,6 +2499,8 @@ export namespace Schemas {
       /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
       aggregationAxisPrefix?: string | null;
       breakdown_histogram_bin_count?: number | null;
+      /** Chart rendering style overrides (line shape, dash style, point markers, gridlines). */
+      chartStyle?: ChartStyle | null;
       confidenceLevel?: number | null;
       /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
       decimalPlaces?: number | null;


### PR DESCRIPTION
## Problem

Insight display options are scattered in ways that hurt discoverability, the toolbar's "Options" dropdown has grown very long, and the new quill charts expose styling capabilities (curve smoothing, dash patterns, point markers, gridlines) that users have no way to control per insight.

Usage data motivated the layout: on US Cloud over 30 days, value labels (~7k clicks), legend (~5.3k), and unit formatting (~4.1k) dominate option interactions, trend lines get ~2.5k, while goal lines (buried in the editor panel) are almost never configured, and smoothing/statistical options barely register - so frequent options should be one click, rare ones can collapse, and the rarest can go.

## Changes

Two feature flags, both default off:

**`product-analytics-insight-overlays-section`** - a new **Overlays** accordion in the insight editor panel gathering everything drawn on top of the chart data: goal lines (from "Advanced options"), trend lines, alert threshold lines, alert anomaly points, confidence intervals (+ level), moving average (+ intervals), and annotations (all from the Options dropdown, which loses those rows plus the whole "Statistical analysis" section). All rows render as switches for consistency with the surrounding panel sections, with a divider between the goal lines editor and the toggle list.

**`product-analytics-insight-style-menu`** - a reorganized Options menu:

- **Display accordion, auto-open** - value labels, legend, percent stack and friends lead the menu, expanded by default
- **Line style accordion** - the new per-insight chart style controls (shape straight/smooth, dash solid/dashed/dotted, show points, gradient fill), for line/area trends displays
- **Axes accordion** - y-axis unit, y-axis scale, multiple y-axes, axis labels, decimal places
- **Smoothing and color-assignment sections dropped** - both barely register in usage data (smoothing is set on <1% of saved trends insights); per-series colors remain reachable via the legend/series click-through modal
- Accordion rows carry a min-width so the menu stays a constant width when a section expands. Content renders only while expanded and enters with a fade-in - both keeping it hidden-but-mounted and animating its height (grid-rows with overflow hidden) caused stale paints in the popover (controls not rendering until hovered), so no clipping geometry is used. The accordions are stable module-level components sharing a `useDisplayOptionsState` hook - an earlier inline-component version remounted on every render, collapsing the accordion whenever an option inside it updated the query

Earlier iterations split style options into a separate "Style" toolbar button (dropped: two buttons collapsed into cryptic icons at narrow widths) and then nested popover submenus (dropped: popover-in-popover interaction felt bad).

**New `ChartStyle` schema object** on `TrendsFilter` backing the Line style controls, wired through the quill trends line/area chart: curve and gridlines via chart config (overriding the style-refresh defaults), dash pattern and point markers per series. Unset fields fall through to app-level defaults, so existing insights render unchanged. `chartStyle` is registered as visualization-only in both cache-key sanitizers (frontend `cleanInsightQuery`, backend `schema_helpers.serialize_query`), so style changes never trigger a query refetch. Schema JSON and Python regenerated.

Supporting changes:

- Shared `InsightDisplayToggle` (checkbox/switch variant) so the same toggle components render as checkboxes in the menu and switches in the panel
- `ShowAlertAnomalyPointsFilter` skips mounting `insightAlertsLogic` for unsaved insights (it now mounts with the panel rather than only inside the opened menu)

With both flags off, nothing changes.

## How did you test this code?

Automated tests only (I didn't run the app manually):

- `trendsChartTransforms.test.ts` (pure functions): stroke pattern applies alone and composes with the in-progress dashed tail, point markers only when set, curve/grid overrides pass through and stay undefined by default (catches styling silently reverting to app defaults)
- `queryUtils.test.ts`: `compareQuery` treats `chartStyle` as visualization-only (catches a style tweak triggering a full requery); `compareQuery` had no coverage before
- `InsightDisplayConfig.test.tsx`: with the flag, Display leads the menu and smoothing/color sections are gone; unit/scale/labels/multiple-y-axes nest under the Axes accordion (and appear nowhere else); accordion rows toggle `aria-expanded`; Line style accordion absent for non-line displays; without the flag everything stays top-level
- `EditorFilters.test.tsx`: Overlays section appears with the flag with goal lines rendered exactly once, absent for paths and absent by default
- All affected suites pass. Lint, oxfmt, ruff, and `ci:preflight --fix` green. Backend `test_schema_helpers.py` needs a live Postgres this workspace doesn't have, so the round-trip rides on CI. Full `typescript:check` has thousands of pre-existing errors here from missing kea typegen artifacts, so I diffed the error set for touched files against master: no new errors

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Flag-gated, not yet user-facing. Docs should follow when the flags roll out.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Code cloud task). Skills invoked: `/writing-tests`.
- This came out of an exploration of per-insight chart style options for the quill charts. We measured option usage first (autocapture clicks on the toggles plus saved-insight prevalence in the query JSON) and designed the reorganization around it. The design iterated live: overlays panel section → separate Style toolbar menu → merged single menu with nested popover submenus → inline accordions with stable width, display toggles first, unit under Axes, smoothing/color dropped.
- `chartStyle` lives on `TrendsFilter` rather than the query base because the visualization-only cache-key sanitizers operate per insight filter and must stay in sync between frontend and backend; the `ChartStyle` interface is shared so other filters (stickiness, SQL insight chart settings) can adopt it later.
- Dropping smoothing entirely (rather than collapsing it) means an existing insight with smoothing set has no control to unset it while the flag is on - flagged to the driver as an accepted trade-off of the experiment; the value still applies and the badge no longer counts it.
- v1 wires the trends line/area chart only - the dominant display type. Bar styling, stickiness/retention line charts, and SQL insights are follow-ups on the same schema.
- Follow-up intentionally left out: an `insight display option changed` analytics event should ship with the rollout to measure the before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




