### PR TITLE
feat(posthog_ai): add staff toggle for run thread debug logs

### DIFF
--- a/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
@@ -1,0 +1,61 @@
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { initKeaTests } from '~/test/init'
+import type { UserType } from '~/types'
+
+import { debugLogsLogic } from './debugLogsLogic'
+
+describe('debugLogsLogic', () => {
+    let logic: ReturnType<typeof debugLogsLogic.build>
+
+    function setup({ user, isDev }: { user: Partial<UserType>; isDev: boolean }): void {
+        userLogic.mount()
+        userLogic.actions.loadUserSuccess({
+            ...MOCK_DEFAULT_USER,
+            is_staff: false,
+            is_impersonated: false,
+            ...user,
+        } as UserType)
+        preflightLogic.mount()
+        preflightLogic.actions.loadPreflightSuccess({ is_debug: isDev } as any)
+        logic = debugLogsLogic()
+        logic.mount()
+    }
+
+    beforeEach(() => {
+        localStorage.clear()
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('defaults to showing debug logs for staff with no stored preference', () => {
+        setup({ user: { is_staff: true }, isDev: false })
+        expect(logic.values.debugLogsEnabled).toBe(true)
+        expect(logic.values.showDebugLogs).toBe(true)
+    })
+
+    it.each([
+        { name: 'staff, toggle on', user: { is_staff: true }, isDev: false, enabled: true, expected: true },
+        { name: 'staff, toggle off', user: { is_staff: true }, isDev: false, enabled: false, expected: false },
+        { name: 'local dev, toggle on', user: {}, isDev: true, enabled: true, expected: true },
+        { name: 'local dev, toggle off', user: {}, isDev: true, enabled: false, expected: false },
+        {
+            name: 'impersonation overrides toggle off',
+            user: { is_impersonated: true },
+            isDev: false,
+            enabled: false,
+            expected: true,
+        },
+        { name: 'non-staff, non-dev never sees', user: {}, isDev: false, enabled: true, expected: false },
+    ])('showDebugLogs — $name', ({ user, isDev, enabled, expected }) => {
+        setup({ user, isDev })
+        logic.actions.setDebugLogsEnabled(enabled)
+        expect(logic.values.showDebugLogs).toBe(expected)
+    })
+})

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
@@ -40,6 +40,13 @@ describe('debugLogsLogic', () => {
         expect(logic.values.showDebugLogs).toBe(true)
     })
 
+    it('offers no toggle to a staff user who is also impersonating, but still forces logs on', () => {
+        // The toggle would be a no-op during impersonation (logs are force-shown), so it must not render.
+        setup({ user: { is_staff: true, is_impersonated: true }, isDev: false })
+        expect(logic.values.canControlDebugLogs).toBe(false)
+        expect(logic.values.showDebugLogs).toBe(true)
+    })
+
     it.each([
         { name: 'staff, toggle on', user: { is_staff: true }, isDev: false, enabled: true, expected: true },
         { name: 'staff, toggle off', user: { is_staff: true }, isDev: false, enabled: false, expected: false },

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.ts
@@ -1,0 +1,47 @@
+import { actions, connect, kea, path, reducers, selectors } from 'kea'
+
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import type { debugLogsLogicType } from './debugLogsLogicType'
+
+/**
+ * Staff-only preference for whether `_posthog/console` debug rows surface in the run thread. Persisted
+ * to localStorage and shared across every run surface (singleton, unkeyed), enabled by default. An
+ * impersonated session always forces debug logs on, independent of the persisted toggle, so an engineer
+ * debugging a customer's session never has them silently hidden.
+ */
+export const debugLogsLogic = kea<debugLogsLogicType>([
+    path(['products', 'posthog_ai', 'frontend', 'logics', 'debugLogsLogic']),
+    connect(() => ({
+        values: [userLogic, ['user'], preflightLogic, ['isDev']],
+    })),
+    actions({
+        setDebugLogsEnabled: (enabled: boolean) => ({ enabled }),
+    }),
+    reducers({
+        debugLogsEnabled: [
+            true,
+            { persist: true, storageKey: 'posthog_ai.debugLogsEnabled' },
+            {
+                setDebugLogsEnabled: (_, { enabled }) => enabled,
+            },
+        ],
+    }),
+    selectors({
+        /** Who may see and toggle debug logs at all: staff or local dev. Impersonation force-shows them. */
+        canControlDebugLogs: [
+            (s) => [s.user, s.isDev],
+            (user, isDev): boolean => !!user?.is_staff || !!isDev,
+        ],
+        /**
+         * Whether debug rows should actually render. Impersonation always shows them; otherwise staff/dev
+         * see them subject to the persisted toggle (on by default); everyone else never does.
+         */
+        showDebugLogs: [
+            (s) => [s.user, s.canControlDebugLogs, s.debugLogsEnabled],
+            (user, canControlDebugLogs, debugLogsEnabled): boolean =>
+                !!user?.is_impersonated || (canControlDebugLogs && debugLogsEnabled),
+        ],
+    }),
+])

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.ts
@@ -29,10 +29,14 @@ export const debugLogsLogic = kea<debugLogsLogicType>([
         ],
     }),
     selectors({
-        /** Who may see and toggle debug logs at all: staff or local dev. Impersonation force-shows them. */
+        /**
+         * Who may see and toggle debug logs: staff or local dev, but never an impersonated session.
+         * Impersonation force-shows debug logs unconditionally (see `showDebugLogs`), so surfacing a
+         * toggle there would be a no-op that contradicts that invariant — exclude it here instead.
+         */
         canControlDebugLogs: [
             (s) => [s.user, s.isDev],
-            (user, isDev): boolean => !!user?.is_staff || !!isDev,
+            (user, isDev): boolean => !user?.is_impersonated && (!!user?.is_staff || !!isDev),
         ],
         /**
          * Whether debug rows should actually render. Impersonation always shows them; otherwise staff/dev

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -48,6 +48,7 @@ import {
     isSessionUpdateUserMessage,
     isTaskRunStateFrame,
 } from '../types/wireTypes'
+import { debugLogsLogic } from './debugLogsLogic'
 import type { runStreamLogicType } from './runStreamLogicType'
 
 export type RunSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
@@ -1185,7 +1186,7 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
  * Whether a folded item renders any content. Empty priming thoughts and step-less progress rows fold
  * into the thread but render nothing; drop them here so a virtualized consumer never reserves an empty,
  * gap-padded row. Tool items are always paired with an invocation (see `upsertInvocationItem`), and
- * `debug` rows are gated separately by `showDebugItems`, so neither needs a content check here.
+ * `debug` rows are gated separately by `showDebugLogs`, so neither needs a content check here.
  */
 function rendersThreadItemContent(item: ThreadItem): boolean {
     switch (item.type) {
@@ -1229,6 +1230,8 @@ export const runStreamLogic = kea<runStreamLogicType>([
             ['isDev'],
             userLogic,
             ['user'],
+            debugLogsLogic,
+            ['showDebugLogs'],
         ],
     })),
     actions({
@@ -1663,23 +1666,16 @@ export const runStreamLogic = kea<runStreamLogicType>([
             (s) => [s.log, s.isBootstrapResumeRun],
             (log, isResumeRun): FoldedThread => foldLogToThread(log.entries, { isResumeRun }),
         ],
-        /**
-         * Whether `_posthog/console` debug rows should surface in the thread. Derived from the current
-         * user's staff/impersonation flag and dev environment, so debug items are filtered out of
-         * `threadItems` for non-privileged users — never reaching the virtualizer.
-         */
-        showDebugItems: [
-            (s) => [s.user, s.isDev],
-            (user, isDev): boolean => !!user?.is_staff || !!user?.is_impersonated || !!isDev,
-        ],
         threadItems: [
-            (s) => [s.foldedThread, s.showDebugItems],
-            (foldedThread, showDebugItems): ThreadItem[] =>
+            (s) => [s.foldedThread, s.showDebugLogs],
+            (foldedThread, showDebugLogs): ThreadItem[] =>
                 // Filtering lives here, not in the renderer: a row the renderer would return `null` for
                 // (a content-less item, or a debug row a non-privileged user can't see) still reserves an
                 // empty, gap-padded slot in the virtualized thread. Drop them before they become rows.
+                // Debug rows are gated by `debugLogsLogic.showDebugLogs` (staff/dev toggle, force-on when
+                // impersonating).
                 foldedThread.threadItems.filter(
-                    (item: ThreadItem) => (item.type !== 'debug' || showDebugItems) && rendersThreadItemContent(item)
+                    (item: ThreadItem) => (item.type !== 'debug' || showDebugLogs) && rendersThreadItemContent(item)
                 ),
         ],
         toolInvocations: [

--- a/products/posthog_ai/frontend/messages/DebugMessage.tsx
+++ b/products/posthog_ai/frontend/messages/DebugMessage.tsx
@@ -17,8 +17,10 @@ const LEVEL_STYLES: Record<string, string> = {
 }
 
 /**
- * Staff-only inline console line rendered from `_posthog/console` wire frames. Not a chat bubble —
- * a muted, monospace debug row visually distinct from assistant failures (`AssistantFailureMessage`).
+ * Inline console line rendered from `_posthog/console` wire frames. Not a chat bubble — a muted,
+ * monospace debug row visually distinct from assistant failures (`AssistantFailureMessage`). Whether
+ * these rows surface at all is gated upstream by `debugLogsLogic.showDebugLogs` (staff/dev toggle,
+ * always on when impersonating).
  */
 export const DebugMessage = memo(function DebugMessage({ text, level }: DebugMessageProps): JSX.Element {
     const levelStyle = LEVEL_STYLES[level] ?? LEVEL_STYLES.info

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDebugLogsMenu.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDebugLogsMenu.tsx
@@ -1,0 +1,31 @@
+import { useActions, useValues } from 'kea'
+
+import { SceneMenuBarCheckboxItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
+
+import { debugLogsLogic } from '../../../logics/debugLogsLogic'
+
+/**
+ * Staff-only menu exposing the debug-logs toggle for the run thread. Renders nothing unless the current
+ * user may control debug logs (staff or local dev) — impersonated sessions force debug logs on and have
+ * no toggle. The checkmark reflects the persisted (localStorage) preference, on by default.
+ */
+export function TaskDebugLogsMenu(): JSX.Element | null {
+    const { canControlDebugLogs, debugLogsEnabled } = useValues(debugLogsLogic)
+    const { setDebugLogsEnabled } = useActions(debugLogsLogic)
+
+    if (!canControlDebugLogs) {
+        return null
+    }
+
+    return (
+        <SceneMenuBarMenu label="Staff only" dataAttr="task-menubar-staff">
+            <SceneMenuBarCheckboxItem
+                checked={debugLogsEnabled}
+                onCheckedChange={(checked) => setDebugLogsEnabled(!!checked)}
+                data-attr="task-menubar-show-debug-logs"
+            >
+                Show debug logs
+            </SceneMenuBarCheckboxItem>
+        </SceneMenuBarMenu>
+    )
+}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunSceneShell.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunSceneShell.tsx
@@ -24,8 +24,8 @@ import {
 } from '~/layout/scenes/SceneLayout'
 
 import { Task, TaskRun } from '../../../types/taskTypes'
-import { TaskPanelSkeleton, TaskRunMetadataSkeleton } from './taskDetailSkeletons'
 import { TaskDebugLogsMenu } from './TaskDebugLogsMenu'
+import { TaskPanelSkeleton, TaskRunMetadataSkeleton } from './taskDetailSkeletons'
 import { TaskErrorBanner } from './TaskErrorBanner'
 import { TaskRunMetadata } from './TaskRunMetadata'
 

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunSceneShell.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunSceneShell.tsx
@@ -25,6 +25,7 @@ import {
 
 import { Task, TaskRun } from '../../../types/taskTypes'
 import { TaskPanelSkeleton, TaskRunMetadataSkeleton } from './taskDetailSkeletons'
+import { TaskDebugLogsMenu } from './TaskDebugLogsMenu'
 import { TaskErrorBanner } from './TaskErrorBanner'
 import { TaskRunMetadata } from './TaskRunMetadata'
 
@@ -77,6 +78,7 @@ export function TaskRunSceneShell({
                             Archive task
                         </SceneMenuBarItem>
                     </SceneMenuBarMenu>
+                    <TaskDebugLogsMenu />
                 </SceneMenuBar>
             )}
             <ScenePanel>


### PR DESCRIPTION
## Problem

The PostHog AI run thread renders `_posthog/console` debug rows inline. Today they show for any staff member, impersonated session, or local dev, with no way to turn them off. Staff who don't want the console noise in a thread have no control over it.

## Changes

Add a localStorage-backed setting that controls whether debug logs render, enabled by default.

- New singleton `debugLogsLogic` owns the setting: a persisted `debugLogsEnabled` reducer (default on, key `posthog_ai.debugLogsEnabled`), a `canControlDebugLogs` selector (`is_staff || isDev`), and a `showDebugLogs` gate. The gate force-shows logs during impersonation regardless of the toggle, so an engineer debugging a customer's session never has them silently hidden.
- `runStreamLogic` gates debug items on `debugLogsLogic.showDebugLogs`, replacing its old inline staff/impersonation check (nothing else referenced it).
- A `Staff only` menu with a `Show debug logs` checkbox is added to the task run scene menu bar (`TaskRunSceneShell`). It renders only for users who can control debug logs, so non-staff never see it, and impersonated sessions (logs already forced on) get no redundant toggle.

The setting is global (a localStorage singleton), so flipping it in the task run menu bar affects debug visibility everywhere `runStreamLogic` is consumed.

## How did you test this code?

Added `debugLogsLogic.test.ts`, a kea logic test covering the requested invariants that had no prior coverage: default-on for staff, staff toggle hides logs, dev toggle, **impersonation overrides a disabled toggle**, and non-staff/non-dev never see logs.

I (Claude) could not run the toolchain in this environment (no `node_modules`/`hogli`), so typegen, typecheck, lint, and Jest were not run locally. The generated `*LogicType.ts` files are gitignored and regenerated in CI, which also runs typecheck, lint, and the new test. No manual UI testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) via PostHog Code, directed by the assignee.

- Skills invoked: `/scene-menu-bar` (to place the toggle in the canonical `Staff only` menu with a stable-label checkbox item) and `/writing-tests` (to gate the test on a named regression).
- Placement decision: the toggle went into the `SceneMenuBar` of `TaskRunSceneShell` at the DRI's direction, rather than an inline thread control. The setting itself was kept global in a dedicated singleton logic rather than per-run state, so it behaves like a persistent preference across surfaces.
- The impersonation-override was implemented as an unconditional short-circuit in `showDebugLogs`, keeping it independent of the persisted toggle.
