### PR TITLE
fix(conversations): reject empty @supporthog mentions

### DIFF
--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -108,6 +108,32 @@ class TestSlackMessageRouting(BaseTest):
 
     @parameterized.expand(
         [
+            ("bare_mention", "<@U0BOT001>", None, False),
+            ("mention_with_whitespace", "<@U0BOT001>   ", None, False),
+            ("mention_with_only_other_mentions", "<@U0BOT001> <@U0USER99>", None, False),
+            ("mention_with_text", "<@U0BOT001> help me", None, True),
+            ("bare_mention_with_files", "<@U0BOT001>", [{"url_private": "https://x/y.png"}], True),
+        ]
+    )
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_empty_mention_does_not_create_ticket(self, _name, text, files, should_create, mock_create_or_update):
+        handle_support_mention(
+            {
+                "type": "app_mention",
+                "channel": "C_ANY",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": text,
+                "files": files,
+            },
+            self.team,
+            "T123",
+        )
+
+        assert mock_create_or_update.called is should_create
+
+    @parameterized.expand(
+        [
             # No ticket yet: seed from the thread's parent message and backfill replies.
             (
                 "seeds_from_parent",

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -153,6 +153,11 @@ def extract_slack_user_ids(text: str, blocks: list[JSON] | None = None) -> set[s
     return ids
 
 
+def strip_slack_user_mentions(text: str) -> str:
+    """Remove ``<@USERID>`` mention tokens, leaving only the message's own text."""
+    return _RE_SLACK_USER_MENTION.sub("", text)
+
+
 def content_to_slack_mrkdwn(content: str) -> str:
     """Convert markdown comment content to Slack mrkdwn text."""
     if not content:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -35,7 +35,7 @@ from .cache import (
     set_cached_slack_user,
     slack_ticket_create_lock,
 )
-from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content
+from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content, strip_slack_user_mentions
 from .models import Ticket
 from .models.constants import Channel, ChannelDetail, Status
 from .services.attachments import (
@@ -728,6 +728,17 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
                 if ticket:
                     _backfill_thread_replies(client, team, ticket, channel, thread_ts)
                 return
+
+    # A bare "@supporthog" (mention only, no message or files) must not create an empty
+    # ticket. The parent-seeding branch above already handled thread-escalation mentions.
+    if not strip_slack_user_mentions(text).strip() and not files:
+        logger.info(
+            "slack_support_mention_empty_skipped",
+            team_id=_get_team_id(team),
+            slack_channel_id=channel,
+            thread_ts=thread_ts,
+        )
+        return
 
     create_or_update_slack_ticket(
         team=team,


### PR DESCRIPTION
## Problem

Mentioning `@supporthog` in Slack with no message created an empty support ticket. Reported in [Zendesk #61849](https://posthoghelp.zendesk.com/agent/tickets/61849).

An `app_mention` event's `text` always contains the bot mention token (`<@BOTID>`) — for a bare mention it's exactly that token — so it's never blank. The existing empty-content guard in `create_or_update_slack_ticket` checks the rendered text, where the token resolves to the bot's display name and stays non-empty, so the guard passes and the bot's name becomes the ticket body.

Our other Slack product (`slack_app`) already strips the bot self-mention centrally for the same reason.

## Changes

Strip user-mention tokens before the emptiness check in `handle_support_mention`. A mention with no real message and no files is skipped instead of creating a ticket. The "reply `@supporthog` to escalate a thread" flow is unaffected (it seeds from the parent message and returns earlier).

## How did you test this code?

Added `test_empty_mention_does_not_create_ticket` (bare mention, whitespace-only, mentions-only all skip; mention-with-text and mention-with-files still create). Ran the routing (30) and formatting (34) suites, all green. No manual Slack testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta directed this from the Zendesk report. I (Claude) root-caused why the existing guard missed bare mentions, confirmed the `app_mention` payload shape against Slack docs, and checked how `slack_app` handles the same case. Invoked `/writing-tests` for the regression test and ran a `/simplify` review pass.
