### PR TITLE
chore(billing): add real time alerts to scale and enterprise plan comparison table in storybook

### DIFF
--- a/frontend/src/mocks/fixtures/_billing_platform_addons.tsx
+++ b/frontend/src/mocks/fixtures/_billing_platform_addons.tsx
@@ -115,6 +115,12 @@ const highFrequencyAlerts = feature(
     'Run insight alerts as frequently as every 15 minutes.',
     { entitlement_only: true }
 )
+const realTimeAlerts = feature(
+    'real_time_alerts',
+    'Real time alerts',
+    'Run insight alerts in real time as events are ingested.',
+    { entitlement_only: true }
+)
 const prioritySupport = (note: string = 'Target response time 24 hours'): AddonPlanFeature =>
     feature(
         'priority_support',
@@ -217,6 +223,7 @@ const SCALE_FEATURES: AddonPlanFeature[] = [
     organizationSecuritySettings,
     sessionReplayDataRetention(12),
     highFrequencyAlerts,
+    realTimeAlerts,
 ]
 
 const ENTERPRISE_FEATURES: AddonPlanFeature[] = [
@@ -245,6 +252,7 @@ const ENTERPRISE_FEATURES: AddonPlanFeature[] = [
     saml,
     approvals,
     highFrequencyAlerts,
+    realTimeAlerts,
 ]
 
 type AddonSpec = {


### PR DESCRIPTION
## Problem

The billing plan comparison table on the billing overview page was missing the \"Real time alerts\" feature for Scale and Enterprise plans. This feature gates real-time alert intervals (as opposed to scheduled intervals) and the entitlement check in the alerts product already references it, but it wasn't surfaced in the plan comparison.

## Changes

Added `real_time_alerts` as a feature entry in the Scale and Enterprise plan fixtures used by the billing comparison table Storybook stories.

> **Note for reviewer:** This fixture file drives Storybook stories and test mocks only. The production billing comparison table pulls feature data from the external billing service. To surface this on the live billing page, the billing service's YAML plan config files for Scale and Enterprise also need to be updated (separate repo/deployment).

## How did you test this code?

Agent was not able to run the dev server to visually verify. The change follows the exact same pattern as the existing `highFrequencyAlerts` entry. The existing `BillingProductPlatformAddonsOnScale` and related stories will automatically reflect the new row when the "Compare all features" section is expanded.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (claude-sonnet-4-6). User asked to add real time alerts to the billing plan comparison table for scale plans and above.

Explored the billing comparison table data flow: the `PlatformAddonComparison` component reads features from the billing API response, and `_billing_platform_addons.tsx` is the fixture file that mirrors that data for Storybook/tests. Added the `realTimeAlerts` constant (key `real_time_alerts`, matching the existing `AvailableFeature.REAL_TIME_ALERTS` enum value) and added it to `SCALE_FEATURES` and `ENTERPRISE_FEATURES`. No new stories were needed since the existing platform addon stories already exercise the full comparison table.