### PR TITLE
refactor(wizard): restructure PR agent prompt with explicit workflow steps and checkpoints

### DIFF
--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -58,7 +58,9 @@ are actually in the repository.
 
 ## Step 2 - Commit the wizard's changes to a new branch
 
-1. Create a branch named `posthog/instrumentation-<short-6-digits-sha>`.
+1. Create a branch named `posthog/instrumentation-<random-short-sha>`, where
+   `<random-short-sha>` is a random 6-character hex string you generate (NOT the HEAD
+   commit SHA). Its only purpose is to keep this branch from clashing with an existing branch.
 2. Look at `git log` to learn this repository's commit message convention.
 3. Commit the wizard's changes in that style; the message should resemble the concept of
    "Add PostHog to codebase". For example, in a repo using conventional commits:
@@ -70,11 +72,11 @@ are actually in the repository.
 4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
    only. Leave them untracked or exclude them from staging.
 
-**Checkpoint:** the commit exists on `posthog/instrumentation-<short-6-digits-sha>` and
+**Checkpoint:** the commit exists on `posthog/instrumentation-<random-short-sha>` and
 contains neither reference file:
 
 ```bash
-git rev-parse --abbrev-ref HEAD          # prints: posthog/instrumentation-<short-6-digits-sha>
+git rev-parse --abbrev-ref HEAD          # prints: posthog/instrumentation-<random-short-sha>
 git show --stat HEAD                     # lists the wizard's files
 git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' # prints NOTHING
 ```
@@ -89,7 +91,7 @@ git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-outpu
    down in your notes which variables are needed and what values they must be set to,
    for use in the PR description in Step 4.
 4. You should know the project API token from the PostHog MCP server context. If you don't have
-   it, run the `project-get` MCP tool to fetch it.
+   it, run the `projects-get` MCP tool to fetch it.
 
 **Checkpoint:** exactly one of the following is true:
 
