### PR TITLE
perf(ci): make the E2E playwright schema cache hit reliably

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -86,6 +86,7 @@ env:
     # Schema cache epoch. Bump to abandon every shared schema cache entry at once
     # (key is posthog-schema-mig-<epoch>-<hash>). Single-sourced so the merge-base (PR)
     # and HEAD (push) key computations below can't drift.
+    # ci-e2e-playwright.yml restores by the same key — keep its copy in sync when bumping.
     SCHEMA_CACHE_EPOCH: v1
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -32,6 +32,7 @@ env:
     # Schema cache epoch. Bump to abandon every shared schema cache entry at once
     # (key is posthog-schema-mig-<epoch>-<hash>). Single-sourced so it can't drift
     # between the merge-base (PR) and HEAD (push) key computations below.
+    # ci-e2e-playwright.yml restores by the same key — keep its copy in sync when bumping.
     SCHEMA_CACHE_EPOCH: v1
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -92,6 +92,7 @@ jobs:
             shouldRun: ${{ steps.decide.outputs.shouldRun }}
             oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
             schema_cache_key: ${{ steps.schema-key.outputs.key }}
+            schema_migrations_key: ${{ steps.schema-key.outputs.migrations_key }}
         steps:
             # fetch-depth=1000 + blob:none mirrors ci-backend / ci-dagster so HEAD^2
             # (PR branch tip) is reachable for the merge-base step below without the
@@ -102,13 +103,15 @@ jobs:
             # and the per-blob credential lookup intermittently fails with "could not
             # read Username for github.com" (e.g. #59779 on 2026-05-23, blocked merge
             # until the job was retried). Materializing only the one file this job
-            # reads collapses the lazy fetch to a single blob.
+            # reads collapses the lazy fetch to a handful of blobs.
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 1000
                   filter: blob:none
                   clean: false
-                  sparse-checkout: .github/clickhouse-versions.json
+                  sparse-checkout: |
+                      .github/clickhouse-versions.json
+                      docker-compose.base.yml
                   sparse-checkout-cone-mode: false
 
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -210,19 +213,54 @@ jobs:
               # remote.origin.fetch and pull every branch.
               run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
-            - name: Compute schema cache key from merge-base
+            - name: Compute schema cache keys
               id: schema-key
-              if: steps.decide.outputs.shouldRun == 'true' && github.event_name == 'pull_request'
+              if: steps.decide.outputs.shouldRun == 'true'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  EVENT_BEFORE: ${{ github.event.before }}
+                  # Manual cache-bust knob — keep in sync with SCHEMA_CACHE_EPOCH in
+                  # ci-backend.yml, which saves these caches on master pushes.
+                  SCHEMA_CACHE_EPOCH: v1
               run: |
