### PR TITLE
chore(cdp): drop MESSAGE_ASSETS_CAPTURE_ENABLED kill-switch

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -160,7 +160,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'HOG_INVOCATION_RESULTS_ENABLED'
         | 'MESSAGE_ASSETS_TOPIC'
         | 'MESSAGE_ASSETS_PRODUCER'
-        | 'MESSAGE_ASSETS_CAPTURE_ENABLED'
         | 'CDP_PREFILTERED_EVENTS_TOPIC'
         | 'CDP_PREFILTERED_EVENTS_PRODUCER'
         | 'CDP_PRECALCULATED_PERSON_PROPERTIES_TOPIC'
@@ -395,7 +394,7 @@ export function createCdpCoreServices(
     const trackingCodeSigner = new EmailTrackingCodeSigner(config.ENCRYPTION_SALT_KEYS, config.CDP_EMAIL_TRACKING_URL)
     const teamWorkflowsConfigService = new TeamWorkflowsConfigService(deps.postgres)
     const outputs = createCdpOutputsRegistry().build(deps.cdpProducerRegistry, config)
-    const messageAssetsService = new MessageAssetsService(outputs, config)
+    const messageAssetsService = new MessageAssetsService(outputs)
     const emailService = new EmailService(
         {
             sesAccessKeyId: config.SES_ACCESS_KEY_ID,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -119,10 +119,9 @@ export type CdpConfig = ClickhouseConfig & {
     HOG_INVOCATION_RESULTS_ENABLED: boolean
     // Message assets: rendered emails snapshotted to object storage + a metadata
     // row in the message_assets ClickHouse table, surfaced in the workflow
-    // "Assets" tab. Capture is a global ops kill-switch, not a per-team toggle.
+    // "Assets" tab.
     MESSAGE_ASSETS_TOPIC: string
     MESSAGE_ASSETS_PRODUCER: CdpProducerName
-    MESSAGE_ASSETS_CAPTURE_ENABLED: boolean
     HOG_INVOCATION_RERUN_MAX_COUNT: number
     // How many rerun wrapper jobs the worker dequeues per cyclotron-v2 poll.
     // Kept small by default — each job runs a full ClickHouse query per page.
@@ -252,7 +251,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         // Same cyclotron Warpstream cluster as hog_invocation_results — ClickHouse
         // consumes message_assets from the warpstream_cyclotron named collection.
         MESSAGE_ASSETS_PRODUCER: WARPSTREAM_CYCLOTRON_PRODUCER,
-        MESSAGE_ASSETS_CAPTURE_ENABLED: isDevEnv() ? true : false,
         // Hard cap on rows a single rerun wrapper job will drain. Mirrors the
         // Django serializer's HOG_INVOCATION_RERUN_MAX_COUNT (same env var).
         HOG_INVOCATION_RERUN_MAX_COUNT: 10000,

--- a/nodejs/src/cdp/services/messaging/message-assets.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/message-assets.service.test.ts
@@ -6,10 +6,6 @@ import { createExampleInvocation } from '../../_tests/fixtures'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, MessageAssetRow } from '../../types'
 import { MessageAssetsService } from './message-assets.service'
 
-const CONFIG = {
-    MESSAGE_ASSETS_CAPTURE_ENABLED: true,
-}
-
 const buildOutputsMock = (): jest.Mocked<IngestionOutputs<'message_assets'>> =>
     ({ produce: jest.fn().mockResolvedValue(undefined) }) as unknown as jest.Mocked<IngestionOutputs<'message_assets'>>
 
@@ -50,7 +46,7 @@ describe('MessageAssetsService', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         outputs = buildOutputsMock()
-        service = new MessageAssetsService(outputs, CONFIG)
+        service = new MessageAssetsService(outputs)
     })
 
     describe('buildRowForEmail', () => {
@@ -76,14 +72,6 @@ describe('MessageAssetsService', () => {
             const invocation = createExampleInvocation({ id: 'fn-1', team_id: 3 })
 
             const row = service.buildRowForEmail(invocation, emailParams())
-
-            expect(row).toBeNull()
-        })
-
-        it('returns null when capture is globally disabled', () => {
-            service = new MessageAssetsService(outputs, { MESSAGE_ASSETS_CAPTURE_ENABLED: false })
-
-            const row = service.buildRowForEmail(invocationWithAction('flow-1'), emailParams())
 
             expect(row).toBeNull()
         })

--- a/nodejs/src/cdp/services/messaging/message-assets.service.ts
+++ b/nodejs/src/cdp/services/messaging/message-assets.service.ts
@@ -33,10 +33,6 @@ const messageAssetsPendingRows = new Gauge({
     help: 'Message-asset rows queued in-memory waiting for the next flush. Resets to 0 after each flush.',
 })
 
-export interface MessageAssetsServiceConfig {
-    MESSAGE_ASSETS_CAPTURE_ENABLED: boolean
-}
-
 const microsecondsSinceEpoch = (): string => {
     const ms = BigInt(Date.now())
     const subMs = BigInt(Math.floor((performance.now() % 1) * 1000))
@@ -89,21 +85,15 @@ const oversizedPlaceholderHtml = (bytes: number): string => {
 export class MessageAssetsService {
     private queuedRows: MessageAssetRow[] = []
 
-    constructor(
-        private outputs: IngestionOutputs<MessageAssetsOutput>,
-        private config: MessageAssetsServiceConfig
-    ) {}
+    constructor(private outputs: IngestionOutputs<MessageAssetsOutput>) {}
 
-    // Returns null when capture is disabled, no content (neither html nor
-    // text), or no action id — the Assets API filters by `function_kind='hog_flow'`
-    // and keys off the action node id, so a row without one is unreachable.
+    // Returns null when there's no content (neither html nor text) or no action id —
+    // the Assets API filters by `function_kind='hog_flow'` and keys off the action
+    // node id, so a row without one is unreachable.
     buildRowForEmail(
         invocation: CyclotronJobInvocationHogFunction,
         params: CyclotronInvocationQueueParametersEmailType
     ): MessageAssetRow | null {
-        if (!this.config.MESSAGE_ASSETS_CAPTURE_ENABLED) {
-            return null
-        }
         if (!invocation.state.actionId) {
             return null
         }

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1729,12 +1729,6 @@ describe('Workflows E2E (email queue)', () => {
 
         hub = await createHub()
         hub.CDP_CYCLOTRON_BATCH_DELAY_MS = 50
-        // Default in non-dev envs is `false`, so the message-assets capture path stays
-        // dormant in CI. The asset-capture tests below assert the row lands in the
-        // dedicated Kafka topic, so we flip the kill-switch on for this describe block.
-        // Set before `createCdpConsumerDeps` / worker construction so the value is
-        // captured in `MessageAssetsService` at instantiation.
-        hub.MESSAGE_ASSETS_CAPTURE_ENABLED = true
 
         // Enforce mode for the whole block: existing tests prove deliverable recipients
         // pass validation untouched; the skip test proves dead domains never reach the queue.
@@ -2893,8 +2887,7 @@ describe('Workflows E2E (email queue)', () => {
     // boundary and bulk-produces, gated on broker ack before the consumer commits
     // offsets. These tests pin the end-to-end behavior: one workflow → one asset row in
     // the `message_assets` Kafka topic with the right metadata, and a single batch with
-    // multiple emails produces all rows. The kill-switch is flipped on in this block's
-    // `beforeEach` so the asset Kafka topic actually receives writes.
+    // multiple emails produces all rows.
     describe('message_assets bulk capture', () => {
         const buildEmailWorkflow = (subject: string) =>
             new FixtureHogFlowBuilder()
@@ -3016,39 +3009,6 @@ describe('Workflows E2E (email queue)', () => {
                     expect(row.key).toBe(value.invocation_id)
                 }
             }, 20000)
-        })
-
-        it('emits no message_assets rows when the kill-switch is disabled', async () => {
-            // Restart the email worker with capture disabled — `MessageAssetsService` reads
-            // the config at construction time, so we have to recreate the deps + worker.
-            await emailWorker.stop()
-            hub.MESSAGE_ASSETS_CAPTURE_ENABLED = false
-            deps = createCdpConsumerDeps(hub, kafkaProducer)
-            const restartedQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
-            emailWorker = new CdpCyclotronWorkerEmail(hub, deps, restartedQueue)
-            await emailWorker.start()
-
-            mockProducerObserver.resetKafkaProducer()
-
-            const hogFlow = buildEmailWorkflow('Capture disabled')
-            await insertHogFlow(hub.postgres, hogFlow)
-
-            const { backgroundTask } = await eventsConsumer.processBatch([createGlobals()])
-            await backgroundTask
-
-            await waitForExpect(async () => {
-                const jobs = await queryCyclotronJobs()
-                const terminal = jobs.filter(
-                    (j: any) => j.status === 'completed' || j.status === 'failed' || j.status === 'canceled'
-                )
-                expect(terminal.length).toBeGreaterThanOrEqual(1)
-            }, 15000)
-
-            // Give the asset producer a chance to run — if anything is going to fire it
-            // happens within the same flush window. Re-check after a short delay so we
-            // don't accept a false negative from races.
-            await new Promise((resolve) => setTimeout(resolve, 500))
-            expect(assetMessages()).toHaveLength(0)
         })
     })
 })


### PR DESCRIPTION
## Problem

`MESSAGE_ASSETS_CAPTURE_ENABLED` was a process-level ops kill-switch that kept the rendered-email snapshot path dormant outside dev while the feature was in rollout. The workflow Assets tab and the person Emails tab are now on for every team (PR #68842), so the gate has no reason to exist. Also, no environment ever set it in charts, so keeping it around just means every workflow email in prod is currently being sent without a snapshot ever landing in the `message_assets` ClickHouse table.

## Changes

Deleted the flag and its guard:

- `nodejs/src/cdp/config.ts` — removed the `MESSAGE_ASSETS_CAPTURE_ENABLED: boolean` type entry and the `isDevEnv() ? true : false` default.
- `nodejs/src/cdp/cdp-services.ts` — removed the flag from the `Pick<...>` union and from the `MessageAssetsService` constructor call (`new MessageAssetsService(outputs)` now).
- `nodejs/src/cdp/services/messaging/message-assets.service.ts` — removed the `MessageAssetsServiceConfig` interface, the `config` constructor param, and the `if (!this.config.MESSAGE_ASSETS_CAPTURE_ENABLED) return null` short-circuit at the top of `buildRowForEmail`.

Net effect at runtime: every workflow email send that has an `actionId` and a non-empty body now buffers a row through `MessageAssetsService` and flushes it to the `message_assets` Kafka topic at the batch boundary. The Kafka produce, batching, size-cap, and best-effort failure semantics are unchanged.

Only the CDP email cyclotron worker actually calls `buildRowForEmail` (via `email.service.ts` inside `emailService.executeInvocation`), so removing the gate doesn't cause other CDP consumers to start producing rows — they instantiate the service but never reach the build call.

## Blast radius to watch

- `message_assets` Kafka topic write rate goes from ~0 in prod to one row per workflow email send.
- `message_assets` ClickHouse table starts receiving rows for the first time in prod. Retention on the table is already 30d.
- `cdp_message_assets_captured{kind=\"email\"}`, `cdp_message_assets_failed`, `cdp_message_assets_truncated`, and `cdp_message_assets_pending_rows` counters begin reporting non-zero in prod. Worth eyeballing the failed/truncated counters for the first day or two.

## How did you test this code?

I (Claude) did not do any manual testing. What I did do:

- Confirmed via grep that no source file still references `MESSAGE_ASSETS_CAPTURE_ENABLED` or `MessageAssetsServiceConfig`.
- Removed two tests that only existed to exercise the flag-off branch: the `MessageAssetsService` unit test `returns null when capture is globally disabled` and the workflows e2e test `emits no message_assets rows when the kill-switch is disabled`. The remaining tests still cover the on path (which is the only path now).
- Removed the `hub.MESSAGE_ASSETS_CAPTURE_ENABLED = true` setup line in the workflows e2e block; those tests always ran with capture on, they just no longer need to say so.

Not tested by me: the actual Kafka + ClickHouse write path in dev. The service and its tests are the same as before this PR modulo the deleted gate, so if the on-path tests pass we get the same behavior we already had in dev.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Meikel drove this. I used Claude Code (Opus 4.7, 1M context) — no subagents, no skills. The change was mechanical: strike the flag out of the config type, the default, the `Pick<>` union in cdp-services, the service constructor, the runtime check, and the two tests that only existed to test the disabled branch. The `\"Capture is a global ops kill-switch\"` sentence in the config comment above the block was the only comment referencing the removed semantics; trimmed that too.

Initial framing floated a charts change to set `MESSAGE_ASSETS_CAPTURE_ENABLED: \"true\"` on the `cdp-cyclotron-worker-email` values file. Meikel redirected: no charts entry, make it the code default. That's a cleaner end state — one less env var, one less place where dev and prod defaults can diverge — so we went with it.