### PR TITLE
feat(alerts): include project name in insight alert emails

### DIFF
--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -179,6 +179,7 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
         props = {
             "alert_id": str(alert.id),
             "alert_name": alert.name,
+            "project_name": alert.team.name,
             "insight_name": alert.insight.name,
             "insight_id": alert.insight.short_id,
             "state": alert.state,

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -218,7 +218,7 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
     """
     email_targets = alert.get_subscribed_users_emails()
     if email_targets:
-        subject = f"PostHog alert {alert.name} is firing"
+        subject = f"PostHog alert {alert.name} is firing for {alert.team.name}"
         campaign_key = f"alert-firing-notification-{idempotency_key}"
         insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
         alert_url = f"{insight_url}?alert_id={alert.id}"
@@ -232,6 +232,7 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
                 "insight_name": alert.insight.name,
                 "alert_url": alert_url,
                 "alert_name": alert.name,
+                "project_name": alert.team.name,
             },
         )
 
@@ -414,7 +415,7 @@ def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> AlertCheck:
 def send_notifications_for_disabled(alert: AlertConfiguration, reason: str, targets: list[str]) -> None:
     logger.info("Sending alert disabled notification", alert_id=alert.id, reason=reason)
 
-    subject = f"PostHog alert {alert.name} has been disabled"
+    subject = f"PostHog alert {alert.name} for {alert.team.name} has been disabled"
     campaign_key = f"alert-disabled-notification-{alert.id}-{timezone.now().timestamp()}"
     insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
     alert_url = f"{insight_url}?alert_id={alert.id}"
@@ -428,6 +429,7 @@ def send_notifications_for_disabled(alert: AlertConfiguration, reason: str, targ
             "insight_url": insight_url,
             "insight_name": alert.insight.name,
             "alert_error": reason,
+            "project_name": alert.team.name,
         },
     )
     for target in targets:

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,7 +1,7 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert is firing for <a
-            href="{% absolute_uri insight_url %}">{{ insight_name }}</a>:
+            href="{% absolute_uri insight_url %}">{{ insight_name }}</a> in project <strong>{{ project_name }}</strong>:
     </p>
     <ul>
         {% for item in match_descriptions %}

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,7 +1,7 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a
-            href="{% absolute_uri insight_url %}">{{ insight_name }}</a> has been <strong>automatically disabled</strong> because its configuration is no longer valid:
+            href="{% absolute_uri insight_url %}">{{ insight_name }}</a> in project <strong>{{ project_name }}</strong> has been <strong>automatically disabled</strong> because its configuration is no longer valid:
     </p>
     <p><i>{{ alert_error }}</i></p>
     <p>


### PR DESCRIPTION
## Problem

Insight alert emails (firing and auto-disabled) never say which project the insight belongs to. If you're subscribed to alerts across multiple projects, the emails are ambiguous. You can only tell them apart by the insight name or by clicking through. The same gap exists for alert destinations (Slack/webhook hog functions), which had no project field to reference.

## Changes

- Alert firing email now names the project in the subject (`... is firing for <project>`) and body (`... in project <project>`).
- Alert disabled email does the same in its subject and body.
- Added `project_name` to the template context for both emails.
- Added `project_name` to the `$insight_alert_firing` internal event that drives hog function destinations, so Slack/webhook destinations can reference the project.

## How did you test this code?

Ran `posthog/tasks/alerts/test/test_alert_subscriptions.py::TestAlertEmailNotifications` locally, passes. Confirmed the rendered email HTML snapshot now includes the project name.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt flagged that insight alert emails don't say which project they belong to, then asked whether the same should apply to destinations. I (Claude) traced the two live alert email paths in `posthog/tasks/alerts/utils.py` (`send_notifications_for_breaches`, `send_notifications_for_disabled`) plus `trigger_alert_hog_functions`, and added `project_name` to their contexts, subjects, and the internal destination event. The third `alert_check_failed_to_evaluate` path is dead code (commented out) so I left it alone. No skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