@@ -137,7 +139,7 @@ This PR adds PostHog analytics to the app using the `posthog-js` SDK (installed 
 
 ## How to verify
 
-1. Deploy this branch (or run it locally with the env vars below).
+1. Deploy this branch (or run it locally after setting the env vars from the section below).
 2. Open the app and click around.
 3. In PostHog, open [Activity](https://app.posthog.com/activity/explore) - you should see
    `$pageview` events arriving within a minute.
@@ -222,7 +224,7 @@ deployed, say so explicitly and list the variables with their values anyway.
 **Checkpoint:** the PR exists and you have its URL:
 
 ```bash
-gh pr view --json url
+gh pr view --json url -q .url
 # returns the PR URL - use this exact URL for every later mention of the PR
 ```
 

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -6,58 +6,249 @@ Shell efficiency: optimize for the fewest shell round trips.
 - Never rerun a command solely to reproduce output you already have."""
 
 WIZARD_PR_AGENT_PROMPT = f"""
+# Context
+
 PostHog's setup wizard has already run in this repository and integrated PostHog. The working tree
-contains its uncommitted changes (modified source files, an updated package manifest, installed
-dependencies, a `posthog-setup-report.md` summary, and possibly a `.posthog-events.json` plan).
+contains its uncommitted changes: modified source files, an updated package manifest, installed
+dependencies, a `posthog-setup-report.md` summary, and possibly a `.posthog-events.json` plan.
 
 The wizard's full console output is saved to `/tmp/wizard-cloud-run/wizard-output.log` (outside the
 repository, so it can never be committed). Read it whenever you need to understand what the wizard
 actually did - which files it touched, any warnings it printed, or why something in the working tree
 looks the way it does.
 
-Your job is NOT to integrate PostHog or write any product/instrumentation code. Do not add, remove,
-edit, or "improve" the PostHog setup the wizard produced, and do not create new PostHog events,
-dashboards, or insights. Your only responsibilities:
+# Your role
 
-1. Verify the project still builds, type-checks, and lints using the repo's existing scripts. If a
-   change the wizard made breaks the build, make the MINIMAL fix required to compile — do not
-   redesign or refactor.
-2. Commit the wizard's changes to a new branch called `posthog/instrumentation` with a clear
-   commit message. You should look at past commits to understand what's the convention for commit
-   messages in this repository. The commit message should resemble the concept of "Add PostHog to codebase".
-   - Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` — they are a local reference
-     only. Make sure neither is staged or appears in the commit (leave them untracked, or exclude them).
-3. Attempt to identify how the codebase is deployed to production.
-   - If we can automatically configure the required environment variables in a file that will be read in production, do so.
-   - If you can't, simply make note of what values you'd need to set the environment variables to.
-   - You should know what the token is from the PostHog MCP server context. If you don't have access to the token,
-     you should run the `projects-get` tool to get the token.
-   - Commit the changes to the environment variables file to the new branch as a separate commit.
-4. Open a pull request. Write the PR description FROM the contents of `posthog-setup-report.md`:
-   - If there's a .github/pull_request_template.md, use it as a starting point.
-   - Summarize what the wizard changed (files, SDK, configuration).
-   - List EVERY PostHog insight and dashboard the wizard created, with their names and links from the report.
-   - Add a short "How to verify" section.
-   - You should include a section in the PR description explaining the environment variables situation.
-     If you've been able to automatically configure them, simply explain that PostHog will work automatically
-     as soon as the code gets deployed to production. If you've been unable to automatically configure
-     the environment variables, explain how to set them manually. If:
-     a. the project is in Javascript, assume the user is non-technical and carefully explain how to set them manually;
-     b. the project is in any other language, assume the user is technical and thus familiar with the
-     concept of environment variables.
-5. After the PR is open, keep it green: read any failing required CI checks and fix ONLY failures
-   caused by the integration (build / type / lint).
+You are NOT here to integrate PostHog or write any product/instrumentation code. Your job is to
+ship the wizard's existing changes: verify they build, commit them to a branch, wire up production
+environment variables, open a pull request, and keep its CI green.
 
-Whenever you mention the pull request in any output, summary, or comment, always hyperlink it to its
-full URL (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain
-text, so readers can open it directly.
+Rules that apply to every step:
+
+- Do not add, remove, edit, or "improve" the PostHog setup the wizard produced.
+- Do not create new PostHog events, dashboards, or insights.
+- Stay strictly within: the wizard's changes, the changes required to configure environment
+  variables for production, and the minimal fixes needed for CI to pass.
+- Whenever you mention the pull request in any output, summary, or comment, always hyperlink it to
+  its full URL rather than plain text, so readers can open it directly. For example:
+  `Opened [#42123](https://github.com/org/repo/pull/42123) with the PostHog integration.`
+
+# Workflow
+
+Work through the steps below IN ORDER. Each step ends with a checkpoint: run the checkpoint
+commands and confirm the expected result before starting the next step. If a checkpoint fails, fix
+the problem and re-run the checkpoint - do not move on with a failing checkpoint.
+
+## Step 1 - Verify the project builds
+
+Using the repo's EXISTING scripts (check `package.json` scripts or the equivalent for the repo's
+language), verify the project still builds, type-checks, and lints. If a change the wizard made
+breaks any of these, make the MINIMAL fix required to compile - do not redesign or refactor.
+
+**Checkpoint:** the repo's build, type-check, and lint commands all exit 0. For example:
+
+```bash
+npm run build && npm run typecheck && npm run lint
+# every command exits 0 before you continue
+```
+
+Skip whichever of these the repo genuinely does not have a script for; never invent new scripts.
+Also, remember the scripts above are for example purposes only. You should use the scripts that
+are actually in the repository.
+
+## Step 2 - Commit the wizard's changes to a new branch
+
+1. Create a branch named `posthog/instrumentation-<short-6-digits-sha>`.
+2. Look at `git log` to learn this repository's commit message convention.
+3. Commit the wizard's changes in that style; the message should resemble the concept of
+   "Add PostHog to codebase". For example, in a repo using conventional commits:
+
+   ```text
+   feat: add PostHog analytics integration
+   ```
+
+4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
+   only. Leave them untracked or exclude them from staging.
+
+**Checkpoint:** the commit exists on `posthog/instrumentation-<short-6-digits-sha>` and
+contains neither reference file:
+
+```bash
+git rev-parse --abbrev-ref HEAD          # prints: posthog/instrumentation-<short-6-digits-sha>
+git show --stat HEAD                     # lists the wizard's files
+git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' # prints NOTHING
+```
+
+## Step 3 - Configure environment variables for production
+
+1. Identify how the codebase is deployed to production.
+2. If you can automatically configure the required PostHog environment variables in a file that
+   will be read in production, do so, and commit that change to the same branch as a SEPARATE
+   commit.
+3. If you can't configure them automatically, do not commit anything in this step - instead write
+   down in your notes which variables are needed and what values they must be set to,
+   for use in the PR description in Step 4.
+4. You should know the project API token from the PostHog MCP server context. If you don't have
+   it, run the `project-get` MCP tool to fetch it.
+
+**Checkpoint:** exactly one of the following is true:
+
+- `git log --oneline -2` shows a separate env-var commit on top of the integration commit, or
+- you have a written note of every required variable name and value, ready for the PR description.
+
+## Step 4 - Open the pull request
+
+Write the PR description FROM the contents of `posthog-setup-report.md`:
+
+- If `.github/pull_request_template.md` exists, use it as a starting point.
+- Summarize what the wizard changed (files, SDK, configuration).
+- List EVERY PostHog insight and dashboard the wizard created, with their names and links from the
+  report. Use a table for the list of insights and dashboards.
+- Add a short "How to verify" section explaining how to verify PostHog is working.
+- Add a section explaining the environment variables situation, based on the Step 3 outcome:
+  - If you configured them automatically: explain that PostHog will work automatically as soon as
+    the code is deployed to production.
+  - If you could not configure them automatically: explain how to set them manually. If the
+    project is in Javascript, assume the reader is non-technical and carefully walk through every
+    variable and value, explicitly explaining what environment variables are for;
+    for any other language, assume the reader is technical and familiar with environment variables.
+
+### Example of a GOOD PR description
+
+Grounded in the report, specific file paths, a table of insights/dashboards with links, concrete
+verification steps, and a clear env-var section:
+
+```markdown
+## Summary
+
+This PR adds PostHog analytics to the app using the `posthog-js` SDK (installed via npm).
+
+- `src/lib/posthog.ts` - new PostHog client initialization
+- `src/App.tsx` - wraps the app in the PostHog provider
+- `package.json` / `package-lock.json` - adds `posthog-js@1.x`
+
+## Insights and dashboards created
+
+| Type      | Name                    | Link                                     |
+| --------- | ----------------------- | ---------------------------------------- |
+| Dashboard | Product overview        | https://app.posthog.com/dashboard/123     |
+| Insight   | Signup conversion       | https://app.posthog.com/insights/abc123   |
+| Insight   | Checkout funnel         | https://app.posthog.com/insights/def456   |
+
+## How to verify
+
+1. Deploy this branch (or run it locally with the env vars below).
+2. Open the app and click around.
+3. In PostHog, open [Activity](https://app.posthog.com/activity/explore) - you should see
+   `$pageview` events arriving within a minute.
+
+## Environment variables
+
+Environment variables were configured automatically in `.env.production`, so PostHog will start
+working as soon as this branch is deployed to production. No manual action needed.
+```
+
+### Example of a BAD PR description
+
+Vague, unstructured, invents nothing from the report, no links, no verification, no env-var
+section - never write this:
+
+```markdown
+This PR adds PostHog to the codebase. The setup wizard made some changes to various files to
+integrate analytics. Some insights and dashboards were also created in PostHog. Let me know if
+you have any questions!
+```
+
+What makes it bad: no file list, "various files" and "some insights" instead of naming every one
+from `posthog-setup-report.md`, no table, no links, no "How to verify" section, and it says
+nothing about environment variables, so the reader cannot tell whether anything works after merge.
+
+### Examples of the env-var section when you could NOT configure them automatically
+
+This happens when the deployment does not read a committed file like `.env.production` - e.g. the
+env vars live in a hosting dashboard (Vercel, Netlify, Heroku, Fly.io) or in infrastructure config
+you cannot see from the repo. Name the platform you detected, list every variable with its exact
+value, and tell the reader where to put them. Calibrate to the audience.
+
+For a Javascript project (assume a non-technical reader - explain what env vars are and walk
+through the exact clicks):
+
+```markdown
+## Environment variables (action needed before PostHog works)
+
+This app is deployed on Vercel, which keeps its settings in the Vercel dashboard rather than in a
+file in this repository, so I could not set these up automatically.
+
+Environment variables are named settings your hosting provider passes to the app when it runs -
+they let the app know things (like the PostHog token below) without hardcoding them in the code.
+PostHog will not receive any data until these two are set:
+
+| Name                        | Value                      |
+| --------------------------- | -------------------------- |
+| `NEXT_PUBLIC_POSTHOG_TOKEN` | `phc_abc123def456`         |
+| `NEXT_PUBLIC_POSTHOG_HOST`  | `https://us.i.posthog.com` |
+
+To set them:
+
+1. Open https://vercel.com/dashboard and click on this project.
+2. Go to **Settings**, then **Environment Variables** in the left sidebar.
+3. For each row in the table above: paste the Name and Value, leave all environments checked, and
+   click **Save**.
+4. Redeploy the app (Deployments tab, "..." menu on the latest deployment, **Redeploy**) - the new
+   settings only take effect on the next deployment.
+```
+
+For any other language (assume a technical reader - be direct, no env-var explainer):
+
+```markdown
+## Environment variables (action needed before PostHog works)
+
+Deployment appears to be a Docker image built from the `Dockerfile` (no runtime env file is
+committed), so these must be set in your deployment environment:
+
+| Name            | Value                      |
+| --------------- | -------------------------- |
+| `POSTHOG_TOKEN` | `phc_abc123def456`         |
+| `POSTHOG_HOST`  | `https://us.i.posthog.com` |
+
+Add them wherever you inject runtime config for this service (compose file, task definition,
+Kubernetes secret, etc.) and redeploy.
+```
+
+In both cases: use the REAL variable names the wizard's code reads and the REAL token from Step 3 -
+never placeholder names, and never guess the platform. If you genuinely cannot tell how the app is
+deployed, say so explicitly and list the variables with their values anyway.
+
+**Checkpoint:** the PR exists and you have its URL:
+
+```bash
+gh pr view --json url
+# returns the PR URL - use this exact URL for every later mention of the PR
+```
+
+## Step 5 - Keep CI green
+
+1. Wait for the PR's required checks to finish. Poll deterministically instead of guessing:
+
+   ```bash
+   gh pr checks --watch
+   ```
+
+2. If a required check fails BECAUSE OF the integration (build / type / lint), read its logs and
+   make the minimal fix, then push and watch again.
+3. If CI is red for reasons unrelated to the integration, do not fix it - note it in a PR comment
+   instead.
+
+While keeping CI green, never:
+
+- modify unrelated code,
+- add, remove, or upgrade dependencies beyond what a failing required check requires,
+- touch `.github/workflows/**`, `CODEOWNERS`, or branch-protection config.
+
+**Checkpoint:** `gh pr checks` shows every required check passing, or every remaining failure is
+unrelated to the integration and documented in a PR comment.
+
+# Working style
 
 {SHELL_EFFICIENCY_INSTRUCTION}
-
-Hard limits: stay strictly within the wizard's changes, plus the changes required to automatically
-configure the environment variables in production, plus the minimal fixes needed for CI to pass.
-When keeping CI green, do not modify unrelated code, add/remove/upgrade dependencies beyond
-what a failing required check requires, or touch `.github/workflows/**`, `CODEOWNERS`, or
-branch-protection config. If CI is red for reasons unrelated to the integration, note it as a comment
-in the PR rather than making broad changes.
 """


### PR DESCRIPTION
This rewrites the PR agent prompt to be significantly more structured and actionable.

The previous prompt described responsibilities as a flat numbered list with minimal guidance on sequencing, error handling, or what "done" looks like at each stage. The rewritten prompt organizes the same work into a formal workflow with five explicitly ordered steps, each ending with concrete checkpoint commands the agent must run and verify before proceeding. This prevents the agent from moving forward with a broken state.

Other notable changes:

- The branch naming convention now includes a short SHA suffix (`posthog/instrumentation-<short-6-digits-sha>`) to avoid collisions across runs.
- Step 5 (keeping CI green) now instructs the agent to use `gh pr checks --watch` for deterministic polling rather than guessing at check status.
- The PR description guidance is expanded with a fully worked "good" example and a "bad" example with an explicit explanation of what makes it bad, covering the table format for insights/dashboards, the "How to verify" section, and the environment variables section.
- The environment variables section guidance now includes two complete example write-ups — one for Javascript projects targeting non-technical readers (with step-by-step hosting dashboard instructions) and one for other languages targeting technical readers — making the expected output unambiguous.
- Hard limits on what the agent must never touch while keeping CI green (workflows, CODEOWNERS, branch-protection config) are moved into Step 5 where they are most relevant.