### PR TITLE
feat(replay-vision): add "What to summarize" targeting to the action editor

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useMemo } from 'react'
 
-import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonInputSelect } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { NotFound } from 'lib/components/NotFound'
@@ -25,6 +25,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { ReplayVisionFeedbackButton } from '../components/ReplayVisionFeedbackButton'
 import { actionEditorSceneLogic } from './actionEditorSceneLogic'
 import { DEFAULT_CADENCE } from './cadence'
+import { replayScannerLogic } from './replayScannerLogic'
 
 export const scene: SceneExport = {
     component: ActionEditorSceneComponent,
@@ -145,6 +146,132 @@ function ScheduleSection(): JSX.Element {
     )
 }
 
+const VERDICT_OPTIONS: { value: 'yes' | 'no' | 'inconclusive'; label: string }[] = [
+    { value: 'yes', label: 'Yes' },
+    { value: 'no', label: 'No' },
+    { value: 'inconclusive', label: 'Inconclusive' },
+]
+
+// Type-specific "run this on…" targeting controls. Empty controls mean the action runs on all of the
+// scanner's observations; the selected values narrow it (verdicts for monitors, tags for classifiers,
+// a score range for scorers). Summarizers have no outcome to filter on.
+function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | null {
+    const { actionForm, actionFormErrors } = useValues(actionEditorSceneLogic)
+    const { setActionFormValue } = useActions(actionEditorSceneLogic)
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
+
+    if (!scanner) {
+        return null
+    }
+
+    const toNumberOrNull = (val: number | undefined): number | null => (val === undefined || isNaN(val) ? null : val)
+
+    let controls: JSX.Element
+    switch (scanner.scanner_type) {
+        case 'monitor':
+            controls = (
+                <div className="flex flex-col gap-1">
+                    <div className="flex gap-1">
+                        {VERDICT_OPTIONS.map(({ value, label }) => (
+                            <LemonButton
+                                key={value}
+                                size="small"
+                                type={actionForm.verdict.includes(value) ? 'primary' : 'secondary'}
+                                onClick={() =>
+                                    setActionFormValue(
+                                        'verdict',
+                                        actionForm.verdict.includes(value)
+                                            ? actionForm.verdict.filter((v) => v !== value)
+                                            : [...actionForm.verdict, value]
+                                    )
+                                }
+                                data-attr={`vision-action-targeting-verdict-${value}`}
+                            >
+                                {label}
+                            </LemonButton>
+                        ))}
+                    </div>
+                    <span className="text-xs text-muted">
+                        Only run on observations with these verdicts. Leave all unselected to run on every observation.
+                    </span>
+                </div>
+            )
+            break
+        case 'classifier': {
+            const configuredTags: string[] = scanner.scanner_config?.tags ?? []
+            const allowFreeform = !!scanner.scanner_config?.allow_freeform_tags
+            controls = (
+                <div className="flex flex-col gap-1">
+                    <LemonInputSelect
+                        mode="multiple"
+                        allowCustomValues={allowFreeform}
+                        placeholder="Pick tags…"
+                        value={actionForm.tags}
+                        onChange={(tags) => setActionFormValue('tags', tags)}
+                        options={[...new Set([...configuredTags, ...actionForm.tags])].map((t) => ({
+                            key: t,
+                            label: t,
+                        }))}
+                        data-attr="vision-action-targeting-tags"
+                    />
+                    <span className="text-xs text-muted">
+                        Only run on observations tagged with any of these. Leave empty to run on every observation.
+                    </span>
+                </div>
+            )
+            break
+        }
+        case 'scorer': {
+            const scale = scanner.scanner_config?.scale
+            controls = (
+                <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                        <LemonInput
+                            type="number"
+                            placeholder={scale ? String(scale.min) : 'Min'}
+                            value={actionForm.min_score ?? undefined}
+                            onChange={(val) => setActionFormValue('min_score', toNumberOrNull(val))}
+                            className="w-24"
+                            data-attr="vision-action-targeting-min-score"
+                        />
+                        <span className="text-muted">to</span>
+                        <LemonInput
+                            type="number"
+                            placeholder={scale ? String(scale.max) : 'Max'}
+                            value={actionForm.max_score ?? undefined}
+                            onChange={(val) => setActionFormValue('max_score', toNumberOrNull(val))}
+                            className="w-24"
+                            data-attr="vision-action-targeting-max-score"
+                        />
+                    </div>
+                    {actionFormErrors?.min_score ? (
+                        <span className="text-xs text-danger">{String(actionFormErrors.min_score)}</span>
+                    ) : null}
+                    <span className="text-xs text-muted">
+                        Only run on observations scored in this range (inclusive
+                        {scale ? `; this scanner scores ${scale.min}–${scale.max}` : ''}). Leave empty to run on every
+                        observation.
+                    </span>
+                </div>
+            )
+            break
+        }
+        default:
+            controls = (
+                <span className="text-xs text-muted">
+                    Runs on all of this scanner's summaries — summarizers have no outcome to filter on.
+                </span>
+            )
+    }
+
+    return (
+        <div>
+            <h4 className="mb-1">Run this on</h4>
+            {controls}
+        </div>
+    )
+}
+
 function DeliverySection(): JSX.Element {
     const { actionForm } = useValues(actionEditorSceneLogic)
     const { setActionFormValue } = useActions(actionEditorSceneLogic)
@@ -249,6 +376,8 @@ export function ActionEditorSceneComponent(): JSX.Element {
                                 <h4 className="mb-1">Schedule</h4>
                                 <ScheduleSection />
                             </div>
+
+                            {effectiveScannerId ? <TargetingSection scannerId={effectiveScannerId} /> : null}
 
                             <LemonField
                                 name="prompt_guide"

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useMemo } from 'react'
 
-import { LemonButton, LemonInput, LemonInputSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonInputSelect, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { NotFound } from 'lib/components/NotFound'
@@ -156,8 +156,8 @@ const VERDICT_OPTIONS: { value: 'yes' | 'no' | 'inconclusive'; label: string }[]
 // the selected values narrow it (verdicts for monitors, tags for classifiers, a score range for
 // scorers). Summarizers have no outcome to filter on, so the section is hidden entirely.
 function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | null {
-    const { actionForm, actionFormErrors } = useValues(actionEditorSceneLogic)
-    const { setActionFormValue } = useActions(actionEditorSceneLogic)
+    const { actionForm, actionFormErrors, targetingMode } = useValues(actionEditorSceneLogic)
+    const { setActionFormValue, setTargetingMode } = useActions(actionEditorSceneLogic)
     const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
 
     if (!scanner) {
@@ -191,10 +191,7 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                             </LemonButton>
                         ))}
                     </div>
-                    <span className="text-xs text-muted">
-                        Only summarize observations with these verdicts. Leave all unselected to summarize every
-                        observation.
-                    </span>
+                    <span className="text-xs text-muted">Only summarize observations with these verdicts.</span>
                 </div>
             )
             break
