### PR TITLE
feat(dashboards): experiment on subscribe placement

### DIFF
--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -189,6 +189,15 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
 
                 if (updatedSub.id !== props.id) {
                     router.actions.replace(urlForSubscription(updatedSub.id, props))
+                    // props.id === 'new' here, so this is a freshly created subscription — the conversion
+                    // signal for subscribe-placement experiments.
+                    posthog.capture('subscription created', {
+                        resource_type: isAi ? 'ai' : props.dashboardId ? 'dashboard' : 'insight',
+                        dashboard_id: props.dashboardId,
+                        insight_short_id: props.insightShortId,
+                        subscription_id: updatedSub.id,
+                        target_type: updatedSub.target_type,
+                    })
                 }
 
                 // If a subscriptionsLogic for this insight/dashboard is mounted already, refresh both

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -189,8 +189,6 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
 
                 if (updatedSub.id !== props.id) {
                     router.actions.replace(urlForSubscription(updatedSub.id, props))
-                    // props.id === 'new' here, so this is a freshly created subscription — the conversion
-                    // signal for subscribe-placement experiments.
                     posthog.capture('subscription created', {
                         resource_type: isAi ? 'ai' : props.dashboardId ? 'dashboard' : 'insight',
                         dashboard_id: props.dashboardId,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -277,6 +277,7 @@ export const FEATURE_FLAGS = {
     DASHBOARD_INLINE_TILE_INSERTION: 'dashboard-inline-tile-insertion', // owner: @MattPua #team-analytics-platform
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
     DASHBOARD_QUICK_FILTERS_EXPERIMENT: 'dashboard-quick-filters-experiment', // owner: @vdekrijger #team-product-analytics multivariate=control,test
+    DASHBOARD_SUBSCRIBE_PLACEMENT: 'dashboard-subscribe-placement', // owner: @MattPua #team-analytics-platform multivariate=control,button,menu
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
     DASHBOARD_WIDGETS: 'dashboard-widgets', // owner: @mattp #team-analytics-platform
     DASHBOARDS_LIST_VIEW: 'dashboards-list-view', // owner: @vdekrijger #team-product-analytics multivariate=control,tree

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -215,8 +215,8 @@ export function EditModeActions(): JSX.Element {
 
     return (
         <>
-            {layoutEditMode && <DashboardEditSaveCancelButtons />}
             <DashboardSubscribeExperiment placement="button" />
+            {layoutEditMode && <DashboardEditSaveCancelButtons />}
             <DashboardAddTileButton />
             <DashboardSubscribeExperiment placement="menu" />
         </>
@@ -250,6 +250,7 @@ export function ViewModeActions(): JSX.Element {
 
     return (
         <>
+            <DashboardSubscribeExperiment placement="button" />
             <LemonButton
                 type="secondary"
                 data-attr="dashboard-share-button"
@@ -283,7 +284,6 @@ export function ViewModeActions(): JSX.Element {
                     </LemonButton>
                 </Shortcut>
             )}
-            <DashboardSubscribeExperiment placement="button" />
             <DashboardAddTileButton />
             <DashboardSubscribeExperiment placement="menu" />
         </>

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -216,7 +216,9 @@ export function EditModeActions(): JSX.Element {
     return (
         <>
             {layoutEditMode && <DashboardEditSaveCancelButtons />}
+            <DashboardSubscribeExperiment placement="button" />
             <DashboardAddTileButton />
+            <DashboardSubscribeExperiment placement="menu" />
         </>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -19,6 +19,7 @@ import { AccessControlLevel, AccessControlResourceType, DashboardMode } from '~/
 
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
+import { DashboardSubscribeExperiment } from './DashboardSubscribeExperiment'
 
 export function getAddTileMenuItems({
     dashboardId,
@@ -280,7 +281,9 @@ export function ViewModeActions(): JSX.Element {
                     </LemonButton>
                 </Shortcut>
             )}
+            <DashboardSubscribeExperiment placement="button" />
             <DashboardAddTileButton />
+            <DashboardSubscribeExperiment placement="menu" />
         </>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.scss
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.scss
@@ -1,0 +1,36 @@
+.DashboardSubscribeBell {
+    transform-origin: top center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .LemonButton:hover .DashboardSubscribeBell {
+        animation: DashboardSubscribeExperiment__ring 0.7s ease-in-out;
+    }
+}
+
+@keyframes DashboardSubscribeExperiment__ring {
+    0%,
+    100% {
+        transform: rotate(0);
+    }
+
+    15% {
+        transform: rotate(16deg);
+    }
+
+    30% {
+        transform: rotate(-14deg);
+    }
+
+    45% {
+        transform: rotate(10deg);
+    }
+
+    60% {
+        transform: rotate(-6deg);
+    }
+
+    75% {
+        transform: rotate(3deg);
+    }
+}

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -1,3 +1,5 @@
+import './DashboardSubscribeExperiment.scss'
+
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
@@ -24,12 +26,12 @@ function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
     const { subscriptions } = useValues(subscriptionsLogic({ dashboardId }))
 
     if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
-        return <IconBell fontSize="16" />
+        return <IconBell className="DashboardSubscribeBell" fontSize="16" />
     }
 
     return (
         <IconWithCount count={subscriptions?.length} showZero={false}>
-            <IconBell fontSize="16" />
+            <IconBell className="DashboardSubscribeBell" fontSize="16" />
         </IconWithCount>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -24,12 +24,12 @@ function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
     const { subscriptions } = useValues(subscriptionsLogic({ dashboardId }))
 
     if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
-        return <IconBell />
+        return <IconBell fontSize="16" />
     }
 
     return (
         <IconWithCount count={subscriptions?.length} showZero={false}>
-            <IconBell />
+            <IconBell fontSize="16" />
         </IconWithCount>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -21,19 +21,26 @@ import { dashboardLogic } from './dashboardLogic'
 
 type SubscribePlacement = 'button' | 'menu'
 
-function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
-    const { hasAvailableFeature } = useValues(userLogic)
+function SubscribeCountIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
     const { subscriptions } = useValues(subscriptionsLogic({ dashboardId }))
-
-    if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
-        return <IconBell className="DashboardSubscribeBell" fontSize="16" />
-    }
 
     return (
         <IconWithCount count={subscriptions?.length} showZero={false}>
             <IconBell className="DashboardSubscribeBell" fontSize="16" />
         </IconWithCount>
     )
+}
+
+function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
+    const { hasAvailableFeature } = useValues(userLogic)
+
+    // Only read the count when the subscriptions logic is already mounted (e.g. side panel opened),
+    // so an experiment arm never triggers an extra fetch just to render this badge.
+    if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS) || !subscriptionsLogic.isMounted({ dashboardId })) {
+        return <IconBell className="DashboardSubscribeBell" fontSize="16" />
+    }
+
+    return <SubscribeCountIcon dashboardId={dashboardId} />
 }
 
 // Both placements mount in the header; each renders only when it matches the assigned variant.

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -34,11 +34,7 @@ function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
     )
 }
 
-/**
- * A/B tests surfacing dashboard subscriptions outside the side panel. `button` renders an explicit
- * header button; `menu` renders a hamburger menu to the right of Add. Only the slot matching the
- * assigned flag variant renders — the other returns null so both placements can live in the header.
- */
+// Both placements mount in the header; each renders only when it matches the assigned variant.
 export function DashboardSubscribeExperiment({ placement }: { placement: SubscribePlacement }): JSX.Element | null {
     const { dashboard, canEditDashboard } = useValues(dashboardLogic)
     const { push } = useActions(router)

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconBell, IconMenu } from '@posthog/icons'
+import { IconBell, IconList } from '@posthog/icons'
 import { useFeatureFlagVariantKey } from '@posthog/react'
 
 import { subscriptionsLogic } from 'lib/components/Subscriptions/subscriptionsLogic'
@@ -69,7 +69,7 @@ export function DashboardSubscribeExperiment({ placement }: { placement: Subscri
                 <LemonButton
                     type="secondary"
                     size="small"
-                    icon={<IconMenu fontSize="16" />}
+                    icon={<IconList fontSize="16" />}
                     data-attr="dashboard-subscribe-menu"
                     aria-label="More actions"
                 />

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconBell, IconList } from '@posthog/icons'
+import { IconBell, IconEllipsis } from '@posthog/icons'
 import { useFeatureFlagVariantKey } from '@posthog/react'
 
 import { subscriptionsLogic } from 'lib/components/Subscriptions/subscriptionsLogic'
@@ -67,9 +67,9 @@ export function DashboardSubscribeExperiment({ placement }: { placement: Subscri
                 ]}
             >
                 <LemonButton
-                    type="secondary"
+                    type="tertiary"
                     size="small"
-                    icon={<IconList fontSize="16" />}
+                    icon={<IconEllipsis fontSize="16" />}
                     data-attr="dashboard-subscribe-menu"
                     aria-label="More actions"
                 />
@@ -79,7 +79,7 @@ export function DashboardSubscribeExperiment({ placement }: { placement: Subscri
 
     return (
         <LemonButton
-            type="secondary"
+            type="tertiary"
             size="small"
             icon={<SubscribeIcon dashboardId={dashboardId} />}
             data-attr="dashboard-subscribe-prominent-button"

--- a/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSubscribeExperiment.tsx
@@ -1,0 +1,95 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import posthog from 'posthog-js'
+
+import { IconBell, IconMenu } from '@posthog/icons'
+import { useFeatureFlagVariantKey } from '@posthog/react'
+
+import { subscriptionsLogic } from 'lib/components/Subscriptions/subscriptionsLogic'
+import { urlForSubscriptions } from 'lib/components/Subscriptions/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { IconWithCount } from 'lib/lemon-ui/icons/icons'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+import { userLogic } from 'scenes/userLogic'
+
+import { AvailableFeature } from '~/types'
+
+import { dashboardLogic } from './dashboardLogic'
+
+type SubscribePlacement = 'button' | 'menu'
+
+function SubscribeIcon({ dashboardId }: { dashboardId: number }): JSX.Element {
+    const { hasAvailableFeature } = useValues(userLogic)
+    const { subscriptions } = useValues(subscriptionsLogic({ dashboardId }))
+
+    if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
+        return <IconBell />
+    }
+
+    return (
+        <IconWithCount count={subscriptions?.length} showZero={false}>
+            <IconBell />
+        </IconWithCount>
+    )
+}
+
+/**
+ * A/B tests surfacing dashboard subscriptions outside the side panel. `button` renders an explicit
+ * header button; `menu` renders a hamburger menu to the right of Add. Only the slot matching the
+ * assigned flag variant renders — the other returns null so both placements can live in the header.
+ */
+export function DashboardSubscribeExperiment({ placement }: { placement: SubscribePlacement }): JSX.Element | null {
+    const { dashboard, canEditDashboard } = useValues(dashboardLogic)
+    const { push } = useActions(router)
+    const variant = useFeatureFlagVariantKey(FEATURE_FLAGS.DASHBOARD_SUBSCRIBE_PLACEMENT)
+
+    if (!dashboard || !canEditDashboard || variant !== placement) {
+        return null
+    }
+
+    const dashboardId = dashboard.id
+    const openSubscriptions = (): void => {
+        posthog.capture('dashboard subscribe clicked', {
+            dashboard_id: dashboardId,
+            variant,
+            surface: placement,
+        })
+        push(urlForSubscriptions({ dashboardId }))
+    }
+
+    if (placement === 'menu') {
+        return (
+            <LemonMenu
+                items={[
+                    {
+                        label: 'Subscribe',
+                        icon: <SubscribeIcon dashboardId={dashboardId} />,
+                        onClick: openSubscriptions,
+                        'data-attr': 'dashboard-subscribe-menu-item',
+                    },
+                ]}
+            >
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    icon={<IconMenu fontSize="16" />}
+                    data-attr="dashboard-subscribe-menu"
+                    aria-label="More actions"
+                />
+            </LemonMenu>
+        )
+    }
+
+    return (
+        <LemonButton
+            type="secondary"
+            size="small"
+            icon={<SubscribeIcon dashboardId={dashboardId} />}
+            data-attr="dashboard-subscribe-prominent-button"
+            onClick={openSubscriptions}
+        >
+            Subscribe
+        </LemonButton>
+    )
+}


### PR DESCRIPTION
## Problem

Dashboard subscriptions live only in the side panel, which is easy to miss. We want to know whether pulling subscribe out into a more visible spot in the header drives more people to actually subscribe.

This mirrors the [insight subscribe prominent button experiment](https://us.posthog.com/project/2/feature_flags), which shipped after the prominent placement won.

## Changes



A/B test behind the multivariate flag `dashboard-subscribe-placement` with three arms:

- **control** - nothing new, subscribe stays in the side panel only (baseline)
- **button** - explicit Subscribe button grouped with Share / Edit layout
<img width="2596" height="858" alt="CleanShot 2026-07-07 at 16 26 58@2x" src="https://github.com/user-attachments/assets/edbb03b7-bed8-4ce1-aced-5af8c89b1867" />


- **menu** - hamburger menu to the right of Add, containing only Subscribe for now
<img width="2606" height="518" alt="CleanShot 2026-07-07 at 16 27 42@2x" src="https://github.com/user-attachments/assets/064867a8-fb62-4e44-9471-b14778c8516b" />

The side panel and scene menu bar entries stay in all arms, so this is purely additive on top of today's behavior.

Instrumentation:

- `dashboard subscribe clicked` fires on either new surface with `{ dashboard_id, variant, surface }` (secondary metric, click-through)
- `subscription created` fires on any new subscription with `{ resource_type, dashboard_id, insight_short_id, ... }` (goal metric). There was no create event before, so this also benefits the insight experiment surface.

New surfaces are gated on `canEditDashboard` to match where the baseline side-panel entry shows, keeping the exposed populations comparable across arms.

Experiment created in draft (not launched): [Dashboard subscribe placement](https://us.posthog.com/project/2/experiments/381582).

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` passes
- oxlint + oxfmt clean on changed files
- No automated tests added: this is a small presentational A/B surface reading a flag variant, with the real signal being the two capture events measured by the experiment. I (Claude) did not manually exercise the three variants in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt directed this; I (Claude) implemented it. I explored the existing insight subscribe experiment (`INSIGHT_SUBSCRIBE_PROMINENT_BUTTON`) to mirror its pattern, then built the dashboard equivalent.

Skills invoked: `/scene-menu-bar` (to confirm the side-panel / scene-menu-bar subscribe entries and the dual-write rule).

Decisions:
- Went with 3 arms (control + button + menu) so both ideas are measured against today's baseline, rather than just head-to-head.
- Kept the side-panel entry in all arms (additive) rather than removing it in the test arms, to lower risk and match how the insight experiment was run.
- Added a reusable `subscription created` event rather than a dashboard-only one, since no create event existed and the insight surface benefits too.
- Used `IconMenu` (hamburger) for the menu variant per the request, though `IconEllipsis` is the more conventional overflow affordance.

The feature flag and experiment were created in PostHog project 2 via MCP and left in draft. `allow_unknown_events` was set when attaching metrics because both events are brand new instrumentation shipping in this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
