### PR TITLE
feat(session-replay): enable rust anonymizer by default in ml-mirror

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -36,7 +36,7 @@ export type MlMirrorConfig = {
     // Scrub-phase budget. Sized so scrub + 2x the S3 write timeout stays under Kafka's max.poll.interval.ms
     // (300s), or a hung sidecar/S3 evicts us mid-batch and livelocks.
     SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: number
-    /** Route anonymization through the native Rust addon (`@posthog/replay-anonymizer`); off → the TS scrubbers. */
+    /** Route anonymization through the native Rust addon (`@posthog/replay-anonymizer`, the default); off → the TS scrubbers. */
     SESSION_RECORDING_ML_RUST_ANONYMIZER: boolean
 }
 
@@ -63,6 +63,6 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: 3,
         SESSION_RECORDING_ML_IMAGE_SCRUB_S3_WRITE_TIMEOUT_MS: 30 * 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: 120 * 1000,
-        SESSION_RECORDING_ML_RUST_ANONYMIZER: false,
+        SESSION_RECORDING_ML_RUST_ANONYMIZER: true,
     }
 }


### PR DESCRIPTION
## Problem

The ml-mirror pipeline has two anonymizer implementations: the TS scrubbers and the native Rust addon (`@posthog/replay-anonymizer`), selected by the `SESSION_RECORDING_ML_RUST_ANONYMIZER` env var. The Rust path is the one we want running everywhere, but it's still opt-in.

## Changes

Flips the default of `SESSION_RECORDING_ML_RUST_ANONYMIZER` from `false` to `true`, so the Rust anonymizer runs unless explicitly disabled. The env var still works as an escape hatch (`SESSION_RECORDING_ML_RUST_ANONYMIZER=false` routes back through the TS scrubbers via `overrideConfigWithEnv`'s boolean coercion).

## How did you test this code?

Ran the existing ml-mirror suites locally, both pass:

- `nodejs/src/servers/ingestion-session-replay-ml-mirror-server.test.ts`
- `nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.test.ts`

No new tests: this is a one-line default flip and no existing test asserts the default value.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal config only, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) at Robbie's direction. Located the switch, confirmed the env override path coerces "false" correctly so the flag remains a working kill switch, flipped the default, and updated the field's doc comment to match. Verified no tests or docs assert the old default.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*