### PR TITLE
fix(web-analytics): trim paths precompute per-day cap back to 10k

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -252,13 +252,16 @@ def _entry_breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
 # Cap on stored breakdown rows: only the top-K paths PER DAY by the query's sort
 # metric. The PATHS tile shows a paginated top-N and the read's `LIMIT` can't prune
 # the scan (it must aggregate every path to find the top), so the long tail — paths
-# that never reach the display — is pure dead weight. K is sized so that the vast
-# majority of teams (fleet-wide, >99% of active teams have fewer distinct cleaned
-# paths per week than this) store their full path set and only extreme-cardinality
-# outliers (typically one-path-per-pageview instrumentation) get truncated. Capping
-# per day rather than per job window keeps sub-range reads correct — see
-# `INSERT_QUERY_TEMPLATE_CAPPED`.
-PATHS_TOP_K = 100_000
+# that never reach the display — is pure dead weight. Reads pay for every stored
+# row of the covering jobs, so K directly prices read latency: at 100k the two
+# highest-cardinality teams' stored sets grew ~8× and their reads regressed from
+# ~300ms to multi-second during recompute windows, while ~95% of active teams
+# (fewer than 10k distinct cleaned paths per week fleet-wide) never notice K at
+# all. 10k per day keeps those teams' full path set, and because the cap is per
+# day (see `INSERT_QUERY_TEMPLATE_CAPPED`) a multi-day job stores the union of
+# daily top-Ks — strictly more coverage than the original per-job 10k cap, and
+# sub-range reads stay correct.
+PATHS_TOP_K = 10_000
 
 # The per-(hour, breakdown) state aggregation — shared by the capped and uncapped
 # inserts. The lazy_computation framework substitutes the placeholders (incl.


### PR DESCRIPTION
## Problem

#65842 raised the paths precompute per-day cap from 10k to 100k alongside the per-day partitioning fix. Production monitoring since the deploy shows the read-cost trade-off isn't worth it: reads pay for every stored row of the covering jobs, and for the two highest-cardinality enrolled teams the stored sets grew ~8×, pushing warm read medians from ~300ms to 1–2s and tails to 5–8s during recompute windows. Fleet-wide, ~95% of active teams have fewer than 10k distinct cleaned paths per week, so they never benefit from the larger K — the cost lands entirely on the teams the cap exists to protect.

## Changes

- Trim `PATHS_TOP_K` from 100,000 back to 10,000. The per-day capping from #65842 is kept, so this is strictly more coverage than the original pre-#65842 cap: a multi-day job stores the union of daily top-10ks (sub-range reads stay correct), rather than a single job-wide top-10k.
- Comment rewritten to record the read-latency pricing rationale so the next K discussion starts from the measured trade-off.

Existing capped jobs are untouched; new/refreshed windows store the smaller set as TTLs roll over (the cap value is not part of the job hash, so no cache rotation).

## How did you test this code?

Agent-authored (Claude Code). One-constant change; the existing paths suite (44 passed / 9 pre-existing skips) covers the capped-insert round trip and the per-day partitioning revert-guard. No new tests — no new behavior, only the K value.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal storage policy, documented inline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follows a week of production monitoring after #65842: per-team analysis showed the 100k cap only affected the highest-cardinality teams, and negatively — reads slowed roughly in proportion to stored-set growth while ~95% of teams saw no difference. The DRI chose returning to 10k over excluding degenerate teams or a mid-point value.
