### PR TITLE
fix(data-warehouse): v3 loader poll resilience — statement timeout and backoff

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import random
 import signal
 import asyncio
 from collections import defaultdict
@@ -37,6 +38,10 @@ RECONCILE_GRACE_SECONDS = 120  # don't race a _fail_run that is still in flight
 RECONCILE_LOOKBACK_SECONDS = 24 * 60 * 60  # wide enough to catch jobs orphaned by consumer outages
 
 SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
+
+# Cap on the exponential backoff between failed polls — flat retries make the
+# whole fleet hammer a degraded queue DB in lockstep.
+POLL_BACKOFF_MAX_SECONDS = 30.0
 
 # Per-poll fetch cap multiplier: fetch at most (free slots x this) batches so a poll
 # never leases far more groups than it can dispatch. Runs average ~2 batches per
@@ -77,6 +82,9 @@ class BatchConsumerConfig:
     connect_timeout_seconds: int = 10
     poll_timeout_seconds: float | None = 180.0
     sweep_timeout_seconds: float | None = 300.0
+    # Added to each connection's client ceiling to form its server-side
+    # statement_timeout, so an abandoned poll or sweep can't keep burning DB CPU.
+    statement_timeout_margin_seconds: float = 30.0
     # When set, the consumer stops reporting itself healthy once any single batch
     # has been executing longer than this, so a wedged sink connection turns into
     # a liveness-probe restart instead of an indefinite, invisible stall.
@@ -252,11 +260,20 @@ class BatchConsumer:
     def _lease_ttl_seconds(self) -> int:
         return self._config.lease_ttl_seconds or self._config.recovery_grace_seconds or RECOVERY_GRACE_SECONDS
 
-    async def _connect(self) -> psycopg.AsyncConnection[Any]:
+    def _statement_timeout_options(self, client_timeout_seconds: float | None) -> str | None:
+        """libpq options for the server-side statement_timeout backstop; None when
+        the client ceiling is disabled (same "0 disables" contract)."""
+        if not client_timeout_seconds:
+            return None
+        timeout_ms = int((client_timeout_seconds + self._config.statement_timeout_margin_seconds) * 1000)
+        return f"-c statement_timeout={timeout_ms}"
+
+    async def _connect(self, *, statement_timeout_options: str | None = None) -> psycopg.AsyncConnection[Any]:
         return await psycopg.AsyncConnection.connect(
             self._config.database_url,
             autocommit=True,
             connect_timeout=self._config.connect_timeout_seconds,
+            options=statement_timeout_options,
         )
 
     async def _drop_conn(self, attr: str) -> None:
@@ -281,7 +298,9 @@ class BatchConsumer:
         async with self._poll_conn_lock:
             if self._poll_conn is None or self._poll_conn.closed or self._poll_conn.broken:
                 logger.warning(self._event("queue_db_poll_connection_reconnecting"))
-                self._poll_conn = await self._connect()
+                self._poll_conn = await self._connect(
+                    statement_timeout_options=self._statement_timeout_options(self._config.poll_timeout_seconds)
+                )
             return self._poll_conn
 
     async def _ensure_recovery_conn(self) -> psycopg.AsyncConnection[Any]:
@@ -291,7 +310,9 @@ class BatchConsumer:
         async with self._recovery_conn_lock:
             if self._recovery_conn is None or self._recovery_conn.closed or self._recovery_conn.broken:
                 logger.warning(self._event("queue_db_recovery_connection_reconnecting"))
-                self._recovery_conn = await self._connect()
+                self._recovery_conn = await self._connect(
+                    statement_timeout_options=self._statement_timeout_options(self._config.sweep_timeout_seconds)
+                )
             return self._recovery_conn
 
     async def _wait_or_shutdown(self, timeout: float) -> None:
@@ -303,8 +324,12 @@ class BatchConsumer:
     async def run(self) -> None:
         self._install_signal_handlers()
 
-        self._poll_conn = await self._connect()
-        self._recovery_conn = await self._connect()
+        self._poll_conn = await self._connect(
+            statement_timeout_options=self._statement_timeout_options(self._config.poll_timeout_seconds)
+        )
+        self._recovery_conn = await self._connect(
+            statement_timeout_options=self._statement_timeout_options(self._config.sweep_timeout_seconds)
+        )
 
         logger.info(
             self._event("batch_consumer_started"),
@@ -353,13 +378,13 @@ class BatchConsumer:
                     )
                     self._note_poll_failure("timeout", duration=time.monotonic() - poll_start)
                     await self._drop_conn("_poll_conn")
