### PR TITLE
chore: guide agents on rich markdown in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,6 +65,12 @@
 - Agent-authored PRs always require human review — do not self-merge or auto-approve.
 - Do NOT claim manual testing you haven't done.
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
+- Use GitHub's rich markdown when it makes review faster, never as decoration:
+  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, before first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
+  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
+  - Collapse long supporting content (test output, logs) in `<details>` blocks.
+  - Use fenced `diff` code blocks for config before/after.
+  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
 - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
 - Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
 - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,7 +66,7 @@
 - Do NOT claim manual testing you haven't done.
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 - Use GitHub's rich markdown when it makes review faster, never as decoration:
-  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, before first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
+  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, with the before diagram first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
   - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
   - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
   - Use fenced `diff` code blocks for config before/after.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,7 +68,7 @@
 - Use GitHub's rich markdown when it makes review faster, never as decoration:
   - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, before first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
   - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
-  - Collapse long supporting content (test output, logs) in `<details>` blocks.
+  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
   - Use fenced `diff` code blocks for config before/after.
   - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
 - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.


### PR DESCRIPTION
## Problem

- Agents underuse GitHub's native markdown rendering in PR descriptions, even where it would make review faster.
- Example of the payoff: the before/after mermaid flowcharts in [gate container workflows on trigger-level paths](https://github.com/PostHog/posthog/pull/68975).

## Changes

- Add a rich-markdown bullet to the agent rules block in the PR template: before/after mermaid flowcharts for flow/topology changes, alerts for risk callouts, `<details>` for long output, `diff` blocks, and code permalinks.
- Guidance is conditional so trivial PRs don't get decorative diagrams (this PR, per its own rule, has none).

## How did you test this code?

- Comment-only template change: the new text lives inside the existing HTML comment, so nothing renders in PR bodies.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Raúl asked whether agents should be steered toward mermaid and other GitHub rendering features; I (Claude via PostHog Code) drafted the template guidance. No skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
