### PR TITLE
feat(replay-vision): show the daily digest as the scanner page hero

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -22,6 +22,7 @@ import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { quotaBannerState } from '../utils/quotaProjection'
 import { ObservationSearchMaxChat } from './components/ObservationSearchMaxChat'
 import { ScannerConfigReadonly } from './components/ScannerConfigReadonly'
+import { ScannerDigestCard } from './components/ScannerDigestCard'
 import { ScannerObservationsTable } from './components/ScannerObservationsTable'
 import { ScannerOverview } from './components/ScannerOverview'
 import { ScannerQualityTab } from './components/ScannerQualityTab'
@@ -112,6 +113,9 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                         label: 'Observations',
                         content: (
                             <div className="flex flex-col gap-6">
+                                {actionsTabEnabled && (
+                                    <ScannerDigestCard scannerId={scannerId} scannerName={scanner.name || ''} />
+                                )}
                                 <ScannerOverview scannerId={scannerId} />
                                 <div className="flex flex-col gap-2">
                                     <SummarizerMaxChat scannerId={scannerId} />

--- a/products/replay_vision/frontend/replay_scanners/VisionActionRunScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/VisionActionRunScene.tsx
@@ -123,7 +123,10 @@ function VisionActionRunScene(): JSX.Element {
 
             {run.synthesized_markdown ? (
                 <LemonCard hoverEffect={false} className="p-4">
-                    <LemonMarkdown className="text-base">{summaryMarkdown}</LemonMarkdown>
+                    {/* Same untrusted-content guard as the scanner-page digest card. */}
+                    <LemonMarkdown className="text-base" disableImages>
+                        {summaryMarkdown}
+                    </LemonMarkdown>
                 </LemonCard>
             ) : run.status === 'running' ? (
                 <div className="text-muted italic">This run is in progress — check back shortly for the summary.</div>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -124,7 +124,7 @@ export function ScannerDigestCard({
                     <LemonButton
                         type="secondary"
                         size="small"
-                        to={`${urls.replayVision(scannerId)}?tab=actions`}
+                        to={urls.replayVisionActionEdit(digest.id)}
                         data-attr="vision-scanner-digest-edit"
                     >
                         Edit schedule
@@ -168,7 +168,7 @@ export function ScannerDigestCard({
                     <LemonButton
                         size="xsmall"
                         type="secondary"
-                        to={`${urls.replayVision(scannerId)}?tab=actions`}
+                        to={urls.replayVisionActionEdit(digest.id)}
                         data-attr="vision-scanner-digest-slack"
                     >
                         Get this in Slack

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -152,7 +152,10 @@ export function ScannerDigestCard({
                 }
             />
             <div className={expanded ? undefined : 'max-h-60 overflow-hidden'}>
-                <LemonMarkdown className="text-sm">{latestRun.synthesized_markdown}</LemonMarkdown>
+                {/* LLM/replay-derived content: render non-PostHog images as links, not auto-fetched <img>s. */}
+                <LemonMarkdown className="text-sm" disableImages>
+                    {latestRun.synthesized_markdown}
+                </LemonMarkdown>
             </div>
             <div className="flex flex-wrap items-center gap-2 border-t pt-2">
                 <LemonButton

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -1,0 +1,188 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPlus } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { TZLabel } from 'lib/components/TZLabel'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { urls } from 'scenes/urls'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { scannerDigestLogic } from '../scannerDigestLogic'
+
+function EditorGate({ children }: { children: JSX.Element }): JSX.Element {
+    return (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.SessionRecording}
+            minAccessLevel={AccessControlLevel.Editor}
+        >
+            {children}
+        </AccessControlAction>
+    )
+}
+
+function CardShell({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        <div className="border rounded p-4 flex flex-col gap-2" data-attr="vision-scanner-digest-card">
+            {children}
+        </div>
+    )
+}
+
+function CardHeader({ meta }: { meta?: React.ReactNode }): JSX.Element {
+    return (
+        <div className="flex items-baseline justify-between gap-2">
+            <span className="text-sm font-medium">Daily digest</span>
+            {meta && <span className="text-xs text-muted">{meta}</span>}
+        </div>
+    )
+}
+
+// The scanner page's hero: the built-in daily digest. Shows the latest summary when one exists,
+// otherwise the state that gets the user there (turn on / paused / first run pending).
+export function ScannerDigestCard({
+    scannerId,
+    scannerName,
+}: {
+    scannerId: string
+    scannerName: string
+}): JSX.Element | null {
+    const logic = scannerDigestLogic({ scannerId, scannerName })
+    const { digest, latestRun, latestRunLoading, digestCreating, expanded, visionActionsLoading } = useValues(logic)
+    const { createDigest, toggleExpanded, toggleActionEnabled } = useActions(logic)
+
+    if (visionActionsLoading && !digest) {
+        return null
+    }
+
+    if (!digest) {
+        return (
+            <CardShell>
+                <CardHeader />
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-sm text-muted">
+                        Get a daily AI summary of what this scanner finds, right here.
+                    </span>
+                    <EditorGate>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            icon={<IconPlus />}
+                            onClick={createDigest}
+                            loading={digestCreating}
+                            data-attr="vision-scanner-digest-create"
+                        >
+                            Turn on daily digest
+                        </LemonButton>
+                    </EditorGate>
+                </div>
+            </CardShell>
+        )
+    }
+
+    if (!digest.enabled) {
+        return (
+            <CardShell>
+                <CardHeader />
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-sm text-muted">The daily digest is paused.</span>
+                    <EditorGate>
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => toggleActionEnabled(digest.id)}
+                            data-attr="vision-scanner-digest-resume"
+                        >
+                            Resume
+                        </LemonButton>
+                    </EditorGate>
+                </div>
+            </CardShell>
+        )
+    }
+
+    if (!latestRun) {
+        if (latestRunLoading) {
+            return null
+        }
+        return (
+            <CardShell>
+                <CardHeader />
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-sm text-muted">
+                        Nothing summarized yet.
+                        {digest.next_run_at && (
+                            <>
+                                {' '}
+                                The next digest arrives{' '}
+                                <TZLabel time={digest.next_run_at} formatDate="MMM D, YYYY" formatTime="HH:mm" />.
+                            </>
+                        )}
+                    </span>
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        to={urls.replayVisionActionEdit(digest.id)}
+                        data-attr="vision-scanner-digest-edit"
+                    >
+                        Edit schedule
+                    </LemonButton>
+                </div>
+            </CardShell>
+        )
+    }
+
+    const delivers = (digest.delivery_config?.length ?? 0) > 0
+
+    return (
+        <CardShell>
+            <CardHeader
+                meta={
+                    <>
+                        <TZLabel
+                            time={latestRun.scheduled_at ?? latestRun.created_at}
+                            formatDate="MMM D, YYYY"
+                            formatTime="HH:mm"
+                        />
+                        {' · '}
+                        {latestRun.observation_count} observation{latestRun.observation_count === 1 ? '' : 's'}
+                    </>
+                }
+            />
+            <div className={expanded ? undefined : 'max-h-60 overflow-hidden'}>
+                <LemonMarkdown className="text-sm">{latestRun.synthesized_markdown}</LemonMarkdown>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 border-t pt-2">
+                <LemonButton
+                    size="xsmall"
+                    type="tertiary"
+                    onClick={toggleExpanded}
+                    data-attr="vision-scanner-digest-expand"
+                >
+                    {expanded ? 'Show less' : 'Show more'}
+                </LemonButton>
+                <div className="flex-1" />
+                {!delivers && (
+                    <LemonButton
+                        size="xsmall"
+                        type="secondary"
+                        to={urls.replayVisionActionEdit(digest.id)}
+                        data-attr="vision-scanner-digest-slack"
+                    >
+                        Get this in Slack
+                    </LemonButton>
+                )}
+                <LemonButton
+                    size="xsmall"
+                    type="secondary"
+                    to={urls.replayVisionAction(digest.id)}
+                    data-attr="vision-scanner-digest-history"
+                >
+                    View history
+                </LemonButton>
+            </div>
+        </CardShell>
+    )
+}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -124,7 +124,7 @@ export function ScannerDigestCard({
                     <LemonButton
                         type="secondary"
                         size="small"
-                        to={urls.replayVisionActionEdit(digest.id)}
+                        to={`${urls.replayVision(scannerId)}?tab=actions`}
                         data-attr="vision-scanner-digest-edit"
                     >
                         Edit schedule
@@ -168,7 +168,7 @@ export function ScannerDigestCard({
                     <LemonButton
                         size="xsmall"
                         type="secondary"
-                        to={urls.replayVisionActionEdit(digest.id)}
+                        to={`${urls.replayVision(scannerId)}?tab=actions`}
                         data-attr="vision-scanner-digest-slack"
                     >
                         Get this in Slack

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 
 import * as xRayPng from '@posthog/brand/hoggies/png/x-ray'
 import { IconPencil, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonSwitch, LemonTable, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -104,13 +104,16 @@ function VisionActionsTable({ scannerId }: { scannerId: string }): JSX.Element {
             title: 'Name',
             key: 'name',
             render: (_, action) => (
-                <Link
-                    className="font-semibold"
-                    to={urls.replayVisionAction(action.id)}
-                    data-attr="vision-action-view-runs"
-                >
-                    {action.name}
-                </Link>
+                <span className="flex items-center gap-2">
+                    <Link
+                        className="font-semibold"
+                        to={urls.replayVisionAction(action.id)}
+                        data-attr="vision-action-view-runs"
+                    >
+                        {action.name}
+                    </Link>
+                    {action.is_scanner_digest && <LemonTag type="highlight">Default</LemonTag>}
+                </span>
             ),
         },
         {

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
@@ -1,0 +1,107 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import type { VisionActionApi } from '../generated/api.schemas'
+import { scannerDigestLogic } from './scannerDigestLogic'
+
+const DIGEST = {
+    id: 'd1',
+    name: 'Daily digest: my-scanner',
+    scanner: 's1',
+    enabled: true,
+    is_scanner_digest: true,
+    trigger_config: { rrule: 'FREQ=DAILY;BYHOUR=8;BYMINUTE=0', timezone: 'UTC' },
+    delivery_config: [],
+} as unknown as VisionActionApi
+
+const OTHER_SUMMARY = {
+    id: 'a1',
+    name: 'slack summary',
+    scanner: 's1',
+    enabled: true,
+    is_scanner_digest: false,
+    trigger_config: { rrule: 'FREQ=DAILY' },
+    delivery_config: [],
+} as unknown as VisionActionApi
+
+const RUNS = [
+    { id: 'r-skip', status: 'skipped', scheduled_at: '2026-01-02T08:00:00Z', observation_count: 0 },
+    { id: 'r-done', status: 'completed', scheduled_at: '2026-01-01T08:00:00Z', observation_count: 4 },
+]
+
+describe('scannerDigestLogic', () => {
+    let logic: ReturnType<typeof scannerDigestLogic.build>
+
+    const mocksFor = (actions: VisionActionApi[]): Parameters<typeof useMocks>[0] => ({
+        get: {
+            '/api/projects/:team/vision/actions/': { results: actions, count: actions.length },
+            '/api/projects/:team/vision/actions/:action/runs/': { results: RUNS, count: RUNS.length },
+            '/api/projects/:team/vision/actions/:action/runs/:run/': {
+                ...RUNS[1],
+                synthesized_markdown: '## What happened\nUsers struggled with checkout.',
+            },
+        },
+        post: {
+            '/api/projects/:team/vision/actions/': () => [201, { ...DIGEST, id: 'd-new' }],
+        },
+    })
+
+    const mountLogic = (): void => {
+        initKeaTests()
+        logic = scannerDigestLogic({ scannerId: 's1', scannerName: 'my-scanner' })
+        logic.mount()
+    }
+
+    afterEach(() => logic.unmount())
+
+    it('picks the digest among the scanner summaries and loads its newest completed run', async () => {
+        // The lookback must skip non-completed runs (they carry no report) and a non-digest summary
+        // must never claim the hero card.
+        useMocks(mocksFor([OTHER_SUMMARY, DIGEST]))
+        mountLogic()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.digest?.id).toEqual('d1')
+        expect(logic.values.latestRun?.id).toEqual('r-done')
+        expect(logic.values.latestRun?.synthesized_markdown).toContain('checkout')
+        expect(logic.values.latestRunLoading).toEqual(false)
+    })
+
+    it('settles into the opt-in state when the scanner has no digest', async () => {
+        useMocks(mocksFor([OTHER_SUMMARY]))
+        mountLogic()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.digest).toBeNull()
+        expect(logic.values.latestRun).toBeNull()
+        // Stuck-true here means the card renders nothing instead of the "turn on" entrypoint.
+        expect(logic.values.latestRunLoading).toEqual(false)
+    })
+
+    it('one-click create sends the digest marker and defaults, then reloads the list', async () => {
+        useMocks(mocksFor([]))
+        mountLogic()
+        await expectLogic(logic).toFinishAllListeners()
+        let body: any = null
+        useMocks({
+            post: {
+                '/api/projects/:team/vision/actions/': async ({ request }) => {
+                    body = await request.json()
+                    return [201, { ...DIGEST, id: 'd-new' }]
+                },
+            },
+        })
+        await expectLogic(logic, () => {
+            logic.actions.createDigest()
+        })
+            .toDispatchActions(['createDigestSuccess', 'loadActions'])
+            .toFinishAllListeners()
+        expect(body).toMatchObject({
+            name: 'Daily digest: my-scanner',
+            scanner: 's1',
+            is_scanner_digest: true,
+            trigger_config: { rrule: 'FREQ=DAILY;BYHOUR=8;BYMINUTE=0' },
+            delivery_config: [],
+        })
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
@@ -1,0 +1,161 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { visionActionsCreate, visionActionsRunsList, visionActionsRunsRetrieve } from '../generated/api'
+import { VisionActionRunStatusEnumApi } from '../generated/api.schemas'
+import type { VisionActionApi, VisionActionRunApi } from '../generated/api.schemas'
+import type { scannerDigestLogicType } from './scannerDigestLogicType'
+import { visionActionsLogic } from './visionActionsLogic'
+
+export interface ScannerDigestLogicProps {
+    scannerId: string
+    scannerName: string
+}
+
+// Mirrors the backend default (digest.py); every morning at 8:00 in the team's timezone.
+export const SCANNER_DIGEST_RRULE = 'FREQ=DAILY;BYHOUR=8;BYMINUTE=0'
+
+// How many recent runs to scan for the newest completed one (skipped/failed runs don't carry a summary).
+const RUN_LOOKBACK = 10
+
+export const scannerDigestLogic = kea<scannerDigestLogicType>([
+    path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'scannerDigestLogic']),
+    props({} as ScannerDigestLogicProps),
+    key((props) => props.scannerId),
+
+    connect((props: ScannerDigestLogicProps) => ({
+        values: [visionActionsLogic({ scannerId: props.scannerId }), ['visionActions', 'visionActionsLoading']],
+        actions: [
+            visionActionsLogic({ scannerId: props.scannerId }),
+            ['loadActions', 'loadActionsSuccess', 'toggleActionEnabled'],
+        ],
+    })),
+
+    actions({
+        loadLatestRun: true,
+        loadLatestRunSuccess: (run: VisionActionRunApi | null) => ({ run }),
+        loadLatestRunFailure: true,
+        createDigest: true,
+        createDigestSuccess: true,
+        createDigestFailure: true,
+        toggleExpanded: true,
+    }),
+
+    reducers({
+        // The digest's newest completed run; kept while a refresh is in flight so the card doesn't flash.
+        latestRun: [
+            null as VisionActionRunApi | null,
+            {
+                loadLatestRunSuccess: (_, { run }) => run,
+            },
+        ],
+        latestRunLoading: [
+            true,
+            {
+                loadLatestRun: () => true,
+                loadLatestRunSuccess: () => false,
+                loadLatestRunFailure: () => false,
+            },
+        ],
+        digestCreating: [
+            false,
+            {
+                createDigest: () => true,
+                createDigestSuccess: () => false,
+                createDigestFailure: () => false,
+            },
+        ],
+        expanded: [
+            false,
+            {
+                toggleExpanded: (state) => !state,
+            },
+        ],
+    }),
+
+    selectors({
+        digest: [
+            (s) => [s.visionActions],
+            (visionActions: VisionActionApi[]): VisionActionApi | null =>
+                visionActions.find((a) => a.is_scanner_digest) ?? null,
+        ],
+    }),
+
+    listeners(({ actions, props, values }) => ({
+        loadActionsSuccess: () => {
+            if (values.digest) {
+                actions.loadLatestRun()
+            } else {
+                // No digest → nothing to fetch; clear the initial loading state so the opt-in card shows.
+                actions.loadLatestRunSuccess(null)
+            }
+        },
+
+        loadLatestRun: async (_, breakpoint) => {
+            const teamId = teamLogic.values.currentTeamId
+            const digest = values.digest
+            if (!teamId || !digest) {
+                actions.loadLatestRunFailure()
+                return
+            }
+            try {
+                const page = await visionActionsRunsList(String(teamId), digest.id, { limit: RUN_LOOKBACK })
+                breakpoint()
+                const completed = (page.results ?? []).find((r) => r.status === VisionActionRunStatusEnumApi.Completed)
+                if (!completed) {
+                    actions.loadLatestRunSuccess(null)
+                    return
+                }
+                // The run list is deliberately light (no report body); fetch the full run for the markdown.
+                const run = await visionActionsRunsRetrieve(String(teamId), digest.id, completed.id)
+                breakpoint()
+                actions.loadLatestRunSuccess(run)
+            } catch {
+                // Silent: the card falls back to the "first digest is on its way" state.
+                actions.loadLatestRunFailure()
+            }
+        },
+
+        createDigest: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                actions.createDigestFailure()
+                return
+            }
+            try {
+                await visionActionsCreate(String(teamId), {
+                    // Mirrors the backend provisioning defaults (digest.py) for scanners created before
+                    // digests existed, or after the digest was deleted.
+                    name: `Daily digest: ${props.scannerName}`.slice(0, 255),
+                    scanner: props.scannerId,
+                    is_scanner_digest: true,
+                    trigger_config: {
+                        rrule: SCANNER_DIGEST_RRULE,
+                        timezone: teamLogic.values.currentTeam?.timezone || 'UTC',
+                    },
+                    delivery_config: [],
+                })
+                actions.createDigestSuccess()
+                lemonToast.success('Daily digest turned on')
+                actions.loadActions()
+            } catch (error: any) {
+                actions.createDigestFailure()
+                lemonToast.error(`Couldn't turn on the daily digest${error?.detail ? `: ${error.detail}` : ''}`)
+            }
+        },
+    })),
+
+    afterMount(({ actions, values }) => {
+        // visionActionsLogic loads on its own mount; if it already settled (tab was visited first),
+        // loadActionsSuccess won't fire again, so resolve the card state here.
+        if (!values.visionActionsLoading) {
+            if (values.digest) {
+                actions.loadLatestRun()
+            } else {
+                actions.loadLatestRunSuccess(null)
+            }
+        }
+    }),
+])


### PR DESCRIPTION
## Problem

The daily digest (#69051) needs a home. The scanner page should lead with the AI narrative, not hide it behind a tab.

Stacked on #69051 (digest backend) only. Management links point at the summaries tab for now; a follow-up deep-links the editor page once #68817 lands.

## Changes

- New `ScannerDigestCard` at the top of the Observations tab, styled like the overview chart cards. States:
  - **Latest summary** (hero): the digest's newest completed run rendered as markdown with show more/less, run date + observation count, "View history", and a "Get this in Slack" upsell that deep-links into the digest editor (hidden once delivery is configured).
  - **First run pending**: "Nothing summarized yet, the next digest arrives {next_run_at}" + edit schedule.
  - **Paused**: resume button (digest disabled).
  - **No digest** (pre-digest scanners, or deleted): one-click "Turn on daily digest" that recreates it with the backend defaults.
- New `scannerDigestLogic` (keyed per scanner): finds the digest among the scanner's summaries, walks recent runs for the newest completed one, fetches its full report, and owns the one-click create.
- Digest rows get a "Default" tag in the summaries and alerts tab.
- Replaces the earlier above-the-tabs setup banner from this PR's first revision.

## How did you test this code?

- `scannerDigestLogic.test.ts`: digest selection among mixed summaries + newest-completed-run resolution (skipped runs carry no report and must be passed over); opt-in state settles when no digest exists (a stuck loading flag would blank the card); one-click create sends `is_scanner_digest` + backend-matching defaults and reloads the list.
- Not manually tested by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — behind the `replay-vision-actions` internal flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), directed by Kim. Skills invoked: /writing-kea-logics, /writing-tests, /adopting-generated-api-types. This PR was originally a static "set up a summary" banner above the tabs; Kim redirected it to a first-class hero card inside the Observations tab backed by the default digest, so the commit was amended rather than stacked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


