### PR TITLE
fix(phai): address review findings on context injection and tool stream

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -30,7 +30,7 @@ import {
 import { initKeaTests } from '~/test/init'
 import { Conversation, ConversationDetail, ConversationStatus, ConversationType } from '~/types'
 
-import { runStreamLogic } from 'products/posthog_ai/frontend/api/logics'
+import { attachedContextLogic, runStreamLogic } from 'products/posthog_ai/frontend/api/logics'
 
 import { EnhancedToolCall, TOOL_DEFINITIONS } from './max-constants'
 import { maxContextLogic } from './maxContextLogic'
@@ -3584,6 +3584,29 @@ describe('maxThreadLogic', () => {
 
             expect(openSpy).not.toHaveBeenCalled()
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+        })
+
+        it('degrades a keyed non-allowlisted context item to a text attachment instead of dropping it', async () => {
+            const openSpy = jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+            // initKeaTests() in beforeEach resets the kea context, so no explicit unmount is needed
+            attachedContextLogic.mount()
+            attachedContextLogic.actions.registerContext('test-provider', [
+                { type: 'trace', key: '0189-abc', label: 'LLM trace' },
+            ])
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['openSandboxSse'])
+
+            expect(openSpy).toHaveBeenCalledWith(
+                MOCK_CONVERSATION_ID,
+                expect.objectContaining({
+                    attached_context: expect.arrayContaining([{ type: 'text', value: 'trace 0189-abc ("LLM trace")' }]),
+                })
+            )
         })
     })
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -742,8 +742,17 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                                     id: item.key,
                                     name: item.label,
                                 })
-                            } else if (item.value) {
-                                attachedContext.push({ type: 'text', value: item.value })
+                            } else {
+                                // Keyed items outside the allowlist (e.g. a trace ref) carry no `value`,
+                                // so render their key/label the way posthogContextBlock's formatItem does.
+                                const keyedFallback =
+                                    item.key != null && item.key !== ''
+                                        ? `${item.type} ${item.key}${item.label ? ` ("${item.label}")` : ''}`
+                                        : ''
+                                const fallback = item.value || keyedFallback
+                                if (fallback.trim()) {
+                                    attachedContext.push({ type: 'text', value: fallback })
+                                }
                             }
                         }
                         if (values.agentMode) {

--- a/frontend/src/scenes/max/posthogAiContextBridgeLogic.ts
+++ b/frontend/src/scenes/max/posthogAiContextBridgeLogic.ts
@@ -36,23 +36,20 @@ export const posthogAiContextBridgeLogic = kea<posthogAiContextBridgeLogicType>(
         actions: [attachedContextLogic, ['registerContext', 'deregisterContext']],
     })),
     subscriptions(({ actions }) => ({
-        // Re-registering the same provider id is an upsert, so each scene change replaces the mirrored set.
+        // Single register path: kea-subscriptions fires with the current value on mount and on every
+        // change; re-registering the same provider id is an upsert, so each scene change replaces the
+        // mirrored set.
         sceneContext: (sceneContext: MaxContextItem[]) => {
             actions.registerContext(BRIDGE_PROVIDER_ID, projectSceneContext(sceneContext))
         },
     })),
-    events(({ actions, cache, values }) => ({
+    events(({ actions, cache }) => ({
         afterMount: () => {
             // `pauseOnPageHidden: false`: a hide-paused registration would drop scene context from a
             // queued follow-up that flushes while the tab is hidden; the registration is idle-cost-free.
-            cache.disposables.add(
-                () => {
-                    actions.registerContext(BRIDGE_PROVIDER_ID, projectSceneContext(values.sceneContext))
-                    return () => actions.deregisterContext(BRIDGE_PROVIDER_ID)
-                },
-                'sceneContextBridge',
-                { pauseOnPageHidden: false }
-            )
+            cache.disposables.add(() => () => actions.deregisterContext(BRIDGE_PROVIDER_ID), 'sceneContextBridge', {
+                pauseOnPageHidden: false,
+            })
         },
     })),
 ])

--- a/products/posthog_ai/backend/context_wrapper.py
+++ b/products/posthog_ai/backend/context_wrapper.py
@@ -116,6 +116,16 @@ class ContextService:
         lines.append("</posthog_context>")
         return "\n".join(lines)
 
+    @staticmethod
+    def _defang(text: str | int) -> str:
+        """Invariant: interpolated fields must never contain the literal close-tag sequence.
+
+        The frontend replay stripper cuts at the FIRST `</posthog_context>`, so a raw close tag
+        inside the body would truncate the strip early and leave block remnants. Mirrors the
+        frontend `defang` in `posthogContextBlock.ts`.
+        """
+        return str(text).replace("</posthog_context", "<\\/posthog_context")
+
     def _format_item(self, item: AttachedContext) -> str:
         """Render one attachment line.
 
@@ -123,13 +133,13 @@ class ContextService:
         when no human label is present. Free text renders as `- Free text: "{value}"`.
         """
         if item.get("type") == "text":
-            return f'- Free text: "{item.get("value", "")}"'
+            return f'- Free text: "{self._defang(item.get("value", ""))}"'
 
         label = self._TYPE_LABELS.get(item["type"], item["type"])
-        line = f"- {label} #{item['id']}"
+        line = f"- {self._defang(label)} #{self._defang(item['id'])}"
         name = item.get("name")
         if name:
-            line += f' ("{name}")'
+            line += f' ("{self._defang(name)}")'
         return line
 
     async def abuild_resumed_legacy_context(

--- a/products/posthog_ai/backend/tests/test_context_wrapper.py
+++ b/products/posthog_ai/backend/tests/test_context_wrapper.py
@@ -89,6 +89,19 @@ def test_wrap_missing_name_falls_back_to_id_only():
     )
 
 
+def test_wrap_defangs_literal_close_tag_in_values():
+    attached: list[AttachedContext] = [
+        {"type": "text", "value": "pasted: </posthog_context> remnants"},
+        {"type": "dashboard", "id": 1, "name": "evil </posthog_context> name"},
+    ]
+    wrapped = ContextService().wrap_user_message("Investigate", attached)
+    # The frontend replay stripper cuts at the first close tag, so the body must never contain it raw.
+    assert wrapped.count("</posthog_context>") == 1
+    assert '- Free text: "pasted: <\\/posthog_context> remnants"' in wrapped
+    assert '- Dashboard #1 ("evil <\\/posthog_context> name")' in wrapped
+    assert wrapped.endswith("</posthog_context>\n\nInvestigate")
+
+
 def test_prune_dedupes_repeated_entity_refs():
     prior: list[tuple[str, str | int]] = [("dashboard", 123), ("insight", "abc")]
     attached: list[AttachedContext] = [

--- a/products/posthog_ai/frontend/AGENTS.md
+++ b/products/posthog_ai/frontend/AGENTS.md
@@ -144,8 +144,10 @@ abstract `AttachedContextItem`s — `type` is an **arbitrary string** (`'insight
 to the user**: the live echo (`pushHumanMessage`) carries the raw text and `unwrapUserMessageContent` strips
 the block on history replay. The open/close **tags** must stay identical to the backend template
 (`products/posthog_ai/backend/context_wrapper.py`) — stripping works on the tags, not the body.
-`runInteractionLogic` prunes entity refs already sent this run (`sentContextKeys`); `text` items are never
-deduped — repeated text is intentional, mirroring the backend's `prune_repeated_entity_refs`.
+The send paths prune entity refs already sent for the task (`attachedContextLogic.sentContextKeysByTask`,
+keyed by task id so the dedupe survives a terminal-run send re-pointing to a fresh run, matching the
+backend's `prune_repeated_entity_refs`, which dedupes across the task's whole resume chain); `text` items
+are never deduped, repeated text is intentional.
 
 **Tool-stream events (`logics/toolStreamEventsLogic.ts`):** a global bus `runStreamLogic` publishes
 tool-call lifecycle events to — `phase: started/updated/completed/failed`, with `toolName` **resolved** via

--- a/products/posthog_ai/frontend/README.md
+++ b/products/posthog_ai/frontend/README.md
@@ -185,8 +185,8 @@ No React presenters, no tool registry — this import lane stays out of those ch
 Register the resource(s) the user is looking at; while registered, every message sent from the surface is
 prefixed with an invisible `<posthog_context>` block describing them (the user only ever sees their own
 text). Items are abstract — `type` is any string (`'insight'`, `'trace'`, `'text'`…), plus
-`key`/`label`/`value` — and are deduped across providers and across sends within a run (except `text`,
-which always resends).
+`key`/`label`/`value` — and are deduped across providers and across sends within a task (the whole
+resume chain of runs, matching the backend's per-task semantics; except `text`, which always resends).
 
 ```tsx
 import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'

--- a/products/posthog_ai/frontend/logics/attachedContextLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/attachedContextLogic.test.ts
@@ -52,4 +52,19 @@ describe('attachedContextLogic', () => {
             logic.actions.registerContext('p', [{ type: 'insight' }, { type: 'text', value: 'keep me' }])
         }).toMatchValues({ contextItems: [{ type: 'text', value: 'keep me' }] })
     })
+
+    // Sent-context keys are scoped per task: a global (unkeyed) store would prune context from the first
+    // message of an unrelated task just because the same resource was sent from another one.
+    it('accumulates sent context keys per task without leaking across tasks', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.markContextSent('task-a', ['insight:x'])
+            logic.actions.markContextSent('task-a', ['insight:x', 'dashboard:9'])
+            logic.actions.markContextSent('task-b', ['insight:x'])
+        }).toMatchValues({
+            sentContextKeysByTask: {
+                'task-a': ['insight:x', 'dashboard:9'],
+                'task-b': ['insight:x'],
+            },
+        })
+    })
 })