@@ -215,10 +212,7 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                         }))}
                         data-attr="vision-action-targeting-tags"
                     />
-                    <span className="text-xs text-muted">
-                        Only summarize observations tagged with any of these. Leave empty to summarize every
-                        observation.
-                    </span>
+                    <span className="text-xs text-muted">Only summarize observations tagged with any of these.</span>
                 </div>
             )
             break
@@ -251,8 +245,7 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                     ) : null}
                     <span className="text-xs text-muted">
                         Only summarize observations scored in this range (inclusive
-                        {scale ? `; this scanner scores ${scale.min}–${scale.max}` : ''}). Leave empty to summarize
-                        every observation.
+                        {scale ? `; this scanner scores ${scale.min}–${scale.max}` : ''}).
                     </span>
                 </div>
             )
@@ -264,9 +257,19 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
     }
 
     return (
-        <div>
-            <h4 className="mb-1">What to summarize</h4>
-            {controls}
+        <div className="flex flex-col gap-2">
+            <h4 className="mb-0">What to summarize</h4>
+            <LemonSegmentedButton
+                size="small"
+                value={targetingMode}
+                onChange={(mode) => setTargetingMode(mode)}
+                options={[
+                    { value: 'all' as const, label: 'All observations' },
+                    { value: 'filtered' as const, label: 'Only matching observations' },
+                ]}
+                data-attr="vision-action-targeting-mode"
+            />
+            {targetingMode === 'filtered' && controls}
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -152,9 +152,9 @@ const VERDICT_OPTIONS: { value: 'yes' | 'no' | 'inconclusive'; label: string }[]
     { value: 'inconclusive', label: 'Inconclusive' },
 ]
 
-// Type-specific "run this on…" targeting controls. Empty controls mean the action runs on all of the
-// scanner's observations; the selected values narrow it (verdicts for monitors, tags for classifiers,
-// a score range for scorers). Summarizers have no outcome to filter on.
+// Type-specific "what to summarize" controls. Empty controls mean every observation is summarized;
+// the selected values narrow it (verdicts for monitors, tags for classifiers, a score range for
+// scorers). Summarizers have no outcome to filter on, so the section is hidden entirely.
 function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | null {
     const { actionForm, actionFormErrors } = useValues(actionEditorSceneLogic)
     const { setActionFormValue } = useActions(actionEditorSceneLogic)
@@ -192,7 +192,8 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                         ))}
                     </div>
                     <span className="text-xs text-muted">
