### PR TITLE
perf(lazy-precompute): stop retrying builds that hit the read byte cap

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -311,6 +311,11 @@ NON_RETRYABLE_CLICKHOUSE_ERROR_CODES = {
     # Too many simultaneous queries means the cluster is overloaded.
     # Rather than adding to the load with retries, surface the error.
     202,  # TOO_MANY_SIMULTANEOUS_QUERIES
+    # The rows/bytes-to-read cap is deterministic for a given window: the data
+    # won't shrink between attempts, so an immediate retry re-scans the same
+    # terabytes only to fail the same way. Fail fast so the caller can fall
+    # back or narrow the window.
+    307,  # TOO_MANY_ROWS_OR_BYTES
     # An OOM won't succeed on an immediate retry with the same window — retrying just
     # adds memory pressure to a cluster that already signaled it's out of memory. Fail
     # fast so the caller can react (e.g. cap the team's window) and fall back.

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -2650,6 +2650,9 @@ class TestIsNonRetryableError(BaseTest):
             ("no_such_column", 16, "No such column"),
             ("timeout", 159, "Timeout exceeded"),
             ("too_many_queries", 202, "Too many simultaneous queries"),
+            # The read cap is deterministic for a given window: a retry re-scans
+            # the same data only to fail the same way.
+            ("too_many_rows_or_bytes", 307, "Limit for rows or bytes to read exceeded"),
             # An OOM won't succeed on an immediate retry — retrying just re-pressures the
             # cluster. Fail fast so the caller can react (e.g. cap the team's window).
             ("memory_limit", 241, "Memory limit exceeded"),


### PR DESCRIPTION
## Problem

ClickHouse has a safety limit on how much data a single query may read (error 307, `TOO_MANY_ROWS_OR_BYTES`). When a lazy computation build fails, the executor retries it once, on the theory that the failure might be transient (like a dropped connection).

For error 307 that theory is always wrong. The amount of data in a time window doesn't shrink between attempt one and attempt two, so the retry re-scans the same multi-terabyte range and fails the exact same way. Experiment precompute builds over long time windows hit this every day, and each one pays for the giant scan twice.

## Changes

Added 307 to `NON_RETRYABLE_CLICKHOUSE_ERROR_CODES`, the list of errors where the executor gives up immediately instead of retrying. It now sits next to 159 (timeout) and 241 (out of memory), which are already in the list for the same reason: retrying can't help. Builds that hit the read cap now fail once and fall back right away.

This doesn't fix the underlying problem (the build windows are too big, which we'll address separately by capping job width). It just stops burning cluster capacity on scans that are guaranteed to fail.

## How did you test this code?

Added a parameterized case to `TestIsNonRetryableError::test_clickhouse_non_retryable_error_codes` asserting 307 is detected as non-retryable and present in the set. It guards against 307 being dropped from the set, which would silently bring back the doubled scans. Fail-fast executor behavior for non-retryable codes is already covered by `test_non_retryable_error_exits_immediately`. Ran the full `test_lazy_computation_executor.py` file locally, 128 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. The lazy computation README does not enumerate individual error codes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while investigating recurring experiment precompute build failures on long-running experiments. We traced the doubled multi-TB scans in the query performance data to the retry loop treating 307 as transient. This is the first, smallest fix from that investigation. Bounding precompute job window width (via the existing `TtlSchedule.max_window_days`) is planned separately. Invoked the /writing-tests skill; per its gate the test is a single parameterized row on an existing case rather than a new test.