### PR TITLE
feat(alerts): extract shared calendar scheduling (quiet hours, intervals, weekend skip) (6/7)

### DIFF
--- a/.agents/skills/adopting-shared-alerting/SKILL.md
+++ b/.agents/skills/adopting-shared-alerting/SKILL.md
@@ -63,8 +63,16 @@ Grid-cadence scheduling math (used by logs; billing will use it too):
 - `advance_next_check_at(...)` — next check time on a fixed cadence grid.
 - `compute_shard_offset_seconds(...)` — spreads checks across a window so they don't stampede.
 
+## Layer 1 — `common/alerting/calendar.py`
+
+Calendar-anchored scheduling math (used by insight alerts):
+
+- `CalendarInterval` + `next_calendar_check_time(...)` — anchors checks to local instants (daily 1am, weekly Monday 3am, monthly 1st 4am) in the team timezone; sub-daily intervals advance from the prior check.
+- `is_weekend(now, tz_name)` — weekend-skip predicate in local time.
+- Quiet hours: window validation (`validate_and_normalize_schedule_restriction`), minute math (`is_local_minute_blocked`, `is_utc_datetime_blocked`), and `scan_next_unblocked_utc(...)` which snaps a candidate past blocked windows (returns None at the step cap; the caller owns the fallback, see `posthog/tasks/alerts/schedule_restriction.py`).
+
 > [!NOTE]
-> Two scheduling models coexist deliberately. **Grid** (this file) is for products that check on a fixed cadence. **Calendar** anchoring (interval enum + quiet hours + weekend skip, used by insight alerts) has not been extracted into `common/alerting/` yet — it still lives in `posthog/tasks/alerts/`. Pick one when you adopt; do not mix.
+> Two scheduling models coexist deliberately. **Grid** (`scheduling.py`) is for products that check on a fixed cadence. **Calendar** (`calendar.py`) anchors to local wall-clock instants with quiet hours and weekend skip. Pick one when you adopt; do not mix.
 
 ## Layer 2 — `posthog/alerting/`
 
@@ -88,6 +96,6 @@ Django-aware glue that the pure layer can't hold:
 
 - A config contract (`AlertConfigLike` Protocol + abstract base model) so new products get the shape for free.
 - A generic Temporal harness with a product registry and two trigger modes: scheduled sweep (grid or calendar) and **push** (`submit_check(product, alert_id, CheckInput)`) for event-driven products.
-- Insight alerts moving onto the shared machine; calendar scheduling extracted into `common/alerting/`.
+- Insight alerts moving onto the shared machine.
 
 When those land, this skill gains the full "register a product and write only an evaluator" walkthrough. Until then, follow the logs pattern above.

