### PR TITLE
feat(marketing-analytics): dedup cost chart to match overview tile

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -5,6 +5,7 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { HogDebug } from 'scenes/debug/HogDebug'
 import { MarketingAnalyticsOverview } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview'
+import { MarketingAnalyticsTrends } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTrends/MarketingAnalyticsTrends'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { DataNode } from '~/queries/nodes/DataNode/DataNode'
@@ -42,6 +43,7 @@ import {
     isHogQuery,
     isInsightVizNode,
     isMarketingAnalyticsAggregatedQuery,
+    isMarketingAnalyticsTrendsQuery,
     isRevenueAnalyticsGrossRevenueQuery,
     isRevenueAnalyticsMRRQuery,
     isRevenueAnalyticsMetricsQuery,
@@ -263,6 +265,16 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
     } else if (isMarketingAnalyticsAggregatedQuery(query)) {
         component = (
             <MarketingAnalyticsOverview
+                attachTo={props.attachTo}
+                query={query}
+                cachedResults={props.cachedResults}
+                context={queryContext}
+                uniqueKey={uniqueKey}
+            />
+        )
+    } else if (isMarketingAnalyticsTrendsQuery(query)) {
+        component = (
+            <MarketingAnalyticsTrends
                 attachTo={props.attachTo}
                 query={query}
                 cachedResults={props.cachedResults}

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -803,6 +803,9 @@
                     "$ref": "#/definitions/MarketingAnalyticsAggregatedQuery"
                 },
                 {
+                    "$ref": "#/definitions/MarketingAnalyticsTrendsQuery"
+                },
+                {
                     "$ref": "#/definitions/NonIntegratedConversionsTableQuery"
                 },
                 {
@@ -8842,6 +8845,91 @@
                 },
                 "types": {
                     "items": {},
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedMarketingAnalyticsTrendsQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "description": "Insights-style time series: one GraphDataset per source_name breakdown.",
+                    "items": {},
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
                     "type": "array"
                 },
                 "warnings": {
@@ -28267,6 +28355,163 @@
             "required": ["results"],
             "type": "object"
         },
+        "MarketingAnalyticsTrendsMetric": {
+            "description": "A single cost metric the trends chart can plot over time, broken down by source.",
+            "enum": [
+                "cost",
+                "clicks",
+                "impressions",
+                "reported_conversion",
+                "reported_conversion_value",
+                "roas",
+                "cost_per_reported_conversion"
+            ],
+            "type": "string"
+        },
+        "MarketingAnalyticsTrendsQuery": {
+            "additionalProperties": false,
+            "description": "Time series of a single cost metric, de-duplicated per (source, campaign, day) via the same argMax(computed_at) + job_id read the aggregated tile uses, then bucketed by interval and broken down by source_name. Unlike a raw TrendsQuery over marketing_costs_preaggregated, this does not double-count re-materialized cost cells, so the chart total reconciles with the overview tile.",
+            "properties": {
+                "aggregation_group_type_index": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation - not used in Web Analytics but required for type compatibility"
+                },
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter"
+                },
+                "conversionGoal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "dataColorTheme": {
+                    "description": "Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility",
+                    "type": ["number", "null"]
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "doPathCleaning": {
+                    "type": "boolean"
+                },
+                "filterTestAccounts": {
+                    "type": "boolean"
+                },
+                "includeRevenue": {
+                    "deprecated": "ignored, always treated as disabled",
+                    "type": "boolean"
+                },
+                "integrationFilter": {
+                    "$ref": "#/definitions/IntegrationFilter",
+                    "description": "Filter by integration IDs"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType",
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
+                },
+                "kind": {
+                    "const": "MarketingAnalyticsTrendsQuery",
+                    "type": "string"
+                },
+                "metric": {
+                    "$ref": "#/definitions/MarketingAnalyticsTrendsMetric",
+                    "description": "Which cost metric to plot over time"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters"
+                },
+                "response": {
+                    "$ref": "#/definitions/MarketingAnalyticsTrendsQueryResponse"
+                },
+                "sampling": {
+                    "$ref": "#/definitions/WebAnalyticsSampling",
+                    "deprecated": "Use samplingFactor instead"
+                },
+                "samplingFactor": {
+                    "description": "Sampling rate",
+                    "type": ["number", "null"]
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "useSessionsTable": {
+                    "deprecated": "ignored, always treated as enabled *",
+                    "type": "boolean"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["kind", "metric", "properties"],
+            "type": "object"
+        },
+        "MarketingAnalyticsTrendsQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "description": "Insights-style time series: one GraphDataset per source_name breakdown.",
+                    "items": {},
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
         "MarketingIntegrationConfig": {
             "anyOf": [
                 {
@@ -30681,6 +30926,7 @@
                 "RevenueAnalyticsTopCustomersQuery",
                 "MarketingAnalyticsTableQuery",
                 "MarketingAnalyticsAggregatedQuery",
+                "MarketingAnalyticsTrendsQuery",
                 "NonIntegratedConversionsTableQuery",
                 "ExperimentMetric",
                 "ExperimentQuery",
@@ -34509,6 +34755,56 @@
                         },
                         "samplingRate": {
                             "$ref": "#/definitions/SamplingRate"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_compare_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The resolved previous/comparison period date range, when comparing against another period"
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "description": "Insights-style time series: one GraphDataset per source_name breakdown.",
+                            "items": {},
+                            "type": "array"
                         },
                         "timings": {
                             "description": "Measured timings for different parts of the query generation process",
@@ -38646,6 +38942,9 @@
                 },
                 {
                     "$ref": "#/definitions/MarketingAnalyticsAggregatedQuery"
+                },
+                {
+                    "$ref": "#/definitions/MarketingAnalyticsTrendsQuery"
                 },
                 {
                     "$ref": "#/definitions/NonIntegratedConversionsTableQuery"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -157,6 +157,7 @@ export enum NodeKind {
     // Marketing analytics queries
     MarketingAnalyticsTableQuery = 'MarketingAnalyticsTableQuery',
     MarketingAnalyticsAggregatedQuery = 'MarketingAnalyticsAggregatedQuery',
+    MarketingAnalyticsTrendsQuery = 'MarketingAnalyticsTrendsQuery',
     NonIntegratedConversionsTableQuery = 'NonIntegratedConversionsTableQuery',
 
     // Experiment queries
@@ -228,6 +229,7 @@ export type AnyDataNode =
     | RevenueAnalyticsTopCustomersQuery
     | MarketingAnalyticsTableQuery
     | MarketingAnalyticsAggregatedQuery
+    | MarketingAnalyticsTrendsQuery
     | NonIntegratedConversionsTableQuery
     | WebOverviewQuery
     | WebStatsTableQuery
@@ -330,6 +332,7 @@ export type QuerySchema =
     // Marketing analytics
     | MarketingAnalyticsTableQuery
     | MarketingAnalyticsAggregatedQuery
+    | MarketingAnalyticsTrendsQuery
     | NonIntegratedConversionsTableQuery
 
     // Interface nodes
@@ -6022,6 +6025,42 @@ export interface MarketingAnalyticsAggregatedQuery extends Omit<
     integrationFilter?: IntegrationFilter
     /** Drill-down hierarchy level: channel, source, or campaign (default) */
     drillDownLevel?: MarketingAnalyticsDrillDownLevel
+}
+
+/** A single cost metric the trends chart can plot over time, broken down by source. */
+export enum MarketingAnalyticsTrendsMetric {
+    Cost = 'cost',
+    Clicks = 'clicks',
+    Impressions = 'impressions',
+    ReportedConversion = 'reported_conversion',
+    ReportedConversionValue = 'reported_conversion_value',
+    Roas = 'roas',
+    CostPerReportedConversion = 'cost_per_reported_conversion',
+}
+
+export interface MarketingAnalyticsTrendsQueryResponse extends AnalyticsQueryResponseBase {
+    /** Insights-style time series: one GraphDataset per source_name breakdown. */
+    results: unknown[]
+    hogql?: string
+}
+
+export type CachedMarketingAnalyticsTrendsQueryResponse = CachedQueryResponse<MarketingAnalyticsTrendsQueryResponse>
+
+/**
+ * Time series of a single cost metric, de-duplicated per (source, campaign, day) via the same
+ * argMax(computed_at) + job_id read the aggregated tile uses, then bucketed by interval and broken
+ * down by source_name. Unlike a raw TrendsQuery over marketing_costs_preaggregated, this does not
+ * double-count re-materialized cost cells, so the chart total reconciles with the overview tile.
+ */
+export interface MarketingAnalyticsTrendsQuery extends Omit<
+    WebAnalyticsQueryBase<MarketingAnalyticsTrendsQueryResponse>,
+    'orderBy' | 'limit' | 'offset'
+> {
+    kind: NodeKind.MarketingAnalyticsTrendsQuery
+    /** Which cost metric to plot over time */
+    metric: MarketingAnalyticsTrendsMetric
+    /** Filter by integration IDs */
+    integrationFilter?: IntegrationFilter
 }
 
 /** Columns for non-integrated conversions table */

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -43,6 +43,7 @@ import {
     LifecycleDataWarehouseNode,
     LifecycleQuery,
     MarketingAnalyticsAggregatedQuery,
+    MarketingAnalyticsTrendsQuery,
     MarketingAnalyticsTableQuery,
     MathType,
     Node,
@@ -306,6 +307,12 @@ export function isMarketingAnalyticsAggregatedQuery(
     node?: Record<string, any> | null
 ): node is MarketingAnalyticsAggregatedQuery {
     return node?.kind === NodeKind.MarketingAnalyticsAggregatedQuery
+}
+
+export function isMarketingAnalyticsTrendsQuery(
+    node?: Record<string, any> | null
+): node is MarketingAnalyticsTrendsQuery {
+    return node?.kind === NodeKind.MarketingAnalyticsTrendsQuery
 }
 
 export function isNonIntegratedConversionsTableQuery(

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -587,6 +587,11 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         icon: IconHogQL,
         inMenu: false,
     },
+    [NodeKind.MarketingAnalyticsTrendsQuery]: {
+        name: 'Marketing Analytics Trends',
+        icon: IconHogQL,
+        inMenu: false,
+    },
     [NodeKind.NonIntegratedConversionsTableQuery]: {
         name: 'Non-Integrated Conversions Table',
         icon: IconHogQL,

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTrends/MarketingAnalyticsTrends.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTrends/MarketingAnalyticsTrends.tsx
@@ -1,0 +1,112 @@
+import { BindLogic, BuiltLogic, LogicWrapper, useMountedLogic, useValues } from 'kea'
+import { useState } from 'react'
+
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { getCurrencySymbol } from 'lib/utils/currency'
+import { InsightEmptyState, InsightErrorState, InsightLoadingState } from 'scenes/insights/EmptyStates'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { InsightsWrapper } from 'scenes/insights/InsightsWrapper'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import {
+    AnyResponseType,
+    MARKETING_ANALYTICS_SCHEMA,
+    MarketingAnalyticsColumnsSchemaNames,
+    MarketingAnalyticsTrendsMetric,
+    MarketingAnalyticsTrendsQuery,
+    MarketingAnalyticsTrendsQueryResponse,
+    TrendsFilter,
+} from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { GraphDataset } from '~/types'
+
+import { MarketingAnalyticsTrendsChart } from './MarketingAnalyticsTrendsChart'
+
+let uniqueNode = 0
+
+// roas / cost_per_reported_conversion are derived ratios, not part of the raw column schema, so they fall
+// through to non-currency formatting — matching the previous TrendsQuery-backed tile behavior.
+const isCurrencyMetric = (metric: MarketingAnalyticsTrendsMetric): boolean =>
+    MARKETING_ANALYTICS_SCHEMA[metric as unknown as MarketingAnalyticsColumnsSchemaNames]?.isCurrency ?? false
+
+export function MarketingAnalyticsTrends(props: {
+    query: MarketingAnalyticsTrendsQuery
+    cachedResults?: AnyResponseType
+    context: QueryContext
+    attachTo?: LogicWrapper | BuiltLogic
+    uniqueKey?: string | number
+}): JSX.Element | null {
+    const { onData, loadPriority, dataNodeCollectionId } = props.context.insightProps ?? {}
+    const [_key] = useState(() => `MarketingAnalyticsTrends.${uniqueNode++}`)
+    const key = props.uniqueKey ? String(props.uniqueKey) : _key
+    const dataNodeLogicProps = {
+        query: props.query,
+        key,
+        cachedResults: props.cachedResults,
+        loadPriority,
+        onData,
+        dataNodeCollectionId: dataNodeCollectionId ?? key,
+    }
+
+    useAttachedLogic(insightLogic(props.context.insightProps ?? {}), props.attachTo)
+    useAttachedLogic(insightVizDataLogic(props.context.insightProps ?? {}), props.attachTo)
+    useAttachedLogic(dataNodeLogic(dataNodeLogicProps), props.attachTo)
+
+    return (
+        <BindLogic logic={insightLogic} props={props.context.insightProps ?? {}}>
+            <BindLogic logic={insightVizDataLogic} props={props.context.insightProps ?? {}}>
+                <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                    <MarketingTrendsTile query={props.query} context={props.context} />
+                </BindLogic>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+function MarketingTrendsTile({
+    query,
+    context,
+}: {
+    query: MarketingAnalyticsTrendsQuery
+    context: QueryContext
+}): JSX.Element {
+    const logic = useMountedLogic(dataNodeLogic)
+    const { response, responseLoading, responseError, queryId } = useValues(logic)
+    const { baseCurrency } = useValues(teamLogic)
+
+    const results = ((response as MarketingAnalyticsTrendsQueryResponse | null)?.results as GraphDataset[]) ?? []
+
+    const { symbol: currencySymbol, isPrefix: currencyIsPrefix } = getCurrencySymbol(baseCurrency)
+    const isCurrency = isCurrencyMetric(query.metric)
+    const trendsFilter: TrendsFilter = {
+        aggregationAxisFormat: 'numeric',
+        aggregationAxisPrefix: isCurrency && currencyIsPrefix ? currencySymbol : undefined,
+        aggregationAxisPostfix: isCurrency && !currencyIsPrefix ? ` ${currencySymbol}` : undefined,
+    }
+
+    let content: JSX.Element
+    if (responseLoading) {
+        content = <InsightLoadingState queryId={queryId} key={queryId} insightProps={context.insightProps ?? {}} />
+    } else if (responseError && results.length === 0) {
+        content = <InsightErrorState query={query} queryId={queryId} />
+    } else if (results.length === 0) {
+        content = <InsightEmptyState heading={context.emptyStateHeading} detail={context.emptyStateDetail} />
+    } else {
+        content = (
+            <MarketingAnalyticsTrendsChart
+                dataAttr="marketing-analytics-trends"
+                datasets={results.map((result, seriesIndex) => ({ ...result, seriesIndex }))}
+                labels={results[0]?.labels ?? []}
+                trendsFilter={trendsFilter}
+            />
+        )
+    }
+
+    return (
+        <InsightsWrapper>
+            <div className="TrendsInsight TrendsInsight--ActionsLineGraph">{content}</div>
+        </InsightsWrapper>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTrends/MarketingAnalyticsTrendsChart.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsTrends/MarketingAnalyticsTrendsChart.tsx
@@ -1,0 +1,136 @@
+import { useValues } from 'kea'
+import { useCallback, useMemo } from 'react'
+
+import { ChartLegend, TimeSeriesBarChart, TimeSeriesLineChart, legendItemsFromSeries } from '@posthog/quill-charts'
+import type {
+    Series,
+    TimeSeriesBarChartConfig,
+    TimeSeriesLineChartConfig,
+    TooltipConfig,
+    TooltipContext,
+    YAxisConfig,
+} from '@posthog/quill-charts'
+
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { teamLogic } from 'scenes/teamLogic'
+
+import type { TrendsFilter } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+import type { GraphDataset } from '~/types'
+
+import { trendsFilterToYFormatterConfig } from 'products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat'
+import type { TrendsSeriesMeta } from 'products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta'
+import { TrendsTooltip } from 'products/product_analytics/frontend/insights/trends/shared/TrendsTooltip'
+
+import { marketingAnalyticsLogic } from '../../logic/marketingAnalyticsLogic'
+
+const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
+
+type MarketingChartKind = 'line' | 'area' | 'bar'
+
+const DISPLAY_TYPE_TO_KIND: Partial<Record<ChartDisplayType, MarketingChartKind>> = {
+    [ChartDisplayType.ActionsLineGraph]: 'line',
+    [ChartDisplayType.ActionsAreaGraph]: 'area',
+    [ChartDisplayType.ActionsBar]: 'bar',
+}
+
+function buildSeries(datasets: GraphDataset[], kind: MarketingChartKind): Series<TrendsSeriesMeta>[] {
+    return datasets.map((dataset, index) => ({
+        key: String(dataset.id ?? index),
+        label: dataset.label ?? '',
+        data: (dataset.data ?? []) as number[],
+        fill: kind === 'area' ? {} : undefined,
+        meta: {
+            action: dataset.action,
+            breakdown_value: dataset.breakdown_value,
+            days: dataset.days,
+            order: dataset.action?.order ?? index,
+        },
+    }))
+}
+
+export interface MarketingAnalyticsTrendsChartProps {
+    dataAttr: string
+    datasets: GraphDataset[]
+    labels: string[]
+    trendsFilter?: TrendsFilter | null
+}
+
+export function MarketingAnalyticsTrendsChart({
+    dataAttr,
+    datasets,
+    labels,
+    trendsFilter,
+}: MarketingAnalyticsTrendsChartProps): JSX.Element {
+    const { timezone, baseCurrency } = useValues(teamLogic)
+    const { chartDisplayType, dateFilter } = useValues(marketingAnalyticsLogic)
+
+    const theme = useChartTheme()
+    const kind = DISPLAY_TYPE_TO_KIND[chartDisplayType] ?? 'bar'
+
+    const series = useMemo(() => buildSeries(datasets, kind), [datasets, kind])
+
+    const yAxis = useMemo<YAxisConfig>(
+        () => ({ ...trendsFilterToYFormatterConfig(trendsFilter, false, baseCurrency), showGrid: true }),
+        [trendsFilter, baseCurrency]
+    )
+
+    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
+
+    const renderTooltip = useCallback(
+        (ctx: TooltipContext<TrendsSeriesMeta>) => (
+            <TrendsTooltip
+                context={ctx}
+                timezone={timezone}
+                interval={dateFilter.interval}
+                trendsFilter={trendsFilter}
+                baseCurrency={baseCurrency}
+                groupTypeLabel=""
+            />
+        ),
+        [timezone, dateFilter.interval, trendsFilter, baseCurrency]
+    )
+
+    // No xAxis config: the backend ships pre-formatted period labels, so the time-axis date formatter is
+    // intentionally left inert (it would otherwise re-format the labels itself).
+    const barConfig = useChartConfig<TimeSeriesBarChartConfig>(
+        () => ({ yAxis, barLayout: 'stacked', tooltip: TOOLTIP_CONFIG }),
+        [yAxis]
+    )
+    const lineConfig = useChartConfig<TimeSeriesLineChartConfig>(
+        () => ({ yAxis, showCrosshair: true, tooltip: TOOLTIP_CONFIG }),
+        [yAxis]
+    )
+
+    const showLegend = series.length > 1
+
+    if (kind === 'bar') {
+        return (
+            <ChartLegend show={showLegend} items={legendItems} position="right" legendDataAttr={`${dataAttr}-legend`}>
+                <TimeSeriesBarChart<TrendsSeriesMeta>
+                    series={series}
+                    labels={labels}
+                    theme={theme}
+                    config={barConfig}
+                    tooltip={renderTooltip}
+                    className="BarGraph"
+                    dataAttr={dataAttr}
+                />
+            </ChartLegend>
+        )
+    }
+
+    return (
+        <ChartLegend show={showLegend} items={legendItems} position="right" legendDataAttr={`${dataAttr}-legend`}>
+            <TimeSeriesLineChart<TrendsSeriesMeta>
+                series={series}
+                labels={labels}
+                theme={theme}
+                config={lineConfig}
+                tooltip={renderTooltip}
+                className="LineGraph"
+                dataAttr={dataAttr}
+            />
+        </ChartLegend>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
@@ -20,19 +20,11 @@ import {
     MarketingAnalyticsConstants,
     MarketingAnalyticsDrillDownLevel,
     MarketingAnalyticsTableQuery,
+    MarketingAnalyticsTrendsMetric,
     NodeKind,
     getEffectiveExcludedColumns,
 } from '~/queries/schema/schema-general'
-import {
-    BaseMathType,
-    ChartDisplayType,
-    DataWarehousePropertyFilter,
-    HogQLMathType,
-    InsightLogicProps,
-    IntervalType,
-    PropertyFilterType,
-    PropertyOperator,
-} from '~/types'
+import { BaseMathType, ChartDisplayType, InsightLogicProps, IntervalType } from '~/types'
 
 import { marketingAnalyticsLogic } from './marketingAnalyticsLogic'
 import { marketingAnalyticsTableLogic } from './marketingAnalyticsTableLogic'
@@ -50,18 +42,6 @@ export const MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID = 'marketing-analytics'
 
 const isSchemaBackedMarketingColumn = (column: validColumnsForTiles): column is rawColumnsForTiles =>
     column !== 'roas' && column !== 'cost_per_reported_conversion'
-
-// Maps a chart column to a HogQL aggregate over the native cost precompute table. Costs are already
-// converted to the team's base currency at materialization time, so no convertCurrency() is needed.
-const PRECOMPUTE_METRIC_EXPR: Record<validColumnsForTiles, string> = {
-    cost: 'sum(cost)',
-    clicks: 'sum(clicks)',
-    impressions: 'sum(impressions)',
-    reported_conversion: 'sum(reported_conversions)',
-    reported_conversion_value: 'sum(reported_conversion_value)',
-    roas: 'sum(reported_conversion_value) / nullIf(sum(cost), 0)',
-    cost_per_reported_conversion: 'sum(cost) / nullIf(sum(reported_conversions), 0)',
-}
 
 const createInsightProps = (tile: TileId, tab?: string): InsightLogicProps => ({
     dashboardItemId: getDashboardItemId(tile, tab, false),
@@ -148,92 +128,64 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
             ): QueryTile => {
                 const tileColumnSelectionName = tileColumnSelection?.split('_').join(' ')
                 const hasSources = createMarketingDataWarehouseNodes.length > 0
-                const metricExpr = PRECOMPUTE_METRIC_EXPR[tileColumnSelection] ?? 'sum(cost)'
                 const isCurrency =
                     tileColumnSelection && isSchemaBackedMarketingColumn(tileColumnSelection)
                         ? MARKETING_ANALYTICS_SCHEMA[tileColumnSelection].isCurrency
                         : false
                 const { symbol: currencySymbol, isPrefix: currencyIsPrefix } = getCurrencySymbol(baseCurrency)
 
-                // Gated behind the same flag as the backend cost precompute read-side: when off, the tile
-                // keeps reading the S3-backed cost adapters (createMarketingDataWarehouseNodes) so the
-                // precompute table can roll out independently. When on, read the native precompute table
-                // via a single DataWarehouseNode — TrendsQuery then gives us compare, per-source breakdown
-                // and currency formatting for free while the read stays off S3. `grain = 'campaign'` avoids
-                // double-counting the ad-group/ad grains; `expires_at > today()` keeps only fresh rows. The
-                // table exposes a virtual `timestamp` (cost_date as DateTime) so a DataWarehouseNode can target it.
+                // Gated behind the same flag as the backend cost precompute read-side. When on (and sources
+                // exist), the chart runs MarketingAnalyticsTrendsQuery, which reads the native precompute
+                // table with the SAME argMax(computed_at) + job_id de-dup as the overview tile — so the chart
+                // total reconciles with the big number instead of double-counting re-materialized cost cells
+                // the way a raw DataWarehouseNode sum over the table does. When off, the tile keeps reading the
+                // S3-backed cost adapters so the precompute table can roll out independently.
+                // NOTE: compare is not yet wired into the native path (the backend runner ignores compareFilter);
+                // the overview tile still compares. Compare overlay for this chart is a fast-follow.
                 const costsPrecomputeEnabled = !!featureFlags[FEATURE_FLAGS.MARKETING_ANALYTICS_COSTS_PRECOMPUTATION]
-                const selectedSourceIds = integrationFilter.integrationSourceIds || []
-                // Typed property filter, not raw HogQL interpolation: source IDs come from the
-                // integration_sources URL param, so embedding them in a HogQL string would allow
-                // injection. PropertyOperator.Exact over a list compiles to a parameterized `IN (...)`.
-                const sourceFilters: DataWarehousePropertyFilter[] =
-                    selectedSourceIds.length > 0
-                        ? [
-                              {
-                                  type: PropertyFilterType.DataWarehouse,
-                                  key: 'source_id',
-                                  operator: PropertyOperator.Exact,
-                                  value: selectedSourceIds,
-                              },
-                          ]
-                        : []
-                const costSeriesNode: DataWarehouseNode = {
-                    kind: NodeKind.DataWarehouseNode,
-                    id: 'marketing_costs_preaggregated',
-                    name: tileColumnSelectionName,
-                    custom_name: tileColumnSelectionName,
-                    table_name: 'posthog.marketing_costs_preaggregated',
-                    id_field: 'campaign_id',
-                    distinct_id_field: 'campaign_id',
-                    timestamp_field: 'timestamp',
-                    math: HogQLMathType.HogQL,
-                    math_hogql: metricExpr,
-                    properties: [
-                        {
-                            type: PropertyFilterType.HogQL,
-                            key: `grain = 'campaign' AND expires_at > today()`,
-                        },
-                        ...sourceFilters,
-                    ],
-                }
-                const chartQuery: QueryTile['query'] = {
-                    kind: NodeKind.InsightVizNode,
-                    embedded: true,
-                    hidePersonsModal: true,
-                    hideTooltipOnScroll: true,
-                    source: {
-                        kind: NodeKind.TrendsQuery,
-                        series: !hasSources
-                            ? [
-                                  {
-                                      kind: NodeKind.EventsNode,
-                                      event: 'no_sources_configured',
-                                      custom_name: 'No marketing sources configured',
-                                      math: BaseMathType.TotalCount,
+
+                const chartQuery: QueryTile['query'] =
+                    costsPrecomputeEnabled && hasSources
+                        ? {
+                              kind: NodeKind.MarketingAnalyticsTrendsQuery,
+                              metric: tileColumnSelection as MarketingAnalyticsTrendsMetric,
+                              dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
+                              interval: dateFilter.interval,
+                              integrationFilter,
+                              properties: [],
+                              tags: MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS,
+                          }
+                        : {
+                              kind: NodeKind.InsightVizNode,
+                              embedded: true,
+                              hidePersonsModal: true,
+                              hideTooltipOnScroll: true,
+                              source: {
+                                  kind: NodeKind.TrendsQuery,
+                                  series: hasSources
+                                      ? createMarketingDataWarehouseNodes
+                                      : [
+                                            {
+                                                kind: NodeKind.EventsNode,
+                                                event: 'no_sources_configured',
+                                                custom_name: 'No marketing sources configured',
+                                                math: BaseMathType.TotalCount,
+                                            },
+                                        ],
+                                  compareFilter: compareFilter || undefined,
+                                  interval: dateFilter.interval,
+                                  dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
+                                  trendsFilter: {
+                                      display: chartDisplayType,
+                                      aggregationAxisFormat: 'numeric',
+                                      aggregationAxisPrefix:
+                                          isCurrency && currencyIsPrefix ? currencySymbol : undefined,
+                                      aggregationAxisPostfix:
+                                          isCurrency && !currencyIsPrefix ? ` ${currencySymbol}` : undefined,
                                   },
-                              ]
-                            : costsPrecomputeEnabled
-                              ? [costSeriesNode]
-                              : createMarketingDataWarehouseNodes,
-                        compareFilter: compareFilter || undefined,
-                        // The precompute path reads a single node, so split by source here; the S3 adapters
-                        // are already per-source series and need no breakdown.
-                        breakdownFilter:
-                            costsPrecomputeEnabled && hasSources
-                                ? { breakdowns: [{ type: 'data_warehouse', property: 'source_name' }] }
-                                : undefined,
-                        interval: dateFilter.interval,
-                        dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
-                        trendsFilter: {
-                            display: chartDisplayType,
-                            aggregationAxisFormat: 'numeric',
-                            aggregationAxisPrefix: isCurrency && currencyIsPrefix ? currencySymbol : undefined,
-                            aggregationAxisPostfix: isCurrency && !currencyIsPrefix ? ` ${currencySymbol}` : undefined,
-                        },
-                        tags: MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS,
-                    },
-                }
+                                  tags: MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS,
+                              },
+                          }
                 return {
                     kind: 'query',
                     tileId: TileId.MARKETING,

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -63,6 +63,7 @@ import {
     DataVisualizationNode,
     InsightVizNode,
     MarketingAnalyticsColumnsSchemaNames,
+    MarketingAnalyticsTrendsQuery,
     NodeKind,
     ProductIntentContext,
     ProductKey,
@@ -856,7 +857,10 @@ export const MarketingAnalyticsTrendTile = ({
     insightProps,
     attachTo,
     uniqueKey,
-}: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean; uniqueKey: string }): JSX.Element => {
+}: QueryWithInsightProps<InsightVizNode | MarketingAnalyticsTrendsQuery> & {
+    showIntervalTile?: boolean
+    uniqueKey: string
+}): JSX.Element => {
     const { setDateInterval, setChartDisplayType, setTileColumnSelection } = useActions(marketingAnalyticsLogic)
     const { dateFilter, chartDisplayType, tileColumnSelection } = useValues(marketingAnalyticsLogic)
 
@@ -1495,7 +1499,10 @@ export const WebQuery = ({
         )
     }
 
-    if (query.kind === NodeKind.InsightVizNode && tileId === TileId.MARKETING) {
+    if (
+        tileId === TileId.MARKETING &&
+        (query.kind === NodeKind.InsightVizNode || query.kind === NodeKind.MarketingAnalyticsTrendsQuery)
+    ) {
         return (
             <MarketingAnalyticsTrendTile
                 attachTo={attachTo}

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1105,6 +1105,20 @@ def get_query_runner(
             user=user,
         )
 
+    if kind == NodeKind.MARKETING_ANALYTICS_TRENDS_QUERY:
+        from products.marketing_analytics.backend.hogql_queries.marketing_analytics_trends_query_runner import (
+            MarketingAnalyticsTrendsQueryRunner,
+        )
+
+        return MarketingAnalyticsTrendsQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+            user=user,
+        )
+
     if kind == NodeKind.NON_INTEGRATED_CONVERSIONS_TABLE_QUERY:
         from products.marketing_analytics.backend.hogql_queries.non_integrated_conversions_table_query_runner import (
             NonIntegratedConversionsTableQueryRunner,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -155,6 +155,7 @@ from posthog.schema_enums import (
     MarketingAnalyticsDrillDownLevel as MarketingAnalyticsDrillDownLevel,
     MarketingAnalyticsOrderByEnum as MarketingAnalyticsOrderByEnum,
     MarketingAnalyticsSchemaFieldTypes as MarketingAnalyticsSchemaFieldTypes,
+    MarketingAnalyticsTrendsMetric as MarketingAnalyticsTrendsMetric,
     MatchedOn as MatchedOn,
     MatchField as MatchField,
     MaterializationMode as MaterializationMode,
@@ -2129,7 +2130,7 @@ class QueryResponseAlternative7(BaseModel):
     stdout: str | None = None
 
 
-class QueryResponseAlternative83(BaseModel):
+class QueryResponseAlternative84(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5569,7 +5570,7 @@ class QueryResponseAlternative29(BaseModel):
     status: ExternalQueryStatus
 
 
-class QueryResponseAlternative89(BaseModel):
+class QueryResponseAlternative90(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -10929,6 +10930,61 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class CachedMarketingAnalyticsTrendsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None,
+        description=("What triggered the calculation of the query, leave empty if user/immediate"),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list = Field(
+        ...,
+        description=("Insights-style time series: one GraphDataset per source_name breakdown."),
+    )
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16801,6 +16857,50 @@ class MarketingAnalyticsTableQueryResponse(BaseModel):
     )
 
 
+class MarketingAnalyticsTrendsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list = Field(
+        ...,
+        description=("Insights-style time series: one GraphDataset per source_name breakdown."),
+    )
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
 class MaxBillingContext(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -18269,6 +18369,50 @@ class QueryResponseAlternative38(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list = Field(
+        ...,
+        description=("Insights-style time series: one GraphDataset per source_name breakdown."),
+    )
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class QueryResponseAlternative39(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     columns: list | None = None
     error: str | None = Field(
         default=None,
@@ -18312,7 +18456,7 @@ class QueryResponseAlternative38(BaseModel):
     )
 
 
-class QueryResponseAlternative39(BaseModel):
+class QueryResponseAlternative40(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18359,7 +18503,7 @@ class QueryResponseAlternative39(BaseModel):
     )
 
 
-class QueryResponseAlternative40(BaseModel):
+class QueryResponseAlternative41(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18406,7 +18550,7 @@ class QueryResponseAlternative40(BaseModel):
     )
 
 
-class QueryResponseAlternative41(BaseModel):
+class QueryResponseAlternative42(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18453,7 +18597,7 @@ class QueryResponseAlternative41(BaseModel):
     )
 
 
-class QueryResponseAlternative42(BaseModel):
+class QueryResponseAlternative43(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18500,7 +18644,7 @@ class QueryResponseAlternative42(BaseModel):
     )
 
 
-class QueryResponseAlternative43(BaseModel):
+class QueryResponseAlternative44(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18545,54 +18689,6 @@ class QueryResponseAlternative43(BaseModel):
     )
 
 
-class QueryResponseAlternative44(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: list | None = None
-    error: str | None = Field(
-        default=None,
-        description=(
-            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
-        ),
-    )
-    hasMore: bool | None = None
-    hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    limit: int | None = None
-    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    offset: int | None = None
-    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
-    query_status: QueryStatus | None = Field(
-        default=None,
-        description=("Query status indicates whether next to the provided data, a query is still running."),
-    )
-    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None,
-        description=("The resolved previous/comparison period date range, when comparing against another period"),
-    )
-    resolved_date_range: ResolvedDateRangeResponse | None = Field(
-        default=None, description="The date range used for the query"
-    )
-    results: list
-    samplingRate: SamplingRate | None = None
-    timings: list[QueryTiming] | None = Field(
-        default=None,
-        description=("Measured timings for different parts of the query generation process"),
-    )
-    types: list | None = None
-    warnings: list[DataWarehouseSyncWarning] | None = Field(
-        default=None,
-        description=(
-            "Warnings about data warehouse sources referenced by the query whose latest"
-            " sync failed, is paused, hit a billing limit, or is otherwise stale."
-            " Results may not reflect current source data. Accumulated across every"
-            " HogQL execution that contributes to this response — so insights backed by"
-            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
-            " HogQL queries."
-        ),
-    )
-
-
 class QueryResponseAlternative45(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -18609,6 +18705,7 @@ class QueryResponseAlternative45(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -18656,7 +18753,6 @@ class QueryResponseAlternative46(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
-    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -18689,6 +18785,54 @@ class QueryResponseAlternative46(BaseModel):
 
 
 class QueryResponseAlternative47(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    samplingRate: SamplingRate | None = None
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    types: list | None = None
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class QueryResponseAlternative48(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18730,7 +18874,7 @@ class QueryResponseAlternative47(BaseModel):
     )
 
 
-class QueryResponseAlternative48(BaseModel):
+class QueryResponseAlternative49(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18776,7 +18920,7 @@ class QueryResponseAlternative48(BaseModel):
     )
 
 
-class QueryResponseAlternative49(BaseModel):
+class QueryResponseAlternative50(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18822,7 +18966,7 @@ class QueryResponseAlternative49(BaseModel):
     )
 
 
-class QueryResponseAlternative50(BaseModel):
+class QueryResponseAlternative51(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18864,7 +19008,7 @@ class QueryResponseAlternative50(BaseModel):
     )
 
 
-class QueryResponseAlternative51(BaseModel):
+class QueryResponseAlternative52(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18906,7 +19050,7 @@ class QueryResponseAlternative51(BaseModel):
     )
 
 
-class QueryResponseAlternative52(BaseModel):
+class QueryResponseAlternative53(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18948,7 +19092,7 @@ class QueryResponseAlternative52(BaseModel):
     )
 
 
-class QueryResponseAlternative53(BaseModel):
+class QueryResponseAlternative54(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -18989,7 +19133,7 @@ class QueryResponseAlternative53(BaseModel):
     )
 
 
-class QueryResponseAlternative54(BaseModel):
+class QueryResponseAlternative55(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19031,7 +19175,7 @@ class QueryResponseAlternative54(BaseModel):
     )
 
 
-class QueryResponseAlternative55(BaseModel):
+class QueryResponseAlternative56(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19077,7 +19221,7 @@ class QueryResponseAlternative55(BaseModel):
     )
 
 
-class QueryResponseAlternative57(BaseModel):
+class QueryResponseAlternative58(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19124,7 +19268,7 @@ class QueryResponseAlternative57(BaseModel):
     )
 
 
-class QueryResponseAlternative58(BaseModel):
+class QueryResponseAlternative59(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19166,7 +19310,7 @@ class QueryResponseAlternative58(BaseModel):
     )
 
 
-class QueryResponseAlternative59(BaseModel):
+class QueryResponseAlternative60(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19213,7 +19357,7 @@ class QueryResponseAlternative59(BaseModel):
     )
 
 
-class QueryResponseAlternative60(BaseModel):
+class QueryResponseAlternative61(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19258,7 +19402,7 @@ class QueryResponseAlternative60(BaseModel):
     )
 
 
-class QueryResponseAlternative64(BaseModel):
+class QueryResponseAlternative65(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19303,7 +19447,7 @@ class QueryResponseAlternative64(BaseModel):
     )
 
 
-class QueryResponseAlternative65(BaseModel):
+class QueryResponseAlternative66(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19349,7 +19493,7 @@ class QueryResponseAlternative65(BaseModel):
     )
 
 
-class QueryResponseAlternative66(BaseModel):
+class QueryResponseAlternative67(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19400,7 +19544,7 @@ class QueryResponseAlternative66(BaseModel):
     )
 
 
-class QueryResponseAlternative67(BaseModel):
+class QueryResponseAlternative68(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19443,7 +19587,7 @@ class QueryResponseAlternative67(BaseModel):
     )
 
 
-class QueryResponseAlternative68(BaseModel):
+class QueryResponseAlternative69(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19491,7 +19635,7 @@ class QueryResponseAlternative68(BaseModel):
     )
 
 
-class QueryResponseAlternative69(BaseModel):
+class QueryResponseAlternative70(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19532,7 +19676,7 @@ class QueryResponseAlternative69(BaseModel):
     )
 
 
-class QueryResponseAlternative70(BaseModel):
+class QueryResponseAlternative71(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19573,7 +19717,7 @@ class QueryResponseAlternative70(BaseModel):
     )
 
 
-class QueryResponseAlternative71(BaseModel):
+class QueryResponseAlternative72(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19614,7 +19758,7 @@ class QueryResponseAlternative71(BaseModel):
     )
 
 
-class QueryResponseAlternative73(BaseModel):
+class QueryResponseAlternative74(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19660,7 +19804,7 @@ class QueryResponseAlternative73(BaseModel):
     )
 
 
-class QueryResponseAlternative75(BaseModel):
+class QueryResponseAlternative76(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19706,7 +19850,7 @@ class QueryResponseAlternative75(BaseModel):
     )
 
 
-class QueryResponseAlternative76(BaseModel):
+class QueryResponseAlternative77(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19752,7 +19896,7 @@ class QueryResponseAlternative76(BaseModel):
     )
 
 
-class QueryResponseAlternative77(BaseModel):
+class QueryResponseAlternative78(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19794,7 +19938,7 @@ class QueryResponseAlternative77(BaseModel):
     )
 
 
-class QueryResponseAlternative78(BaseModel):
+class QueryResponseAlternative79(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19835,7 +19979,7 @@ class QueryResponseAlternative78(BaseModel):
     )
 
 
-class QueryResponseAlternative79(BaseModel):
+class QueryResponseAlternative80(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19880,7 +20024,7 @@ class QueryResponseAlternative79(BaseModel):
     )
 
 
-class QueryResponseAlternative80(BaseModel):
+class QueryResponseAlternative81(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19925,7 +20069,7 @@ class QueryResponseAlternative80(BaseModel):
     )
 
 
-class QueryResponseAlternative81(BaseModel):
+class QueryResponseAlternative82(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -19970,7 +20114,7 @@ class QueryResponseAlternative81(BaseModel):
     )
 
 
-class QueryResponseAlternative82(BaseModel):
+class QueryResponseAlternative83(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20015,7 +20159,7 @@ class QueryResponseAlternative82(BaseModel):
     )
 
 
-class QueryResponseAlternative84(BaseModel):
+class QueryResponseAlternative85(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20059,7 +20203,7 @@ class QueryResponseAlternative84(BaseModel):
     )
 
 
-class QueryResponseAlternative85(BaseModel):
+class QueryResponseAlternative86(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20103,7 +20247,7 @@ class QueryResponseAlternative85(BaseModel):
     )
 
 
-class QueryResponseAlternative86(BaseModel):
+class QueryResponseAlternative87(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20144,7 +20288,7 @@ class QueryResponseAlternative86(BaseModel):
     )
 
 
-class QueryResponseAlternative87(BaseModel):
+class QueryResponseAlternative88(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20189,7 +20333,7 @@ class QueryResponseAlternative87(BaseModel):
     )
 
 
-class QueryResponseAlternative90(BaseModel):
+class QueryResponseAlternative91(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20230,7 +20374,7 @@ class QueryResponseAlternative90(BaseModel):
     )
 
 
-class QueryResponseAlternative91(BaseModel):
+class QueryResponseAlternative92(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20271,7 +20415,7 @@ class QueryResponseAlternative91(BaseModel):
     )
 
 
-class QueryResponseAlternative92(BaseModel):
+class QueryResponseAlternative93(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20322,7 +20466,7 @@ class QueryResponseAlternative92(BaseModel):
     )
 
 
-class QueryResponseAlternative93(BaseModel):
+class QueryResponseAlternative94(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20363,7 +20507,7 @@ class QueryResponseAlternative93(BaseModel):
     )
 
 
-class QueryResponseAlternative94(BaseModel):
+class QueryResponseAlternative95(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20409,7 +20553,7 @@ class QueryResponseAlternative94(BaseModel):
     )
 
 
-class QueryResponseAlternative95(BaseModel):
+class QueryResponseAlternative96(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20450,7 +20594,7 @@ class QueryResponseAlternative95(BaseModel):
     )
 
 
-class QueryResponseAlternative96(BaseModel):
+class QueryResponseAlternative97(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20491,7 +20635,7 @@ class QueryResponseAlternative96(BaseModel):
     )
 
 
-class QueryResponseAlternative97(BaseModel):
+class QueryResponseAlternative98(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20532,7 +20676,7 @@ class QueryResponseAlternative97(BaseModel):
     )
 
 
-class QueryResponseAlternative98(BaseModel):
+class QueryResponseAlternative99(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20573,7 +20717,7 @@ class QueryResponseAlternative98(BaseModel):
     )
 
 
-class QueryResponseAlternative99(BaseModel):
+class QueryResponseAlternative100(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20617,7 +20761,7 @@ class QueryResponseAlternative99(BaseModel):
     )
 
 
-class QueryResponseAlternative100(BaseModel):
+class QueryResponseAlternative101(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20658,7 +20802,7 @@ class QueryResponseAlternative100(BaseModel):
     )
 
 
-class QueryResponseAlternative101(BaseModel):
+class QueryResponseAlternative102(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20699,7 +20843,7 @@ class QueryResponseAlternative101(BaseModel):
     )
 
 
-class QueryResponseAlternative102(BaseModel):
+class QueryResponseAlternative103(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20740,7 +20884,7 @@ class QueryResponseAlternative102(BaseModel):
     )
 
 
-class QueryResponseAlternative103(BaseModel):
+class QueryResponseAlternative104(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -20781,7 +20925,7 @@ class QueryResponseAlternative103(BaseModel):
     )
 
 
-class QueryResponseAlternative104(BaseModel):
+class QueryResponseAlternative105(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -23372,6 +23516,43 @@ class MarketingAnalyticsTableQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class MarketingAnalyticsTrendsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    aggregation_group_type_index: int | None = Field(
+        default=None,
+        description=("Groups aggregation - not used in Web Analytics but required for type compatibility"),
+    )
+    compareFilter: CompareFilter | None = None
+    conversionGoal: ActionConversionGoal | CustomEventConversionGoal | None = None
+    dataColorTheme: float | None = Field(
+        default=None,
+        description=(
+            "Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility"
+        ),
+    )
+    dateRange: DateRange | None = None
+    doPathCleaning: bool | None = None
+    filterTestAccounts: bool | None = None
+    includeRevenue: bool | None = None
+    integrationFilter: IntegrationFilter | None = Field(default=None, description="Filter by integration IDs")
+    interval: IntervalType | None = Field(
+        default=None,
+        description=("Interval for date range calculation (affects date_to rounding for hour vs day ranges)"),
+    )
+    kind: Literal["MarketingAnalyticsTrendsQuery"] = "MarketingAnalyticsTrendsQuery"
+    metric: MarketingAnalyticsTrendsMetric = Field(..., description="Which cost metric to plot over time")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    properties: list[EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter]
+    response: MarketingAnalyticsTrendsQueryResponse | None = None
+    sampling: WebAnalyticsSampling | None = None
+    samplingFactor: float | None = Field(default=None, description="Sampling rate")
+    tags: QueryLogTags | None = None
+    useSessionsTable: bool | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class MaxInnerUniversalFiltersGroup(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -25456,7 +25637,7 @@ class QueryResponseAlternative19(BaseModel):
     )
 
 
-class QueryResponseAlternative62(BaseModel):
+class QueryResponseAlternative63(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -25476,7 +25657,7 @@ class QueryResponseAlternative62(BaseModel):
     )
 
 
-class QueryResponseAlternative63(BaseModel):
+class QueryResponseAlternative64(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -25497,7 +25678,7 @@ class QueryResponseAlternative63(BaseModel):
     )
 
 
-class QueryResponseAlternative74(BaseModel):
+class QueryResponseAlternative75(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -25875,8 +26056,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
-        | Any
         | QueryResponseAlternative39
+        | Any
         | QueryResponseAlternative40
         | QueryResponseAlternative41
         | QueryResponseAlternative42
@@ -25893,11 +26074,11 @@ class QueryResponseAlternative(
         | QueryResponseAlternative53
         | QueryResponseAlternative54
         | QueryResponseAlternative55
-        | QueryResponseAlternative57
+        | QueryResponseAlternative56
         | QueryResponseAlternative58
         | QueryResponseAlternative59
         | QueryResponseAlternative60
-        | QueryResponseAlternative62
+        | QueryResponseAlternative61
         | QueryResponseAlternative63
         | QueryResponseAlternative64
         | QueryResponseAlternative65
@@ -25907,7 +26088,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative69
         | QueryResponseAlternative70
         | QueryResponseAlternative71
-        | QueryResponseAlternative73
+        | QueryResponseAlternative72
         | QueryResponseAlternative74
         | QueryResponseAlternative75
         | QueryResponseAlternative76
@@ -25922,7 +26103,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
-        | QueryResponseAlternative89
+        | QueryResponseAlternative88
         | QueryResponseAlternative90
         | QueryResponseAlternative91
         | QueryResponseAlternative92
@@ -25938,6 +26119,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative102
         | QueryResponseAlternative103
         | QueryResponseAlternative104
+        | QueryResponseAlternative105
     ]
 ):
     root: (
@@ -25978,8 +26160,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative36
         | QueryResponseAlternative37
         | QueryResponseAlternative38
-        | Any
         | QueryResponseAlternative39
+        | Any
         | QueryResponseAlternative40
         | QueryResponseAlternative41
         | QueryResponseAlternative42
@@ -25996,11 +26178,11 @@ class QueryResponseAlternative(
         | QueryResponseAlternative53
         | QueryResponseAlternative54
         | QueryResponseAlternative55
-        | QueryResponseAlternative57
+        | QueryResponseAlternative56
         | QueryResponseAlternative58
         | QueryResponseAlternative59
         | QueryResponseAlternative60
-        | QueryResponseAlternative62
+        | QueryResponseAlternative61
         | QueryResponseAlternative63
         | QueryResponseAlternative64
         | QueryResponseAlternative65
@@ -26010,7 +26192,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative69
         | QueryResponseAlternative70
         | QueryResponseAlternative71
-        | QueryResponseAlternative73
+        | QueryResponseAlternative72
         | QueryResponseAlternative74
         | QueryResponseAlternative75
         | QueryResponseAlternative76
@@ -26025,7 +26207,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative85
         | QueryResponseAlternative86
         | QueryResponseAlternative87
-        | QueryResponseAlternative89
+        | QueryResponseAlternative88
         | QueryResponseAlternative90
         | QueryResponseAlternative91
         | QueryResponseAlternative92
@@ -26041,6 +26223,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative102
         | QueryResponseAlternative103
         | QueryResponseAlternative104
+        | QueryResponseAlternative105
     )
 
 
@@ -27066,6 +27249,7 @@ class HogQLAutocomplete(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | WebOverviewQuery
         | WebStatsTableQuery
@@ -27163,6 +27347,7 @@ class HogQLMetadata(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | WebOverviewQuery
         | WebStatsTableQuery
@@ -27298,6 +27483,7 @@ class MaxInsightContext(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -27427,6 +27613,7 @@ class QueryRequest(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -27548,6 +27735,7 @@ class QuerySchemaRoot(
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -27639,6 +27827,7 @@ class QuerySchemaRoot(
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -27735,6 +27924,7 @@ class QueryUpgradeRequest(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -27831,6 +28021,7 @@ class QueryUpgradeResponse(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode
@@ -28104,6 +28295,7 @@ class VisualizationArtifactContent(BaseModel):
         | RevenueAnalyticsTopCustomersQuery
         | MarketingAnalyticsTableQuery
         | MarketingAnalyticsAggregatedQuery
+        | MarketingAnalyticsTrendsQuery
         | NonIntegratedConversionsTableQuery
         | DataVisualizationNode
         | DataTableNode

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2362,6 +2362,16 @@ class MarketingAnalyticsSchemaFieldTypes(StrEnum):
     BOOLEAN = "boolean"
 
 
+class MarketingAnalyticsTrendsMetric(StrEnum):
+    COST = "cost"
+    CLICKS = "clicks"
+    IMPRESSIONS = "impressions"
+    REPORTED_CONVERSION = "reported_conversion"
+    REPORTED_CONVERSION_VALUE = "reported_conversion_value"
+    ROAS = "roas"
+    COST_PER_REPORTED_CONVERSION = "cost_per_reported_conversion"
+
+
 class MatchField(StrEnum):
     CAMPAIGN_NAME = "campaign_name"
     CAMPAIGN_ID = "campaign_id"
@@ -2537,6 +2547,7 @@ class NodeKind(StrEnum):
     REVENUE_ANALYTICS_TOP_CUSTOMERS_QUERY = "RevenueAnalyticsTopCustomersQuery"
     MARKETING_ANALYTICS_TABLE_QUERY = "MarketingAnalyticsTableQuery"
     MARKETING_ANALYTICS_AGGREGATED_QUERY = "MarketingAnalyticsAggregatedQuery"
+    MARKETING_ANALYTICS_TRENDS_QUERY = "MarketingAnalyticsTrendsQuery"
     NON_INTEGRATED_CONVERSIONS_TABLE_QUERY = "NonIntegratedConversionsTableQuery"
     EXPERIMENT_METRIC = "ExperimentMetric"
     EXPERIMENT_QUERY = "ExperimentQuery"

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -200,13 +200,15 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             return level
         return MarketingAnalyticsDrillDownLevel.CAMPAIGN
 
-    def _build_costs_from_precompute(
+    def _resolve_precompute_cost_jobs(
         self, date_range: QueryDateRange
-    ) -> Optional[ast.SelectQuery | ast.SelectSetQuery]:
-        """Native-table cost source: ensure each source's cost rows are materialized at the grain
-        matching the current drill-down (one lazy job per source), then read them with the SAME column
-        contract `build_union_query_ast` produces — so `_build_campaign_cost_select` is unchanged.
-        Returns None if any source isn't ready → caller falls back to the live S3 adapter union.
+    ) -> Optional[tuple[MarketingAnalyticsDrillDownLevel, list, list[MarketingSourceAdapter], MarketingSourceFactory]]:
+        """Ensure each source's cost rows are materialized at the grain matching the current drill-down
+        (one lazy job per source) and resolve the job set that covers this request. Shared by every native
+        cost reader — the campaign_costs CTE and the trends chart — so the exact same job set, and hence
+        the same argMax de-dup, backs both. Returns (grain, job_ids, s3_fallback_adapters, mat_factory),
+        or None when nothing is materializable/ready (caller falls back to the live S3 union). Also sets
+        the cost-precompute telemetry attributes.
         """
         grain = self._cost_materialization_grain()
         # Adapters at the materialization grain (not the drill-down level, which may be SOURCE/CHANNEL).
@@ -288,13 +290,6 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             )
             return None
 
-        cost_sources: list[ast.SelectQuery | ast.SelectSetQuery] = [
-            self._costs_native_read_query(job_ids, grain, date_range)
-        ]
-        # Sources that couldn't materialize stay on the live S3 union so the dashboard stays complete.
-        if s3_fallback_adapters:
-            cost_sources.append(mat_factory.build_union_query_ast(s3_fallback_adapters))
-
         self._costs_precompute_used = True
         self._costs_sources_materialized = len(mat_adapters) - len(s3_fallback_adapters)
         self._costs_grain = grain_value
@@ -308,12 +303,37 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             s3_fallback_sources=len(s3_fallback_adapters),
             job_count=len(job_ids),
         )
+        return grain, job_ids, s3_fallback_adapters, mat_factory
+
+    def _build_costs_from_precompute(
+        self, date_range: QueryDateRange
+    ) -> Optional[ast.SelectQuery | ast.SelectSetQuery]:
+        """Native-table cost source: read the materialized cost rows with the SAME column contract
+        `build_union_query_ast` produces — so `_build_campaign_cost_select` is unchanged. Returns None if
+        nothing is materialized → caller falls back to the live S3 adapter union.
+        """
+        resolved = self._resolve_precompute_cost_jobs(date_range)
+        if resolved is None:
+            return None
+        grain, job_ids, s3_fallback_adapters, mat_factory = resolved
+
+        cost_sources: list[ast.SelectQuery | ast.SelectSetQuery] = [
+            self._costs_native_read_query(job_ids, grain, date_range)
+        ]
+        # Sources that couldn't materialize stay on the live S3 union so the dashboard stays complete.
+        if s3_fallback_adapters:
+            cost_sources.append(mat_factory.build_union_query_ast(s3_fallback_adapters))
+
         if len(cost_sources) == 1:
             return cost_sources[0]
         return ast.SelectSetQuery.create_from_queries(cost_sources, set_operator="UNION ALL")
 
     def _costs_native_read_query(
-        self, job_ids: list, grain: MarketingAnalyticsDrillDownLevel, date_range: QueryDateRange
+        self,
+        job_ids: list,
+        grain: MarketingAnalyticsDrillDownLevel,
+        date_range: QueryDateRange,
+        include_cost_date: bool = False,
     ) -> ast.SelectQuery:
         """Read materialized cost rows for the given source jobs + grain, re-aliased to the adapter
         column contract so the campaign_costs CTE GROUP BY works identically to the live union.
@@ -372,8 +392,12 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             ]
         )
 
-        # cost_date stays out of the SELECT (the downstream campaign_costs CTE sums across days per
-        # campaign) but anchors the grouping so each per-day cell collapses independently.
+        # cost_date normally stays out of the SELECT (the downstream campaign_costs CTE sums across days
+        # per campaign) but anchors the grouping so each per-day cell collapses independently. Time-series
+        # readers (the trends chart) promote it into the SELECT so the deduped rows keep their day and can
+        # be rolled up per interval instead of summed across the whole range.
+        if include_cost_date:
+            select_columns.append(ast.Alias(alias="cost_date", expr=field("cost_date")))
         group_by_exprs: list[ast.Expr] = [field(name) for _, name in dimension_columns]
         group_by_exprs.append(field("cost_date"))
 

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_trends_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_trends_query_runner.py
@@ -1,0 +1,191 @@
+from datetime import datetime
+from functools import cached_property
+
+import structlog
+
+from posthog.schema import (
+    CachedMarketingAnalyticsTrendsQueryResponse,
+    HogQLQueryResponse,
+    MarketingAnalyticsTrendsMetric,
+    MarketingAnalyticsTrendsQuery,
+    MarketingAnalyticsTrendsQueryResponse,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.database.models import UnknownDatabaseField
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.hogql_queries.utils.timestamp_utils import format_label_date
+
+from .adapters.base import MarketingSourceAdapter
+from .marketing_analytics_base_query_runner import MarketingAnalyticsBaseQueryRunner
+
+logger = structlog.get_logger(__name__)
+
+BREAKDOWN_ALIAS = "breakdown_by"
+PERIOD_START_ALIAS = "period_start"
+AMOUNT_ALIAS = "amount"
+
+
+class MarketingAnalyticsTrendsQueryRunner(MarketingAnalyticsBaseQueryRunner[MarketingAnalyticsTrendsQueryResponse]):
+    """Time series of a single cost metric, de-duplicated per (source, campaign, day) via the SAME
+    argMax(computed_at) + job_id read the aggregated tile uses, then bucketed by interval and broken down
+    by source_name. A raw TrendsQuery over marketing_costs_preaggregated sums every surviving job
+    generation of a cost cell and double-counts; reusing the tile's deduped read means the chart total
+    reconciles with the overview tile.
+    """
+
+    query: MarketingAnalyticsTrendsQuery
+    cached_response: CachedMarketingAnalyticsTrendsQueryResponse
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        # The base runner pins interval=None (it never buckets); the chart needs the requested interval.
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=self.query.interval,
+            now=datetime.now(),
+        )
+
+    def _metric_amount_expr(self) -> ast.Expr:
+        """SUM (or ratio of sums) of the selected metric over the deduped per-cell cost rows. Costs are
+        already in the team's base currency at materialization time, so no convertCurrency() is needed."""
+        adapter = MarketingSourceAdapter
+
+        def total(field_name: str) -> ast.Expr:
+            return ast.Call(name="sum", args=[ast.Field(chain=[field_name])])
+
+        def ratio(numerator: str, denominator: str) -> ast.Expr:
+            return ast.ArithmeticOperation(
+                op=ast.ArithmeticOperationOp.Div,
+                left=total(numerator),
+                right=ast.Call(name="nullIf", args=[total(denominator), ast.Constant(value=0)]),
+            )
+
+        metric = self.query.metric
+        metric_exprs: dict[MarketingAnalyticsTrendsMetric, ast.Expr] = {
+            MarketingAnalyticsTrendsMetric.COST: total(adapter.cost_field),
+            MarketingAnalyticsTrendsMetric.CLICKS: total(adapter.clicks_field),
+            MarketingAnalyticsTrendsMetric.IMPRESSIONS: total(adapter.impressions_field),
+            MarketingAnalyticsTrendsMetric.REPORTED_CONVERSION: total(adapter.reported_conversion_field),
+            MarketingAnalyticsTrendsMetric.REPORTED_CONVERSION_VALUE: total(adapter.reported_conversion_value_field),
+            MarketingAnalyticsTrendsMetric.ROAS: ratio(adapter.reported_conversion_value_field, adapter.cost_field),
+            MarketingAnalyticsTrendsMetric.COST_PER_REPORTED_CONVERSION: ratio(
+                adapter.cost_field, adapter.reported_conversion_field
+            ),
+        }
+        try:
+            return metric_exprs[metric]
+        except KeyError:
+            raise ValueError(f"Unsupported marketing trends metric: {metric}")
+
+    def _empty_query(self) -> ast.SelectQuery:
+        columns = [BREAKDOWN_ALIAS, PERIOD_START_ALIAS, AMOUNT_ALIAS]
+        return ast.SelectQuery.empty(columns={key: UnknownDatabaseField(name=key) for key in columns})
+
+    def to_query(self) -> ast.SelectQuery:
+        date_range = self.query_date_range
+        resolved = self._resolve_precompute_cost_jobs(date_range)
+        if resolved is None:
+            # Nothing materialized yet (sources still syncing / unmaterializable) — well-typed empty series.
+            return self._empty_query()
+        grain, job_ids, s3_fallback_adapters, _ = resolved
+        if s3_fallback_adapters:
+            # The chart reads only the deduped native table; sources that can't materialize (and would
+            # otherwise fall back to the live S3 union) are omitted here. They still appear in the overview
+            # tile, so this is a known, logged gap rather than a silent one.
+            logger.warning(
+                "marketing_costs_trends_excludes_s3_fallback",
+                team_id=self.team.pk,
+                grain=str(grain.value),
+                excluded_sources=[a.get_source_id() for a in s3_fallback_adapters],
+            )
+
+        inner = self._costs_native_read_query(job_ids, grain, date_range, include_cost_date=True)
+        # toStartOfWeek / toStartOfDay / toStartOfMonth — matches how TrendsQuery buckets, so the axis
+        # produced by query_date_range.all_values() lines up with the data.
+        interval_fn = f"toStartOf{self.query_date_range.interval_name.title()}"
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(alias=BREAKDOWN_ALIAS, expr=ast.Field(chain=[MarketingSourceAdapter.source_name_field])),
+                ast.Alias(
+                    alias=PERIOD_START_ALIAS,
+                    expr=ast.Call(
+                        name=interval_fn,
+                        args=[ast.Call(name="toDateTime", args=[ast.Field(chain=["cost_date"])])],
+                    ),
+                ),
+                ast.Alias(alias=AMOUNT_ALIAS, expr=self._metric_amount_expr()),
+            ],
+            select_from=ast.JoinExpr(table=inner),
+            group_by=[ast.Field(chain=[BREAKDOWN_ALIAS]), ast.Field(chain=[PERIOD_START_ALIAS])],
+            order_by=[
+                # amount first so the biggest series sorts to the front (matches revenue analytics)
+                ast.OrderExpr(expr=ast.Field(chain=[AMOUNT_ALIAS]), order="DESC"),
+                ast.OrderExpr(expr=ast.Field(chain=[BREAKDOWN_ALIAS]), order="ASC"),
+                ast.OrderExpr(expr=ast.Field(chain=[PERIOD_START_ALIAS]), order="ASC"),
+            ],
+            # (# periods x # sources) rows — small, but keep a generous ceiling like revenue analytics.
+            limit=ast.Constant(value=10000),
+        )
+
+    def _build_results(self, response: HogQLQueryResponse) -> list[dict]:
+        """Shape rows into Insights-style GraphDataset dicts (one series per source) so the frontend can
+        render them with the shared trends chart components."""
+        all_dates = self.query_date_range.all_values()
+        days = [date.strftime("%Y-%m-%d") for date in all_dates]
+        labels = [format_label_date(item, self.query_date_range, self.team.week_start_day) for item in all_dates]
+
+        def _build_result(breakdown: str, data: list) -> dict:
+            return {
+                "action": {"days": all_dates, "id": breakdown, "name": breakdown},
+                "data": data,
+                "days": days,
+                "label": breakdown,
+                "labels": labels,
+            }
+
+        grouped_results: dict[tuple[str, str], float] = {}
+        breakdowns: list[str] = []
+        for breakdown_by, period_start, amount in response.results:
+            breakdown_by = breakdown_by or ""
+            if breakdown_by not in breakdowns:
+                breakdowns.append(breakdown_by)
+            grouped_results[(breakdown_by, period_start.strftime("%Y-%m-%d"))] = amount
+
+        return [
+            _build_result(breakdown, [grouped_results.get((breakdown, day), 0) for day in days])
+            for breakdown in breakdowns
+        ]
+
+    def _calculate(self) -> MarketingAnalyticsTrendsQueryResponse:
+        with self.timings.measure("to_query"):
+            query = self.to_query()
+
+        with self.timings.measure("execute_hogql_query"):
+            response = execute_hogql_query(
+                query_type="marketing_analytics_trends_query",
+                query=query,
+                team=self.team,
+                user=self.user,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+        with self.timings.measure("build_results"):
+            results = self._build_results(response)
+
+        return MarketingAnalyticsTrendsQueryResponse(
+            results=results,
+            hogql=response.hogql,
+            timings=response.timings,
+            modifiers=self.modifiers,
+        )
+
+    def _build_main_select_query(self, conversion_aggregator) -> ast.SelectQuery:
+        # Unused: this runner overrides to_query() and does not build the campaign_costs CTE / conversion
+        # goals join. Present only to satisfy the abstract base contract.
+        raise NotImplementedError("MarketingAnalyticsTrendsQueryRunner builds its query in to_query()")

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_trends_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_trends_query_runner.py
@@ -1,0 +1,175 @@
+import uuid
+from datetime import date, datetime
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from parameterized import parameterized
+
+from posthog.schema import (
+    DateRange,
+    IntervalType,
+    MarketingAnalyticsDrillDownLevel,
+    MarketingAnalyticsTrendsMetric,
+    MarketingAnalyticsTrendsQuery,
+)
+
+from posthog.clickhouse.client.execute import sync_execute
+from posthog.clickhouse.preaggregation.marketing_costs_sql import DISTRIBUTED_MARKETING_COSTS_TABLE
+
+from products.marketing_analytics.backend.hogql_queries.marketing_analytics_trends_query_runner import (
+    MarketingAnalyticsTrendsQueryRunner,
+)
+
+_INSERT_COLUMNS = (
+    "team_id, job_id, source_id, source_name, grain, match_key, campaign_id, campaign_name, "
+    "ad_group_id, ad_group_name, ad_id, ad_name, cost_date, cost, clicks, impressions, "
+    "reported_conversions, reported_conversion_value, computed_at, expires_at"
+)
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestMarketingAnalyticsTrendsQueryRunner(ClickhouseTestMixin, BaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def _insert_cell(
+        self,
+        *,
+        job_id: str,
+        source_name: str,
+        campaign_id: str,
+        cost_date: date,
+        computed_at: datetime,
+        clicks: float = 0.0,
+        cost: float = 0.0,
+        reported_conversions: float = 0.0,
+        reported_conversion_value: float = 0.0,
+    ) -> None:
+        sync_execute(
+            f"INSERT INTO {DISTRIBUTED_MARKETING_COSTS_TABLE()} ({_INSERT_COLUMNS}) VALUES",
+            [
+                (
+                    self.team.pk,
+                    job_id,
+                    f"{source_name}_test",
+                    source_name,
+                    "campaign",
+                    campaign_id,
+                    campaign_id,
+                    campaign_id,
+                    "",
+                    "",
+                    "",
+                    "",
+                    cost_date,
+                    cost,
+                    clicks,
+                    0.0,
+                    reported_conversions,
+                    reported_conversion_value,
+                    computed_at,
+                    date(2099, 1, 1),
+                )
+            ],
+        )
+
+    def _run(self, *, metric: MarketingAnalyticsTrendsMetric, date_range: DateRange, job_ids: list[str]) -> list[dict]:
+        runner = MarketingAnalyticsTrendsQueryRunner(
+            query=MarketingAnalyticsTrendsQuery(
+                metric=metric,
+                interval=IntervalType.MONTH,
+                dateRange=date_range,
+                properties=[],
+            ),
+            team=self.team,
+        )
+        with patch.object(
+            MarketingAnalyticsTrendsQueryRunner,
+            "_resolve_precompute_cost_jobs",
+            lambda self, dr: (MarketingAnalyticsDrillDownLevel.CAMPAIGN, job_ids, [], None),
+        ):
+            return runner._calculate().results  # type: ignore[return-value]
+
+    @parameterized.expand(
+        [
+            (MarketingAnalyticsTrendsMetric.CLICKS, "clicks", 100.0, 150.0),
+            (MarketingAnalyticsTrendsMetric.COST, "cost", 100.0, 150.0),
+        ]
+    )
+    def test_trends_series_takes_latest_job_per_cell_not_sum(self, metric, field, stale_value, matured_value):
+        # Same (campaign, day) cell under two job_ids — a stale value and a matured one. job_id is in the
+        # ReplacingMergeTree sort key so both rows survive; the bucketed time series must roll up the
+        # latest-computed value (argMax), not the sum, or the chart double-counts like the raw TrendsQuery.
+        job_old, job_new = str(uuid.uuid4()), str(uuid.uuid4())
+        self._insert_cell(
+            job_id=job_old,
+            source_name="google",
+            campaign_id="c1",
+            cost_date=date(2023, 1, 15),
+            computed_at=datetime(2023, 1, 15, 10, 0),
+            **{field: stale_value},
+        )
+        self._insert_cell(
+            job_id=job_new,
+            source_name="google",
+            campaign_id="c1",
+            cost_date=date(2023, 1, 15),
+            computed_at=datetime(2023, 1, 16, 10, 0),
+            **{field: matured_value},
+        )
+
+        results = self._run(
+            metric=metric,
+            date_range=DateRange(date_from="2023-01-01", date_to="2023-01-31"),
+            job_ids=[job_old, job_new],
+        )
+
+        assert len(results) == 1, f"expected a single 'google' series, got {[r['label'] for r in results]}"
+        series_total = sum(float(v) for v in results[0]["data"])
+        assert series_total == matured_value, (
+            f"expected latest-job {field} {matured_value} (argMax), got {series_total} (sum would be {stale_value + matured_value})"
+        )
+
+    def test_trends_buckets_by_interval_and_breaks_down_by_source(self):
+        # Two sources across two months: the runner must emit one series per source, each bucketed by
+        # interval — not a single flattened total.
+        job = str(uuid.uuid4())
+        self._insert_cell(
+            job_id=job,
+            source_name="google",
+            campaign_id="c1",
+            cost_date=date(2023, 1, 10),
+            computed_at=datetime(2023, 1, 11, 10, 0),
+            clicks=100.0,
+        )
+        self._insert_cell(
+            job_id=job,
+            source_name="google",
+            campaign_id="c1",
+            cost_date=date(2023, 2, 10),
+            computed_at=datetime(2023, 2, 11, 10, 0),
+            clicks=40.0,
+        )
+        self._insert_cell(
+            job_id=job,
+            source_name="bing",
+            campaign_id="c2",
+            cost_date=date(2023, 1, 20),
+            computed_at=datetime(2023, 1, 21, 10, 0),
+            clicks=25.0,
+        )
+
+        results = self._run(
+            metric=MarketingAnalyticsTrendsMetric.CLICKS,
+            date_range=DateRange(date_from="2023-01-01", date_to="2023-02-28"),
+            job_ids=[job],
+        )
+
+        by_source = {r["label"]: [float(v) for v in r["data"]] for r in results}
+        assert set(by_source) == {"google", "bing"}
+        # Two monthly buckets (Jan, Feb) in range → each series has two data points.
+        assert all(len(data) == 2 for data in by_source.values())
+        assert sum(by_source["google"]) == 140.0  # 100 (Jan) + 40 (Feb)
+        assert sum(by_source["bing"]) == 25.0  # Jan only

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26291,6 +26291,71 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export type MarketingAnalyticsTrendsMetric = typeof MarketingAnalyticsTrendsMetric[keyof typeof MarketingAnalyticsTrendsMetric];
+
+
+    export const MarketingAnalyticsTrendsMetric = {
+      Cost: 'cost',
+      Clicks: 'clicks',
+      Impressions: 'impressions',
+      ReportedConversion: 'reported_conversion',
+      ReportedConversionValue: 'reported_conversion_value',
+      Roas: 'roas',
+      CostPerReportedConversion: 'cost_per_reported_conversion',
+    } as const;
+
+    export interface MarketingAnalyticsTrendsQueryResponse {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      /** Insights-style time series: one GraphDataset per source_name breakdown. */
+      results: unknown[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface MarketingAnalyticsTrendsQuery {
+      /** Groups aggregation - not used in Web Analytics but required for type compatibility */
+      aggregation_group_type_index?: number | null;
+      compareFilter?: CompareFilter | null;
+      conversionGoal?: ActionConversionGoal | CustomEventConversionGoal | null;
+      /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
+      dataColorTheme?: number | null;
+      dateRange?: DateRange | null;
+      doPathCleaning?: boolean | null;
+      filterTestAccounts?: boolean | null;
+      includeRevenue?: boolean | null;
+      /** Filter by integration IDs */
+      integrationFilter?: IntegrationFilter | null;
+      /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
+      interval?: IntervalType | null;
+      kind?: 'MarketingAnalyticsTrendsQuery';
+      /** Which cost metric to plot over time */
+      metric: MarketingAnalyticsTrendsMetric;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      properties: (EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter | CohortPropertyFilter)[];
+      response?: MarketingAnalyticsTrendsQueryResponse | null;
+      sampling?: WebAnalyticsSampling | null;
+      /** Sampling rate */
+      samplingFactor?: number | null;
+      tags?: QueryLogTags | null;
+      useSessionsTable?: boolean | null;
+      /** version of the node, used for schema migrations */
+      version?: number | null;
+    }
+
     export interface PageURL {
       url: string;
     }
@@ -27536,7 +27601,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLMetadataResponse | null;
       /** Query within which "expr" and "template" are validated. Defaults to "select * from events" */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | MarketingAnalyticsTrendsQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | null;
       tags?: QueryLogTags | null;
       /** Variables to be subsituted into the query */
       variables?: HogQLMetadataVariables;
@@ -27562,7 +27627,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLAutocompleteResponse | null;
       /** Query in whose context to validate. */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | MarketingAnalyticsTrendsQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | null;
       /** Start position of the editor word */
       startPosition: number;
       tags?: QueryLogTags | null;
@@ -45780,7 +45845,7 @@ export namespace Schemas {
        * ```
        *
        * For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | MarketingAnalyticsTrendsQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
        * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
        * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
@@ -46552,6 +46617,27 @@ export namespace Schemas {
     }
 
     export interface QueryResponseAlternative38 {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      /** Insights-style time series: one GraphDataset per source_name breakdown. */
+      results: unknown[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative39 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46577,7 +46663,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative39 {
+    export interface QueryResponseAlternative40 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46604,7 +46690,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative40 {
+    export interface QueryResponseAlternative41 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46630,7 +46716,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative41 {
+    export interface QueryResponseAlternative42 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46656,7 +46742,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative42 {
+    export interface QueryResponseAlternative43 {
       /** Executed ClickHouse query */
       clickhouse?: string | null;
       /** Returned columns */
@@ -46691,7 +46777,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative43 {
+    export interface QueryResponseAlternative44 {
       dateFrom?: string | null;
       dateTo?: string | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -46715,33 +46801,6 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative44 {
-      columns?: unknown[] | null;
-      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-      error?: string | null;
-      hasMore?: boolean | null;
-      /** Generated HogQL query. */
-      hogql?: string | null;
-      limit?: number | null;
-      /** Modifiers used when performing the query */
-      modifiers?: HogQLQueryModifiers | null;
-      offset?: number | null;
-      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
-      /** Query status indicates whether next to the provided data, a query is still running. */
-      query_status?: QueryStatus | null;
-      /** The resolved previous/comparison period date range, when comparing against another period */
-      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
-      /** The date range used for the query */
-      resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: unknown[];
-      samplingRate?: SamplingRate | null;
-      /** Measured timings for different parts of the query generation process */
-      timings?: QueryTiming[] | null;
-      types?: unknown[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-      warnings?: DataWarehouseSyncWarning[] | null;
-    }
-
     export interface QueryResponseAlternative45 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -46753,6 +46812,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -46779,7 +46839,6 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
-      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -46796,6 +46855,33 @@ export namespace Schemas {
     }
 
     export interface QueryResponseAlternative47 {
+      columns?: unknown[] | null;
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      hasMore?: boolean | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      limit?: number | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: unknown[];
+      samplingRate?: SamplingRate | null;
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative48 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -46820,7 +46906,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative48 {
+    export interface QueryResponseAlternative49 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46845,7 +46931,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative49 {
+    export interface QueryResponseAlternative50 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46870,7 +46956,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative50 {
+    export interface QueryResponseAlternative51 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46891,7 +46977,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative51 {
+    export interface QueryResponseAlternative52 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46912,7 +46998,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative52 {
+    export interface QueryResponseAlternative53 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46933,7 +47019,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative53 {
+    export interface QueryResponseAlternative54 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -46953,7 +47039,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative54 {
+    export interface QueryResponseAlternative55 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46974,7 +47060,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative55 {
+    export interface QueryResponseAlternative56 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -46999,7 +47085,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative57 {
+    export interface QueryResponseAlternative58 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47025,56 +47111,56 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative58Results = {[key: string]: MarketingAnalyticsItem};
-
-    export interface QueryResponseAlternative58 {
-      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-      error?: string | null;
-      /** Generated HogQL query. */
-      hogql?: string | null;
-      /** Modifiers used when performing the query */
-      modifiers?: HogQLQueryModifiers | null;
-      /** Query status indicates whether next to the provided data, a query is still running. */
-      query_status?: QueryStatus | null;
-      /** The resolved previous/comparison period date range, when comparing against another period */
-      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
-      /** The date range used for the query */
-      resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: QueryResponseAlternative58Results;
-      samplingRate?: SamplingRate | null;
-      /** Measured timings for different parts of the query generation process */
-      timings?: QueryTiming[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-      warnings?: DataWarehouseSyncWarning[] | null;
-    }
+    export type QueryResponseAlternative59Results = {[key: string]: MarketingAnalyticsItem};
 
     export interface QueryResponseAlternative59 {
-      columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
-      hasMore?: boolean | null;
       /** Generated HogQL query. */
       hogql?: string | null;
-      limit?: number | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
-      offset?: number | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: MarketingAnalyticsItem[][];
+      results: QueryResponseAlternative59Results;
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      types?: unknown[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
     export interface QueryResponseAlternative60 {
+      columns?: unknown[] | null;
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      hasMore?: boolean | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      limit?: number | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      offset?: number | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MarketingAnalyticsItem[][];
+      samplingRate?: SamplingRate | null;
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      types?: unknown[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative61 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47098,19 +47184,19 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative62CredibleIntervals = {[key: string]: number[]};
+    export type QueryResponseAlternative63CredibleIntervals = {[key: string]: number[]};
 
-    export type QueryResponseAlternative62InsightItemItem = { [key: string]: unknown };
+    export type QueryResponseAlternative63InsightItemItem = { [key: string]: unknown };
 
-    export type QueryResponseAlternative62Probability = {[key: string]: number};
+    export type QueryResponseAlternative63Probability = {[key: string]: number};
 
-    export interface QueryResponseAlternative62 {
-      credible_intervals: QueryResponseAlternative62CredibleIntervals;
+    export interface QueryResponseAlternative63 {
+      credible_intervals: QueryResponseAlternative63CredibleIntervals;
       expected_loss: number;
       funnels_query?: FunnelsQuery | null;
-      insight: QueryResponseAlternative62InsightItemItem[][];
+      insight: QueryResponseAlternative63InsightItemItem[][];
       kind?: 'ExperimentFunnelsQuery';
-      probability: QueryResponseAlternative62Probability;
+      probability: QueryResponseAlternative63Probability;
       significance_code: ExperimentSignificanceCode;
       significant: boolean;
       stats_version?: number | null;
@@ -47119,20 +47205,20 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative63CredibleIntervals = {[key: string]: number[]};
+    export type QueryResponseAlternative64CredibleIntervals = {[key: string]: number[]};
 
-    export type QueryResponseAlternative63InsightItem = { [key: string]: unknown };
+    export type QueryResponseAlternative64InsightItem = { [key: string]: unknown };
 
-    export type QueryResponseAlternative63Probability = {[key: string]: number};
+    export type QueryResponseAlternative64Probability = {[key: string]: number};
 
-    export interface QueryResponseAlternative63 {
+    export interface QueryResponseAlternative64 {
       count_query?: TrendsQuery | null;
-      credible_intervals: QueryResponseAlternative63CredibleIntervals;
+      credible_intervals: QueryResponseAlternative64CredibleIntervals;
       exposure_query?: TrendsQuery | null;
-      insight: QueryResponseAlternative63InsightItem[];
+      insight: QueryResponseAlternative64InsightItem[];
       kind?: 'ExperimentTrendsQuery';
       p_value: number;
-      probability: QueryResponseAlternative63Probability;
+      probability: QueryResponseAlternative64Probability;
       significance_code: ExperimentSignificanceCode;
       significant: boolean;
       stats_version?: number | null;
@@ -47141,7 +47227,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative64 {
+    export interface QueryResponseAlternative65 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47165,7 +47251,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative65 {
+    export interface QueryResponseAlternative66 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47190,7 +47276,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative66 {
+    export interface QueryResponseAlternative67 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47218,9 +47304,9 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative67ResultsItem = { [key: string]: unknown };
+    export type QueryResponseAlternative68ResultsItem = { [key: string]: unknown };
 
-    export interface QueryResponseAlternative67 {
+    export interface QueryResponseAlternative68 {
       boxplot_data?: BoxPlotDatum[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47236,14 +47322,14 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: QueryResponseAlternative67ResultsItem[];
+      results: QueryResponseAlternative68ResultsItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative68 {
+    export interface QueryResponseAlternative69 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47265,7 +47351,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative69 {
+    export interface QueryResponseAlternative70 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47285,7 +47371,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative70 {
+    export interface QueryResponseAlternative71 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47305,9 +47391,9 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative71ResultsItem = { [key: string]: unknown };
+    export type QueryResponseAlternative72ResultsItem = { [key: string]: unknown };
 
-    export interface QueryResponseAlternative71 {
+    export interface QueryResponseAlternative72 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47320,14 +47406,14 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: QueryResponseAlternative71ResultsItem[];
+      results: QueryResponseAlternative72ResultsItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative73 {
+    export interface QueryResponseAlternative74 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47352,14 +47438,14 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative74Tables = {[key: string]: DatabaseSchemaPostHogTable | DatabaseSchemaSystemTable | DatabaseSchemaDataWarehouseTable | DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable | DatabaseSchemaBatchExportTable | DatabaseSchemaMaterializedViewTable | DatabaseSchemaEndpointTable};
-
-    export interface QueryResponseAlternative74 {
-      joins: DataWarehouseViewLink[];
-      tables: QueryResponseAlternative74Tables;
-    }
+    export type QueryResponseAlternative75Tables = {[key: string]: DatabaseSchemaPostHogTable | DatabaseSchemaSystemTable | DatabaseSchemaDataWarehouseTable | DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable | DatabaseSchemaBatchExportTable | DatabaseSchemaMaterializedViewTable | DatabaseSchemaEndpointTable};
 
     export interface QueryResponseAlternative75 {
+      joins: DataWarehouseViewLink[];
+      tables: QueryResponseAlternative75Tables;
+    }
+
+    export interface QueryResponseAlternative76 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       has_next: boolean;
@@ -47382,7 +47468,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative76 {
+    export interface QueryResponseAlternative77 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47408,7 +47494,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative77 {
+    export interface QueryResponseAlternative78 {
       count: number;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47429,7 +47515,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative78 {
+    export interface QueryResponseAlternative79 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47449,7 +47535,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative79 {
+    export interface QueryResponseAlternative80 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       hasMore?: boolean | null;
@@ -47474,7 +47560,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative80 {
+    export interface QueryResponseAlternative81 {
       /** Result rows for the comparison period when `compareFilter.compare` is true. */
       compare?: AggregatedSpanRow[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -47496,7 +47582,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative81 {
+    export interface QueryResponseAlternative82 {
       /** Result rows for the comparison period when `compareFilter.compare` is true. */
       compare?: SpanTreeNode[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -47518,7 +47604,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative82 {
+    export interface QueryResponseAlternative83 {
       /** Result rows for the comparison period when `compareFilter.compare` is true. */
       compare?: AttributeBreakdownRow[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -47540,13 +47626,13 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative83 {
+    export interface QueryResponseAlternative84 {
       questions: string[];
       /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative84 {
+    export interface QueryResponseAlternative85 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       hasMore?: boolean | null;
@@ -47569,7 +47655,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative85 {
+    export interface QueryResponseAlternative86 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       hasMore?: boolean | null;
@@ -47592,7 +47678,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative86 {
+    export interface QueryResponseAlternative87 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47612,7 +47698,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative87 {
+    export interface QueryResponseAlternative88 {
       columns?: string[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47636,7 +47722,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative89 {
+    export interface QueryResponseAlternative90 {
       /** Timestamp of the newer trace */
       newerTimestamp?: string | null;
       /** ID of the newer trace (chronologically after current) */
@@ -47651,7 +47737,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative90 {
+    export interface QueryResponseAlternative91 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47671,7 +47757,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative91 {
+    export interface QueryResponseAlternative92 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47691,7 +47777,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative92 {
+    export interface QueryResponseAlternative93 {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47719,7 +47805,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative93 {
+    export interface QueryResponseAlternative94 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47739,7 +47825,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative94 {
+    export interface QueryResponseAlternative95 {
       columns?: unknown[] | null;
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -47764,27 +47850,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative95ResultsItem = { [key: string]: unknown };
-
-    export interface QueryResponseAlternative95 {
-      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-      error?: string | null;
-      /** Generated HogQL query. */
-      hogql?: string | null;
-      /** Modifiers used when performing the query */
-      modifiers?: HogQLQueryModifiers | null;
-      /** Query status indicates whether next to the provided data, a query is still running. */
-      query_status?: QueryStatus | null;
-      /** The resolved previous/comparison period date range, when comparing against another period */
-      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
-      /** The date range used for the query */
-      resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: QueryResponseAlternative95ResultsItem[];
-      /** Measured timings for different parts of the query generation process */
-      timings?: QueryTiming[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-      warnings?: DataWarehouseSyncWarning[] | null;
-    }
+    export type QueryResponseAlternative96ResultsItem = { [key: string]: unknown };
 
     export interface QueryResponseAlternative96 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -47799,7 +47865,7 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: MCPHarnessBreakdownItem[];
+      results: QueryResponseAlternative96ResultsItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
@@ -47819,7 +47885,7 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: MCPToolTopUserItem[];
+      results: MCPHarnessBreakdownItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
@@ -47839,7 +47905,7 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: MCPToolFailureItem[];
+      results: MCPToolTopUserItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
@@ -47847,6 +47913,26 @@ export namespace Schemas {
     }
 
     export interface QueryResponseAlternative99 {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MCPToolFailureItem[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative100 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47867,7 +47953,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative100 {
+    export interface QueryResponseAlternative101 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47887,7 +47973,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative101 {
+    export interface QueryResponseAlternative102 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47907,7 +47993,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative102 {
+    export interface QueryResponseAlternative103 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47927,7 +48013,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative103 {
+    export interface QueryResponseAlternative104 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47947,7 +48033,7 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export interface QueryResponseAlternative104 {
+    export interface QueryResponseAlternative105 {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
       /** Generated HogQL query. */
@@ -47967,18 +48053,18 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative = { [key: string]: unknown } | QueryResponseAlternative1 | QueryResponseAlternative2 | QueryResponseAlternative3 | QueryResponseAlternative4 | QueryResponseAlternative5 | QueryResponseAlternative6 | QueryResponseAlternative7 | QueryResponseAlternative8 | QueryResponseAlternative9 | QueryResponseAlternative10 | QueryResponseAlternative11 | QueryResponseAlternative14 | QueryResponseAlternative15 | QueryResponseAlternative16 | QueryResponseAlternative17 | QueryResponseAlternative18 | QueryResponseAlternative19 | QueryResponseAlternative20 | QueryResponseAlternative21 | QueryResponseAlternative22 | QueryResponseAlternative23 | QueryResponseAlternative24 | QueryResponseAlternative25 | QueryResponseAlternative26 | QueryResponseAlternative27 | QueryResponseAlternative28 | QueryResponseAlternative29 | QueryResponseAlternative30 | QueryResponseAlternative31 | QueryResponseAlternative32 | QueryResponseAlternative33 | QueryResponseAlternative34 | QueryResponseAlternative35 | QueryResponseAlternative36 | QueryResponseAlternative37 | QueryResponseAlternative38 | unknown | QueryResponseAlternative39 | QueryResponseAlternative40 | QueryResponseAlternative41 | QueryResponseAlternative42 | QueryResponseAlternative43 | QueryResponseAlternative44 | QueryResponseAlternative45 | QueryResponseAlternative46 | QueryResponseAlternative47 | QueryResponseAlternative48 | QueryResponseAlternative49 | QueryResponseAlternative50 | QueryResponseAlternative51 | QueryResponseAlternative52 | QueryResponseAlternative53 | QueryResponseAlternative54 | QueryResponseAlternative55 | QueryResponseAlternative57 | QueryResponseAlternative58 | QueryResponseAlternative59 | QueryResponseAlternative60 | QueryResponseAlternative62 | QueryResponseAlternative63 | QueryResponseAlternative64 | QueryResponseAlternative65 | QueryResponseAlternative66 | QueryResponseAlternative67 | QueryResponseAlternative68 | QueryResponseAlternative69 | QueryResponseAlternative70 | QueryResponseAlternative71 | QueryResponseAlternative73 | QueryResponseAlternative74 | QueryResponseAlternative75 | QueryResponseAlternative76 | QueryResponseAlternative77 | QueryResponseAlternative78 | QueryResponseAlternative79 | QueryResponseAlternative80 | QueryResponseAlternative81 | QueryResponseAlternative82 | QueryResponseAlternative83 | QueryResponseAlternative84 | QueryResponseAlternative85 | QueryResponseAlternative86 | QueryResponseAlternative87 | QueryResponseAlternative89 | QueryResponseAlternative90 | QueryResponseAlternative91 | QueryResponseAlternative92 | QueryResponseAlternative93 | QueryResponseAlternative94 | QueryResponseAlternative95 | QueryResponseAlternative96 | QueryResponseAlternative97 | QueryResponseAlternative98 | QueryResponseAlternative99 | QueryResponseAlternative100 | QueryResponseAlternative101 | QueryResponseAlternative102 | QueryResponseAlternative103 | QueryResponseAlternative104;
+    export type QueryResponseAlternative = { [key: string]: unknown } | QueryResponseAlternative1 | QueryResponseAlternative2 | QueryResponseAlternative3 | QueryResponseAlternative4 | QueryResponseAlternative5 | QueryResponseAlternative6 | QueryResponseAlternative7 | QueryResponseAlternative8 | QueryResponseAlternative9 | QueryResponseAlternative10 | QueryResponseAlternative11 | QueryResponseAlternative14 | QueryResponseAlternative15 | QueryResponseAlternative16 | QueryResponseAlternative17 | QueryResponseAlternative18 | QueryResponseAlternative19 | QueryResponseAlternative20 | QueryResponseAlternative21 | QueryResponseAlternative22 | QueryResponseAlternative23 | QueryResponseAlternative24 | QueryResponseAlternative25 | QueryResponseAlternative26 | QueryResponseAlternative27 | QueryResponseAlternative28 | QueryResponseAlternative29 | QueryResponseAlternative30 | QueryResponseAlternative31 | QueryResponseAlternative32 | QueryResponseAlternative33 | QueryResponseAlternative34 | QueryResponseAlternative35 | QueryResponseAlternative36 | QueryResponseAlternative37 | QueryResponseAlternative38 | QueryResponseAlternative39 | unknown | QueryResponseAlternative40 | QueryResponseAlternative41 | QueryResponseAlternative42 | QueryResponseAlternative43 | QueryResponseAlternative44 | QueryResponseAlternative45 | QueryResponseAlternative46 | QueryResponseAlternative47 | QueryResponseAlternative48 | QueryResponseAlternative49 | QueryResponseAlternative50 | QueryResponseAlternative51 | QueryResponseAlternative52 | QueryResponseAlternative53 | QueryResponseAlternative54 | QueryResponseAlternative55 | QueryResponseAlternative56 | QueryResponseAlternative58 | QueryResponseAlternative59 | QueryResponseAlternative60 | QueryResponseAlternative61 | QueryResponseAlternative63 | QueryResponseAlternative64 | QueryResponseAlternative65 | QueryResponseAlternative66 | QueryResponseAlternative67 | QueryResponseAlternative68 | QueryResponseAlternative69 | QueryResponseAlternative70 | QueryResponseAlternative71 | QueryResponseAlternative72 | QueryResponseAlternative74 | QueryResponseAlternative75 | QueryResponseAlternative76 | QueryResponseAlternative77 | QueryResponseAlternative78 | QueryResponseAlternative79 | QueryResponseAlternative80 | QueryResponseAlternative81 | QueryResponseAlternative82 | QueryResponseAlternative83 | QueryResponseAlternative84 | QueryResponseAlternative85 | QueryResponseAlternative86 | QueryResponseAlternative87 | QueryResponseAlternative88 | QueryResponseAlternative90 | QueryResponseAlternative91 | QueryResponseAlternative92 | QueryResponseAlternative93 | QueryResponseAlternative94 | QueryResponseAlternative95 | QueryResponseAlternative96 | QueryResponseAlternative97 | QueryResponseAlternative98 | QueryResponseAlternative99 | QueryResponseAlternative100 | QueryResponseAlternative101 | QueryResponseAlternative102 | QueryResponseAlternative103 | QueryResponseAlternative104 | QueryResponseAlternative105;
 
     export interface QueryStatusResponse {
       query_status: QueryStatus;
     }
 
     export interface QueryUpgradeRequest {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | MarketingAnalyticsTrendsQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
     }
 
     export interface QueryUpgradeResponse {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | MarketingAnalyticsTrendsQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | MCPToolStatsQuery | MCPToolDailyStatsQuery | MCPToolDescriptionsQuery | MCPToolSampleIntentsQuery | MCPToolNeighborsQuery | PropertyValuesQuery;
     }
 
     export interface QuotaResourceLimit {


### PR DESCRIPTION
## Problem

On the Marketing analytics page the overview "big number" and the chart below it disagreed badly: clicks read ~110k in the tile but summed to ~221k in the chart. Same for the other cost metrics.

Both surfaces read the same table (`marketing_costs_preaggregated`, a `ReplacingMergeTree` where `job_id` is in the sort key). A single cost cell (source / campaign / day) can exist as several rows under different `job_id`s: a re-materialization after TTL, a double-triggered job, or a compare-period window reuse. Reading it therefore requires de-duplication.

- The overview tile (`MarketingAnalyticsAggregatedQuery`) de-dupes correctly: `job_id IN (...)` + `argMax(metric, computed_at)` per cell.
- The chart was a raw `TrendsQuery` + `DataWarehouseNode` doing a bare `sum(clicks)` filtered only by `grain = 'campaign' AND expires_at > today()`. No `job_id` scoping, no `argMax`, so it summed every surviving job generation and double-counted.

I confirmed this against prod-EU (team 85299, June 2026): 707 rows across 354 cells (353 with exactly 2 job generations), raw `sum(clicks)` = 220,996 vs `argMax`-deduped = 110,548. The 220,996 matched the chart response exactly. Ratio 1.9991x.

The backend read got its dedup fix in #66582; the chart path (#62785) predates it and was never updated.

## Changes

A new backend query kind, `MarketingAnalyticsTrendsQuery`, that reuses the tile's de-duplicated read and reshapes it into a time series:

- Extracted `_resolve_precompute_cost_jobs` from `_build_costs_from_precompute` so the chart and the tile resolve the exact same job set (hence the same dedup), and added an `include_cost_date` flag to `_costs_native_read_query` so the per-cell day survives for bucketing.
- `MarketingAnalyticsTrendsQueryRunner` reads the deduped rows, buckets by `toStartOf{interval}`, breaks down by `source_name`, and returns Insights-style `GraphDataset` series.
- Frontend: a new `MarketingAnalyticsTrends` node renders those series via the shared quill trend charts (following the revenue-analytics precedent). The chart tile now emits the new query on the cost-precompute path; the legacy S3 path is unchanged.

Net effect: the chart total now reconciles with the overview big number.

Two deliberate, documented limitations on this path:
- Compare is not yet wired in (the runner ignores `compareFilter`); the overview tile still compares. Compare overlay for the chart is a fast-follow.
- Sources that can't be materialized (and fall back to the live S3 union in the tile) are omitted from the chart and logged, rather than silently dropped. In the common case all sources materialize.

## How did you test this code?

Automated only. I (Claude, agent-assisted) have not verified the live UI in a running app.

- New backend tests in `test_marketing_analytics_trends_query_runner.py` (7 total across this file + the existing precompute suite pass):
  - `test_trends_series_takes_latest_job_per_cell_not_sum` (parameterized over clicks/cost): inserts the same cell under two `job_id`s and asserts the bucketed series rolls up the latest `computed_at` value (150), not the sum (250). This is the regression that motivated the PR — no existing test covered the time-series aggregation on top of the deduped read, only the read in isolation.
  - `test_trends_buckets_by_interval_and_breaks_down_by_source`: asserts one series per source, each bucketed, not a single flattened total.
- Verified the base-runner refactor doesn't regress the existing `test_marketing_costs_precompute.py`.
- `ruff check`/`format` clean; `ci:preflight --strict` passed with 0 failures. Changed frontend files type-check clean (the broader `tsgo` run surfaces pre-existing kea-typegen staleness in unrelated logics — none in this diff).

Live verification still to do: load the Marketing analytics page with the `marketing-analytics-costs-precomputation` flag on and confirm the chart total matches the tile, across metrics and bar/line/area.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Xander directed this: it started as a "why do these two numbers disagree?" investigation from a live marketing dashboard, which I (Claude, via PostHog Code) traced to the chart's missing dedup, then implemented the fix.

Skills invoked while producing this PR: `/writing-tests` (gated the new tests), `/query-clickhouse-via-metabase` (quantified the duplication in prod-EU).

Design notes: I considered a de-duplicating ClickHouse view that the existing `DataWarehouseNode` could point at (smaller change, keeps compare/breakdown for free) but it can't reproduce the tile's `job_id`-set selection, so it lands ~0.1% off the tile. We chose the backend query kind for exact parity with the tile, accepting that compare and the bar/line/area formatting have to be reproduced on this path. Compare was scoped out of this first cut rather than shipped half-done.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
