### PR TITLE
feat(llma): add pre-publish diff review for prompt versions

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4689,13 +4689,13 @@ snapshots:
     replay-scenes-group--group-recording-tab-multiple-and-not-found--light:
         hash: v1.k794b7964.8882d784aa07c42f09438e0d5a78eacbe6ad9823f560e97af87187086967c5d5.Wv5mIcMYIYKrtccR28_x_IyOQdhTcLgwNJHChxS4Hig
     replay-scenes-person--person-recording-tab-empty--dark:
-        hash: v1.k794b7964.e7a85d7b00de6109ee2e3c3101d8c7885c112b5602ae884d18d66fe9e6d602bb.1smERv9wJq0szZ5t7ebDzWOJLul9JimrxhEM9uysImE
+        hash: v1.k794b7964.d337c9b3822884b424ceca688c767202c2b1a72e2b0e466092ae5f9795dbcabd.TZsx90e31kbDKuYkmYXRtlH0jo7mxK0xNIrohR9Jf-Y
     replay-scenes-person--person-recording-tab-empty--light:
-        hash: v1.k794b7964.adfb464e56d7d9c5a8d74709f012bea88abf526f83a551d0c04e59076c303989.sRTHOTFsjmYEf6J4Of4QwieHU8XnbLRadjPIGd1lEB0
+        hash: v1.k794b7964.e29314b81472a69779a7da88417f5d840eec03de97125db890eafa3d5190e0c5.y27QikyGJb8Eoewgpuj-zbqSGWjYT4ZmwD_GUvqyL4I
     replay-scenes-person--person-recording-tab-multiple-and-not-found--dark:
-        hash: v1.k794b7964.9493123578498f55816cd5cdd6727fa6f79e6b5cfebf33296f06d55d1bf84791.ABNajIMGuPwwJd2xDzNh4YeUIX2NEvUE7q-SL5oFTZc
+        hash: v1.k794b7964.92ab5a5985dc1b5209348f1d30de2cdf71d6978379917ba7dc74e5d9a9720cf8.8HFE0rDgSg7JKGgYezsFVnNyVFJ0fu0lCt7O3YhrJhE
     replay-scenes-person--person-recording-tab-multiple-and-not-found--light:
-        hash: v1.k794b7964.3b0e39fe814c16e7b3d356e61c2add9dd0f07d1e8704b72a910fab1ffed94934._6Q9oRjQqPslyCIJ0i5ukKK20UHYpkCZLh9mVtj7sJk
+        hash: v1.k794b7964.51bffeb0d092102facf451dfc55f6796ff6bae977e725a6df5038f549dda3db2._h_Clf5Iii97OCXqmC5qU0AOGXUD0m93xf6ycFI1sAk
     replay-sharing--private-link--dark:
         hash: v1.k794b7964.5ef4bd7e1d49d4506c360881a3a1482e857b5240362d76c855692eab18fc0764.0IvXqC6Lmuj5NeaGPbu0_5gr6mVBAtiGtBfKu7gvQXA
     replay-sharing--private-link--light:

--- a/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
@@ -24,6 +24,7 @@ import {
     PromptUsage,
     PromptVersionSidebar,
     PromptViewDetails,
+    PublishReviewModal,
     cleanPromptSearchParams,
 } from './promptSceneComponents'
 import { openArchivePromptDialog } from './utils'