--- a/common/alerting/calendar.py
+++ b/common/alerting/calendar.py
@@ -1,0 +1,352 @@
+"""Calendar-anchored scheduling math for alert checks.
+
+The second of the two scheduling models (see scheduling.py for grid cadence):
+checks anchor to calendar instants in the team's local timezone — daily at 1am,
+weekly Monday 3am, monthly on the 1st at 4am — with quiet hours (blocked local
+time windows) and weekend skipping layered on top. Extracted from insight
+alerts (posthog/tasks/alerts/), which keeps model-aware wrappers.
+
+Pure Python — no Django, no product imports. Timezones are passed as IANA
+names, quiet-hours windows as parsed tuples.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+import pytz
+from dateutil.relativedelta import MO, relativedelta
+
+
+class CalendarInterval(StrEnum):
+    """Mirrors posthog.schema.AlertCalculationInterval values; wrappers convert."""
+
+    REAL_TIME = "real_time"
+    EVERY_15_MINUTES = "every_15_minutes"
+    HOURLY = "hourly"
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"
+
+
+REAL_TIME_CADENCE_MINUTES = 2
+EVERY_15_MINUTES_CADENCE_MINUTES = 15
+
+
+def to_calendar_interval(value: str) -> CalendarInterval:
+    try:
+        return CalendarInterval(value)
+    except ValueError:
+        raise ValueError(f"Unhandled alert calculation interval: {value!r}") from None
+
+
+def calendar_interval_to_relativedelta(interval: CalendarInterval) -> relativedelta:
+    match interval:
+        case CalendarInterval.REAL_TIME:
+            return relativedelta(minutes=REAL_TIME_CADENCE_MINUTES)
+        case CalendarInterval.EVERY_15_MINUTES:
+            return relativedelta(minutes=EVERY_15_MINUTES_CADENCE_MINUTES)
+        case CalendarInterval.HOURLY:
+            return relativedelta(hours=1)
+        case CalendarInterval.DAILY:
+            return relativedelta(days=1)
+        case CalendarInterval.WEEKLY:
+            return relativedelta(weeks=1)
+        case CalendarInterval.MONTHLY:
+            return relativedelta(months=1)
+        case _ as unreachable:
+            raise ValueError(f"Unhandled alert calculation interval: {unreachable!r}")
+
+
+def is_weekend(now: datetime, tz_name: str) -> bool:
+    team_timezone = pytz.timezone(tz_name)
+    now_local = now.astimezone(team_timezone)
+    return now_local.isoweekday() in [6, 7]
+
+
+def next_calendar_check_time(
+    interval: CalendarInterval,
+    *,
+    now: datetime,
+    tz_name: str,
+    next_check_at: datetime | None,
+) -> datetime:
+    """Nominal next check instant, before quiet-hours snapping.
+
+    Sub-daily intervals advance from the previous next_check_at (falling back to
+    now) so per-alert spread from creation time is preserved. Daily/weekly/monthly
+    anchor to fixed local instants: 1am tomorrow, 3am next Monday, 4am on the 1st
+    of next month — hour-only replacement keeps the minute/second spread.
+    """
+    team_timezone = pytz.timezone(tz_name)
+
+    match interval:
+        case CalendarInterval.REAL_TIME:
+            return (next_check_at or now) + relativedelta(minutes=REAL_TIME_CADENCE_MINUTES)
+        case CalendarInterval.EVERY_15_MINUTES:
+            return (next_check_at or now) + relativedelta(minutes=EVERY_15_MINUTES_CADENCE_MINUTES)
+        case CalendarInterval.HOURLY:
+            return (next_check_at or now) + relativedelta(hours=1)
+        case CalendarInterval.DAILY:
+            tomorrow_local = now.astimezone(team_timezone) + relativedelta(days=1)
+            one_am_local = tomorrow_local.replace(hour=1)
+            return one_am_local.astimezone(pytz.utc)
+        case CalendarInterval.WEEKLY:
+            next_monday_local = now.astimezone(team_timezone) + relativedelta(days=1, weekday=MO(1))
+            next_monday_3am_local = next_monday_local.replace(hour=3)
+            return next_monday_3am_local.astimezone(pytz.utc)
+        case CalendarInterval.MONTHLY:
+            next_month_local = now.astimezone(team_timezone) + relativedelta(months=1)
+            next_month_4am_local = next_month_local.replace(day=1, hour=4)
+            return next_month_4am_local.astimezone(pytz.utc)
+        case _ as unreachable:
+            raise ValueError(f"Unhandled alert calculation interval: {unreachable!r}")
+
+
+# --- Quiet hours (blocked local time windows) ---
+
+MAX_BLOCKED_WINDOWS = 5
+MINUTES_PER_DAY = 1440
+# Minimum length of each declared blocked window on the local daily timeline (half-open; same rules as expand).
+MIN_BLOCKED_WINDOW_MINUTES = 30
+# When quiet hours hit an unusual corner case, computing the next allowed send time must not
+# run indefinitely or hold up other alerts; we cap how long we spend on that lookup.
+MAX_UNBLOCK_STEPS = MINUTES_PER_DAY * 14
+
+# (start_minute, end_minute, overnight)
+BlockedWindow = tuple[int, int, bool]
+
+
+def _hhmm(minutes: int) -> str:
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def normalize_schedule_restriction_value(raw: Any) -> dict[str, Any] | None:
+    """Coerce payloads that mean 'off' to None. Returns dict ready to validate or None."""
+    if raw is None:
+        return None
+    if raw == {}:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("schedule_restriction must be an object or null")
+    windows = raw.get("blocked_windows")
+    if windows is None:
+        return None
+    if windows == []:
+        return None
+    if not isinstance(windows, list):
+        raise ValueError("blocked_windows must be an array")
+    return raw
+
+
+def _parse_hhmm(value: str) -> int:
+    if not isinstance(value, str):
+        raise ValueError("Time must be a string HH:MM")
+    s = value.strip()
+    if s.count(":") != 1:
+        raise ValueError("Time must be HH:MM (seconds not allowed)")
+    parts = s.split(":")
+    try:
+        h = int(parts[0], 10)
+        m = int(parts[1], 10)
+    except ValueError as e:
+        raise ValueError("Invalid HH:MM") from e
+    if h < 0 or h > 23 or m < 0 or m > 59:
+        raise ValueError("Invalid HH:MM")
+    return h * 60 + m
+
+
+def _parse_window_pair(start_s: str, end_s: str) -> BlockedWindow:
+    start = _parse_hhmm(start_s)
+    end = _parse_hhmm(end_s)
+    if start == end:
+        raise ValueError("Start and end must differ for a blocked window")
+    overnight = start > end
+    return start, end, overnight
+
+
+def _blocked_window_span_minutes(start: int, end: int, overnight: bool) -> int:
+    """Total minutes blocked in one local 24h cycle for this window (matches _expand_windows_for_coverage)."""
+    if not overnight:
+        return end - start
+    if end == 0:
+        return MINUTES_PER_DAY - start
+    return (MINUTES_PER_DAY - start) + end
+
+
+def _expand_windows_for_coverage(windows: list[BlockedWindow]) -> list[tuple[int, int]]:
+    """Half-open intervals within [0, MINUTES_PER_DAY) for one synthetic day."""
+    out: list[tuple[int, int]] = []
+    for start, end, overnight in windows:
+        if not overnight:
+            if start < end:
+                out.append((start, end))
+            else:
+                raise ValueError("Invalid window")
+        else:
+            if end == 0:
+                # e.g. 19:00–00:00 = block from 19:00 through end of local calendar day (end exclusive at midnight)
+                out.append((start, MINUTES_PER_DAY))
+            else:
+                out.append((start, MINUTES_PER_DAY))
+                out.append((0, end))
+    return out
+
+
+def _merge_intervals_sorted(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not intervals:
+        return []
+    intervals = sorted(intervals, key=lambda x: (x[0], x[1]))
+    merged: list[tuple[int, int]] = []
+    for a, b in intervals:
+        if b <= a:
+            continue
+        if not merged or merged[-1][1] < a:
+            merged.append((a, b))
+        else:
+            prev_a, prev_b = merged[-1]
+            merged[-1] = (prev_a, max(prev_b, b))
+    return merged
+
+
+def merged_intervals_cover_full_day(merged: list[tuple[int, int]]) -> bool:
+    return bool(merged) and merged[0][0] == 0 and merged[0][1] >= MINUTES_PER_DAY
+
+
+def _encode_merged_to_blocked_windows(merged: list[tuple[int, int]]) -> list[dict[str, str]]:
+    """Round-trip merged [0,1440) half-open segments to stored window dicts."""
+    if not merged:
+        return []
+    if len(merged) == 1:
+        a, b = merged[0]
+        if a < b:
+            if b == MINUTES_PER_DAY and a > 0:
+                return [{"start": _hhmm(a), "end": "00:00"}]
+            return [{"start": _hhmm(a), "end": _hhmm(b)}]
+        raise ValueError("Invalid merged interval")
+    if len(merged) == 2:
+        a1, b1 = merged[0]
+        a2, b2 = merged[1]
+        # Overnight split into [0, morning_end) and [evening_start, 1440) after sorting by start
+        if a1 == 0 and b2 == MINUTES_PER_DAY and a2 > b1:
+            return [{"start": _hhmm(a2), "end": _hhmm(b1)}]
+    out: list[dict[str, str]] = []
+    for a, b in merged:
+        if not a < b:
+            continue
+        if b == MINUTES_PER_DAY and a > 0:
+            out.append({"start": _hhmm(a), "end": "00:00"})
+        else:
+            out.append({"start": _hhmm(a), "end": _hhmm(b)})
+    return out
+
+
+def validate_and_normalize_schedule_restriction(raw: Any) -> dict[str, Any] | None:
+    """
+    Validate API/store shape; merge overlaps on the daily timeline; return normalized dict or None.
+    Raises ValueError on invalid input.
+    """
+    normalized_in = normalize_schedule_restriction_value(raw)
+    if normalized_in is None:
+        return None
+
+    windows_in = normalized_in.get("blocked_windows")
+    if not isinstance(windows_in, list):
+        raise ValueError("blocked_windows must be an array")
+    if len(windows_in) > MAX_BLOCKED_WINDOWS:
+        raise ValueError(f"At most {MAX_BLOCKED_WINDOWS} blocked time windows are allowed")
+
+    parsed: list[BlockedWindow] = []
+    for idx, w in enumerate(windows_in):
+        if not isinstance(w, dict):
+            raise ValueError(f"blocked_windows[{idx}] must be an object")
+        start_s = w.get("start")
+        end_s = w.get("end")
+        if start_s is None or end_s is None:
+            raise ValueError(f"blocked_windows[{idx}] must have start and end (HH:MM)")
+        start_i, end_i, overnight = _parse_window_pair(str(start_s), str(end_s))
+        span = _blocked_window_span_minutes(start_i, end_i, overnight)
+        if span < MIN_BLOCKED_WINDOW_MINUTES:
+            raise ValueError(
+                f"blocked_windows[{idx}] must span at least {MIN_BLOCKED_WINDOW_MINUTES} minutes "
+                f"(half-open local window [start, end))"
+            )
+        parsed.append((start_i, end_i, overnight))
+
+    expanded = _expand_windows_for_coverage(parsed)
+    merged = _merge_intervals_sorted(expanded)
+    if merged_intervals_cover_full_day(merged):
+        raise ValueError("Leave at least one time in the day when this alert can run")
+
+    encoded = _encode_merged_to_blocked_windows(merged)
+    if not encoded:
+        return None
+    return {"blocked_windows": encoded}
+
+
+def parse_blocked_windows_tuples(schedule_restriction: dict[str, Any] | None) -> list[BlockedWindow] | None:
+    if not schedule_restriction:
+        return None
+    windows = schedule_restriction.get("blocked_windows")
+    if not windows:
+        return None
+    out: list[BlockedWindow] = []
+    for w in windows:
+        if isinstance(w, dict) and "start" in w and "end" in w:
+            out.append(_parse_window_pair(str(w["start"]), str(w["end"])))
+    return out or None
+
+
+def is_local_minute_blocked(minute: int, windows: list[BlockedWindow]) -> bool:
+    for start, end, overnight in windows:
+        if not overnight:
+            if start <= minute < end:
+                return True
+        else:
+            if end == 0:
+                if minute >= start:
+                    return True
+            elif minute >= start or minute < end:
+                return True
+    return False
+
+
+def _minute_of_local_datetime(dt_local: datetime) -> int:
+    return dt_local.hour * 60 + dt_local.minute
+
+
+def is_utc_datetime_blocked(dt_utc: datetime, tz_name: str, windows: list[BlockedWindow] | None) -> bool:
+    if not windows:
+        return False
+    tz = pytz.timezone(tz_name)
+    local = dt_utc.astimezone(tz).replace(second=0, microsecond=0)
+    return is_local_minute_blocked(_minute_of_local_datetime(local), windows)
+
+
+def scan_next_unblocked_utc(
+    from_utc: datetime,
+    tz_name: str,
+    windows: list[BlockedWindow] | None,
+    *,
+    max_steps: int = MAX_UNBLOCK_STEPS,
+) -> datetime | None:
+    """Smallest UTC instant >= from_utc (minute precision) outside every blocked window.
+
+    Returns None when no unblocked minute is found within max_steps — callers own
+    the fallback (insight alerts bump a day and retry, with logging).
+    """
+    if not windows:
+        return from_utc.astimezone(UTC).replace(microsecond=0)
+
+    tz = pytz.timezone(tz_name)
+    cur = from_utc.astimezone(tz).replace(second=0, microsecond=0)
+    steps = 0
+    while steps < max_steps:
+        m = _minute_of_local_datetime(cur)
+        if not is_local_minute_blocked(m, windows):
+            return cur.astimezone(pytz.UTC)
+        cur = cur + timedelta(minutes=1)
+        steps += 1
+    return None

--- a/common/alerting/test/test_calendar.py
+++ b/common/alerting/test/test_calendar.py
@@ -1,0 +1,134 @@
+from datetime import UTC, datetime
+
+from parameterized import parameterized
+
+from common.alerting.calendar import (
+    CalendarInterval,
+    is_weekend,
+    next_calendar_check_time,
+    parse_blocked_windows_tuples,
+    scan_next_unblocked_utc,
+    validate_and_normalize_schedule_restriction,
+)
+
+# Wednesday 2026-03-18 12:00 UTC
+NOW = datetime(2026, 3, 18, 12, 0, tzinfo=UTC)
+PREV_CHECK = datetime(2026, 3, 18, 11, 47, tzinfo=UTC)
+
+
+class TestNextCalendarCheckTime:
+    @parameterized.expand(
+        [
+            # Sub-daily intervals advance from the prior next_check_at, preserving per-alert spread
+            ("real_time_from_prev", CalendarInterval.REAL_TIME, PREV_CHECK, datetime(2026, 3, 18, 11, 49, tzinfo=UTC)),
+            ("real_time_first_check", CalendarInterval.REAL_TIME, None, datetime(2026, 3, 18, 12, 2, tzinfo=UTC)),
+            (
+                "15min_from_prev",
+                CalendarInterval.EVERY_15_MINUTES,
+                PREV_CHECK,
+                datetime(2026, 3, 18, 12, 2, tzinfo=UTC),
+            ),
+            ("hourly_from_prev", CalendarInterval.HOURLY, PREV_CHECK, datetime(2026, 3, 18, 12, 47, tzinfo=UTC)),
+        ]
+    )
+    def test_sub_daily_advances_from_previous(
+        self, _name: str, interval: CalendarInterval, next_check_at: datetime | None, expected: datetime
+    ) -> None:
+        result = next_calendar_check_time(interval, now=NOW, tz_name="UTC", next_check_at=next_check_at)
+        assert result == expected
+
+    @parameterized.expand(
+        [
+            # Daily anchors to ~1am local tomorrow; minute preserved for spread. US/Pacific is UTC-7 on this date.
+            ("daily_pacific", CalendarInterval.DAILY, "US/Pacific", (2026, 3, 19, 8, 0)),
+            # Weekly anchors to ~3am next Monday local (Mon 2026-03-23), 3am PDT = 10:00 UTC
+            ("weekly_pacific", CalendarInterval.WEEKLY, "US/Pacific", (2026, 3, 23, 10, 0)),
+            # Monthly anchors to ~4am on the 1st of next month, 4am PDT = 11:00 UTC
+            ("monthly_pacific", CalendarInterval.MONTHLY, "US/Pacific", (2026, 4, 1, 11, 0)),
+        ]
+    )
+    def test_calendar_anchors_in_team_timezone(
+        self, _name: str, interval: CalendarInterval, tz_name: str, expected_utc: tuple
+    ) -> None:
+        result = next_calendar_check_time(interval, now=NOW, tz_name=tz_name, next_check_at=PREV_CHECK)
+        assert (result.year, result.month, result.day, result.hour, result.minute) == expected_utc
+        assert result.tzinfo is not None
+
+    def test_daily_across_dst_spring_forward(self) -> None:
+        # US spring-forward was 2026-03-08: local 1am tomorrow maps PST(-8) -> PDT(-7),
+        # so the UTC anchor shifts from 09:00 to 08:00 across the transition.
+        before = next_calendar_check_time(
+            CalendarInterval.DAILY,
+            now=datetime(2026, 3, 7, 12, 0, tzinfo=UTC),
+            tz_name="US/Pacific",
+            next_check_at=None,
+        )
+        after = next_calendar_check_time(
+            CalendarInterval.DAILY,
+            now=datetime(2026, 3, 8, 12, 0, tzinfo=UTC),
+            tz_name="US/Pacific",
+            next_check_at=None,
+        )
+        assert before.hour == 9
+        assert after.hour == 8
+
+
+class TestIsWeekend:
+    @parameterized.expand(
+        [
+            # Friday 23:00 UTC is already Saturday 08:00 in Tokyo
+            ("tokyo_saturday", datetime(2026, 3, 20, 23, 0, tzinfo=UTC), "Asia/Tokyo", True),
+            ("utc_friday", datetime(2026, 3, 20, 23, 0, tzinfo=UTC), "UTC", False),
+            # Sunday 05:00 UTC is still Saturday 22:00 in Pacific
+            ("pacific_saturday", datetime(2026, 3, 22, 5, 0, tzinfo=UTC), "US/Pacific", True),
+            ("monday_utc", datetime(2026, 3, 23, 9, 0, tzinfo=UTC), "UTC", False),
+        ]
+    )
+    def test_weekend_is_local(self, _name: str, now: datetime, tz_name: str, expected: bool) -> None:
+        assert is_weekend(now, tz_name) == expected
+
+
+class TestScanNextUnblockedUtc:
+    def _windows(self, *pairs: tuple[str, str]):
+        raw = {"blocked_windows": [{"start": s, "end": e} for s, e in pairs]}
+        return parse_blocked_windows_tuples(validate_and_normalize_schedule_restriction(raw))
+
+    @parameterized.expand(
+        [
+            # Candidate inside a same-day window snaps to the window end (half-open)
+            ("inside_window", ("09:00", "17:00"), datetime(2026, 3, 18, 12, 30, tzinfo=UTC), "UTC", (17, 0)),
+            # Candidate outside any window is returned unchanged (minute precision)
+            ("outside_window", ("09:00", "17:00"), datetime(2026, 3, 18, 18, 15, tzinfo=UTC), "UTC", (18, 15)),
+            # Overnight window (22:00-06:00): a 23:00 candidate snaps to 06:00 next day
+            ("overnight_window", ("22:00", "06:00"), datetime(2026, 3, 18, 23, 0, tzinfo=UTC), "UTC", (6, 0)),
+        ]
+    )
+    def test_snapping(
+        self, _name: str, window: tuple[str, str], candidate: datetime, tz_name: str, expected_hm: tuple
+    ) -> None:
+        result = scan_next_unblocked_utc(candidate, tz_name, self._windows(window))
+        assert result is not None
+        assert (result.hour, result.minute) == expected_hm
+
+    def test_window_is_evaluated_in_local_time(self) -> None:
+        # Blocked 09:00-17:00 in Pacific (PDT, UTC-7). 12:00 UTC = 05:00 local -> not blocked.
+        windows = self._windows(("09:00", "17:00"))
+        result = scan_next_unblocked_utc(datetime(2026, 3, 18, 12, 0, tzinfo=UTC), "US/Pacific", windows)
+        assert result == datetime(2026, 3, 18, 12, 0, tzinfo=UTC)
+        # 18:00 UTC = 11:00 local -> blocked until 17:00 local = 00:00 UTC next day.
+        result = scan_next_unblocked_utc(datetime(2026, 3, 18, 18, 0, tzinfo=UTC), "US/Pacific", windows)
+        assert result is not None
+        assert result == datetime(2026, 3, 19, 0, 0, tzinfo=UTC)
+
+    def test_no_windows_returns_candidate(self) -> None:
+        candidate = datetime(2026, 3, 18, 12, 30, 45, 123456, tzinfo=UTC)
+        assert scan_next_unblocked_utc(candidate, "UTC", None) == candidate.replace(microsecond=0)
+
+    def test_full_day_coverage_is_rejected_at_validation(self) -> None:
+        try:
+            validate_and_normalize_schedule_restriction(
+                {"blocked_windows": [{"start": "00:00", "end": "12:00"}, {"start": "12:00", "end": "00:00"}]}
+            )
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass

--- a/posthog/tasks/alerts/schedule_restriction.py
+++ b/posthog/tasks/alerts/schedule_restriction.py
@@ -1,231 +1,55 @@
-"""Schedule restrictions (blocked local time windows) for insight alerts."""
+"""Schedule restrictions (blocked local time windows) for insight alerts.
+
+The pure minute-math and validation live in common/alerting/calendar.py; this
+module keeps the AlertConfiguration-aware entry points plus the cap-exceeded
+retry/logging fallback.
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
-import pytz
 import structlog
 
 from products.alerts.backend.models.alert import AlertConfiguration
 
