### PR TITLE
feat(billing): add read-only billing access for non-admin members

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -31,6 +31,8 @@ logger = structlog.get_logger(__name__)
 
 BILLING_SERVICE_JWT_AUD = "posthog:license-key"
 
+READ_ONLY_BILLING_ACCESS_FLAG = "read-only-billing-access"
+
 
 class IsOrganizationAdmin(permissions.BasePermission):
     """
@@ -45,6 +47,35 @@ class IsOrganizationAdmin(permissions.BasePermission):
         return OrganizationMembership.objects.filter(
             user=request.user, organization=org, level__gte=OrganizationMembership.Level.ADMIN
         ).exists()
+
+
+class IsOrganizationAdminOrReadOnlyBillingMember(permissions.BasePermission):
+    """
+    Permission for read-only billing data endpoints (usage, spend).
+
+    Allows organization admins (level >= ADMIN) as usual, and additionally allows any organization member
+    when the organization has the read-only-billing-access feature flag enabled. Mutating billing endpoints
+    remain guarded by IsOrganizationAdmin.
+    """
+
+    def has_permission(self, request, view):
+        try:
+            org = view._get_org_required()
+        except Exception:
+            return False
+        membership = OrganizationMembership.objects.filter(user=request.user, organization=org).first()
+        if not membership:
+            return False
+        if membership.level >= OrganizationMembership.Level.ADMIN:
+            return True
+        return bool(
+            posthoganalytics.feature_enabled(
+                READ_ONLY_BILLING_ACCESS_FLAG,
+                str(org.id),
+                groups={"organization": str(org.id)},
+                group_properties={"organization": {"id": str(org.id)}},
+            )
+        )
 
 
 class BillingSerializer(serializers.Serializer):
@@ -535,7 +566,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="usage",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdminOrReadOnlyBillingMember],
     )
     def usage(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -571,7 +602,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="spend",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdminOrReadOnlyBillingMember],
     )
     def spend(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         """Endpoint to fetch spend data (proxy to billing service)."""

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1195,6 +1195,26 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         response = self.client.get("/api/billing/spend/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    def test_get_usage_allowed_for_member_with_read_only_flag(self, mock_get_usage_data, _mock_feature_enabled):
+        mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        response = self.client.get("/api/billing/usage/?start_date=2025-01-01")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), self.MOCK_USAGE_DATA)
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    @patch("ee.billing.billing_manager.BillingManager.get_spend_data")
+    def test_get_spend_allowed_for_member_with_read_only_flag(self, mock_get_spend_data, _mock_feature_enabled):
+        mock_get_spend_data.return_value = self.MOCK_SPEND_DATA
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        response = self.client.get("/api/billing/spend/?start_date=2025-01-01")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), self.MOCK_SPEND_DATA)
+
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
     @patch("ee.api.billing.BillingViewset._get_teams_map")
     def test_get_usage_empty_teams_map_graceful_handling(self, mock_get_teams_map, mock_get_usage_data):

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -141,7 +141,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
     const { currentOrganization } = useValues(organizationLogic)
     const { isCloudOrDev, isCloud, preflight } = useValues(preflightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { billing, canAccessBilling } = useValues(billingLogic)
+    const { billing, canViewBilling } = useValues(billingLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { reportInviteMembersButtonClicked } = useActions(eventUsageLogic)
     const { reportAccountOwnerClicked } = useActions(eventUsageLogic)
@@ -185,7 +185,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                             </div>
                         </Link>
                     </DropdownMenuItem>
-                    {isCloudOrDev && canAccessBilling ? (
+                    {isCloudOrDev && canViewBilling ? (
                         <DropdownMenuItem asChild>
                             <Link
                                 to={

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -63,7 +63,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const hasPendingInvites = pendingInvites.length > 0
     const { preflight } = useValues(preflightLogic)
     const { currentOrganization } = useValues(organizationLogic)
-    const { canAccessBilling } = useValues(billingLogic)
+    const { canViewBilling } = useValues(billingLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { showCreateOrganizationModal } = useActions(globalModalsLogic)
@@ -303,7 +303,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                     </Menu.Portal>
                                 </Menu.SubmenuRoot>
 
-                                {isCloudOrDev && canAccessBilling ? (
+                                {isCloudOrDev && canViewBilling ? (
                                     <Menu.Item
                                         render={(props) => (
                                             <Link

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -404,6 +404,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_WIZARD_SYNC: 'onboarding-wizard-sync', // owner: @fercgomes #team-growth multivariate=control,test — gates the live wizard sync progress panel
     ONBOARDING_WIZARD_SYNC_MODE: 'onboarding-wizard-sync-mode', // owner: @fercgomes #team-growth multivariate=sse,polling — how the wizard sync panel pulls run updates (SSE stream vs REST polling); payload carries polling_interval_secs
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
+    READ_ONLY_BILLING_ACCESS: 'read-only-billing-access', // owner: @pawelcebula #team-billing — lets non-admin members view billing read-only
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
     PAGE_REPORTS_RANKED_URL_SEARCH: 'page-reports-ranked-url-search', // owner: @jordanm-posthog #team-web-analytics
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -54,7 +54,8 @@ export function Billing(): JSX.Element {
         showBillingSummary,
         showCreditCTAHero,
         showBillingHero,
-        minimumBillingAccessLevel,
+        minimumBillingViewLevel,
+        isBillingReadOnly,
         hasSupportAddonPlan,
     } = useValues(billingLogic)
     const { reportBillingShown } = useActions(billingLogic)
@@ -66,7 +67,7 @@ export function Billing(): JSX.Element {
     const { memberCount } = useValues(membersLogic)
 
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: minimumBillingAccessLevel,
+        minimumAccessLevel: minimumBillingViewLevel,
         scope: RestrictionScope.Organization,
     })
 
@@ -124,7 +125,13 @@ export function Billing(): JSX.Element {
 
     return (
         <div className="@container">
-            {showLicenseDirectInput && (
+            {isBillingReadOnly && (
+                <LemonBanner type="info" className="mb-2">
+                    You have read-only access to billing. Contact an organization admin to make changes.
+                </LemonBanner>
+            )}
+
+            {!isBillingReadOnly && showLicenseDirectInput && (
                 <>
                     <Form
                         logic={billingLogic}
@@ -196,7 +203,7 @@ export function Billing(): JSX.Element {
                 </div>
             )}
 
-            {!showBillingSummary && <StripePortalButton />}
+            {!showBillingSummary && !isBillingReadOnly && <StripePortalButton />}
 
             {!couponsOverviewLoading && activeCoupons.length > 0 && (
                 <div className="mt-6 max-w-300">
@@ -282,7 +289,7 @@ export function Billing(): JSX.Element {
                 </div>
             )}
             <div>
-                {billing?.subscription_level == 'paid' && !!platformAndSupportProduct ? (
+                {billing?.subscription_level == 'paid' && !!platformAndSupportProduct && !isBillingReadOnly ? (
                     <>
                         <LemonDivider />
                         <UnsubscribeCard product={platformAndSupportProduct} />

--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -14,7 +14,7 @@ import { billingProductLogic } from './billingProductLogic'
 
 export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const limitInputRef = useRef<HTMLInputElement | null>(null)
-    const { billing, billingLoading } = useValues(billingLogic)
+    const { billing, billingLoading, isBillingReadOnly } = useValues(billingLogic)
     const { isEditingBillingLimit, customLimitUsd, hasCustomLimitSet, currentAndUpgradePlans, billingLimitNextPeriod } =
         useValues(billingProductLogic({ product, billingLimitInputRef: limitInputRef }))
     const { setIsEditingBillingLimit, setBillingLimitInput, submitBillingLimitInput, removeBillingLimitNextPeriod } =
@@ -62,26 +62,30 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                             </Tooltip>
                                         )}
 
-                                        <LemonButton
-                                            onClick={() => setIsEditingBillingLimit(true)}
-                                            status="danger"
-                                            size="small"
-                                        >
-                                            Edit limit
-                                        </LemonButton>
+                                        {!isBillingReadOnly && (
+                                            <LemonButton
+                                                onClick={() => setIsEditingBillingLimit(true)}
+                                                status="danger"
+                                                size="small"
+                                            >
+                                                Edit limit
+                                            </LemonButton>
+                                        )}
                                     </>
                                 ) : (
                                     <>
                                         <span className="text-sm" data-attr={`billing-limit-not-set-${product.type}`}>
                                             You do not have a billing limit set for {product?.name?.toLowerCase()}.
                                         </span>
-                                        <LemonButton
-                                            onClick={() => setIsEditingBillingLimit(true)}
-                                            status="danger"
-                                            size="small"
-                                        >
-                                            Set a billing limit
-                                        </LemonButton>
+                                        {!isBillingReadOnly && (
+                                            <LemonButton
+                                                onClick={() => setIsEditingBillingLimit(true)}
+                                                status="danger"
+                                                size="small"
+                                            >
+                                                Set a billing limit
+                                            </LemonButton>
+                                        )}
                                     </>
                                 )}
                             </>
@@ -148,14 +152,16 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                             <span className="text-sm xl:text-right">
                                 Your limit for next period: <b>${billingLimitNextPeriod.toLocaleString()}</b>.
                             </span>
-                            <LemonButton
-                                size="small"
-                                status="danger"
-                                onClick={() => removeBillingLimitNextPeriod(product.type)}
-                                data-attr={`remove-billing-limit-next-period-${product.type}`}
-                            >
-                                Remove limit for next period
-                            </LemonButton>
+                            {!isBillingReadOnly && (
+                                <LemonButton
+                                    size="small"
+                                    status="danger"
+                                    onClick={() => removeBillingLimitNextPeriod(product.type)}
+                                    data-attr={`remove-billing-limit-next-period-${product.type}`}
+                                >
+                                    Remove limit for next period
+                                </LemonButton>
+                            )}
                         </div>
                     ) : null}
                 </div>

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -58,7 +58,7 @@ export const getTierDescription = (
 
 export const BillingProduct = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const productRef = useRef<HTMLDivElement | null>(null)
-    const { billing, isUnlicensedDebug } = useValues(billingLogic)
+    const { billing, isUnlicensedDebug, isBillingReadOnly } = useValues(billingLogic)
     const {
         hasCustomLimitSet,
         showTierBreakdown,
@@ -178,7 +178,8 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                     </LemonButton>
                                 </>
                             ) : (
-                                product.subscribed && (
+                                product.subscribed &&
+                                !isBillingReadOnly && (
                                     <More
                                         overlay={
                                             <>
@@ -547,16 +548,18 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                             {addonSectionLabel} are only available on paid plans. Upgrade to access
                                             these features.
                                         </div>
-                                        <BillingUpgradeCTA
-                                            type="primary"
-                                            status="alt"
-                                            data-attr="billing-page-addon-cta-upgrade-cta"
-                                            disableClientSideRouting
-                                            loading={!!billingProductLoading}
-                                            onClick={() => startPaymentEntryFlow(product)}
-                                        >
-                                            Upgrade now
-                                        </BillingUpgradeCTA>
+                                        {!isBillingReadOnly && (
+                                            <BillingUpgradeCTA
+                                                type="primary"
+                                                status="alt"
+                                                data-attr="billing-page-addon-cta-upgrade-cta"
+                                                disableClientSideRouting
+                                                loading={!!billingProductLoading}
+                                                onClick={() => startPaymentEntryFlow(product)}
+                                            >
+                                                Upgrade now
+                                            </BillingUpgradeCTA>
+                                        )}
                                     </div>
                                 </LemonBanner>
                             )}

--- a/frontend/src/scenes/billing/BillingSpendView.tsx
+++ b/frontend/src/scenes/billing/BillingSpendView.tsx
@@ -27,9 +27,9 @@ import { billingSpendLogic } from './billingSpendLogic'
 import { USAGE_TYPES } from './constants'
 
 export function BillingSpendView(): JSX.Element {
-    const { minimumBillingAccessLevel } = useValues(billingLogic)
+    const { minimumBillingViewLevel } = useValues(billingLogic)
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: minimumBillingAccessLevel,
+        minimumAccessLevel: minimumBillingViewLevel,
         scope: RestrictionScope.Organization,
     })
     const logic = billingSpendLogic({ syncWithUrl: true })

--- a/frontend/src/scenes/billing/BillingUsage.tsx
+++ b/frontend/src/scenes/billing/BillingUsage.tsx
@@ -26,9 +26,9 @@ import { billingUsageLogic } from './billingUsageLogic'
 import { USAGE_TYPES } from './constants'
 
 export function BillingUsage(): JSX.Element {
-    const { minimumBillingAccessLevel } = useValues(billingLogic)
+    const { minimumBillingViewLevel } = useValues(billingLogic)
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: minimumBillingAccessLevel,
+        minimumAccessLevel: minimumBillingViewLevel,
         scope: RestrictionScope.Organization,
     })
     const logic = billingUsageLogic({ syncWithUrl: true })

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -10,6 +10,7 @@ import {
     buildUsageLimitApproachingMessage,
     buildUsageLimitExceededMessage,
     canAccessBilling,
+    canViewBilling,
     convertAmountToUsage,
     convertLargeNumberToWords,
     convertUsageToAmount,
@@ -17,6 +18,7 @@ import {
     formatProductNames,
     formatWithDecimals,
     getMinimumBillingAccessLevel,
+    getMinimumBillingViewLevel,
     getProration,
     getUsageLimitConsequence,
     projectUsage,
@@ -666,4 +668,33 @@ describe('canAccessBilling', () => {
     ])('returns $expected for level=$level, ownerOnly=$ownerOnly', ({ level, ownerOnly, expected }) => {
         expect(canAccessBilling(level, ownerOnly)).toBe(expected)
     })
+})
+
+describe('getMinimumBillingViewLevel', () => {
+    it.each([
+        { ownerOnly: false, readOnly: false, expected: OrganizationMembershipLevel.Admin },
+        { ownerOnly: true, readOnly: false, expected: OrganizationMembershipLevel.Owner },
+        // read-only access lowers the view threshold to Member regardless of ownerOnly
+        { ownerOnly: false, readOnly: true, expected: OrganizationMembershipLevel.Member },
+        { ownerOnly: true, readOnly: true, expected: OrganizationMembershipLevel.Member },
+    ])('returns $expected for ownerOnly=$ownerOnly, readOnly=$readOnly', ({ ownerOnly, readOnly, expected }) => {
+        expect(getMinimumBillingViewLevel(ownerOnly, readOnly)).toBe(expected)
+    })
+})
+
+describe('canViewBilling', () => {
+    it.each([
+        // Without the read-only flag, viewing requires the same level as managing
+        { level: OrganizationMembershipLevel.Member, ownerOnly: false, readOnly: false, expected: false },
+        { level: OrganizationMembershipLevel.Admin, ownerOnly: false, readOnly: false, expected: true },
+        // With the read-only flag, any member can view
+        { level: OrganizationMembershipLevel.Member, ownerOnly: false, readOnly: true, expected: true },
+        { level: OrganizationMembershipLevel.Member, ownerOnly: true, readOnly: true, expected: true },
+        { level: null, ownerOnly: false, readOnly: true, expected: false },
+    ])(
+        'returns $expected for level=$level, ownerOnly=$ownerOnly, readOnly=$readOnly',
+        ({ level, ownerOnly, readOnly, expected }) => {
+            expect(canViewBilling(level, ownerOnly, readOnly)).toBe(expected)
+        }
+    )
 })

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -425,21 +425,50 @@ export const currencyFormatter = (value: number): string => {
 }
 
 /**
- * Returns the minimum membership level required to access billing.
- * When ownerOnlyBilling is true (via the owner-only-billing feature flag), only org owners can access billing.
+ * Returns the minimum membership level required to *manage* billing (edit limits, subscribe, change plans).
+ * When ownerOnlyBilling is true (via the owner-only-billing feature flag), only org owners can manage billing.
  */
 export function getMinimumBillingAccessLevel(ownerOnlyBilling: boolean): OrganizationMembershipLevel {
     return ownerOnlyBilling ? OrganizationMembershipLevel.Owner : OrganizationMembershipLevel.Admin
 }
 
 /**
- * Determines if the user has sufficient permissions to access billing based on their org membership level.
+ * Returns the minimum membership level required to *view* billing.
+ * When readOnlyBillingAccess is true (via the read-only-billing-access feature flag), any member can view billing
+ * read-only. Otherwise viewing requires the same level as managing.
+ */
+export function getMinimumBillingViewLevel(
+    ownerOnlyBilling: boolean,
+    readOnlyBillingAccess: boolean
+): OrganizationMembershipLevel {
+    if (readOnlyBillingAccess) {
+        return OrganizationMembershipLevel.Member
+    }
+    return getMinimumBillingAccessLevel(ownerOnlyBilling)
+}
+
+/**
+ * Determines if the user has sufficient permissions to *manage* billing based on their org membership level.
  */
 export function canAccessBilling(membershipLevel: number | null | undefined, ownerOnlyBilling: boolean): boolean {
     if (!membershipLevel) {
         return false
     }
     return membershipLevel >= getMinimumBillingAccessLevel(ownerOnlyBilling)
+}
+
+/**
+ * Determines if the user can *view* billing (read-only or full) based on their org membership level.
+ */
+export function canViewBilling(
+    membershipLevel: number | null | undefined,
+    ownerOnlyBilling: boolean,
+    readOnlyBillingAccess: boolean
+): boolean {
+    if (!membershipLevel) {
+        return false
+    }
+    return membershipLevel >= getMinimumBillingViewLevel(ownerOnlyBilling, readOnlyBillingAccess)
 }
 
 /**

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -34,7 +34,9 @@ import {
     buildUsageLimitApproachingMessage,
     buildUsageLimitExceededMessage,
     canAccessBilling as canAccessBillingUtil,
+    canViewBilling as canViewBillingUtil,
     getMinimumBillingAccessLevel,
+    getMinimumBillingViewLevel,
 } from './billing-utils'
 import type { billingLogicType } from './billingLogicType'
 import { DEFAULT_ESTIMATED_MONTHLY_CREDIT_AMOUNT_USD } from './CreditCTAHero'
@@ -522,6 +524,14 @@ export const billingLogic = kea<billingLogicType>([
             (featureFlags): OrganizationMembershipLevel =>
                 getMinimumBillingAccessLevel(!!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING]),
         ],
+        minimumBillingViewLevel: [
+            (s) => [s.featureFlags],
+            (featureFlags): OrganizationMembershipLevel =>
+                getMinimumBillingViewLevel(
+                    !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING],
+                    !!featureFlags[FEATURE_FLAGS.READ_ONLY_BILLING_ACCESS]
+                ),
+        ],
         canAccessBilling: [
             (s) => [s.currentOrganization, s.featureFlags],
             (currentOrganization, featureFlags): boolean =>
@@ -529,6 +539,19 @@ export const billingLogic = kea<billingLogicType>([
                     currentOrganization?.membership_level,
                     !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING]
                 ),
+        ],
+        canViewBilling: [
+            (s) => [s.currentOrganization, s.featureFlags],
+            (currentOrganization, featureFlags): boolean =>
+                canViewBillingUtil(
+                    currentOrganization?.membership_level,
+                    !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING],
+                    !!featureFlags[FEATURE_FLAGS.READ_ONLY_BILLING_ACCESS]
+                ),
+        ],
+        isBillingReadOnly: [
+            (s) => [s.canViewBilling, s.canAccessBilling],
+            (canViewBilling, canAccessBilling): boolean => canViewBilling && !canAccessBilling,
         ],
         upgradeLink: [(s) => [s.preflight], (): string => '/organization/billing'],
         isUnlicensedDebug: [

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -75,7 +75,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
     connect(() => ({
         values: [
             billingLogic,
-            ['billing', 'billingPeriodUTC', 'canAccessBilling', 'currentOrganization'],
+            ['billing', 'billingPeriodUTC', 'canViewBilling', 'currentOrganization'],
             preflightLogic,
             ['isHobby'],
         ],
@@ -102,7 +102,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
             null as BillingSpendResponse | null,
             {
                 loadBillingSpend: async () => {
-                    if (!values.canAccessBilling || values.isHobby) {
+                    if (!values.canViewBilling || values.isHobby) {
                         return null
                     }
                     const { usage_types, team_ids, breakdowns, interval } = values.filters

--- a/frontend/src/scenes/billing/billingUsageLogic.ts
+++ b/frontend/src/scenes/billing/billingUsageLogic.ts
@@ -78,7 +78,7 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
     connect(() => ({
         values: [
             billingLogic,
-            ['billing', 'billingPeriodUTC', 'canAccessBilling', 'currentOrganization'],
+            ['billing', 'billingPeriodUTC', 'canViewBilling', 'currentOrganization'],
             preflightLogic,
             ['isHobby'],
         ],
@@ -105,7 +105,7 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
             null as BillingUsageResponse | null,
             {
                 loadBillingUsage: async () => {
-                    if (!values.canAccessBilling || values.isHobby) {
+                    if (!values.canViewBilling || values.isHobby) {
                         return null
                     }
                     const { usage_types, team_ids, breakdowns, interval } = values.filters

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -94,7 +94,7 @@ export const settingsLogic = kea<settingsLogicType>([
             organizationIntegrationsLogic,
             ['organizationIntegrations'],
             billingLogic,
-            ['canAccessBilling'],
+            ['canViewBilling'],
         ],
     })),
 
@@ -264,7 +264,7 @@ export const settingsLogic = kea<settingsLogicType>([
                 s.currentOrganization,
                 s.organizationIntegrations,
                 s.preflight,
-                s.canAccessBilling,
+                s.canViewBilling,
                 s.isAdminOrOwner,
             ],
             (
@@ -274,7 +274,7 @@ export const settingsLogic = kea<settingsLogicType>([
                 currentOrganization,
                 organizationIntegrations,
                 preflight,
-                canAccessBilling,
+                canViewBilling,
                 isAdminOrOwner
             ): SettingSection[] => {
                 const isSettingVisible = (setting: Setting): boolean => {
@@ -302,7 +302,7 @@ export const settingsLogic = kea<settingsLogicType>([
                     }
 
                     // Explicit gates to avoid showing this in the sidebar when the use doesn't have access to it
-                    if (section.id === 'organization-billing' && !canAccessBilling) {
+                    if (section.id === 'organization-billing' && !canViewBilling) {
                         return false
                     }
                     if (section.id === 'organization-legal-documents' && !isAdminOrOwner) {


### PR DESCRIPTION
## Problem

Some customers want their non-admin org members to see the billing and usage pages without being granted full Admin. Today there's no way to do that: the billing scene, usage dashboard, and spend dashboard are all gated to Admin (or Owner under `owner-only-billing`), so viewing billing means handing over write access to everything.

## Changes

This adds a `read-only-billing-access` feature flag that opens billing up read-only to any org member, while keeping every mutating action Admin-only. It's opt-in per org via the flag, so default behavior is unchanged.

The core idea is splitting billing access into two tiers instead of one:

- **View** (`canViewBilling` / `minimumBillingViewLevel`) - drops to Member level when the flag is on, otherwise unchanged (Admin, or Owner under `owner-only-billing`).
- **Manage** (`canAccessBilling` / `minimumBillingAccessLevel`) - unchanged, still Admin/Owner.

Frontend:
- New selectors in `billingLogic` plus `isBillingReadOnly` (can view but not manage).
- The billing scene, usage dashboard, and spend dashboard now gate on the view level, so members can open them.
- Settings nav and the account menus show the billing link based on view access.
- The usage/spend data loaders fetch on `canViewBilling`.
- For view-only members: a read-only banner at the top of the billing page, and the write controls are hidden (license activation, Stripe portal button, unsubscribe card, subscribe/upgrade CTAs, and the billing-limit edit/set/remove buttons - the limit value still shows, just not the buttons).

Backend:
- `usage` and `spend` move to a new `IsOrganizationAdminOrReadOnlyBillingMember` permission: admins as before, plus any member when the org has the flag enabled.
- All mutating endpoints stay behind `IsOrganizationAdmin`, so the server remains the enforcement boundary for writes regardless of what the UI shows.

Note: the main `GET /api/billing` overview endpoint was already accessible to any member, so this mostly closes the gap between that and the UI, and extends the same read-only posture to the usage/spend data.

## How did you test this code?

Automated tests I (Claude, via the PostHog Slack app) actually ran:
- Frontend unit tests for the new access logic - `billing-utils.spec.ts` passes, including new parameterized cases for `getMinimumBillingViewLevel` and `canViewBilling`. These guard the core regression: the flag→level mapping that decides whether a member can see billing (grant when it shouldn't, or deny when it should).
- `oxlint` clean on the edited files, `oxfmt` applied, `ruff check`/`ruff format` clean on the Python files, and `py_compile` on the backend.

Backend tests added but not run locally (the Django + ClickHouse test env isn't available in this session, so CI will run them): two cases in `TestBillingUsageAndSpendAPI` asserting a Member with the flag enabled gets `200` from `usage`/`spend`. The existing "denied for member" tests (flag off) still cover the over-exposure direction.

I did not run the app manually or do a full `typescript:check` (the kea `*Type.ts` files are gitignored and regenerated by CI, so a full local typecheck wasn't practical). CI will cover typegen + typecheck + the backend suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via the PostHog Slack app, from an inbox item asking for read-only billing access for non-admin members, at Matt Brooker's request.

Skills invoked: `/writing-tests` (before adding the util and API tests).

Key decisions:
- Gated the feature behind a flag (mirroring the existing `owner-only-billing` pattern) rather than changing billing visibility defaults for every org - that's a product call that shouldn't ship silently.
- Modeled it as a view-vs-manage split so the existing manage-level semantics (and the "ask an admin" usage-limit messaging) stay intact.
- Relied on the existing server-side `IsOrganizationAdmin` guards as the security boundary for writes, and used the frontend gating + read-only banner for UX. A few less-common write surfaces on the overview page (credit purchase CTA, some subscribe flows) are not individually hidden yet and still depend on the backend 403; worth a follow-up pass if we want a fully button-free read-only overview.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1783429812945789?thread_ts=1783429812.945789&cid=C0B8ZE81ZT7)*