@@ -62,8 +63,15 @@ export function LLMPromptScene(): JSX.Element {
     const activeViewTab =
         searchParams?.tab === 'usage' ? 'usage' : searchParams?.tab === 'experiments' ? 'experiments' : 'overview'
 
-    const { submitPromptForm, deletePrompt, setMode, setPromptFormValues, loadMoreVersions, cancelEditing } =
-        useActions(llmPromptLogic)
+    const {
+        submitPromptForm,
+        requestPublish,
+        deletePrompt,
+        setMode,
+        setPromptFormValues,
+        loadMoreVersions,
+        cancelEditing,
+    } = useActions(llmPromptLogic)
     const sourcePromptName = !isNewPrompt && prompt && isPrompt(prompt) ? prompt.name : null
     const sourcePromptVersion = isHistoricalVersion && isPrompt(prompt) ? prompt.version : null
     const openInPlaygroundUrl = sourcePromptName
@@ -249,8 +257,13 @@ export function LLMPromptScene(): JSX.Element {
                             >
                                 <LemonButton
                                     type="primary"
-                                    onClick={submitPromptForm}
+                                    onClick={isNewPrompt ? submitPromptForm : requestPublish}
                                     loading={isPromptFormSubmitting}
+                                    disabledReason={
+                                        !isNewPrompt && !isHistoricalVersion && !isPromptFormDirty
+                                            ? 'No changes to publish'
+                                            : undefined
+                                    }
                                     size="small"
                                     data-attr={isNewPrompt ? 'prompt-create-button' : 'prompt-save-button'}
                                 >
@@ -289,6 +302,7 @@ export function LLMPromptScene(): JSX.Element {
                             isHistoricalVersion={isHistoricalVersion}
                             selectedVersion={isPrompt(prompt) ? prompt.version : null}
                         />
+                        <PublishReviewModal />
                     </div>
 
                     {!isNewPrompt && (

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -7,7 +7,7 @@ import api from '~/lib/api'
 import { ApiError } from '~/lib/api-error'
 import { EventsQuery, NodeKind, TracesQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { LLMPromptResolveResponse, PropertyFilterType, PropertyOperator } from '~/types'
+import { LLMPrompt, LLMPromptResolveResponse, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { PromptAnalyticsScope, PromptMode, llmPromptLogic } from './llmPromptLogic'
 
@@ -342,6 +342,46 @@ describe('llmPromptLogic', () => {
 
         logic.actions.setMode(PromptMode.View)
         expect(router.values.searchParams.edit).toBeUndefined()
+
+        logic.unmount()
+    })
+
+    it('routes publish through the review step for existing prompts', async () => {
+        const { versions, has_more, ...promptFields } = mockPrompt
+        jest.spyOn(api.llmPrompts, 'resolveByName').mockResolvedValue({
+            prompt: promptFields,
+            versions,
+            has_more,
+        } as unknown as LLMPromptResolveResponse)
+        const updateSpy = jest.spyOn(api.llmPrompts, 'update').mockResolvedValue({
+            ...promptFields,
+            id: 'prompt-version-3',
+            version: 3,
+            latest_version: 3,
+        } as unknown as LLMPrompt)
+
+        const logic = llmPromptLogic({ promptName: 'my-test-prompt' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPromptSuccess'])
+        logic.actions.setMode(PromptMode.Edit)
+
+        // Empty content skips the review and goes to submit, surfacing validation errors
+        logic.actions.setPromptFormValues({ prompt: '   ' })
+        logic.actions.requestPublish()
+        expect(logic.values.isPublishReviewOpen).toBe(false)
+        expect(updateSpy).not.toHaveBeenCalled()
+
+        // Real edits open the review without hitting the API
+        logic.actions.setPromptFormValues({ prompt: 'My edited prompt.' })
+        logic.actions.requestPublish()
+        expect(logic.values.isPublishReviewOpen).toBe(true)
+        expect(updateSpy).not.toHaveBeenCalled()
+
+        // Confirming from the review publishes and closes it
+        logic.actions.submitPromptForm()
+        await expectLogic(logic).toDispatchActions(['submitPromptFormSuccess'])
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+        expect(logic.values.isPublishReviewOpen).toBe(false)
 
         logic.unmount()
     })

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -163,6 +163,9 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         toggleOutlineExpanded: true,
         cancelEditing: true,
         setPublishConflict: (publishConflict: PublishConflict | null) => ({ publishConflict }),
+        requestPublish: true,
+        openPublishReview: true,
+        closePublishReview: true,
     }),
 
     reducers(({ props }) => ({
@@ -232,6 +235,17 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 setPublishConflict: (_, { publishConflict }) => publishConflict,
                 setMode: () => null,
                 loadPromptSuccess: () => null,
+            },
+        ],
+        isPublishReviewOpen: [
+            false,
+            {
+                openPublishReview: () => true,
+                closePublishReview: () => false,
+                submitPromptFormSuccess: () => false,
+                // A publish conflict (409) needs the editor visible again to show the banner
+                setPublishConflict: () => false,
+                setMode: () => false,
             },
         ],
     })),
@@ -672,6 +686,16 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
     }),
 
     listeners(({ actions, props, values }) => ({
+        requestPublish: () => {
+            // New prompts publish directly (v1, nothing to diff against); an empty form
+            // goes through submit so kea-forms surfaces the validation errors.
+            if (values.isNewPrompt || !values.promptForm.prompt?.trim()) {
+                actions.submitPromptForm()
+                return
+            }
+            actions.openPublishReview()
+        },
+
         cancelEditing: () => {
             const exitEditMode = (): void => {
                 if (values.isNewPrompt) {

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -3,7 +3,7 @@ import { combineUrl } from 'kea-router'
 import { lazy, Suspense, useRef } from 'react'
 
 import { IconColumns, IconMarkdown, IconMarkdownFilled } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonSelect, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonModal, LemonSelect, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { dayjs } from 'lib/dayjs'
@@ -167,6 +167,77 @@ export function PromptViewDetails(): JSX.Element {
                 </div>
             )}
         </div>
+    )
+}
+
+export function PublishReviewModal(): JSX.Element | null {
+    const { isPublishReviewOpen, prompt, promptForm, nextVersion, isPromptFormSubmitting } = useValues(llmPromptLogic)
+    const { closePublishReview, submitPromptForm } = useActions(llmPromptLogic)
+
+    if (!isPrompt(prompt)) {
+        return null
+    }
+
+    const publishLabel = nextVersion ? `Publish v${nextVersion}` : 'Publish version'
+
+    return (
+        <LemonModal
+            isOpen={isPublishReviewOpen}
+            onClose={closePublishReview}
+            title="Review changes"
+            description={`Comparing v${prompt.version} with your edits. Publishing creates ${
+                nextVersion ? `v${nextVersion}` : 'a new version'
+            } — previous versions stay unchanged.`}
+            width={880}
+            footer={
+                <>
+                    <LemonButton
+                        type="secondary"
+                        onClick={closePublishReview}
+                        disabledReason={isPromptFormSubmitting ? 'Publishing…' : undefined}
+                        data-attr="llma-prompt-review-back-button"
+                    >
+                        Back to editing
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={submitPromptForm}
+                        loading={isPromptFormSubmitting}
+                        data-attr="llma-prompt-review-publish-button"
+                    >
+                        {publishLabel}
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="overflow-hidden rounded border" data-attr="llma-prompt-publish-review-diff">
+                <Suspense
+                    fallback={
+                        <div className="space-y-2 p-4">
+                            <LemonSkeleton active className="h-4 w-full" />
+                            <LemonSkeleton active className="h-4 w-3/4" />
+                        </div>
+                    }
+                >
+                    <MonacoDiffEditor
+                        original={prompt.prompt}
+                        value={promptForm.prompt}
+                        modified={promptForm.prompt}
+                        language="markdown"
+                        options={{
+                            readOnly: true,
+                            renderSideBySide: true,
+                            minimap: { enabled: false },
+                            scrollBeyondLastLine: false,
+                            wordWrap: 'on',
+                            lineNumbers: 'off',
+                            folding: false,
+                            hideUnchangedRegions: { enabled: true },
+                        }}
+                    />
+                </Suspense>
+            </div>
+        </LemonModal>
     )
 }
 


### PR DESCRIPTION
## Problem

Clicking "Publish v{N}" creates the new version immediately — there's no moment to see what actually changed before it becomes what every SDK fetch returns. Publishing an unchanged prompt is also possible, creating pointless versions.

## Changes

- Publishing an existing prompt now opens a "Review changes" modal with a side-by-side Monaco diff of your edits against the version you started from, and a "Publish v{N}" confirm. Same pattern as competitors.
- New prompts still publish directly (v1 has nothing to diff against); an invalid form goes straight to submit so validation errors surface in the editor.
- A publish conflict (409) closes the review and returns to the editor so the conflict banner is visible; reopening the review then diffs against the refreshed latest.
- The publish button is disabled with "No changes to publish" when editing the latest version with a pristine form. (Restoring a historical version unchanged is still allowed — that's a legitimate publish.)

## How did you test this code?

<img width="885" height="303" alt="image" src="https://github.com/user-attachments/assets/dd12460a-c3ea-49ce-bd13-ae246280ad99" />

Added one logic test covering the routing: empty content skips review and goes to submit, real edits open the review without calling the API, and confirming publishes and closes it — catches the review being bypassed or blocking publish. All 25 prompts-suite tests pass; oxlint and typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Will fold into the pending prompt-management docs PR (PostHog/posthog.com#18157) once this ships.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as part of the prompt management UX pass; skills invoked: /writing-tests. Design note: the diff baseline is the version the form was seeded from (the currently viewed version), not a freshly fetched latest — no extra fetch, and after a 409 the underlying prompt state is already refreshed to the new latest so the baseline stays honest. The planned optional "what changed?" description input (next PRs, backend first) will live in this review modal.