### PR TITLE
fix(max): center capability badges in legacy /ai welcome view

### DIFF
--- a/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInputWithSuggestions.tsx
@@ -73,7 +73,7 @@ export function SidebarQuestionInputWithSuggestions({
             >
                 <h3 className="text-center text-xs font-medium mb-0 text-secondary">{tip}</h3>
                 {showBadges ? (
-                    <div className="flex flex-col gap-6 w-full">
+                    <div className="flex flex-col items-center gap-6 w-full">
                         <CapabilityBadges
                             capabilities={capabilities}
                             selectedKey={selectedCapability}


### PR DESCRIPTION
## Problem

In the legacy chat view on the `/ai` route, the product tiles (capability badges) under the chat input sit left-aligned instead of centered, unlike the new `/ai` view and the `/home` view where they are centered. Raised in [this Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783451557912769?thread_ts=1783451557.912769&cid=C0ACRAMJUAG).

## Changes

`CapabilityBadges` is constrained to `max-w-[500px]` with no `mx-auto`, so it relies on its parent flex column to center it. The `/home` view does this with `items-center` on the wrapper (`HomepageInput.tsx`), but the legacy `/ai` wrapper in `SidebarQuestionInputWithSuggestions.tsx` used `flex flex-col gap-6 w-full` without `items-center`, leaving the badges left-aligned. Added `items-center` to match. The `CapabilitySuggestions` swap area below stays `w-full`, so only the badge row is affected.

## How did you test this code?

Static change only. I (the PostHog Slack app agent) could not run the frontend format/typecheck in this environment (node_modules not installed). The change is a single Tailwind className string mirroring the existing `/home` wrapper pattern, so no automated tests were added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent from a Slack thread. Traced the three homepage-style views (legacy `/ai` `ChatArea`, new `/ai` `EmbeddedRunner`, and `/home` `HomepageInput`), compared how each wraps the shared `CapabilityBadges` component, and found the legacy `/ai` wrapper was missing the `items-center` that the `/home` wrapper uses. One-line className fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783451557912769?thread_ts=1783451557.912769&cid=C0ACRAMJUAG)*
