### PR TITLE
feat(data-management): log activity for bulk tag updates

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -21,6 +21,7 @@ from posthog.api.event_definition_generators.typescript import TypeScriptGenerat
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import (
+    BulkTagActivityContext,
     BulkUpdateTagsUUIDRequestSerializer,
     BulkUpdateTagsUUIDResponseSerializer,
     TaggedItemSerializerMixin,
@@ -478,7 +479,16 @@ class EventDefinitionViewSet(
         found_ids = {obj.id for obj in objects}
         skipped = [{"id": obj_id, "reason": "Not found"} for obj_id in validated_ids if obj_id not in found_ids]
 
-        updated = apply_bulk_tag_changes(objects, validated["action"], validated["tags"])
+        activity_context = BulkTagActivityContext(
+            scope="EventDefinition",
+            user=cast(User, request.user),
+            was_impersonated=is_impersonated(request),
+            # The single-object event-definition update path logs under the "changed" verb.
+            activity="changed",
+        )
+        updated = apply_bulk_tag_changes(
+            objects, validated["action"], validated["tags"], activity_context=activity_context
+        )
         return response.Response({"updated": updated, "skipped": skipped})
 
     def perform_create(self, serializer):

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -1,5 +1,6 @@
+import dataclasses
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from django.db import models
 from django.db.models import Prefetch, Q, QuerySet, prefetch_related_objects
@@ -10,9 +11,14 @@ from rest_framework.viewsets import GenericViewSet
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.helpers.impersonation import is_impersonated
 from posthog.models import Tag, TaggedItem
+from posthog.models.activity_logging.activity_log import Change, Detail, LogActivityEntry, bulk_log_activity
 from posthog.models.tag import tagify
 from posthog.rbac.user_access_control import access_level_satisfied_for_resource
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
 
 
 def set_tags_on_object(tags: list[str], obj: Any) -> list[TaggedItem]:
@@ -42,17 +48,45 @@ def cleanup_orphan_tags(team_id: int) -> None:
     Tag.objects.filter(Q(team_id=team_id) & Q(tagged_items__isnull=True)).delete()
 
 
-def apply_bulk_tag_changes(objects: Sequence, tag_action: str, tags: list[str]) -> list[dict[str, Any]]:
+@dataclasses.dataclass(frozen=True)
+class BulkTagActivityContext:
+    """Context needed to write an activity-log entry for each object mutated in bulk.
+
+    ``scope`` is the resource's ``ActivityScope`` (e.g. ``"FeatureFlag"``) and ``activity`` is the
+    verb its single-object update path uses ("updated" for flags/insights/dashboards, "changed" for
+    event definitions), so a bulk entry matches what that path already writes. Passing this to
+    ``apply_bulk_tag_changes`` makes the bulk path leave the same audit trail; omitting it preserves
+    the old silent behavior.
+    """
+
+    scope: str
+    user: "User"
+    was_impersonated: bool
+    activity: str
+
+
+def apply_bulk_tag_changes(
+    objects: Sequence,
+    tag_action: str,
+    tags: list[str],
+    *,
+    activity_context: Optional[BulkTagActivityContext] = None,
+) -> list[dict[str, Any]]:
     """Apply an add/remove/set tag mutation to each object and return a per-object result.
 
     Callers are responsible for team-scoping and access-checking ``objects`` first. When a
     ``prefetched_tags`` attribute is present it is used to avoid a per-object tag query.
     Orphaned tags are cleaned up per affected team, since ``objects`` may span multiple teams
     when the caller scopes by project (e.g. event definitions across environments).
+
+    When ``activity_context`` is provided, an activity-log entry carrying a ``tags`` diff is
+    recorded for every object whose tags actually change, mirroring the single-object update path
+    so the bulk endpoint leaves the same audit trail.
     """
     normalized_tags = {tagify(t) for t in tags}
     updated: list[dict[str, Any]] = []
     team_ids: set[int] = set()
+    activity_entries: list[LogActivityEntry] = []
 
     for obj in objects:
         team_ids.add(obj.team_id)
@@ -73,10 +107,43 @@ def apply_bulk_tag_changes(objects: Sequence, tag_action: str, tags: list[str]) 
         set_tags_on_object(list(new_tags), obj)
         updated.append({"id": obj.id, "tags": sorted(new_tags)})
 
+        if activity_context is not None and current_tags != new_tags:
+            activity_entries.append(
+                _bulk_tag_activity_entry(obj, sorted(current_tags), sorted(new_tags), activity_context)
+            )
+
     for team_id in team_ids:
         cleanup_orphan_tags(team_id)
 
+    if activity_entries:
+        bulk_log_activity(activity_entries)
+
     return updated
+
+
+def _bulk_tag_activity_entry(
+    obj: Any, before: list[str], after: list[str], context: BulkTagActivityContext
+) -> LogActivityEntry:
+    """Build an activity-log entry for a single bulk-tagged object.
+
+    ``organization_id`` is left ``None`` (the team is enough to scope the entry, and ``objects``
+    can span teams within a project), matching the single-object update path.
+    """
+    return LogActivityEntry(
+        organization_id=None,
+        team_id=obj.team_id,
+        user=context.user,
+        was_impersonated=context.was_impersonated,
+        item_id=str(obj.id),
+        scope=context.scope,
+        activity=context.activity,
+        detail=Detail(
+            name=getattr(obj, "name", None) or getattr(obj, "key", None),
+            # short_id is how insights are linked in the activity feed; None (and ignored) elsewhere.
+            short_id=getattr(obj, "short_id", None),
+            changes=[Change(type=context.scope, action="changed", field="tags", before=before, after=after)],
+        ),
+    )
 
 
 class TaggedItemSerializerMixin(serializers.Serializer):
@@ -210,6 +277,22 @@ def _prefetch_tags_for_instances(instances: Sequence) -> None:
 
 
 class TaggedItemViewSetMixin(viewsets.GenericViewSet):
+    # Set to the resource's ActivityScope (e.g. "FeatureFlag") to record an activity-log entry per
+    # object whose tags change via ``bulk_update_tags``. Left ``None`` for resources that don't log
+    # bulk tag edits, which leaves their behavior unchanged.
+    bulk_tag_activity_scope: Optional[str] = None
+
+    def _bulk_tag_activity_context(self) -> Optional[BulkTagActivityContext]:
+        if not self.bulk_tag_activity_scope:
+            return None
+        return BulkTagActivityContext(
+            scope=self.bulk_tag_activity_scope,
+            user=cast("User", self.request.user),
+            was_impersonated=is_impersonated(self.request),
+            # Flags, insights, and dashboards log single-object updates under the "updated" verb.
+            activity="updated",
+        )
+
     def prefetch_tagged_items_if_available(self, queryset: QuerySet | models.query.RawQuerySet) -> QuerySet:
         if isinstance(queryset, models.query.RawQuerySet):
             return queryset  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
@@ -296,7 +379,9 @@ class TaggedItemViewSetMixin(viewsets.GenericViewSet):
             if obj_id not in found_ids:
                 errors.append({"id": obj_id, "reason": "Not found"})
 
-        updated = apply_bulk_tag_changes(editable_objects, tag_action, tags)
+        updated = apply_bulk_tag_changes(
+            editable_objects, tag_action, tags, activity_context=self._bulk_tag_activity_context()
+        )
         return response.Response({"updated": updated, "skipped": errors})
 
 

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -570,7 +570,9 @@ class TestEventDefinitionAPI(APIBaseTest):
             scope="EventDefinition", activity="changed", item_id__in=[str(ed1.id), str(ed2.id)]
         )
         assert {log.item_id for log in logs} == {str(ed1.id), str(ed2.id)}
-        assert logs.get(item_id=str(ed1.id)).detail["changes"] == [
+        log = logs.get(item_id=str(ed1.id))
+        assert log.detail is not None
+        assert log.detail["changes"] == [
             {"type": "EventDefinition", "action": "changed", "field": "tags", "before": [], "after": ["pii"]}
         ]
 

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -553,6 +553,45 @@ class TestEventDefinitionAPI(APIBaseTest):
         assert not Tag.objects.filter(name="orphan_a", team=self.demo_team).exists()
         assert not Tag.objects.filter(name="orphan_b", team=other_env).exists()
 
+    def test_bulk_update_tags_logs_activity_per_event_definition(self):
+        # The single-object update path leaves a tags audit trail; the bulk path must too, or tagging
+        # 50 definitions is silent while tagging one is logged. Guards that the override threads an
+        # activity context through to apply_bulk_tag_changes.
+        ed1 = EventDefinition.objects.create(team=self.demo_team, name="logged_a")
+        ed2 = EventDefinition.objects.create(team=self.demo_team, name="logged_b")
+
+        response = self.client.post(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/",
+            {"ids": [str(ed1.id), str(ed2.id)], "action": "add", "tags": ["pii"]},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        logs = ActivityLog.objects.filter(
+            scope="EventDefinition", activity="changed", item_id__in=[str(ed1.id), str(ed2.id)]
+        )
+        assert {log.item_id for log in logs} == {str(ed1.id), str(ed2.id)}
+        assert logs.get(item_id=str(ed1.id)).detail["changes"] == [
+            {"type": "EventDefinition", "action": "changed", "field": "tags", "before": [], "after": ["pii"]}
+        ]
+
+    def test_bulk_update_tags_noop_does_not_log_activity(self):
+        # Adding a tag a definition already has changes nothing; it must not write an empty activity
+        # entry. Guards the current_tags != new_tags skip in apply_bulk_tag_changes.
+        ed = EventDefinition.objects.create(team=self.demo_team, name="noop_event")
+        self.client.post(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/",
+            {"ids": [str(ed.id)], "action": "set", "tags": ["kept"]},
+        )
+        ActivityLog.objects.filter(scope="EventDefinition").delete()
+
+        response = self.client.post(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/",
+            {"ids": [str(ed.id)], "action": "add", "tags": ["kept"]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert not ActivityLog.objects.filter(scope="EventDefinition", item_id=str(ed.id)).exists()
+
 
 class TestEventDefinitionExcludeStale(APIBaseTest):
     """Stale filter tests need real wall-clock times so the Postgres NOW() comparison

--- a/posthog/api/test/test_tagged_item.py
+++ b/posthog/api/test/test_tagged_item.py
@@ -210,7 +210,9 @@ class TestBulkUpdateTags(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         logs = ActivityLog.objects.filter(scope="Dashboard", activity="updated", item_id=str(dashboard.id))
         assert logs.count() == 1
-        assert logs.first().detail["changes"] == [
+        log = logs.get()
+        assert log.detail is not None
+        assert log.detail["changes"] == [
             {
                 "type": "Dashboard",
                 "action": "changed",

--- a/posthog/api/test/test_tagged_item.py
+++ b/posthog/api/test/test_tagged_item.py
@@ -3,7 +3,7 @@ from posthog.test.base import APIBaseTest
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.models import Organization, Tag, Team
+from posthog.models import ActivityLog, Organization, Tag, Team
 from posthog.models.tagged_item import TaggedItem
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -194,6 +194,31 @@ class TestBulkUpdateTags(APIBaseTest):
         data = response.json()
         assert data["updated"][0]["tags"] == ["existing"]
         assert data["skipped"] == []
+
+    def test_bulk_update_tags_logs_activity(self):
+        # A silent bulk edit was the reported gap: single-object updates log tag changes, the bulk
+        # path didn't. Guards that the shared mixin threads its bulk_tag_activity_scope into an
+        # activity entry (scope + "updated" verb + tags diff) for the resource.
+        dashboard = self._create_dashboard_with_tags("dash", ["existing"])
+
+        response = self.client.post(
+            self._bulk_update_url(),
+            {"ids": [dashboard.id], "action": "add", "tags": ["new"]},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        logs = ActivityLog.objects.filter(scope="Dashboard", activity="updated", item_id=str(dashboard.id))
+        assert logs.count() == 1
+        assert logs.first().detail["changes"] == [
+            {
+                "type": "Dashboard",
+                "action": "changed",
+                "field": "tags",
+                "before": ["existing"],
+                "after": ["existing", "new"],
+            }
+        ]
 
     # --- Validation errors ---
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2072,6 +2072,8 @@ class DashboardsViewSet(
     viewsets.ModelViewSet,
 ):
     scope_object = "dashboard"
+    # Record a tags change per dashboard when bulk_update_tags mutates it, matching the single-object path.
+    bulk_tag_activity_scope = "Dashboard"
     queryset = Dashboard.objects_including_soft_deleted.order_by("-pinned", "name")
     permission_classes = [CanEditDashboard]
     renderer_classes = [SafeJSONRenderer, ServerSentEventRenderer]

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2683,6 +2683,8 @@ class FeatureFlagViewSet(
     """
 
     scope_object = "feature_flag"
+    # Record a tags change per flag when bulk_update_tags mutates it, matching the single-object path.
+    bulk_tag_activity_scope = "FeatureFlag"
     psak_allowed_actions = ["remote_config"]
     # Opt the shared TaggedItemViewSetMixin action into feature_flag:write.
     # Other inheritors of the mixin don't extend write actions and so still

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1427,6 +1427,8 @@ class InsightViewSet(
     viewsets.ModelViewSet,
 ):
     scope_object = "insight"
+    # Record a tags change per insight when bulk_update_tags mutates it, matching the single-object path.
+    bulk_tag_activity_scope = "Insight"
     serializer_class = InsightSerializer
     throttle_classes = [
         ClickHouseBurstRateThrottle,


### PR DESCRIPTION
## Problem

Bulk tag updates leave no activity-log trail.
Tagging a single flag, insight, dashboard, or event definition is audited (the single-object update path logs a `tags` change), but tagging fifty of them in one bulk request is silent.
This came up in review of #67249, which added bulk tag editing for event definitions: the same gap already existed for feature flags, insights, and dashboards through the shared `TaggedItemViewSetMixin.bulk_update_tags`.

## Changes

`apply_bulk_tag_changes` (the shared implementation #67249 extracted for both the mixin and the event-definition override) now takes an optional `BulkTagActivityContext`.
When present, it records one activity entry per object whose tags actually change, carrying a `tags` before/after diff, via `bulk_log_activity` (batched inserts, not one per object).

Each entry mirrors the resource's single-object update path so bulk and single edits read the same in the activity feed:

- Feature flags, insights, and dashboards log under the `updated` verb (through the shared mixin).
- Event definitions log under `changed` (through their override).

Resources opt in explicitly:

- The mixin exposes a `bulk_tag_activity_scope` attribute, set to `"FeatureFlag"`, `"Insight"`, and `"Dashboard"` on those viewsets.
- The event-definition override passes its own `"EventDefinition"` context.

Mixin consumers that don't set the scope keep the old silent behavior, so nothing starts logging by accident.
No-op changes (adding a tag an object already has) are skipped, so they don't spam the log.

No API surface change: the request and response shapes of `bulk_update_tags` are untouched, so no generated types change.

## How did you test this code?

I (Claude) added automated tests.
This session ran without a Python/JS toolchain or a database, so I could not run the suite locally — CI will.
I did run `ruff check` and `ruff format --check` on every changed file (clean).

Tests added:

- `test_tagged_item.py::TestBulkUpdateTags::test_bulk_update_tags_logs_activity` — the mixin path (dashboards): a bulk tag change writes one `Dashboard` / `updated` entry with the `tags` diff. Catches a regression where the mixin stops threading `bulk_tag_activity_scope` into the context, or `apply_bulk_tag_changes` stops logging.
- `test_event_definition.py::test_bulk_update_tags_logs_activity_per_event_definition` — the override path: bulk tagging two definitions writes a `changed` entry per definition. Catches the override dropping the context (the exact reported gap for event definitions).
- `test_event_definition.py::test_bulk_update_tags_noop_does_not_log_activity` — a no-op add writes nothing. Catches removal of the `current_tags != new_tags` skip, which would spam empty entries.

No existing test covered bulk-path activity, so these are new rather than extensions of existing cases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change: this is an internal audit-trail parity fix, not a new API or user-facing config.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8), driven by Jake, as the fast-follow requested in review of #67249.
Skills invoked while shaping it: `/improving-drf-endpoints` (confirmed the change adds no serializer or response surface, so no OpenAPI regeneration is needed) and `/writing-tests` (applied the value gate: three tests, one per code path, rather than repeating the shared logic for every resource).

Key decisions:

- Logged inside the shared `apply_bulk_tag_changes` rather than at each call site, so all four resources (and future mixin consumers) get the audit trail from one place. That is what the reviewer suggested.
- Made the activity verb per-resource (`updated` vs `changed`) after checking each resource's single-object path, so bulk entries group with single-object ones in the feed instead of appearing under a different verb.
- Made logging opt-in per viewset (`bulk_tag_activity_scope`) instead of auto-deriving the scope from the model class, so the other mixin consumers whose describer and verb conventions I did not verify do not start logging silently.

Stacked on #67249, so this targets that branch and the diff shows only the logging change. Once #67249 merges, this should be rebased onto master.