+from common.alerting.calendar import (
+    MAX_BLOCKED_WINDOWS,
+    MAX_UNBLOCK_STEPS,
+    MIN_BLOCKED_WINDOW_MINUTES,
+    MINUTES_PER_DAY,
+    is_local_minute_blocked,
+    is_utc_datetime_blocked as _is_utc_datetime_blocked_pure,
+    merged_intervals_cover_full_day,
+    normalize_schedule_restriction_value,
+    parse_blocked_windows_tuples,
+    scan_next_unblocked_utc,
+    validate_and_normalize_schedule_restriction,
+)
+
 logger = structlog.get_logger(__name__)
 
-MAX_BLOCKED_WINDOWS = 5
-MINUTES_PER_DAY = 1440
-# Minimum length of each declared blocked window on the local daily timeline (half-open; same rules as expand).
-MIN_BLOCKED_WINDOW_MINUTES = 30
-# When quiet hours hit an unusual corner case, computing the next allowed send time must not
-# run indefinitely or hold up other alerts; we cap how long we spend on that lookup.
-_MAX_UNBLOCK_STEPS = MINUTES_PER_DAY * 14
+# Module-level so tests can monkeypatch the cap; passed through to the pure scan.
+_MAX_UNBLOCK_STEPS = MAX_UNBLOCK_STEPS
 
