### PR TITLE
fix(mcp): suppress structuredContent for inline-exec UI-app hosts

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -410,7 +410,8 @@ export class ToolExecutor {
             commandReference,
             clientContext.mcpConsumer,
             trackInnerCall,
-            state.scopeGatedTools
+            state.scopeGatedTools,
+            { isInlineExecUiHost: state.clientProfile.isInlineExecUiHost() }
         )
 
         return {

--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -21,6 +21,15 @@ export interface BuildToolResultOptions {
     params: unknown
     /** Whether formatted-result text should win over structuredContent for this client profile. */
     suppressStructuredContentForFormattedResults?: boolean | undefined
+    /**
+     * For inline-exec UI-app hosts (PostHog Code, Claude Code, Cowork): always drop
+     * top-level `structuredContent` toward the model and re-home the app payload onto
+     * `_meta` instead — even when there's no formatted table (the model then reads the
+     * TOON text). These hosts surface `structuredContent` to the model, so it must
+     * never carry the raw results; the UI app hydrates from `_meta` (see APP_DATA_META_KEY).
+     * Overridden by an explicit `output_format=json` from the caller.
+     */
+    forceUiDataToMeta?: boolean | undefined
     /** PostHog distinctId for analytics metadata (only read when a UI resource is present). */
     distinctId?: string | undefined
     /**
@@ -98,6 +107,7 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         toolName,
         params,
         suppressStructuredContentForFormattedResults,
+        forceUiDataToMeta,
         distinctId,
         includeUiResponseMeta,
     } = opts
@@ -142,8 +152,12 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
 
     const text = formattedResults ?? (useJson ? JSON.stringify(rawResult) : formatResponse(rawResult))
 
+    // Inline-exec UI-app hosts always drop top-level structuredContent (routed to
+    // `_meta` below); other coding-agent clients only drop it when a formatted table
+    // is available to take its place. An explicit `output_format=json` overrides both.
     const suppressStructuredContent =
-        formattedResults !== undefined && !callerWantsJson && !!suppressStructuredContentForFormattedResults
+        !callerWantsJson &&
+        (!!forceUiDataToMeta || (formattedResults !== undefined && !!suppressStructuredContentForFormattedResults))
 
     const payload: ToolResultPayload = {
         content: [{ type: 'text', text }],

--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -3,7 +3,7 @@ import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { formatResponse } from '@/lib/response'
 import { POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY, POSTHOG_META_KEY } from '@/tools/types'
-import type { AnalyticsMetadata, WithAnalytics } from '@/ui-apps/types'
+import { APP_DATA_META_KEY, type AnalyticsMetadata, type WithAnalytics } from '@/ui-apps/types'
 
 export interface ToolResultMeta {
     ui?: { resourceUri?: string }
@@ -155,6 +155,13 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         payload._meta = {
             ui: { resourceUri },
             [RESOURCE_URI_META_KEY]: resourceUri,
+        }
+        // `structuredContent` was dropped so the model reads the compact formatted
+        // table, but the UI app still needs the data to render. `_meta` is host-
+        // and app-only (never surfaced to the model), so carry the app payload here
+        // and let `useToolResult` hydrate from it. See APP_DATA_META_KEY.
+        if (suppressStructuredContent && hasUiResource) {
+            payload._meta[APP_DATA_META_KEY] = structuredContent as Record<string, unknown>
         }
     }
     return payload

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -174,6 +174,12 @@ export const VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS = ['lovable', 'replit', 'no
 // misclassify Claude Code as a UI host.
 export const ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS = ['claudeai'] as const
 
+// Anthropic coding-agent surfaces that render MCP UI apps inline through the
+// single-exec `exec` tool. `ClaudeCode` and `Cowork` render UI apps on the exec
+// response itself (unlike `ClaudeAI`, which uses the separate `render-ui` tool),
+// so they get the same treatment as the PostHog Code consumer.
+export const INLINE_EXEC_UI_APP_VENDOR_FRAGMENTS = ['claudecode', 'cowork'] as const
+
 // User-Agent Anthropic clients send when they connect without the
 // `x-anthropic-client` header (Claude.ai web/desktop and internal Anthropic
 // tooling). It's a generic Anthropic signal — Claude Code and Cowork can send it
@@ -282,6 +288,16 @@ export class MCPClientProfile {
             return matchesAnyFragment(this.vendorClient, ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS)
         }
         return matchesAnyFragment(this.userAgent, ANTHROPIC_UI_HOST_USER_AGENT_FRAGMENTS)
+    }
+
+    isInlineExecUiHost(): boolean {
+        // Anthropic coding-agent surfaces that render MCP UI apps inline through the
+        // single-exec `exec` tool (Claude Code, Cowork) — as opposed to Claude.ai
+        // web/desktop, which renders via the separate `render-ui` tool. Like PostHog
+        // Code, these hosts surface `structuredContent` to the model, so the exec
+        // UI-app branch suppresses it and re-homes the app data onto `_meta`. The
+        // per-request vendor header (`ClaudeCode` / `Cowork`) is the reliable signal.
+        return matchesAnyFragment(this.vendorClient, INLINE_EXEC_UI_APP_VENDOR_FRAGMENTS)
     }
 
     get capabilities(): ClientCapabilities {

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -279,8 +279,10 @@ export class MCPClientProfile {
     isClaudeUiHost(): boolean {
         // The per-request vendor client (`x-anthropic-client`) is authoritative: it
         // distinguishes the Claude surfaces that pool the same MCP transport —
-        // `ClaudeAI` (web/desktop, a UI-Apps host) from `Cowork` and `ClaudeCode`,
-        // which render no MCP-Apps UI. When it's present, trust it exclusively; only
+        // `ClaudeAI` (web/desktop, a UI-Apps host that renders via the separate
+        // `render-ui` tool) from `Cowork` and `ClaudeCode`, which render UI apps
+        // inline on the `exec` response instead (see `isInlineExecUiHost`) and so
+        // are not `render-ui` hosts. When it's present, trust it exclusively; only
         // fall back to the `Claude-User` user-agent when the vendor header is absent.
         // Otherwise a non-UI surface like Cowork — which can share the `Claude-User`
         // user-agent with web/desktop — would be misclassified as a UI host.

--- a/services/mcp/src/templates/sections/cli-syntax.md
+++ b/services/mcp/src/templates/sections/cli-syntax.md
@@ -5,7 +5,7 @@ tools — list available tool names
 search <regex_pattern> — search tools by JavaScript regex (matches name, title, description)
 info [--json] <tool_name> — show tool name, description, and input schema (summarized if too large). Pass `--json` for raw JSON output.
 schema <tool_name> [field_path] — drill into a specific field schema (supports dot-notation, e.g. series, breakdownFilter.breakdowns)
-call [--json] [--confirm] <tool_name> <json_input> — call a tool with JSON input (--json returns raw JSON instead of formatted text. Use raw JSON for scripts. --confirm is required by the CLI for destructive tools.)
+call [--json] [--confirm] <tool_name> <json_input> — call a tool with JSON input (--json returns raw JSON instead of optimized output in supported tools. Use raw JSON for scripts. --confirm is required by the CLI for destructive tools.)
 ```
 
 **Namespaced references (`posthog:<tool-name>`):** strip the `posthog:` prefix and route through `exec`. Run `info <name>` to inspect, then `call <name> <json>`. E.g. `posthog:insights-list` → `posthog:exec({ "command": "info insights-list" })` then `posthog:exec({ "command": "call insights-list {}" })`. If the bare name isn't found, fall back to `search <pattern>` — it may have been renamed.

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -460,10 +460,13 @@ export function createExecTool(
                                 toolMeta: tool._meta,
                                 toolName: tool.name,
                                 params: useJson ? { ...input, output_format: 'json' } : input,
-                                // Consumer is the UI-apps host; keep `structuredContent` for the UI.
-                                // Passing `false` bypasses coding-agent suppression in
-                                // `buildToolResultPayload` because this path explicitly wants it.
-                                suppressStructuredContentForFormattedResults: false,
+                                // PostHog Code is a coding-agent host: it surfaces
+                                // `structuredContent` to the model in preference to the text
+                                // content, which would bury the compact formatted table under
+                                // the raw JSON. Suppress it so the model reads the optimized
+                                // table; `buildToolResultPayload` re-homes the UI app's data
+                                // onto `_meta` (see APP_DATA_META_KEY) so the chart still renders.
+                                suppressStructuredContentForFormattedResults: true,
                                 distinctId,
                                 includeUiResponseMeta: true,
                             })

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -191,6 +191,28 @@ export function formatInputValidationError(toolName: string, error: z.ZodError):
     return `Invalid input for "${toolName}": ${[...new Set(parts)].join('; ')}`
 }
 
+/** Whether the tool's input schema declares an `output_format` field. */
+function schemaHasOutputFormat(schema: ZodObjectAny): boolean {
+    return schema instanceof z.ZodObject && 'output_format' in schema.shape
+}
+
+/**
+ * Exec mode owns output encoding through the `--json` call flag, so tools must
+ * not also advertise their `output_format` input — an agent passing
+ * `output_format: "json"` would make the handler skip the server-side formatter
+ * only for exec to TOON-encode the raw result anyway. `call` folds the flag back
+ * into the field for tools that have it (see the `call` verb), so hiding it here
+ * loses no capability.
+ */
+function stripOutputFormatProperty(jsonSchema: Record<string, unknown>): Record<string, unknown> {
+    const properties = jsonSchema.properties as Record<string, unknown> | undefined
+    if (!properties || !('output_format' in properties)) {
+        return jsonSchema
+    }
+    const { output_format: _omitted, ...rest } = properties
+    return { ...jsonSchema, properties: rest }
+}
+
 function findTool(tools: Tool<ZodObjectAny>[], name: string): Tool<ZodObjectAny> {
     const tool = tools.find((t) => t.name === name)
     if (!tool) {
@@ -313,7 +335,7 @@ export function createExecTool(
                         throw new Error('Usage: info [--json] <tool_name>')
                     }
                     const tool = findTool(allTools, infoArgs)
-                    const fullSchema = z.toJSONSchema(tool.schema)
+                    const fullSchema = stripOutputFormatProperty(z.toJSONSchema(tool.schema) as Record<string, unknown>)
                     // YAML for the top shape, but inputSchema stays as a JSON
                     // string dumped inside the YAML — JSON Schema is conventionally
                     // JSON and converting it to YAML obscures `$ref`, `oneOf`, etc.
@@ -350,7 +372,9 @@ export function createExecTool(
                     }
                     const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest)
                     const schemaTool = findTool(allTools, schemaToolName)
-                    const fullJsonSchema = z.toJSONSchema(schemaTool.schema) as Record<string, unknown>
+                    const fullJsonSchema = stripOutputFormatProperty(
+                        z.toJSONSchema(schemaTool.schema) as Record<string, unknown>
+                    )
 
                     if (!fieldPath) {
                         // The bare `schema <tool>` view is always a summary. Any
@@ -413,7 +437,25 @@ export function createExecTool(
                         }
                     }
 
-                    const useJson = forceJson || tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
+                    // `output_format` is hidden from exec-mode schemas — `--json` owns output
+                    // encoding. Honor a stray `output_format: "json"` as `--json` instead of
+                    // letting the handler skip the formatter only for the result to be
+                    // TOON-encoded anyway.
+                    let strayOutputFormat: unknown
+                    if ('output_format' in input) {
+                        ;({ output_format: strayOutputFormat, ...input } = input)
+                    }
+                    const useJson =
+                        forceJson ||
+                        strayOutputFormat === 'json' ||
+                        tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
+                    // Fold the flag back into the tool's own `output_format` field when it has
+                    // one: formatter-toggle tools then skip the server-side formatter (clean raw
+                    // JSON, no `__formatted_results_override` duplication), and tools where the
+                    // field is a real backend param (dashboard-insights-run) keep full function.
+                    if (useJson && schemaHasOutputFormat(tool.schema)) {
+                        input.output_format = 'json'
+                    }
 
                     // Same validation gate as the non-exec MCP path (`tool-executor.ts`) —
                     // otherwise bad input reaches the HTTP layer and builds URLs like

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -48,6 +48,13 @@ export type ExecInnerCallTracker = (toolName: string, properties: ExecInnerCallP
 
 export interface ExecToolOptions {
     requireDestructiveConfirmation?: boolean
+    /**
+     * Client is an inline-exec UI-app host that renders MCP UI apps on the exec
+     * response (Claude Code, Cowork). Gets the same UI-app payload treatment as the
+     * PostHog Code consumer: structuredContent suppressed toward the model, app data
+     * re-homed onto `_meta`. Computed from the client profile at the call site.
+     */
+    isInlineExecUiHost?: boolean
 }
 
 function makeExecSchema(commandReference: string): z.ZodObject<{ command: z.ZodString }> {
@@ -451,7 +458,8 @@ export function createExecTool(
                     // ride on the per-call response. Gated on the consumer because other
                     // single-exec callers (direct Claude Code, cline, Slack- and posthog_ai-launched
                     // runs, etc.) don't render UI apps — they should see plain text.
-                    if (tool._meta?.ui?.resourceUri && isPostHogCodeConsumer(mcpConsumer)) {
+                    const isInlineUiAppHost = isPostHogCodeConsumer(mcpConsumer) || options.isInlineExecUiHost === true
+                    if (tool._meta?.ui?.resourceUri && isInlineUiAppHost) {
                         const isStringResult = typeof result === 'string'
                         const distinctId = isStringResult ? undefined : await context.getDistinctId()
                         const payload = markExecPayload(
@@ -460,13 +468,13 @@ export function createExecTool(
                                 toolMeta: tool._meta,
                                 toolName: tool.name,
                                 params: useJson ? { ...input, output_format: 'json' } : input,
-                                // PostHog Code is a coding-agent host: it surfaces
-                                // `structuredContent` to the model in preference to the text
-                                // content, which would bury the compact formatted table under
-                                // the raw JSON. Suppress it so the model reads the optimized
-                                // table; `buildToolResultPayload` re-homes the UI app's data
-                                // onto `_meta` (see APP_DATA_META_KEY) so the chart still renders.
-                                suppressStructuredContentForFormattedResults: true,
+                                // Inline-exec UI-app hosts (PostHog Code, Claude Code, Cowork)
+                                // surface `structuredContent` to the model in preference to the
+                                // text content, which would bury the compact formatted table
+                                // under the raw JSON. Always re-home the UI app's data onto
+                                // `_meta` (see APP_DATA_META_KEY) so the model reads the optimized
+                                // table (or the TOON text when unformatted) and the chart still renders.
+                                forceUiDataToMeta: true,
                                 distinctId,
                                 includeUiResponseMeta: true,
                             })

--- a/services/mcp/src/ui-apps/hooks/useToolResult.ts
+++ b/services/mcp/src/ui-apps/hooks/useToolResult.ts
@@ -44,7 +44,7 @@ import {
     identifyUser,
     initPostHog,
 } from '../analytics/posthog'
-import { extractAnalytics } from '../types'
+import { APP_DATA_META_KEY, extractAnalytics } from '../types'
 
 export interface UseToolResultOptions {
     /** App name shown to the host */
@@ -82,12 +82,20 @@ export interface UseToolResultReturn<T> {
 }
 
 /**
- * Parse tool result content, preferring structuredContent over text parsing.
+ * Parse tool result content, preferring structuredContent over the `_meta`
+ * fallback. Never falls back to text content.
  */
-function parseToolResultContent<T>(structuredContent: unknown): T | null {
-    // Always use structuredContent, never attempt to use text content
+function parseToolResultContent<T>(structuredContent: unknown, meta?: unknown): T | null {
+    // Prefer structuredContent when the host forwards it.
     if (structuredContent !== undefined && structuredContent !== null) {
         return structuredContent as T
+    }
+
+    // Coding-agent hosts suppress `structuredContent` so the model reads the
+    // compact text table; the app's data then rides on `_meta` instead.
+    const appData = (meta as Record<string, unknown> | undefined)?.[APP_DATA_META_KEY]
+    if (appData !== undefined && appData !== null) {
+        return appData as T
     }
 
     return null
@@ -186,7 +194,8 @@ export function useToolResult<T = unknown>({
             // Register tool result handler
             appInstance.ontoolresult = (params) => {
                 try {
-                    const parsed = parseToolResultContent<T>(params.structuredContent)
+                    const meta = (params as { _meta?: Record<string, unknown> })._meta
+                    const parsed = parseToolResultContent<T>(params.structuredContent, meta)
 
                     // Extract analytics metadata and identify the user
                     const analytics = extractAnalytics(parsed)

--- a/services/mcp/src/ui-apps/types.ts
+++ b/services/mcp/src/ui-apps/types.ts
@@ -20,6 +20,16 @@ export interface AnalyticsMetadata {
     toolName?: string
 }
 
+/**
+ * Result `_meta` key that carries a UI app's data payload when the top-level
+ * `structuredContent` is suppressed from the model. Coding-agent hosts (e.g.
+ * PostHog Code) surface `structuredContent` to the model, so when a compact
+ * formatted table is returned we drop `structuredContent` to keep the model's
+ * context lean. The UI app still needs the data to render, and `_meta` is host-
+ * and app-only (never shown to the model), so the app hydrates from here.
+ */
+export const APP_DATA_META_KEY = 'com.posthog.mcp/app_data' as const
+
 // ============================================================================
 // Type utilities for tool results
 // ============================================================================

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -52,6 +52,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             capabilities: { supportsInstructions: true },
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
+            isInlineExecUiHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -78,6 +78,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             capabilities: { supportsInstructions: true },
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
+            isInlineExecUiHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -55,6 +55,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             capabilities: { supportsInstructions: true },
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
+            isInlineExecUiHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -49,6 +49,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             capabilities: { supportsInstructions: true },
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
+            isInlineExecUiHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -5,7 +5,7 @@ tools — list available tool names
 search <regex_pattern> — search tools by JavaScript regex (matches name, title, description)
 info [--json] <tool_name> — show tool name, description, and input schema (summarized if too large). Pass `--json` for raw JSON output.
 schema <tool_name> [field_path] — drill into a specific field schema (supports dot-notation, e.g. series, breakdownFilter.breakdowns)
-call [--json] [--confirm] <tool_name> <json_input> — call a tool with JSON input (--json returns raw JSON instead of formatted text. Use raw JSON for scripts. --confirm is required by the CLI for destructive tools.)
+call [--json] [--confirm] <tool_name> <json_input> — call a tool with JSON input (--json returns raw JSON instead of optimized output in supported tools. Use raw JSON for scripts. --confirm is required by the CLI for destructive tools.)
 ```
 
 **Namespaced references (`posthog:<tool-name>`):** strip the `posthog:` prefix and route through `exec`. Run `info <name>` to inspect, then `call <name> <json>`. E.g. `posthog:insights-list` → `posthog:exec({ "command": "info insights-list" })` then `posthog:exec({ "command": "call insights-list {}" })`. If the bare name isn't found, fall back to `search <pattern>` — it may have been renamed.

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -448,6 +448,24 @@ describe('MCPClientProfile', () => {
         })
     })
 
+    describe('isInlineExecUiHost()', () => {
+        it.each([['ClaudeCode'], ['Cowork']])('is true for the %s vendor client', (vendorClient) => {
+            expect(new MCPClientProfile({ vendorClient }).isInlineExecUiHost()).toBe(true)
+        })
+
+        // Claude.ai renders via the separate render-ui tool, not the inline exec payload.
+        it.each([['ClaudeAI'], ['ClaudeDesign'], ['some-random-tool'], ['']])(
+            'is false for the %s vendor client',
+            (vendorClient) => {
+                expect(new MCPClientProfile({ vendorClient }).isInlineExecUiHost()).toBe(false)
+            }
+        )
+
+        it('is false when no vendor client is set (the user-agent is not a fallback here)', () => {
+            expect(new MCPClientProfile({ userAgent: 'Claude-User' }).isInlineExecUiHost()).toBe(false)
+        })
+    })
+
     describe('capabilities.supportsInstructions', () => {
         it.each([['codex'], ['Codex'], ['CODEX'], ['codex-cli'], ['Codex CLI'], ['codex/1.2.3'], ['openai-codex']])(
             'is false for Codex variant %s',

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -18,6 +18,7 @@ import {
     type Tool,
     type ZodObjectAny,
 } from '@/tools/types'
+import { APP_DATA_META_KEY } from '@/ui-apps/types'
 
 function makeMockTool(overrides: Partial<Tool<ZodObjectAny>> = {}): Tool<ZodObjectAny> {
     return {
@@ -202,6 +203,36 @@ describe('exec tool', () => {
             // through unchanged; without it the outer wrapper would re-run
             // buildToolResultPayload and object-rest-destructure the content.
             expect(result.__execBuiltPayload).toBe(true)
+        })
+
+        it('suppresses structuredContent toward the model but re-homes UI data onto _meta when consumer is posthog-code and result has a formatted override', async () => {
+            const tool = makeMockTool({
+                _meta: { ui: { resourceUri: 'ui://posthog/mock-app.html' } },
+                handler: async () => ({
+                    results: [{ data: [1, 2, 3], count: 6 }],
+                    _posthogUrl: 'http://localhost:8010/insights/new#q=...',
+                    [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
+                }),
+            })
+            const exec = createExec([tool], 'posthog-code')
+            const result = (await exec.handler(mockContext, { command: 'call mock-tool' })) as {
+                content: { type: string; text: string }[]
+                structuredContent?: Record<string, unknown>
+                _meta: { ui: { resourceUri: string }; [key: string]: unknown }
+            }
+
+            // Model sees ONLY the compact table, not the raw results JSON.
+            expect(result.content[0]!.text).toBe('Date|count\n2026-05-07|6')
+            // Top-level structuredContent is dropped so coding agents don't surface it.
+            expect(result.structuredContent).toBeUndefined()
+            // The UI app's data (with analytics) rides on _meta instead.
+            const appData = result._meta[APP_DATA_META_KEY] as {
+                results: unknown
+                _analytics: { distinctId: string; toolName: string }
+            }
+            expect(appData.results).toEqual([{ data: [1, 2, 3], count: 6 }])
+            expect(appData._analytics).toEqual({ distinctId: 'test-distinct-id', toolName: 'mock-tool' })
+            expect(result._meta.ui.resourceUri).toBe('ui://posthog/mock-app.html')
         })
 
         // posthog_ai is sent as its own consumer for attribution but is NOT a UI-apps host.

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -42,8 +42,21 @@ const mockContext = {
     getDistinctId: async () => 'test-distinct-id',
 } as unknown as Context
 
-function createExec(tools: Tool<ZodObjectAny>[] = [makeMockTool()], mcpConsumer?: string): Tool<any> {
-    return createExecTool(tools, mockContext, 'test description', 'test command reference', mcpConsumer)
+function createExec(
+    tools: Tool<ZodObjectAny>[] = [makeMockTool()],
+    mcpConsumer?: string,
+    options?: { isInlineExecUiHost?: boolean }
+): Tool<any> {
+    return createExecTool(
+        tools,
+        mockContext,
+        'test description',
+        'test command reference',
+        mcpConsumer,
+        undefined,
+        [],
+        options ?? {}
+    )
 }
 
 describe('exec tool', () => {
@@ -173,23 +186,28 @@ describe('exec tool', () => {
             )
         })
 
-        it('propagates _meta.ui.resourceUri and structuredContent when the inner tool has a UI app and consumer is posthog-code', async () => {
+        it('propagates the UI resource URI and exec brand when the inner tool has a UI app and consumer is posthog-code', async () => {
             const tool = makeMockTool({
                 _meta: { ui: { resourceUri: 'ui://posthog/mock-app.html' } },
             })
             const exec = createExec([tool], 'posthog-code')
             const result = (await exec.handler(mockContext, { command: 'call mock-tool' })) as {
                 content: { type: string; text: string }[]
-                structuredContent: { id: number; name: string; _analytics: { distinctId: string; toolName: string } }
+                structuredContent?: Record<string, unknown>
                 _meta: { ui: { resourceUri: string }; [key: string]: unknown }
                 __execBuiltPayload?: true
             }
 
             // Text content still includes the TOON-formatted result for model context
             expect(result.content[0]!.text).toContain('id: 1')
-            // structuredContent carries the raw object plus analytics for the UI app
-            expect(result.structuredContent.id).toBe(1)
-            expect(result.structuredContent._analytics).toEqual({
+            // structuredContent is dropped; the UI data (with analytics) rides on _meta.
+            expect(result.structuredContent).toBeUndefined()
+            const appData = result._meta[APP_DATA_META_KEY] as {
+                id: number
+                _analytics: { distinctId: string; toolName: string }
+            }
+            expect(appData.id).toBe(1)
+            expect(appData._analytics).toEqual({
                 distinctId: 'test-distinct-id',
                 toolName: 'mock-tool',
             })
@@ -205,34 +223,66 @@ describe('exec tool', () => {
             expect(result.__execBuiltPayload).toBe(true)
         })
 
-        it('suppresses structuredContent toward the model but re-homes UI data onto _meta when consumer is posthog-code and result has a formatted override', async () => {
+        // Inline-exec UI-app hosts: PostHog Code (via consumer) plus Claude Code and
+        // Cowork (via the client-profile flag). All three surface structuredContent to
+        // the model, so it must be dropped and the UI data re-homed onto _meta.
+        it.each([
+            ['posthog-code consumer', 'posthog-code', undefined],
+            ['claude-code client', undefined, { isInlineExecUiHost: true }],
+            ['cowork client', undefined, { isInlineExecUiHost: true }],
+        ])(
+            'suppresses structuredContent toward the model but re-homes UI data onto _meta for %s (with a formatted override)',
+            async (_label, consumer, options) => {
+                const tool = makeMockTool({
+                    _meta: { ui: { resourceUri: 'ui://posthog/mock-app.html' } },
+                    handler: async () => ({
+                        results: [{ data: [1, 2, 3], count: 6 }],
+                        _posthogUrl: 'http://localhost:8010/insights/new#q=...',
+                        [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
+                    }),
+                })
+                const exec = createExec([tool], consumer, options)
+                const result = (await exec.handler(mockContext, { command: 'call mock-tool' })) as {
+                    content: { type: string; text: string }[]
+                    structuredContent?: Record<string, unknown>
+                    _meta: { ui: { resourceUri: string }; [key: string]: unknown }
+                }
+
+                // Model sees ONLY the compact table, not the raw results JSON.
+                expect(result.content[0]!.text).toBe('Date|count\n2026-05-07|6')
+                // Top-level structuredContent is dropped so coding agents don't surface it.
+                expect(result.structuredContent).toBeUndefined()
+                // The UI app's data (with analytics) rides on _meta instead.
+                const appData = result._meta[APP_DATA_META_KEY] as {
+                    results: unknown
+                    _analytics: { distinctId: string; toolName: string }
+                }
+                expect(appData.results).toEqual([{ data: [1, 2, 3], count: 6 }])
+                expect(appData._analytics).toEqual({ distinctId: 'test-distinct-id', toolName: 'mock-tool' })
+                expect(result._meta.ui.resourceUri).toBe('ui://posthog/mock-app.html')
+            }
+        )
+
+        it('re-homes UI data onto _meta and gives the model TOON text even when there is no formatted override', async () => {
             const tool = makeMockTool({
                 _meta: { ui: { resourceUri: 'ui://posthog/mock-app.html' } },
                 handler: async () => ({
                     results: [{ data: [1, 2, 3], count: 6 }],
                     _posthogUrl: 'http://localhost:8010/insights/new#q=...',
-                    [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
                 }),
             })
             const exec = createExec([tool], 'posthog-code')
             const result = (await exec.handler(mockContext, { command: 'call mock-tool' })) as {
                 content: { type: string; text: string }[]
                 structuredContent?: Record<string, unknown>
-                _meta: { ui: { resourceUri: string }; [key: string]: unknown }
+                _meta: { [key: string]: unknown }
             }
 
-            // Model sees ONLY the compact table, not the raw results JSON.
-            expect(result.content[0]!.text).toBe('Date|count\n2026-05-07|6')
-            // Top-level structuredContent is dropped so coding agents don't surface it.
+            // Without a compact table the model reads TOON text, never verbose structuredContent.
             expect(result.structuredContent).toBeUndefined()
-            // The UI app's data (with analytics) rides on _meta instead.
-            const appData = result._meta[APP_DATA_META_KEY] as {
-                results: unknown
-                _analytics: { distinctId: string; toolName: string }
-            }
+            expect(result.content[0]!.text).toContain('_posthogUrl')
+            const appData = result._meta[APP_DATA_META_KEY] as { results: unknown }
             expect(appData.results).toEqual([{ data: [1, 2, 3], count: 6 }])
-            expect(appData._analytics).toEqual({ distinctId: 'test-distinct-id', toolName: 'mock-tool' })
-            expect(result._meta.ui.resourceUri).toBe('ui://posthog/mock-app.html')
         })
 
         // posthog_ai is sent as its own consumer for attribution but is NOT a UI-apps host.

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -508,6 +508,63 @@ describe('exec tool', () => {
         })
     })
 
+    describe('output_format suppression', () => {
+        // Mirrors the generated query wrappers / insight-query: `output_format`
+        // toggles whether the handler surfaces the server-side formatted table.
+        function makeFormatterTool(received: Record<string, unknown>[]): Tool<ZodObjectAny> {
+            return makeMockTool({
+                schema: z.object({
+                    series: z.string().optional().describe('Query series'),
+                    output_format: z.enum(['optimized', 'json']).default('optimized').optional(),
+                }),
+                handler: async (_ctx, params) => {
+                    received.push(params as Record<string, unknown>)
+                    const optimized = (params as { output_format?: string }).output_format !== 'json'
+                    return {
+                        results: [{ count: 6 }],
+                        ...(optimized ? { [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6' } : {}),
+                    }
+                },
+            })
+        }
+
+        it.each(['info mock-tool', 'schema mock-tool'])(
+            'hides output_format from the schema rendered by "%s"',
+            async (command) => {
+                const exec = createExec([makeFormatterTool([])])
+                const result = (await exec.handler(mockContext, { command })) as string
+                expect(result).toContain('series')
+                expect(result).not.toContain('output_format')
+            }
+        )
+
+        it('returns raw JSON when output_format:"json" is passed in the call input', async () => {
+            const exec = createExec([makeFormatterTool([])])
+            const result = (await exec.handler(mockContext, {
+                command: 'call mock-tool {"output_format":"json"}',
+            })) as string
+            const parsed = JSON.parse(result)
+            expect(parsed.results).toEqual([{ count: 6 }])
+            expect(parsed[POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]).toBeUndefined()
+        })
+
+        it('folds --json into the dispatched output_format so the handler skips the formatter', async () => {
+            const received: Record<string, unknown>[] = []
+            const exec = createExec([makeFormatterTool(received)])
+            const result = (await exec.handler(mockContext, { command: 'call --json mock-tool' })) as string
+            expect(received[0]!.output_format).toBe('json')
+            expect(JSON.parse(result).results).toEqual([{ count: 6 }])
+        })
+
+        it('still dispatches the schema default "optimized" so the formatted table wins by default', async () => {
+            const received: Record<string, unknown>[] = []
+            const exec = createExec([makeFormatterTool(received)])
+            const result = await exec.handler(mockContext, { command: 'call mock-tool' })
+            expect(received[0]!.output_format).toBe('optimized')
+            expect(result).toBe('Date|count\n2026-05-07|6')
+        })
+    })
+
     describe('info command', () => {
         it('returns YAML for the top shape with the input schema embedded as JSON', async () => {
             const tool = makeMockTool({ schema: z.object({ name: z.string().describe('Person name') }) })


### PR DESCRIPTION
## Problem

Regression that PostHog Code and Claude Code/Cowork have started to receive structuredContent back – they must receive the text content for better insight analysis. Agents can explicitly retrieve json-friendly results.

Also fixed here: in CLI/single-exec mode, query tools advertised an `output_format: 'optimized' | 'json'` input, but passing `output_format: "json"` made the handler skip the server-side formatter only for the exec `call` path to TOON-encode the raw result anyway — the agent asked for JSON and got TOON. The `call --json` flag is the escape hatch that actually works, and the exec instructions already steer agents to it.

## Changes

### Suppress `structuredContent` for inline-exec UI-app hosts

Suppress `structuredContent` toward the model for inline-exec UI-app hosts and re-home the UI app's data onto `_meta` instead. `_meta` is host- and app-only and is never surfaced to the model, so the model reads the compact table (or the TOON text when there's no formatted table) while the chart keeps its data.

- `client-detection.ts`: add `isInlineExecUiHost()` (matches the `ClaudeCode` / `Cowork` vendor clients).
- `exec.ts`: the UI-app branch now fires for PostHog Code plus any client flagged `isInlineExecUiHost`, and passes `forceUiDataToMeta: true`.
- `build-tool-result.ts`: `forceUiDataToMeta` always drops top-level `structuredContent` and routes the app payload to `_meta` under a new `APP_DATA_META_KEY`, independent of whether a formatted override exists. An explicit `output_format=json` still overrides.
- `useToolResult.ts`: the UI app hydrates from the `_meta` fallback when `structuredContent` is absent.
- `tool-executor.ts`: pass `isInlineExecUiHost` from the client profile into `createExecTool`.

Non-UI tools and the full-tools (non-exec) path are unchanged.

### Remove `output_format` from tool schemas in exec mode

Exec mode now owns output encoding through `--json` exclusively (`exec.ts`):

- `info` and `schema` strip `output_format` from every rendered tool schema.
- `call` pops a stray `output_format` from the input and honors `"json"` as `--json`, instead of silently TOON-encoding unformatted results.
- When JSON output is requested and the tool's schema declares the field, `call` injects `output_format: "json"` into the dispatched params — formatter-toggle tools (the `query-*` wrappers, `insight-query`) skip the server-side formatter so `--json` output no longer duplicates the formatted table under `__formatted_results_override`, and `dashboard-insights-run` (where the field is a real backend query param) still returns raw per-insight results via `--json`.

Validation still runs against the original schema, so the `'optimized'` default keeps applying — `insight-query` reads `params.output_format` directly and keeps surfacing the formatted summary by default. Tools-mode (non-CLI clients) is unchanged: those schemas keep `output_format` and `buildToolResultPayload` handles it correctly there.

## How did you test this code?

Automated (all run by me, the agent):
- `vitest run` (full unit suite) — 2068 passed (2034 after the exec-mode change, all green). New/updated cases: `isInlineExecUiHost()` detection for `ClaudeCode` / `Cowork` (and false for `ClaudeAI`, no user-agent fallback); a parameterized exec test asserting PostHog Code, Claude Code, and Cowork all suppress `structuredContent` and re-home data to `_meta` when a formatted override exists; and a no-override case asserting the model gets TOON text with data on `_meta` (never verbose `structuredContent`).
- For the exec-mode `output_format` change: 5 new cases in `tests/unit/exec.test.ts` — `info`/`schema` hide `output_format`; `call` with a stray `output_format:"json"` returns raw JSON (the reported bug); `--json` folds into the dispatched `output_format` so the handler skips the formatter; a plain `call` still dispatches the schema default `'optimized'` so the formatted table wins. Updated the instructions snapshot for the `cli-syntax.md` wording tweak.
- `vitest run --config vitest.hono.config.mts` — 289 passed, 1 skipped (updated the `clientProfile` fixtures with the new method).
- `tsgo --noEmit` — clean (after building the `@posthog/quill` workspace packages).
- `oxlint` / `oxfmt` on the changed files — clean (pre-existing unrelated warnings only).
- End-to-end against the local MCP server: `info query-trends` and `info dashboard-insights-run` no longer show `output_format`; `call query-trends {..., "output_format":"json"}` returns clean raw JSON; the default call still returns the formatted table; `call --json dashboard-insights-run` returns raw per-insight results; `call insight-query` still returns the formatted summary.

New test rationale: no existing test covered inline-exec UI-app hosts + a formatted override, nor the no-override `_meta` routing. The new cases lock in the suppress-plus-`_meta`-rehome behavior so a revert (narrowing the host gate, or dropping `forceUiDataToMeta`) fails. The exec-mode cases lock in schema suppression, the stray-`json` mapping, and the `--json` param injection — each fails if its wiring is removed.

I did not manually exercise a live Claude Code / Cowork / PostHog Code session or render the chart iframe end-to-end. The app-side `_meta` fallback assumes the ext-apps host forwards `_meta` to the app's `ontoolresult` (part of the MCP `CallToolResult` shape); worth a reviewer confirming against the live UI-apps hosts.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy directed this from a Slack thread. It started as a question about why a `query-trends` result came back verbose instead of the optimized variant, then became: suppress structured content for PostHog Code, and then also for Claude Code and Cowork. A follow-up session added the exec-mode `output_format` schema suppression after Georgiy noticed agents passing `output_format:"json"` got TOON back.

Design notes: the first pass suppressed only when a formatted override existed, which would have regressed the no-override case (verbose `structuredContent` leaking to the model) once the branch was extended to Claude Code and Cowork. I generalized to `forceUiDataToMeta` so these hosts never emit top-level `structuredContent` at all — the model always reads text (compact table or TOON), the UI app always hydrates from `_meta`. Claude.ai is deliberately excluded since it renders via `render-ui`, not the inline exec payload. For the `output_format` suppression, Georgiy chose to hide the field for every tool (not just the formatter-toggle ones) with `--json` driving the field internally, which preserves `dashboard-insights-run`'s backend param. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1783443671101729)*
