### PR TITLE
fix(replay): only copy presentational attributes to canvas replay image

### DIFF
--- a/common/replay-shared/src/canvas/canvas-plugin.test.ts
+++ b/common/replay-shared/src/canvas/canvas-plugin.test.ts
@@ -361,6 +361,39 @@ describe('CanvasReplayerPlugin', () => {
         })
     })
 
+    describe('reconstructed image attribute copying', () => {
+        it.each(['onload', 'onerror', 'onclick', 'onmouseover', 'onanimationstart', 'ontoggle'])(
+            'does not copy the %s event handler attribute from the recorded canvas',
+            (handlerName) => {
+                const canvas = document.createElement('canvas')
+                canvas.setAttribute(handlerName, 'globalThis.__canvasXss = true')
+                canvas.setAttribute('class', 'my-canvas')
+
+                const plugin = CanvasReplayerPlugin([])
+                plugin.onBuild?.(canvas, { id: 1, replayer: mockReplayer } as any)
+
+                expect(mockImage.hasAttribute(handlerName)).toBe(false)
+                // benign attributes are still copied so playback styling is preserved
+                expect(mockImage.getAttribute('class')).toBe('my-canvas')
+            }
+        )
+
+        it.each(['src', 'srcset'])(
+            'does not copy the %s resource-loading attribute from the recorded canvas',
+            (attrName) => {
+                const canvas = document.createElement('canvas')
+                canvas.setAttribute(attrName, 'https://attacker.example/x')
+                canvas.setAttribute('class', 'my-canvas')
+
+                const plugin = CanvasReplayerPlugin([])
+                plugin.onBuild?.(canvas, { id: 1, replayer: mockReplayer } as any)
+
+                expect(mockImage.hasAttribute(attrName)).toBe(false)
+                expect(mockImage.getAttribute('class')).toBe('my-canvas')
+            }
+        )
+    })
+
     describe('target canvas sizing from snapshot mutations', () => {
         const makeCanvasEvent = (
             id: number,

--- a/common/replay-shared/src/canvas/canvas-plugin.ts
+++ b/common/replay-shared/src/canvas/canvas-plugin.ts
@@ -368,6 +368,15 @@ export const CanvasReplayerPlugin = (
 
                 for (let i = 0; i < canvasElement.attributes.length; i++) {
                     const attr = canvasElement.attributes[i]
+                    const name = attr.name.toLowerCase()
+                    // The reconstructed <img> lives in the top-level document, so it inherits only
+                    // presentational attributes from the recorded canvas. Skip inline event handlers
+                    // (every handler is named `on<event>`, so this covers the whole class) and the
+                    // URL-loading attributes — the plugin points `src` at the rendered canvas blob
+                    // itself, so a copied `src`/`srcset` would only fetch an attacker-controlled URL.
+                    if (name.startsWith('on') || name === 'src' || name === 'srcset') {
+                        continue
+                    }
                     el.setAttribute(attr.name, attr.value)
                 }
 


### PR DESCRIPTION
This ensures we don't copy over JS handlers . rrweb already does this for `onload`, `onclick`, and a few others.