-                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
-                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  if [ -n "$MERGE_BASE" ]; then
-                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                  if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      SCHEMA_REF=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      if [ -z "$SCHEMA_REF" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                          exit 0
+                      fi
+                      echo "key=posthog-schema-master-${SCHEMA_REF}" >> $GITHUB_OUTPUT
                   else
-                      echo "key=" >> $GITHUB_OUTPUT
-                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                      # push / workflow_dispatch: key the schema off HEAD's migration set,
+                      # falling back to the previous master tip's SHA key (saved by that
+                      # push's ci-backend run).
+                      SCHEMA_REF=HEAD
+                      zero=0000000000000000000000000000000000000000
+                      if [ -n "$EVENT_BEFORE" ] && [ "$EVENT_BEFORE" != "$zero" ]; then
+                          echo "key=posthog-schema-master-${EVENT_BEFORE}" >> $GITHUB_OUTPUT
+                      else
+                          echo "key=" >> $GITHUB_OUTPUT
+                      fi
+                  fi
+                  # Shared migration-set key: mirrors the save-side computation in
+                  # ci-backend.yml (same inputs, hash, and prefix) so it hits whenever
+                  # master's migration files are unchanged — far more stable than the
+                  # per-SHA key, which needs the exact commit's cache to still be alive.
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$SCHEMA_REF" \
+                      | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
+                      | grep -vE '/(clickhouse|async_migrations)/migrations/' \
+                      | LC_ALL=C sort) || true
+                  PG_IMAGE=$(git show "${SCHEMA_REF}:docker-compose.base.yml" 2>/dev/null \
+                      | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
+                  if [ -z "$MIG_FILES" ]; then
+                      echo "migrations_key=" >> $GITHUB_OUTPUT
+                      echo "::notice::no migration files matched — restore will fall back to the SHA schema key"
+                  else
+                      MIG_HASH=$(printf '%s\n%s' "$MIG_FILES" "$PG_IMAGE" | sha256sum | cut -c1-40)
+                      echo "migrations_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-${MIG_HASH}" >> $GITHUB_OUTPUT
                   fi
 
     playwright:
@@ -457,29 +495,40 @@ jobs:
               uses: ./.github/actions/setup-sqlx-cli
 
             - name: Restore schema cache from master
-              # Cache key is the merge-base SHA — produced by ci-backend on master push.
-              # Cache miss falls through to a full migrate below.
-              if: github.event_name == 'pull_request' && needs.changes.outputs.schema_cache_key != ''
+              # Both keys are produced by ci-backend on master push. Prefer the shared
+              # migration-set key (stable while master's migration files are unchanged);
+              # fall back to the exact SHA key (merge-base for PRs, previous master tip
+              # for pushes). Cache miss falls through to a full migrate below.
+              if: needs.changes.outputs.schema_migrations_key != '' || needs.changes.outputs.schema_cache_key != ''
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               id: schema-cache
               with:
                   path: schema.sql.gz
-                  key: ${{ needs.changes.outputs.schema_cache_key }}
+                  key: ${{ needs.changes.outputs.schema_migrations_key || needs.changes.outputs.schema_cache_key }}
+                  restore-keys: |
+                      ${{ needs.changes.outputs.schema_cache_key }}
 
             - name: Prime posthog_e2e_test from cached schema
               # Schema dump is from master's `posthog` db but schemas are db-name agnostic.
               # Hogli's db:restore-schema-fresh DROPs+CREATEs the target db, restores the
               # schema, and runs ensure_migration_defaults to seed RunPython data that's
               # missing from a schema-only dump. The migrate step below still runs and
-              # layers any PR-added migrations on top — the cache just skips the bulk of
-              # the historical migration work.
-              if: steps.schema-cache.outputs.cache-hit == 'true'
+              # layers any newer migrations on top — the cache just skips the bulk of
+              # the historical migration work. Treat cache/restore problems as misses:
+              # restore-schema-fresh leaves a fresh empty db on failure, so the migrate
+              # step below runs the full history.
               env:
                   TARGET_DB: posthog_e2e_test
               run: |
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss — the migrate step below runs the full history"
+                      exit 0
+                  fi
                   mkdir -p .postgres-backups
                   mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
-                  ./bin/hogli db:restore-schema-fresh
+                  if ! ./bin/hogli db:restore-schema-fresh; then
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?) — the migrate step below runs the full history"
+                  fi
 
             - name: Apply postgres and clickhouse migrations and setup dev
               run: |

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -215,45 +215,35 @@ jobs:
 
             - name: Compute schema cache keys
               id: schema-key
-              if: steps.decide.outputs.shouldRun == 'true'
+              # PRs only: master pushes deliberately skip the schema cache and run the
+              # full migration history, so the canonical run never relies on this
+              # optimization.
+              if: steps.decide.outputs.shouldRun == 'true' && github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-                  EVENT_BEFORE: ${{ github.event.before }}
                   # Manual cache-bust knob — keep in sync with SCHEMA_CACHE_EPOCH in
                   # ci-backend.yml, which saves these caches on master pushes.
                   SCHEMA_CACHE_EPOCH: v1
               run: |
-                  if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
-                      SCHEMA_REF=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                      if [ -z "$SCHEMA_REF" ]; then
-                          echo "key=" >> $GITHUB_OUTPUT
-                          echo "migrations_key=" >> $GITHUB_OUTPUT
-                          echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
-                          exit 0
-                      fi
-                      echo "key=posthog-schema-master-${SCHEMA_REF}" >> $GITHUB_OUTPUT
-                  else
-                      # push / workflow_dispatch: key the schema off HEAD's migration set,
-                      # falling back to the previous master tip's SHA key (saved by that
-                      # push's ci-backend run).
-                      SCHEMA_REF=HEAD
-                      zero=0000000000000000000000000000000000000000
-                      if [ -n "$EVENT_BEFORE" ] && [ "$EVENT_BEFORE" != "$zero" ]; then
-                          echo "key=posthog-schema-master-${EVENT_BEFORE}" >> $GITHUB_OUTPUT
-                      else
-                          echo "key=" >> $GITHUB_OUTPUT
-                      fi
+                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                  if [ -z "$MERGE_BASE" ]; then
+                      echo "key=" >> $GITHUB_OUTPUT
+                      echo "migrations_key=" >> $GITHUB_OUTPUT
+                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                      exit 0
                   fi
+                  echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
                   # Shared migration-set key: mirrors the save-side computation in
                   # ci-backend.yml (same inputs, hash, and prefix) so it hits whenever
-                  # master's migration files are unchanged — far more stable than the
-                  # per-SHA key, which needs the exact commit's cache to still be alive.
-                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$SCHEMA_REF" \
+                  # the merge-base's migration files match a saved master schema — far
+                  # more stable than the per-SHA key, which needs the exact merge-base
+                  # commit's cache to still be alive.
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" \
                       | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
                       | grep -vE '/(clickhouse|async_migrations)/migrations/' \
                       | LC_ALL=C sort) || true
