### PR TITLE
chore(cdp): deflake rerun e2e fetch-count assertions

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -375,7 +375,10 @@ describe('CDP hog invocation rerun e2e', () => {
         }, 30_000)
 
         // ── 6. The hog function's fetch was called twice — once original, once rerun ─
-        expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2)
+        // The wait above can pass on the paginator's running row, before the worker executes; poll for the fetch.
+        await waitForExpect(() => {
+            expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2)
+        }, 30_000)
     })
 
     it('reruns successfully when person rehydration misses and the input reads person.properties', async () => {
@@ -508,8 +511,13 @@ describe('CDP hog invocation rerun e2e', () => {
         // Pre-fix, the input eval crashed on `undefined.properties` and this
         // count stayed at 1 (just the original). Post-fix, it's 2 (original +
         // rerun), and the rerun's body carries `foo=from-event`.
+        // Job 'completed' only means the paginator finished re-enqueueing; the worker executes asynchronously, so poll.
+        await waitForExpect(() => {
+            expect(
+                mockFetch.mock.calls.filter(([url]) => String(url).startsWith(FALLBACK_WEBHOOK_URL)).length
+            ).toBeGreaterThanOrEqual(2)
+        }, 30_000)
         const ourCalls = mockFetch.mock.calls.filter(([url]) => String(url).startsWith(FALLBACK_WEBHOOK_URL))
-        expect(ourCalls.length).toBeGreaterThanOrEqual(2)
         const rerunBody = String((ourCalls[ourCalls.length - 1] as any)[1]?.body ?? '')
         expect(rerunBody).toContain('foo=from-event')
     })


### PR DESCRIPTION
## Problem

`src/cdp/rerun/rerun-e2e.test.ts › reruns successfully when person rehydration misses and the input reads person.properties` is flaky. Measured from run data: it failed two master Node.js CI runs this morning (28852040768, 28852944535) and passed others in the same shard (e.g. run 28869324826), always with the identical assertion (`expected >= 2 fetch calls, got 1`). It also blocked PR #68850 three consecutive times.

The test's last gate before asserting is the rerun's cyclotron wrapper job reaching `status = 'completed'`. That milestone means the paginator finished re-enqueueing the invocation onto the hog_function queue. The worker then consumes and executes it asynchronously, so the synchronous `mockFetch` count assertion races the consume-execute-fetch hop and loses on slow runners.

The file's first test has the same latent pattern: its `is_retry = 1` wait can be satisfied by the paginator's running row alone (its own comment says "either the paginator's running row, the worker's terminal row, or both"), which also lands before execution.

## Changes

Poll for the exact observable being asserted with `waitForExpect` in both tests, instead of asserting fetch counts synchronously after enqueue-level waits. Assertions are unchanged and strict; no timeouts were raised and no retries added. If the rerun genuinely never fires (the regression the test guards), the poll times out and fails with the same assertion.

## How did you test this code?

- Measured the flake from GitHub run data (interleaved pass/fail on master within the same shard, so flaky rather than deterministic).
- Validation is analytical: this e2e suite is not runnable in my local environment (the `posthog_test` ClickHouse Kafka consumers never deliver rows, so both tests fail at the first ClickHouse-dependent wait, a failure mode CI does not show). The fix is grounded in the test's own structure: the first test's ClickHouse-row wait pattern already demonstrates polling is the intended synchronization, and the racy assertions are the only unpolled ones in the file.
- Prettier, eslint, and tsc pass on the touched file. This draft PR's CI run exercises the suite for real.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke hit this flake three times on PR #68850 and asked me (Claude, via PostHog Code) to fix it as a separate PR. I diagnosed it with the debugging-ci-failures and fixing-flaky-tests skills: confirmed the flake from raw run data (not just the digest), verified the failing test passed in a green master run of the same shard, and root-caused the enqueue-vs-execute race from the test structure. I fixed the sibling test's identical latent pattern in the same change since it was mechanical. Local reproduction was attempted and abandoned: the local ClickHouse-Kafka bridge for the test database is broken in a way CI never shows, so validation is analytical and labeled as such above.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
