### PR TITLE
fix(slack-app): rebuild mention inputs dataclass in no-github gate

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/messaging.py
+++ b/posthog/temporal/ai/slack_app/activities/messaging.py
@@ -1,4 +1,5 @@
 import json
+import dataclasses
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -19,6 +20,22 @@ POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     'You can also add routing rules with `@PostHog rules add "description" [org/repo]`.'
 )
 POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE = "Select the repository for this routing rule."
+
+
+def coerce_mention_inputs(inputs: Any) -> PostHogCodeSlackMentionWorkflowInputs:
+    """Rebuild the mention-inputs dataclass when Temporal hands it over as a raw dict.
+
+    Temporal reconstructs a dataclass activity argument from its JSON payload only when the
+    activity is invoked with as many positional arguments as it declares. An activity called
+    with fewer (e.g. a caller that omits a trailing defaulted parameter) receives ``inputs`` as
+    a plain dict, so the first attribute access raises ``AttributeError``. Filtering to declared
+    fields keeps the reconstruction safe across a rolling deploy that adds or removes a field on
+    the dataclass, where an older history's payload can carry keys the current class no longer has.
+    """
+    if isinstance(inputs, PostHogCodeSlackMentionWorkflowInputs):
+        return inputs
+    field_names = {field.name for field in dataclasses.fields(PostHogCodeSlackMentionWorkflowInputs)}
+    return PostHogCodeSlackMentionWorkflowInputs(**{key: inputs[key] for key in inputs if key in field_names})
 
 
 @activity.defn
