### PR TITLE
chore(storybook): silence noisy warnings in CI storybook build

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -232,8 +232,9 @@ jobs:
             # Consumed by the select-stories job below. Uploaded separately so
             # the visual-regression matrix doesn't pay to download it on every
             # shard.
+            # module-graph.json only exists once the Vite build completes, so no
+            # `if: always()`: on a failed/cancelled build it would just warn.
             - name: Upload module-graph artifact
-              if: always()
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: storybook-module-graph

--- a/common/storybook/.storybook/main.ts
+++ b/common/storybook/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath } from 'node:url'
 import * as path from 'path'
-import { mergeConfig } from 'vite'
+import { mergeConfig, type Rollup } from 'vite'
 
 import { frontendResolvePlugin } from './plugins/vite-frontend-resolve-plugin.ts'
 import { moduleGraphPlugin } from './plugins/vite-module-graph-plugin.ts'
@@ -99,6 +99,20 @@ const config: StorybookConfig = {
             },
             optimizeDeps: {
                 include: ['buffer'],
+            },
+            build: {
+                rollupOptions: {
+                    onwarn(warning: Rollup.RollupLog, defaultHandler: (warning: Rollup.RollupLog) => void) {
+                        // "use client" directives from RSC-oriented deps (framer-motion, radix)
+                        // are meaningless here, and barrel-file re-export cycles are endemic to
+                        // the app's index.ts files. Together they bury real warnings in ~1000
+                        // lines of noise per CI build.
+                        if (warning.code === 'MODULE_LEVEL_DIRECTIVE' || warning.code === 'CYCLIC_CROSS_CHUNK_REEXPORT') {
+                            return
+                        }
+                        defaultHandler(warning)
+                    },
+                },
             },
         }),
 

--- a/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
+++ b/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
 import * as React from 'react'
 


### PR DESCRIPTION
## Problem

The Storybook CI build log (for example [this run](https://github.com/PostHog/posthog/actions/runs/28860698083/job/85598344826)) carries roughly 1000 lines of non-actionable warnings per run, which buries the warnings that actually matter:

- ~490 Vite "Module level directives cause errors when bundled" warnings, from `use client` directives in framer-motion, radix, and one of our own files
- ~500 Rollup cyclic cross-chunk re-export warnings, caused by barrel `index.ts` files
- a `No files were found` artifact warning whenever the build is cancelled, because `module-graph.json` is only written when the Vite build completes but the upload step ran `if: always()`

## Changes

- Filter `MODULE_LEVEL_DIRECTIVE` and `CYCLIC_CROSS_CHUNK_REEXPORT` warnings in the Storybook Vite config via `rollupOptions.onwarn`. Everything else still goes through the default handler.
- Drop the stray `use client` directive from `ContextMenu.tsx`. This isn't an RSC app, so the directive does nothing except trigger the bundler warning.
- Remove `if: always()` from the module-graph artifact upload so it skips (like the main build artifact upload) instead of warning when the build didn't finish.

Not addressed here: the esbuild CSS minify warning coming from react-data-grid's beta CSS, and a handful of "dynamically imported but also statically imported" notices, which are informational and go through Vite's logger rather than onwarn.

## How did you test this code?

No automated tests apply. This environment has no node_modules, so I couldn't run the Storybook build locally. The draft CI run's Build Storybook log is the verification: it should shrink by ~1000 warning lines.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked PostHog Code (Claude) to dig into the warnings/errors in a Storybook CI run. I downloaded the job log, bucketed the 600+ warning lines into four categories, and fixed the three that are pure noise. The job's cancelled conclusion itself was just concurrency superseding the run, so nothing to fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)