### PR TITLE
fix(data-warehouse): match managed sources by display label in search

### DIFF
--- a/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
@@ -6,6 +6,7 @@ import posthog from 'posthog-js'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { createFuse, Fuse } from 'lib/utils/fuseSearch'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 
 import { DatabaseSchemaDataWarehouseTable } from '~/queries/schema/schema-general'
@@ -17,6 +18,7 @@ import {
     ExternalDataSourceSchema,
 } from '~/types'
 
+import { availableSourcesLogic } from '../../scenes/NewSourceScene/availableSourcesLogic'
 import { joinsLogic } from './joinsLogic'
 import type { sourceManagementLogicType } from './sourceManagementLogicType'
 import { sourcesDataLogic } from './sourcesDataLogic'
@@ -31,6 +33,8 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
             ['database', 'dataWarehouseTables'],
             sourcesDataLogic,
             ['dataWarehouseSources', 'dataWarehouseSourcesLoading'],
+            availableSourcesLogic,
+            ['availableSources'],
         ],
         actions: [
             databaseTableListLogic,
@@ -146,22 +150,38 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
                 return selfManagedTables.filter((table) => table.name.toLowerCase().includes(normalizedSearch))
             },
         ],
-        filteredManagedSources: [
-            (s) => [s.dataWarehouseSources, s.managedSearchTerm],
-            (dataWarehouseSources, managedSearchTerm): ExternalDataSource[] => {
-                const sources = (dataWarehouseSources?.results ?? []).filter(
+        managedSources: [
+            (s) => [s.dataWarehouseSources],
+            (dataWarehouseSources): ExternalDataSource[] =>
+                (dataWarehouseSources?.results ?? []).filter(
                     (source) => source.access_method?.toLowerCase() !== 'direct'
-                )
-                if (!managedSearchTerm?.trim()) {
-                    return sources
+                ),
+        ],
+        // Match the display label ("Google Ads") as well as the internal source_type ("GoogleAds"),
+        // so a search with the label's spacing/casing finds the source. Fuzzy, like the source catalog.
+        managedSourcesFuse: [
+            (s) => [s.managedSources, s.availableSources],
+            (managedSources, availableSources): Fuse<ExternalDataSource> =>
+                createFuse(managedSources, {
+                    keys: [
+                        {
+                            name: 'label',
+                            getFn: (source) => availableSources?.[source.source_type]?.label ?? source.source_type,
+                        },
+                        'source_type',
+                        'prefix',
+                        'description',
+                    ],
+                }),
+        ],
+        filteredManagedSources: [
+            (s) => [s.managedSources, s.managedSourcesFuse, s.managedSearchTerm],
+            (managedSources, managedSourcesFuse, managedSearchTerm): ExternalDataSource[] => {
+                const trimmed = managedSearchTerm?.trim()
+                if (!trimmed) {
+                    return managedSources
                 }
-                const normalizedSearch = managedSearchTerm.toLowerCase()
-                return sources.filter(
-                    (source) =>
-                        source.source_type.toLowerCase().includes(normalizedSearch) ||
-                        source.prefix?.toLowerCase().includes(normalizedSearch) ||
-                        source.description?.toLowerCase().includes(normalizedSearch)
-                )
+                return managedSourcesFuse.search(trimmed).map((r) => r.item)
             },
         ],
         hasZendeskSource: [

--- a/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
@@ -157,8 +157,7 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
                     (source) => source.access_method?.toLowerCase() !== 'direct'
                 ),
         ],
-        // Match the display label ("Google Ads") as well as the internal source_type ("GoogleAds"),
-        // so a search with the label's spacing/casing finds the source. Fuzzy, like the source catalog.
+        // Search the display label as well as the internal source_type. Fuzzy, like the source catalog.
         managedSourcesFuse: [
             (s) => [s.managedSources, s.availableSources],
             (managedSources, availableSources): Fuse<ExternalDataSource> =>

--- a/products/data_warehouse/frontend/shared/logics/tests/sourceManagementLogic.test.ts
+++ b/products/data_warehouse/frontend/shared/logics/tests/sourceManagementLogic.test.ts
@@ -8,6 +8,7 @@ import { DatabaseSchemaQueryResponse } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { ExternalDataSource } from '~/types'
 
+import { availableSourcesLogic } from '../../../scenes/NewSourceScene/availableSourcesLogic'
 import { sourceManagementLogic } from '../sourceManagementLogic'
 
 jest.mock('lib/api')
@@ -41,6 +42,34 @@ describe('sourceManagementLogic', () => {
     afterEach(() => {
         logic.unmount()
         databaseLogic.unmount()
+    })
+
+    it('matches managed sources by display label as well as internal source_type', async () => {
+        jest.spyOn(api.externalDataSources, 'wizard').mockResolvedValue({
+            GoogleAds: { name: 'GoogleAds', label: 'Google Ads' },
+        } as any)
+
+        logic.mount()
+        await expectLogic(availableSourcesLogic).toDispatchActions(['loadSuccess'])
+
+        sourceManagementLogic.actions.loadSourcesSuccess({
+            results: [{ id: 's1', source_type: 'GoogleAds', access_method: 'warehouse', schemas: [] }],
+            count: 1,
+            next: null,
+            previous: null,
+        } as any)
+
+        // Display label spelling ("Google ads" with a space) must find the "GoogleAds" source
+        logic.actions.setManagedSearchTerm('Google ads')
+        await expectLogic(logic).toMatchValues({
+            filteredManagedSources: [expect.objectContaining({ source_type: 'GoogleAds' })],
+        })
+
+        // Internal source_type spelling still matches
+        logic.actions.setManagedSearchTerm('googleads')
+        await expectLogic(logic).toMatchValues({
+            filteredManagedSources: [expect.objectContaining({ source_type: 'GoogleAds' })],
+        })
     })
 
     it('only includes tables with no source in selfManagedTables', async () => {

--- a/products/data_warehouse/frontend/shared/logics/tests/sourceManagementLogic.test.ts
+++ b/products/data_warehouse/frontend/shared/logics/tests/sourceManagementLogic.test.ts
@@ -44,7 +44,10 @@ describe('sourceManagementLogic', () => {
         databaseLogic.unmount()
     })
 
-    it('matches managed sources by display label as well as internal source_type', async () => {
+    it.each([
+        ['display label', 'Google ads'],
+        ['internal source_type', 'googleads'],
+    ])('finds a managed source by its %s', async (_, searchTerm) => {
         jest.spyOn(api.externalDataSources, 'wizard').mockResolvedValue({
             GoogleAds: { name: 'GoogleAds', label: 'Google Ads' },
         } as any)
@@ -59,14 +62,7 @@ describe('sourceManagementLogic', () => {
             previous: null,
         } as any)
 
-        // Display label spelling ("Google ads" with a space) must find the "GoogleAds" source
-        logic.actions.setManagedSearchTerm('Google ads')
-        await expectLogic(logic).toMatchValues({
-            filteredManagedSources: [expect.objectContaining({ source_type: 'GoogleAds' })],
-        })
-
-        // Internal source_type spelling still matches
-        logic.actions.setManagedSearchTerm('googleads')
+        logic.actions.setManagedSearchTerm(searchTerm)
         await expectLogic(logic).toMatchValues({
             filteredManagedSources: [expect.objectContaining({ source_type: 'GoogleAds' })],
         })


### PR DESCRIPTION
## Problem

Searching the managed sources list in Data warehouse only matched against the internal `source_type` (`"GoogleAds"`), the prefix, and the description. It never matched the user-facing label (`"Google Ads"`).

So typing `googleads` found the source, but the natural spelling `Google ads` (with a space, the way it's shown in the UI) returned "No sources matching your search". Confusing, since the label is exactly what the user sees on screen.

## Changes

`filteredManagedSources` now runs the same fuzzy search the "New source" catalog uses (`createFuse`), with the resolved display label added as a search key alongside `source_type`, `prefix`, and `description`. The label is pulled from `availableSourcesLogic` via `getFn`, so it stays in sync with whatever the backend reports.

Practical effect for the search box:

- `Google ads`, `google ads`, `Google Ads` all match `GoogleAds` now (via the label)
- `googleads` still matches (via `source_type`)
- Typo and diacritic tolerance come for free from the shared Fuse defaults (`threshold 0.3`, `ignoreDiacritics`)

Split the old single selector into `managedSources` (the non-direct sources) plus a memoized `managedSourcesFuse` so the index isn't rebuilt on every keystroke.

## How did you test this code?

Added a kea logic test in `sourceManagementLogic.test.ts` asserting that both the display-label spelling (`Google ads`) and the internal spelling (`googleads`) find the `GoogleAds` source. It guards exactly the regression this fixes: if the label key is dropped from the search, the space-spelling case fails again. No existing test exercised `filteredManagedSources`.

I (Claude) ran that suite in the primary checkout and both tests pass. I did not manually click through the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Javier flagged the search mismatch (label vs internal name) and pointed at the "New source" catalog as the reference behavior. I traced the bug to `filteredManagedSources` in `sourceManagementLogic`, then reused the catalog's `createFuse` approach rather than hand-rolling a second `includes()` chain, so both surfaces search the same way. `availableSources` is now connected into the logic to resolve labels.

Skills invoked: `/writing-tests` (to gate the added test).


Here we have the same result
<img width="1307" height="344" alt="image" src="https://github.com/user-attachments/assets/675feb60-8b63-4b9c-83f6-2c688d137702" />


as here of the sources we have:
<img width="1088" height="558" alt="image" src="https://github.com/user-attachments/assets/44e317da-8519-404e-af7f-f7b8f43b46a6" />

prod:
<img width="1340" height="234" alt="image" src="https://github.com/user-attachments/assets/973bac8e-f2fe-4a3a-80f5-62ed2398b442" />
<img width="1333" height="173" alt="image" src="https://github.com/user-attachments/assets/16547da4-3b43-4022-8562-e7b91295a424" />
