### PR TITLE
ci: narrow POE-on backend run to query-engine folders

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -650,8 +650,7 @@ jobs:
                   # Partition selected files by the Django segment that owns them.
                   # Mirrors the positional path arguments in the Run Core / Run Temporal pytest invocations:
                   #   Core (POE off): posthog ee/  (minus posthog/temporal, posthog/dags)
-                  #   Core POE on:    posthog/clickhouse, posthog/queries, posthog/api/test/test_insight*,
-                  #                   posthog/api/test/dashboards/test_dashboard.py, ee/clickhouse/
+                  #   Core POE on:    posthog/clickhouse, posthog/queries, ee/clickhouse/
                   #   Temporal:       posthog/temporal, products/{batch_exports,tasks}/backend/temporal,
                   #                   products/signals/backend/emission
                   # Files outside posthog/ and ee/ (e.g. products/foo/backend/test_*) are not in this
@@ -665,8 +664,12 @@ jobs:
                           posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/signals/backend/emission/*)
                               temporal+=("$f")
                               ;;
-                          posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*|products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
+                          posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*)
                               poe+=("$f")
+                              core+=("$f")
+                              ;;
+                          products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
+                              # Single-run core coverage only; the POE toggle's SQL is already exercised by the query-engine folders above.
                               core+=("$f")
                               ;;
                           posthog/dags/*|common/hogvm/python/test/*)
@@ -1599,7 +1602,7 @@ jobs:
                         && env.CLICKHOUSE_COMPAT_PYTEST_TARGETS
                         || (
                         matrix.person-on-events
-                        && './posthog/clickhouse/ ./posthog/queries/ ./products/product_analytics/backend/api/test/ ./posthog/api/test/dashboards/test_dashboard.py'
+                        && './posthog/clickhouse/ ./posthog/queries/'
                         || 'posthog'
                         )
                     }} ${{ !matrix.compat && (matrix.person-on-events && 'ee/clickhouse/' || 'ee/') || '' }} -m "not async_migrations" \

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -584,8 +584,7 @@ jobs:
                   # Partition selected files by the Django segment that owns them.
                   # Mirrors the positional path arguments in the Run Core / Run Temporal pytest invocations:
                   #   Core (POE off): posthog ee/  (minus posthog/temporal, posthog/dags)
-                  #   Core POE on:    posthog/clickhouse, posthog/queries, posthog/api/test/test_insight*,
-                  #                   posthog/api/test/dashboards/test_dashboard.py, ee/clickhouse/
+                  #   Core POE on:    posthog/clickhouse, posthog/queries, ee/clickhouse/
                   #   Temporal:       posthog/temporal, products/{batch_exports,tasks}/backend/temporal,
                   #                   products/signals/backend/emission
                   # Files outside posthog/ and ee/ (e.g. products/foo/backend/test_*) are not in this
@@ -599,8 +598,12 @@ jobs:
                           posthog/temporal/*|products/batch_exports/backend/tests/temporal/*|products/tasks/backend/temporal/*|products/signals/backend/emission/*)
                               temporal+=("$f")
                               ;;
-                          posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*|products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
+                          posthog/clickhouse/*|posthog/queries/*|ee/clickhouse/*)
                               poe+=("$f")
+                              core+=("$f")
+                              ;;
+                          products/product_analytics/backend/api/test/*|posthog/api/test/test_insight*|posthog/api/test/dashboards/test_dashboard.py)
+                              # Single-run core coverage only; the POE toggle's SQL is already exercised by the query-engine folders above.
                               core+=("$f")
                               ;;
                           posthog/dags/*|common/hogvm/python/test/*)
@@ -2476,7 +2479,7 @@ jobs:
                         && env.CLICKHOUSE_COMPAT_PYTEST_TARGETS
                         || (
                         matrix.person-on-events
-                        && './posthog/clickhouse/ ./posthog/queries/ ./products/product_analytics/backend/api/test/ ./posthog/api/test/dashboards/test_dashboard.py'
+                        && './posthog/clickhouse/ ./posthog/queries/'
                         || 'posthog'
                         )
                     }} ${{ !matrix.compat && (matrix.person-on-events && 'ee/clickhouse/' || 'ee/') || '' }} -m "not async_migrations" \


### PR DESCRIPTION
## Problem

The backend `persons-on-events on` arm re-runs API and dashboard integration tests (`products/product_analytics/backend/api/test/`, `posthog/api/test/dashboards/test_dashboard.py`) a second time under the POE toggle. The toggle only changes generated ClickHouse SQL, and that path is already exercised by the query-engine folders in the same arm. This is the "we don't need to run all the tests twice" trim discussed in #team-platform-ux.

## Changes

- POE-on full run now targets only `posthog/clickhouse/`, `posthog/queries/`, `ee/clickhouse/`.
- Draft-mode classifier splits accordingly: query-engine folders still double-run; API/dashboard/`test_insight*` files keep single-run core coverage (unchanged).
- Mirrored in `.github` and `.depot`.

Coverage-neutral for the POE-off / core path. Only the redundant second (POE-on) run of API-surface tests is dropped.

## How did you test this code?

Both workflows parse (`yaml.safe_load`); `hogli ci:preflight --strict` green. No new tests. Behavior needs a real CI run to confirm shard timings and that no POE-specific assertion lived only in the dropped API tests.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl asked me (Claude) to propose a further narrowing of the POE test split after researching what POE tests are and their current state (Slack + PR history). Chose the query-engine-only cut because the `person_on_events` toggle's behavior is SQL-generation, fully covered by `clickhouse/`/`queries/`. Deliberately left `posthog/queries/` (legacy engine, being retired alongside the PoE-mode cleanup) in place as the bigger follow-up lever rather than cutting it blind. Open question for reviewers (platform-ux/devex): do any POE regressions rely on the dropped API/dashboard integration tests that the query-layer tests miss? Draft pending that validation.