@@ -163,6 +180,12 @@ def block_posthog_code_task_if_no_personal_github_activity(
     PostHog app identity instead of the user's. Rather than degrading silently, hold
     the task and surface the one-click path to the personal integration setup.
     """
+    # The workflow invokes this activity without the trailing ``allow_bot_prs`` (relying on its
+    # default), so Temporal delivers ``inputs`` as a raw dict rather than the dataclass; rebuild it
+    # here instead of making the parameter required, which would break in-flight histories already
+    # scheduled with the shorter arg list. See ``coerce_mention_inputs`` for the full rationale.
+    inputs = coerce_mention_inputs(inputs)
+
     from django.conf import settings
 
     from posthog.models.integration import Integration, SlackIntegration

--- a/posthog/temporal/tests/ai/test_block_missing_user_github.py
+++ b/posthog/temporal/tests/ai/test_block_missing_user_github.py
@@ -1,3 +1,6 @@
+import dataclasses
+from typing import Any
+
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -13,6 +16,7 @@ from posthog.temporal.ai.slack_app import (
     PostHogCodeSlackMentionWorkflowInputs,
     block_posthog_code_task_if_no_personal_github_activity,
 )
+from posthog.temporal.ai.slack_app.activities.messaging import coerce_mention_inputs
 
 
 def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
@@ -30,14 +34,26 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
         self.user = User.objects.create(email="alice@test.com")
         self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
+    @parameterized.expand(
+        [
+            ("dataclass_inputs", False),
+            # Temporal skips dataclass reconstruction when the workflow invokes this activity with
+            # fewer positional args than it declares (it omits the trailing ``allow_bot_prs``), so
+            # ``inputs`` arrives as a raw dict. This case guards the coercion: without it the
+            # activity crashes on ``inputs.integration_id`` and the mention fails with an internal
+            # error instead of posting the Connect GitHub prompt.
+            ("dict_inputs", True),
+        ]
+    )
     @patch("posthog.models.integration.SlackIntegration")
-    def test_returns_true_and_posts_block_when_user_has_no_personal_github(self, mock_slack_cls):
+    def test_returns_true_and_posts_block_when_user_has_no_personal_github(self, _name, inputs_as_dict, mock_slack_cls):
         mock_slack = MagicMock()
         mock_slack_cls.return_value = mock_slack
 
-        blocked = block_posthog_code_task_if_no_personal_github_activity(
-            _make_inputs(self.integration.id), "C123", "1234.5678", self.user.id
-        )
+        built = _make_inputs(self.integration.id)
+        inputs: Any = dataclasses.asdict(built) if inputs_as_dict else built
+
+        blocked = block_posthog_code_task_if_no_personal_github_activity(inputs, "C123", "1234.5678", self.user.id)
 
         assert blocked is True
         mock_slack.client.chat_postMessage.assert_called_once()
@@ -138,3 +154,22 @@ class TestBlockPostHogCodeTaskIfNoPersonalGitHub(TestCase):
 
         assert blocked is True
         mock_slack.client.chat_postMessage.assert_called_once()
+
+
+class TestCoerceMentionInputs(TestCase):
+    @parameterized.expand(
+        [
+            ("known_fields_only", {}),
+            # A rolling deploy that drops a field leaves older histories carrying a key the current
+            # dataclass no longer declares; reconstruction must ignore it rather than raise TypeError.
+            ("tolerates_unknown_field", {"stale_removed_field": "x"}),
+        ]
+    )
+    def test_rebuilds_dataclass_from_temporal_dict_payload(self, _name, extra_keys):
+        payload = {**dataclasses.asdict(_make_inputs(123, slack_team_id="T_X")), **extra_keys}
+
+        result = coerce_mention_inputs(payload)
+
+        assert isinstance(result, PostHogCodeSlackMentionWorkflowInputs)
+        assert result.integration_id == 123
+        assert result.slack_team_id == "T_X"


### PR DESCRIPTION
## Problem

Mentioning @PostHog in Slack fails with "Sorry, I hit an internal error while processing that request" whenever the mentioning user has not connected a personal GitHub integration and their team does have GitHub connected. It reproduces on every such mention, returns in about 6 seconds regardless of message content, and leaves no application log behind (the failure surfaces only in the Temporal workflow history).

## Changes

The mention workflow's personal-GitHub gate, `block_posthog_code_task_if_no_personal_github_activity`, declares a trailing optional `allow_bot_prs` parameter that every workflow call site omits. Temporal only rebuilds a dataclass argument from its JSON payload when the activity is invoked with as many positional args as it declares. The short call makes it skip reconstruction and hand `inputs` over as a raw dict, so the first `inputs.integration_id` access raises `AttributeError: 'dict' object has no attribute 'integration_id'`. The workflow's catch-all then posts the internal error after three retries, which is the ~6s the user sees.

The fix rebuilds `inputs` inside the activity through a small `coerce_mention_inputs` helper when Temporal delivers a dict. I chose this over the two alternatives on purpose:

- Not making `allow_bot_prs` required. That breaks in-flight workflow histories already scheduled with the shorter 4-arg list, since a new worker would fail to bind the missing arg.
- Not passing `allow_bot_prs` from the workflow. That leaves in-flight runs still broken (their 4-arg input is already recorded in history), and it touches workflow code, which relies on the subtlety that Temporal does not diff activity inputs on replay.

The activity-side coercion has zero replay blast radius and rescues the runs failing mid-flight right now, not just new mentions. The helper filters to declared dataclass fields so reconstruction stays safe across a rolling deploy that adds or removes a field on the inputs dataclass, where an older history's payload can carry a key the current class no longer has. After the fix a user without personal GitHub gets the actionable "Connect GitHub" prompt instead of an internal error.

This is a regression from #63009, which added `allow_bot_prs` plus the bot-PRs bypass shortly before it was reported. One thing worth a look by that PR's author, separately from this fix: the `allow_bot_prs=True` bypass is never passed by any call site, so the "continue as PostHog bot" path is currently unreachable from the workflow.

## How did you test this code?

I (Claude) am an agent and did not run this against real Slack. Two test groups, both run locally (10 passed):

- Parameterized the existing activity test over dataclass-vs-dict input, where the dict is the form Temporal actually delivers (`dataclasses.asdict`). This guards the wiring. Reverting the coercion makes the dict case fail with the exact production `AttributeError`, which I confirmed.
- Added a pure-function test for `coerce_mention_inputs` covering the rolling-deploy case where the payload carries an unknown key. Reverting the field filter makes it fail with `TypeError: unexpected keyword argument`, which I confirmed.

Every existing test passed a real dataclass and so never crossed the Temporal serialization boundary, which is why none of them caught this.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta drove the investigation from a support ticket. I (Claude) traced it through production logs and the Temporal workflow history down to the failing activity, then implemented the fix. Skills invoked: `/writing-tests`, which gated the tests down to the cheapest rung (a parameterized dict-vs-dataclass activity case plus a pure-function helper test) rather than a full-worker integration test.

I first drafted making `allow_bot_prs` required and passing it explicitly from the workflow, then rejected both on Temporal backward-compat grounds: a required param breaks in-flight histories, and a workflow-side arg change does nothing for runs whose input is already recorded. Settled on the activity-side coercion, then extracted it into a documented `coerce_mention_inputs` helper and hardened it to filter unknown keys so it survives an inputs-dataclass schema change across a rolling deploy.
