### PR TITLE
chore(ci): gate container workflows on trigger-level paths

### DIFF
--- a/.github/workflows/cd-llm-analytics-image.yml
+++ b/.github/workflows/cd-llm-analytics-image.yml
@@ -22,8 +22,22 @@ on:
             - '.github/workflows/cd-llm-analytics-image.yml'
             - 'pyproject.toml'
             - 'bin/temporal-django-worker'
+    # paths mirror the push trigger; the build-llm-analytics-image label only
+    # forces a build on PRs touching these paths — use workflow_dispatch otherwise.
     pull_request:
         types: [opened, synchronize, reopened, labeled]
+        paths:
+            - 'posthog/temporal/ai_observability/**'
+            - 'posthog/temporal/llm_analytics/**'
+            - 'products/ai_observability/**'
+            - 'products/llm_analytics/**'
+            - 'posthog/temporal/common/**'
+            - 'posthog/management/commands/start_temporal_worker.py'
+            - 'posthog/clickhouse/migrations/**'
+            - 'Dockerfile.llm-analytics'
+            - '.github/workflows/cd-llm-analytics-image.yml'
+            - 'pyproject.toml'
+            - 'bin/temporal-django-worker'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cd-llm-analytics-image.yml
+++ b/.github/workflows/cd-llm-analytics-image.yml
@@ -23,7 +23,7 @@ on:
             - 'pyproject.toml'
             - 'bin/temporal-django-worker'
     # paths mirror the push trigger; the build-llm-analytics-image label only
-    # forces a build on PRs touching these paths — use workflow_dispatch otherwise.
+    # forces a build on PRs touching these paths, use workflow_dispatch otherwise.
     pull_request:
         types: [opened, synchronize, reopened, labeled]
         paths:

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -14,7 +14,7 @@ on:
             - 'services/mcp/**'
             - '.github/workflows/cd-mcp-image.yml'
     # paths mirror the push trigger; the build-mcp-image label only forces a
-    # build on PRs touching these paths — use workflow_dispatch otherwise.
+    # build on PRs touching these paths, use workflow_dispatch otherwise.
     pull_request:
         types: [opened, synchronize, reopened, labeled]
         paths:

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -13,8 +13,13 @@ on:
         paths:
             - 'services/mcp/**'
             - '.github/workflows/cd-mcp-image.yml'
+    # paths mirror the push trigger; the build-mcp-image label only forces a
+    # build on PRs touching these paths — use workflow_dispatch otherwise.
     pull_request:
         types: [opened, synchronize, reopened, labeled]
+        paths:
+            - 'services/mcp/**'
+            - '.github/workflows/cd-mcp-image.yml'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -4,7 +4,13 @@ on:
     push:
         branches:
             - master
+    # paths mirror the changes job's dorny filter, which still gates push events.
     pull_request:
+        paths:
+            - '.github/workflows/cd-sandbox-base-image.yml'
+            - 'products/tasks/backend/sandbox/images/**'
+            - 'products/*/skills/**'
+            - 'products/posthog_ai/scripts/**'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -37,6 +37,7 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Keep in sync with the trigger-level pull_request paths above.
                   filters: |
                       sandbox_image:
                         - '.github/workflows/cd-sandbox-base-image.yml'
@@ -255,6 +256,10 @@ jobs:
 
     # Single required status check for branch protection. Add future sandbox
     # image jobs to `needs` here rather than reconfiguring GitHub.
+    # NOT registered as required yet: the trigger-level pull_request paths
+    # filter means this check never reports on PRs that don't touch sandbox
+    # paths, and a required check that never reports blocks merging forever.
+    # Before registering it in the ruleset, remove that paths filter.
     sandbox_base_image_check:
         needs: [changes, build_skills, sandbox_base_build]
         name: Sandbox Base Image Pass

--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -61,6 +61,7 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Keep in sync with the trigger-level pull_request paths above.
                   filters: |
                       agent_files:
                         - 'products/agent_platform/services/**'

--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -8,7 +8,25 @@ name: Build and deploy agent platform container images
 
 on:
     workflow_dispatch:
+    # paths mirror the changes job's dorny filter, which still gates push and
+    # merge_group events (merge_group triggers don't support paths).
     pull_request:
