### PR TITLE
fix(clickhouse): shallow-copy query tags instead of deep copy

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -82,6 +82,9 @@ def _cache_reverse_rel_identity() -> None:
             entry = cache[id(other)] = (other, orig_eq(self, other))
         return entry[1]
 
+    # _eq_cache is per-instance and per-session (unbounded), holding strong refs to every
+    # object each rel is ever compared with. Bounded by schema size, not test count, so
+    # harmless in practice — but don't mistake it for a per-test cache.
     ForeignObjectRel.__eq__ = cached_eq  # type: ignore[method-assign, assignment]
 
 
@@ -153,9 +156,13 @@ def _cache_url_resolution() -> None:
             hit = orig_resolve(self, path)
             by_path[str(path)] = hit
         # ResolverMatch blocks copy.copy via __reduce_ex__, so clone through __dict__.
+        # Copy every mutable attribute so consumers can mutate the match freely without
+        # poisoning the cached original for subsequent tests.
         match = object.__new__(type(hit))
         match.__dict__.update(hit.__dict__)
         match.kwargs = dict(hit.kwargs)
+        match.captured_kwargs = dict(getattr(hit, "captured_kwargs", {}))
+        match.extra_kwargs = dict(getattr(hit, "extra_kwargs", {}))
         return match
 
     resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]

--- a/conftest.py
+++ b/conftest.py
@@ -62,7 +62,7 @@ def _cache_reverse_rel_identity() -> None:
             self._identity_hash = h = hash(self.identity)
             return h
 
-    ForeignObjectRel.__hash__ = cached_hash  # type: ignore[assignment]
+    ForeignObjectRel.__hash__ = cached_hash  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
     # __eq__ compares the full identity tuples element by element (each element itself a
     # Field with a non-trivial __eq__), and dict probing in select-mask construction calls
@@ -85,7 +85,7 @@ def _cache_reverse_rel_identity() -> None:
     # _eq_cache is per-instance and per-session (unbounded), holding strong refs to every
     # object each rel is ever compared with. Bounded by schema size, not test count, so
     # harmless in practice — but don't mistake it for a per-test cache.
-    ForeignObjectRel.__eq__ = cached_eq  # type: ignore[method-assign, assignment]
+    ForeignObjectRel.__eq__ = cached_eq  # type: ignore[method-assign, assignment]  # ty: ignore[invalid-assignment]
 
 
 def _cache_select_masks() -> None:
@@ -112,7 +112,7 @@ def _cache_select_masks() -> None:
             mask = masks[key] = orig_get_select_mask(self)
         return mask
 
-    Query.get_select_mask = get_select_mask  # type: ignore[method-assign]
+    Query.get_select_mask = get_select_mask  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
 def _cache_drf_field_info() -> None:
@@ -131,7 +131,7 @@ def _cache_drf_field_info() -> None:
             info = infos[key] = orig_get_field_info(model)
         return info
 
-    model_meta.get_field_info = get_field_info
+    model_meta.get_field_info = get_field_info  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
 def _cache_url_resolution() -> None:
@@ -166,7 +166,7 @@ def _cache_url_resolution() -> None:
         match.extra_kwargs = dict(getattr(hit, "extra_kwargs", None) or {})
         return match
 
-    resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]
+    resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
 def pytest_configure(config) -> None:

--- a/conftest.py
+++ b/conftest.py
@@ -151,10 +151,11 @@ def _cache_url_resolution() -> None:
         by_path = cache.get(self)
         if by_path is None:
             by_path = cache.setdefault(self, {})
-        hit = by_path.get(str(path))
+        path_str = str(path)
+        hit = by_path.get(path_str)
         if hit is None:
             hit = orig_resolve(self, path)
-            by_path[str(path)] = hit
+            by_path[path_str] = hit
         # ResolverMatch blocks copy.copy via __reduce_ex__, so clone through __dict__.
         # Copy every mutable attribute so consumers can mutate the match freely without
         # poisoning the cached original for subsequent tests.

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,144 @@ def _end_gc_boot_window() -> None:
     warnings.filterwarnings("ignore", message=r"It looks like `register_random` was passed")
 
 
