### PR TITLE
fix(aio): cap single-event LLM judge input like the trace-level judge

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -39,10 +39,14 @@ from products.ai_observability.backend.llm.errors import (
     RateLimitError,
     StructuredOutputParseError,
 )
+from products.ai_observability.backend.text_repr.formatters import reduce_by_uniform_sampling
 
 logger = structlog.get_logger(__name__)
 
 DEFAULT_JUDGE_MODEL = DEFAULT_MODEL_BY_PROVIDER["openai"]
+
+# Same cap as the trace-level judge (JUDGE_TRACE_MAX_CHARS).
+JUDGE_EVENT_MAX_CHARS = 150_000
 
 LLM_JUDGE_RETRY_POLICY = RetryPolicy(
     maximum_attempts=3,
@@ -230,6 +234,7 @@ def _execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> EvaluationActi
         sections.append(f"Tools available:\n{tools_data}")
     sections.append(f"Output: {output_data}")
     user_prompt = "\n\n".join(sections)
+    user_prompt, _ = reduce_by_uniform_sampling(user_prompt, JUDGE_EVENT_MAX_CHARS)
 
     return call_llm_judge(
         evaluation=evaluation,

--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -39,7 +39,7 @@ from products.ai_observability.backend.llm.errors import (
     RateLimitError,
     StructuredOutputParseError,
 )
-from products.ai_observability.backend.text_repr.formatters import reduce_by_uniform_sampling
+from products.ai_observability.backend.text_repr.formatters import add_line_numbers, reduce_by_uniform_sampling
 
 logger = structlog.get_logger(__name__)
 
@@ -234,7 +234,12 @@ def _execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> EvaluationActi
         sections.append(f"Tools available:\n{tools_data}")
     sections.append(f"Output: {output_data}")
     user_prompt = "\n\n".join(sections)
-    user_prompt, _ = reduce_by_uniform_sampling(user_prompt, JUDGE_EVENT_MAX_CHARS)
+    if len(user_prompt) > JUDGE_EVENT_MAX_CHARS:
+        # Line-number first so the sampler's "gaps indicate omitted content" header is truthful,
+        # then hard-truncate to guarantee the cap for low-newline payloads the sampler leaves whole.
+        user_prompt = add_line_numbers(user_prompt)
+        user_prompt, _ = reduce_by_uniform_sampling(user_prompt, JUDGE_EVENT_MAX_CHARS)
+        user_prompt = user_prompt[:JUDGE_EVENT_MAX_CHARS]
 
     return call_llm_judge(
         evaluation=evaluation,

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -205,8 +205,18 @@ class TestRunEvaluationWorkflow:
             assert result["reasoning"] == "The answer is correct"
             mock_client.complete.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "oversized_input",
+        [
+            pytest.param(
+                [{"role": "user", "content": f"message {i}: " + "x" * 200} for i in range(3000)],
+                id="many_lines",
+            ),
+            pytest.param([{"role": "user", "content": "x" * 600_000}], id="single_line_blob"),
+        ],
+    )
     @pytest.mark.django_db(transaction=True)
-    def test_execute_llm_judge_activity_bounds_oversized_input(self, setup_data):
+    def test_execute_llm_judge_activity_bounds_oversized_input(self, oversized_input, setup_data):
         team = setup_data["team"]
         evaluation_obj = setup_data["evaluation"]
 
@@ -220,7 +230,6 @@ class TestRunEvaluationWorkflow:
             "team_id": team.id,
         }
 
-        oversized_input = [{"role": "user", "content": f"message {i}: " + "x" * 200} for i in range(3000)]
         event_data = create_mock_event_data(
             team.id,
             properties={

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -36,6 +36,7 @@ from .evaluation_errors import (
     status_reason_detail_for_terminal_user_error,
     terminal_user_error_result_from_application_error,
 )
+from .evaluation_llm_judge import JUDGE_EVENT_MAX_CHARS
 from .run_evaluation import (
     BooleanEvalResult,
     BooleanWithNAEvalResult,
@@ -203,6 +204,45 @@ class TestRunEvaluationWorkflow:
             assert result["verdict"] is True
             assert result["reasoning"] == "The answer is correct"
             mock_client.complete.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_llm_judge_activity_bounds_oversized_input(self, setup_data):
+        team = setup_data["team"]
+        evaluation_obj = setup_data["evaluation"]
+
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this response factually accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+
+        oversized_input = [{"role": "user", "content": f"message {i}: " + "x" * 200} for i in range(3000)]
+        event_data = create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": oversized_input,
+                "$ai_output_choices": [{"role": "assistant", "content": "ok"}],
+            },
+        )
+
+        with patch("posthog.temporal.ai_observability.evaluation_llm_judge.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="ok")
+            mock_response.usage = MagicMock(input_tokens=1, output_tokens=1, total_tokens=1)
+            mock_client.complete.return_value = mock_response
+
+            execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
+
+            sent_prompt = mock_client.complete.call_args.args[0].messages[0]["content"]
+            raw_size = sum(len(message["content"]) for message in oversized_input)
+            assert len(sent_prompt) <= JUDGE_EVENT_MAX_CHARS
+            assert len(sent_prompt) < raw_size
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)

--- a/products/ai_observability/backend/text_repr/formatters/__init__.py
+++ b/products/ai_observability/backend/text_repr/formatters/__init__.py
@@ -15,11 +15,12 @@ Main entry points:
 """
 
 from .event_formatter import format_event_text_repr, format_event_text_repr_from_ai_events_row
-from .message_formatter import FormatterOptions, reduce_by_uniform_sampling
+from .message_formatter import FormatterOptions, add_line_numbers, reduce_by_uniform_sampling
 from .trace_formatter import format_trace_text_repr, llm_trace_to_formatter_format
 
 __all__ = [
     "FormatterOptions",
+    "add_line_numbers",
     "format_event_text_repr",
     "format_event_text_repr_from_ai_events_row",
     "format_trace_text_repr",


### PR DESCRIPTION
## Problem

The trace-level judge already bounds its transcript at `JUDGE_TRACE_MAX_CHARS`. The single-event path was missing the equivalent guard.

## Changes

- Reuse the trace-level truncation primitive, `reduce_by_uniform_sampling` (from `text_repr.formatters`), on the assembled single-event judge prompt, capped at `JUDGE_EVENT_MAX_CHARS = 150_000` (same value the trace-level judge uses).
- It no-ops when the prompt is within budget, so normal evals are byte-identical; oversized prompts get uniformly line-sampled down to the cap with a header noting the sampled percentage.

I first wrote a bespoke head+tail truncation helper, then swapped it for `reduce_by_uniform_sampling` so we reuse the exact mechanism the trace-level judge already uses rather than introducing a third truncation variant (there's also `truncate_to_head_tail` in the sentiment path).

## How did you test this code?

- Added `test_execute_llm_judge_activity_bounds_oversized_input` in `test_run_evaluation.py`: feeds a ~600k-char multi-message input through the activity with a mocked `Client`, and asserts the prompt actually sent to `complete` is `<= JUDGE_EVENT_MAX_CHARS` and smaller than the raw input. This guards the wiring, if the sampling call is dropped, an oversized prompt reaches the judge again. The sampling primitive itself is already covered by `test_uniform_sampling.py`, so I did not re-test it.
- Ran the new test plus the existing `test_execute_llm_judge_activity` and the full `test_message_utils.py` suite (54 passed), and `ruff`/`ty check` (clean).
- I (Claude, via PostHog Code) did not run the evals workflow end to end.

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Carlos directed this while triaging failed LLM-as-a-judge eval workflows. Radu had suggested applying the trace-level truncation to the single-event judge path, which is what this does. Skill invoked: `/writing-tests` (the test gate).

Initial pass added a standalone head+tail helper; on review we chose to reuse the trace-level `reduce_by_uniform_sampling` primitive instead, for a single shared truncation mechanism. A separate Gemini `429` quota error found in the same triage turned out to be a free-tier key issue, not code, so it's being fixed via a secrets update rather than here. The non-BYOK provider-error retry/hard-fail asymmetry is a known follow-up, not in this PR.
