### PR TITLE
chore(temporal): guard long-running workflow command sequences

### DIFF
--- a/.agents/skills/versioning-temporal-workflows/SKILL.md
+++ b/.agents/skills/versioning-temporal-workflows/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: versioning-temporal-workflows
+description: >
+  Use when editing the body of any `@workflow.defn` class that may have in-flight executions —
+  adding, removing, or reordering `execute_activity` / `start_child_workflow` / timer calls,
+  changing a child workflow id, or restructuring control flow around them. Covers deciding whether
+  `workflow.patched()` gating is required, the patch/deprecate/remove lifecycle, and the
+  fingerprint guard for long-running workflows (external-data-job, CDC). Trigger terms:
+  workflow.patched, NondeterminismError, Temporal versioning, workflow replay, deprecate_patch,
+  workflow_fingerprints.
+---
+
+# Versioning Temporal workflows
+
+Temporal workflows are replayed: whenever a worker picks up an in-flight execution (after a deploy, a worker restart, or an activity completing days later), it re-runs the workflow function from the top against the recorded event history.
+If the code now issues a different command sequence than the history records, replay fails with `NondeterminismError` and the execution wedges in Running — the workflow task retries forever and even cancel requests can't be processed.
+
+This is not hypothetical: on 2026-07-01 two unversioned edits to `ExternalDataJobWorkflow.run` wedged every in-flight external-data-job execution and blocked all scheduled syncs for the affected schemas.
+Long-running workflows are guaranteed to have in-flight executions across every deploy — external-data-job activities run with timeouts up to 1 week plus retries.
+
+## Decide: does this change need `workflow.patched()`?
+
+**Needs gating** (changes the command sequence seen on replay):
+
+- Adding, removing, or reordering `workflow.execute_activity` / `start_activity` / `execute_child_workflow` / `start_child_workflow` calls.
+- Changing which activity function or child workflow a call targets, or a child workflow's `id`.
+- Adding or removing `workflow.sleep` / `asyncio.sleep` (timers) or `continue_as_new`.
+- Moving a command in or out of a conditional whose outcome is the same during replay.
+
+**Safe without gating** (not part of the replayed command sequence):
+
+- Changing activity _input payloads_ (adding a dataclass field — but see the worker-rollout caveat below), timeouts, retry policies, or heartbeat settings.
+- Log lines, comments, metrics, renames of local variables.
+- Changes inside _activities_ — activities are not replayed, only their recorded results are.
+- A brand-new workflow definition (no history exists yet).
+
+Worker-rollout caveat: payload shape changes are replay-safe but not deploy-atomic — old workers may still receive the new payload mid-rollout (see the tuple-vs-dataclass safety net in `external_data_job.py`).
+
+## How to gate a change
+
+```python
+if workflow.patched("my-change-id"):
+    # new command sequence
+    await workflow.execute_activity(new_activity, ...)
+else:
+    # exact command sequence the old code issued
+    await workflow.execute_activity(old_activity, ...)
+```
+
+- Executions started _before_ the deploy replay down the `else` branch (their history has no patch marker); new executions record the marker and take the new path.
+- The patch id must be unique within the workflow; use a short kebab-case description of the change.
+- Purely _additive_ commands still need the gate: `if workflow.patched("add-repartition"): await workflow.execute_activity(maybe_repartition_table_activity, ...)` — with no `else`.
+
+Lifecycle (upstream docs: [Temporal Python versioning](https://docs.temporal.io/develop/python/versioning)):
+
+1. Ship the `workflow.patched("id")` gate.
+2. Once no execution started before step 1 can still be running or replaying (for external-data-job: activity timeout × retries — think weeks, not days), optionally replace the conditional with `workflow.deprecate_patch("id")` + only the new code.
+3. Once no execution from step 2 remains, delete the marker entirely.
+
+Steps 2–3 are cleanup; skipping them is safe, just untidy. Removing a `patched()` call too early is itself a replay-breaking change.
+
+## The fingerprint guard
+
+Long-running workflow files are registered in `posthog/temporal/common/workflow_fingerprints.py` (`REGISTERED_WORKFLOW_FILES`).
+A test (`posthog/temporal/common/test_workflow_fingerprints.py`) extracts each `@workflow.defn` class's source-ordered command sequence and compares it against the committed baseline `workflow_fingerprints.json`.
+Any sequence-affecting edit fails the test until the baseline is regenerated:
+
+```sh
+python posthog/temporal/common/workflow_fingerprints.py
+```
+
+Only regenerate after the change is gated with `workflow.patched()` (or the workflow verifiably has no in-flight executions).
+The baseline diff in your PR shows reviewers exactly what changed in the command sequence.
+
+To enroll another long-running workflow file, add its repo-relative path to `REGISTERED_WORKFLOW_FILES` and regenerate.
+Enroll any workflow whose executions routinely span deploys (currently: external-data-job and CDC; batch exports is a good candidate — coordinate with the owning team before enrolling files you don't own).
+
+## If production is already wedged
+
+An unversioned change already deployed shows up as workflows stuck in Running with `NondeterminismError` in the workflow task failure (Temporal UI), unprocessable cancels, and schedules not producing new runs (buffered behind the stuck one).
+
+- Fastest fix: make replay succeed again — revert the change, or re-ship it behind `workflow.patched()` with the old sequence in the `else` branch. Stuck executions recover on the next workflow task retry; no data is lost.
+- If the old code path is truly gone: `temporal workflow terminate` the stuck executions (they cannot be cancelled) and let the schedule start fresh runs. Terminated syncs restart from their last committed state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,4 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/sending-notifications` — adding notification support
 - `/writing-skills` — creating or updating skills in `.agents/skills/`
 - `/gating-production-deploys` — any workflow that builds and pushes a production image or dispatches a deploy
+- `/versioning-temporal-workflows` — editing the body of an existing `@workflow.defn` class (activity/child-workflow/timer calls added, removed, or reordered)

--- a/posthog/temporal/AGENTS.md
+++ b/posthog/temporal/AGENTS.md
@@ -6,6 +6,10 @@ Pointers, not content. Read the linked docs before changing code or tests in thi
 
 - [Temporal at PostHog](./README.md) — concepts, workflows, activities, the conventions we use, common pitfalls, links to the upstream Temporal SDK docs.
 
+## Changing an existing `@workflow.defn` body
+
+- Adding, removing, or reordering activity/child-workflow/timer calls in a deployed workflow breaks replay for in-flight executions (`NondeterminismError`, execution wedges in Running) unless gated with `workflow.patched()`. Read [Version workflow code that has running executions](./README.md#version-workflow-code-that-has-running-executions) and use the `versioning-temporal-workflows` skill before editing. Long-running workflows are guarded by a fingerprint baseline in [`posthog/temporal/common/workflow_fingerprints.py`](./common/workflow_fingerprints.py).
+
 ## Writing or modifying tests in this tree
 
 - [Testing patterns](./README.md#testing-patterns) — when to use real Worker vs `ActivityEnvironment` vs no harness, why some files need `@pytest.mark.django_db(transaction=True)`, the module-scoped Worker pattern that avoids booting the temporal-test-server per test, the `connection.connect()` monkeypatch escape hatch, and the parametrize-don't-copy-paste rule.

--- a/posthog/temporal/README.md
+++ b/posthog/temporal/README.md
@@ -447,6 +447,23 @@ Moreover, notice that in the workflow every trigger step comes after a check ste
 > [!NOTE]
 > Temporal workers stop polling for new tasks when a shutdown is initiated, and the deployments can configure a timeout for the shutdown, which can give time for all workflows currently running to finish. Configuring this correctly can minimize the disruption caused by triggering new deployments, but it can be hard to find the right timeout that ensures everything has time to finish without waiting forever.
 
+### Version workflow code that has running executions
+
+Once a workflow is in production, changing the body of its `@workflow.defn` class is no longer a regular code change. Temporal replays in-flight executions against the current code — after every deploy, worker restart, or long activity completing — and expects the code to issue the exact command sequence recorded in the execution's history. If your change adds, removes, or reorders `execute_activity` / `start_child_workflow` / timer calls, or changes a child workflow's id, replay fails with `NondeterminismError` and the execution wedges in Running: the workflow task retries forever, and cancel requests can't even be processed. For long-running workflows (data imports, batch exports, CDC), some executions are always in flight, so an ungated change is guaranteed to wedge them — this took down all scheduled external data syncs on 2026-07-01.
+
+Gate such changes with [`workflow.patched()`](https://docs.temporal.io/develop/python/versioning):
+
+```python
+if workflow.patched("my-change-id"):
+    await workflow.execute_activity(new_activity, ...)
+else:
+    await workflow.execute_activity(old_activity, ...)  # what the old code issued, exactly
+```
+
+Old executions replay down the `else` branch; new executions record the patch marker and take the new path. Changes to activity input payloads, timeouts, retry policies, logging, or anything inside an _activity_ do not need gating — only the command sequence matters. See the `versioning-temporal-workflows` skill (`.agents/skills/versioning-temporal-workflows/SKILL.md`) for the decision table, the patch lifecycle (`deprecate_patch` and removal timing), and how to recover if production is already wedged.
+
+Long-running workflows are protected by a command-sequence fingerprint baseline: files registered in `posthog/temporal/common/workflow_fingerprints.py` are checked by `test_workflow_fingerprints.py`, and any sequence-affecting edit fails CI until the baseline is regenerated with `python posthog/temporal/common/workflow_fingerprints.py` — which should only happen once the change is properly gated. If your workflow's executions routinely span deploys, register its file there.
+
 ### Execute workflows
 
 The most straight-forward way to execute a workflow is with the `execute_temporal_workflow` command:

--- a/posthog/temporal/common/test_workflow_fingerprints.py
+++ b/posthog/temporal/common/test_workflow_fingerprints.py
@@ -1,0 +1,120 @@
+import json
+import difflib
+import textwrap
+
+import pytest
+
+from posthog.temporal.common.workflow_fingerprints import (
+    BASELINE_PATH,
+    REGISTERED_WORKFLOW_FILES,
+    REPO_ROOT,
+    compute_registered_fingerprints,
+    extract_fingerprints,
+)
+
+REGENERATE_COMMAND = "python posthog/temporal/common/workflow_fingerprints.py"
+SKILL_POINTER = ".agents/skills/versioning-temporal-workflows/SKILL.md"
+
+
+def test_extractor_captures_command_sequence() -> None:
+    source = textwrap.dedent(
+        """
+        import asyncio
+
+        from temporalio import workflow
+        from temporalio.workflow import start_child_workflow
+
+
+        @workflow.defn(name="my-workflow")
+        class MyWorkflow:
+            @workflow.run
+            async def run(self, inputs):
+                await workflow.execute_activity(first_activity, inputs)
+                if workflow.patched("use-v2-path"):
+                    await workflow.execute_activity(second_activity_v2, inputs)
+                else:
+                    await workflow.execute_activity(second_activity, inputs)
+                await asyncio.sleep(60)
+                await start_child_workflow(workflow="child-by-name", id=f"child-{inputs.job_id}")
+                await workflow.start_child_workflow(ChildWorkflow.run, inputs, id="fixed-id")
+
+
+        class NotAWorkflow:
+            async def run(self):
+                await workflow.execute_activity(ignored_activity)
+        """
+    )
+
+    assert extract_fingerprints(source) == {
+        "my-workflow": [
+            "execute_activity(first_activity)",
+            "patched('use-v2-path')",
+            "execute_activity(second_activity_v2)",
+            "execute_activity(second_activity)",
+            "sleep(60)",
+            "start_child_workflow('child-by-name') id=f'child-{inputs.job_id}'",
+            "start_child_workflow(ChildWorkflow.run) id='fixed-id'",
+        ]
+    }
+
+
+def test_fingerprints_match_committed_baseline() -> None:
+    for relative_path in REGISTERED_WORKFLOW_FILES:
+        assert (REPO_ROOT / relative_path).exists(), (
+            f"{relative_path} is registered in REGISTERED_WORKFLOW_FILES but does not exist. "
+            f"If the file moved, update the registry in posthog/temporal/common/workflow_fingerprints.py "
+            f"and regenerate the baseline with `{REGENERATE_COMMAND}`."
+        )
+
+    computed = compute_registered_fingerprints(REPO_ROOT)
+
+    for relative_path, workflows in computed.items():
+        assert workflows, (
+            f"{relative_path} is registered but no `@workflow.defn` class was found in it — "
+            f"the guard would be vacuous. Update REGISTERED_WORKFLOW_FILES in "
+            f"posthog/temporal/common/workflow_fingerprints.py."
+        )
+
+    baseline = json.loads(BASELINE_PATH.read_text())
+    if computed == baseline:
+        return
+
+    diff_sections: list[str] = []
+    added_patch_marker = False
+    for relative_path in sorted(set(baseline) | set(computed)):
+        baseline_workflows = baseline.get(relative_path, {})
+        computed_workflows = computed.get(relative_path, {})
+        if baseline_workflows == computed_workflows:
+            continue
+        for workflow_name in sorted(set(baseline_workflows) | set(computed_workflows)):
+            old = baseline_workflows.get(workflow_name, [])
+            new = computed_workflows.get(workflow_name, [])
+            if old == new:
+                continue
+            diff = "\n".join(
+                difflib.unified_diff(old, new, fromfile="committed baseline", tofile="your change", lineterm="")
+            )
+            diff_sections.append(f"{relative_path} :: {workflow_name}\n{diff}")
+            added_patch_marker = added_patch_marker or any(
+                line.startswith("patched(") or line.startswith("deprecate_patch(") for line in set(new) - set(old)
+            )
+
+    patch_note = (
+        "New workflow.patched()/deprecate_patch() markers detected — if every changed command path "
+        "is gated by them, this change is safe to land."
+        if added_patch_marker
+        else "No new workflow.patched() marker detected. Unless this workflow has no in-flight executions, "
+        "gate the change before landing it."
+    )
+
+    pytest.fail(
+        "The scheduled-command sequence of a long-running Temporal workflow changed.\n\n"
+        "In-flight executions of these workflows replay their recorded history against the new code; "
+        "a changed command sequence fails replay with NondeterminismError and wedges the execution in "
+        "Running (this blocked all external data syncs on 2026-07-01). Adding, removing, or reordering "
+        "activity/child-workflow/timer calls — or changing a child workflow id — must be gated with "
+        f"workflow.patched(). See {SKILL_POINTER} and posthog/temporal/README.md.\n\n"
+        f"{patch_note}\n\n"
+        f"Once the change is correctly gated (or the workflow is new), regenerate the baseline with:\n"
+        f"    {REGENERATE_COMMAND}\n\n" + "\n\n".join(diff_sections)
+    )

--- a/posthog/temporal/common/workflow_fingerprints.json
+++ b/posthog/temporal/common/workflow_fingerprints.json
@@ -1,0 +1,26 @@
+{
+    "products/warehouse_sources/backend/temporal/data_imports/cdc/workflows.py": {
+        "cdc-extraction": ["execute_activity(cdc_extract_activity)"],
+        "cdc-slot-cleanup": ["execute_activity(cleanup_orphan_slots_activity)"]
+    },
+    "products/warehouse_sources/backend/temporal/data_imports/external_data_job.py": {
+        "external-data-job": [
+            "execute_activity(check_pipeline_version_activity)",
+            "execute_activity(acquire_v3_pipeline_lock_activity)",
+            "execute_activity(create_external_data_job_model_activity)",
+            "execute_activity(check_billing_limits_activity)",
+            "execute_activity(maybe_repartition_table_activity)",
+            "execute_activity(import_data_activity_sync)",
+            "start_child_workflow('dwh-cdp-producer-job') id=f'dwh-cdp-producer-job-{job_id}'",
+            "start_child_workflow('emit-data-import-signals') id=f'emit-data-import-signals-{job_id}'",
+            "start_child_workflow(EnrichTableSemanticsWorkflow.run) id=f'enrich-warehouse-table-semantics-{inputs.external_data_schema_id}'",
+            "start_child_workflow(ComputeTableStatisticsWorkflow.run) id=f'compute-warehouse-table-statistics-{inputs.external_data_schema_id}'",
+            "execute_activity(create_source_templates)",
+            "execute_activity(calculate_table_size_activity)",
+            "start_child_workflow(DuckLakeCopyDataImportsWorkflow.run) id=f'ducklake-copy-data-imports-{inputs.team_id}-{inputs.external_data_schema_id}'",
+            "execute_activity(trigger_schedule_buffer_one_activity)",
+            "execute_activity(update_external_data_job_model)",
+            "execute_activity(release_v3_pipeline_lock_activity)"
+        ]
+    }
+}

--- a/posthog/temporal/common/workflow_fingerprints.py
+++ b/posthog/temporal/common/workflow_fingerprints.py
@@ -1,0 +1,156 @@
+"""Command-sequence fingerprints for long-running Temporal workflow definitions.
+
+Temporal replays a workflow's recorded history against the current code whenever a
+worker picks up an in-flight execution. If the code now issues a different command
+sequence (an activity or child workflow added, removed, or reordered, or a child
+workflow id changed), replay fails with NondeterminismError and the execution wedges
+in Running — unprocessable, retrying forever — unless the change is gated with
+``workflow.patched()``. For workflows that run for days or weeks this is guaranteed
+to hit in-flight executions.
+
+This module extracts, per ``@workflow.defn`` class, the source-ordered sequence of
+command-issuing calls (activities, child workflows, timers) plus ``workflow.patched()``
+/ ``workflow.deprecate_patch()`` markers. ``test_workflow_fingerprints.py`` compares
+the result for each registered file against the committed baseline
+(``workflow_fingerprints.json``), so a replay-breaking edit can't land unnoticed:
+the test fails until the baseline is regenerated, and the failure message walks
+through the ``workflow.patched()`` requirement.
+
+After an intentional, properly gated change, regenerate the baseline with:
+
+    python posthog/temporal/common/workflow_fingerprints.py
+
+To enroll another long-running workflow file, add its repo-relative path to
+``REGISTERED_WORKFLOW_FILES`` and regenerate. See
+``.agents/skills/versioning-temporal-workflows/SKILL.md`` for the full workflow.
+
+Stdlib-only on purpose: it must run as a plain script and stay importable without
+Django or the temporal SDK.
+"""
+
+import ast
+import json
+from pathlib import Path
+
+# Long-running workflows whose in-flight executions span worker deploys. Teams opt
+# their files in here; every `@workflow.defn` class in a registered file is guarded.
+REGISTERED_WORKFLOW_FILES: tuple[str, ...] = (
+    "products/warehouse_sources/backend/temporal/data_imports/external_data_job.py",
+    "products/warehouse_sources/backend/temporal/data_imports/cdc/workflows.py",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_PATH = Path(__file__).resolve().parent / "workflow_fingerprints.json"
+
+# Calls that make the workflow issue a command (or mark a patch point). Matched by
+# attribute or bare name so both `workflow.execute_activity(...)` and directly
+# imported `start_child_workflow(...)` are caught.
+_COMMAND_CALL_NAMES = frozenset(
+    {
+        "execute_activity",
+        "start_activity",
+        "execute_activity_method",
+        "start_activity_method",
+        "execute_local_activity",
+        "start_local_activity",
+        "execute_local_activity_method",
+        "start_local_activity_method",
+        "execute_child_workflow",
+        "start_child_workflow",
+        "sleep",
+        "continue_as_new",
+        "patched",
+        "deprecate_patch",
+    }
+)
+
+_CHILD_WORKFLOW_CALL_NAMES = frozenset({"execute_child_workflow", "start_child_workflow"})
+
+
+def _command_call_name(func: ast.expr) -> str | None:
+    if isinstance(func, ast.Attribute) and func.attr in _COMMAND_CALL_NAMES:
+        return func.attr
+    if isinstance(func, ast.Name) and func.id in _COMMAND_CALL_NAMES:
+        return func.id
+    return None
+
+
+def _call_target(call: ast.Call) -> str:
+    if call.args:
+        return ast.unparse(call.args[0])
+    for keyword in call.keywords:
+        # `start_child_workflow(workflow="...")` / `execute_activity(activity=...)`
+        if keyword.arg in ("workflow", "activity"):
+            return ast.unparse(keyword.value)
+    return ""
+
+
+def _child_workflow_id(call: ast.Call) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == "id":
+            return ast.unparse(keyword.value)
+    return None
+
+
+def _workflow_defn_name(class_def: ast.ClassDef) -> str | None:
+    """Return the workflow name if the class is decorated with `@workflow.defn`, else None."""
+    for decorator in class_def.decorator_list:
+        call = decorator if isinstance(decorator, ast.Call) else None
+        target = call.func if call is not None else decorator
+        is_defn = (isinstance(target, ast.Attribute) and target.attr == "defn") or (
+            isinstance(target, ast.Name) and target.id == "defn"
+        )
+        if not is_defn:
+            continue
+        if call is not None:
+            for keyword in call.keywords:
+                if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+                    return str(keyword.value.value)
+        return class_def.name
+    return None
+
+
+def _fingerprint_class(class_def: ast.ClassDef) -> list[str]:
+    entries: list[tuple[int, int, str]] = []
+    for node in ast.walk(class_def):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _command_call_name(node.func)
+        if name is None:
+            continue
+        entry = f"{name}({_call_target(node)})"
+        if name in _CHILD_WORKFLOW_CALL_NAMES:
+            child_id = _child_workflow_id(node)
+            if child_id is not None:
+                entry += f" id={child_id}"
+        entries.append((node.lineno, node.col_offset, entry))
+    return [entry for _, _, entry in sorted(entries, key=lambda item: (item[0], item[1]))]
+
+
+def extract_fingerprints(source: str) -> dict[str, list[str]]:
+    """Map workflow name -> source-ordered command entries, for every `@workflow.defn` class."""
+    module = ast.parse(source)
+    fingerprints: dict[str, list[str]] = {}
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef):
+            workflow_name = _workflow_defn_name(node)
+            if workflow_name is not None:
+                fingerprints[workflow_name] = _fingerprint_class(node)
+    return fingerprints
+
+
+def compute_registered_fingerprints(repo_root: Path) -> dict[str, dict[str, list[str]]]:
+    return {
+        relative_path: extract_fingerprints((repo_root / relative_path).read_text())
+        for relative_path in REGISTERED_WORKFLOW_FILES
+    }
+
+
+def main() -> None:
+    baseline = compute_registered_fingerprints(REPO_ROOT)
+    BASELINE_PATH.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {BASELINE_PATH.relative_to(REPO_ROOT)}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/products/warehouse_sources/backend/temporal/data_imports/README.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/README.md
@@ -1,5 +1,9 @@
 # Data Stack - Import Pipeline
 
+## Changing the workflows in this directory
+
+`ExternalDataJobWorkflow` and the CDC workflows are long-running: executions are always in flight across deploys (activity timeouts go up to 1 week, plus retries). Any change to their command sequence — adding, removing, or reordering `execute_activity` / `start_child_workflow` calls, or changing a child workflow id — must be gated with `workflow.patched()`, or every in-flight execution wedges in Running with `NondeterminismError` on replay (this blocked all scheduled syncs on 2026-07-01). Use the `versioning-temporal-workflows` skill (`.agents/skills/versioning-temporal-workflows/SKILL.md`). A fingerprint baseline (`posthog/temporal/common/workflow_fingerprints.py`) fails CI on ungated sequence changes; regenerate it with `python posthog/temporal/common/workflow_fingerprints.py` once your change is gated.
+
 ## How to detect a OOM:
 
 In the logs, you'll often see the last operation of the job being a delta merge - such as `Merging partition=...`. Followed by heartbeat logs. There will then be a 2-min gap between the last heartbeat and the start of the next retry, or if its the last attempt, then you'll see a 2-min gap before a `activity Heartbeat timeout` error log. The 2-mins (as of Oct 2025) comes from the current `heartbeat_timeout` set on the `import_data_activity` in the workflow.


### PR DESCRIPTION
## Problem

Editing the body of a deployed `@workflow.defn` class is not a regular code change. Temporal replays in-flight executions against the current code, and if the command sequence changed (an activity or child workflow added, removed, or reordered, or a child workflow id changed) without `workflow.patched()` gating, replay fails with `NondeterminismError`. The execution wedges in Running, the workflow task retries forever, and cancels can't even be processed.

This happened on 2026-07-01: ca876fe4a8f and 4346bf4848c changed `ExternalDataJobWorkflow.run`'s command sequence unversioned, wedging in-flight external data jobs and blocking scheduled syncs for affected schemas. Long-running workflows (external-data-job activities run with up to 1 week timeouts plus retries) always have executions in flight across a deploy, so an ungated change is guaranteed to hit.

Nothing in the repo guarded against this. This PR adds the guardrail, following the automation ladder (lint first, then skill, then docs).

## Changes

**Fingerprint guard (the lint rung).** A semgrep rule can't work here since our devex rules are full-scan pattern matchers and this check is inherently a diff against the previous state. Instead, same pattern as the team-scoping `baseline_unmigrated.txt` check, a committed baseline:

- `posthog/temporal/common/workflow_fingerprints.py` – stdlib-only AST extractor. For each `@workflow.defn` class in a registered file, it records the source-ordered sequence of `execute_activity` / `start_child_workflow` / timer / `continue_as_new` calls, `workflow.patched()` markers, and child workflow `id=` expressions. Handles both attribute calls and the bare-imported `start_child_workflow(workflow="...")` kwarg form used in `external_data_job.py`. Running the file regenerates the baseline.
- `posthog/temporal/common/workflow_fingerprints.json` – the committed baseline. Any sequence-affecting edit shows up as a readable diff of this file in the PR, so reviewers see exactly what changed in the command topology.
- `posthog/temporal/common/test_workflow_fingerprints.py` – fails on any mismatch with a unified diff, whether a new `patched()` marker was detected, the regen command, and a pointer to the skill. Runs in the Temporal CI segment (plain pytest, no DB, ~0.2s).

Registered files are scoped to the data warehouse workflows from the incident: `external-data-job` and the two CDC workflows. Other teams opt in by adding their file to `REGISTERED_WORKFLOW_FILES` and regenerating (batch exports is an obvious candidate, but that's the owning team's call, so I didn't enroll it here).

**Skill.** `.agents/skills/versioning-temporal-workflows/` covers the needs-gating vs safe decision table, the `patched()` / `deprecate_patch()` lifecycle and removal timing, how the guard works, and how to recover when production is already wedged.

**Docs.** New "Version workflow code that has running executions" section in `posthog/temporal/README.md` (the README previously had zero coverage of versioning), pointer sections in `posthog/temporal/AGENTS.md` and the data_imports README, and the skill added to the root AGENTS.md mandatory-skill list.

## How did you test this code?

- `pytest posthog/temporal/common/test_workflow_fingerprints.py` – 2 passed, 0.2s.
- Negative test: replayed the incident shape by changing a child workflow id in `external_data_job.py`. The guard failed with the exact one-line diff, flagged that no new `patched()` marker was present, and printed the remediation instructions. Reverted afterwards.
- The extractor self-test locks the extraction behavior on a synthetic workflow (regression it catches: the extractor silently returning nothing, which would make the baseline check vacuous). The baseline test catches the regression no existing test covers: an ungated command-sequence change to a long-running workflow.
- Verified CI wiring: the Temporal test segment is gated on the backend path filter, which matches `products/**/backend/**/*`, so a PR touching only warehouse workflow files runs the guard.
- `ruff`, `oxfmt`, `hogli lint:skills`, and `hogli ci:preflight` all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Developer-facing docs updated in this PR (`posthog/temporal/README.md`, AGENTS.md files, data_imports README). No posthog.com docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Claude Fable 5) at Daniel's direction. Skills invoked: /writing-skills and /writing-tests. Decisions along the way: a semgrep rule was considered first per the automation ladder but rejected because the devex semgrep jobs are full-repo scans and can't express "sequence changed vs master"; a committed-baseline pytest check was chosen instead because it mirrors an existing repo pattern, runs locally, and needs no CI workflow edits. Enforcement was deliberately scoped to data-warehouse-owned workflows rather than repo-wide, leaving enrollment of other teams' workflows (e.g. batch exports, which already uses `workflow.patched()`) to those teams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