--- a/products/posthog_ai/frontend/logics/attachedContextLogic.ts
+++ b/products/posthog_ai/frontend/logics/attachedContextLogic.ts
@@ -12,6 +12,12 @@ import type { attachedContextLogicType } from './attachedContextLogicType'
  * A consumer reads `contextItems` at send time and wraps the outgoing message with a
  * `<posthog_context>` block (`utils/posthogContextBlock`). Nothing here is keyed by conversation —
  * the on-screen context is global to the app at any instant.
+ *
+ * This store also keeps the sent-context bookkeeping (`sentContextKeysByTask`): which non-text refs
+ * were already wrapped into a sent message, keyed by task id. The send paths mark keys after a
+ * successful send and prune already-sent refs from the next wrap. It is task-scoped (not run-scoped)
+ * so the dedupe survives a terminal-run send re-pointing the consumer to a fresh run, mirroring the
+ * backend's `prune_repeated_entity_refs`, which dedupes across a task's whole resume chain.
  */
 export const attachedContextLogic = kea<attachedContextLogicType>([
     path(['products', 'posthog_ai', 'frontend', 'logics', 'attachedContextLogic']),
@@ -20,6 +26,8 @@ export const attachedContextLogic = kea<attachedContextLogicType>([
         /** Idempotent upsert — re-register the same `providerId` to update its items. */
         registerContext: (providerId: string, items: AttachedContextItem[]) => ({ providerId, items }),
         deregisterContext: (providerId: string) => ({ providerId }),
+        /** Record context item keys already wrapped into a message sent for `taskId`. */
+        markContextSent: (taskId: string, keys: string[]) => ({ taskId, keys }),
     }),
 
     reducers({
@@ -33,6 +41,24 @@ export const attachedContextLogic = kea<attachedContextLogicType>([
                     }
                     const { [providerId]: _dropped, ...rest } = state
                     return rest
+                },
+            },
+        ],
+        // Per-task set of `attachedContextItemKey`s already wrapped into a sent message. Append-only for
+        // the session: entity refs sent once anywhere in a task's resume chain stay pruned from later sends.
+        sentContextKeysByTask: [
+            {} as Record<string, string[]>,
+            {
+                markContextSent: (state, { taskId, keys }) => {
+                    if (keys.length === 0) {
+                        return state
+                    }
+                    const existing = state[taskId] ?? []
+                    const added = keys.filter((key) => !existing.includes(key))
+                    if (added.length === 0) {
+                        return state
+                    }
+                    return { ...state, [taskId]: [...existing, ...added] }
                 },
             },
         ],

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
@@ -275,7 +275,7 @@ describe('runInteractionLogic', () => {
         expect(logic.values.composerForm.draft).toBe('continue from here')
     })
 
-    it('wraps outgoing content with the attached-context block while echoing the raw text, and dedupes per run', async () => {
+    it('wraps outgoing content with the attached-context block while echoing the raw text, and dedupes per task', async () => {
         attachedContextLogic().actions.registerContext('scene', [
             { type: 'insight', key: 'sig', label: 'Signups' },
             { type: 'text', value: 'always resend me' },
@@ -299,7 +299,7 @@ describe('runInteractionLogic', () => {
                 action.type === stream.actionTypes.pushHumanMessage && action.payload.content === 'why the drop?',
         ])
 
-        // A second send in the same run must not re-inflate already-sent entity refs — but `text`
+        // A second send on the same task must not re-inflate already-sent entity refs — but `text`
         // items are never deduped (repeated text is intentional, mirroring the backend).
         ;(tasksRunsCommandCreate as jest.Mock).mockClear()
         logic.actions.setComposerFormValues({ draft: 'follow up' })
@@ -313,6 +313,43 @@ describe('runInteractionLogic', () => {
         expect(secondSend.params.content).not.toContain('- insight sig')
         expect(secondSend.params.content).toContain('- text: "always resend me"')
         expect(secondSend.params.content.endsWith('follow up')).toBe(true)
+    })
+
+    it('keeps pruning context sent by a terminal-run send after re-pointing to the fresh run', async () => {
+        attachedContextLogic().actions.registerContext('scene', [{ type: 'insight', key: 'sig', label: 'Signups' }])
+
+        // A send on a finished run starts a fresh run, wrapping the pending context into its seed message.
+        setStatus('completed')
+        logic.actions.setComposerFormValues({ draft: 'continue from here' })
+        await expectLogic(logic, () => {
+            logic.actions.submitComposerForm()
+        }).toFinishAllListeners()
+
+        const createRequest = (tasksRunCreate as jest.Mock).mock.calls[0][2] as { pending_user_message: string }
+        expect(createRequest.pending_user_message).toContain('- insight sig ("Signups")')
+        expect(onRunStarted).toHaveBeenCalledWith('run-2')
+
+        // The consumer re-points to the new run: a fresh logic instance keyed by the new runId, same task.
+        // Sent-context bookkeeping is task-scoped, so the first follow-up must not re-wrap the same ref.
+        const nextStream = runStreamLogic({ streamKey: 'run-2' })
+        nextStream.mount()
+        const nextLogic = runInteractionLogic({ taskId: TASK_ID, runId: 'run-2', onRunStarted })
+        nextLogic.mount()
+        try {
+            nextLogic.actions.setComposerFormValues({ draft: 'follow up' })
+            await expectLogic(nextLogic, () => {
+                nextLogic.actions.submitComposerForm()
+            }).toFinishAllListeners()
+
+            const followUp = (tasksRunsCommandCreate as jest.Mock).mock.calls[0][3] as {
+                params: { content: string }
+            }
+            // The only attached item was already sent this task, so no context block is prepended at all.
+            expect(followUp.params.content).toBe('follow up')
+        } finally {
+            nextLogic.unmount()
+            nextStream.unmount()
+        }
     })
 
     const setProjectId = (id: number | null): void =>

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.ts
@@ -16,7 +16,7 @@ import {
     type ReasoningEffortEnumApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
-import { attachedContextItemKey } from '../types/contextTypes'
+import { type AttachedContextItem, attachedContextItemKey } from '../types/contextTypes'
 import { wrapWithPosthogContext } from '../utils/posthogContextBlock'
 import { attachedContextLogic } from './attachedContextLogic'
 import type { runInteractionLogicType } from './runInteractionLogicType'
@@ -80,11 +80,13 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
             runStreamLogic({ streamKey: props.streamKey ?? props.runId }),
             ['currentRunStatus', 'pendingPermissionRequest', 'respondingToPermission', 'isThinking'],
             attachedContextLogic,
-            ['contextItems'],
+            ['contextItems', 'sentContextKeysByTask'],
         ],
         actions: [
             runStreamLogic({ streamKey: props.streamKey ?? props.runId }),
             ['pushHumanMessage', 'respondToPermission', 'cancelRun', 'markTurnComplete'],
+            attachedContextLogic,
+            ['markContextSent'],
         ],
     })),
 
@@ -115,10 +117,6 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
         // `set_config_option` when the pick actually differs from what the session is already running.
         setSentModel: (model: string) => ({ model }),
         setSentEffort: (effort: string) => ({ effort }),
-        // Internal: record which attached-context items were already wrapped into a sent message this
-        // run, so static on-screen context isn't re-inflated onto every follow-up (mirrors the backend's
-        // `prune_repeated_entity_refs`).
-        markContextSent: (keys: string[]) => ({ keys }),
     }),
 
     reducers({
@@ -182,23 +180,6 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
                 setSentEffort: (_, { effort }) => effort,
             },
         ],
-        // Per-run set of `attachedContextItemKey`s already wrapped into a sent message. The logic is keyed
-        // by `runId`, so a fresh run starts empty.
-        sentContextKeys: [
-            new Set<string>(),
-            {
-                markContextSent: (state, { keys }) => {
-                    if (keys.length === 0) {
-                        return state
-                    }
-                    const next = new Set(state)
-                    for (const key of keys) {
-                        next.add(key)
-                    }
-                    return next
-                },
-            },
-        ],
     }),
 
     forms(({ actions, values }) => ({
@@ -258,152 +239,161 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
         ],
         // In-flight indicator for the composer's send button — a live send or a new-run start.
         isSubmitting: [(s) => [s.sending, s.startingRun], (sending, startingRun): boolean => sending || startingRun],
-        // Attached context not yet wrapped into a message this run — the snapshot the next send wraps.
+        // Attached context not yet wrapped into a message for this task, the snapshot the next send wraps.
+        // The sent-key bookkeeping is task-scoped (`attachedContextLogic.sentContextKeysByTask`), not
+        // run-scoped, so the dedupe survives a terminal-run send re-pointing to a fresh run instance.
         // `text` items are never deduped (matches the backend's `prune_repeated_entity_refs`: repeated
         // text is intentional, e.g. consecutive error snippets).
         pendingContextItems: [
-            (s) => [s.contextItems, s.sentContextKeys],
-            (contextItems, sentContextKeys) =>
-                contextItems.filter(
-                    (item) => item.type === 'text' || !sentContextKeys.has(attachedContextItemKey(item))
-                ),
+            (s) => [s.contextItems, s.sentContextKeysByTask, (_, p: RunInteractionLogicProps) => p.taskId],
+            (contextItems, sentContextKeysByTask, taskId): AttachedContextItem[] => {
+                const sentKeys = new Set(sentContextKeysByTask[taskId] ?? [])
+                return contextItems.filter(
+                    (item) => item.type === 'text' || !sentKeys.has(attachedContextItemKey(item))
+                )
+            },
         ],
     }),
 
-    listeners(({ actions, values, props }) => ({
-        // Drain the staged "Up next" message — only when the run is idle and can actually take it, so a flush
-        // against a busy/terminal/in-flight send is a no-op rather than dropping the message. The buffer is
-        // cleared up-front (not after the send) so a follow-up typed during the in-flight send stages cleanly
-        // instead of being wiped along with this send on success; `sendNow` re-stages it if the send fails.
-        flushQueue: () => {
-            const [queued] = values.queuedMessages
-            if (!queued || values.isBusy || !values.canSend) {
-                return
+    listeners(({ actions, values, props }) => {
+        // Record the non-text refs just wrapped into a send under the task, so no later send anywhere in
+        // the task's resume chain (including the next run after a terminal-run send) re-inflates them.
+        const markPendingContextSent = (pendingContext: AttachedContextItem[]): void => {
+            const sentKeys = pendingContext.filter((item) => item.type !== 'text').map(attachedContextItemKey)
+            if (sentKeys.length > 0) {
+                actions.markContextSent(props.taskId, sentKeys)
             }
-            actions.clearQueue()
-            actions.sendNow(queued.content, 'queue')
-        },
+        }
 
-        sendNow: async ({ content, source }) => {
-            if (values.sending || !content.trim() || values.isTerminal || values.currentProjectId == null) {
-                // Nothing was sent. The queue buffer was already cleared in `flushQueue`, so re-stage for
-                // retry; the draft path leaves its content untouched in the composer.
-                if (source === 'queue') {
-                    actions.prependQueuedMessage(content)
+        return {
+            // Drain the staged "Up next" message — only when the run is idle and can actually take it, so a flush
+            // against a busy/terminal/in-flight send is a no-op rather than dropping the message. The buffer is
+            // cleared up-front (not after the send) so a follow-up typed during the in-flight send stages cleanly
+            // instead of being wiped along with this send on success; `sendNow` re-stages it if the send fails.
+            flushQueue: () => {
+                const [queued] = values.queuedMessages
+                if (!queued || values.isBusy || !values.canSend) {
+                    return
                 }
-                return
-            }
-            actions.setSending(true)
-            // Clear the draft synchronously before the await so text the user types while the send is in
-            // flight isn't clobbered when the request resolves; a failed send restores it ahead of anything
-            // typed since. The queue buffer was already cleared up-front in `flushQueue`.
-            if (source === 'draft') {
-                actions.resetComposerForm()
-            }
-            try {
-                // Sync the picked model/effort to the agent session first, but only what the user actually
-                // changed since the last sync — mid-run config lives as session state, so it must go via a
-                // `set_config_option` command before the message rather than ride inside `user_message`. A
-                // failure here aborts the send (the catch restores the content); `setSent*` runs only after a
-                // successful sync so the next send retries an unsent change.
-                const activeModel = values.sentModel ?? props.currentModel ?? DEFAULT_COMPOSER_MODEL
-                const activeEffort = resolveEffortForModel(
-                    values.sentEffort ?? props.currentEffort ?? DEFAULT_COMPOSER_EFFORT,
-                    activeModel
-                )
-                if (values.selectedModel !== activeModel) {
-                    await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
-                        jsonrpc: '2.0',
-                        method: 'set_config_option',
-                        params: { configId: MODEL_CONFIG_ID, value: values.selectedModel },
-                    })
-                    actions.setSentModel(values.selectedModel)
+                actions.clearQueue()
+                actions.sendNow(queued.content, 'queue')
+            },
+
+            sendNow: async ({ content, source }) => {
+                if (values.sending || !content.trim() || values.isTerminal || values.currentProjectId == null) {
+                    // Nothing was sent. The queue buffer was already cleared in `flushQueue`, so re-stage for
+                    // retry; the draft path leaves its content untouched in the composer.
+                    if (source === 'queue') {
+                        actions.prependQueuedMessage(content)
+                    }
+                    return
                 }
-                if (values.selectedEffort !== activeEffort) {
-                    await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
-                        jsonrpc: '2.0',
-                        method: 'set_config_option',
-                        params: { configId: EFFORT_CONFIG_ID, value: values.selectedEffort },
-                    })
-                    actions.setSentEffort(values.selectedEffort)
-                }
-                // Wrap the outgoing content with the on-screen context block (invisible to the user —
-                // `runStreamLogic.unwrapUserMessageContent` strips it on replay, and the echo below is raw).
-                const pendingContext = values.pendingContextItems
-                await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
-                    jsonrpc: '2.0',
-                    method: 'user_message',
-                    params: { content: wrapWithPosthogContext(content, pendingContext) },
-                })
-                // The SSE echo (`pushHumanMessage`) reopens the turn — always the raw text the user typed.
-                actions.pushHumanMessage(content)
-                const sentKeys = pendingContext.filter((item) => item.type !== 'text').map(attachedContextItemKey)
-                if (sentKeys.length > 0) {
-                    actions.markContextSent(sentKeys)
-                }
-            } catch {
-                // Restore unsent content for retry, preserving send order — draft content goes back ahead of
-                // anything typed during the failed send, queue content re-stages ahead of anything staged since.
+                actions.setSending(true)
+                // Clear the draft synchronously before the await so text the user types while the send is in
+                // flight isn't clobbered when the request resolves; a failed send restores it ahead of anything
+                // typed since. The queue buffer was already cleared up-front in `flushQueue`.
                 if (source === 'draft') {
-                    actions.setComposerFormValues({
-                        draft: values.composerForm.draft ? `${content}\n\n${values.composerForm.draft}` : content,
+                    actions.resetComposerForm()
+                }
+                try {
+                    // Sync the picked model/effort to the agent session first, but only what the user actually
+                    // changed since the last sync — mid-run config lives as session state, so it must go via a
+                    // `set_config_option` command before the message rather than ride inside `user_message`. A
+                    // failure here aborts the send (the catch restores the content); `setSent*` runs only after a
+                    // successful sync so the next send retries an unsent change.
+                    const activeModel = values.sentModel ?? props.currentModel ?? DEFAULT_COMPOSER_MODEL
+                    const activeEffort = resolveEffortForModel(
+                        values.sentEffort ?? props.currentEffort ?? DEFAULT_COMPOSER_EFFORT,
+                        activeModel
+                    )
+                    if (values.selectedModel !== activeModel) {
+                        await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
+                            jsonrpc: '2.0',
+                            method: 'set_config_option',
+                            params: { configId: MODEL_CONFIG_ID, value: values.selectedModel },
+                        })
+                        actions.setSentModel(values.selectedModel)
+                    }
+                    if (values.selectedEffort !== activeEffort) {
+                        await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
+                            jsonrpc: '2.0',
+                            method: 'set_config_option',
+                            params: { configId: EFFORT_CONFIG_ID, value: values.selectedEffort },
+                        })
+                        actions.setSentEffort(values.selectedEffort)
+                    }
+                    // Wrap the outgoing content with the on-screen context block (invisible to the user —
+                    // `runStreamLogic.unwrapUserMessageContent` strips it on replay, and the echo below is raw).
+                    const pendingContext = values.pendingContextItems
+                    await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
+                        jsonrpc: '2.0',
+                        method: 'user_message',
+                        params: { content: wrapWithPosthogContext(content, pendingContext) },
                     })
-                } else {
-                    actions.prependQueuedMessage(content)
+                    // The SSE echo (`pushHumanMessage`) reopens the turn — always the raw text the user typed.
+                    actions.pushHumanMessage(content)
+                    markPendingContextSent(pendingContext)
+                } catch {
+                    // Restore unsent content for retry, preserving send order — draft content goes back ahead of
+                    // anything typed during the failed send, queue content re-stages ahead of anything staged since.
+                    if (source === 'draft') {
+                        actions.setComposerFormValues({
+                            draft: values.composerForm.draft ? `${content}\n\n${values.composerForm.draft}` : content,
+                        })
+                    } else {
+                        actions.prependQueuedMessage(content)
+                    }
+                    lemonToast.error('Failed to send message. Please try again.')
+                } finally {
+                    actions.setSending(false)
                 }
-                lemonToast.error('Failed to send message. Please try again.')
-            } finally {
-                actions.setSending(false)
-            }
-        },
+            },
 
