### PR TITLE
feat(actions): support multiple screen names for matches exactly

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5253,9 +5253,9 @@ snapshots:
     scenes-app-data-management-actions--new-action--light:
         hash: v1.k794b7964.63452e5f18d10890adc95905388cc73a7139ebeb10c19eeace75a7da0e2debec.qpdIi0uow-kdQvBB0FNLFB-yXrl-xNgCWFuohl_l3z0
     scenes-app-data-management-actions--screen-action--dark:
-        hash: v1.k794b7964.5a59039eb5a488be53ba421b3f3c4c27e898f7072b6cedd5c7beaa8a238694c8.zA1HLvprSld1TbMs_m-mxq7sbNicWq2aygPklmdrw8Q
+        hash: v1.k794b7964.a7d45c674c8c2c5b4a953da0a6edc035c483190477dae0d543c1b6b2b1a6cf85.eslQPw_7Y7zBCu9G7OoVbBuAzSA-bqUoje0pbZUki6Q
     scenes-app-data-management-actions--screen-action--light:
-        hash: v1.k794b7964.1c99389ca59324c16f66666552d5e80ec1d4e90d483399d3e05a433ef0426d0d.baRzYMczFsgzl7QcNhMSmI76jh8Dem5j7Jc4kIiulCc
+        hash: v1.k794b7964.39d810c27996398aae992eb54ef4e84e23c3f53c4812346e1931563a4c1ee0cf._NpDegv8HN4WQn2IpzgYw9J0f6Lc1kTMckTXMi6llq0
     scenes-app-data-management-comments--comments--dark:
         hash: v1.k794b7964.e21cefe38419260e81d5eda7e10656d10d1eff95ee3c0445c8a0b9be07b79086.PePuIy_3nZEV8tVawLvzhj85hMz3DwVUBpP0ggnCqeA
     scenes-app-data-management-comments--comments--light:

