### PR TITLE
fix(data-warehouse): cache the duckgres sink's extract-read credential chain

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -169,6 +170,39 @@ def _connect_to_duckgres(team_id: int) -> psycopg.Connection[Any]:
     )
 
 
+# Resolved once per process, not per batch: constructing a boto3.Session builds
+# a fresh credential resolver, which for IRSA/web-identity chains re-reads the
+# token file and can hit the STS/metadata endpoint — a per-batch fixed cost that
+# dominates small live batches and couples every apply to STS availability.
+# botocore's RefreshableCredentials refresh themselves (thread-safely) inside
+# get_frozen_credentials() when inside the mandatory-refresh window, so a cached
+# resolver still hands every batch a token with expiry headroom. A failed
+# resolve is NOT cached — the next batch retries the chain.
+_extract_read_credentials: Any | None = None
+_extract_read_region: str = "us-east-1"
+_extract_read_credentials_lock = threading.Lock()
+
+
+def _resolve_extract_read_credentials() -> tuple[Any, str]:
+    global _extract_read_credentials, _extract_read_region
+    if _extract_read_credentials is None:
+        with _extract_read_credentials_lock:
+            if _extract_read_credentials is None:
+                import boto3  # noqa: PLC0415 — keeps boto3 off the import path for local setups
+
+                session = boto3.Session()
+                creds = session.get_credentials()
+                if creds is None:
+                    raise RuntimeError("No AWS credentials available to read the extract bucket from duckgres")
+                _extract_read_region = session.region_name or "us-east-1"
+                _extract_read_credentials = creds
+    # Refreshable chains re-mint here when close to expiry; static chains no-op.
+    frozen = _extract_read_credentials.get_frozen_credentials()
+    if not frozen.access_key or not frozen.secret_key:
+        raise RuntimeError("AWS credential chain resolved without an access key pair")
+    return frozen, _extract_read_region
+
+
 def _create_extract_read_secret(conn: psycopg.Connection[Any]) -> None:
     """Grant this duckgres session read access to PostHog's extract bucket.
 
@@ -192,20 +226,12 @@ def _create_extract_read_secret(conn: psycopg.Connection[Any]) -> None:
             f"SCOPE {_sql_str(scope)}",
         ]
     else:
-        import boto3
-
-        session = boto3.Session()
-        creds = session.get_credentials()
-        if creds is None:
-            raise RuntimeError("No AWS credentials available to read the extract bucket from duckgres")
-        frozen = creds.get_frozen_credentials()
-        if not frozen.access_key or not frozen.secret_key:
-            raise RuntimeError("AWS credential chain resolved without an access key pair")
+        frozen, region = _resolve_extract_read_credentials()
         parts = [
             "TYPE S3",
             f"KEY_ID {_sql_str(frozen.access_key)}",
             f"SECRET {_sql_str(frozen.secret_key)}",
-            f"REGION {_sql_str(session.region_name or 'us-east-1')}",
+            f"REGION {_sql_str(region)}",
             f"SCOPE {_sql_str(scope)}",
         ]
         if frozen.token:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -1,8 +1,10 @@
+import sys
 from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, Mock, patch
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres import processor
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor import (
     DuckgresColumn,
     _ensure_duckgres_apply_table,
@@ -555,3 +557,47 @@ class TestBackfillProcessing:
             _process_backfill_batch(conn, batch, _make_schema())
 
         insert.assert_not_called()
+
+
+class TestExtractReadCredentialCache:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self, monkeypatch):
+        monkeypatch.setattr(processor, "_extract_read_credentials", None)
+
+    def test_credential_chain_resolved_once_across_batches(self, monkeypatch):
+        # The per-batch boto3.Session() construction is what this cache removes:
+        # each Session builds a fresh resolver (an STS/metadata round trip on
+        # IRSA chains), coupling every apply to STS availability.
+        creds = Mock()
+        creds.get_frozen_credentials.return_value = Mock(access_key="ak", secret_key="sk", token="tok")
+        session = Mock(region_name="us-east-1")
+        session.get_credentials.return_value = creds
+        session_factory = Mock(return_value=session)
+        monkeypatch.setitem(sys.modules, "boto3", Mock(Session=session_factory))
+
+        first = processor._resolve_extract_read_credentials()
+        second = processor._resolve_extract_read_credentials()
+
+        session_factory.assert_called_once()
+        assert first[0].access_key == second[0].access_key == "ak"
+        # Refreshable chains re-mint inside get_frozen_credentials on every call.
+        assert creds.get_frozen_credentials.call_count == 2
+
+    def test_failed_resolve_is_not_cached(self, monkeypatch):
+        # A transient chain failure (STS blip at pod start) must not poison the
+        # cache; the next batch retries the chain and succeeds.
+        good_creds = Mock()
+        good_creds.get_frozen_credentials.return_value = Mock(access_key="ak", secret_key="sk", token=None)
+        bad_session = Mock(region_name=None)
+        bad_session.get_credentials.return_value = None
+        good_session = Mock(region_name="eu-west-1")
+        good_session.get_credentials.return_value = good_creds
+        session_factory = Mock(side_effect=[bad_session, good_session])
+        monkeypatch.setitem(sys.modules, "boto3", Mock(Session=session_factory))
+
+        with pytest.raises(RuntimeError, match="No AWS credentials"):
+            processor._resolve_extract_read_credentials()
+
+        frozen, region = processor._resolve_extract_read_credentials()
+        assert frozen.access_key == "ak"
+        assert region == "eu-west-1"


### PR DESCRIPTION
## Problem

Second finding of the duckgres consumer audit (C1/C3, one root cause). Every batch apply constructs a fresh `boto3.Session()` to mint the S3 extract-read secret. A fresh session builds a fresh credential resolver, which for IRSA/web-identity chains re-reads the token file and can hit the STS/metadata endpoint on every single batch:

- the resolve is a per-batch fixed cost that dominates small live batches, and
- it couples every apply to STS availability - one STS blip or metadata-endpoint throttle during a backlog drain fails apply after apply while duckgres and the queue are perfectly healthy.

The per-batch freeze also means a long backfill-chunk transaction (up to 512 parquet files in one `CREATE TABLE ... AS SELECT`) starts with whatever token happened to be current, with no expiry headroom guarantee.

## Changes

Resolve the credential chain once per process (lazy, lock-guarded) instead of per batch. botocore's `RefreshableCredentials` re-mint themselves thread-safely inside `get_frozen_credentials()` whenever the token is inside the mandatory-refresh window, so every batch still gets a token with expiry headroom - strictly fresher at the start of long chunk transactions than the old code, without any per-batch resolver construction. A failed resolve is not cached: the next batch retries the chain, so a transient STS failure at pod start cannot poison the process.

Dev (`USE_LOCAL_SETUP`) path unchanged. Known residual, documented in the audit: a single chunk transaction that outlives the full token lifetime (~1h IRSA) can still fail mid-read - that needs transaction splitting, out of scope here; this PR maximizes the headroom each chunk starts with.

## How did you test this code?

Automated tests only (I'm an agent). Full `test_processor.py` passes (15 tests). New tests, each catching a regression nothing covered before:

- `test_credential_chain_resolved_once_across_batches` - the boto3 session/resolver is constructed once across consecutive resolves while `get_frozen_credentials` still runs per batch (the refresh seam); catches a revert to per-batch `boto3.Session()`.
- `test_failed_resolve_is_not_cached` - a chain failure raises but does not poison the cache; the next resolve retries and succeeds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal consumer behavior; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5) at Eric's direction, implementing priority 2 from an in-session audit of the duckgres consumer stack.
- Skills invoked: `/writing-tests` (value gate for the two new tests).
- Key decision: rely on botocore's built-in refreshable-credential machinery rather than hand-rolling TTL tracking - it already refreshes thread-safely inside `get_frozen_credentials()` with mandatory headroom, which is exactly the semantics the per-chunk secret needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)