### PR TITLE
fix(tasks): honor the run-pinned redis instance in agent-design relay

### DIFF
--- a/products/tasks/backend/logic/stream/event_ingest.py
+++ b/products/tasks/backend/logic/stream/event_ingest.py
@@ -28,6 +28,7 @@ from products.tasks.backend.logic.stream.redis_stream import (
 )
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.push_dispatcher import notify_task_run_awaiting_input
+from products.tasks.backend.redis import run_uses_dedicated_stream
 
 from ee.hogai.sandbox import is_turn_complete
 
@@ -116,7 +117,9 @@ async def handle_task_run_event_ingest(scope: ASGIMessage, receive: ASGIReceive,
         await _send_json(send, error.status_code, error.payload)
         return True
 
-    redis_stream = TaskRunRedisStream(get_task_run_stream_key(claims.run_id))
+    # Write to the instance the run is pinned to so its SSE reader and relay tail the same stream.
+    state = await TaskRun.objects.filter(id=claims.run_id).values_list("state", flat=True).afirst()
+    redis_stream = TaskRunRedisStream(get_task_run_stream_key(claims.run_id), run_uses_dedicated_stream(state))
 
     try:
         result = await _ingest_event_lines(

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -14,6 +14,7 @@ from products.tasks.backend.logic.stream.redis_stream import (
     get_task_run_stream_key,
 )
 from products.tasks.backend.models import TaskRun as TaskRunModel
+from products.tasks.backend.redis import run_uses_dedicated_stream
 
 from ee.hogai.sandbox import is_turn_complete
 
@@ -101,9 +102,11 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
         return
 
     emitter = SlackAgentDesignSignalEmitter(input.slack_thread_context)
-    # Match the ingest endpoint's stream construction (default, non-dedicated client) so we
-    # read from exactly the key the sandbox events are written to.
-    redis_stream = TaskRunRedisStream(get_task_run_stream_key(input.run_id))
+    # Read from the same Redis instance the run is pinned to. The UI SSE reader and the SSE relay
+    # writer both key off run_uses_dedicated_stream; reading the shared instance while events land
+    # on the dedicated one leaves the tailer starved and the Slack thread silent.
+    state = await TaskRunModel.objects.filter(id=input.run_id).values_list("state", flat=True).afirst()
+    redis_stream = TaskRunRedisStream(get_task_run_stream_key(input.run_id), run_uses_dedicated_stream(state))
 
     try:
         async for item in redis_stream.read_stream_entries(


### PR DESCRIPTION
## Problem

A task run's event stream lives on one of two Redis instances - shared or dedicated - picked per run by `run_uses_dedicated_stream(state)`. Readers and writers have to agree on which one, or they miss each other.

Most of them do agree: the UI SSE reader, the SSE relay writer, and `publish_task_run_stream_event` all pass the pin. Two didn't:

- the Django event-ingest **writer** (`event_ingest.py`)
- the Slack agent-design relay **tailer** (`slack_agent_design_signals.py`)

Both hardcoded the shared instance:

```python
TaskRunRedisStream(get_task_run_stream_key(run_id))   # always shared
```

So for a run pinned to the dedicated Redis, these two land on the wrong instance. The tailer reads a stream nothing is writing and stays empty, so the Slack thread never streams the run's turns. The Task UI is fine throughout - it honors the pin.

## Changes

Both sites now load the run's `state` and pass `run_uses_dedicated_stream(state)`, matching every other reader/writer. Two lines each, same pattern already used by `relay_sandbox_events`.

Fixed together on purpose - they're a writer/reader pair on the ingest path. Fixing only one would split them.

## How did you test this code?

Automated, run by me (the agent) in flox:

- `test_event_ingest.py` - 28 passed (confirms the added state read in the ingest handler doesn't regress the writer)
- `test_slack_agent_design_signals.py` - 6 passed (emitter, unchanged)
- `ruff` clean, lint-staged `ty check` green

No new test: the selection just threads the already-tested `run_uses_dedicated_stream` into the constructor. A tailer-level test would only assert the constructor arg (a change-detector), which the `/writing-tests` gate rejects. I couldn't exercise the live path from here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Opus 4.8) investigated and wrote the change. Skill invoked: `/writing-tests`.

We traced this from the Slack thread not streaming, ruled out the sandbox/proxy/UI (all healthy), and found the tailer + ingest writer are the only two components that ignore the dedicated-stream pin.

One thing for reviewers to confirm: this makes the tailer read whichever instance the run is pinned to, which is correct regardless. It fully fixes Slack streaming only if the agent-proxy persists the run stream to the dedicated tasks Redis (`TASKS_REDIS_URL`) in `TaskRunRedisStream` format. I couldn't verify the proxy's Redis target from this repo. If the proxy keeps events in a private store, the tailer needs to read the proxy leg directly (a larger follow-up) - this fix still stands on its own as an instance-consistency fix.