+def _cache_reverse_rel_identity() -> None:
+    # ForeignObjectRel.identity is a plain property that rebuilds a large nested tuple
+    # (including make_hashable over limit_choices_to) on every __eq__/__hash__ call.
+    # Query compilation over models whose default manager applies .defer()/.only()
+    # (Team, User) hashes and compares these rel objects millions of times per test
+    # session. Rel objects are immutable once django.setup() has run, so caching the
+    # identity tuple and its hash per instance is safe and cuts that cost entirely.
+    from functools import cached_property  # noqa: PLC0415 — deferred until pytest_configure
+
+    from django.db.models.fields.reverse_related import (  # noqa: PLC0415 — deferred until pytest_configure
+        ForeignObjectRel,
+    )
+
+    def walk(klass):
+        yield klass
+        for sub in klass.__subclasses__():
+            yield from walk(sub)
+
+    for klass in walk(ForeignObjectRel):
+        prop = klass.__dict__.get("identity")
+        if isinstance(prop, property) and prop.fget is not None:
+            cached = cached_property(prop.fget)
+            cached.__set_name__(klass, "identity")
+            klass.identity = cached  # type: ignore[assignment]
+
+    def cached_hash(self) -> int:
+        try:
+            return self._identity_hash
+        except AttributeError:
+            self._identity_hash = h = hash(self.identity)
+            return h
+
+    ForeignObjectRel.__hash__ = cached_hash  # type: ignore[assignment]
+
+    # __eq__ compares the full identity tuples element by element (each element itself a
+    # Field with a non-trivial __eq__), and dict probing in select-mask construction calls
+    # it millions of times between the same pairs of objects. Rel objects are stable for
+    # the life of the process, so memoize results pairwise; keeping a strong ref to the
+    # other object means its id() can never be recycled while cached.
+    orig_eq = ForeignObjectRel.__eq__
+
+    def cached_eq(self, other):
+        if self is other:
+            return True
+        cache = self.__dict__.get("_eq_cache")
+        if cache is None:
+            cache = self.__dict__["_eq_cache"] = {}
+        entry = cache.get(id(other))
+        if entry is None:
+            entry = cache[id(other)] = (other, orig_eq(self, other))
+        return entry[1]
+
+    ForeignObjectRel.__eq__ = cached_eq  # type: ignore[method-assign, assignment]
+
+
+def _cache_select_masks() -> None:
+    # Query.get_select_mask() rebuilds the defer/only select-mask dict on every queryset
+    # compile. Models whose default manager applies .defer() (Team, User) recompute the
+    # identical mask thousands of times per test session, and building it probes dicts
+    # keyed by fields/rels with expensive __hash__/__eq__. The result is a pure function
+    # of (model meta, defer flag, deferred names) and its only consumer reads it without
+    # mutating, so memoize it. Queries with filtered relations keep the original path.
+    from django.db.models.sql.query import Query  # noqa: PLC0415 — deferred until pytest_configure
+
+    orig_get_select_mask = Query.get_select_mask
+    masks: dict = {}
+
+    def get_select_mask(self):
+        field_names, defer = self.deferred_loading
+        if not field_names:
+            return {}
+        if self._filtered_relations:
+            return orig_get_select_mask(self)
+        key = (self.get_meta(), defer, frozenset(field_names))
+        mask = masks.get(key)
+        if mask is None:
+            mask = masks[key] = orig_get_select_mask(self)
+        return mask
+
+    Query.get_select_mask = get_select_mask  # type: ignore[method-assign]
+
+
+def _cache_drf_field_info() -> None:
+    # DRF's ModelSerializer.get_fields() calls model_meta.get_field_info(model) on every
+    # serializer *instantiation*, re-walking the model's forward and reverse relations each
+    # time. The result is static per model class and consumers never mutate it, so cache it.
+    from rest_framework.utils import model_meta  # noqa: PLC0415 — deferred until pytest_configure
+
+    orig_get_field_info = model_meta.get_field_info
+    infos: dict = {}
+
+    def get_field_info(model):
+        key = model if isinstance(model, type) else model.__class__
+        info = infos.get(key)
+        if info is None:
+            info = infos[key] = orig_get_field_info(model)
+        return info
+
+    model_meta.get_field_info = get_field_info
+
+
+def _cache_url_resolution() -> None:
+    # URL resolution walks PostHog's very large nested router linearly on every request
+    # (~thousands of pattern match attempts per resolve). Resolution is deterministic per
+    # (resolver, path) and URLResolver instances are stable module-level objects, so memoize
+    # matches. Keyed weakly by resolver so urlconf overrides (which build new resolvers)
+    # can't alias; the per-hit shallow copy keeps callers free to mutate the match/kwargs.
+    import weakref  # noqa: PLC0415 — deferred until pytest_configure
+
+    from django.urls import resolvers  # noqa: PLC0415 — deferred until pytest_configure
+
+    orig_resolve = resolvers.URLResolver.resolve
+    cache: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+    def resolve(self, path):
+        by_path = cache.get(self)
+        if by_path is None:
+            by_path = cache.setdefault(self, {})
+        hit = by_path.get(str(path))
+        if hit is None:
+            hit = orig_resolve(self, path)
+            by_path[str(path)] = hit
+        # ResolverMatch blocks copy.copy via __reduce_ex__, so clone through __dict__.
+        match = object.__new__(type(hit))
+        match.__dict__.update(hit.__dict__)
+        match.kwargs = dict(hit.kwargs)
+        return match
+
+    resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]
+
+
+def pytest_configure(config) -> None:
+    _cache_reverse_rel_identity()
+    _cache_select_masks()
+    _cache_drf_field_info()
+    _cache_url_resolution()
+
+
 def pytest_collection_finish() -> None:
     _end_gc_boot_window()
 

