### PR TITLE
feat(conversations): allow sandbox oauth on conversations gateway product

### DIFF
--- a/products/conversations/backend/temporal/ai_reply/constants.py
+++ b/products/conversations/backend/temporal/ai_reply/constants.py
@@ -71,11 +71,9 @@ BASE_DRAFT_SCOPES: list[str] = [
 # Django/ORM -- it's loaded inside the Temporal workflow sandbox via pipeline.py.
 DIAGNOSTIC_SCOPES_PRESET: Literal["read_only"] = "read_only"
 
-# Sandbox agent model for the draft step. Must be in the LLM gateway's `background_agents`
-# product allowlist (services/llm-gateway/src/llm_gateway/products/config.py) -- that's the
-# product the sandbox agent server routes through, NOT `conversations`. `claude-sonnet-4-6`
-# is allowed for `conversations` (the plain utility/validator calls) but NOT for
-# `background_agents`, so the sandbox draft uses the strongest allowed sonnet instead.
+# Sandbox agent model for the draft step. Must be in the LLM gateway `conversations`
+# product allowlist (services/llm-gateway/src/llm_gateway/products/config.py) — support-reply
+# sandbox tasks route through that product via @posthog/agent's resolveGatewayProduct().
 DRAFT_MODEL = "claude-sonnet-5"
 DRAFT_RUNTIME_ADAPTER = "claude"
 

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -179,8 +179,10 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=True,
     ),
     "conversations": ProductConfig(
-        allowed_application_ids=None,
-        allowed_models=frozenset({"claude-haiku-4-5", "claude-sonnet-4-6"}),
+        # Sandbox support-reply tasks auth with the array (posthog_code) OAuth app but
+        # route through this product so draft spend rolls up with utility prompts.
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
+        allowed_models=frozenset({"claude-haiku-4-5", "claude-sonnet-4-6", "claude-sonnet-5"}),
         allow_api_keys=True,
         billable=False,
     ),

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -72,6 +72,14 @@ class TestCheckProductAccess:
             ("signals", "oauth_access_token", "any-app-id", "claude-haiku-4-5", False, "not authorized"),
             ("signals", "oauth_access_token", POSTHOG_CODE_US_APP_ID, "claude-haiku-4-5", True, None),
             ("signals", "oauth_access_token", POSTHOG_CODE_EU_APP_ID, "claude-sonnet-4-5", True, None),
+            # conversations: utility prompts (API key) and support-reply sandbox (array OAuth app)
+            ("conversations", "personal_api_key", None, "claude-haiku-4-5", True, None),
+            ("conversations", "personal_api_key", None, "claude-sonnet-4-6", True, None),
+            ("conversations", "personal_api_key", None, "claude-sonnet-5", True, None),
+            ("conversations", "personal_api_key", None, "claude-opus-4-8", False, "not allowed"),
+            ("conversations", "oauth_access_token", "any-app-id", "claude-sonnet-5", False, "not authorized"),
+            ("conversations", "oauth_access_token", POSTHOG_CODE_US_APP_ID, "claude-sonnet-5", True, None),
+            ("conversations", "oauth_access_token", POSTHOG_CODE_EU_APP_ID, "claude-sonnet-4-6", True, None),
             # posthog_ai allows API keys with any model and OAuth from the PostHog AI app.
             ("posthog_ai", "personal_api_key", None, "claude-sonnet-4-5", True, None),
             ("posthog_ai", "personal_api_key", None, "gpt-5.3-codex", True, None),


### PR DESCRIPTION
## Problem

AI-reply utility prompts already land under `ai_product=conversations`, but support-reply draft sandbox tasks route through `background_agents` because the agent had no `support_reply` → `conversations` mapping. Draft spend is invisible in conversations cost rollups.

Companion agent-side change: https://github.com/PostHog/code/pull/3235

## Changes

- Allow array/posthog_code OAuth apps on the LLM gateway `conversations` product (same pattern as `signals`)
- Add `claude-sonnet-5` to the conversations model allowlist (matches `DRAFT_MODEL`)
- Update ai-reply constants comment to reflect the new routing
- Add gateway product config tests for conversations OAuth + model allowlist

## How did you test this code?

- Pre-commit: ruff format/check + ty on changed Python files
- Not run locally: `hogli test services/llm-gateway/tests/test_product_config.py` (CI should cover)
