### PR TITLE
feat(aio): stage dedicated AI ingestion endpoint rollout

### DIFF
--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -37,6 +37,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.event_usage import report_user_action
 from posthog.models import Team, User
 from posthog.ph_client import get_client
+from posthog.settings.ingestion import DedicatedAIEndpointRollout
 from posthog.sync import database_sync_to_async
 from posthog.utils import get_instance_region
 
@@ -200,7 +201,11 @@ class BaseAgentRunner(ABC):
 
             # flush_at=1 flushes each event immediately so traces deliver before short runs end;
             # before_send truncates oversized AI blobs so they clear the SDK's per-event size drop.
-            client_kwargs = {"flush_at": 1, "before_send": ai_event_truncator}
+            client_kwargs = {
+                "flush_at": 1,
+                "before_send": ai_event_truncator,
+                "dedicated_ai_endpoint_stage": DedicatedAIEndpointRollout.RUNNER,
+            }
 
             # Local deployment or hobby
             if not is_cloud() and (local_client := posthoganalytics.default_client):

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -201,21 +201,23 @@ class BaseAgentRunner(ABC):
 
             # flush_at=1 flushes each event immediately so traces deliver before short runs end;
             # before_send truncates oversized AI blobs so they clear the SDK's per-event size drop.
-            client_kwargs = {
-                "flush_at": 1,
-                "before_send": ai_event_truncator,
-                "dedicated_ai_endpoint_stage": DedicatedAIEndpointRollout.RUNNER,
-            }
+            def make_client(region: str):
+                return get_client(
+                    region,
+                    flush_at=1,
+                    before_send=ai_event_truncator,
+                    dedicated_ai_endpoint_stage=DedicatedAIEndpointRollout.RUNNER,
+                )
 
             # Local deployment or hobby
             if not is_cloud() and (local_client := posthoganalytics.default_client):
                 self._callback_handlers.append(init_handler(local_client))
             elif region := get_instance_region():
                 # Add regional client first
-                self._callback_handlers.append(init_handler(get_client(region, **client_kwargs)))
+                self._callback_handlers.append(init_handler(make_client(region)))
                 # If we're in EU, add the US client as well, so we can see US and EU traces
                 if region == "EU":
-                    self._callback_handlers.append(init_handler(get_client("US", **client_kwargs)))
+                    self._callback_handlers.append(init_handler(make_client("US")))
 
         self._trace_id = trace_id
         self._parent_span_id = parent_span_id

--- a/ee/hogai/core/test/test_base_callback_handlers.py
+++ b/ee/hogai/core/test/test_base_callback_handlers.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock, patch
 import posthoganalytics
 from posthoganalytics.ai.langchain.callbacks import CallbackHandler
 
+from posthog.settings.ingestion import DedicatedAIEndpointRollout
+
 from products.posthog_ai.backend.models.assistant import Conversation
 
 from ee.hogai.chat_agent.runner import ChatAgentRunner
@@ -67,7 +69,12 @@ class TestBaseAgentRunnerCallbackHandlers(BaseTest):
         )
 
         self.assertEqual(len(runner._callback_handlers), 1)
-        mock_get_client.assert_called_once_with("US", flush_at=1, before_send=ai_event_truncator)
+        mock_get_client.assert_called_once_with(
+            "US",
+            flush_at=1,
+            before_send=ai_event_truncator,
+            dedicated_ai_endpoint_stage=DedicatedAIEndpointRollout.RUNNER,
+        )
 
     @patch("ee.hogai.core.runner.is_cloud")
     @patch("ee.hogai.core.runner.get_instance_region")
@@ -96,8 +103,18 @@ class TestBaseAgentRunnerCallbackHandlers(BaseTest):
 
         self.assertEqual(len(runner._callback_handlers), 2)
         self.assertEqual(mock_get_client.call_count, 2)