--- a/conftest.py
+++ b/conftest.py
@@ -157,13 +157,13 @@ def _cache_url_resolution() -> None:
             hit = orig_resolve(self, path)
             by_path[path_str] = hit
         # ResolverMatch blocks copy.copy via __reduce_ex__, so clone through __dict__.
-        # Copy every mutable attribute so consumers can mutate the match freely without
-        # poisoning the cached original for subsequent tests.
+        # Copy the kwargs dicts — the attributes consumers realistically mutate — so
+        # mutation can't poison the cached original.
         match = object.__new__(type(hit))
         match.__dict__.update(hit.__dict__)
         match.kwargs = dict(hit.kwargs)
-        match.captured_kwargs = dict(getattr(hit, "captured_kwargs", {}))
-        match.extra_kwargs = dict(getattr(hit, "extra_kwargs", {}))
+        match.captured_kwargs = dict(getattr(hit, "captured_kwargs", None) or {})
+        match.extra_kwargs = dict(getattr(hit, "extra_kwargs", None) or {})
         return match
 
     resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -573,9 +573,16 @@ def get_query_tag_value(key: str) -> Optional[Any]:
         return None
 
 
+# Tag snapshots are isolated copy-on-write: every mutation goes through a top-level attribute
+# assignment on a fresh shallow copy (see update/with_temporal/with_dagster), and nested tag
+# objects are only ever replaced, never mutated in place. That makes shallow model_copy()
+# sufficient for isolation — deep copies here were the dominant cost of tag_queries, which runs
+# on every request and every ClickHouse query. Keep that invariant when adding new tag helpers.
+
+
 def update_tags(new_query_tags: QueryTags):
     current_tags = get_query_tags()
-    updated_tags = current_tags.model_copy(deep=True)
+    updated_tags = current_tags.model_copy()
     updated_tags.update(**new_query_tags.model_dump(exclude_none=True))
     query_tags.set(updated_tags)
 
