### PR TITLE
fix(dashboards): warn before navigating away from unsaved layout edits

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -14,7 +14,8 @@ import {
     sharedListeners,
 } from 'kea'
 import { loaders } from 'kea-loaders'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { actionToUrl, beforeUnload, router, urlToAction } from 'kea-router'
+import { CombinedLocation } from 'kea-router/lib/utils'
 import uniqBy from 'lodash.uniqby'
 import { ResponsiveLayouts } from 'react-grid-layout'
 
@@ -3259,6 +3260,23 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     lemonToast.success('Tile filters saved')
                 },
             })
+        },
+    })),
+
+    beforeUnload(({ values, actions }) => ({
+        enabled: (newLocation?: CombinedLocation) => {
+            if (values.dashboardMode !== DashboardMode.Edit || !values.hasUnsavedLayoutChanges) {
+                return false
+            }
+            // Ignore in-page navigations such as opening a side panel
+            if (newLocation && newLocation.pathname === router.values.location.pathname) {
+                return false
+            }
+            return true
+        },
+        message: 'Leave dashboard?\nChanges you made to the layout will be discarded.',
+        onConfirm: () => {
+            actions.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
         },
     })),
 


### PR DESCRIPTION
## Problem

Editing a dashboard's layout and then navigating away (for example clicking a tile to edit its insight, then hitting back) silently discarded the layout edits. The in-progress tile positions live only in the dashboard reducer, and `dashboardLogic` unmounts on scene change, so the edits were gone with no prompt.

## Changes

Added a kea-router `beforeUnload` guard to `dashboardLogic`. It prompts when leaving a dashboard that is in edit mode with unsaved layout changes, covering both in-app (SPA) navigation and browser tab close/refresh. On confirm it restores the last-saved layout via the existing discard path. Ships unconditionally, this is accidental data loss rather than a deliberate action.

This uses the same `beforeUnload` mechanism as other scenes (feature flags, definitions, replay playlists), so it is the native browser confirm dialog. It is intentionally separate from the existing `dashboard-layout-discard-prompt` flagged LemonDialog, which only covers the explicit Cancel/Esc exit and cannot block tab close.

## How did you test this code?

Tested manually in local dev. Clicking cancel returns user to where they were, unsaved edits are preserved. Clicking ok moves the user on to the location they wanted to go to.

Opening side action bar does not prompt this change as it doesn't navigate away from the page.

<img width="1585" height="835" alt="image" src="https://github.com/user-attachments/assets/ff14da87-3aba-444b-8bcc-776450b1a16a" />

No manual testing by me (the agent). I ran the frontend typecheck and confirmed the new code is type-clean. No new automated test was added, following the existing convention in `featureFlagLogic.test.ts` of testing the dirty-state selector (`hasUnsavedLayoutChanges`, already covered) rather than the kea-router interceptor plumbing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) implemented this at Xander's direction. We traced the bug to `dashboardLogic` unmounting on navigation, discarding the layout held in the `dashboard.tiles` reducer. We considered caching the unsaved layout across navigation but rejected it as a larger feature (reconciliation with server changes, restore UX, invalidation) in favour of the established `beforeUnload` prompt. Xander confirmed it should ship unconditionally and chose the native `beforeUnload` mechanism over building a LemonDialog navigation interceptor.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
