### PR TITLE
fix(hogli): scope ci:preflight --strict to committed diff

### DIFF
--- a/tools/hogli-commands/hogli_commands/change_detection.py
+++ b/tools/hogli-commands/hogli_commands/change_detection.py
@@ -20,7 +20,7 @@ def _git(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["git", *args], cwd=REPO_ROOT, capture_output=True, text=True)
 
 
-def changed_files(against: str | None = None) -> list[str]:
+def changed_files(against: str | None = None, *, include_worktree: bool = True) -> list[str]:
     """Files the branch touches vs a base ref (merge-base), plus uncommitted/untracked work.
 
     An explicit *against* raises on a bad ref so a typo can't masquerade as a clean
@@ -29,6 +29,11 @@ def changed_files(against: str | None = None) -> list[str]:
     working-tree-only detection when neither exists (single-branch clones, bare
     sandboxes). ``-z`` output keeps paths with spaces/non-ASCII unquoted, and
     ``--untracked-files=all`` lists files inside brand-new directories.
+
+    ``include_worktree=False`` restricts the result to the committed branch diff,
+    dropping uncommitted and untracked work — the correct scope for a pre-push gate,
+    where only committed changes are actually pushed (and can reach CI). Callers that
+    iterate on local edits (``build``, ``test --changed``) keep the default.
     """
     files: set[str] = set()
     for base in [against] if against is not None else ["origin/master", "master"]:
@@ -38,6 +43,8 @@ def changed_files(against: str | None = None) -> list[str]:
             break
         if against is not None:
             raise click.UsageError(f"git diff against {against!r} failed: {diff.stderr.strip()}")
+    if not include_worktree:
+        return sorted(files)
     status = _git("status", "--porcelain", "-z", "--no-renames", "--untracked-files=all")
     if status.returncode != 0:
         # A failed status (e.g. index.lock contention) must not read as "no uncommitted work".

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -424,7 +424,11 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
     # Fetch first so both the diff base and the staleness check see a fresh
     # origin/master — a stale local ref would inflate the diff with master's own commits.
     _fetch_master()
-    files = changed_files(against)
+    # --strict is the blocking pre-push hook: scope it to the committed diff, since a
+    # push only carries commits. Untracked/uncommitted work never reaches CI, so gating
+    # a push on lint errors in a scratch file is a false block. Advisory/--fix runs keep
+    # the working tree in scope so agents can clean edits before committing.
+    files = changed_files(against, include_worktree=not strict)
     base = against or "origin/master"
 
     triggered: list[DiffCheck] = []

--- a/tools/hogli-commands/hogli_commands/tests/test_change_detection.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_change_detection.py
@@ -58,6 +58,14 @@ class TestChangedFiles:
             changed_files("orgin/master")
 
     @patch("hogli_commands.change_detection.subprocess.run")
+    def test_exclude_worktree_returns_committed_diff_only(self, mock_run: MagicMock) -> None:
+        # Pre-push scope: only the committed branch diff is pushed, so untracked/uncommitted
+        # work must not leak in. git status is never consulted (a single subprocess call).
+        mock_run.side_effect = [_completed(stdout="file_branch.py\0")]
+        assert changed_files(include_worktree=False) == ["file_branch.py"]
+        assert mock_run.call_count == 1
+
+    @patch("hogli_commands.change_detection.subprocess.run")
     def test_status_failure_raises_instead_of_dropping_uncommitted_work(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = [
             _completed(stdout="file_branch.py\0"),


### PR DESCRIPTION
## Problem

The `ci:preflight` pre-push hook (`hogli ci:preflight --strict`) blocks pushes over files that aren't being pushed. It scopes its checks via `changed_files()`, which folds in uncommitted and untracked work (`git status --untracked-files=all`). A push only carries commits, so a stray untracked `.py`/`.md` never reaches CI, yet it still trips `ruff`/`oxfmt` and exits 1.

## Changes

- `changed_files(..., include_worktree=True)`: new keyword, `False` returns the committed branch diff only.
- `ci:preflight` calls it with `include_worktree=not strict`. Strict (the pre-push gate) now checks the committed payload. Advisory and `--fix` keep the working-tree scope so the agent pre-commit loop still cleans edits.
- No coverage lost, since at pre-push time everything being pushed is already committed.

## How did you test this code?

I (Claude) reproduced it: an untracked lint-broken file made `--strict` exit 1. After the fix `--strict` exits 0 while the advisory run still flags it. Added a `test_change_detection.py` case pinning the committed-only scope (guards a revert that re-folds untracked work into the strict gate); no existing test covered `include_worktree=False`. All 28 hogli change-detection and ci:preflight tests pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl flagged that the strict gate was false-blocking on unstaged files. I (Claude) root-caused it to the working-tree scope in `changed_files` (introduced in #65581), confirmed with a local repro, and fixed it by scoping the blocking mode to the committed diff. Invoked the `/writing-tests` skill before adding the regression test.
