### PR TITLE
feat(llma): protect unsaved prompt edits from silent discard

### DIFF
--- a/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
@@ -34,7 +34,8 @@ export const scene: SceneExport<PromptLogicProps> = {
     productKey: ProductKey.AI_OBSERVABILITY,
     paramsToProps: ({ params: { name }, searchParams }) => ({
         promptName: name && name !== 'new' ? name : 'new',
-        mode: searchParams?.edit === 'true' ? PromptMode.Edit : PromptMode.View,
+        // kea-router JSON-decodes query values, so ?edit=true arrives as boolean true
+        mode: String(searchParams?.edit) === 'true' ? PromptMode.Edit : PromptMode.View,
         selectedVersion: searchParams?.version ? Number(searchParams.version) || null : null,
     }),
 }
@@ -54,13 +55,14 @@ export function LLMPromptScene(): JSX.Element {
         versions,
         canLoadMoreVersions,
         nextVersion,
+        isPromptFormDirty,
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
     const currentSearchParams = searchParams ?? {}
     const activeViewTab =
         searchParams?.tab === 'usage' ? 'usage' : searchParams?.tab === 'experiments' ? 'experiments' : 'overview'
 
-    const { submitPromptForm, deletePrompt, setMode, setPromptFormValues, loadMoreVersions } =
+    const { submitPromptForm, deletePrompt, setMode, setPromptFormValues, loadMoreVersions, cancelEditing } =
         useActions(llmPromptLogic)
     const sourcePromptName = !isNewPrompt && prompt && isPrompt(prompt) ? prompt.name : null
     const sourcePromptVersion = isHistoricalVersion && isPrompt(prompt) ? prompt.version : null
@@ -218,7 +220,13 @@ export function LLMPromptScene(): JSX.Element {
                                     type="secondary"
                                     icon={<IconPlay />}
                                     to={openInPlaygroundUrl}
-                                    disabledReason={isPromptFormSubmitting ? 'Saving…' : undefined}
+                                    disabledReason={
+                                        isPromptFormSubmitting
+                                            ? 'Saving…'
+                                            : isPromptFormDirty
+                                              ? 'You have unsaved edits — publish or cancel first'
+                                              : undefined
+                                    }
                                     size="small"
                                     data-attr="llma-playground-open-from-prompt"
                                 >
@@ -227,15 +235,7 @@ export function LLMPromptScene(): JSX.Element {
                             ) : null}
                             <LemonButton
                                 type="secondary"
-                                onClick={() => {
-                                    if (isNewPrompt) {
-                                        router.actions.push(
-                                            combineUrl(urls.aiObservabilityPrompts(), currentSearchParams).url
-                                        )
-                                    } else {
-                                        setMode(PromptMode.View)
-                                    }
-                                }}
+                                onClick={() => cancelEditing()}
                                 disabledReason={isPromptFormSubmitting ? 'Saving…' : undefined}
                                 size="small"
                                 data-attr="llma-prompt-cancel-button"
@@ -300,6 +300,7 @@ export function LLMPromptScene(): JSX.Element {
                             canLoadMoreVersions={canLoadMoreVersions}
                             loadMoreVersions={loadMoreVersions}
                             searchParams={currentSearchParams}
+                            readOnly
                         />
                     )}
                 </div>

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -1,4 +1,7 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 
 import api from '~/lib/api'
 import { ApiError } from '~/lib/api-error'
