### PR TITLE
chore(ci): upload remaining test suites to Trunk for flaky-test detection

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -7,6 +7,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true # We only want one AI CI run per PR concurrently
 
+env:
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+
 jobs:
     eval:
         timeout-minutes: 45
@@ -197,3 +200,15 @@ jobs:
               with:
                   name: junit-results-ai-evals
                   path: eval-artifacts/*/junit.xml
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: eval-artifacts/*/junit.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -799,13 +799,28 @@ jobs:
                   # ClickHouse drop/create race conditions with ReplicatedMergeTree ZK metadata.
                   # --durations-path: turbo runs products from products/<name>/, so pytest-split
                   # needs an explicit path back to the repo-root durations file for balanced sharding.
+                  # --junitxml: written relative to each product's dir (turbo's cwd), so every
+                  # product in the group gets its own products/<name>/junit-product.xml.
                   # On master, also collect timing data for pytest-split sharding.
                   PYTEST_ADDOPTS: >-
                       --reuse-db
                       --durations-path ../../.test_durations
+                      --junitxml=junit-product.xml
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations' || '' }}
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: products/*/junit-product.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -421,6 +421,18 @@ jobs:
                   name: junit-results-dagster-${{ matrix.group }}
                   path: junit-*.xml
 
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-dagster-${{ matrix.group }}.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
+
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: ${{ github.ref == 'refs/heads/master' && always() }}

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -23,6 +23,9 @@ permissions:
     contents: read
     pull-requests: read
 
+env:
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+
 jobs:
     changes:
         runs-on: ubuntu-latest
@@ -93,6 +96,18 @@ jobs:
               with:
                   name: junit-results-llm-gateway
                   path: services/llm-gateway/junit.xml
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: services/llm-gateway/junit.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
     # Single required status check for branch protection. Add future LLM
     # services test jobs to `needs` here rather than reconfiguring GitHub.

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -22,6 +22,9 @@ permissions:
     contents: read
     pull-requests: read
 
+env:
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+
 jobs:
     changes:
         runs-on: ubuntu-24.04
@@ -550,12 +553,25 @@ jobs:
                   verbose: true
 
             - name: Run integration tests
-              run: cd services/mcp && pnpm run test:integration
+              # The junit reporter (alongside the default console one) feeds the Trunk upload below.
+              run: cd services/mcp && pnpm run test:integration -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
               env:
                   TEST_POSTHOG_API_BASE_URL: http://localhost:8000
                   TEST_POSTHOG_PERSONAL_API_KEY: phx_e2e_demo_api_key
                   TEST_ORG_ID: ${{ env.TEST_ORG_ID }}
                   TEST_PROJECT_ID: ${{ env.TEST_PROJECT_ID }}
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: services/mcp/junit-integration.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
             - name: Show server logs on failure
               if: failure()

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -15,6 +15,7 @@ env:
     OBJECT_STORAGE_BUCKET: 'posthog'
     # set the max buffer size small enough that the functional tests behave the same in CI as when running locally
     SESSION_RECORDING_MAX_BUFFER_SIZE_KB: 1024
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -366,6 +367,13 @@ jobs:
                   LOG_LEVEL: info
                   # Enable localstack integration tests for DynamoDB/KMS
                   LOCALSTACK_ENABLED: '1'
+                  # Emit JUnit XML for the Trunk upload below (turbo passes JEST_JUNIT_* through).
+                  JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results
+                  JEST_JUNIT_OUTPUT_NAME: junit-nodejs-${{ matrix.shard }}.xml
+                  # Trunk attributes flakes by test file; jest-junit's default suite name is the
+                  # describe block, so make it the file path instead.
+                  JEST_JUNIT_SUITE_NAME: '{filepath}'
+                  JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
               run: bin/turbo run test --filter=@posthog/nodejs
 
             - name: Test postgres-parity (isolated DB)
@@ -378,7 +386,23 @@ jobs:
                   REDIS_URL: 'redis://localhost'
                   NODE_OPTIONS: '--max_old_space_size=4096'
                   LOG_LEVEL: info
+                  JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results
+                  JEST_JUNIT_OUTPUT_NAME: junit-nodejs-postgres-parity.xml
+                  JEST_JUNIT_SUITE_NAME: '{filepath}'
+                  JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
               run: cd nodejs && pnpm run test:postgres-parity
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-results/junit-*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
             - name: Output logs on failure
               if: failure()

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -15,6 +15,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+
 jobs:
     # Job to decide if we should run python ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
@@ -222,6 +225,18 @@ jobs:
               with:
                   name: junit-results-dependency-detection
                   path: junit-dependency-detection.xml
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: junit-*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
             # - name: Check if "taxonomy.json/taxonomy.tsx" is up to date
             #   if: needs.changes.outputs.python == 'true'

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
     CARGO_TERM_COLOR: always
     UV_HTTP_TIMEOUT: 120
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
 
 jobs:
     # Job to decide if we should run rust ci
@@ -397,6 +398,15 @@ jobs:
               run: |
                   cd ../ && ./bin/download-mmdb
 
+            - name: Install cargo-binstall
+              uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
+
+            - name: Install cargo-nextest
+              # --force: Swatinem/rust-cache restores ~/.cargo/.crates2.json but not the
+              # binary itself, so without --force binstall can short-circuit ("already
+              # installed") and leave no `cargo nextest` binary.
+              run: cargo binstall --no-confirm --force cargo-nextest@0.9.140
+
             - name: Run cargo test
               env:
                   RUST_BACKTRACE: 1
@@ -404,6 +414,21 @@ jobs:
                   PERSONS_READ_DATABASE_URL: ${{ contains(format(' {0} ', matrix.packages), ' feature-flags ') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
                   PERSONS_WRITE_DATABASE_URL: ${{ contains(format(' {0} ', matrix.packages), ' feature-flags ') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
               run: |
+                  # nextest (instead of plain `cargo test`) emits JUnit XML for the Trunk upload
+                  # below. It does not run doctests, so those keep running via `cargo test --doc`.
+                  # --no-tests=pass matches `cargo test` semantics for packages/filters with no tests.
+                  # Each run overwrites target/nextest/ci/junit.xml, so stash it per package —
+                  # even on failure, so the failing results still reach Trunk before we exit.
+                  run_nextest() {
+                      local junit_name=$1
+                      shift
+                      local rc=0
+                      cargo nextest run --profile ci --no-tests=pass "$@" || rc=$?
+                      if [ -f target/nextest/ci/junit.xml ]; then
+                          mv target/nextest/ci/junit.xml "junit-nextest-$junit_name.xml"
+                      fi
+                      return $rc
+                  }
                   for pkg in ${{ matrix.packages }}; do
                       echo "::group::Testing $pkg"
                       # Free cgroups, overlayfs, and network namespaces from previous testcontainers
@@ -411,19 +436,36 @@ jobs:
                       extra_args=""
                       # Limit test threads for packages with sqlx pool exhaustion issues
                       if [ "$pkg" = "property-defs-rs" ]; then
-                          extra_args="-- --test-threads=4"
+                          extra_args="--test-threads=4"
                       fi
-                      cargo test -p "$pkg" $extra_args
+                      run_nextest "$pkg" -p "$pkg" $extra_args
+                      # nextest skips doctests; run them only for packages with a lib target
+                      # (`cargo test --doc` errors on bin-only packages).
+                      if cargo metadata --no-deps --format-version 1 | jq -e --arg p "$pkg" '[.packages[] | select(.name == $p) | .targets[] | select(.kind | index("lib"))] | length > 0' >/dev/null; then
+                          cargo test --doc -p "$pkg"
+                      fi
                       # Error-tracking rate-limiter e2e tests are #[ignore]'d (they need a real Redis
                       # via testcontainers/Docker, absent in some environments). This job has Docker,
                       # so run them here, single-threaded to avoid concurrent-container flakes. The
                       # `rate_limiting` filter matches nothing on branches without these tests, so it
                       # stays safe for unrebased PRs.
                       if [ "$pkg" = "cymbal" ]; then
-                          cargo test -p cymbal rate_limiting -- --ignored --test-threads=1
+                          run_nextest cymbal-ignored -p cymbal -E 'test(rate_limiting)' --run-ignored only --test-threads=1
                       fi
                       echo "::endgroup::"
                   done
+
+            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
+            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            - name: Upload test results to Trunk
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+              continue-on-error: true
+              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              with:
+                  junit-paths: rust/junit-nextest-*.xml
+                  org-slug: posthog-inc
+                  token: ${{ secrets.TRUNK_API_TOKEN }}
 
     linting:
         name: Lint Rust services (depot-ubuntu-22.04-4)

--- a/nodejs/jest.config.js
+++ b/nodejs/jest.config.js
@@ -8,6 +8,8 @@ module.exports = {
         ],
     },
     testEnvironment: 'node',
+    // Emit JUnit XML for Trunk flaky-test detection only when JEST_JUNIT_OUTPUT_DIR is set.
+    reporters: process.env.JEST_JUNIT_OUTPUT_DIR ? ['default', 'jest-junit'] : ['default'],
     clearMocks: true,
     coverageProvider: 'v8',
     setupFiles: ['./jest.setup-env.ts'],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -186,6 +186,7 @@
         "eslint-plugin-no-only-tests": "^3.1.0",
         "jest": "^30.0.0",
         "jest-environment-node": "^30.0.0",
+        "jest-junit": "^16.0.0",
         "pino-pretty": "^9.1.0",
         "prettier": "~3.6.2",
         "supertest": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1770,6 +1770,9 @@ importers:
       jest-environment-node:
         specifier: ^30.0.0
         version: 30.0.5
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
       pino-pretty:
         specifier: ^9.1.0
         version: 9.4.0

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,4 @@
+# CI profile: emits JUnit XML (target/nextest/ci/junit.xml) so test results can be
+# uploaded to Trunk for flaky-test detection.
+[profile.ci.junit]
+path = "junit.xml"

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,4 +1,9 @@
 # CI profile: emits JUnit XML (target/nextest/ci/junit.xml) so test results can be
 # uploaded to Trunk for flaky-test detection.
+[profile.ci]
+# Run the whole suite even after a failure, so the JUnit output captures every
+# failing/flaky test for Trunk instead of stopping at the first one.
+fail-fast = false
+
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
## Problem

Only the Django (Core + Temporal), frontend Jest, E2E Playwright, and Storybook suites upload results to Trunk, so flaky-test detection is blind to the rest of CI. Trunk flagged the gaps: product tests, Node.js ingestion tests, cargo test, MCP integration tests, and the AI evals / Dagster / LLM gateway / Python workflows.

## Changes

Adds Trunk uploads to every missing suite, following the existing examples (same pinned `trunk-io/analytics-uploader` SHA, same internal-PR/Dependabot guard). All new uploads are plain, non-gating uploads (storybook-style) with `continue-on-error: true` – a Trunk outage can never fail CI, and no quarantine gating is introduced. Suites can opt into gating later once history builds up.

Suites that already produced JUnit XML just get an upload step (plus a workflow-level `RUNS_ON_INTERNAL_PR` env where missing):

- **ci-ai.yml** – uploads the merged `eval-artifacts/*/junit.xml` in the `eval-summary` job
- **ci-dagster.yml** – uploads `junit-dagster-<group>.xml` per matrix job
- **ci-llm-gateway.yml** – uploads the pytest junit file
- **ci-python.yml** – uploads all five `junit-*.xml` files (hogli, hogli-commands, query-performance-ai, pr-approval-agent, dependency detection)

Suites that had no JUnit output needed wiring first:

- **Product tests** (`ci-backend.yml` `turbo-tests`) – `--junitxml=junit-product.xml` added to `PYTEST_ADDOPTS` (already in turbo's `passThroughEnv`). Turbo runs pytest from `products/<name>/`, so each product writes its own file and the upload globs `products/*/junit-product.xml`.
- **Node.js ingestion tests** (`ci-nodejs.yml`) – added `jest-junit` to `nodejs/package.json` and the reporter to `nodejs/jest.config.js`, gated on `JEST_JUNIT_OUTPUT_DIR` exactly like the frontend config (turbo's `test` task already passes `JEST_JUNIT_*` through). Both the sharded jest run and the postgres-parity run emit files.
- **MCP integration tests** (`ci-mcp.yml`) – appended `--reporter=default --reporter=junit --outputFile.junit=junit-integration.xml` to the vitest invocation.
- **Cargo test** (`ci-rust.yml`) – `cargo test` can't emit JUnit, so the per-package loop now runs cargo-nextest (pinned 0.9.140, installed via the repo's existing cargo-binstall pattern) with a new `ci` profile in `rust/.config/nextest.toml`. Semantics kept as close as possible: `--no-tests=pass` matches cargo's empty-suite behavior, the property-defs-rs thread limit and cymbal `--run-ignored only` runs carry over, JUnit files are stashed per package even on failure so failing results still reach Trunk, and doctests (which nextest skips) still run via `cargo test --doc`, guarded to lib-target packages only.

One thing to watch on the Rust side: nextest runs each test in its own process instead of threads in one binary. Tests relying on shared in-process state could behave differently, and this branch's CI run will surface any such case.

## How did you test this code?

Static verification only (no runner-side execution is possible locally):

- actionlint and a YAML parse pass clean on all eight modified workflows
- `pnpm install --lockfile-only --frozen-lockfile` confirms the lockfile is consistent with the manifest change (jest-junit@16 was already resolved in the lockfile via the frontend importer)
- `hogli ci:preflight --fix` passes

The real proof is this PR's own CI: each touched workflow triggers on changes to itself, so all suites run here and the Trunk upload steps should appear in the logs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed – CI-internal change, no user-facing behavior, APIs, or documented workflows touched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code task session) from Trunk's feedback on which suites were missing uploads. Decisions along the way:

- Chose plain non-gating uploads over the quarantine-gate pattern used by the Django/Jest/Playwright suites, since the ask was detection coverage and gating changes job pass/fail semantics
- Migrated the Rust test job to cargo-nextest as the only practical way to get JUnit out of cargo, preserving doctests and the existing per-package special cases
- Hand-added the `jest-junit` importer entry to `pnpm-lock.yaml` (the package was already resolved for the frontend); a full pnpm re-resolve was blocked locally by an unrelated `trustPolicy: no-downgrade` error on `undici-types` that also reproduces on master. Verified with a frozen-lockfile install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