-                    await self._wait_or_shutdown(self._config.poll_interval_seconds)
+                    await self._wait_or_shutdown(self._poll_retry_delay())
                     continue
                 except psycopg.OperationalError as e:
                     logger.exception(self._event("poll_failed_queue_db_unreachable"))
                     capture_exception(e)
                     self._note_poll_failure("db_unreachable", duration=time.monotonic() - poll_start)
-                    await self._wait_or_shutdown(self._config.poll_interval_seconds)
+                    await self._wait_or_shutdown(self._poll_retry_delay())
                     continue
                 self._consecutive_poll_failures = 0
                 poll_duration = time.monotonic() - poll_start
@@ -892,6 +917,14 @@ class BatchConsumer:
         self._consecutive_poll_failures += 1
         self._metrics.poll_failures_total.labels(reason=reason).inc()
         self._metrics.poll_duration_seconds.observe(duration)
+
+    def _poll_retry_delay(self) -> float:
+        """Capped, jittered backoff before retrying a failed poll: a degraded queue DB
+        gets exponentially less pressure and the fleet's retries desynchronize."""
+        base = self._config.poll_interval_seconds
+        failures = max(self._consecutive_poll_failures, 1)
+        backoff = min(base * 2 ** (failures - 1), POLL_BACKOFF_MAX_SECONDS)
+        return backoff + random.uniform(0, base)
 
     def _report_health(self) -> None:
         """Report liveness, unless the stuck-batch watchdog or the poll-failure trip fired.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -494,7 +494,9 @@ class TestQueueOperationTimeouts:
             return []
 
         with (
-            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
             patch.object(consumer, "_install_signal_handlers"),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
@@ -536,7 +538,9 @@ class TestQueueOperationTimeouts:
             return []
 
         with (
-            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
             patch.object(consumer, "_install_signal_handlers"),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
@@ -598,7 +602,9 @@ class TestPollFailureLiveness:
             return []
 
         with (
-            patch.object(consumer, "_connect", new_callable=AsyncMock, side_effect=lambda: _make_healthy_conn()),
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
             patch.object(consumer, "_install_signal_handlers"),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
@@ -619,6 +625,65 @@ class TestPollFailureLiveness:
             assert consumer._consecutive_poll_failures == 0
             consumer._shutdown.set()
             await asyncio.wait_for(run_task, timeout=5.0)
+
+
+class TestStatementTimeoutBackstop:
+    @pytest.mark.parametrize(
+        "client_timeout,expected",
+        [
+            (180.0, "-c statement_timeout=210000"),  # 180s + 30s margin, in ms
+            (None, None),  # disabled client ceiling disables the backstop too
+            (0, None),
+        ],
+    )
+    def test_option_string_tracks_client_timeout(self, client_timeout, expected):
+        consumer = _make_consumer(statement_timeout_margin_seconds=30.0)
+        assert consumer._statement_timeout_options(client_timeout) == expected
+
+    @pytest.mark.asyncio
+    async def test_poll_reconnect_applies_statement_timeout(self):
+        # A reconnect that drops the backstop lets an abandoned query keep
+        # burning queue-DB CPU — the exact failure the timeout guards against.
+        consumer = _make_consumer(poll_timeout_seconds=180.0, statement_timeout_margin_seconds=30.0)
+        consumer._poll_conn = _make_healthy_conn(closed=True)  # force the reconnect branch
+        captured: dict[str, Any] = {}
+
+        async def fake_connect(*, statement_timeout_options: str | None = None) -> AsyncMock:
+            captured["options"] = statement_timeout_options
+            return _make_healthy_conn()
+
+        with patch.object(consumer, "_connect", side_effect=fake_connect):
+            await consumer._ensure_poll_conn()
+
+        assert captured["options"] == "-c statement_timeout=210000"
+
+
+class TestPollBackoff:
+    def test_delay_grows_exponentially_and_caps(self):
+        # Losing the backoff means lockstep fleet retries; losing the cap means
+        # unbounded delays.
+        consumer = _make_consumer(poll_interval_seconds=2.0)
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.batch_consumer.random.uniform",
+            return_value=0.0,
+        ):
+            consumer._consecutive_poll_failures = 1
+            assert consumer._poll_retry_delay() == 2.0
+            consumer._consecutive_poll_failures = 2
+            assert consumer._poll_retry_delay() == 4.0
+            consumer._consecutive_poll_failures = 3
+            assert consumer._poll_retry_delay() == 8.0
+            consumer._consecutive_poll_failures = 20  # far past the cap
+            assert consumer._poll_retry_delay() == 30.0  # POLL_BACKOFF_MAX_SECONDS
+
+    def test_jitter_is_added_within_one_interval(self):
+        consumer = _make_consumer(poll_interval_seconds=2.0)
+        consumer._consecutive_poll_failures = 1
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.batch_consumer.random.uniform",
+            return_value=1.5,
+        ):
+            assert consumer._poll_retry_delay() == 3.5  # 2.0 backoff + 1.5 jitter
 
 
 class TestFailRun:
@@ -835,7 +900,7 @@ class TestConnectionRecovery:
         consumer._poll_conn = _make_healthy_conn(closed=True)
         fresh = _make_healthy_conn()
 
-        async def slow_connect() -> AsyncMock:
+        async def slow_connect(**kwargs: Any) -> AsyncMock:
             await asyncio.sleep(0)  # yield so the other coroutines reach the check while we're "dialing"
             return fresh
 


### PR DESCRIPTION
## Problem

Tier 1 follow-up to the loader outage hardening in #68848. When the v3 claim query degrades, the loader today makes it worse: an abandoned poll can keep burning queue-DB CPU after the client cancels it, and every pod retries a slow query after a flat 2s interval, so the whole fleet hammers the degraded DB in near-lockstep and no poll ever gets a chance to complete. That is the self-reinforcing livelock we watched relapse this week.

This PR adds two runtime-bounded mitigations. Neither is the structural fix — that is the claim query's O(backlog) cost, tracked as a separate larger change — but both soften a degradation instead of amplifying it, and neither needs a schema change.

## Changes

**Server-side `statement_timeout` backstop.** Each queue-DB connection now sets `statement_timeout` to its client ceiling plus a margin (`poll_timeout + margin` for the poll connection, `sweep_timeout + margin` for the recovery connection). The asyncio timeout still cancels and drops the connection first in the normal case; this guarantees the Postgres backend aborts even when that drop does not land promptly, so an abandoned poll or sweep cannot keep running server-side. Disabled client ceilings disable the backstop too, matching the existing "0 disables" contract.

**Exponential backoff with jitter between failed polls.** Failed polls previously retried after a flat `poll_interval`. Now the delay grows with consecutive failures (capped at 30s) and carries jitter within one interval, so a persistently degraded queue DB gets exponentially less pressure and the fleet's retries desynchronize instead of firing in lockstep. The success path is unchanged.

## How did you test this code?

Automated tests only (no manual prod testing):

- `TestStatementTimeoutBackstop` (new): the option-string math and the "0/None disables" contract (parameterized), plus a wiring test that a poll reconnect actually applies the backstop — a reconnect that silently drops it is the exact regression, and mirrors how the stuck-batch watchdog once shipped unwired.
- `TestPollBackoff` (new): delay grows exponentially and caps (guards against losing backoff → flat lockstep retry, or losing the cap → unbounded delay), and jitter is added within one interval.
- Updated four existing `_connect` patches to the new keyword-only `statement_timeout_options` signature (mechanical).
- Full `postgres_queue/test_consumer.py` (61) and duckgres (88) suites pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal loader behavior; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude), continuing the tiered plan from the outage investigation. This is "PR B" of the Tier 1 set; Tier 0 landed as #68848.
- Skills invoked: `/writing-tests` before the test additions.
- Decisions: the statement_timeout is a backstop set *above* the client ceiling rather than below it, deliberately — sitting below would reshuffle the error-handling paths (server-side QueryCanceled vs client TimeoutError) for marginal benefit, whereas the above-margin version is purely additive and low-risk. The "degraded-mode narrower poll window" from the audit is intentionally not here: doing it correctly means bounding the candidate scan in the claim query itself, which belongs with the O(backlog) rewrite (a smaller LIMIT alone would not help, since the cost is the pre-LIMIT window-function sort, not the row count returned).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*