-        mock_get_client.assert_any_call("EU", flush_at=1, before_send=ai_event_truncator)
-        mock_get_client.assert_any_call("US", flush_at=1, before_send=ai_event_truncator)
+        mock_get_client.assert_any_call(
+            "EU",
+            flush_at=1,
+            before_send=ai_event_truncator,
+            dedicated_ai_endpoint_stage=DedicatedAIEndpointRollout.RUNNER,
+        )
+        mock_get_client.assert_any_call(
+            "US",
+            flush_at=1,
+            before_send=ai_event_truncator,
+            dedicated_ai_endpoint_stage=DedicatedAIEndpointRollout.RUNNER,
+        )
 
     @patch("ee.hogai.core.runner.is_cloud")
     @patch("ee.hogai.core.runner.get_instance_region")

--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -4,10 +4,13 @@ from numbers import Number
 from typing import Any
 from uuid import UUID
 
+from django.conf import settings
+
 import structlog
 import posthoganalytics
 
 from posthog.cloud_utils import is_cloud
+from posthog.settings.ingestion import DedicatedAIEndpointRollout
 from posthog.utils import get_instance_region
 
 PH_US_API_KEY = "sTMFPsFhdP1Ssg"
@@ -17,6 +20,15 @@ PH_EU_API_KEY = "phc_dZ4GK1LRjhB97XozMSkEwPXx7OVANaJEwLErkY1phUF"
 PH_EU_HOST = "https://eu.i.posthog.com"
 
 logger = structlog.get_logger(__name__)
+
+_DEDICATED_AI_ENDPOINT_STAGES = (DedicatedAIEndpointRollout.RUNNER, DedicatedAIEndpointRollout.ALL)
+
+
+def _use_dedicated_ai_endpoint(caller_stage: DedicatedAIEndpointRollout) -> bool:
+    rollout = settings.POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT
+    if rollout is DedicatedAIEndpointRollout.OFF:
+        return False
+    return _DEDICATED_AI_ENDPOINT_STAGES.index(rollout) >= _DEDICATED_AI_ENDPOINT_STAGES.index(caller_stage)
 
 
 def feature_enabled_or_false(
@@ -84,7 +96,12 @@ def ph_scoped_capture():
         ph_client.shutdown()
 
 
-def get_client(region: str = "US", **kwargs: Any):
+def get_client(
+    region: str = "US",
+    *,
+    dedicated_ai_endpoint_stage: DedicatedAIEndpointRollout = DedicatedAIEndpointRollout.ALL,
+    **kwargs: Any,
+):
     from posthoganalytics import Posthog
 
     api_key = None
@@ -98,4 +115,10 @@ def get_client(region: str = "US", **kwargs: Any):
     else:
         return
 
-    return Posthog(api_key, host=host, super_properties={"region": region}, **kwargs)
+    return Posthog(
+        api_key,
+        host=host,
+        super_properties={"region": region},
+        _dedicated_ai_endpoint=_use_dedicated_ai_endpoint(dedicated_ai_endpoint_stage),
+        **kwargs,
+    )

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,4 +1,5 @@
 import os
+from enum import StrEnum
 
 import structlog
 
@@ -63,6 +64,29 @@ OTLP_LOGS_INGEST_ENDPOINT = os.getenv("OTLP_LOGS_INGEST_ENDPOINT", "")
 CAPTURE_INTERNAL_MAX_WORKERS = get_from_env("CAPTURE_INTERNAL_MAX_WORKERS", type_cast=int, default=8)
 
 NEW_ANALYTICS_CAPTURE_ENDPOINT = os.getenv("NEW_CAPTURE_ENDPOINT", "/i/v0/e/")
+
+
+# Cumulative rollout of the dedicated AI ingestion pipeline for our own `$ai_*` events: each stage
+# also routes the stages before it. Chart-toggled so we can advance or roll back without a deploy.
+class DedicatedAIEndpointRollout(StrEnum):
+    OFF = "off"
+    RUNNER = "runner"
+    ALL = "all"
+
+
+def _parse_dedicated_ai_rollout(value: str) -> "DedicatedAIEndpointRollout":
+    try:
+        return DedicatedAIEndpointRollout(value.strip().lower())
+    except ValueError:
+        logger.warning("invalid_dedicated_ai_endpoint_rollout", value=value)
+        return DedicatedAIEndpointRollout.OFF
+
+
+POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT = get_from_env(
+    "POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT",
+    DedicatedAIEndpointRollout.OFF,
+    type_cast=_parse_dedicated_ai_rollout,
+)
 
 CAPTURE_V1_INTERNAL_ENDPOINT = os.getenv("CAPTURE_V1_INTERNAL_ENDPOINT", "/i/v1/analytics/events")
 CAPTURE_V1_INTERNAL_MAX_ATTEMPTS = get_from_env("CAPTURE_V1_INTERNAL_MAX_ATTEMPTS", type_cast=int, default=4)

--- a/posthog/test/test_ph_client.py
+++ b/posthog/test/test_ph_client.py
@@ -1,0 +1,46 @@
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from posthog.ph_client import get_client
+from posthog.settings.ingestion import (
+    DedicatedAIEndpointRollout as Rollout,
+    _parse_dedicated_ai_rollout,
+)
+
+
+class TestDedicatedAIEndpointRollout(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (Rollout.OFF, Rollout.RUNNER, False),
+            (Rollout.OFF, Rollout.ALL, False),
+            (Rollout.RUNNER, Rollout.RUNNER, True),
+            (Rollout.RUNNER, Rollout.ALL, False),
+            (Rollout.ALL, Rollout.RUNNER, True),
+            (Rollout.ALL, Rollout.ALL, True),
+        ]
+    )
+    def test_dedicated_ai_endpoint_gated_by_rollout_stage(self, rollout, caller_stage, expected):
+        with override_settings(POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT=rollout):
+            client = get_client(
+                "US", dedicated_ai_endpoint_stage=caller_stage, send=False, enable_local_evaluation=False
+            )
+            self.assertEqual(client._dedicated_ai_endpoint, expected)
+
+    def test_general_callers_only_opt_in_at_full_rollout(self):
+        with override_settings(POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT=Rollout.RUNNER):
+            self.assertFalse(get_client("US", send=False, enable_local_evaluation=False)._dedicated_ai_endpoint)
+        with override_settings(POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT=Rollout.ALL):
+            self.assertTrue(get_client("US", send=False, enable_local_evaluation=False)._dedicated_ai_endpoint)
+
+    @parameterized.expand(
+        [
+            ("off", Rollout.OFF),
+            ("runner", Rollout.RUNNER),
+            ("all", Rollout.ALL),
+            ("  RUNNER  ", Rollout.RUNNER),
+            ("bogus", Rollout.OFF),
+        ]
+    )
+    def test_parse_rollout_falls_back_to_off_on_invalid(self, value, expected):
+        self.assertEqual(_parse_dedicated_ai_rollout(value), expected)