--- a/products/actions/frontend/components/ActionStep.tsx
+++ b/products/actions/frontend/components/ActionStep.tsx
@@ -408,7 +408,7 @@ function TypeSwitcher({
                     },
                     {
                         value: '$screen',
-                        label: 'Screen',
+                        label: 'Mobile screen',
                         tooltip: 'Screen views from mobile apps ($screen events sent by the mobile SDKs)',
                         'data-attr': 'action-type-screen',
                         disabledReason,

--- a/products/actions/frontend/components/ActionStep.tsx
+++ b/products/actions/frontend/components/ActionStep.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import { useState } from 'react'
 
 import { IconX } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonInputSelect, LemonSegmentedButton, Link } from '@posthog/lemon-ui'
@@ -438,10 +439,12 @@ function ScreenNameField({
     const rawValue = existingFilter && 'value' in existingFilter ? existingFilter.value : undefined
     const screenNames: string[] =
         rawValue == null || rawValue === '' ? [] : Array.isArray(rawValue) ? rawValue.map(String) : [String(rawValue)]
-    const operator: ScreenNameMatching =
-        existingFilter && 'operator' in existingFilter
-            ? (existingFilter.operator as ScreenNameMatching)
-            : PropertyOperator.IContains
+    const filterOperator: ScreenNameMatching | undefined =
+        existingFilter && 'operator' in existingFilter ? (existingFilter.operator as ScreenNameMatching) : undefined
+
+    // Keep the selected operator even when the value is empty (an empty filter isn't persisted, so we can't
+    // read it back off the step) — otherwise picking "matches exactly" before typing would snap back to the default
+    const [operator, setOperator] = useState<ScreenNameMatching>(filterOperator ?? PropertyOperator.IContains)
 
     // Only "matches exactly" supports multiple values (translated to an IN() query); the rest take a single string
     const isMulti = operator === PropertyOperator.Exact
@@ -468,6 +471,7 @@ function ScreenNameField({
     }
 
     const handleOperatorChange = (op: ScreenNameMatching): void => {
+        setOperator(op)
         const nextValue = op === PropertyOperator.Exact ? screenNames : (screenNames[0] ?? '')
         setFilter(nextValue, op)
     }

--- a/products/actions/frontend/components/ActionStep.tsx
+++ b/products/actions/frontend/components/ActionStep.tsx
@@ -409,6 +409,7 @@ function TypeSwitcher({
                     {
                         value: '$screen',
                         label: 'Screen',
+                        tooltip: 'Screen views from mobile apps ($screen events sent by the mobile SDKs)',
                         'data-attr': 'action-type-screen',
                         disabledReason,
                     },
@@ -479,7 +480,9 @@ function ScreenNameField({
     return (
         <div className="deprecated-space-y-1">
             <div className="flex flex-wrap gap-1">
-                <LemonLabel>Screen name</LemonLabel>
+                <LemonLabel info="Matches the $screen_name property on $screen events sent by the mobile SDKs (iOS, Android, React Native, Flutter). This is the mobile equivalent of a pageview URL.">
+                    Screen name
+                </LemonLabel>
                 <div className="flex flex-1 justify-end">
                     <LemonSegmentedButton
                         onChange={(value) => handleOperatorChange(value as ScreenNameMatching)}

--- a/products/actions/frontend/components/ActionStep.tsx
+++ b/products/actions/frontend/components/ActionStep.tsx
@@ -444,11 +444,13 @@ function ScreenNameField({
         existingFilter && 'operator' in existingFilter ? (existingFilter.operator as ScreenNameMatching) : undefined
 
     // Keep the selected operator even when the value is empty (an empty filter isn't persisted, so we can't
-    // read it back off the step) — otherwise picking "matches exactly" before typing would snap back to the default
+    // read it back off the step) — otherwise picking "matches exactly" before typing would snap back to the default.
+    // Only seeded once: safe because this component remounts when the step's event type changes away from $screen.
     const [operator, setOperator] = useState<ScreenNameMatching>(filterOperator ?? PropertyOperator.IContains)
 
     // Only "matches exactly" supports multiple values (translated to an IN() query); the rest take a single string
     const isMulti = operator === PropertyOperator.Exact
+    const singleValue = screenNames[0] ?? ''
 
     const setFilter = (value: string | string[], op: ScreenNameMatching): void => {
         const otherProperties = (step.properties || []).filter((p) => !isScreenNameFilter(p))
@@ -473,7 +475,7 @@ function ScreenNameField({
 
     const handleOperatorChange = (op: ScreenNameMatching): void => {
         setOperator(op)
-        const nextValue = op === PropertyOperator.Exact ? screenNames : (screenNames[0] ?? '')
+        const nextValue = op === PropertyOperator.Exact ? screenNames : singleValue
         setFilter(nextValue, op)
     }
 
@@ -511,7 +513,7 @@ function ScreenNameField({
                     data-attr="edit-action-screen-name-input"
                     allowClear
                     onChange={(val) => setFilter(val, operator)}
-                    value={screenNames[0] ?? ''}
+                    value={singleValue}
                     placeholder="e.g. HomeScreen"
                     disabledReason={disabledReason}
                 />

--- a/products/actions/frontend/components/ActionStep.tsx
+++ b/products/actions/frontend/components/ActionStep.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 
 import { IconX } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSegmentedButton, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonInputSelect, LemonSegmentedButton, Link } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
@@ -435,21 +435,31 @@ function ScreenNameField({
     disabledReason?: string
 }): JSX.Element {
     const existingFilter = step.properties?.find(isScreenNameFilter)
-    const screenName = (existingFilter && 'value' in existingFilter ? (existingFilter.value as string) : '') ?? ''
+    const rawValue = existingFilter && 'value' in existingFilter ? existingFilter.value : undefined
+    const screenNames: string[] =
+        rawValue == null || rawValue === '' ? [] : Array.isArray(rawValue) ? rawValue.map(String) : [String(rawValue)]
     const operator: ScreenNameMatching =
         existingFilter && 'operator' in existingFilter
             ? (existingFilter.operator as ScreenNameMatching)
             : PropertyOperator.IContains
 
-    const setFilter = (name: string, op: ScreenNameMatching): void => {
+    // Only "matches exactly" supports multiple values (translated to an IN() query); the rest take a single string
+    const isMulti = operator === PropertyOperator.Exact
+
+    const setFilter = (value: string | string[], op: ScreenNameMatching): void => {
         const otherProperties = (step.properties || []).filter((p) => !isScreenNameFilter(p))
+        const isEmpty = Array.isArray(value) ? value.length === 0 : !value
+        if (isEmpty) {
+            sendStep({ ...step, properties: otherProperties })
+            return
+        }
         sendStep({
             ...step,
             properties: [
                 ...otherProperties,
                 {
                     key: SCREEN_NAME_PROPERTY,
-                    value: name,
+                    value,
                     operator: op as PropertyOperator,
                     type: PropertyFilterType.Event,
                 },
@@ -457,8 +467,9 @@ function ScreenNameField({
         })
     }
 
-    const clearFilter = (): void => {
-        sendStep({ ...step, properties: (step.properties || []).filter((p) => !isScreenNameFilter(p)) })
+    const handleOperatorChange = (op: ScreenNameMatching): void => {
+        const nextValue = op === PropertyOperator.Exact ? screenNames : (screenNames[0] ?? '')
+        setFilter(nextValue, op)
     }
 
     return (
@@ -467,7 +478,7 @@ function ScreenNameField({
                 <LemonLabel>Screen name</LemonLabel>
                 <div className="flex flex-1 justify-end">
                     <LemonSegmentedButton
-                        onChange={(value) => setFilter(screenName, value as ScreenNameMatching)}
+                        onChange={(value) => handleOperatorChange(value as ScreenNameMatching)}
                         value={operator}
                         options={Object.entries(SCREEN_NAME_MATCHING_LABEL).map(([value, label]) => ({
                             value,
@@ -478,14 +489,26 @@ function ScreenNameField({
                     />
                 </div>
             </div>
-            <LemonInput
-                data-attr="edit-action-screen-name-input"
-                allowClear
-                onChange={(val) => (val ? setFilter(val, operator) : clearFilter())}
-                value={screenName}
-                placeholder="e.g. HomeScreen, Settings"
-                disabledReason={disabledReason}
-            />
+            {isMulti ? (
+                <LemonInputSelect
+                    data-attr="edit-action-screen-name-input"
+                    mode="multiple"
+                    allowCustomValues
+                    value={screenNames}
+                    onChange={(vals) => setFilter(vals, operator)}
+                    placeholder="e.g. HomeScreen, Settings"
+                    disabled={!!disabledReason}
+                />
+            ) : (
+                <LemonInput
+                    data-attr="edit-action-screen-name-input"
+                    allowClear
+                    onChange={(val) => setFilter(val, operator)}
+                    value={screenNames[0] ?? ''}
+                    placeholder="e.g. HomeScreen"
+                    disabledReason={disabledReason}
+                />
+            )}
         </div>
     )
 }

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -148,7 +148,11 @@ export function ActionsTable(): JSX.Element {
                                                     return (
                                                         <>
                                                             Screen name {SCREEN_NAME_MATCHING_LABEL[operator]}{' '}
-                                                            <strong>{String(screenFilter.value)}</strong>
+                                                            <strong>
+                                                                {Array.isArray(screenFilter.value)
+                                                                    ? screenFilter.value.join(', ')
+                                                                    : String(screenFilter.value)}
+                                                            </strong>
                                                         </>
                                                     )
                                                 }

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -156,7 +156,7 @@ export function ActionsTable(): JSX.Element {
                                                         </>
                                                     )
                                                 }
-                                                return 'Screen'
+                                                return 'Mobile screen'
                                             }
                                             case '':
                                             case null:


### PR DESCRIPTION
## Problem

"Matches exactly" on screen name only accepted one value, so matching several screens meant a regex with pipes. Regular equals filters already support multiple values.

Closes #68543

## Changes

Before:
<img width="3064" height="744" alt="CleanShot 2026-07-07 at 12 02 53@2x" src="https://github.com/user-attachments/assets/f0218b6a-553e-47f5-bbae-28659e10693e" />

After:
<img width="2926" height="718" alt="CleanShot 2026-07-07 at 12 02 34@2x" src="https://github.com/user-attachments/assets/ee2defb2-3416-4816-a4e5-da82cefbbaf0" />


- "Matches exactly" now takes multiple screen names (multi-value input).
- Clarified the tab is mobile-only: renamed to "Mobile screen" + tooltip + field info icon.

No backend change: screen name is a `$screen_name` property filter, and a list-valued `exact` filter already becomes an `IN (...)` query. Existing single-string actions keep working, no migration.

## How did you test this code?

Not run manually. `typescript:check` + lint clean. Backend list path is already covered by existing hogql tests; this is a presentational swap between two shared inputs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Frontend-only fix; the backend already handled list-valued `exact`. Operator is held in local `useState` (an empty filter isn't persisted, so deriving it from the step made "matches exactly" snap back before typing). Ran Paul's `xp-reviewer` skill over the diff and applied its cleanups.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*