### PR TITLE
fix(insights): open info panel not max for endpoint-from-insight flow

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -22,6 +22,7 @@ import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import {
     DashboardFilter,
@@ -113,7 +114,10 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             ['filterTestAccountsDefault'],
             featureFlagLogic,
             ['featureFlags'],
+            sceneLayoutLogic,
+            ['scenePanelIsPresent'],
         ],
+        actions: [sceneLayoutLogic, ['setScenePanelIsPresent']],
     })),
     actions({
         setInsightId: (insightId: InsightShortId) => ({ insightId }),
@@ -444,11 +448,19 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
         setSceneState: [
             sharedListeners.reloadInsightLogic,
             ({ sceneSource }) => {
-                if (sceneSource === 'endpoints') {
+                // Only open here when the scene panel already exists; otherwise Info isn't in
+                // `enabledTabs` yet and SidePanel's fallback reroutes to Max. The fresh-navigation
+                // case is handled by the `setScenePanelIsPresent` listener below.
+                if (sceneSource === 'endpoints' && values.scenePanelIsPresent) {
                     sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Info)
                 }
             },
         ],
+        setScenePanelIsPresent: ({ active }) => {
+            if (active && values.sceneSource === 'endpoints') {
+                sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Info)
+            }
+        },
         upgradeQuery: async ({ query }) => {
             let upgradedQuery: Node | null = null
 


### PR DESCRIPTION
## Problem

In the Endpoints product, creating an endpoint from a new insight (New, then Insight-based endpoint, then a type like Trend) sends you to the insight builder. It is supposed to open with the right-side Info panel, because that panel holds the Create endpoint button you use to finish the flow. Instead it opened with the PostHog AI (Max) panel, so the Create endpoint button was nowhere to be seen and the flow looked like a dead end on the insight page.

## Changes

The insight scene already tried to open the Info panel when `sceneSource === 'endpoints'`, but a mount-order race defeated it. The Info tab is only in the side panel's `enabledTabs` once `scenePanelIsPresent` is true, and that flag only flips true in a React effect when `ScenePanel` mounts, which happens after the kea navigation listener runs. So Info was requested before it was available, and `SidePanel`'s fallback rerouted the panel to Max.

The fix (one file, `insightSceneLogic.tsx`) opens Info once the scene panel is actually present instead of racing it: it connects `sceneLayoutLogic`, guards the existing eager open behind `scenePanelIsPresent`, and adds a `setScenePanelIsPresent` listener that opens Info on the fresh-navigation path. It is scoped to `sceneSource === 'endpoints'` only, so no other scene or source is affected.

## How did you test this code?

I (Claude) regenerated the kea typegen and confirmed the new connected value and action are typed correctly, and ran oxlint and oxfmt on the changed file (clean). I did not drive the flow in a browser this session, so the end-to-end check (New, Insight-based endpoint, Trend, confirm the Info panel opens instead of AI) still needs a manual pass against a running dev stack. No automated tests were added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thiago drove this: he spotted that the endpoint-from-insight flow left users stranded on the insight page, and later pinned it down to the side panel opening on PostHog AI instead of Info. I (Claude Code, Opus 4.8) explored the flow with Explore subagents, root-caused the kea/React mount-order race, and implemented the fix.

Considered but rejected: changing `SidePanel`'s global fallback so it does not clobber a pending tab. That touches every scene and risks regressions, so I kept the fix contained to the insight scene by reacting to scene-panel presence. We also scoped this deliberately to just the panel fix rather than auto-opening the Create endpoint modal after save, which stays as a possible follow-up.
