### PR TITLE
fix(data-warehouse): validate LinkedIn Ads account ID is numeric at setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -138,6 +138,15 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
         if not config.account_id or not config.linkedin_ads_integration_id:
             return False, "Account ID and LinkedIn Ads integration are required"
 
+        # LinkedIn only accepts the numeric ad account ID. A free-text value (a profile URL, a
+        # name, stray whitespace) is otherwise accepted here and only fails on the first sync, so
+        # reject it up front with the same guidance the sync-time error gives.
+        if not config.account_id.isdigit():
+            return (
+                False,
+                "The LinkedIn Ads Account ID must be the numeric account ID from your LinkedIn Campaign Manager (digits only).",
+            )
+
         try:
             Integration.objects.get(id=config.linkedin_ads_integration_id, team_id=team_id)
             return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -55,6 +55,25 @@ class TestLinkedInAdsSource:
         assert error_message is not None
         assert "Account ID and LinkedIn Ads integration are required" in error_message
 
+    @pytest.mark.parametrize(
+        "invalid_account_id",
+        [
+            "Reed Lnkedin",
+            "https://www.linkedin.com/company/recruiteasy-ca",
+            " 789",
+            "789 ",
+            "acc-789",
+        ],
+    )
+    def test_validate_credentials_non_numeric_account_id(self, invalid_account_id):
+        invalid_config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=456, account_id=invalid_account_id)
+
+        is_valid, error_message = self.source.validate_credentials(invalid_config, self.team_id)
+
+        assert is_valid is False
+        assert error_message is not None
+        assert "numeric account ID" in error_message
+
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.source.Integration")
     def test_validate_credentials_integration_not_found(self, mock_integration_model):
         """Test credential validation when integration doesn't exist."""


### PR DESCRIPTION
## Problem

Session reviews of the data-warehouse new-source onboarding flow showed users getting stuck on the LinkedIn Ads connector: the connection appears to succeed, then every schema fails on the first sync with an error saying the account ID must be numeric. The Account ID is a free-text field, so a profile URL, a company name, or stray whitespace all sail past setup and only blow up later, forcing users to disconnect, re-add, and re-authorize while guessing at the real problem.

## Changes

`validate_credentials` for LinkedIn Ads now rejects a non-numeric account ID up front, with the same "must be the numeric account ID from your LinkedIn Campaign Manager (digits only)" guidance the sync-time error already surfaces. The check is `str.isdigit()`, so whitespace-padded values are caught too rather than being accepted and then failing at sync.

No sync behavior or schema changes: this only moves an existing failure earlier, to where the user can act on it.

## How did you test this code?

Added 5 parameterized cases to `test_validate_credentials_non_numeric_account_id` (a profile URL, a name, leading/trailing whitespace, a dashed value) asserting connect-time rejection. This guards the regression where a non-numeric account ID again passes setup validation and only fails on first sync, which no existing test covered (the existing tests cover empty ID and the sync-time non-retryable error classification, not connect-time numeric validation).

Ran the full `TestLinkedInAdsSource` suite locally with `uv run pytest` (24 passed). Did not test manually in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (via the PostHog Code agent) while triaging friction themes from Replay Vision scans of the data-warehouse onboarding flow. Invoked the `/writing-tests` skill to gate the added test. I confirmed this isn't a duplicate of the maintainer's in-flight ad-source work (the backend-driven account picker PR is a stale branch on old paths and doesn't touch LinkedIn's free-text account ID). Chose backend connect-time validation over client-side because the same `validate_credentials` path runs for both new sources and edits, and it mirrors the existing sync-time message rather than inventing new copy.