+        paths:
+            - 'products/agent_platform/services/**'
+            - 'products/agent_platform/packages/**'
+            # Transitional: in-flight branches still have these at the
+            # old paths. Drop once they've rebased onto the move.
+            - 'services/agent-ingress/**'
+            - 'services/agent-runner/**'
+            - 'services/agent-janitor/**'
+            - 'services/agent-shared/**'
+            - 'services/agent-tools/**'
+            - 'services/agent-sandbox-host/**'
+            - 'services/agents/**'
+            - 'packages/quill/**'
+            - '.github/workflows/ci-agent-container.yml'
+            - 'pnpm-lock.yaml'
+            - 'pnpm-workspace.yaml'
     merge_group:
     push:
         branches:

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -55,6 +55,7 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Keep in sync with the trigger-level pull_request paths above.
                   filters: |
                       node_files:
                         - 'nodejs/**'

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -2,7 +2,25 @@ name: Build and deploy node container image
 
 on:
     workflow_dispatch:
+    # paths mirror the changes job's dorny filter, which still gates push and
+    # merge_group events (merge_group triggers don't support paths).
     pull_request:
+        paths:
+            - 'nodejs/**'
+            - 'common/hogvm/typescript/**'
+            - 'common/plugin_transpiler/**'
+            - 'common/esbuilder/**'
+            - 'common/replay-shared/**'
+            - 'common/replay-headless/**'
+            - 'rust/cyclotron-node/**'
+            - 'rust/common/hogvm/**'
+            - 'rust/replay-anonymizer-node/**'
+            - 'Dockerfile.node'
+            - '.github/workflows/ci-nodejs-container.yml'
+            - 'turbo.json'
+            - 'package.json'
+            - 'pnpm-lock.yaml'
+            - 'pnpm-workspace.yaml'
     merge_group:
     push:
         branches:

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -61,6 +61,7 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Keep in sync with the trigger-level pull_request paths above.
                   filters: |
                       rasterizer_files:
                         - 'nodejs/**'

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -2,7 +2,27 @@ name: Build and deploy recording-rasterizer container image
 
 on:
     workflow_dispatch:
+    # paths mirror the changes job's dorny filter, which still gates push and
+    # merge_group events (merge_group triggers don't support paths).
     pull_request:
+        paths:
+            - 'nodejs/**'
+            - 'common/hogvm/typescript/**'
+            - 'common/plugin_transpiler/**'
+            - 'common/esbuilder/**'
+            - 'common/replay-shared/**'
+            - 'common/replay-headless/**'
+            - 'rust/cyclotron-node/**'
+            - 'rust/cyclotron-core/**'
+            - 'Dockerfile.recording-rasterizer'
+            - '.github/workflows/ci-recording-rasterizer-container.yml'
+            - 'bin/turbo'
+            - 'patches/**'
+            - 'turbo.json'
+            - 'tsconfig.json'
+            - 'package.json'
+            - 'pnpm-lock.yaml'
+            - 'pnpm-workspace.yaml'
     merge_group:
     push:
         branches:


### PR DESCRIPTION
## Problem

- Six container CD/CI workflows dispatch a run on every PR push only to skip internally via dorny/paths-filter or a label gate: ~195k no-op dispatches in 30 days.
- Each dispatch counts against GitHub's repo-wide cap of 500 runs/10s, the cap behind our `startup_failure` bursts (context: #68964).

**Before — every push dispatches a run:**

```mermaid
flowchart LR
    p1([PR push]) --> r1[run dispatched] --> d1{dorny filter}
    d1 -->|no match, vast majority| s1[skip — dispatch wasted]
    d1 -->|match| b1[build image]
```

**After — filter moves to the trigger:**

```mermaid
flowchart LR
    p2([PR push]) --> t2{trigger-level paths}
    t2 -->|no match| n2[no run dispatched at all]
    t2 -->|match| r2[run dispatched] --> b2[build image]
```

## Changes

- Add trigger-level `paths:` to the `pull_request` trigger of `cd-mcp-image`, `cd-llm-analytics-image`, `cd-sandbox-base-image`, `ci-nodejs-container`, `ci-recording-rasterizer-container`, `ci-agent-container`, mirroring each workflow's existing dorny filter or push paths.
- Dorny filters stay for `push`/`merge_group` (merge_group can't take paths). None of these report required checks.
- Behavior note: the force-build labels on the two cd-* workflows now only work on PRs touching the listed paths; `workflow_dispatch` remains the escape hatch.

## How did you test this code?

- `hogli ci:preflight` workflow lint via pre-push hook; paths verified against each workflow's own filter list.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude via PostHog Code) derived the paths from each workflow's internal filters during the CI dispatch-capacity sweep.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