### PR DESCRIPTION
## Problem

We need to start routing traffic to the dedicated AI ingestion pipeline as a first step in its rollout.

## Changes

Ship an env var that allows switching first a single feature (PostHog AI), and then all of them.

## How did you test this code?

I (Claude, via PostHog Code) added `posthog/test/test_ph_client.py`: parameterized coverage of the (rollout stage, caller stage) matrix through the public `get_client`, the default-stage behavior, and the lenient env parser. 12 cases, no DB (`SimpleTestCase`), ~0.4s. They guard the stage ordering and the fail-closed default, if someone reorders the enum, flips the comparison, or drifts the default, events would silently misroute. I ran `ruff check`/`format` and this test file locally, plus `hogli ci:preflight --strict` on push. I did not run the full CI suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. This only changes how our own backend routes its internal analytics.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus) via PostHog Code, directed by Carlos. No repo skills shaped the code, I invoked `/writing-tests` to gate the test before writing it.

Key decisions:
- Enum over a boolean so we can roll out to the Max AI runner (our highest-volume internal `$ai_*` source) first, verify it lands, then advance to `all`. Cumulative stages keep the model simple.
- Gated the flag in `get_client` only, not the module-level `default_client`. The SDK's lazy `setup()` doesn't thread this kwarg, and `get_client` already backs the runner. Product wrappers that use `default_client` are out of scope for this first step.
- Checked the gateway paths before committing: the Go ai-gateway and Python llm-gateway capture server-side with their own clients and hand plain (unwrapped) SDK clients to callers, so they're unaffected and there's no double-capture risk from this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