-
-def _hhmm(minutes: int) -> str:
-    return f"{minutes // 60:02d}:{minutes % 60:02d}"
-
-
-def normalize_schedule_restriction_value(raw: Any) -> dict[str, Any] | None:
-    """Coerce payloads that mean 'off' to None. Returns dict ready to validate or None."""
-    if raw is None:
-        return None
-    if raw == {}:
-        return None
-    if not isinstance(raw, dict):
-        raise ValueError("schedule_restriction must be an object or null")
-    windows = raw.get("blocked_windows")
-    if windows is None:
-        return None
-    if windows == []:
-        return None
-    if not isinstance(windows, list):
-        raise ValueError("blocked_windows must be an array")
-    return raw
-
-
-def _parse_hhmm(value: str) -> int:
-    if not isinstance(value, str):
-        raise ValueError("Time must be a string HH:MM")
-    s = value.strip()
-    if s.count(":") != 1:
-        raise ValueError("Time must be HH:MM (seconds not allowed)")
-    parts = s.split(":")
-    try:
-        h = int(parts[0], 10)
-        m = int(parts[1], 10)
-    except ValueError as e:
-        raise ValueError("Invalid HH:MM") from e
-    if h < 0 or h > 23 or m < 0 or m > 59:
-        raise ValueError("Invalid HH:MM")
-    return h * 60 + m
-
-
-def _parse_window_pair(start_s: str, end_s: str) -> tuple[int, int, bool]:
-    start = _parse_hhmm(start_s)
-    end = _parse_hhmm(end_s)
-    if start == end:
-        raise ValueError("Start and end must differ for a blocked window")
-    overnight = start > end
-    return start, end, overnight
-
-
-def _blocked_window_span_minutes(start: int, end: int, overnight: bool) -> int:
-    """Total minutes blocked in one local 24h cycle for this window (matches _expand_windows_for_coverage)."""
-    if not overnight:
-        return end - start
-    if end == 0:
-        return MINUTES_PER_DAY - start
-    return (MINUTES_PER_DAY - start) + end
-
-
-def _expand_windows_for_coverage(windows: list[tuple[int, int, bool]]) -> list[tuple[int, int]]:
-    """Half-open intervals within [0, MINUTES_PER_DAY) for one synthetic day."""
-    out: list[tuple[int, int]] = []
-    for start, end, overnight in windows:
-        if not overnight:
-            if start < end:
-                out.append((start, end))
-            else:
-                raise ValueError("Invalid window")
-        else:
-            if end == 0:
-                # e.g. 19:00–00:00 = block from 19:00 through end of local calendar day (end exclusive at midnight)
-                out.append((start, MINUTES_PER_DAY))
-            else:
-                out.append((start, MINUTES_PER_DAY))
-                out.append((0, end))
-    return out
-
-
-def _merge_intervals_sorted(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
-    if not intervals:
-        return []
-    intervals = sorted(intervals, key=lambda x: (x[0], x[1]))
-    merged: list[tuple[int, int]] = []
-    for a, b in intervals:
-        if b <= a:
-            continue
-        if not merged or merged[-1][1] < a:
-            merged.append((a, b))
-        else:
-            prev_a, prev_b = merged[-1]
-            merged[-1] = (prev_a, max(prev_b, b))
-    return merged
-
-
-def merged_intervals_cover_full_day(merged: list[tuple[int, int]]) -> bool:
-    return bool(merged) and merged[0][0] == 0 and merged[0][1] >= MINUTES_PER_DAY
-
-
-def _encode_merged_to_blocked_windows(merged: list[tuple[int, int]]) -> list[dict[str, str]]:
-    """Round-trip merged [0,1440) half-open segments to stored window dicts."""
-    if not merged:
-        return []
-    if len(merged) == 1:
-        a, b = merged[0]
-        if a < b:
-            if b == MINUTES_PER_DAY and a > 0:
-                return [{"start": _hhmm(a), "end": "00:00"}]
-            return [{"start": _hhmm(a), "end": _hhmm(b)}]
-        raise ValueError("Invalid merged interval")
-    if len(merged) == 2:
-        a1, b1 = merged[0]
-        a2, b2 = merged[1]
-        # Overnight split into [0, morning_end) and [evening_start, 1440) after sorting by start
-        if a1 == 0 and b2 == MINUTES_PER_DAY and a2 > b1:
-            return [{"start": _hhmm(a2), "end": _hhmm(b1)}]
-    out: list[dict[str, str]] = []
-    for a, b in merged:
-        if not a < b:
-            continue
-        if b == MINUTES_PER_DAY and a > 0:
-            out.append({"start": _hhmm(a), "end": "00:00"})
-        else:
-            out.append({"start": _hhmm(a), "end": _hhmm(b)})
-    return out
-
-
-def validate_and_normalize_schedule_restriction(raw: Any) -> dict[str, Any] | None:
-    """
-    Validate API/store shape; merge overlaps on the daily timeline; return normalized dict or None.
-    Raises ValueError on invalid input.
-    """
-    normalized_in = normalize_schedule_restriction_value(raw)
-    if normalized_in is None:
-        return None
-
-    windows_in = normalized_in.get("blocked_windows")
-    if not isinstance(windows_in, list):
-        raise ValueError("blocked_windows must be an array")
-    if len(windows_in) > MAX_BLOCKED_WINDOWS:
-        raise ValueError(f"At most {MAX_BLOCKED_WINDOWS} blocked time windows are allowed")
-
-    parsed: list[tuple[int, int, bool]] = []
-    for idx, w in enumerate(windows_in):
-        if not isinstance(w, dict):
-            raise ValueError(f"blocked_windows[{idx}] must be an object")
-        start_s = w.get("start")
-        end_s = w.get("end")
-        if start_s is None or end_s is None:
-            raise ValueError(f"blocked_windows[{idx}] must have start and end (HH:MM)")
-        start_i, end_i, overnight = _parse_window_pair(str(start_s), str(end_s))
-        span = _blocked_window_span_minutes(start_i, end_i, overnight)
-        if span < MIN_BLOCKED_WINDOW_MINUTES:
-            raise ValueError(
-                f"blocked_windows[{idx}] must span at least {MIN_BLOCKED_WINDOW_MINUTES} minutes "
-                f"(half-open local window [start, end))"
-            )
-        parsed.append((start_i, end_i, overnight))
-
-    expanded = _expand_windows_for_coverage(parsed)
-    merged = _merge_intervals_sorted(expanded)
-    if merged_intervals_cover_full_day(merged):
-        raise ValueError("Leave at least one time in the day when this alert can run")
-
-    encoded = _encode_merged_to_blocked_windows(merged)
-    if not encoded:
-        return None
-    return {"blocked_windows": encoded}
-
-
-def parse_blocked_windows_tuples(schedule_restriction: dict[str, Any] | None) -> list[tuple[int, int, bool]] | None:
-    if not schedule_restriction:
-        return None
-    windows = schedule_restriction.get("blocked_windows")
-    if not windows:
-        return None
-    out: list[tuple[int, int, bool]] = []
-    for w in windows:
-        if isinstance(w, dict) and "start" in w and "end" in w:
-            out.append(_parse_window_pair(str(w["start"]), str(w["end"])))
-    return out or None
-
-
-def is_local_minute_blocked(minute: int, windows: list[tuple[int, int, bool]]) -> bool:
-    for start, end, overnight in windows:
-        if not overnight:
-            if start <= minute < end:
-                return True
-        else:
-            if end == 0:
-                if minute >= start:
-                    return True
-            elif minute >= start or minute < end:
-                return True
-    return False
-
-
-def _minute_of_local_datetime(dt_local: datetime) -> int:
-    return dt_local.hour * 60 + dt_local.minute
+__all__ = [
+    "MAX_BLOCKED_WINDOWS",
+    "MINUTES_PER_DAY",
+    "MIN_BLOCKED_WINDOW_MINUTES",
+    "is_local_minute_blocked",
+    "is_utc_datetime_blocked",
+    "merged_intervals_cover_full_day",
+    "next_unblocked_utc",
+    "normalize_schedule_restriction_value",
+    "parse_blocked_windows_tuples",
+    "snap_candidate_utc_to_schedule_restriction",
+    "validate_and_normalize_schedule_restriction",
+]
 
 
 def is_utc_datetime_blocked(alert: AlertConfiguration, dt_utc: datetime) -> bool:
     windows = parse_blocked_windows_tuples(alert.schedule_restriction)
-    if not windows:
-        return False
-    tz = pytz.timezone(alert.team.timezone)
-    local = dt_utc.astimezone(tz).replace(second=0, microsecond=0)
-    return is_local_minute_blocked(_minute_of_local_datetime(local), windows)
+    return _is_utc_datetime_blocked_pure(dt_utc, alert.team.timezone, windows)
 
 
 def next_unblocked_utc(alert: AlertConfiguration, from_utc: datetime) -> datetime:
@@ -240,23 +64,13 @@ def _next_unblocked_utc(
     recursion_depth: int,
 ) -> datetime:
     windows = parse_blocked_windows_tuples(alert.schedule_restriction)
-    if not windows:
-        return from_utc.astimezone(UTC).replace(microsecond=0)
-
-    tz = pytz.timezone(alert.team.timezone)
-    cur = from_utc.astimezone(tz).replace(second=0, microsecond=0)
-    steps = 0
-    while steps < _MAX_UNBLOCK_STEPS:
-        m = _minute_of_local_datetime(cur)
-        if not is_local_minute_blocked(m, windows):
-            return cur.astimezone(pytz.UTC)
-        cur = cur + timedelta(minutes=1)
-        steps += 1
+    found = scan_next_unblocked_utc(from_utc, alert.team.timezone, windows, max_steps=_MAX_UNBLOCK_STEPS)
+    if found is not None:
+        return found
 
     logger.warning(
         "schedule_restriction.next_unblocked_utc_exceeded_cap",
         alert_id=str(alert.id),
-        steps=steps,
         recursion_depth=recursion_depth,
     )
     if recursion_depth >= 1:

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 import pytz
 import structlog
-from dateutil.relativedelta import MO, relativedelta
+from dateutil.relativedelta import relativedelta
 
 from posthog.schema import AlertCalculationInterval, AlertState, ChartDisplayType, NodeKind, TrendsQuery
 
@@ -15,6 +15,15 @@ from posthog.exceptions_capture import capture_exception
 from posthog.tasks.alerts.schedule_restriction import snap_candidate_utc_to_schedule_restriction
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, derive_detector_event_fields
+
+from common.alerting.calendar import (
+    EVERY_15_MINUTES_CADENCE_MINUTES as EVERY_15_MINUTES_CADENCE_MINUTES,
+    REAL_TIME_CADENCE_MINUTES as REAL_TIME_CADENCE_MINUTES,
+    calendar_interval_to_relativedelta,
+    is_weekend,
+    next_calendar_check_time,
+    to_calendar_interval,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -46,9 +55,6 @@ def is_non_time_series_trend(query: TrendsQuery) -> bool:
     return display in NON_TIME_SERIES_DISPLAY_TYPES
 
 
-REAL_TIME_CADENCE_MINUTES = 2
-EVERY_15_MINUTES_CADENCE_MINUTES = 15
-
 # Cheaper, more time-sensitive checks get workers first when the due batch is large.
 # Single source for both the Python ordering and the ORM Case in
 # posthog/temporal/alerts/activities.py retrieve_due_alerts.
@@ -72,68 +78,23 @@ def calculation_interval_to_order(interval: AlertCalculationInterval | None) -> 
 
 
 def alert_calculation_interval_to_relativedelta(alert_calculation_interval: AlertCalculationInterval) -> relativedelta:
-    match alert_calculation_interval:
-        case AlertCalculationInterval.REAL_TIME:
-            return relativedelta(minutes=REAL_TIME_CADENCE_MINUTES)
-        case AlertCalculationInterval.EVERY_15_MINUTES:
-            return relativedelta(minutes=EVERY_15_MINUTES_CADENCE_MINUTES)
-        case AlertCalculationInterval.HOURLY:
-            return relativedelta(hours=1)
-        case AlertCalculationInterval.DAILY:
-            return relativedelta(days=1)
-        case AlertCalculationInterval.WEEKLY:
-            return relativedelta(weeks=1)
-        case AlertCalculationInterval.MONTHLY:
-            return relativedelta(months=1)
-        case _ as unreachable:
-            raise ValueError(f"Unhandled alert calculation interval: {unreachable!r}")
+    return calendar_interval_to_relativedelta(to_calendar_interval(alert_calculation_interval))
 
 
 def skip_because_of_weekend(alert: AlertConfiguration) -> bool:
     if not alert.skip_weekend:
         return False
-
-    now = datetime.now(pytz.UTC)
-    team_timezone = pytz.timezone(alert.team.timezone)
-
-    now_local = now.astimezone(team_timezone)
-    return now_local.isoweekday() in [6, 7]
+    return is_weekend(datetime.now(pytz.UTC), alert.team.timezone)
 
 
 def _next_check_time_core(alert: AlertConfiguration) -> datetime:
     """Nominal next check instant before schedule_restriction snapping."""
-    now = datetime.now(pytz.UTC)
-    team_timezone = pytz.timezone(alert.team.timezone)
-
-    match alert.calculation_interval:
-        case AlertCalculationInterval.REAL_TIME:
-            return (alert.next_check_at or now) + relativedelta(minutes=REAL_TIME_CADENCE_MINUTES)
-        case AlertCalculationInterval.EVERY_15_MINUTES:
-            return (alert.next_check_at or now) + relativedelta(minutes=15)
-        case AlertCalculationInterval.HOURLY:
-            return (alert.next_check_at or now) + relativedelta(hours=1)
-        case AlertCalculationInterval.DAILY:
-            # Get the next date in the specified timezone
-            tomorrow_local = datetime.now(team_timezone) + relativedelta(days=1)
-            # set hour to 1 AM
-            # only replacing hour and not minute/second... to distribute execution of all daily alerts
-            one_am_local = tomorrow_local.replace(hour=1)
-            # Convert to UTC
-            return one_am_local.astimezone(pytz.utc)
-        case AlertCalculationInterval.WEEKLY:
-            next_monday_local = datetime.now(team_timezone) + relativedelta(days=1, weekday=MO(1))
-            # Set the hour to around 3 AM on next Monday
-            next_monday_1am_local = next_monday_local.replace(hour=3)
-            # Convert to UTC
-            return next_monday_1am_local.astimezone(pytz.utc)
-        case AlertCalculationInterval.MONTHLY:
-            next_month_local = datetime.now(team_timezone) + relativedelta(months=1)
-            # Set hour to 4 AM on first day of next month
-            next_month_1am_local = next_month_local.replace(day=1, hour=4)
-            # Convert to UTC
-            return next_month_1am_local.astimezone(pytz.utc)
-        case _ as unreachable:
-            raise ValueError(f"Unhandled alert calculation interval: {unreachable!r}")
+    return next_calendar_check_time(
+        to_calendar_interval(alert.calculation_interval),
+        now=datetime.now(pytz.UTC),
+        tz_name=alert.team.timezone,
+        next_check_at=alert.next_check_at,
+    )
 
 
 def next_check_time(alert: AlertConfiguration) -> datetime:


### PR DESCRIPTION
## Problem

The platform stack so far only covers grid-cadence scheduling (logs style). Insight alerts carry the richer calendar model: intervals anchored to local wall-clock instants, quiet hours (blocked local windows), and weekend skip, all buried in `posthog/tasks/alerts/` behind the AlertConfiguration model. Products adopting shared alerting could not reuse any of it.

## Changes

- `common/alerting/calendar.py` (pure, tach-enforced): `CalendarInterval` + `next_calendar_check_time` (daily 1am, weekly Monday 3am, monthly 1st 4am in the team timezone, sub-daily advancing from the prior check), `is_weekend`, and the full quiet-hours core moved from `schedule_restriction.py` (window validation, minute math, `scan_next_unblocked_utc`).
- `posthog/tasks/alerts/schedule_restriction.py` and `utils.py` become model-aware wrappers. The cap-exceeded day-bump retry and its logging stay in the wrapper, and the step cap is now a parameter of the pure scan.
- Behavior preserving: every insight call site and signature is unchanged, including the exact "Unhandled alert calculation interval" error message.
- Skill updated: calendar scheduling documented as available instead of "coming".

## How did you test this code?

Automated only:

- Oracle suites pass unchanged: `posthog/tasks/alerts/test/` (utils + schedule restriction), `test_alert_real_time_interval.py`, `test_alert_15_minute_interval.py` (185 tests). Two of them monkeypatch the scan cap and one pins the unknown-interval error message; both caught seam breaks during extraction and drove the `max_steps` parameter and `to_calendar_interval` converter.
- New `common/alerting/test/test_calendar.py` (18 cases): pins the scalar API directly, which no existing test covered without Django. Catches regressions in the calendar anchors per timezone, the daily anchor across DST spring-forward, local-time weekend evaluation, and quiet-hours snapping (same-day, overnight, local-tz windows, full-day rejection).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The `adopting-shared-alerting` skill is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude); skills invoked: `/writing-tests`.
- First net-new extraction in the stack (PRs 1-5 are re-cuts of prior reviewed work). Scoped as a pure move: the wrapper keeps logging and the retry fallback so `common/` stays free of structlog and model types.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
