### PR TITLE
fix(endpoints): stop bucket-override re-enable test needing local temporal

### DIFF
--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1399,17 +1399,19 @@ class TestMaterializationPreview(ClickhouseTestMixin, APIBaseTest):
             {"is_materialized": True, "bucket_overrides": {"timestamp": "hour"}},
             format="json",
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == status.HTTP_200_OK, response.json()
         version = EndpointVersion.objects.get(endpoint__name="clear-bucket", endpoint__team=self.team, version=1)
         assert version.bucket_overrides == {"timestamp": "hour"}
 
-        # Disable materialization
-        response = self.client.patch(
-            f"/api/environments/{self.team.id}/endpoints/clear-bucket/",
-            {"is_materialized": False},
-            format="json",
-        )
-        assert response.status_code == status.HTTP_200_OK
+        # Disabling reverts the saved query, whose schedule teardown talks to Temporal —
+        # mock the facade call so the test doesn't require a running Temporal dev server.
+        with mock.patch("products.data_warehouse.backend.facade.api.delete_saved_query_schedule"):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/endpoints/clear-bucket/",
+                {"is_materialized": False},
+                format="json",
+            )
+        assert response.status_code == status.HTTP_200_OK, response.json()
 
         # Re-enable without bucket_overrides
         response = self.client.patch(
@@ -1417,7 +1419,7 @@ class TestMaterializationPreview(ClickhouseTestMixin, APIBaseTest):
             {"is_materialized": True},
             format="json",
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == status.HTTP_200_OK, response.json()
         version.refresh_from_db()
         assert version.bucket_overrides is None
 


### PR DESCRIPTION
## Problem

`TestMaterializationPreview::test_reenable_materialization_without_bucket_overrides_clears_old_value` fails with `ConnectionRefused (127.0.0.1:7233)` whenever no local Temporal dev server is running: the disable-materialization PATCH reverts the saved query, whose schedule teardown calls Temporal through the data-warehouse facade (`delete_saved_query_schedule`). The failure surfaces as an opaque 400 ("Failed to update endpoint.") because the update service wraps unexpected exceptions.

## Changes

- Mock `products.data_warehouse.backend.facade.api.delete_saved_query_schedule` around the disable step, so the test no longer depends on a running Temporal server.
- Add `response.json()` messages to the bare status-code asserts in this test, so the next failure shows the actual error body instead of `assert 400 == 200`.

## How did you test this code?

- Agent-authored. `pytest products/endpoints/backend/tests/test_endpoint.py::TestMaterializationPreview::test_reenable_materialization_without_bucket_overrides_clears_old_value` passes locally **without** a Temporal dev server (previously failed), and the mock target matches the call-time import in `revert_materialization`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while running the endpoints suite for an unrelated stack; the test only ever passed locally when `./bin/start` happened to be up.