-        // The agent finished a turn — drain any staged follow-ups.
-        markTurnComplete: () => {
-            actions.flushQueue()
-        },
+            // The agent finished a turn — drain any staged follow-ups.
+            markTurnComplete: () => {
+                actions.flushQueue()
+            },
 
-        // The new model may not support the current effort — clamp the override so it never holds an
-        // unsupported value. No network here: the pick is synced to the agent at send time.
-        setModel: ({ model }) => {
-            const currentEffort = values.effortOverride ?? props.currentEffort
-            const resolvedEffort = resolveEffortForModel(currentEffort, model)
-            if (resolvedEffort !== currentEffort) {
-                actions.setEffort(resolvedEffort)
-            }
-        },
+            // The new model may not support the current effort — clamp the override so it never holds an
+            // unsupported value. No network here: the pick is synced to the agent at send time.
+            setModel: ({ model }) => {
+                const currentEffort = values.effortOverride ?? props.currentEffort
+                const resolvedEffort = resolveEffortForModel(currentEffort, model)
+                if (resolvedEffort !== currentEffort) {
+                    actions.setEffort(resolvedEffort)
+                }
+            },
 
-        startNewRun: async ({ content }) => {
-            if (values.startingRun || !content.trim() || values.currentProjectId == null) {
-                return
-            }
-            actions.setStartingRun(true)
-            try {
-                // Same endpoint as the "Run again" button, but seeded with the user's message and chained
-                // from the finished run so the new run continues the thread, and carrying the picked model /
-                // reasoning effort (the resume schema can't, so we send the Claude create shape). The response
-                // carries the new run id as `latest_run`; the consumer-provided `onRunStarted` re-points to it.
-                const pendingContext = values.pendingContextItems
-                const createRequest: ClaudeTaskRunCreateSchemaApi = {
-                    runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
-                    model: values.selectedModel,
-                    reasoning_effort: values.selectedEffort,
-                    resume_from_run_id: props.runId,
-                    pending_user_message: wrapWithPosthogContext(content, pendingContext),
+            startNewRun: async ({ content }) => {
+                if (values.startingRun || !content.trim() || values.currentProjectId == null) {
+                    return
                 }
-                const result = await tasksRunCreate(String(values.currentProjectId), props.taskId, createRequest)
-                actions.resetComposerForm()
-                const sentKeys = pendingContext.filter((item) => item.type !== 'text').map(attachedContextItemKey)
-                if (sentKeys.length > 0) {
-                    actions.markContextSent(sentKeys)
+                actions.setStartingRun(true)
+                try {
+                    // Same endpoint as the "Run again" button, but seeded with the user's message and chained
+                    // from the finished run so the new run continues the thread, and carrying the picked model /
+                    // reasoning effort (the resume schema can't, so we send the Claude create shape). The response
+                    // carries the new run id as `latest_run`; the consumer-provided `onRunStarted` re-points to it.
+                    const pendingContext = values.pendingContextItems
+                    const createRequest: ClaudeTaskRunCreateSchemaApi = {
+                        runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
+                        model: values.selectedModel,
+                        reasoning_effort: values.selectedEffort,
+                        resume_from_run_id: props.runId,
+                        pending_user_message: wrapWithPosthogContext(content, pendingContext),
+                    }
+                    const result = await tasksRunCreate(String(values.currentProjectId), props.taskId, createRequest)
+                    actions.resetComposerForm()
+                    markPendingContextSent(pendingContext)
+                    if (result.latest_run) {
+                        props.onRunStarted?.(result.latest_run)
+                    }
+                } catch {
+                    lemonToast.error('Failed to start a new run. Please try again.')
+                } finally {
+                    actions.setStartingRun(false)
                 }
-                if (result.latest_run) {
-                    props.onRunStarted?.(result.latest_run)
-                }
-            } catch {
-                lemonToast.error('Failed to start a new run. Please try again.')
-            } finally {
-                actions.setStartingRun(false)
-            }
-        },
-    })),
+            },
+        }
+    }),
 ])

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -344,6 +344,27 @@ describe('runStreamLogic', () => {
             expect(replayListener).toHaveBeenCalledTimes(1)
             expect(replayListener.mock.calls[0][0].source).toEqual('replay')
         })
