### PR TITLE
fix(frontend): eliminate remaining console noise from jest tests

### DIFF
--- a/frontend/bin/ci-report/update-ci-report.test.ts
+++ b/frontend/bin/ci-report/update-ci-report.test.ts
@@ -165,6 +165,21 @@ describe('ci-report section helper', () => {
     })
 
     describe('postSection concurrency', () => {
+        // postSection narrates every write/retry/merge to the console — that's its
+        // CLI UX, not test-relevant output
+        let consoleInfoSpy: jest.SpyInstance
+        let consoleWarnSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation()
+            consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        })
+
+        afterEach(() => {
+            consoleInfoSpy.mockRestore()
+            consoleWarnSpy.mockRestore()
+        })
+
         type StoredComment = { id: number; body: string; author: string }
         type FireOnceHook = { fn: (() => void) | null }
         // An in-memory GitHub issue-comments API — the network is the boundary being

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -127,6 +127,16 @@ export function initKea({
                         lemonToast.error(`${identifierToHuman(actionKey)} failed: ${errorMessage}`)
                     }
                 }
+                // Cooperative cancellation (an aborted fetch, or a query superseded via
+                // `abortController.abort('new query started')` as in the logs/tracing data
+                // logics) is expected control flow, not a failure worth logging or reporting.
+                const isCancellation =
+                    error?.name === 'AbortError' ||
+                    error === 'new query started' ||
+                    error?.message === 'new query started'
+                if (isCancellation) {
+                    return
+                }
                 if (!errorsSilenced) {
                     console.error({ error, reducerKey, actionKey })
                 }

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -328,6 +329,10 @@ describe('impersonationNoticeLogic', () => {
 
     describe('returnToPostHog listener', () => {
         it('navigates to the loginas logout endpoint with next pointing back to the app', async () => {
+            // Drain mount-time requests first: while window.location.href holds the relative
+            // logout URL below, MSW can't resolve request URLs against it and errors out
+            await expectLogic(preflightLogic).toFinishAllListeners()
+
             const originalLocation = window.location
             Object.defineProperty(window, 'location', {
                 configurable: true,

--- a/frontend/src/layout/navigation/projectNoticeLogic.test.tsx
+++ b/frontend/src/layout/navigation/projectNoticeLogic.test.tsx
@@ -30,7 +30,7 @@ describe('projectNoticeLogic', () => {
         beforeEach(() => {
             useMocks({
                 get: {
-                    '/api/organizations/@current/proxy_records': [200, { results: [] }],
+                    '/api/organizations/:organization_id/proxy_records': [200, { results: [] }],
                 },
             })
             initKeaTests()
@@ -262,7 +262,7 @@ describe('projectNoticeLogic', () => {
         beforeEach(() => {
             useMocks({
                 get: {
-                    '/api/organizations/@current/proxy_records': [200, { results: [] }],
+                    '/api/organizations/:organization_id/proxy_records': [200, { results: [] }],
                 },
                 post: {
                     '/api/users/request_email_verification/': [200, { success: true }],

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
@@ -139,6 +139,8 @@ describe('addToDashboardModalLogic', () => {
             .toMatchValues({
                 _dashboardToNavigateTo: 99,
             })
+            // Let updateInsight settle before afterEach unmounts the logics it touches
+            .toFinishAllListeners()
     })
 
     it('orders dashboards: on insight first, then mine, then others pinned, then the rest', async () => {

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -347,7 +347,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
                 breakpoint()
                 const result = response.results as [string, number][]
 
-                if (result && result.length === 0) {
+                if (!result || result.length === 0) {
                     return []
                 }
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -76,7 +76,22 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
         const closable = onClose !== undefined
         const clickable = onClick !== undefined
 
-        const ButtonComponent = clickable ? 'button' : 'div'
+        // A native <button> can't contain the nested close <button> (invalid DOM nesting),
+        // so a closeable chip renders as a div with button semantics instead
+        const ButtonComponent = clickable && !closable ? 'button' : 'div'
+        const buttonRoleProps =
+            clickable && ButtonComponent === 'div'
+                ? {
+                      role: 'button',
+                      tabIndex: 0,
+                      onKeyDown: (e: React.KeyboardEvent) => {
+                          if (!disabledReason && (e.key === 'Enter' || e.key === ' ')) {
+                              e.preventDefault()
+                              onClick?.()
+                          }
+                      },
+                  }
+                : {}
 
         const button = (
             <ButtonComponent
@@ -89,6 +104,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
                 })}
                 aria-disabled={!!disabledReason}
                 type={ButtonComponent === 'button' ? 'button' : undefined}
+                {...buttonRoleProps}
             >
                 <PropertyFilterIcon type={item.type} />
                 <span className="PropertyFilterButton-content" title={showGroupCard ? undefined : label}>

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -193,7 +193,8 @@ export const sharingLogic = kea<sharingLogicType>([
                 width: defaultIframeConfig.width,
                 height: defaultIframeConfig.height,
                 frameBorder: 0,
-                allowfullscreen: true,
+                // React prop casing; embedCode lowercases keys, so the HTML snippet still reads "allowfullscreen"
+                allowFullScreen: true,
                 src: embedLink,
                 key: iframeKey,
                 sandbox: 'allow-scripts allow-same-origin allow-popups',

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -139,10 +139,10 @@ const unusedIndicator = (eventNames: string[]): JSX.Element => {
                             <>
                                 the event{eventNames.length > 1 ? 's' : ''}{' '}
                                 {eventNames.map((e, index) => (
-                                    <>
+                                    <span key={e}>
                                         {index === 0 ? '' : index === eventNames.length - 1 ? ' and ' : ', '}
                                         <strong>"{e}"</strong>
-                                    </>
+                                    </span>
                                 ))}
                             </>
                         ) : (

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -11,6 +11,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { mockEventDefinitions, mockEventPropertyDefinitions } from '~/test/mocks'
@@ -452,6 +453,10 @@ describe('infiniteListLogic', () => {
         let staleLogic: ReturnType<typeof infiniteListLogic.build>
         let surveyRequestCount: number
 
+        // The first 'survey' fetch deliberately 500s — silence the loader error log.
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         beforeEach(() => {
             surveyRequestCount = 0
             useMocks({
@@ -530,6 +535,10 @@ describe('infiniteListLogic', () => {
     })
 
     describe('remote fetch failure settles the list', () => {
+        // Every fetch deliberately 500s — silence the loader error log.
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it('falls back to the empty state instead of spinning forever when the fetch fails', async () => {
             useMocks({
                 get: {

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -137,6 +137,9 @@ function PreviewHeader({ details, viewUrl, entry }: PreviewHeaderProps): JSX.Ele
                         variant="link"
                         className="text-primary"
                         size="sm"
+                        // The render prop swaps the native <button> for a Link (<a>),
+                        // so tell Base UI not to expect native button semantics.
+                        nativeButton={false}
                         render={<Link to={viewUrl} target="_blank" className="text-xs underline" />}
                     >
                         View

--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.test.tsx
@@ -17,8 +17,6 @@ describe('LemonFormDialog', () => {
 
     beforeEach(() => {
         initKeaTests()
-        // react-modal needs an app element to hide from screen readers on open.
-        document.body.innerHTML = '<div id="root"></div>'
         captureException = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined as any)
     })
 
@@ -49,7 +47,8 @@ describe('LemonFormDialog', () => {
     }
 
     const submitViaEnter = async (): Promise<void> => {
-        screen.getByRole('textbox').focus()
+        // click focuses the input through userEvent, so the focus state update is act-wrapped
+        await userEvent.click(screen.getByRole('textbox'))
         await userEvent.keyboard('{Enter}')
     }
 

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -230,7 +230,9 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
                     className="LemonInput__input"
                     ref={mergedInputRef}
                     type={(type === 'password' && passwordVisible ? 'text' : type) || 'text'}
-                    value={value}
+                    // A cleared controlled number input holds NaN; pass '' so the input stays
+                    // controlled instead of feeding NaN to the DOM (undefined stays uncontrolled)
+                    value={type === 'number' && typeof value === 'number' && Number.isNaN(value) ? '' : value}
                     disabled={disabled || !!disabledReason}
                     onChange={(event) => {
                         if (stopPropagation) {

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -2,7 +2,7 @@
 import './icons.scss'
 
 import clsx from 'clsx'
-import { CSSProperties, PropsWithChildren, SVGAttributes } from 'react'
+import { CSSProperties, forwardRef, PropsWithChildren, SVGAttributes } from 'react'
 
 import { LemonBadge, LemonBadgeProps } from 'lib/lemon-ui/LemonBadge'
 
@@ -83,19 +83,25 @@ export interface LemonIconProps {
     className?: string
 }
 
-const LemonIconBase: React.FC<SVGAttributes<SVGSVGElement>> = ({ className, ...props }) => (
-    <svg
-        className={clsx('LemonIcon', className)}
-        width="1em"
-        height="1em"
-        fill="none"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-        focusable="false"
-        aria-hidden="true"
-        {...props}
-    />
-)
+const LemonIconBase = forwardRef<SVGSVGElement, SVGAttributes<SVGSVGElement>>(function LemonIconBase(
+    { className, ...props },
+    ref
+) {
+    return (
+        <svg
+            ref={ref}
+            className={clsx('LemonIcon', className)}
+            width="1em"
+            height="1em"
+            fill="none"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            {...props}
+        />
+    )
+})
 
 // material design format-size icon
 export function IconTextSize(props: LemonIconProps): JSX.Element {
@@ -664,16 +670,17 @@ export function IconHeatmap(props: LemonIconProps): JSX.Element {
     )
 }
 
-export function IconUnverifiedEvent(props: LemonIconProps): JSX.Element {
+// forwardRef so wrappers like Tooltip can anchor to the rendered svg
+export const IconUnverifiedEvent = forwardRef<SVGSVGElement, LemonIconProps>(function IconUnverifiedEvent(props, ref) {
     return (
-        <LemonIconBase {...props}>
+        <LemonIconBase ref={ref} {...props}>
             <path
                 d="M4.8 17.4H19.2V15.6H4.8V17.4ZM6.6 21H17.4V19.2H6.6V21ZM19.2 13.8H4.8C3.81 13.8 3 12.99 3 12V4.8C3 3.81 3.81 3 4.8 3H19.2C20.19 3 21 3.81 21 4.8V12C21 12.99 20.19 13.8 19.2 13.8ZM19.2 4.8H4.8V12H19.2V4.8Z"
                 fill="currentColor"
             />
         </LemonIconBase>
     )
-}
+})
 
 export function IconVerifiedEvent(props: LemonIconProps): JSX.Element {
     return (

--- a/frontend/src/lib/lemon-ui/icons/stories/Icons1.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/stories/Icons1.stories.tsx
@@ -33,7 +33,8 @@ export default meta
 
 interface IconDefinition {
     name: string
-    icon: (...args: any[]) => JSX.Element
+    // ElementType also admits forwardRef-wrapped icons (e.g. IconUnverifiedEvent)
+    icon: React.ElementType
 }
 
 const allIcons: IconDefinition[] = Object.entries(icons)

--- a/frontend/src/lib/lemon-ui/icons/stories/Icons2.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/stories/Icons2.stories.tsx
@@ -33,7 +33,8 @@ export default meta
 
 interface IconDefinition {
     name: string
-    icon: (...args: any[]) => JSX.Element
+    // ElementType also admits forwardRef-wrapped icons (e.g. IconUnverifiedEvent)
+    icon: React.ElementType
 }
 
 const allIcons: IconDefinition[] = Object.entries(icons)

--- a/frontend/src/lib/lemon-ui/icons/stories/Icons3.stories.tsx
+++ b/frontend/src/lib/lemon-ui/icons/stories/Icons3.stories.tsx
@@ -37,7 +37,8 @@ export default meta
 
 interface IconDefinition {
     name: string
-    icon: (...args: any[]) => JSX.Element
+    // ElementType also admits forwardRef-wrapped icons (e.g. IconUnverifiedEvent)
+    icon: React.ElementType
 }
 
 const allIcons: IconDefinition[] = Object.entries(icons)

--- a/frontend/src/lib/logic/apiStatusLogic.test.ts
+++ b/frontend/src/lib/logic/apiStatusLogic.test.ts
@@ -52,6 +52,8 @@ describe('apiStatusLogic', () => {
         })
 
         it('triggers auto-logout on 401 for non-impersonated users', async () => {
+            // The real logout listener submits a <form>, which jsdom doesn't implement
+            const submitSpy = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation()
             useMocks({
                 get: {
                     '/api/users/@me/': () => [401, {}],
@@ -74,6 +76,7 @@ describe('apiStatusLogic', () => {
 
             expect(logoutSpy).toHaveBeenCalled()
             logoutSpy.mockRestore()
+            submitSpy.mockRestore()
         })
     })
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -253,7 +253,8 @@ export const defaultMocks: Mocks = {
         '/api/environments/:team_id/insights/my_last_viewed': EMPTY_PAGINATED_RESPONSE,
         'api/projects/:team_id/early_access_feature': EMPTY_PAGINATED_RESPONSE,
         'api/environments/:team_id/early_access_feature': EMPTY_PAGINATED_RESPONSE,
-        '/api/organizations/:organization_id/proxy_records/': [],
+        // projectNoticeLogic reads `.results` off this response
+        '/api/organizations/:organization_id/proxy_records/': { results: [] },
         '/api/projects/:team_id/dashboard_templates/json_schema/': EMPTY_PAGINATED_RESPONSE,
         '/api/organizations/:organization_id/domains/': EMPTY_PAGINATED_RESPONSE,
         '/api/environments/:team_id/default_evaluation_contexts/': {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -253,8 +253,19 @@ export const defaultMocks: Mocks = {
         '/api/environments/:team_id/insights/my_last_viewed': EMPTY_PAGINATED_RESPONSE,
         'api/projects/:team_id/early_access_feature': EMPTY_PAGINATED_RESPONSE,
         'api/environments/:team_id/early_access_feature': EMPTY_PAGINATED_RESPONSE,
-        // projectNoticeLogic reads `.results` off this response
-        '/api/organizations/:organization_id/proxy_records/': { results: [] },
+        // projectNoticeLogic reads `.results` off this response. A configured proxy so the
+        // date-gated missing-reverse-proxy notice can't render (and shift every scene
+        // story's snapshot) during the first week of each month.
+        '/api/organizations/:organization_id/proxy_records/': {
+            results: [
+                {
+                    id: '018f6b3f-0000-0000-0000-000000000000',
+                    domain: 'ph.example.com',
+                    status: 'valid',
+                    target_cname: 'proxy.posthog.example',
+                },
+            ],
+        },
         '/api/projects/:team_id/dashboard_templates/json_schema/': EMPTY_PAGINATED_RESPONSE,
         '/api/organizations/:organization_id/domains/': EMPTY_PAGINATED_RESPONSE,
         '/api/environments/:team_id/default_evaluation_contexts/': {

--- a/frontend/src/models/primaryEventPropertiesModel.test.ts
+++ b/frontend/src/models/primaryEventPropertiesModel.test.ts
@@ -1,10 +1,14 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
 import { initKeaTests } from '~/test/init'
 
 describe('the primary event properties model', () => {
+    // Safety net for the test that calls silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof primaryEventPropertiesModel.build>
 
     beforeEach(() => {
@@ -104,6 +108,8 @@ describe('the primary event properties model', () => {
     })
 
     it('does not mark events as loaded when the load request fails, so they can be retried', async () => {
+        // Deliberate loader failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         useMocks({
             get: { '/api/projects/:team_id/event_definitions/primary_properties/': () => [500, {}] },
         })

--- a/frontend/src/queries/nodes/HogQLX/__snapshots__/render.test.tsx.snap
+++ b/frontend/src/queries/nodes/HogQLX/__snapshots__/render.test.tsx.snap
@@ -23,13 +23,19 @@ exports[`HogQLX render should render Sparkline 1`] = `
 exports[`HogQLX render should render array 1`] = `
 <React.Fragment>
   <React.Fragment>
-    1
+    <React.Fragment>
+      1
+    </React.Fragment>
   </React.Fragment>
   <React.Fragment>
-    2
+    <React.Fragment>
+      2
+    </React.Fragment>
   </React.Fragment>
   <React.Fragment>
-    3
+    <React.Fragment>
+      3
+    </React.Fragment>
   </React.Fragment>
 </React.Fragment>
 `;

--- a/frontend/src/queries/nodes/HogQLX/render.tsx
+++ b/frontend/src/queries/nodes/HogQLX/render.tsx
@@ -63,7 +63,13 @@ export function renderHogQLX(value: any): JSX.Element {
 
     if (typeof object === 'object') {
         if (Array.isArray(object)) {
-            return <>{object.map((obj) => renderHogQLX(obj))}</>
+            return (
+                <>
+                    {object.map((obj, index) => (
+                        <React.Fragment key={index}>{renderHogQLX(obj)}</React.Fragment>
+                    ))}
+                </>
+            )
         }
 
         if (object === null) {

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -140,7 +140,10 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
             headerExtra:
                 isFunnels && (querySource as FunnelsQuery)?.funnelsFilter?.funnelVizType !== FunnelVizTypeEnum.Flow ? (
                     <Tooltip docLink="https://posthog.com/docs/product-analytics/funnels#graph-type">
-                        <FunnelVizType insightProps={insightProps} />
+                        {/* span so the tooltip has a ref-able anchor — FunnelVizType is a plain function component */}
+                        <span className="inline-flex">
+                            <FunnelVizType insightProps={insightProps} />
+                        </span>
                     </Tooltip>
                 ) : null,
             editorFilters: visibleFilters([

--- a/frontend/src/queries/utils.test.ts
+++ b/frontend/src/queries/utils.test.ts
@@ -21,8 +21,12 @@ import {
 window.POSTHOG_APP_CONTEXT = { current_team: { id: MOCK_TEAM_ID } } as unknown as AppContext
 
 describe('hogql tag', () => {
-    initKeaTests()
-    teamLogic.mount()
+    // In beforeEach (not describe scope): mounting at collection time fires the preflight
+    // load before the MSW harness's beforeAll has installed its fetch stub
+    beforeEach(() => {
+        initKeaTests()
+        teamLogic.mount()
+    })
 
     it('properly returns query with no substitutions', () => {
         expect(hogql`SELECT * FROM events`).toEqual('SELECT * FROM events')

--- a/frontend/src/scenes/cohorts/activityDescriptions.test.tsx
+++ b/frontend/src/scenes/cohorts/activityDescriptions.test.tsx
@@ -54,11 +54,18 @@ describe('cohortActivityDescriber', () => {
     })
 
     it('returns null for non-cohort scope', () => {
-        const result = cohortActivityDescriber({
-            ...makeLogItem({ detail: { name: 'x', merge: null, trigger: null, changes: [] } }),
-            scope: ActivityScope.FEATURE_FLAG,
-        })
-        expect(result.description).toBeNull()
+        // the describer deliberately reports the scope mismatch via console.error
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        try {
+            const result = cohortActivityDescriber({
+                ...makeLogItem({ detail: { name: 'x', merge: null, trigger: null, changes: [] } }),
+                scope: ActivityScope.FEATURE_FLAG,
+            })
+            expect(result.description).toBeNull()
+            expect(consoleErrorSpy).toHaveBeenCalledWith('cohort describer received a non-cohort activity')
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 
     it.each([

--- a/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
@@ -2,6 +2,7 @@ import { api } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { mockCohort } from '~/test/mocks'
@@ -164,6 +165,9 @@ describe('cohortCalculationHistorySceneLogic', () => {
     })
 
     describe('error handling', () => {
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         beforeEach(async () => {
             await initLogic({ cohortId: 123 })
         })

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -717,7 +717,13 @@ describe('cohortEditLogic', () => {
                 is_static: true,
             }
             const createSpy = jest.spyOn(api.cohorts, 'create').mockResolvedValue(createdCohort)
-            const setTimeoutSpy = jest.spyOn(window, 'setTimeout').mockImplementation(() => 0 as never)
+            // Suppress only the 1s calculation poll — kea breakpoints schedule shorter
+            // timers through setTimeout too, and those must still fire
+            const realSetTimeout = window.setTimeout.bind(window)
+            const setTimeoutSpy = jest
+                .spyOn(window, 'setTimeout')
+                .mockImplementation(((handler: TimerHandler, timeout?: number, ...args: any[]) =>
+                    timeout === 1000 ? (0 as any) : realSetTimeout(handler, timeout, ...args)) as any)
 
             await expectLogic(logic, async () => {
                 logic.actions.setCohort({
@@ -757,6 +763,8 @@ describe('cohortEditLogic', () => {
             expect(createPayload.get('filters')).toContain('"values"')
             expect(createPayload.get('filters')).not.toContain('"properties":{}')
 
+            // Let the post-submit refreshPersonsData debounce finish before the test ends
+            await expectLogic(logic).toFinishAllListeners()
             setTimeoutSpy.mockRestore()
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1739,13 +1739,16 @@ describe('dashboardLogic', () => {
             expect(container.textContent).toBe('Text card has been removed from the dashboard')
         })
 
-        it('removes the tile from state optimistically before the API call resolves', () => {
+        it('removes the tile from state optimistically before the API call resolves', async () => {
             expect(logic.values.textTiles).toHaveLength(1)
 
             // Dispatch without awaiting listeners — the reducer drops the tile synchronously.
             logic.actions.removeTile(TEXT_TILE)
 
             expect(logic.values.textTiles).toEqual([])
+
+            // Let the in-flight listener settle before teardown unmounts the logic
+            await expectLogic(logic).toFinishAllListeners()
         })
 
         it('restores the tile and suppresses the undo toast when the API call fails', async () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1468,6 +1468,7 @@ describe('dashboardLogic', () => {
 
             // The logic re-fetches the dashboard on mount; without this the unhandled-request
             // floor returns a shape without tiles
+            // oxlint-disable-next-line react-hooks/rules-of-hooks
             useMocks({
                 get: {
                     '/api/environments/:team_id/dashboards/12/': () => [200, dashboardWithVariableOverride],

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -4,7 +4,7 @@ import { MOCK_TEAM_ID } from 'lib/api.mock'
 import { router } from 'kea-router'
 import { expectLogic, truth } from 'kea-test-utils'
 
-import { lemonToast } from '@posthog/lemon-ui'
+import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 import * as dashboardWidgetUtils from '@posthog/products-dashboards/frontend/utils'
 import { DASHBOARD_WIDGET_FETCH_ERROR_MESSAGE } from '@posthog/products-dashboards/frontend/widgets/constants'
 
@@ -759,6 +759,18 @@ describe('dashboardLogic', () => {
         })
 
         describe('cancelEditMode action', () => {
+            // The discard prompt renders a real dialog into its own React root, whose async
+            // updates land outside act(); these tests only assert dispatched actions
+            let dialogOpenSpy: jest.SpyInstance
+
+            beforeEach(() => {
+                dialogOpenSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+            })
+
+            afterEach(() => {
+                dialogOpenSpy.mockRestore()
+            })
+
             const moveFirstTile = (): void => {
                 const firstTile = logic.values.dashboard!.tiles[0]
                 const currentLayouts = logic.values.layouts
@@ -1453,6 +1465,14 @@ describe('dashboardLogic', () => {
                       }
                     : undefined,
             }
+
+            // The logic re-fetches the dashboard on mount; without this the unhandled-request
+            // floor returns a shape without tiles
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/dashboards/12/': () => [200, dashboardWithVariableOverride],
+                },
+            })
 
             variableDataLogic.mount()
             logic = dashboardLogic({ id: 12, dashboard: dashboardWithVariableOverride })

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
@@ -8,6 +8,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
 import { urls } from 'scenes/urls'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 import type { DashboardTemplateType } from '~/types'
 
@@ -19,6 +20,9 @@ jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
 }))
 
 describe('dashboardTemplateCopyLogic', () => {
+    // Safety net for tests that call silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof dashboardTemplateCopyLogic.build> | undefined
 
     beforeEach(() => {
@@ -79,6 +83,8 @@ describe('dashboardTemplateCopyLogic', () => {
     })
 
     it('marks load failed when fetching the source template errors', async () => {
+        // Deliberate failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         const getMock = api.dashboardTemplates.get as jest.Mock
         getMock.mockRejectedValueOnce(new Error('not found'))
 
@@ -143,6 +149,8 @@ describe('dashboardTemplateCopyLogic', () => {
     })
 
     it('submitCopy shows an error toast when the API fails', async () => {
+        // Deliberate failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
         copyMock.mockRejectedValueOnce(new ApiError(undefined, 500, undefined, { detail: 'network' }))
 
@@ -159,6 +167,8 @@ describe('dashboardTemplateCopyLogic', () => {
     })
 
     it('submitCopy without destination shows an error toast', async () => {
+        // Deliberate failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
 
         const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
@@ -174,6 +184,8 @@ describe('dashboardTemplateCopyLogic', () => {
     })
 
     it('submitCopy surfaces ApiError detail in the toast', async () => {
+        // Deliberate failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
         copyMock.mockRejectedValueOnce(
             new ApiError(undefined, 400, undefined, { detail: 'Org template limit reached' })

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.test.ts
@@ -242,6 +242,8 @@ describe('batchExportBackfillsLogic', () => {
         })
 
         it('ignores polling errors and continues', async () => {
+            // The poller reports the deliberate failure via console.warn by design
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
             jest.spyOn(api.batchExports, 'getBackfill')
                 .mockRejectedValueOnce(new Error('Network error'))
                 .mockResolvedValueOnce(makeBackfill({ total_records_count: 3000 }))
@@ -254,6 +256,8 @@ describe('batchExportBackfillsLogic', () => {
             await jest.advanceTimersByTimeAsync(POLL_ADVANCE_MS)
 
             expect(lemonToast.info).toHaveBeenCalledWith('Estimated ~3,000 rows to export', expect.anything())
+            expect(warnSpy).toHaveBeenCalledWith('Failed to poll for backfill estimate', expect.any(Error))
+            warnSpy.mockRestore()
         })
 
         it('cancel button in toast calls cancel API', async () => {

--- a/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.test.ts
@@ -4,8 +4,8 @@ import { expectLogic, partial } from 'kea-test-utils'
 
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
-import { useMocks } from '~/mocks/jest'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import type { Experiment } from '~/types'
 

--- a/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.test.ts
@@ -5,6 +5,7 @@ import { expectLogic, partial } from 'kea-test-utils'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
 import { useMocks } from '~/mocks/jest'
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 import type { Experiment } from '~/types'
 
@@ -71,7 +72,7 @@ describe('variantsPanelLogic', () => {
         },
     ]
 
-    beforeEach(() => {
+    beforeEach(async () => {
         useMocks({
             get: {
                 [`/api/projects/${MOCK_TEAM_ID}/feature_flags/`]: ({ request }) => {
@@ -107,6 +108,11 @@ describe('variantsPanelLogic', () => {
 
         experimentsLogic.mount()
         experimentsLogic.actions.loadExperiments()
+
+        // Let the mount-time loads settle: afterEach unmounts these logics, and an
+        // in-flight loader settling after unmount errors with "[KEA] Can not find path"
+        await expectLogic(featureFlagsLogic).toFinishAllListeners()
+        await expectLogic(experimentsLogic).toFinishAllListeners()
 
         logic = variantsPanelLogic({ experiment: mockExperiment, disabled: false })
         logic.mount()
@@ -285,6 +291,10 @@ describe('variantsPanelLogic', () => {
     })
 
     describe('error handling', () => {
+        // Deliberate loader failure — kea-loaders would log it
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it('handles validation errors gracefully', async () => {
             useMocks({
                 get: {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2530,7 +2530,8 @@ export const experimentLogic = kea<experimentLogicType>([
                     const { experiment, usesNewQueryRunner } = values
 
                     if (!usesNewQueryRunner) {
-                        return
+                        // A bare `return` would make kea error ("Reducer returned undefined")
+                        return values.exposures
                     }
 
                     const query = setLatestVersionsOnQuery({

--- a/frontend/src/scenes/exports/activityDescriptions.test.tsx
+++ b/frontend/src/scenes/exports/activityDescriptions.test.tsx
@@ -70,10 +70,17 @@ describe('exported asset activity descriptions', () => {
     })
 
     it('returns no description for a non-export scope', () => {
-        const { description } = exportedAssetActivityDescriber(
-            makeLogItem({ scope: ActivityScope.INSIGHT, detail: makeDetail('x') })
-        )
-        expect(description).toBeNull()
+        // the describer deliberately reports the scope mismatch via console.error
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        try {
+            const { description } = exportedAssetActivityDescriber(
+                makeLogItem({ scope: ActivityScope.INSIGHT, detail: makeDetail('x') })
+            )
+            expect(description).toBeNull()
+            expect(consoleErrorSpy).toHaveBeenCalledWith('exported asset describer received a non-export activity')
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 
     it('delegates unknown activities to the default describer', () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.cohortOperator.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.cohortOperator.test.tsx
@@ -56,6 +56,13 @@ describe('feature flag release conditions cohort operator', () => {
                 '/api/projects/:team/event_definitions': mockGetEventDefinitions,
                 '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
                 '/api/projects/:team/cohorts/': { results: [cohortPowerUsers], next: null, count: 1 },
+                // featureFlagLogic mounts alongside and loads the flag; the unhandled-request
+                // floor has no `filters`, which crashes payload conversion
+                '/api/projects/:team/feature_flags/1234/': {
+                    id: 1234,
+                    key: 'test-flag',
+                    filters: { groups: [], multivariate: null, payloads: {} },
+                },
                 '/api/projects/:team/actions': { results: [] },
             },
             post: {

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -551,13 +551,12 @@ export function FeatureFlagReleaseConditions({
             description={
                 !readOnly &&
                 !excludeTitle && (
-                    <>
-                        <div className="text-secondary mb-2">
-                            Specify users for flag release. Condition sets are evaluated top to bottom - the first
-                            matching set is used. A condition matches when all property filters pass AND the target
-                            falls within the rollout percentage.
-                        </div>
-                    </>
+                    // span, not div: SceneSection renders the description inside a <p>
+                    <span className="block text-secondary mb-2">
+                        Specify users for flag release. Condition sets are evaluated top to bottom - the first matching
+                        set is used. A condition matches when all property filters pass AND the target falls within the
+                        rollout percentage.
+                    </span>
                 )
             }
         >

--- a/frontend/src/scenes/feature-flags/defaultEvaluationContextsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/defaultEvaluationContextsLogic.test.ts
@@ -2,12 +2,16 @@ import { expectLogic } from 'kea-test-utils'
 
 import { teamLogic } from 'scenes/teamLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { DefaultEvaluationContextsResponse, defaultEvaluationContextsLogic } from './defaultEvaluationContextsLogic'
 
 describe('defaultEvaluationContextsLogic', () => {
+    // Safety net for tests that call silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof defaultEvaluationContextsLogic.build>
     let mockResponse: DefaultEvaluationContextsResponse
 
@@ -139,6 +143,8 @@ describe('defaultEvaluationContextsLogic', () => {
         })
 
         it('should leave availableContexts unchanged when hideContext API call fails', async () => {
+            // Deliberate loader failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             mockResponse.available_contexts = ['production', 'staging']
 
             useMocks({
@@ -161,6 +167,8 @@ describe('defaultEvaluationContextsLogic', () => {
         })
 
         it('should leave hiddenContexts unchanged when unhideContext API call fails', async () => {
+            // Deliberate loader failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             mockResponse.available_contexts = ['staging']
             mockResponse.hidden_contexts = ['production']
 
@@ -229,6 +237,9 @@ describe('defaultEvaluationContextsLogic', () => {
             }).toMatchValues({
                 newContextInput: '',
             })
+
+            // Let addContext settle before afterEach unmounts the logic
+            await expectLogic(logic).toFinishAllListeners()
         })
     })
 

--- a/frontend/src/scenes/feature-flags/featureFlagConfirmationSettingsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConfirmationSettingsLogic.test.ts
@@ -4,8 +4,8 @@ import { expectLogic } from 'kea-test-utils'
 
 import { teamLogic } from 'scenes/teamLogic'
 
-import { useMocks } from '~/mocks/jest'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { featureFlagConfirmationSettingsLogic } from './featureFlagConfirmationSettingsLogic'

--- a/frontend/src/scenes/feature-flags/featureFlagConfirmationSettingsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagConfirmationSettingsLogic.test.ts
@@ -5,11 +5,15 @@ import { expectLogic } from 'kea-test-utils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { useMocks } from '~/mocks/jest'
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 
 import { featureFlagConfirmationSettingsLogic } from './featureFlagConfirmationSettingsLogic'
 
 describe('featureFlagConfirmationSettingsLogic', () => {
+    // Safety net for the test that calls silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof featureFlagConfirmationSettingsLogic.build>
     let lastCapturedPayload: any = null
 
@@ -91,6 +95,8 @@ describe('featureFlagConfirmationSettingsLogic', () => {
         })
 
         it('handles form submission errors correctly', async () => {
+            // Deliberate failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             // Override mock to return an error response
             useMocks({
                 patch: {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -816,9 +816,6 @@ describe('featureFlagLogic', () => {
                 experiment_set_metadata: null,
             }
 
-            const noExperimentLogic = featureFlagLogic({ id: 3 })
-            noExperimentLogic.mount()
-
             useMocks({
                 get: {
                     [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flagWithoutExperiment.id}/`]: () => [
@@ -829,6 +826,9 @@ describe('featureFlagLogic', () => {
                         () => [200, MOCK_FEATURE_FLAG_STATUS],
                 },
             })
+
+            const noExperimentLogic = featureFlagLogic({ id: 3 })
+            noExperimentLogic.mount()
 
             await expectLogic(noExperimentLogic, () => {
                 noExperimentLogic.actions.loadFeatureFlag()

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -1379,65 +1379,86 @@ describe('the feature flag release conditions logic', () => {
             }
         )
 
-        it('falls back to raw ids without caching when the persons request fails', async () => {
-            logic?.unmount()
+        describe('when the persons request fails', () => {
+            // loadDistinctIdNames reports the failed request via console.error by design
+            let consoleErrorSpy: jest.SpyInstance
 
-            useMocks({
-                post: {
-                    '/api/projects/:team/feature_flags/user_blast_radius': () => [200, { affected: 10, total: 100 }],
-                    '/api/environments/:team/persons/batch_by_distinct_ids/': () => [500, {}],
-                },
+            beforeEach(() => {
+                consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
             })
 
-            logic = featureFlagReleaseConditionsLogic({
-                id: 'distinct-id-error',
-                filters: distinctIdFilters(['distinct-1', 'distinct-2']),
+            afterEach(() => {
+                consoleErrorSpy.mockRestore()
             })
 
-            await expectLogic(logic, () => {
-                logic.mount()
-            })
-                .toDispatchActions(['loadDistinctIdNames'])
-                .toFinishAllListeners()
-                // Failed ids stay uncached so a later setFilters/updateConditionSet retries them.
-                .toMatchValues({ distinctIdNameCache: {} })
+            it('falls back to raw ids without caching', async () => {
+                logic?.unmount()
 
-            expect(logic.values.getDistinctIdName('distinct-1')).toBe('distinct-1')
-        })
-
-        it('preserves resolved names from earlier chunks when a later chunk fails', async () => {
-            logic?.unmount()
-
-            // More than one batch worth of ids so the request is chunked.
-            const ids = Array.from({ length: 250 }, (_, i) => `d-${i}`)
-            const firstChunkResults = Object.fromEntries(ids.slice(0, 200).map((id) => [id, { name: `name-${id}` }]))
-
-            let callCount = 0
-            useMocks({
-                post: {
-                    '/api/projects/:team/feature_flags/user_blast_radius': () => [200, { affected: 10, total: 100 }],
-                    '/api/environments/:team/persons/batch_by_distinct_ids/': () => {
-                        callCount += 1
-                        // First chunk resolves, second chunk fails.
-                        return callCount === 1 ? [200, { results: firstChunkResults }] : [500, {}]
+                useMocks({
+                    post: {
+                        '/api/projects/:team/feature_flags/user_blast_radius': () => [
+                            200,
+                            { affected: 10, total: 100 },
+                        ],
+                        '/api/environments/:team/persons/batch_by_distinct_ids/': () => [500, {}],
                     },
-                },
+                })
+
+                logic = featureFlagReleaseConditionsLogic({
+                    id: 'distinct-id-error',
+                    filters: distinctIdFilters(['distinct-1', 'distinct-2']),
+                })
+
+                await expectLogic(logic, () => {
+                    logic.mount()
+                })
+                    .toDispatchActions(['loadDistinctIdNames'])
+                    .toFinishAllListeners()
+                    // Failed ids stay uncached so a later setFilters/updateConditionSet retries them.
+                    .toMatchValues({ distinctIdNameCache: {} })
+
+                expect(logic.values.getDistinctIdName('distinct-1')).toBe('distinct-1')
             })
 
-            logic = featureFlagReleaseConditionsLogic({
-                id: 'distinct-id-chunked',
-                filters: distinctIdFilters(ids),
-            })
+            it('preserves resolved names from earlier chunks when a later chunk fails', async () => {
+                logic?.unmount()
 
-            await expectLogic(logic, () => {
-                logic.mount()
-            })
-                .toDispatchActions(['loadDistinctIdNames', 'setDistinctIdNames'])
-                .toFinishAllListeners()
+                // More than one batch worth of ids so the request is chunked.
+                const ids = Array.from({ length: 250 }, (_, i) => `d-${i}`)
+                const firstChunkResults = Object.fromEntries(
+                    ids.slice(0, 200).map((id) => [id, { name: `name-${id}` }])
+                )
 
-            // First-chunk names survive; the failed second chunk stays uncached and renders raw.
-            expect(logic.values.getDistinctIdName('d-0')).toBe('d-0 (name-d-0)')
-            expect(logic.values.getDistinctIdName('d-200')).toBe('d-200')
+                let callCount = 0
+                useMocks({
+                    post: {
+                        '/api/projects/:team/feature_flags/user_blast_radius': () => [
+                            200,
+                            { affected: 10, total: 100 },
+                        ],
+                        '/api/environments/:team/persons/batch_by_distinct_ids/': () => {
+                            callCount += 1
+                            // First chunk resolves, second chunk fails.
+                            return callCount === 1 ? [200, { results: firstChunkResults }] : [500, {}]
+                        },
+                    },
+                })
+
+                logic = featureFlagReleaseConditionsLogic({
+                    id: 'distinct-id-chunked',
+                    filters: distinctIdFilters(ids),
+                })
+
+                await expectLogic(logic, () => {
+                    logic.mount()
+                })
+                    .toDispatchActions(['loadDistinctIdNames', 'setDistinctIdNames'])
+                    .toFinishAllListeners()
+
+                // First-chunk names survive; the failed second chunk stays uncached and renders raw.
+                expect(logic.values.getDistinctIdName('d-0')).toBe('d-0 (name-d-0)')
+                expect(logic.values.getDistinctIdName('d-200')).toBe('d-200')
+            })
         })
 
         it('resolves names when a distinct_id filter is added to a mounted flag', async () => {

--- a/frontend/src/scenes/feature-flags/featureFlagTestingLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagTestingLogic.test.ts
@@ -1,6 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 
 import type { FeatureFlagTestEvaluationResponseApi } from 'products/feature_flags/frontend/generated/api.schemas'
@@ -445,6 +446,10 @@ describe('featureFlagTestingLogic', () => {
     })
 
     describe('groups validation through testFlagEvaluation', () => {
+        // The invalid-groups cases fail the evaluation loader on purpose; kea-loaders would log each
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it.each([
             { description: 'valid object succeeds', groups: '{"team": "backend"}', expectedError: null },
             { description: 'empty string succeeds', groups: '', expectedError: null },

--- a/frontend/src/scenes/feature-flags/featureFlagTestingLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagTestingLogic.test.ts
@@ -1,7 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
-import { useMocks } from '~/mocks/jest'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import type { FeatureFlagTestEvaluationResponseApi } from 'products/feature_flags/frontend/generated/api.schemas'

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -15,8 +15,8 @@ import {
 } from 'scenes/feature-flags/featureFlagsLogic'
 import { urls } from 'scenes/urls'
 
-import { useMocks } from '~/mocks/jest'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { FeatureFlagType } from '~/types'
 

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -16,6 +16,7 @@ import {
 import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 import { FeatureFlagType } from '~/types'
 
@@ -296,6 +297,10 @@ describe('the feature flags logic', () => {
 
 describe('updateFeatureFlag 409 handling', () => {
     let logic: ReturnType<typeof featureFlagsLogic.build>
+
+    // Every test here rejects updateFeatureFlag on purpose; kea-loaders would log each failure
+    beforeEach(silenceKeaLoadersErrors)
+    afterEach(resumeKeaLoadersErrors)
 
     beforeEach(() => {
         useMocks({

--- a/frontend/src/scenes/hog-functions/backfills/hogFunctionBackfillsLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/backfills/hogFunctionBackfillsLogic.test.ts
@@ -7,16 +7,25 @@ import { HogFunctionType } from '~/types'
 
 import { hogFunctionBackfillsLogic } from './hogFunctionBackfillsLogic'
 
-jest.mock('lib/api', () => ({
-    ...jest.requireActual('lib/api'),
-    hogFunctions: {
-        get: jest.fn(),
-        getTemplate: jest.fn(),
-        update: jest.fn(),
-        create: jest.fn(),
-        enableBackfills: jest.fn(),
-    },
-}))
+// Mock only the hogFunctions namespace on the default api export — replacing the module
+// object wholesale would leave `api.query` & co undefined for connected logics
+jest.mock('lib/api', () => {
+    const actual = jest.requireActual('lib/api')
+    return {
+        ...actual,
+        __esModule: true,
+        default: {
+            ...actual.default,
+            hogFunctions: {
+                get: jest.fn(),
+                getTemplate: jest.fn(),
+                update: jest.fn(),
+                create: jest.fn(),
+                enableBackfills: jest.fn(),
+            },
+        },
+    }
+})
 
 jest.mock('lib/utils/product-intents', () => ({
     addProductIntent: jest.fn().mockResolvedValue(null),

--- a/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
@@ -68,6 +68,16 @@ describe('InsightPageHeader', () => {
         localStorage.clear()
         sessionStorage.clear()
         useMocks({
+            get: {
+                // insightLogic mounts alongside and fetches its insight by short_id; without
+                // a match it errors with "Insight ... not found"
+                '/api/environments/:team_id/insights/': ({ request }: { request: Request }) => [
+                    200,
+                    {
+                        results: [{ id: 1, short_id: new URL(request.url).searchParams.get('short_id'), query: null }],
+                    },
+                ],
+            },
             post: {
                 '/api/environments/:team_id/query/': () => [200, { results: [] }],
             },

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
@@ -114,6 +114,14 @@ describe('ActionFilterRow', () => {
         // Supplement with endpoints specific to ActionFilterRow
         useMocks({
             get: {
+                // insightLogic mounts alongside and fetches its insight by short_id; without
+                // a match it errors with "Insight ... not found"
+                '/api/environments/:team_id/insights/': ({ request }: { request: Request }) => [
+                    200,
+                    {
+                        results: [{ id: 1, short_id: new URL(request.url).searchParams.get('short_id'), query: null }],
+                    },
+                ],
                 '/api/projects/:team/actions/': { results: filtersJson.actions },
                 '/api/environments/:team/groups_types/': MOCK_GROUP_TYPES,
                 '/api/projects/:team/warehouse_tables/': { results: [] },

--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -42,6 +42,14 @@ describe('insightDataLogic', () => {
         useMocks({
             get: {
                 '/api/environments/:team_id/insights/trend': [],
+                // insightLogic mounts alongside and fetches its insight by short_id; without
+                // a match it errors with "Insight ... not found"
+                '/api/environments/:team_id/insights/': ({ request }: { request: Request }) => [
+                    200,
+                    {
+                        results: [{ id: 1, short_id: new URL(request.url).searchParams.get('short_id'), query: null }],
+                    },
+                ],
             },
         })
         initKeaTests()

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
@@ -5,6 +5,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
+import { useMocks } from '~/mocks/jest'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { DataNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -26,6 +27,20 @@ describe('insightsTableDataLogic', () => {
         const props: InsightLogicProps = { dashboardItemId: '123' as any }
 
         beforeEach(() => {
+            useMocks({
+                get: {
+                    // insightLogic mounts alongside and fetches its insight by short_id; without
+                    // a match it errors with "Insight ... not found"
+                    '/api/environments/:team_id/insights/': ({ request }: { request: Request }) => [
+                        200,
+                        {
+                            results: [
+                                { id: 1, short_id: new URL(request.url).searchParams.get('short_id'), query: null },
+                            ],
+                        },
+                    ],
+                },
+            })
             initKeaTests()
             logic = insightsTableDataLogic(props)
             logic.mount()

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
@@ -185,6 +185,7 @@ describe('notebookNodePersonFeedLogic', () => {
         })
 
         it('handles sessions loading failure', async () => {
+            silenceKeaLoadersErrors()
             useMocks({
                 post: {
                     [`/api/environments/${MOCK_TEAM_ID}/query/:kind/`]: () => [
@@ -203,6 +204,7 @@ describe('notebookNodePersonFeedLogic', () => {
                     sessions: null,
                     sessionsLoading: false,
                 })
+            resumeKeaLoadersErrors()
         })
     })
 
@@ -408,6 +410,9 @@ describe('notebookNodePersonFeedLogic', () => {
     })
 
     describe('error handling', () => {
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it('tracks failed summarizations in summaryErrors', async () => {
             await mountLogic()
             logic.actions.summarizeSession('session-4')

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookEditorState.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookEditorState.test.ts
@@ -67,7 +67,10 @@ describe('notebookLogic markdown editor state', () => {
         await expectLogic(logic).toDispatchActions(['loadNotebookSuccess']).toFinishAllListeners()
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+        // Remounting notebookLogic kicks off membersLogic loaders — let them settle before the
+        // kea context is torn down, otherwise they resume against reset state and crash
+        await expectLogic(logic).toFinishAllListeners()
         logic?.unmount()
         jest.restoreAllMocks()
     })

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.test.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.test.ts
@@ -1,5 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -31,6 +33,9 @@ describe('mergeSplitPersonLogic', () => {
         })
         initKeaTests()
 
+        // execute() reports through eventUsageLogic, which must be mounted (in the app it always is)
+        eventUsageLogic.mount()
+
         personsLogicInstance = personsLogic({ syncWithUrl: true, urlId: URL_DISTINCT_ID })
         personsLogicInstance.mount()
 
@@ -38,9 +43,13 @@ describe('mergeSplitPersonLogic', () => {
         logic.mount()
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+        // Drain in-flight execute() calls before unmounting so their success path
+        // doesn't dispatch into an unmounted logic
+        await expectLogic(logic).toFinishAllListeners()
         logic.unmount()
         personsLogicInstance.unmount()
+        eventUsageLogic.unmount()
     })
 
     describe('cancel', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionEventsDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionEventsDataLogic.ts
@@ -153,6 +153,11 @@ AND properties.$lib != 'web'`
                     }
 
                     existingEvents = existingEvents.filter((e) => !e.fullyLoaded)
+                    if (!existingEvents.length) {
+                        // nothing left to load (e.g. the events list was replaced while this action
+                        // was queued) — bail out before reducing over an empty timestamps list
+                        return cachedSessionEventsData
+                    }
                     const timestamps = existingEvents.map((ee) => dayjs(ee.timestamp).utc().valueOf())
                     const eventNames = Array.from(new Set(existingEvents.map((ee) => ee.event)))
                     const eventIds = existingEvents.map((ee) => ee.id)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -329,6 +329,10 @@ describe('sessionRecordingPlayerLogic', () => {
         })
 
         it('load snapshot errors and triggers error state', async () => {
+            silenceKeaLoadersErrors()
+            // the player deliberately reports the missing snapshots via console.error
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+
             logic.unmount()
             overrideSessionRecordingMocks({
                 getMocks: {
@@ -363,6 +367,10 @@ describe('sessionRecordingPlayerLogic', () => {
                 },
                 playerError: 'loadSnapshotSourcesFailure',
             })
+            expect(consoleErrorSpy).toHaveBeenCalledWith('PostHog Recording Playback Error: No snapshots loaded')
+
+            consoleErrorSpy.mockRestore()
+            resumeKeaLoadersErrors()
         })
 
         it('ensures the cache initialization is reset after the player is unmounted', async () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.ts
@@ -89,7 +89,11 @@ export const sessionRecordingsListPropertiesLogic = kea<sessionRecordingsListPro
                     await breakpoint(100)
 
                     const startTime = performance.now()
-                    const sessionIds = sessions.map((x) => x.id)
+                    // An id-less entry would interpolate `undefined` into the query and throw
+                    const sessionIds = sessions.map((x) => x?.id).filter(Boolean)
+                    if (!sessionIds.length) {
+                        return values.recordingProperties
+                    }
 
                     const chronological = (a: string, b: string): number =>
                         new Date(a).getTime() - new Date(b).getTime()

--- a/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.test.ts
+++ b/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.test.ts
@@ -12,8 +12,8 @@ describe('projectSecretAPIKeysLogic', () => {
     beforeEach(() => {
         useMocks({
             get: {
-                '/api/projects/:team_id/project_secret_api_keys': [],
-                '/api/projects/:team_id/project_secret_api_keys/': [],
+                // api.projectSecretApiKeys.list() reads `.results` off a paginated response
+                '/api/projects/:team_id/project_secret_api_keys/': { results: [] },
             },
         })
 

--- a/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
@@ -3,7 +3,7 @@ import { PropertyMatchType } from 'posthog-js'
 import { useMemo } from 'react'
 
 import { IconX } from '@posthog/icons'
-import { LemonButton, LemonCard, LemonCheckbox, LemonCollapse } from '@posthog/lemon-ui'
+import { LemonCard, LemonCheckbox, LemonCollapse } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -171,8 +171,10 @@ function SurveyEventSelector({
                                     panels={[
                                         {
                                             key: panelKey,
-                                            header: (
-                                                <div className="flex items-center gap-2 flex-1 justify-between">
+                                            // sideAction keeps the remove button a sibling of the header <button> - a
+                                            // button can't nest inside a button
+                                            header: {
+                                                children: (
                                                     <div className="flex items-center gap-2 min-w-0">
                                                         <span className="font-semibold text-sm truncate">
                                                             {event.name}
@@ -183,19 +185,13 @@ function SurveyEventSelector({
                                                                 : 'No filters'}
                                                         </span>
                                                     </div>
-                                                    <LemonButton
-                                                        size="xsmall"
-                                                        icon={<IconX />}
-                                                        onClick={(e) => {
-                                                            e.stopPropagation()
-                                                            removeEventAtIndex(index)
-                                                        }}
-                                                        type="tertiary"
-                                                        status="alt"
-                                                        tooltip="Remove event"
-                                                    />
-                                                </div>
-                                            ),
+                                                ),
+                                                sideAction: {
+                                                    icon: <IconX />,
+                                                    onClick: () => removeEventAtIndex(index),
+                                                    tooltip: 'Remove event',
+                                                },
+                                            },
                                             content: (
                                                 <div className="space-y-2">
                                                     <PropertyFilters

--- a/frontend/src/scenes/surveys/surveysLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveysLogic.test.ts
@@ -63,6 +63,8 @@ describe('surveysLogic', () => {
             })
                 .delay(400)
                 .toDispatchActions(['loadSearchResults'])
+                // let the search request settle so its success action doesn't land after unmount
+                .toFinishAllListeners()
         })
 
         it('searchedSurveys reflects backend results once loaded', async () => {

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.test.ts
@@ -283,6 +283,8 @@ describe('heatmapToolbarMenuLogic', () => {
     describe('clickmap loading', () => {
         let logic: ReturnType<typeof heatmapToolbarMenuLogic.build>
 
+        afterEach(resumeKeaLoadersErrors)
+
         beforeEach(() => {
             global.IntersectionObserver = class {
                 observe(): void {}
@@ -350,6 +352,8 @@ describe('heatmapToolbarMenuLogic', () => {
         })
 
         it('keeps heatmapEnabled true after a stats fetch failure so the menu stays open', async () => {
+            // Deliberate loader failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             jest.spyOn(toolbarApi.elementStats, 'list').mockRejectedValue(new Error('network error'))
             await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions([
                 'getElementStats',
@@ -390,6 +394,8 @@ describe('heatmapToolbarMenuLogic', () => {
         })
 
         it('retries the initial load via load more after a stats fetch failure', async () => {
+            // Deliberate loader failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             jest.spyOn(toolbarApi.elementStats, 'list').mockRejectedValueOnce(new Error('network error'))
             await expectLogic(logic, () => logic.actions.enableHeatmap()).toDispatchActions(['getElementStatsFailure'])
             await expectLogic(logic, () => logic.actions.loadMoreElementStats()).toDispatchActions([

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
@@ -12,7 +12,6 @@ jest.mock('~/toolbar/toolbarLogger', () => ({
     toolbarLogger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
-
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
@@ -7,6 +7,12 @@ jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: { success: jest.fn(), error: jest.fn() },
 }))
 
+// The failure-path tests intentionally exercise toolbarLogger, which logs to the console by design
+jest.mock('~/toolbar/toolbarLogger', () => ({
+    toolbarLogger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'

--- a/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
@@ -30,7 +30,14 @@ const featureFlagsWithExtraInfo = [
 
 describe('toolbar featureFlagsLogic', () => {
     let logic: ReturnType<typeof flagsToolbarLogic.build>
+    let consoleErrorSpy: jest.SpyInstance
+    let consoleWarnSpy: jest.SpyInstance
+
     beforeEach(() => {
+        // The token-expiry test exercises auth failure paths that toolbarLogger
+        // reports to the console by design
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
         global.fetch = jest.fn(() =>
             Promise.resolve({
                 ok: true,
@@ -53,6 +60,11 @@ describe('toolbar featureFlagsLogic', () => {
         logic = flagsToolbarLogic()
         logic.mount()
         logic.actions.getUserFlags()
+    })
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore()
+        consoleWarnSpy.mockRestore()
     })
 
     it('has expected defaults', () => {

--- a/frontend/src/toolbar/index.test.ts
+++ b/frontend/src/toolbar/index.test.ts
@@ -203,6 +203,9 @@ describe('Toolbar flag loading', () => {
     })
 
     it('should still load toolbar even if flag fetching fails', async () => {
+        // The failed flags fetch is reported through toolbarLogger's console.warn by design
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
         await import('./index')
 
         const mockPostHog = {
@@ -225,5 +228,7 @@ describe('Toolbar flag loading', () => {
         // Verify toolbar container was created
         const container = document.querySelector('div')
         expect(container).toBeTruthy()
+
+        consoleWarnSpy.mockRestore()
     })
 })

--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -46,8 +46,18 @@ describe('toolbar toolbarConfigLogic', () => {
     afterAll(resumeKeaLoadersErrors)
 
     let mockOpen: jest.SpyInstance
+    let consoleSpies: jest.SpyInstance[]
 
     beforeEach(() => {
+        // The auth/config failure-path tests intentionally exercise toolbarLogger, which
+        // logs to the console by design. Module-mocking it doesn't work here: the MSW
+        // setup chain preloads toolbarConfigLogic (via heatmapDataLogic) before any
+        // test-file jest.mock registration.
+        consoleSpies = [
+            jest.spyOn(console, 'error').mockImplementation(),
+            jest.spyOn(console, 'warn').mockImplementation(),
+            jest.spyOn(console, 'info').mockImplementation(),
+        ]
         initKeaTests()
         localStorage.clear()
         sessionStorage.clear()
@@ -59,6 +69,9 @@ describe('toolbar toolbarConfigLogic', () => {
 
     afterEach(() => {
         mockOpen.mockRestore()
+        consoleSpies.forEach((spy) => spy.mockRestore())
+        // Safety net for tests that call silenceKeaLoadersErrors() inline
+        resumeKeaLoadersErrors()
     })
 
     it('is not authenticated without any token', () => {
@@ -260,7 +273,9 @@ describe('toolbar toolbarConfigLogic', () => {
 
         it('confirmAuthenticate opens the config modal when authStatus flipped to error after modal was shown', async () => {
             // Simulate: user opened the modal, then the in-flight reachability check failed
-            // before they clicked Continue.
+            // before they clicked Continue. The rejecting fetch also fails the mounted
+            // preflight loader, which kea-loaders would log.
+            silenceKeaLoadersErrors()
             ;(global.fetch as jest.Mock).mockImplementation(() => Promise.reject(new Error('network')))
             const logic = toolbarConfigLogic.build({ uiHost: 'https://selfhosted.example.com' } as any)
             logic.mount()
@@ -826,6 +841,11 @@ describe('toolbar toolbarConfigLogic', () => {
     })
 
     describe('token refresh on 401', () => {
+        // The 401-first fetch mocks also fail the mounted preflight loader,
+        // which kea-loaders would log
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it('retries request with new token after successful refresh', async () => {
             const logic = toolbarConfigLogic.build({
                 apiURL: 'http://localhost',

--- a/frontend/src/toolbar/toolbarController.test.ts
+++ b/frontend/src/toolbar/toolbarController.test.ts
@@ -123,6 +123,17 @@ describe('PostHogToolbarController', () => {
     })
 
     describe('authenticate()', () => {
+        // toolbarConfigLogic's authenticate flow narrates progress via toolbarLogger by design
+        let consoleInfoSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation()
+        })
+
+        afterEach(() => {
+            consoleInfoSpy.mockRestore()
+        })
+
         it('calls authenticate action on toolbarConfigLogic when loaded and not authenticated', () => {
             const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
             logic.mount()

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
@@ -6,8 +6,8 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
-import { WebVitalsToolbarMenu } from './WebVitalsToolbarMenu'
 import { webVitalsToolbarLogic } from './webVitalsToolbarLogic'
+import { WebVitalsToolbarMenu } from './WebVitalsToolbarMenu'
 
 describe('WebVitalsToolbarMenu', () => {
     beforeEach(() => {

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom'
 
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
 import { WebVitalsToolbarMenu } from './WebVitalsToolbarMenu'
+import { webVitalsToolbarLogic } from './webVitalsToolbarLogic'
 
 describe('WebVitalsToolbarMenu', () => {
     beforeEach(() => {
@@ -20,11 +22,17 @@ describe('WebVitalsToolbarMenu', () => {
             .mount()
     })
 
-    it('uses the PostHog ui host for the settings link', () => {
+    it('uses the PostHog ui host for the settings link', async () => {
         render(<WebVitalsToolbarMenu />)
 
         const settingsLink = screen.getByText('settings page').closest('a')
         expect(settingsLink).toHaveAttribute('href', 'https://us.posthog.com/settings/project')
         expect(settingsLink).toHaveAttribute('target', '_blank')
+
+        // Rendering mounts webVitalsToolbarLogic, whose mount-time load updates state
+        // asynchronously — settle it inside act so React doesn't warn
+        await act(async () => {
+            await expectLogic(webVitalsToolbarLogic).toFinishAllListeners()
+        })
     })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,7 +372,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -457,7 +457,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1866,7 +1866,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2596,9 +2596,6 @@ importers:
       '@testing-library/jest-dom':
         specifier: '*'
         version: 5.16.5
-      '@testing-library/react':
-        specifier: '*'
-        version: 13.4.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: '*'
         version: 13.5.0(@testing-library/dom@10.4.0)
@@ -2616,7 +2613,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -2660,6 +2657,9 @@ importers:
         specifier: 'catalog:'
         version: 2.9.0
     devDependencies:
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -3379,7 +3379,7 @@ importers:
         version: 2.1.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3533,9 +3533,6 @@ importers:
       '@testing-library/jest-dom':
         specifier: '*'
         version: 5.16.5
-      '@testing-library/react':
-        specifier: '*'
-        version: 13.4.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: '*'
         version: 13.5.0(@testing-library/dom@10.4.0)
@@ -3603,6 +3600,9 @@ importers:
         specifier: '*'
         version: 9.0.3(react@18.3.1)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -4242,7 +4242,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -11628,10 +11628,6 @@ packages:
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
 
-  '@testing-library/dom@8.19.0':
-    resolution: {integrity: sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==}
-    engines: {node: '>=12'}
-
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
@@ -11647,13 +11643,6 @@ packages:
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
-
-  '@testing-library/react@13.4.0':
-    resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
 
   '@testing-library/react@14.3.1':
     resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
@@ -12010,9 +11999,6 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
-
-  '@types/aria-query@4.2.2':
-    resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -26699,7 +26685,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26714,7 +26700,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -26735,7 +26721,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -26750,7 +26736,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -31738,17 +31724,6 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/dom@8.19.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
-      '@types/aria-query': 4.2.2
-      aria-query: 5.3.0
-      chalk: 4.1.2
-      dom-accessibility-api: 0.5.14
-      lz-string: 1.5.0
-      pretty-format: 27.5.1
-
   '@testing-library/dom@9.3.4':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -31792,16 +31767,6 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
-
-  '@testing-library/react@13.4.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@testing-library/dom': 8.19.0
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@testing-library/react@14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -32152,8 +32117,6 @@ snapshots:
       '@types/node': 22.18.8
 
   '@types/argparse@1.0.38': {}
-
-  '@types/aria-query@4.2.2': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -37947,15 +37910,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -37966,15 +37929,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38112,6 +38075,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -38142,40 +38138,6 @@ snapshots:
       '@types/node': 22.18.8
       esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.0.1
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.0.5
-      '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.0.5
-      jest-docblock: 30.0.1
-      jest-environment-node: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-runner: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.0.5
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.28.0)
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38213,40 +38175,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.0.1
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.0.5
-      '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.0.5
-      jest-docblock: 30.0.1
-      jest-environment-node: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-runner: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.0.5
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      esbuild-register: 3.6.0(esbuild@0.28.0)
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -38276,6 +38204,38 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39170,12 +39130,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39183,12 +39143,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/products/ai_observability/frontend/ConversationDisplay/messageActionsMenuLogic.test.ts
+++ b/products/ai_observability/frontend/ConversationDisplay/messageActionsMenuLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { organizationLogic } from 'scenes/organizationLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import api from '~/lib/api'
 import { initKeaTests } from '~/test/init'
 import { AppContext } from '~/types'
@@ -129,6 +130,10 @@ describe('messageActionsMenuLogic', () => {
         })
 
         describe('translationError', () => {
+            // These tests deliberately fail the translate loader.
+            beforeEach(silenceKeaLoadersErrors)
+            afterEach(resumeKeaLoadersErrors)
+
             it('clears error on resetTranslation', async () => {
                 // Ensure org is loaded first
                 const orgLogic = organizationLogic()
@@ -326,20 +331,26 @@ describe('messageActionsMenuLogic', () => {
             })
 
             it('throws error when data processing not accepted', async () => {
-                initKeaTests(true, undefined, undefined, {
-                    ...MOCK_DEFAULT_ORGANIZATION,
-                    is_ai_data_processing_approved: false,
-                })
+                // The translate loader deliberately throws when consent is missing.
+                silenceKeaLoadersErrors()
+                try {
+                    initKeaTests(true, undefined, undefined, {
+                        ...MOCK_DEFAULT_ORGANIZATION,
+                        is_ai_data_processing_approved: false,
+                    })
 
-                const logic = messageActionsMenuLogic({ content: mockContent })
-                logic.mount()
+                    const logic = messageActionsMenuLogic({ content: mockContent })
+                    logic.mount()
 
-                await expectLogic(logic, () => {
-                    logic.actions.translate()
-                }).toFinishAllListeners()
+                    await expectLogic(logic, () => {
+                        logic.actions.translate()
+                    }).toFinishAllListeners()
 
-                expect(logic.values.translationError).toBeTruthy()
-                expect(mockApi.aiObservability.translate).not.toHaveBeenCalled()
+                    expect(logic.values.translationError).toBeTruthy()
+                    expect(mockApi.aiObservability.translate).not.toHaveBeenCalled()
+                } finally {
+                    resumeKeaLoadersErrors()
+                }
             })
         })
     })

--- a/products/ai_observability/frontend/aiObservabilityAIDataLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityAIDataLogic.test.ts
@@ -168,30 +168,45 @@ describe('aiObservabilityAIDataLogic', () => {
 
     it('degrades gracefully to the passed-in values when the lookup throws', async () => {
         jest.spyOn(mockApi, 'queryHogQL').mockRejectedValue(new Error('network down'))
+        // The logic warns (by design) once per failed source before falling back.
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
 
-        const logic = aiObservabilityAIDataLogic()
-        logic.mount()
+        try {
+            const logic = aiObservabilityAIDataLogic()
+            logic.mount()
 
-        await expectLogic(logic, () => {
-            logic.actions.loadAIDataForEvent({
-                eventId: 'event-1',
-                input: 'fallback-input',
-                output: undefined,
-                tools: undefined,
-                traceId: 'trace-1',
-                timestamp: '2026-04-30T10:00:00Z',
+            await expectLogic(logic, () => {
+                logic.actions.loadAIDataForEvent({
+                    eventId: 'event-1',
+                    input: 'fallback-input',
+                    output: undefined,
+                    tools: undefined,
+                    traceId: 'trace-1',
+                    timestamp: '2026-04-30T10:00:00Z',
+                })
             })
-        })
-            .toFinishAllListeners()
-            .toMatchValues({
-                aiDataCache: {
-                    'event-1': {
-                        input: 'fallback-input',
-                        output: undefined,
-                        tools: undefined,
+                .toFinishAllListeners()
+                .toMatchValues({
+                    aiDataCache: {
+                        'event-1': {
+                            input: 'fallback-input',
+                            output: undefined,
+                            tools: undefined,
+                        },
                     },
-                },
-            })
+                })
+
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[aiObservabilityAIDataLogic] failed to load heavy AI props from ai_events',
+                expect.any(Error)
+            )
+            expect(warnSpy).toHaveBeenCalledWith(
+                '[aiObservabilityAIDataLogic] failed to load heavy AI props from events',
+                expect.any(Error)
+            )
+        } finally {
+            warnSpy.mockRestore()
+        }
     })
 
     it.each([

--- a/products/ai_observability/frontend/clusters/clustersAdminLogic.test.ts
+++ b/products/ai_observability/frontend/clusters/clustersAdminLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { DEFAULT_CLUSTERING_PARAMS, clustersAdminLogic } from './clustersAdminLogic'
@@ -9,6 +10,17 @@ describe('clustersAdminLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
+        // clusteringConfigLogic (connected) loads this on mount; the unhandled-request
+        // floor lacks event_filters, which would corrupt its localEventFilters reducer.
+        useMocks({
+            get: {
+                '/api/environments/:team_id/llm_analytics/clustering_config/': {
+                    event_filters: [],
+                    created_at: '2026-01-01T00:00:00Z',
+                    updated_at: '2026-01-01T00:00:00Z',
+                },
+            },
+        })
         logic = clustersAdminLogic()
         logic.mount()
     })

--- a/products/ai_observability/frontend/clusters/clustersLogic.test.ts
+++ b/products/ai_observability/frontend/clusters/clustersLogic.test.ts
@@ -734,6 +734,8 @@ describe('clustersLogic', () => {
                     // filteredSortedClusters reads off the currentRun; seed a run and hydrate the cache.
                     // We pass the run's level so the level-mismatch guard in `sortedClusters` (which
                     // exists to suppress stale cards during a level switch) treats the seed as live.
+                    // Window bounds must be real strings — the summary/metrics loaders interpolate
+                    // them into hogql templates, which reject undefined.
                     logic.actions.loadClusteringRunSuccess({
                         runId: 'test-run',
                         // Without window bounds the success listeners interpolate undefined
@@ -741,11 +743,13 @@ describe('clustersLogic', () => {
                         windowStart: '2026-04-19T00:00:00Z',
                         windowEnd: '2026-04-21T00:00:00Z',
                         clusters: sampleClusters,
+                        windowStart: '2026-04-13T00:00:00Z',
+                        windowEnd: '2026-04-20T00:00:00Z',
                         level: level ?? logic.values.clusteringLevel,
                     } as ClusteringRun)
                 }
 
-                it('returns clusters unchanged when no filter is active', () => {
+                it('returns clusters unchanged when no filter is active', async () => {
                     setEvalLevelAndAttrs()
                     loadClustersAsCurrentRun()
 
@@ -754,9 +758,12 @@ describe('clustersLogic', () => {
                     const byId = Object.fromEntries(result.map((c) => [c.cluster_id, c]))
                     expect(byId[0].size).toBe(3)
                     expect(byId[1].size).toBe(2)
+
+                    // Let the run-triggered background loads settle before unmount.
+                    await expectLogic(logic).toFinishAllListeners()
                 })
 
-                it('drops non-matching traces, rewrites size, and prunes clusters that empty out', () => {
+                it('drops non-matching traces, rewrites size, and prunes clusters that empty out', async () => {
                     setEvalLevelAndAttrs()
                     loadClustersAsCurrentRun()
                     logic.actions.setEvalVerdictsFilter(['pass'])
@@ -767,6 +774,9 @@ describe('clustersLogic', () => {
                     expect(result[0].cluster_id).toBe(0)
                     expect(Object.keys(result[0].traces).sort()).toEqual(['id-pass-a', 'id-pass-b'])
                     expect(result[0].size).toBe(2)
+
+                    // Let the run-triggered background loads settle before unmount.
+                    await expectLogic(logic).toFinishAllListeners()
                 })
 
                 it('narrows clusters by propertyFilteredItemIds (cohort / property filter)', () => {
@@ -797,7 +807,7 @@ describe('clustersLogic', () => {
                     expect(byId[1].size).toBe(1)
                 })
 
-                it('combines property and eval filters (intersection)', () => {
+                it('combines property and eval filters (intersection)', async () => {
                     setEvalLevelAndAttrs()
                     loadClustersAsCurrentRun()
                     // Property filter narrows to {id-pass-a, id-pass-b, id-fail-b}, eval verdict
@@ -811,6 +821,9 @@ describe('clustersLogic', () => {
                     expect(result).toHaveLength(1)
                     expect(result[0].cluster_id).toBe(0)
                     expect(Object.keys(result[0].traces).sort()).toEqual(['id-pass-a', 'id-pass-b'])
+
+                    // Let the run-triggered background loads settle before unmount.
+                    await expectLogic(logic).toFinishAllListeners()
                 })
 
                 it('treats null propertyFilteredItemIds as "no property filter applied"', () => {

--- a/products/ai_observability/frontend/clusters/clustersLogic.test.ts
+++ b/products/ai_observability/frontend/clusters/clustersLogic.test.ts
@@ -740,11 +740,9 @@ describe('clustersLogic', () => {
                         runId: 'test-run',
                         // Without window bounds the success listeners interpolate undefined
                         // into hogql templates and log load failures.
-                        windowStart: '2026-04-19T00:00:00Z',
-                        windowEnd: '2026-04-21T00:00:00Z',
-                        clusters: sampleClusters,
                         windowStart: '2026-04-13T00:00:00Z',
                         windowEnd: '2026-04-20T00:00:00Z',
+                        clusters: sampleClusters,
                         level: level ?? logic.values.clusteringLevel,
                     } as ClusteringRun)
                 }

--- a/products/ai_observability/frontend/modelPickerLogic.test.ts
+++ b/products/ai_observability/frontend/modelPickerLogic.test.ts
@@ -121,7 +121,6 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
-                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 
@@ -247,7 +246,6 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
-                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 
@@ -268,7 +266,6 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
-                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 

--- a/products/ai_observability/frontend/modelPickerLogic.test.ts
+++ b/products/ai_observability/frontend/modelPickerLogic.test.ts
@@ -121,6 +121,7 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
+                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 
@@ -246,6 +247,7 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
+                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 
@@ -266,6 +268,7 @@ describe('modelPickerLogic', () => {
                     '/api/environments/:team_id/llm_analytics/evaluation_config/': {
                         active_provider_key: null,
                     },
+                    '/api/llm_proxy/models/': () => [200, []],
                 },
             })
 
@@ -369,6 +372,17 @@ const GROUPS: ProviderModelGroup[] = [
 ]
 
 describe('parseTrialProviderKeyId', () => {
+    // The 'trial:' case exercises the unknown-provider path, which logs a console.error by design.
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    })
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore()
+    })
+
     it.each([
         ['trial:openai', 'openai'],
         ['trial:anthropic', 'anthropic'],
@@ -377,6 +391,9 @@ describe('parseTrialProviderKeyId', () => {
         ['trial:', null],
     ])('parseTrialProviderKeyId(%s) => %s', (input, expected) => {
         expect(parseTrialProviderKeyId(input)).toBe(expected)
+        if (input === 'trial:') {
+            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown LLM provider'))
+        }
     })
 })
 

--- a/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
@@ -3,6 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { urls } from 'scenes/urls'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -479,27 +480,30 @@ describe('llmPlaygroundLogic', () => {
         })
 
         it('should preserve trial models when reload fails', async () => {
-            await expectLogic(runLogic).toFinishAllListeners()
-            expect(modelPickerLogic.values.trialModels).toEqual(MOCK_MODEL_OPTIONS)
+            // The reload deliberately fails the loadTrialModels loader.
+            silenceKeaLoadersErrors()
+            try {
+                await expectLogic(runLogic).toFinishAllListeners()
+                expect(modelPickerLogic.values.trialModels).toEqual(MOCK_MODEL_OPTIONS)
 
-            useMocks({
-                get: {
-                    '/api/llm_proxy/models/': () => {
-                        throw new Error('API Error')
+                useMocks({
+                    get: {
+                        '/api/llm_proxy/models/': () => [500, { detail: 'API Error' }],
+                        '/api/environments/:team_id/llm_analytics/evaluation_config/': () => [
+                            500,
+                            { detail: 'API Error' },
+                        ],
+                        '/api/environments/:team_id/llm_analytics/provider_keys/': () => [500, { detail: 'API Error' }],
                     },
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': () => {
-                        throw new Error('API Error')
-                    },
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': () => {
-                        throw new Error('API Error')
-                    },
-                },
-            })
+                })
 
-            modelPickerLogic.actions.loadTrialModels()
-            await expectLogic(runLogic).toFinishAllListeners()
+                modelPickerLogic.actions.loadTrialModels()
+                await expectLogic(runLogic).toFinishAllListeners()
 
-            expect(modelPickerLogic.values.trialModels).toEqual(MOCK_MODEL_OPTIONS)
+                expect(modelPickerLogic.values.trialModels).toEqual(MOCK_MODEL_OPTIONS)
+            } finally {
+                resumeKeaLoadersErrors()
+            }
         })
     })
 
@@ -691,25 +695,29 @@ describe('llmPlaygroundLogic', () => {
         })
 
         it('should return trial models when provider keys API fails', async () => {
-            useMocks({
-                get: {
-                    '/api/environments/:team_id/llm_analytics/evaluation_config/': {
-                        active_provider_key: null,
+            // The provider keys loader deliberately fails here.
+            silenceKeaLoadersErrors()
+            try {
+                useMocks({
+                    get: {
+                        '/api/environments/:team_id/llm_analytics/evaluation_config/': {
+                            active_provider_key: null,
+                        },
+                        '/api/environments/:team_id/llm_analytics/provider_keys/': () => [500, { detail: 'API Error' }],
+                        '/api/llm_proxy/models/': MOCK_MODEL_OPTIONS,
                     },
-                    '/api/environments/:team_id/llm_analytics/provider_keys/': () => {
-                        throw new Error('API Error')
-                    },
-                    '/api/llm_proxy/models/': MOCK_MODEL_OPTIONS,
-                },
-            })
+                })
 
-            const testRunLogic = llmPlaygroundRunLogic()
-            testRunLogic.mount()
-            await expectLogic(testRunLogic).toFinishAllListeners()
+                const testRunLogic = llmPlaygroundRunLogic()
+                testRunLogic.mount()
+                await expectLogic(testRunLogic).toFinishAllListeners()
 
-            expect(llmPlaygroundModelLogic.values.effectiveModelOptions).toEqual(MOCK_MODEL_OPTIONS)
+                expect(llmPlaygroundModelLogic.values.effectiveModelOptions).toEqual(MOCK_MODEL_OPTIONS)
 
-            testRunLogic.unmount()
+                testRunLogic.unmount()
+            } finally {
+                resumeKeaLoadersErrors()
+            }
         })
 
         it('should return BYOK models when valid keys exist and models have loaded', async () => {

--- a/products/ai_observability/package.json
+++ b/products/ai_observability/package.json
@@ -15,6 +15,7 @@
         "yaml": "catalog:"
     },
     "devDependencies": {
+        "@testing-library/react": "^14.3.1",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
@@ -10,7 +10,11 @@ import type { AccountsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import type { UserBasicType, UserType } from '~/types'
 
-import { accountsPartialUpdate, accountsRetrieve } from 'products/customer_analytics/frontend/generated/api'
+import {
+    accountsPartialUpdate,
+    accountsRetrieve,
+    customPropertyDefinitionsList,
+} from 'products/customer_analytics/frontend/generated/api'
 import type { AccountApi } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import { customerAnalyticsSceneLogic } from '../../customerAnalyticsSceneLogic'
@@ -33,10 +37,14 @@ jest.mock('products/customer_analytics/frontend/generated/api', () => ({
     ...jest.requireActual('products/customer_analytics/frontend/generated/api'),
     accountsRetrieve: jest.fn(),
     accountsPartialUpdate: jest.fn(),
+    customPropertyDefinitionsList: jest.fn(),
 }))
 
 const mockAccountsRetrieve = accountsRetrieve as jest.MockedFunction<typeof accountsRetrieve>
 const mockAccountsPartialUpdate = accountsPartialUpdate as jest.MockedFunction<typeof accountsPartialUpdate>
+const mockCustomPropertyDefinitionsList = customPropertyDefinitionsList as jest.MockedFunction<
+    typeof customPropertyDefinitionsList
+>
 
 const buildAccount = (overrides: Partial<AccountApi> = {}): AccountApi => ({
     id: 'acc-1',
@@ -70,6 +78,8 @@ describe('accountsLogic', () => {
     beforeEach(() => {
         initKeaTests()
         jest.resetAllMocks()
+        // accountsColumnConfigLogic (connected) loads custom property definitions on mount.
+        mockCustomPropertyDefinitionsList.mockResolvedValue({ count: 0, results: [] })
         // accountsLogic connects to the (localStorage-persisted) shared scene logic;
         // clear it so a "mine only" write in one test can't leak into the next.
         localStorage.clear()

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { userLogic } from 'scenes/userLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -92,6 +93,8 @@ describe('customPropertyDefinitionsLogic', () => {
         userLogic.mount()
         jest.spyOn(window, 'open').mockReturnValue(null)
     })
+
+    afterEach(resumeKeaLoadersErrors)
 
     it('loads definitions on mount', async () => {
         useMocks(defaultMocks())
@@ -215,6 +218,7 @@ describe('customPropertyDefinitionsLogic', () => {
     })
 
     it('treats an already-deleted definition (404) as a successful delete', async () => {
+        silenceKeaLoadersErrors() // the 404 loader failure is the scenario under test
         useMocks({
             ...defaultMocks(),
             delete: { ...defaultMocks().delete, [DEFINITION_URL]: () => [404, { detail: 'Not found.' }] },
@@ -318,6 +322,7 @@ describe('customPropertyDefinitionsLogic', () => {
     })
 
     it('fails the workflow CTA with a field error when the name is missing', async () => {
+        silenceKeaLoadersErrors() // the MissingNameError loader failure is the scenario under test
         useMocks(defaultMocks())
         mountLogic()
         logic.actions.openCreateModal()

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.test.tsx
@@ -335,6 +335,9 @@ describe('DashboardWidgetItem', () => {
     })
 
     it('contains unknown widget errors in the card body while keeping the header', () => {
+        // The thrown render error is expected: React and jsdom both report it to
+        // console.error before the error boundary contains it
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
         const catalogEntryMock = getDashboardWidgetCatalogEntry as jest.Mock
         ;(tryGetDashboardWidgetCatalogEntry as jest.Mock).mockReturnValue(undefined)
         catalogEntryMock.mockImplementation(() => {
@@ -375,5 +378,6 @@ describe('DashboardWidgetItem', () => {
             label: 'Top issues',
             headerTitle: 'Top issues',
         }))
+        consoleErrorSpy.mockRestore()
     })
 })

--- a/products/dashboards/frontend/logics/dashboardsFileSystemLogic.test.ts
+++ b/products/dashboards/frontend/logics/dashboardsFileSystemLogic.test.ts
@@ -3,6 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -11,6 +12,9 @@ import { initKeaTests } from '~/test/init'
 import { dashboardsFileSystemLogic } from './dashboardsFileSystemLogic'
 
 describe('dashboardsFileSystemLogic', () => {
+    // Safety net for tests that call silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof dashboardsFileSystemLogic.build>
 
     useMocks({
@@ -168,6 +172,8 @@ describe('dashboardsFileSystemLogic', () => {
         await expectLogic(logic).toDispatchActions(['loadDashboardFileSystemEntriesSuccess'])
         const error = jest.spyOn(lemonToast, 'error').mockReturnValue('' as any)
         ;(api.fileSystem.list as jest.Mock).mockRejectedValueOnce(new Error('boom'))
+        // Deliberate loader failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         await expectLogic(logic, () => {
             logic.actions.loadDashboardFileSystemEntries()
         }).toDispatchActions(['loadDashboardFileSystemEntriesFailure'])
@@ -178,6 +184,8 @@ describe('dashboardsFileSystemLogic', () => {
         await expectLogic(logic).toDispatchActions(['loadFolderEntriesSuccess'])
         const error = jest.spyOn(lemonToast, 'error').mockReturnValue('' as any)
         ;(api.fileSystem.list as jest.Mock).mockRejectedValueOnce(new Error('boom'))
+        // Deliberate loader failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         await expectLogic(logic, () => {
             logic.actions.loadFolderEntries()
         }).toDispatchActions(['loadFolderEntriesFailure'])

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -3,6 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import api from 'lib/api'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 import { ExternalDataSource, ExternalDataSourceSchema } from '~/types'
 
@@ -37,6 +38,9 @@ const makeSource = (schemas: ExternalDataSourceSchema[]): ExternalDataSource =>
     }) as ExternalDataSource
 
 describe('sourceSettingsLogic', () => {
+    // Safety net for the test that calls silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof sourceSettingsLogic.build>
 
     beforeEach(() => {
@@ -286,6 +290,8 @@ describe('sourceSettingsLogic', () => {
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
+        // Deliberate loader failure — kea-loaders would log it
+        silenceKeaLoadersErrors()
         const serverError = Object.assign(new Error('boom'), { status: 500 })
         jest.spyOn(api.externalDataSources, 'jobs').mockRejectedValueOnce(serverError)
 

--- a/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifestBuilderLogic.test.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifestBuilderLogic.test.ts
@@ -3,6 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import { ApiError } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 
 import { externalDataSourcesDraftCustomManifestCreate } from 'products/warehouse_sources/frontend/generated/api'
@@ -28,6 +29,9 @@ const pushedFields = (setValue: jest.Mock): Record<string, unknown> =>
     Object.fromEntries(setValue.mock.calls.map(([path, value]) => [(path as (string | number)[]).join('.'), value]))
 
 describe('customSourceManifestBuilderLogic', () => {
+    // Safety net for tests that call silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof customSourceManifestBuilderLogic.build>
     let setValue: jest.Mock
 
@@ -258,6 +262,8 @@ describe('customSourceManifestBuilderLogic', () => {
         ] as [string, number, Record<string, string>][])(
             'surfaces the backend reason (%s) instead of a generic failure',
             async (_label, status, data) => {
+                // Deliberate loader failure — kea-loaders would log it
+                silenceKeaLoadersErrors()
                 mockDraft.mockRejectedValue(new ApiError('failed', status, undefined, data))
                 logic.actions.setDocsUrl('https://docs.example.com')
 

--- a/products/endpoints/frontend/endpointSceneLogic.test.ts
+++ b/products/endpoints/frontend/endpointSceneLogic.test.ts
@@ -63,6 +63,12 @@ describe('endpointSceneLogic', () => {
 
     beforeEach(async () => {
         jest.clearAllMocks()
+        // The bare jest.fn() in the module mock resolves undefined, which the endpoint
+        // loader would feed straight into its reducer. Echo the requested version so the
+        // URL's version param survives the mount-time viewingVersion sync.
+        ;(api.endpoint.get as jest.Mock).mockImplementation((_name: string, version?: number) =>
+            Promise.resolve(version === undefined ? endpoint : { ...endpoint, version })
+        )
         initKeaTests(false)
         localStorage.clear()
         sessionStorage.clear()
@@ -71,6 +77,9 @@ describe('endpointSceneLogic', () => {
 
         logic = endpointSceneLogic()
         logic.mount()
+        // Let the mount-time load settle with the default mock, so per-test overrides
+        // apply cleanly to the fetches each test triggers
+        await expectLogic(logic).toFinishAllListeners()
     })
 
     afterEach(() => {

--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
@@ -5,6 +5,7 @@ import { ApiConfig, ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { urls } from 'scenes/urls'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { initKeaTests } from '~/test/init'
 
 import {
@@ -250,6 +251,7 @@ describe('engineeringAnalyticsLogic', () => {
 
     afterEach(() => {
         jest.restoreAllMocks()
+        resumeKeaLoadersErrors()
     })
 
     it.each([
@@ -683,6 +685,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('flags notConnected when no GitHub source is connected (cards 400s)', async () => {
+        silenceKeaLoadersErrors() // the 400 loader failure is the scenario under test
         mockCiCards.mockRejectedValue(
             new ApiError('Connect a GitHub data warehouse source to use engineering analytics.', 400)
         )
@@ -696,6 +699,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('flags notConnected from the workflow-health loader too (the Workflows scene renders no cards)', async () => {
+        silenceKeaLoadersErrors() // the 400 loader failure is the scenario under test
         // notConnected must react to any loader's 400, not cards alone — else the Workflows scene
         // could miss the connect prompt.
         mockWorkflowHealth.mockRejectedValue(new ApiError('Connect a GitHub data warehouse source.', 400))
@@ -708,6 +712,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('a cards/PR 500 errors the PR scene only — not the Workflows scene', async () => {
+        silenceKeaLoadersErrors() // the 500 loader failure is the scenario under test
         mockCiCards.mockRejectedValue(new ApiError('Internal Server Error', 500))
         logic = engineeringAnalyticsLogic()
         logic.mount()
@@ -719,6 +724,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('a workflow-health 500 errors the Workflows scene only — not the PR scene', async () => {
+        silenceKeaLoadersErrors() // the 500 loader failure is the scenario under test
         mockWorkflowHealth.mockRejectedValue(new ApiError('Internal Server Error', 500))
         logic = engineeringAnalyticsLogic()
         logic.mount()
@@ -829,6 +835,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('flags quarantineLoadFailed when the quarantine endpoint 400s', async () => {
+        silenceKeaLoadersErrors() // the loader failure is the scenario under test
         mockQuarantine.mockRejectedValue(
             new Error('Connect a GitHub data warehouse source to use engineering analytics.')
         )
@@ -914,6 +921,7 @@ describe('engineeringAnalyticsLogic', () => {
     })
 
     it('a failed submit keeps the modal open so the user can retry', async () => {
+        silenceKeaLoadersErrors() // the submit failure is the scenario under test
         mockQuarantineRequest.mockRejectedValue({ detail: "The App isn't installed on PostHog." })
         logic = engineeringAnalyticsLogic()
         logic.mount()

--- a/products/engineering_analytics/frontend/scenes/workflowRunsLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/workflowRunsLogic.test.ts
@@ -5,6 +5,7 @@ import { ApiConfig } from 'lib/api'
 import { initKeaTests } from '~/test/init'
 
 import {
+    engineeringAnalyticsJobAggregates,
     engineeringAnalyticsWorkflowJobs,
     engineeringAnalyticsWorkflowRunActivity,
     engineeringAnalyticsWorkflowRunnerCosts,
@@ -14,6 +15,7 @@ import { engineeringAnalyticsFiltersLogic } from './engineeringAnalyticsFiltersL
 import { workflowRunsLogic } from './workflowRunsLogic'
 
 jest.mock('../generated/api', () => ({
+    engineeringAnalyticsJobAggregates: jest.fn(),
     engineeringAnalyticsWorkflowJobs: jest.fn(),
     engineeringAnalyticsWorkflowRunActivity: jest.fn(),
     engineeringAnalyticsWorkflowRunnerCosts: jest.fn(),
@@ -28,6 +30,9 @@ const mockRunnerCosts = engineeringAnalyticsWorkflowRunnerCosts as jest.MockedFu
     typeof engineeringAnalyticsWorkflowRunnerCosts
 >
 const mockJobs = engineeringAnalyticsWorkflowJobs as jest.MockedFunction<typeof engineeringAnalyticsWorkflowJobs>
+const mockJobAggregates = engineeringAnalyticsJobAggregates as jest.MockedFunction<
+    typeof engineeringAnalyticsJobAggregates
+>
 
 describe('workflowRunsLogic', () => {
     let logic: ReturnType<typeof workflowRunsLogic.build>
@@ -40,6 +45,7 @@ describe('workflowRunsLogic', () => {
         mockRunActivity.mockResolvedValue({ points: [], truncated: false, limit: 0 })
         mockRunnerCosts.mockResolvedValue([])
         mockJobs.mockResolvedValue([])
+        mockJobAggregates.mockResolvedValue([])
     })
 
     afterEach(() => {

--- a/products/live_debugger/frontend/liveDebuggerLogic.test.ts
+++ b/products/live_debugger/frontend/liveDebuggerLogic.test.ts
@@ -67,6 +67,9 @@ describe('liveDebuggerLogic', () => {
 
     beforeEach(() => {
         jest.useFakeTimers()
+        // lib/api is automocked, so api.get resolves undefined unless a test overrides it —
+        // give loaders a benign default so mount-time loads don't crash
+        jest.spyOn(api, 'get').mockResolvedValue({ results: [], count: 0, has_more: false })
         initKeaTests()
     })
 

--- a/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
@@ -48,6 +48,16 @@ describe('logsExportLogic', () => {
             ;(api.logs.query as jest.Mock).mockResolvedValue({ results: [], hasMore: false, maxExportableLogs: 10000 })
             ;(api.logs.sparkline as jest.Mock).mockResolvedValue([])
 
+            // Mounting the viewer fires fetchLogs/fetchSparkline; the automock returns
+            // undefined, which would crash the loaders.
+            ;(api.logs.query as jest.Mock).mockResolvedValue({
+                results: [],
+                hasMore: false,
+                nextCursor: null,
+                maxExportableLogs: 10_000,
+            })
+            ;(api.logs.sparkline as jest.Mock).mockResolvedValue([])
+
             viewerLogic = logsViewerLogic({ id: 'test-tab' })
             viewerLogic.mount()
 

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -12,6 +12,7 @@
         "posthog-js": "catalog:"
     },
     "devDependencies": {
+        "@testing-library/react": "^14.3.1",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {

--- a/products/posthog_ai/frontend/logics/tasksLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { userLogic } from 'scenes/userLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -29,6 +30,9 @@ const createMockTask = (id: string): Task => ({
 })
 
 describe('tasksLogic', () => {
+    // Safety net for the test that calls silenceKeaLoadersErrors() inline
+    afterEach(resumeKeaLoadersErrors)
+
     let logic: ReturnType<typeof tasksLogic.build>
 
     beforeEach(() => {
@@ -125,6 +129,8 @@ describe('tasksLogic', () => {
         // and the infinite-scroll spinner never goes away after a failed page load.
         it('clears tasksNext on failure so the list stops reporting more pages', async () => {
             logic.actions.setTasksNext('/api/projects/1/tasks/?cursor=page-2')
+            // Deliberate loader failure — kea-loaders would log it
+            silenceKeaLoadersErrors()
             jest.spyOn(api, 'get').mockRejectedValueOnce(new Error('network error'))
 
             logic.actions.loadMoreTasks()

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveyTriggerLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveyTriggerLogic.test.ts
@@ -1,6 +1,7 @@
 import { resetContext } from 'kea'
 import { expectLogic, testUtilsPlugin } from 'kea-test-utils'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { Survey } from '~/types'
@@ -236,6 +237,9 @@ describe('surveyTriggerLogic', () => {
     })
 
     describe('error handling', () => {
+        beforeEach(silenceKeaLoadersErrors)
+        afterEach(resumeKeaLoadersErrors)
+
         it('handles loadSurveys failure', async () => {
             useSetupMocks({ listError: true })
 

--- a/products/workflows/frontend/Workflows/workflowLogic.externalEdits.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.externalEdits.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { ResourceEditedEvent } from '~/types'
@@ -83,6 +84,8 @@ describe('workflowLogic external edits', () => {
         expect(getCalls).toBe(1)
     })
 
+    afterEach(resumeKeaLoadersErrors)
+
     it('silently reconciles (sync + reload) when the local state is clean', async () => {
         await expectLogic(logic, () => {
             resourceEditedLogic.actions.resourceEdited(makeEvent({ updated_at: NEWER }))
@@ -164,6 +167,7 @@ describe('workflowLogic external edits', () => {
     })
 
     it('shows the banner when a save is rejected as stale (409 backstop)', async () => {
+        silenceKeaLoadersErrors() // the 409 save failure is the scenario under test
         useMocks({
             get: {
                 '/api/environments/:team_id/hog_flows/:id/': () => [200, makeWorkflow()],


### PR DESCRIPTION
## Problem

Jest output, especially in CI, is drowned in console noise: kea-loader error dumps, React warnings, MSW warnings, toolbar logger output. #68892 fixed a large chunk of it; this PR hunts down what's left, so a run is close to just a row of PASS lines.

## Changes

Root-cause fixes, not output suppression:

**Test harness**

- `mocksToHandlers` now interprets a static array mock of the `[status, body]` shape as a status+body tuple, matching the function-handler behavior. Dozens of test files already used static tuples like `[500, {}]`, and they silently served the tuple as a 200 JSON body, so "deliberate failure" mocks were returning 200s with garbage bodies and loaders crashed on the wrong shape instead.
- `handlers.ts`: the default `proxy_records` mock now returns `{ results: [] }` (the logic reads `.results`).

**App code bugs surfaced by the noise**

- `initKea`: also skip logging/reporting for cooperative-cancellation failures whose abort reason is the string `new query started` (logs/tracing data logics) - previously each superseded query logged a console error and hit `captureException`, in production too.
- `LemonInput`: a cleared controlled number input renders `''` instead of feeding `NaN` to the DOM.
- `experimentLogic.loadExposures`: bare `return` made kea error with "Reducer returned undefined" for every old-runner experiment.
- `authorizedUrlListLogic`: inverted guard let an undefined query result crash `.map`.
- `sessionRecordingsListPropertiesLogic`: skip building a HogQL query when session entries carry no ids (interpolating `undefined` throws).
- `PropertyFilterButton`: a closeable chip renders as `div[role=button]` so the close button no longer nests `<button>` inside `<button>`.
- `IconUnverifiedEvent`/`LemonIconBase`: forwardRef so the "Event property" tooltip can actually anchor.
- `FeatureFlagReleaseConditions`: description no longer renders a `<div>` inside SceneSection's `<p>`.
- `SurveyEventTrigger`: remove button moved to the collapse header's `sideAction` (button-in-button).
- `sharingLogic`: `allowFullScreen` React prop casing (embed snippet output unchanged).
- `HogQLX` render + `InfiniteList`/`Combobox`: key mapped children.
- `EditorFilters`: give the funnel viz-type tooltip a ref-able span anchor.
- Quill `PreviewPane`/`TaxonomicFilterMenu`: `nativeButton={false}` on non-button render targets (Base UI warnings).

**Dependency fix**

- `products/ai_observability` and `products/logs` resolved @testing-library/react 13.4.0 via a bare `*` peer dep, producing `ReactDOMTestUtils.act` deprecation warnings in every component test there. Pinned to ^14.3.1 like sibling products.

**Test fixes** (~60 files)

- Deliberate-failure tests now use the established `silenceKeaLoadersErrors`/`resumeKeaLoadersErrors` pattern, scoped to the failing tests.
- Broken mocks fixed where loaders crashed on wrong-shaped responses (these were silent test bugs - the logic under test crashed while the test passed).
- Lifecycle fixes where listeners settled after unmount (`[KEA] Can not find path`), including a cohortEditLogic test whose blanket `setTimeout` noop permanently wedged a kea breakpoint.
- Tests that intentionally exercise console-logging paths (toolbar logger, error boundaries, CI-report script) spy the console narrowly and assert where valuable.
- Deleted two unreferenced `heatmapResults.json` manual mocks and renamed a colliding fixture (jest-haste-map duplicate-mock warnings on every run).

**Known remaining** (needs a design-system-level fix, left out deliberately): LemonMenu items that embed a LemonSelect/LemonInput inside the item button (MathSelector, RollingDateRangeFilter) still trigger one button-in-button warning in a handful of component tests.

## How did you test this code?

Automated only (no manual testing): ran the full frontend jest suite (~18k tests) before and after, plus targeted re-runs of every touched test file verifying zero `console.*` blocks and all tests passing. One snapshot updated (HogQLX keyed fragments). No new tests added - this is cleanup of existing tests and the bugs they surfaced.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code session). Process: ran the full suite to build a noise inventory (~90 files, ~700 console blocks), categorized by root cause, then fixed by category. Subagents assisted with per-file fixes for the TaxonomicFilter, toolbar, scenes, and products batches; all agent output was re-verified by running each touched file.

Decisions worth knowing:

- Tried enabling RTL's act environment repo-wide (it silently never activates because the RTL import happens in a `setupFiles` module before jest hooks exist). Reverted: it surfaced hundreds of new "not wrapped in act" warnings, a net noise increase. Kept the status quo and fixed the two quill tests via RTL `act` imports instead.
- Rebased over #68892 mid-flight (same goal, overlapping files) and kept master's version wherever it covered the same fix.
- `mocksToHandlers` static-tuple interpretation changes mock semantics repo-wide; the full suite passes, and it aligns behavior with what test authors clearly intended.