### PR TITLE
fix(data-warehouse): disable Sync now while a sync is running

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -301,7 +301,12 @@ function DetailsSection({
                                 type="primary"
                                 onClick={() => reloadSchema(schema)}
                                 disabledReason={
-                                    disabledReason ?? (!schema.sync_type ? 'Set up the sync method first' : undefined)
+                                    disabledReason ??
+                                    (!schema.sync_type
+                                        ? 'Set up the sync method first'
+                                        : schema.status === 'Running'
+                                          ? 'A sync is already running'
+                                          : undefined)
                                 }
                             >
                                 {schema.sync_type === 'cdc' ? 'Sync CDC now' : 'Sync now'}

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -773,7 +773,13 @@ function SchemaRowMore({
                                     size="xsmall"
                                     fullWidth
                                     onClick={() => reloadSchema(schema)}
-                                    disabledReason={!schema.sync_type ? 'Set up the sync method first' : undefined}
+                                    disabledReason={
+                                        !schema.sync_type
+                                            ? 'Set up the sync method first'
+                                            : schema.status === 'Running'
+                                              ? 'A sync is already running'
+                                              : undefined
+                                    }
                                 >
                                     {schema.sync_type === 'cdc' ? 'Sync CDC now' : 'Sync now'}
                                 </LemonButton>


### PR DESCRIPTION
## Problem

Reported in Slack: triggering a table sync via **Sync now** leaves the button enabled, so users can start overlapping sync runs on the same schema while one is already in progress.

## Changes

Disable the per-schema **Sync now** button with the reason "A sync is already running" whenever the schema status is `Running`. Applied in both places the button appears:
- the schema row overflow menu (`SchemasTab.tsx`)
- the schema detail page (`ConfigurationTab.tsx`)

The `reloadSchema` listeners already optimistically set the schema status to `Running` on click, so the button disables immediately after triggering a sync rather than waiting for a server round-trip. Both spots already reference `schema.status === 'Running'` nearby (to show the Cancel button), so this reuses the existing convention.

## How did you test this code?

Not manually tested by the agent. Change is a small, self-contained addition to existing `disabledReason` logic; no automated tests were added or run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app in response to a feedback report that the "Sync now" button stays enabled during an in-flight sync. Explored the data warehouse frontend to locate the two button instances and confirmed the `reloadSchema` kea listeners set an optimistic `Running` status, which makes a `disabledReason` guard sufficient without extra loading state. No skills were required.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A6L24BU0P/p1783441776408439?thread_ts=1783441776.408439&cid=C0A6L24BU0P)*