@@ -588,7 +595,7 @@ def tag_queries(**kwargs) -> None:
     :param kwargs: Key->value pairs of tags to be set.
     """
     current_tags = get_query_tags()
-    updated_tags = current_tags.model_copy(deep=True)
+    updated_tags = current_tags.model_copy()
     updated_tags.update(**kwargs)
     query_tags.set(updated_tags)
 
@@ -639,7 +646,7 @@ def get_team_query_tags(team: "Team") -> dict[str, Any]:
 def clear_tag(key):
     with suppress(LookupError):
         current_tags = query_tags.get()
-        updated_tags = current_tags.model_copy(deep=True)
+        updated_tags = current_tags.model_copy()
         setattr(updated_tags, key, None)
         query_tags.set(updated_tags)
 
@@ -800,7 +807,7 @@ def tags_context(**tags_to_set: Any) -> Generator[None]:
     """
     tags_copy: Optional[QueryTags] = None
     try:
-        tags_copy = get_query_tags().model_copy(deep=True)
+        tags_copy = get_query_tags().model_copy()
         if tags_to_set:
             tag_queries(**tags_to_set)
         yield

--- a/posthog/clickhouse/schema.py
+++ b/posthog/clickhouse/schema.py
@@ -144,6 +144,7 @@ from posthog.models.app_metrics2.sql import (
 from posthog.models.channel_type.sql import (
     CHANNEL_DEFINITION_DATA_SQL,
     CHANNEL_DEFINITION_DICTIONARY_SQL,
+    CHANNEL_DEFINITION_TABLE_NAME,
     CHANNEL_DEFINITION_TABLE_SQL,
 )
 from posthog.models.cohortmembership.sql import (
@@ -178,6 +179,7 @@ from posthog.models.event.sql import (
 from posthog.models.exchange_rate.sql import (
     EXCHANGE_RATE_DATA_BACKFILL_SQL,
     EXCHANGE_RATE_DICTIONARY_SQL,
+    EXCHANGE_RATE_TABLE_NAME,
     EXCHANGE_RATE_TABLE_SQL,
 )
 from posthog.models.group.sql import (
@@ -554,8 +556,17 @@ CREATE_DICTIONARY_QUERIES = (
 )
 
 
+# Single source of truth for seed-data tables: (table_name, query_fn).
+# CREATE_DATA_QUERIES is derived from this tuple; conftest.py imports it too
+# so the per-table skip-if-present gate in create_clickhouse_tables stays in sync.
+SEED_DATA_TABLES: tuple[tuple[str, object], ...] = (
+    (CHANNEL_DEFINITION_TABLE_NAME, CHANNEL_DEFINITION_DATA_SQL),
+    (EXCHANGE_RATE_TABLE_NAME, EXCHANGE_RATE_DATA_BACKFILL_SQL),
+)
+
+
 def CREATE_DATA_QUERIES():
-    return (CHANNEL_DEFINITION_DATA_SQL(), EXCHANGE_RATE_DATA_BACKFILL_SQL())
+    return tuple(fn() for _, fn in SEED_DATA_TABLES)
 
 
 CREATE_VIEW_QUERIES = (

--- a/posthog/clickhouse/schema.py
+++ b/posthog/clickhouse/schema.py
@@ -1,5 +1,6 @@
 # This file contains all CREATE TABLE queries, used to sync and test schema
 import re
+from collections.abc import Callable
 
 from posthog.clickhouse.dead_letter_queue import (
     DEAD_LETTER_QUEUE_TABLE_MV_SQL,
@@ -559,7 +560,7 @@ CREATE_DICTIONARY_QUERIES = (
 # Single source of truth for seed-data tables: (table_name, query_fn).
 # CREATE_DATA_QUERIES is derived from this tuple; conftest.py imports it too
 # so the per-table skip-if-present gate in create_clickhouse_tables stays in sync.
-SEED_DATA_TABLES: tuple[tuple[str, object], ...] = (
+SEED_DATA_TABLES: tuple[tuple[str, Callable[[], str]], ...] = (
     (CHANNEL_DEFINITION_TABLE_NAME, CHANNEL_DEFINITION_DATA_SQL),
     (EXCHANGE_RATE_TABLE_NAME, EXCHANGE_RATE_DATA_BACKFILL_SQL),
 )

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -16,6 +16,7 @@ from posthog.clickhouse.query_tagging import (
     _PROJECT_ROOT_PREFIX,
     _SOURCE_SKIP_PREFIXES,
     AccessMethod,
+    DagsterTags,
     Feature,
     HogQLFeatures,
     Product,
@@ -139,6 +140,27 @@ def test_tags_context():
 
     # Verify tags are restored
     assert get_query_tags() == create_base_tags(team_id=123)
+
+
+def test_tags_context_snapshot_isolation():
+    # Shallow-copy invariant: mutations through public helpers must not corrupt the
+    # saved snapshot that tags_context restores. Regression guard for the switch from
+    # deep to shallow model_copy in update_tags/tag_queries.
+    reset_query_tags()
+    tag_queries(team_id=1)
+
+    with tags_context(user_id=42):
+        snapshot = get_query_tags()
+        # Drive every public mutation helper after the snapshot is taken.
+        tag_queries(team_id=2)
+        update_tags(create_base_tags(cohort_id=99))
+        clear_tag("user_id")
+        qt = get_query_tags()
+        qt.with_temporal(TemporalTags(workflow_type="wt"))
+        qt.with_dagster(DagsterTags(run_id="run-1"))
+
+    # The snapshot taken inside tags_context must be untouched by all mutations above.
+    assert snapshot == create_base_tags(team_id=1, user_id=42)
 
 
 @pytest.mark.asyncio
@@ -312,7 +334,7 @@ def test_tag_contains_user_hogql_is_idempotent():
 
 def test_tag_contains_user_hogql_short_circuits_after_first_call():
     # Repeated calls (recursive property_to_expr, breakdown loops, @property accessors)
-    # must skip the model_copy(deep=True) inside tag_queries after the first call.
+    # must skip the model_copy() inside tag_queries after the first call.
     reset_query_tags()
     tag_contains_user_hogql()
     first_tags = get_query_tags()

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -146,10 +146,18 @@ def test_tags_context_snapshot_isolation():
     # Shallow-copy invariant: mutations through public helpers must not corrupt the
     # saved snapshot that tags_context restores. Regression guard for the switch from
     # deep to shallow model_copy in update_tags/tag_queries.
+    #
+    # A nested tag object set *before* taking the snapshot inside tags_context exercises
+    # the shallow-copy hazard: if the copy is truly shallow and with_temporal were to
+    # mutate the nested object in place (rather than replace the attribute), the snapshot
+    # would be corrupted. Setting a sentinel value before the snapshot lets us assert
+    # the nested object is untouched after all the in-context mutations.
     reset_query_tags()
     tag_queries(team_id=1)
 
     with tags_context(user_id=42):
+        # Set a nested tag before taking the snapshot, then snapshot.
+        get_query_tags().with_temporal(TemporalTags(workflow_type="wt-before"))
         snapshot = get_query_tags()
         # Drive every public mutation helper after the snapshot is taken.
         tag_queries(team_id=2)
@@ -159,8 +167,13 @@ def test_tags_context_snapshot_isolation():
         qt.with_temporal(TemporalTags(workflow_type="wt"))
         qt.with_dagster(DagsterTags(run_id="run-1"))
 
-    # The snapshot taken inside tags_context must be untouched by all mutations above.
-    assert snapshot == create_base_tags(team_id=1, user_id=42)
+    # The snapshot taken inside tags_context must be untouched by all mutations above,
+    # including the nested temporal object that was set before the snapshot was taken.
+    expected = create_base_tags(team_id=1, user_id=42)
+    expected.with_temporal(TemporalTags(workflow_type="wt-before"))
+    assert snapshot == expected
+    assert snapshot.temporal is not None
+    assert snapshot.temporal.workflow_type == "wt-before"
 
 
 @pytest.mark.asyncio

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -27,7 +27,6 @@ def create_clickhouse_tables():
     # Create clickhouse tables to default before running test
     # Mostly so that test runs locally work correctly
     from posthog.clickhouse.schema import (
-        CREATE_DATA_QUERIES,
         CREATE_DICTIONARY_QUERIES,
         CREATE_DISTRIBUTED_TABLE_QUERIES,
         CREATE_KAFKA_TABLE_QUERIES,
@@ -76,19 +75,26 @@ def create_clickhouse_tables():
 
     # Building the exchange-rate INSERT parses a 9 MB CSV and renders a ~100k-row VALUES
     # string on every pytest invocation. With a reused database the seed data is already
-    # there, so skip the reload when both seed tables are populated (mirroring the
-    # `missing()` check above for tables). TRUNCATE-based resets go through
-    # reset_clickhouse_tables, which still reloads unconditionally.
-    from posthog.models.channel_type.sql import CHANNEL_DEFINITION_TABLE_NAME
-    from posthog.models.exchange_rate.sql import EXCHANGE_RATE_TABLE_NAME
+    # there, so skip the reload per-table (mirroring the `missing()` check above for tables).
+    # Gated per-table so a new entry in CREATE_DATA_QUERIES is never silently skipped.
+    # TRUNCATE-based resets go through reset_clickhouse_tables, which reloads unconditionally.
+    from posthog.models.channel_type.sql import (  # noqa: PLC0415
+        CHANNEL_DEFINITION_DATA_SQL,
+        CHANNEL_DEFINITION_TABLE_NAME,
+    )
+    from posthog.models.exchange_rate.sql import (  # noqa: PLC0415
+        EXCHANGE_RATE_DATA_BACKFILL_SQL,
+        EXCHANGE_RATE_TABLE_NAME,
+    )
 
-    seed_counts = sync_execute(
-        f"SELECT (SELECT count() FROM {CHANNEL_DEFINITION_TABLE_NAME}),"
-        f" (SELECT count() FROM {EXCHANGE_RATE_TABLE_NAME})"
-    )[0]
-    if not all(seed_counts):
-        data_queries = list(map(build_query, CREATE_DATA_QUERIES()))
-        run_clickhouse_statement_in_parallel(data_queries)
+    seed_table_queries = [
+        (CHANNEL_DEFINITION_TABLE_NAME, CHANNEL_DEFINITION_DATA_SQL),
+        (EXCHANGE_RATE_TABLE_NAME, EXCHANGE_RATE_DATA_BACKFILL_SQL),
+    ]
+    for table_name, query_fn in seed_table_queries:
+        count = sync_execute(f"SELECT count() FROM {table_name}")[0][0]
+        if not count:
+            run_clickhouse_statement_in_parallel([build_query(query_fn)])
 
 
 def reset_clickhouse_tables():

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -74,8 +74,21 @@ def create_clickhouse_tables():
     if dictionary_queries:
         run_clickhouse_statement_in_parallel(dictionary_queries)
 
-    data_queries = list(map(build_query, CREATE_DATA_QUERIES()))
-    run_clickhouse_statement_in_parallel(data_queries)
+    # Building the exchange-rate INSERT parses a 9 MB CSV and renders a ~100k-row VALUES
+    # string on every pytest invocation. With a reused database the seed data is already
+    # there, so skip the reload when both seed tables are populated (mirroring the
+    # `missing()` check above for tables). TRUNCATE-based resets go through
+    # reset_clickhouse_tables, which still reloads unconditionally.
+    from posthog.models.channel_type.sql import CHANNEL_DEFINITION_TABLE_NAME
+    from posthog.models.exchange_rate.sql import EXCHANGE_RATE_TABLE_NAME
+
+    seed_counts = sync_execute(
+        f"SELECT (SELECT count() FROM {CHANNEL_DEFINITION_TABLE_NAME}),"
+        f" (SELECT count() FROM {EXCHANGE_RATE_TABLE_NAME})"
+    )[0]
+    if not all(seed_counts):
+        data_queries = list(map(build_query, CREATE_DATA_QUERIES()))
+        run_clickhouse_statement_in_parallel(data_queries)
 
 
 def reset_clickhouse_tables():

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -33,6 +33,7 @@ def create_clickhouse_tables():
         CREATE_MERGETREE_TABLE_QUERIES,
         CREATE_MV_TABLE_QUERIES,
         CREATE_VIEW_QUERIES,
+        SEED_DATA_TABLES,
         build_query,
         get_table_name,
     )
@@ -79,8 +80,6 @@ def create_clickhouse_tables():
     # Derived from SEED_DATA_TABLES in schema.py, which also drives CREATE_DATA_QUERIES,
     # so a new seed table added there is automatically picked up here.
     # TRUNCATE-based resets go through reset_clickhouse_tables, which reloads unconditionally.
-    from posthog.clickhouse.schema import SEED_DATA_TABLES  # noqa: PLC0415
-
     for table_name, query_fn in SEED_DATA_TABLES:
         count = sync_execute(f"SELECT count() FROM {table_name}")[0][0]
         if not count:

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -76,22 +76,12 @@ def create_clickhouse_tables():
     # Building the exchange-rate INSERT parses a 9 MB CSV and renders a ~100k-row VALUES
     # string on every pytest invocation. With a reused database the seed data is already
     # there, so skip the reload per-table (mirroring the `missing()` check above for tables).
-    # Gated per-table so a new entry in CREATE_DATA_QUERIES is never silently skipped.
+    # Derived from SEED_DATA_TABLES in schema.py, which also drives CREATE_DATA_QUERIES,
+    # so a new seed table added there is automatically picked up here.
     # TRUNCATE-based resets go through reset_clickhouse_tables, which reloads unconditionally.
-    from posthog.models.channel_type.sql import (  # noqa: PLC0415
-        CHANNEL_DEFINITION_DATA_SQL,
-        CHANNEL_DEFINITION_TABLE_NAME,
-    )
-    from posthog.models.exchange_rate.sql import (  # noqa: PLC0415
-        EXCHANGE_RATE_DATA_BACKFILL_SQL,
-        EXCHANGE_RATE_TABLE_NAME,
-    )
+    from posthog.clickhouse.schema import SEED_DATA_TABLES  # noqa: PLC0415
 
-    seed_table_queries = [
-        (CHANNEL_DEFINITION_TABLE_NAME, CHANNEL_DEFINITION_DATA_SQL),
-        (EXCHANGE_RATE_TABLE_NAME, EXCHANGE_RATE_DATA_BACKFILL_SQL),
-    ]
-    for table_name, query_fn in seed_table_queries:
+    for table_name, query_fn in SEED_DATA_TABLES:
         count = sync_execute(f"SELECT count() FROM {table_name}")[0][0]
         if not count:
             run_clickhouse_statement_in_parallel([build_query(query_fn)])

--- a/posthog/git.py
+++ b/posthog/git.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+from functools import cache
 from typing import Optional
 
 _git_commit_baked_in: Optional[str] = None
@@ -12,10 +13,14 @@ except FileNotFoundError:
     pass
 
 
+@cache
 def get_git_commit_short() -> Optional[str]:
     """Return the short hash of the last commit.
 
     Example: get_git_commit_short() => "86a3c3b529"
+
+    Cached: the commit cannot change within a running process, and callers on the
+    request path (SLO events) would otherwise spawn a `git rev-parse` per request.
     """
     if _git_commit_baked_in:
         return _git_commit_baked_in[:10]  # 10 characters is almost guaranteed to identify a commit uniquely
@@ -25,10 +30,13 @@ def get_git_commit_short() -> Optional[str]:
         return None
 
 
+@cache
 def get_git_branch() -> Optional[str]:
     """Returns the symbolic name of the current active branch. Will return None in case of failure.
 
     Example: get_git_branch() => "master"
+
+    Cached for the same reason as get_git_commit_short.
     """
 
     try:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