+
+        it('resolves a live completion against a tool_call ingested during replay with no replay listener', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            const liveListener = jest.fn()
+            toolStreamEventsLogic.actions.registerToolListener('live-only', {
+                tools: ['create_issue'],
+                onEvent: liveListener,
+            })
+
+            await expectLogic(logic, () => {
+                // No replay subscriber registered, so this frame emits nothing on the bus, but the
+                // live terminal update must still resolve its name and phase off it.
+                logic.actions.ingestAcpFrame(issueCall, 'replay')
+                logic.actions.ingestAcpFrame(issueDone, 'live')
+            }).toFinishAllListeners()
+
+            expect(liveListener.mock.calls.map(([event]) => [event.phase, event.toolName])).toEqual([
+                ['completed', 'create_issue'],
+            ])
+            expect(captureSpy.mock.calls.filter((c) => c[0] === 'tool_call_completed')).toHaveLength(1)
+        })
     })
 
     describe('showThinkingIndicator', () => {

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -809,6 +809,90 @@ function dedupeBufferedAgainstHistory(buffered: StoredLogEntry[], history: Store
     return survivors
 }
 
+/**
+ * The invocation a `tool_call` frame creates, replacing any prior invocation for the id. Shared by
+ * the `foldLogToThread` projection and the per-frame tracker in `ingestAcpFrame`, so tool-stream
+ * events carry exactly the invocation the projection derives without re-folding the whole log.
+ */
+function invocationFromToolCall(update: Record<string, unknown>): ToolInvocation | null {
+    const toolCallId = String(update.toolCallId ?? '')
+    if (!toolCallId) {
+        return null
+    }
+    return {
+        toolCallId,
+        rawServerName: String(update.serverName ?? 'posthog'),
+        rawToolName: String(update.toolName ?? ''),
+        input: (update.rawInput ?? update.input ?? {}) as Record<string, unknown>,
+        status: mapAcpStatus(update.status),
+        title: update.title as string | undefined,
+        kind: update.kind as string | undefined,
+        locations: update.locations as { path: string; line?: number }[] | undefined,
+        contentBlocks: Array.isArray(update.content) ? update.content : [],
+        meta: update._meta,
+    }
+}
+
+/**
+ * Folds one `tool_call_update` frame into the existing invocation (field-wise, newer-wins; the
+ * invocation-level twin of `mergeToolCallUpdateEntries`). A reconnect can deliver a terminal update
+ * whose creating `tool_call` was lost, so with no existing invocation this builds a minimal one and
+ * the card still renders instead of vanishing. Shared by the projection and the per-frame tracker.
+ */
+function invocationFromToolCallUpdate(
+    existing: ToolInvocation | undefined,
+    update: Record<string, unknown>,
+    notification: StoredLogEntry['notification']
+): ToolInvocation | null {
+    const toolCallId = String(update.toolCallId ?? '')
+    if (!toolCallId) {
+        return null
+    }
+    const status = mapAcpStatus(update.status ?? existing?.status)
+    const rawInput =
+        update.rawInput && typeof update.rawInput === 'object'
+            ? (update.rawInput as Record<string, unknown>)
+            : update.input && typeof update.input === 'object'
+              ? (update.input as Record<string, unknown>)
+              : undefined
+    const denialReason = status === 'failed' ? extractDenialReason(update._meta) : undefined
+    const errorMessage =
+        (update.error as { message?: string } | null)?.message ??
+        denialReason ??
+        (status === 'failed' ? notification.error?.message : undefined)
+    const updateContent = Array.isArray(update.content) ? update.content : []
+
+    if (!existing) {
+        return {
+            toolCallId,
+            rawServerName: 'posthog',
+            rawToolName: '',
+            input: rawInput ?? {},
+            status,
+            title: update.title as string | undefined,
+            locations: update.locations as { path: string; line?: number }[] | undefined,
+            contentBlocks: updateContent,
+            meta: update._meta,
+            ...(errorMessage !== undefined ? { error: { message: errorMessage } } : {}),
+        }
+    }
+
+    return {
+        ...existing,
+        status,
+        title: (update.title as string | undefined) ?? existing.title,
+        progress: update.progress ?? existing.progress,
+        output: update.rawOutput ?? existing.output,
+        locations: (update.locations as { path: string; line?: number }[] | undefined) ?? existing.locations,
+        // ACP update semantics: a present `content` replaces the collection (the agent re-sends
+        // the full accumulated blocks) — appending would duplicate every prior snapshot.
+        contentBlocks: updateContent.length > 0 ? updateContent : existing.contentBlocks,
+        error: errorMessage !== undefined ? { message: errorMessage } : existing.error,
+        ...(rawInput ? { input: rawInput } : {}),
+        ...(update._meta ? { meta: update._meta } : {}),
+    }
+}
+
 export interface FoldedThread {
     threadItems: ThreadItem[]
     toolInvocations: Map<string, ToolInvocation>
@@ -935,60 +1019,15 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
         update: Record<string, unknown>,
         notification: StoredLogEntry['notification']
     ): void => {
-        const toolCallId = String(update.toolCallId ?? '')
-        if (!toolCallId) {
+        const existing = invocations.get(String(update.toolCallId ?? ''))
+        const next = invocationFromToolCallUpdate(existing, update, notification)
+        if (!next) {
             return
         }
-        const existing = invocations.get(toolCallId)
-        const status = mapAcpStatus(update.status ?? existing?.status)
-        const rawInput =
-            update.rawInput && typeof update.rawInput === 'object'
-                ? (update.rawInput as Record<string, unknown>)
-                : update.input && typeof update.input === 'object'
-                  ? (update.input as Record<string, unknown>)
-                  : undefined
-        const denialReason = status === 'failed' ? extractDenialReason(update._meta) : undefined
-        const errorMessage =
-            (update.error as { message?: string } | null)?.message ??
-            denialReason ??
-            (status === 'failed' ? notification.error?.message : undefined)
-        const updateContent = Array.isArray(update.content) ? update.content : []
-
-        if (!existing) {
-            // A reconnect can deliver a terminal update whose creating `tool_call` was lost — upsert a
-            // minimal invocation so the card still renders instead of vanishing.
-            invocations.set(toolCallId, {
-                toolCallId,
-                rawServerName: 'posthog',
-                rawToolName: '',
-                input: rawInput ?? {},
-                status,
-                title: update.title as string | undefined,
-                locations: update.locations as { path: string; line?: number }[] | undefined,
-                contentBlocks: updateContent,
-                meta: update._meta,
-                ...(errorMessage !== undefined ? { error: { message: errorMessage } } : {}),
-            })
-            if (!subagentParentToolCallId(update._meta)) {
-                upsertInvocationItem(toolCallId)
-            }
-            return
+        invocations.set(next.toolCallId, next)
+        if (!existing && !subagentParentToolCallId(update._meta)) {
+            upsertInvocationItem(next.toolCallId)
         }
-
-        invocations.set(toolCallId, {
-            ...existing,
-            status,
-            title: (update.title as string | undefined) ?? existing.title,
-            progress: update.progress ?? existing.progress,
-            output: update.rawOutput ?? existing.output,
-            locations: (update.locations as { path: string; line?: number }[] | undefined) ?? existing.locations,
-            // ACP update semantics: a present `content` replaces the collection (the agent re-sends
-            // the full accumulated blocks) — appending would duplicate every prior snapshot.
-            contentBlocks: updateContent.length > 0 ? updateContent : existing.contentBlocks,
-            error: errorMessage !== undefined ? { message: errorMessage } : existing.error,
-            ...(rawInput ? { input: rawInput } : {}),
-            ...(update._meta ? { meta: update._meta } : {}),
-        })
     }
 
     for (const { entry, source } of entries) {
@@ -1151,26 +1190,15 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
                 )
                 break
             case 'tool_call': {
-                const toolCallId = String(update.toolCallId ?? '')
-                if (!toolCallId) {
+                const invocation = invocationFromToolCall(update)
+                if (!invocation) {
                     break
                 }
-                invocations.set(toolCallId, {
-                    toolCallId,
-                    rawServerName: String(update.serverName ?? 'posthog'),
-                    rawToolName: String(update.toolName ?? ''),
-                    input: (update.rawInput ?? update.input ?? {}) as Record<string, unknown>,
-                    status: mapAcpStatus(update.status),
-                    title: update.title as string | undefined,
-                    kind: update.kind as string | undefined,
-                    locations: update.locations as { path: string; line?: number }[] | undefined,
-                    contentBlocks: Array.isArray(update.content) ? update.content : [],
-                    meta: update._meta,
-                })
+                invocations.set(invocation.toolCallId, invocation)
                 // A subagent's inner tool calls carry the parent Task's id; they belong inside that
                 // card, not as top-level siblings, so keep them out of the thread.
                 if (!subagentParentToolCallId(update._meta)) {
-                    upsertInvocationItem(toolCallId)
+                    upsertInvocationItem(invocation.toolCallId)
                 }
                 break
             }
@@ -2491,7 +2519,9 @@ export const runStreamLogic = kea<runStreamLogicType>([
             cache.disposables.dispose('event-source')
         },
         reset: () => {
-            // `log` clears via its own reducer on `reset`, so the projection empties with it.
+            // `log` clears via its own reducer on `reset`, so the projection empties with it. The
+            // per-frame invocation tracker mirrors the log, so it must clear alongside it.
+            cache.trackedToolInvocations = undefined
             cache.activeRun = undefined
             cache.turnStartedAtMs = undefined
             cache.isBootstrapping = false
@@ -2552,13 +2582,29 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // (so history replay doesn't pay per-frame resolution for nobody).
             const emitToolStream = !isReplay || hasReplayListener(values.toolListeners)
 
-            // Pre-update tool status for the once-per-transition `tool_call_completed` telemetry and the
-            // tool-stream phase, read from the projection BEFORE the append folds this update in.
+            // Per-frame tool-invocation tracker: the same fold the projection applies, maintained
+            // O(1) per tool frame so the telemetry and tool-stream emits below never read the
+            // `toolInvocations` projection (each such read re-folds the entire log, which turns a
+            // long tool-heavy history replay quadratic). Maintained for every source so a live update
+            // whose `tool_call` arrived during replay still sees the right prior status.
+            // `preToolStatus` is the status BEFORE this frame folds in; it gates the
+            // once-per-transition `tool_call_completed` telemetry and the tool-stream phase.
+            const trackedInvocations: Map<string, ToolInvocation> = (cache.trackedToolInvocations ??= new Map())
             let preToolStatus: ToolInvocationStatus | undefined
-            if (emitToolStream && method === 'session/update') {
+            if (method === 'session/update') {
                 const u = notification.params?.update
-                if (isRecord(u) && u.sessionUpdate === 'tool_call_update') {
-                    preToolStatus = values.toolInvocations.get(String(u.toolCallId ?? ''))?.status
+                if (isRecord(u) && u.sessionUpdate === 'tool_call') {
+                    const invocation = invocationFromToolCall(u)
+                    if (invocation) {
+                        trackedInvocations.set(invocation.toolCallId, invocation)
+                    }
+                } else if (isRecord(u) && u.sessionUpdate === 'tool_call_update') {
+                    const existing = trackedInvocations.get(String(u.toolCallId ?? ''))
+                    preToolStatus = existing?.status
+                    const invocation = invocationFromToolCallUpdate(existing, u, notification)
+                    if (invocation) {
+                        trackedInvocations.set(invocation.toolCallId, invocation)
+                    }
                 }
             }
 
@@ -2674,11 +2720,11 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 return
             }
             if (update.sessionUpdate === 'tool_call') {
-                // A fresh tool call — the projection folded it into `toolInvocations` above, so resolve
-                // its name off the merged invocation and publish a `started` event on the bus.
+                // A fresh tool call — the tracker folded it in above, so resolve its name off the
+                // merged invocation and publish a `started` event on the bus.
                 if (emitToolStream) {
                     const toolCallId = String(update.toolCallId ?? '')
-                    const invocation = toolCallId ? values.toolInvocations.get(toolCallId) : undefined
+                    const invocation = toolCallId ? trackedInvocations.get(toolCallId) : undefined
                     if (invocation) {
                         actions.emitToolEvent({
                             streamKey: props.streamKey,
@@ -2696,8 +2742,8 @@ export const runStreamLogic = kea<runStreamLogicType>([
             if (update.sessionUpdate === 'tool_call_update') {
                 // TOOL_CALL_COMPLETED telemetry — emit once when a tool call first transitions to a
                 // terminal status. `preToolStatus` (read before the upsert) gates the once-only fire;
-                // the resolved key comes from the merged invocation in the projection. Suppressed on
-                // replay, and skipped when the creating `tool_call` was lost (no pre-status).
+                // the resolved key comes from the tracked merged invocation. Suppressed on replay,
+                // and skipped when the creating `tool_call` was lost (no pre-status).
                 const toolCallId = String(update.toolCallId ?? '')
                 if (!toolCallId) {
                     return
@@ -2710,7 +2756,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
                     preToolStatus !== 'failed' &&
                     (status === 'completed' || status === 'failed')
                 ) {
-                    const invocation = values.toolInvocations.get(toolCallId)
+                    const invocation = trackedInvocations.get(toolCallId)
                     const startedAt = cache.turnStartedAtMs as number | undefined
                     posthog.capture('tool_call_completed', {
                         conversation_id: props.conversationId,
@@ -2725,7 +2771,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 // Tool-stream event: phase from the pre-fold status → new status transition. A crossing
                 // into a terminal status is `completed`/`failed`; any other update is `updated`.
                 if (emitToolStream) {
-                    const invocation = values.toolInvocations.get(toolCallId)
+                    const invocation = trackedInvocations.get(toolCallId)
                     if (invocation) {
                         const wasTerminal = preToolStatus === 'completed' || preToolStatus === 'failed'
                         const phase: ToolStreamPhase =

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
+import { attachedContextLogic } from '../../api/logics'
 import { OriginProduct, Task, TaskRunEnvironment, TaskRunStatus } from '../../types/taskTypes'
 import { taskTrackerSceneLogic } from './taskTrackerSceneLogic'
 
@@ -82,6 +83,28 @@ describe('taskTrackerSceneLogic', () => {
             pending_user_message: 'do the thing',
         })
         expect(router.values.location.pathname).toContain('/tasks/new-task')
+    })
+
+    // The seeded first message wraps the on-screen context, and the wrapped non-text refs must be marked
+    // sent under the created task's id — otherwise the run's first follow-up (sent via
+    // `runInteractionLogic`, which prunes against the task-scoped store) re-wraps the same refs.
+    it('marks seeded context sent for the created task so the first follow-up will not re-wrap it', async () => {
+        logic.mount()
+        attachedContextLogic().actions.registerContext('scene', [
+            { type: 'insight', key: 'sig', label: 'Signups' },
+            { type: 'text', value: 'always resend me' },
+        ])
+
+        logic.actions.setNewTaskData({ description: 'why the drop?' })
+        logic.actions.submitNewTask()
+        await expectLogic(logic).toFinishAllListeners()
+
+        // The message sent to the agent is wrapped; the task description stays raw.
+        expect(runBody?.pending_user_message).toContain('<posthog_context>')
+        expect(runBody?.pending_user_message).toContain('- insight sig ("Signups")')
+        expect(createBody?.description).toBe('why the drop?')
+        // Only the entity ref is marked sent (text items always resend), under the created task's id.
+        expect(attachedContextLogic().values.sentContextKeysByTask).toEqual({ 'new-task': ['insight:sig'] })
     })
 
     // The repo picker only renders once `repositoryConfig.integrationId` is set (auto-selected from the

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -13,7 +13,7 @@ import {
     TaskExecutionModeEnumApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
-import { attachedContextLogic, runStreamLogic } from '../../api/logics'
+import { attachedContextItemKey, attachedContextLogic, runStreamLogic } from '../../api/logics'
 import type { SuggestionGroup, SuggestionItem } from '../../api/primitives'
 import { DEFAULT_HEADLINES, pickHeadline } from '../../api/primitives'
 import { runnerPanelLogic } from '../../logics/runnerPanelLogic'
@@ -83,6 +83,8 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
             ['loadTasks', 'loadRepositories', 'deleteTask'],
             integrationsLogic,
             ['loadIntegrationsSuccess'],
+            attachedContextLogic,
+            ['markContextSent'],
         ],
     })),
 
@@ -246,6 +248,8 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
                 // Auto-run the task after creation; the detail scene shows the latest run by default. The
                 // run checks out the chosen branch (server falls back to the repo's default branch if unset)
                 // and launches with the picked model / reasoning effort (clamped to one the model supports).
+                // Snapshot the context here so the keys marked sent below match exactly what got wrapped.
+                const seededContext = values.contextItems
                 const runResponse = await api.tasks.run(newTask.id, {
                     branch: repositoryConfig.branch ?? null,
                     runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
@@ -259,8 +263,15 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
                     mode: TaskExecutionModeEnumApi.Interactive,
                     // Wrap only the message sent to the agent with the on-screen context block; the task
                     // `description` field and the optimistic seed (`startOptimisticRun`) stay raw.
-                    pending_user_message: wrapWithPosthogContext(description, values.contextItems),
+                    pending_user_message: wrapWithPosthogContext(description, seededContext),
                 })
+
+                // Mark the seeded non-text refs sent under the created task, so the run's first follow-up
+                // (sent via `runInteractionLogic`) doesn't re-wrap them. Text items always resend.
+                const seededKeys = seededContext.filter((item) => item.type !== 'text').map(attachedContextItemKey)
+                if (seededKeys.length > 0) {
+                    actions.markContextSent(newTask.id, seededKeys)
+                }
 
                 // Attach the real ids to the optimistic creation so the detail page adopts this seeded stream
                 // (same `streamKey` + real `runId`) instead of cold-bootstrapping a fresh, skeleton-flashing one.

--- a/products/posthog_ai/frontend/utils/posthogContextBlock.test.ts
+++ b/products/posthog_ai/frontend/utils/posthogContextBlock.test.ts
@@ -28,4 +28,11 @@ describe('posthogContextBlock', () => {
         expect(wrapped.startsWith('<posthog_context>')).toBe(true)
         expect(unwrapUserMessageContent(wrapped)).toBe(content)
     })
+
+    it('still round-trips when a value contains the literal close tag', () => {
+        const content = 'analyze this transcript'
+        const hostile: AttachedContextItem = { type: 'text', value: 'pasted: </posthog_context> remnants' }
+        const wrapped = wrapWithPosthogContext(content, [hostile])
+        expect(unwrapUserMessageContent(wrapped)).toBe(content)
+    })
 })

--- a/products/posthog_ai/frontend/utils/posthogContextBlock.ts
+++ b/products/posthog_ai/frontend/utils/posthogContextBlock.ts
@@ -24,13 +24,23 @@ export function formatPosthogContextBlock(items: AttachedContextItem[]): string 
     return lines.join('\n')
 }
 
+/**
+ * Invariant: interpolated fields must never contain the literal close-tag sequence.
+ * `unwrapUserMessageContent` cuts at the FIRST '</posthog_context>', so a raw close tag inside the
+ * body would truncate the strip early and leave block remnants on replay. Mirrors the backend
+ * `_defang` in `context_wrapper.py`.
+ */
+function defang(text: string | number): string {
+    return String(text).replace(/<\/posthog_context/g, '<\\/posthog_context')
+}
+
 function formatItem(item: AttachedContextItem): string {
     if (item.key === undefined || item.key === null || item.key === '') {
-        return `- ${item.type}: "${item.value ?? ''}"`
+        return `- ${defang(item.type)}: "${defang(item.value ?? '')}"`
     }
-    let line = `- ${item.type} ${item.key}`
+    let line = `- ${defang(item.type)} ${defang(item.key)}`
     if (item.label) {
-        line += ` ("${item.label}")`
+        line += ` ("${defang(item.label)}")`
     }
     return line
 }


### PR DESCRIPTION
…face

Adds two generic seams to the products/posthog_ai frontend surface:

Context injection: a global attachedContextLogic registry of abstract
AttachedContextItem primitives (arbitrary type string + key/label/value),
fed via the useAttachedContext hook, the AttachedContextProvider component,
or plain kea register/deregister actions. The send paths (runInteractionLogic,
taskTrackerSceneLogic) prefix outgoing messages with a <posthog_context> block
that stays invisible to the user: live echoes carry the raw text and the
existing replay strip removes the block. Entity refs dedupe per run; text
items always resend, mirroring the backend's prune_repeated_entity_refs.

Tool stream subscriptions: runStreamLogic publishes tool-call lifecycle
events (resolved tool names via toolResolver) onto a global
toolStreamEventsLogic bus; consumers subscribe with useToolStreamListener
or kea-natively. Replay-sourced events are suppressed unless a subscription
opts in, and subscriber exceptions never break frame ingestion.

Coexistence bridges live in scenes/max for clean later removal:
posthogAiContextBridgeLogic mirrors the active scene's maxContext into the
new store (mounted by PhaiSidePanelChat), and maxThreadLogic's sandbox send
merges the new store's items into the conversations attached_context.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QC7oN9pa9AWPqzwKfhk9Tn## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