-                  PG_IMAGE=$(git show "${SCHEMA_REF}:docker-compose.base.yml" 2>/dev/null \
+                  PG_IMAGE=$(git show "${MERGE_BASE}:docker-compose.base.yml" 2>/dev/null \
                       | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
                   if [ -z "$MIG_FILES" ]; then
                       echo "migrations_key=" >> $GITHUB_OUTPUT
@@ -495,11 +485,12 @@ jobs:
               uses: ./.github/actions/setup-sqlx-cli
 
             - name: Restore schema cache from master
+              # PRs only — master pushes run the full migration history on purpose.
               # Both keys are produced by ci-backend on master push. Prefer the shared
               # migration-set key (stable while master's migration files are unchanged);
-              # fall back to the exact SHA key (merge-base for PRs, previous master tip
-              # for pushes). Cache miss falls through to a full migrate below.
-              if: needs.changes.outputs.schema_migrations_key != '' || needs.changes.outputs.schema_cache_key != ''
+              # fall back to the exact merge-base SHA key. Cache miss falls through to
+              # a full migrate below.
+              if: github.event_name == 'pull_request' && (needs.changes.outputs.schema_migrations_key != '' || needs.changes.outputs.schema_cache_key != '')
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               id: schema-cache
               with:
@@ -517,6 +508,7 @@ jobs:
               # the historical migration work. Treat cache/restore problems as misses:
               # restore-schema-fresh leaves a fresh empty db on failure, so the migrate
               # step below runs the full history.
+              if: github.event_name == 'pull_request'
               env:
                   TARGET_DB: posthog_e2e_test
               run: |


### PR DESCRIPTION
## Problem

In the E2E CI Playwright workflow, the step "Apply postgres and clickhouse migrations and setup dev" takes ~14 minutes whenever the schema cache misses. Breaking down a recent run's logs: ~13 of those minutes are the full Django Postgres migration history, ClickHouse migrations take ~40s, and setup_dev ~25s.

The workflow already has a schema cache meant to skip the Postgres migration history on PRs, but it misses a lot: PR runs restore only by the exact merge-base SHA key (`posthog-schema-master-<sha>`). That's a one-shot key that is frequently evicted or not yet saved, so roughly half of recent PR runs missed (step time ~10 min on miss vs ~1.3 min on hit).

ci-backend already solved this with a content-addressed migration-set key (`posthog-schema-mig-<epoch>-<hash>` over the migration file blobs + uv.lock + postgres image), which stays stable while master's migration files are unchanged and is kept warm by every ci-backend PR run. This workflow never adopted it.

Master pushes keep running the full migration history on purpose — the canonical run should not rely on this optimization, and this PR now documents that explicitly.

## Changes

- The `changes` job now computes both keys for PRs: the shared migration-set key (mirroring ci-backend's save-side computation exactly, from the merge-base) and the exact merge-base SHA key as fallback.
- The restore step prefers the migration-set key with the SHA key as `restore-keys` fallback. Still PR-only, with a comment stating master pushes skip the cache deliberately.
- The prime step keys off the restored file instead of the exact `cache-hit` flag (fallback restores set `cache-hit=false` but still deliver the file), and treats a failed restore as a miss. `hogli db:restore-schema-fresh` recreates an empty db on failure, so the migrate step below safely falls back to the full history.
- Added `docker-compose.base.yml` to the sparse checkout so the key computation doesn't rely on a lazy blob fetch (the flake called out in the existing checkout comment).
- Noted in ci-backend.yml (and its depot shadow) that the `SCHEMA_CACHE_EPOCH` bump knob now has a consumer to keep in sync.

Expected effect: PR miss rate drops to near zero since the migration-set key survives cache eviction far better than per-SHA keys — about 10 minutes saved per previously-missing PR run.

## How did you test this code?

- Ran the mirrored key computation locally against the current master tip: it produces `posthog-schema-mig-v1-2a4afdf3...`, byte-identical to the key ci-backend's latest master-push run computed on the save side (from that run's logs), and that run's save was rejected with "another job may be creating this cache", confirming the key already exists in the cache backend, so the new restore path hits immediately.
- Validated both workflow files parse as YAML and ran `hogli ci:preflight --fix`.
- The E2E Playwright run on this PR exercises the changed restore path directly (this workflow file is in its own path filter).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-internal change only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) directed by @mariusandra. The agent pulled per-step timings and raw logs from recent workflow runs to attribute the 14 minutes (full Postgres migrate on PR cache misses), found ci-backend's existing two-tier schema cache convention, and mirrored it here rather than inventing a new caching scheme. Two decisions shaped the final state: a loose prefix `restore-keys` fallback (`posthog-schema-mig-v1-`) was rejected because it could restore a schema from a newer master containing migrations this checkout doesn't have, so only exact keys are used, matching ci-backend; and an initial version that also restored the cache on master pushes was reverted after review feedback — the canonical master run should keep exercising the full migration history. No skills were invoked (no matching skill for workflow-only changes).