@@ -285,6 +288,60 @@ describe('llmPromptLogic', () => {
         expect(logic.values.publishConflict).toEqual({ latestVersion: 3 })
         expect(logic.values.prompt).toMatchObject({ latest_version: 3 })
         expect(logic.values.mode).toBe(PromptMode.Edit)
+
+        logic.unmount()
+    })
+
+    it('guards cancel behind a confirmation only when the form is dirty', async () => {
+        const { versions, has_more, ...promptFields } = mockPrompt
+        jest.spyOn(api.llmPrompts, 'resolveByName').mockResolvedValue({
+            prompt: promptFields,
+            versions,
+            has_more,
+        } as unknown as LLMPromptResolveResponse)
+        const dialogSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+
+        const logic = llmPromptLogic({ promptName: 'my-test-prompt' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPromptSuccess'])
+
+        // Clean form: cancel exits edit mode directly, no dialog
+        logic.actions.setMode(PromptMode.Edit)
+        logic.actions.cancelEditing()
+        expect(logic.values.mode).toBe(PromptMode.View)
+        expect(dialogSpy).not.toHaveBeenCalled()
+
+        // Dirty form: cancel keeps edit mode until the dialog's discard is confirmed
+        logic.actions.setMode(PromptMode.Edit)
+        logic.actions.setPromptFormValues({ prompt: 'My in-progress edit.' })
+        logic.actions.cancelEditing()
+        expect(logic.values.mode).toBe(PromptMode.Edit)
+        expect(dialogSpy).toHaveBeenCalledTimes(1)
+
+        dialogSpy.mock.calls[0][0].primaryButton?.onClick?.(undefined as any)
+        expect(logic.values.mode).toBe(PromptMode.View)
+        expect(logic.values.promptForm.prompt).toBe(mockPrompt.prompt)
+
+        logic.unmount()
+    })
+
+    it('reflects edit mode in the url', async () => {
+        const { versions, has_more, ...promptFields } = mockPrompt
+        jest.spyOn(api.llmPrompts, 'resolveByName').mockResolvedValue({
+            prompt: promptFields,
+            versions,
+            has_more,
+        } as unknown as LLMPromptResolveResponse)
+
+        const logic = llmPromptLogic({ promptName: 'my-test-prompt' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPromptSuccess'])
+
+        logic.actions.setMode(PromptMode.Edit)
+        expect(router.values.searchParams.edit).toBe(true)
+
+        logic.actions.setMode(PromptMode.View)
+        expect(router.values.searchParams.edit).toBeUndefined()
 
         logic.unmount()
     })

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -807,6 +807,8 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 const handler = (e: BeforeUnloadEvent): void => {
                     if (values.isEditMode && values.isPromptFormDirty && !values.isPromptFormSubmitting) {
                         e.preventDefault()
+                        // Some engines only show the native dialog when returnValue is set
+                        e.returnValue = ''
                     }
                 }
                 window.addEventListener('beforeunload', handler)

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -14,7 +14,7 @@ import {
 } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
-import { combineUrl, router, urlToAction } from 'kea-router'
+import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 
 import api, { ApiError } from '~/lib/api'
 import { lemonToast } from '~/lib/lemon-ui/LemonToast/LemonToast'
@@ -44,7 +44,7 @@ import {
 import type { llmPromptLogicType } from './llmPromptLogicType'
 import { llmPromptsLogic } from './llmPromptsLogic'
 import { LLM_PROMPTS_FORCE_RELOAD_PARAM } from './llmPromptsLogic'
-import { getApiErrorDetail, validatePromptName } from './utils'
+import { getApiErrorDetail, openDiscardChangesDialog, validatePromptName } from './utils'
 
 export enum PromptMode {
     View = 'view',
@@ -161,6 +161,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         toggleMarkdownRendering: true,
         setCompareVersion: (compareVersion: number | null) => ({ compareVersion }),
         toggleOutlineExpanded: true,
+        cancelEditing: true,
         setPublishConflict: (publishConflict: PublishConflict | null) => ({ publishConflict }),
     }),
 
@@ -368,6 +369,16 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         ],
 
         isHistoricalVersion: [(s) => [s.prompt], (prompt) => (isPrompt(prompt) ? !prompt.is_latest : false)],
+
+        isPromptFormDirty: [
+            (s) => [s.promptForm, s.prompt, s.isNewPrompt],
+            (promptForm, prompt, isNewPrompt): boolean => {
+                if (isNewPrompt) {
+                    return !!promptForm.name.trim() || !!promptForm.prompt.trim()
+                }
+                return isPrompt(prompt) ? promptForm.prompt !== prompt.prompt : false
+            },
+        ],
 
         nextVersion: [
             (s) => [s.prompt],
@@ -661,6 +672,26 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
     }),
 
     listeners(({ actions, props, values }) => ({
+        cancelEditing: () => {
+            const exitEditMode = (): void => {
+                if (values.isNewPrompt) {
+                    const { edit: _edit, ...searchParams } = router.values.searchParams
+                    router.actions.push(combineUrl(urls.aiObservabilityPrompts(), searchParams).url)
+                    return
+                }
+                if (isPrompt(values.prompt)) {
+                    actions.setPromptFormValues(getPromptFormDefaults(values.prompt))
+                }
+                actions.setMode(PromptMode.View)
+            }
+
+            if (values.isPromptFormDirty) {
+                openDiscardChangesDialog(exitEditMode)
+            } else {
+                exitEditMode()
+            }
+        },
+
         deletePrompt: async () => {
             if (props.promptName !== 'new' && values.prompt && isPrompt(values.prompt)) {
                 try {
@@ -762,13 +793,28 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         }
     ),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, values, cache }) => {
         if (values.isNewPrompt) {
             actions.setPrompt(DEFAULT_PROMPT_FORM_VALUES)
             actions.resetPromptForm(DEFAULT_PROMPT_FORM_VALUES)
         } else {
             actions.loadPrompt()
         }
+
+        // pauseOnPageHidden: false — closing a background tab must still warn about unsaved edits.
+        cache.disposables.add(
+            () => {
+                const handler = (e: BeforeUnloadEvent): void => {
+                    if (values.isEditMode && values.isPromptFormDirty && !values.isPromptFormSubmitting) {
+                        e.preventDefault()
+                    }
+                }
+                window.addEventListener('beforeunload', handler)
+                return () => window.removeEventListener('beforeunload', handler)
+            },
+            'unsavedEditsGuard',
+            { pauseOnPageHidden: false }
+        )
     }),
 
     beforeUnmount(({ actions, props }) => {
@@ -780,6 +826,23 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         const existing = findExistingPrompt(props.promptName)
         actions.setPromptFormValues(existing ? getPromptFormDefaults(existing) : DEFAULT_PROMPT_FORM_VALUES)
     }),
+
+    actionToUrl(({ props }) => ({
+        // replace, not push: a push would re-trigger loadPrompt via urlToAction and
+        // its success handler would reset the form under the user's edits.
+        setMode: ({ mode }) => {
+            if (props.promptName === 'new') {
+                return undefined
+            }
+            const { edit: _edit, ...searchParams } = router.values.searchParams
+            return [
+                router.values.location.pathname,
+                mode === PromptMode.Edit ? { ...searchParams, edit: true } : searchParams,
+                router.values.hashParams,
+                { replace: true },
+            ]
+        },
+    })),
 
     urlToAction(({ actions, values }) => ({
         '/prompt-management/prompts/:name': (_, __, ___, { method }) => {

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -571,6 +571,7 @@ export function PromptVersionSidebar({
     canLoadMoreVersions,
     loadMoreVersions,
     searchParams,
+    readOnly = false,
 }: {
     promptName: string
     prompt: LLMPrompt | null
@@ -579,6 +580,7 @@ export function PromptVersionSidebar({
     canLoadMoreVersions: boolean
     loadMoreVersions: () => void
     searchParams: Record<string, any>
+    readOnly?: boolean
 }): JSX.Element {
     const { compareVersion } = useValues(llmPromptLogic)
     const { setCompareVersion } = useActions(llmPromptLogic)
@@ -599,22 +601,11 @@ export function PromptVersionSidebar({
                     {versions.map((versionPrompt) => {
                         const selected = prompt?.id === versionPrompt.id
                         const isCompareTarget = compareVersion === versionPrompt.version
-                        const canCompare = prompt?.version !== versionPrompt.version
+                        const canCompare = !readOnly && prompt?.version !== versionPrompt.version
                         const versionUrl = buildPromptUrl(promptName, searchParams, versionPrompt.version)
 
-                        return (
-                            <Link
-                                key={versionPrompt.id}
-                                to={versionUrl}
-                                className={`block rounded border p-3 no-underline ${
-                                    selected
-                                        ? 'border-primary bg-primary-highlight'
-                                        : isCompareTarget
-                                          ? 'border-warning bg-warning-highlight'
-                                          : 'border-primary/10 hover:bg-fill-secondary'
-                                }`}
-                                data-attr={`llma-prompt-version-link-${versionPrompt.version}`}
-                            >
+                        const cardContent = (
+                            <>
                                 <div className="mb-1 flex items-center justify-between">
                                     <div className="flex items-center gap-2">
                                         <span className="font-mono text-sm">v{versionPrompt.version}</span>
@@ -654,6 +645,35 @@ export function PromptVersionSidebar({
                                 {versionPrompt.created_by?.email ? (
                                     <div className="mt-1 text-xs text-secondary">{versionPrompt.created_by.email}</div>
                                 ) : null}
+                            </>
+                        )
+
+                        const cardClassName = `block rounded border p-3 no-underline ${
+                            selected
+                                ? 'border-primary bg-primary-highlight'
+                                : isCompareTarget
+                                  ? 'border-warning bg-warning-highlight'
+                                  : readOnly
+                                    ? 'border-primary/10 opacity-75'
+                                    : 'border-primary/10 hover:bg-fill-secondary'
+                        }`
+
+                        if (readOnly) {
+                            return (
+                                <div key={versionPrompt.id} className={cardClassName}>
+                                    {cardContent}
+                                </div>
+                            )
+                        }
+
+                        return (
+                            <Link
+                                key={versionPrompt.id}
+                                to={versionUrl}
+                                className={cardClassName}
+                                data-attr={`llma-prompt-version-link-${versionPrompt.version}`}
+                            >
+                                {cardContent}
                             </Link>
                         )
                     })}

--- a/products/ai_observability/frontend/prompts/utils.ts
+++ b/products/ai_observability/frontend/prompts/utils.ts
@@ -25,6 +25,23 @@ export function getApiErrorDetail(error: unknown): string | undefined {
     return undefined
 }
 
+export function openDiscardChangesDialog(onDiscard: () => void): void {
+    LemonDialog.open({
+        title: 'Discard changes?',
+        description: 'Your unsaved edits will be lost.',
+        primaryButton: {
+            children: 'Discard',
+            type: 'primary',
+            status: 'danger',
+            onClick: onDiscard,
+        },
+        secondaryButton: {
+            children: 'Keep editing',
+            type: 'secondary',
+        },
+    })
+}
+
 export function openArchivePromptDialog(onArchive: () => void): void {
     LemonDialog.open({
         title: 'Archive prompt?',


### PR DESCRIPTION
## Problem

The prompt editor discards in-progress edits without warning: Cancel exits immediately, a refresh drops back to view mode (edit mode was never reflected in the URL), closing the tab loses everything silently, and the version history sidebar stays fully interactive while editing — one stray click on a version card navigates away and destroys the edit. The sidebar's compare buttons also still fire in edit mode but the diff only renders in view mode, so they load data and display nothing.

## Changes

- New `isPromptFormDirty` selector and `cancelEditing` action: Cancel with edits opens a "Discard changes?" dialog; clean cancel exits directly. Discarding resets the form.
- "Open in Playground" is disabled while dirty.
- Edit mode syncs `?edit=true` to the URL (via replace — a push would re-trigger `loadPrompt`, whose success handler resets the form mid-typing). Refresh now stays in edit mode. Also fixed the latent deep-link check: kea-router JSON-decodes query values, so `?edit=true` arrives as boolean `true` and the old `=== 'true'` comparison never matched.
- `beforeunload` warning when leaving with unsaved edits, registered through the kea disposables plugin with `pauseOnPageHidden: false` so closing a background tab still warns.
- Version sidebar gets a `readOnly` mode used while editing: cards are non-clickable and the dead compare buttons are hidden.

## How did you test this code?

Added two logic tests: the cancel guard (dirty cancel keeps edit mode until the dialog's Discard is confirmed; clean cancel exits with no dialog — catches the guard being removed or bypassed) and the `?edit=true` URL round-trip (catches the sync being dropped, which silently reverts refresh-loses-edit-mode). All 24 prompts-suite tests pass; oxlint and typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — the publish flow docs (PostHog/posthog.com#18157) are unaffected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as part of the prompt management UX pass. Skills invoked: /using-kea-disposables (beforeunload listener), /writing-tests. Design choice worth reviewing: URL sync uses replace rather than push, so the browser back button exits the page rather than exiting edit mode — chosen to avoid the loadPrompt-reset race described in Changes.