### PR TITLE
chore(ci): fold four more workflows into pr housekeeping

### DIFF
--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -1,7 +1,15 @@
 name: Migration & Service Separation Check
 
+# Reusable workflow — called by pr-housekeeping.yml on every PR push.
+# merge_group stays as a direct trigger for the merge queue.
+
 on:
-    pull_request:
+    workflow_call:
+        secrets:
+            GH_APP_POSTHOG_PATHS_FILTER_APP_ID:
+                required: false
+            GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY:
+                required: false
     merge_group:
 
 permissions:

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -1,6 +1,6 @@
 name: PR housekeeping
 
-# One dispatch per PR event instead of four. GitHub's run-queue cap
+# One dispatch per PR event instead of eight. GitHub's run-queue cap
 # (500 runs/10s/repo) counts workflow runs, and a run that calls reusable
 # workflows counts once — so folding the small always-fire PR workflows
 # under this parent divides the burst budget every push consumes.
@@ -50,3 +50,32 @@ jobs:
         # secrets: block too.
         # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
         secrets: inherit
+
+    pr-opened:
+        if: contains(fromJSON('["opened", "ready_for_review"]'), github.event.action)
+        uses: ./.github/workflows/pr-opened.yml
+        permissions:
+            pull-requests: write
+        secrets:
+            GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+            GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
+    resolve-bot-comments:
+        if: github.event.action == 'synchronize'
+        uses: ./.github/workflows/pr-resolve-outdated-bot-comments.yml
+        secrets:
+            GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID }}
+            GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
+
+    migrations-separation:
+        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+        uses: ./.github/workflows/ci-migrations-service-separation-check.yml
+        secrets:
+            GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
+            GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
+
+    release-plan:
+        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+        uses: ./.github/workflows/release.yml
+        secrets:
+            POSTHOG_API_TOKEN: ${{ secrets.POSTHOG_API_TOKEN }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,8 +1,14 @@
 name: Opened PR
 
+# Reusable workflow — called by pr-housekeeping.yml on PR opened/ready_for_review.
+
 on:
-    pull_request:
-        types: [opened, ready_for_review]
+    workflow_call:
+        secrets:
+            GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID:
+                required: false
+            GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY:
+                required: false
 
 permissions:
     pull-requests: write

--- a/.github/workflows/pr-resolve-outdated-bot-comments.yml
+++ b/.github/workflows/pr-resolve-outdated-bot-comments.yml
@@ -1,15 +1,18 @@
 name: Resolve outdated bot comments
 
+# Reusable workflow — called by pr-housekeeping.yml on PR synchronize.
+# Push-cancels-previous-push comes from the caller's concurrency group.
+
 on:
-    pull_request:
-        types: [synchronize]
+    workflow_call:
+        secrets:
+            GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID:
+                required: false
+            GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY:
+                required: false
 
 permissions:
     contents: read
-
-concurrency:
-    group: resolve-bot-comments-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
 
 jobs:
     resolve-outdated:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,12 @@ env:
     CARGO_DIST_INSTALLER_SHA256: b657cf8c04a8b7bc28f39d220f7e6dd11bbd2bdb072c552262bd9ccf597261b5
 
 # Publishing is handled by the Release CLI workflow after Release environment approval.
+# Reusable workflow — called by pr-housekeeping.yml on every PR push.
 on:
-    pull_request:
+    workflow_call:
+        secrets:
+            POSTHOG_API_TOKEN:
+                required: false
 
 jobs:
     # Run 'dist plan' (or host) to determine what tasks we need to do


### PR DESCRIPTION
## Problem

- Phase 2 of the run-dispatch consolidation started in #68964: four more always-fire PR workflows dispatch ~91k runs/30d that can ride the single `PR housekeeping` dispatch instead.

## Changes

- Fold `Opened PR`, `Resolve outdated bot comments`, `Migration & Service Separation Check`, and `Release` (cargo-dist plan check) into `pr-housekeeping.yml` via `workflow_call`.
- Event-type scoping moves to job-level `if`s; app secrets are passed explicitly (declared `required: false` for forks); `pr-opened` gets `pull-requests: write` at the job level only, so other callees keep read-only tokens.
- Migrations check keeps its direct `merge_group` trigger; the resolver's per-PR concurrency is covered by the parent group. None of these are required checks.

```mermaid
flowchart LR
    e([PR event]) --> hk["PR housekeeping — one dispatch"]
    hk -->|opened, edited, synchronize| lint[lint-pr]
    hk -->|opened, synchronize, reopened| turbo[turbo]
    hk -->|opened, synchronize| rl[rate-limit-monitor]
    hk -->|any except edited| fb[flags-project-board]
    hk -->|opened, ready_for_review| po["pr-opened (new)"]
    hk -->|synchronize| rb["resolve-bot-comments (new)"]
    hk -->|opened, synchronize, reopened| ms["migrations-separation (new)"]
    hk -->|opened, synchronize, reopened| rp["release-plan (new)"]
```

## How did you test this code?

- `hogli ci:preflight` workflow lint via pre-push hook; live validation on this draft PR (stacked on #68964).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None (covered by `docs/internal/ci-capacity-limits.md` in the base PR).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude via PostHog Code) scoped candidates to non-required checks; `pull_request_target` workflows (auto-assign, posthog-js reviewer) were deliberately left standalone to preserve fork write semantics.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