-                        Only run on observations with these verdicts. Leave all unselected to run on every observation.
+                        Only summarize observations with these verdicts. Leave all unselected to summarize every
+                        observation.
                     </span>
                 </div>
             )
@@ -215,7 +216,8 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                         data-attr="vision-action-targeting-tags"
                     />
                     <span className="text-xs text-muted">
-                        Only run on observations tagged with any of these. Leave empty to run on every observation.
+                        Only summarize observations tagged with any of these. Leave empty to summarize every
+                        observation.
                     </span>
                 </div>
             )
@@ -248,25 +250,22 @@ function TargetingSection({ scannerId }: { scannerId: string }): JSX.Element | n
                         <span className="text-xs text-danger">{String(actionFormErrors.min_score)}</span>
                     ) : null}
                     <span className="text-xs text-muted">
-                        Only run on observations scored in this range (inclusive
-                        {scale ? `; this scanner scores ${scale.min}–${scale.max}` : ''}). Leave empty to run on every
-                        observation.
+                        Only summarize observations scored in this range (inclusive
+                        {scale ? `; this scanner scores ${scale.min}–${scale.max}` : ''}). Leave empty to summarize
+                        every observation.
                     </span>
                 </div>
             )
             break
         }
         default:
-            controls = (
-                <span className="text-xs text-muted">
-                    Runs on all of this scanner's summaries — summarizers have no outcome to filter on.
-                </span>
-            )
+            // Summarizers have no outcome to filter on, so there's nothing to configure here.
+            return null
     }
 
     return (
         <div>
-            <h4 className="mb-1">Run this on</h4>
+            <h4 className="mb-1">What to summarize</h4>
             {controls}
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.test.ts
@@ -61,6 +61,8 @@ describe('actionEditorSceneLogic', () => {
             .toMatchValues({
                 isNew: false,
                 effectiveScannerId: 's1',
+                // The stored selection must surface as the "only matching" state, not hide behind "all".
+                targetingMode: 'filtered',
                 actionForm: {
                     name: 'action-e',
                     cadence: { weekdays: [0, 2], hour: 14, minute: 30 },
@@ -74,6 +76,13 @@ describe('actionEditorSceneLogic', () => {
                     max_score: null,
                 },
             })
+
+        // Switching back to "all" must clear the filter values — otherwise a hidden filter would
+        // silently keep narrowing the summary after save.
+        logic.actions.setTargetingMode('all')
+        await expectLogic(logic).toMatchValues({
+            actionForm: expect.objectContaining({ verdict: [], tags: [], min_score: null, max_score: null }),
+        })
     })
 
     it('creating an action submits and navigates to the new action page', async () => {

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.test.ts
@@ -16,6 +16,7 @@ const existingAction = {
     scanner: 's1',
     enabled: true,
     trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
+    selection: { verdict: ['yes'], min_score: 2 },
     synthesis_config: { prompt_guide: 'focus on checkout' },
     delivery_config: [{ type: 'slack', integration_id: 5, channel: 'C123' }],
 } as unknown as VisionActionApi
@@ -67,6 +68,10 @@ describe('actionEditorSceneLogic', () => {
                     prompt_guide: 'focus on checkout',
                     integration_id: 5,
                     channel: 'C123',
+                    verdict: ['yes'],
+                    tags: [],
+                    min_score: 2,
+                    max_score: null,
                 },
             })
     })

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
@@ -28,6 +28,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
         setScannerId: (scannerId: string) => ({ scannerId }),
         setScannerName: (scannerName: string) => ({ scannerName }),
         setActionId: (actionId: string) => ({ actionId }),
+        setTargetingMode: (mode: 'all' | 'filtered') => ({ mode }),
         loadAction: (actionId: string) => ({ actionId }),
         loadActionSuccess: (action: VisionActionApi) => ({ action }),
         loadActionFailure: true,
@@ -53,6 +54,16 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
             'new' as string,
             {
                 setActionId: (_, { actionId }) => actionId,
+            },
+        ],
+        // Whether the summary covers everything or only matching observations. Explicit state (not
+        // derived from the filter values) so picking "only matching" shows the controls before any
+        // value is chosen.
+        targetingMode: [
+            'all' as 'all' | 'filtered',
+            {
+                setTargetingMode: (_, { mode }) => mode,
+                setActionId: () => 'all',
             },
         ],
         loadedAction: [
@@ -163,6 +174,13 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
+        setTargetingMode: ({ mode }) => {
+            if (mode === 'all') {
+                // Clear the filter values so a hidden filter can't silently narrow the summary.
+                actions.setActionFormValues({ verdict: [], tags: [], min_score: null, max_score: null })
+            }
+        },
+
         setScannerId: async ({ scannerId }, breakpoint) => {
             // Only fetch the scanner name on the new-action route — the edit title uses the action name instead.
             if (!values.isNew) {
@@ -202,6 +220,14 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
 
         loadActionSuccess: ({ action }) => {
             actions.setScannerId(action.scanner)
+            const selection = action.selection
+            const hasFilter = !!(
+                selection?.verdict?.length ||
+                selection?.tags?.length ||
+                selection?.min_score != null ||
+                selection?.max_score != null
+            )
+            actions.setTargetingMode(hasFilter ? 'filtered' : 'all')
             actions.setActionFormValues({
                 name: action.name,
                 cadence: parseRruleToCadence(action.trigger_config?.rrule),

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
@@ -123,12 +123,16 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
     forms(({ values }) => ({
         actionForm: {
             defaults: NEW_ACTION_FORM(),
-            errors: ({ name, cadence, integration_id, channel }: VisionActionForm) => ({
+            errors: ({ name, cadence, integration_id, channel, min_score, max_score }: VisionActionForm) => ({
                 name: !name?.trim() ? 'Give this summary a name' : undefined,
                 // kea-forms can't carry a string error on the weekdays array, so hang it on `hour` to
                 // mark the form invalid and block Enter-to-submit; the visible copy is the inline text.
                 cadence: cadence.weekdays.length === 0 ? { hour: 'Pick at least one day' } : undefined,
                 channel: integration_id && !channel ? 'Pick a channel' : undefined,
+                min_score:
+                    min_score != null && max_score != null && min_score > max_score
+                        ? "Min score can't exceed max score"
+                        : undefined,
             }),
             submit: async (form: VisionActionForm) => {
                 const teamId = teamLogic.values.currentTeamId
@@ -205,6 +209,10 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 prompt_guide: action.synthesis_config?.prompt_guide ?? '',
                 integration_id: action.delivery_config?.[0]?.integration_id ?? null,
                 channel: action.delivery_config?.[0]?.channel ?? '',
+                verdict: action.selection?.verdict ?? [],
+                tags: action.selection?.tags ?? [],
+                min_score: action.selection?.min_score ?? null,
+                max_score: action.selection?.max_score ?? null,
             })
         },
 

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -88,7 +88,7 @@ describe('visionActionsLogic', () => {
         })
     })
 
-    it('buildActionBody maps the form to the API body, including a Slack delivery target', () => {
+    it('buildActionBody maps the form to the API body, including a Slack delivery target and targeting', () => {
         const form: VisionActionForm = {
             name: '  Daily digest  ',
             cadence: { weekdays: [0, 2], hour: 14, minute: 30 },
@@ -96,11 +96,16 @@ describe('visionActionsLogic', () => {
             prompt_guide: 'focus on checkout',
             integration_id: 5,
             channel: 'C123|#general',
+            verdict: ['yes'],
+            tags: ['bug'],
+            min_score: 1,
+            max_score: 5,
         }
         expect(buildActionBody(form, 's1')).toEqual({
             name: 'Daily digest', // trimmed
             scanner: 's1',
             trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
+            selection: { verdict: ['yes'], tags: ['bug'], min_score: 1, max_score: 5 },
             synthesis_config: { prompt_guide: 'focus on checkout' },
             // The full `${id}|#${name}` composite is stored so the actions table can show the channel
             // name; the backend strips it to the bare id for the Slack destination.
@@ -108,7 +113,7 @@ describe('visionActionsLogic', () => {
         })
     })
 
-    it('buildActionBody emits an empty delivery_config when no integration/channel is set', () => {
+    it('buildActionBody emits empty delivery_config and selection when nothing is set', () => {
         const form: VisionActionForm = {
             name: 'No delivery',
             cadence: { weekdays: [0, 1, 2, 3, 4, 5, 6], hour: 9, minute: 0 },
@@ -116,7 +121,13 @@ describe('visionActionsLogic', () => {
             prompt_guide: '',
             integration_id: null,
             channel: '',
+            verdict: [],
+            tags: [],
+            min_score: null,
+            max_score: null,
         }
         expect(buildActionBody(form, 's1').delivery_config).toEqual([])
+        // Empty selection is sent explicitly so clearing targeting on edit persists as "run on everything".
+        expect(buildActionBody(form, 's1').selection).toEqual({})
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -11,7 +11,7 @@ import {
     visionActionsPartialUpdate,
 } from '../generated/api'
 import { DeliveryTargetTypeEnumApi } from '../generated/api.schemas'
-import type { VisionActionApi } from '../generated/api.schemas'
+import type { VerdictEnumApi, VisionActionApi } from '../generated/api.schemas'
 import { CadenceState, cadenceToRrule, DEFAULT_CADENCE } from './cadence'
 import type { visionActionsLogicType } from './visionActionsLogicType'
 
@@ -27,6 +27,11 @@ export interface VisionActionForm {
     prompt_guide: string
     integration_id: number | null
     channel: string
+    // Targeting ("run this on…") — empty means all of the scanner's observations.
+    verdict: VerdictEnumApi[]
+    tags: string[]
+    min_score: number | null
+    max_score: number | null
 }
 
 export const NEW_ACTION_FORM = (): VisionActionForm => ({
@@ -36,16 +41,36 @@ export const NEW_ACTION_FORM = (): VisionActionForm => ({
     prompt_guide: '',
     integration_id: null,
     channel: '',
+    verdict: [],
+    tags: [],
+    min_score: null,
+    max_score: null,
 })
 
 // Map the UI form shape to the API body shared by create + partial-update. Kept standalone so the
 // rrule + delivery-target mapping (the part most likely to grow beyond a single Slack target) is
 // unit-testable without the form machinery.
 export function buildActionBody(form: VisionActionForm, scannerId: string): Parameters<typeof visionActionsCreate>[1] {
+    // Always send selection (even empty) so clearing every targeting control on edit persists as
+    // "run on everything" rather than silently keeping the previous predicate.
+    const selection: NonNullable<Parameters<typeof visionActionsCreate>[1]['selection']> = {}
+    if (form.verdict.length) {
+        selection.verdict = form.verdict
+    }
+    if (form.tags.length) {
+        selection.tags = form.tags
+    }
+    if (form.min_score != null) {
+        selection.min_score = form.min_score
+    }
+    if (form.max_score != null) {
+        selection.max_score = form.max_score
+    }
     return {
         name: form.name.trim(),
         scanner: scannerId,
         trigger_config: { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
+        selection,
         synthesis_config: { prompt_guide: form.prompt_guide },
         delivery_config:
             form.integration_id && form.channel


### PR DESCRIPTION
## Problem

With the targeting predicate now applied in synthesis (#69005), the action editor needs UI to set it. Without controls, `selection` is only reachable via the API.

Part 3 of the vision-action enhancements stack (targeting UI). Stacked on #69005.

## Changes

- New "What to summarize" section in the action editor page: an explicit "All observations" vs "Only matching observations" toggle (no invisible leave-empty-means-everything state), with type-specific filter controls revealed in the matching state, driven by the bound scanner's type:
    - monitors: verdict chips (yes / no / inconclusive)
    - classifiers: tag multi-select seeded with the configured vocabulary, allowing freeform entries when the scanner does
    - scorers: inclusive min/max score range with min ≤ max validation
    - summarizers: the section is hidden entirely (no outcome to filter on)
- The form maps to/from `selection` and always sends it explicitly, so clearing filters actually persists (empty = run on all).

## How did you test this code?  
  
![Screenshot 2026-07-08 at 12.42.15 PM.png](https://app.graphite.com/user-attachments/assets/2306d36a-1d3d-4ac0-ade2-0d67efe4c1b3.png)![Screenshot 2026-07-08 at 12.41.45 PM.png](https://app.graphite.com/user-attachments/assets/2e927265-d592-4e28-9e4b-ee68850300e2.png)![Screenshot 2026-07-08 at 12.41.41 PM.png](https://app.graphite.com/user-attachments/assets/b9709c03-20b2-470e-bb25-b9c56e4ed2e7.png)



- `actionEditorSceneLogic.test.ts` / `visionActionsLogic.test.ts`: form round-trip of `selection` (seed from a loaded action, build into the request body, explicit-empty on clear) and the min ≤ max validation. These catch regressions where clearing a filter stops persisting or the predicate silently drops out of the body.
- No manual testing beyond the automated suites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — feature is behind the `replay-vision-actions` internal flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-kea-logics, /adopting-generated-api-types, /writing-tests. Decision: targeting controls render from the scanner's `scanner_type` rather than a generic filter builder, keeping each type's predicate honest to what synthesis can actually filter on.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)