### PR TITLE
fix(ci): clean frontend/dist before base build in dist-size comparison

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -417,6 +417,11 @@ jobs:
               run: |
                   git fetch -n origin "$BASE_SHA"
                   git reset --hard "$BASE_SHA"
+                  # dist/ is untracked so it survives the reset. Without a clean, the base
+                  # build layers differently-hashed chunks on top of the PR's, inflating the
+                  # base measurement by hundreds of MiB and making every PR's dist-size delta
+                  # a large spurious negative. The build never cleans dist/ itself.
+                  rm -rf frontend/dist
                   pnpm --filter=@posthog/frontend... install
                   pnpm --filter=@posthog/frontend build:with-report
                   du -sb frontend/dist | cut -f1 > frontend/dist-size-base.txt


### PR DESCRIPTION
## Problem

The dist-size section of the frontend CI report shows a large spurious negative delta on essentially every PR (e.g. -334.78 MiB / -18.6% on #68898, whose real JS delta was -26 B; neighboring PRs show -349, -289, -135 MiB).

The frontend-build job measures the PR's `frontend/dist`, then does `git reset --hard $BASE_SHA` and rebuilds the base branch in the same workspace. `frontend/dist` is untracked so it survives the reset, and nothing cleans it (`copy-scripts` is just `mkdir -p dist/`, and `build.mjs` never removes the output dir). The base build writes its content-hashed chunks next to the PR's leftovers, so the base measurement is base build plus stale PR-only files, inflated by hundreds of MiB. PR minus base then comes out as a big fake shrink.

## Changes

Add `rm -rf frontend/dist` in the "Build base branch for size comparison" step, right after the reset and before the base rebuild, so both measurements cover a clean build. Purely a workflow-internal change, so unrebased in-flight PRs are unaffected.

## How did you test this code?

Verified the mechanism by reading the workflow and build scripts: `frontend/dist` is never cleaned by the build, and the CI report files the later steps need (`frontend/dist-report/`, `frontend/bundle-size-report*.json`, `frontend/dist-size-pr.txt`) all live outside `frontend/dist`, so removing it is safe. The base build doesn't rerun `build:products`, but that writes to `frontend/src/`, not dist. Ran `hogli ci:preflight --fix` (workflow lint passed). The real proof is the dist-size section on the next few PRs reporting ~0 deltas instead of hundreds of MiB.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-internal measurement fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code session). Thomas asked why #68898 showed a -334.78 MiB dist-size change; I traced it to the uncleaned dist folder in the base rebuild, confirmed the same artifact on unrelated PRs, checked no existing PR fixes it, and made this one-line workflow change. Considered measuring the base build in a separate directory instead, but a pre-build clean is simpler and keeps the step's existing shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
