### PR TITLE
fix(hogvm): parse datetimes at millisecond precision to match node

### DIFF
--- a/rust/common/hogvm/src/stl.rs
+++ b/rust/common/hogvm/src/stl.rs
@@ -1614,9 +1614,13 @@ fn naive_to_seconds(naive: NaiveDateTime, zone: Option<&str>) -> Result<f64, VmE
     }
 }
 
-/// `f64` epoch seconds with sub-second precision, matching Python's `datetime.timestamp()`.
+/// `f64` epoch seconds at millisecond precision, matching the reference VM (luxon
+/// `DateTime.fromISO(...).toSeconds()`), which parses to milliseconds and truncates finer digits.
+/// The Node HogVM is the ingestion shadow baseline, so preserving microseconds (as Python's
+/// `datetime.timestamp()` does) surfaced as a `result_mismatch` on any sub-millisecond event
+/// timestamp — e.g. `toUnixTimestamp(toDateTime(event.timestamp))` in a "first seen" transform.
 fn datetime_to_seconds<Tz: TimeZone>(dt: DateTime<Tz>) -> f64 {
-    dt.timestamp() as f64 + f64::from(dt.timestamp_subsec_nanos()) / 1_000_000_000.0
+    dt.timestamp_millis() as f64 / 1000.0
 }
 
 // Extract every element as a Num and return them sorted ascending. Single allocation + early error,

--- a/rust/common/hogvm/tests/datetime_millis.rs
+++ b/rust/common/hogvm/tests/datetime_millis.rs
@@ -1,0 +1,42 @@
+//! `toDateTime`/`toUnixTimestamp` parse strings at millisecond precision, matching the reference
+//! VM (luxon `fromISO(...).toSeconds()`). Preserving microseconds — as Python's
+//! `datetime.timestamp()` does — made `toUnixTimestamp(toDateTime(event.timestamp))` diverge from
+//! the Node shadow on any sub-millisecond timestamp (the dominant EU `result_mismatch` bucket).
+
+use hogvm::{sync_execute, ExecutionContext, Program};
+use serde_json::{json, Value};
+
+const OP_CALL_GLOBAL: i64 = 2;
+const OP_STRING: i64 = 32;
+const OP_RETURN: i64 = 38;
+
+fn unix_ts(input: &str) -> Value {
+    let bc = vec![
+        json!("_H"),
+        json!(1),
+        json!(OP_STRING),
+        json!(input),
+        json!(OP_CALL_GLOBAL),
+        json!("toDateTime"),
+        json!(1),
+        json!(OP_CALL_GLOBAL),
+        json!("toUnixTimestamp"),
+        json!(1),
+        json!(OP_RETURN),
+    ];
+    let program = Program::new(bc).expect("valid program");
+    sync_execute(&ExecutionContext::with_defaults(program), false).expect("execution succeeds")
+}
+
+#[test]
+fn sub_millisecond_precision_is_truncated_to_millis() {
+    // Microseconds are dropped: `.123456` -> `.123`, matching luxon / JS `Date.parse`.
+    assert_eq!(
+        unix_ts("2026-07-07T12:00:00.123456Z"),
+        json!(1783425600.123)
+    );
+    // Millisecond input is preserved exactly.
+    assert_eq!(unix_ts("2026-07-07T12:00:00.123Z"), json!(1783425600.123));
+    // Whole seconds stay whole.
+    assert_eq!(unix_ts("2026-07-07T12:00:00Z"), json!(1783425600.0));
+}


### PR DESCRIPTION
## Problem

The Rust HogVM runs in shadow behind the Node HogVM on ingestion transformations. After #68665 landed, the dominant remaining `result_mismatch` bucket in EU (thousands per 2h) is a datetime precision difference. `toDateTime`/`toUnixTimestamp` parsed strings at microsecond precision (matching Python's `datetime.timestamp()`), but the Node shadow baseline uses luxon, which parses ISO strings to millisecond precision and truncates finer digits. On any sub-millisecond event timestamp, `toUnixTimestamp(toDateTime(event.timestamp))` — e.g. a "first seen" transform writing `$set_once.first_seen` — differed only in the trailing digits: Node wrote `…123`, Rust wrote `…123456`.

Reproduced end to end: microsecond input diverges (Rust `1783425600.123456` vs Node `1783425600.123`), while millisecond and whole-second inputs already matched. Once Rust replaces Node this would change the stored value for those fields, so aligning to the Node baseline is the correct behavior.

## Changes

- Truncate parsed datetimes to millisecond precision in `datetime_to_seconds` (via chrono `timestamp_millis()`), matching luxon `DateTime.fromISO(...).toSeconds()`.
- Whole-second and millisecond inputs are unchanged; only sub-millisecond digits are dropped.

## How did you test this code?

Automated tests added and run by the agent (I did not manually exercise production traffic):

- `tests/datetime_millis.rs` — `toUnixTimestamp(toDateTime('…123456Z'))` truncates to `…123`; millisecond and whole-second inputs are preserved.
- Ran locally: `cargo fmt`, `cargo clippy -p hogvm --all-targets --all-features -- -D warnings` (clean), and the full `hogvm` suite, including the `stl_parity`, `js_coercion`, and `datetime` parity guards (all whole-second datetime cases, so unaffected).

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, as a follow-up to #68665. The datetime bucket was originally treated as a deliberate Python-vs-luxon precision choice, but reproducing it in a local dual-VM check showed it is purely a millisecond-vs-microsecond parse difference on sub-second event timestamps. Rather than tolerate it in the shadow comparator, Rust now truncates to milliseconds to match the Node baseline directly.

This touches the shared `hogvm` crate, so it also affects `cymbal` and `cohort-stream-processor`; the change moves all consumers toward the production Node VM semantics.
