### PR TITLE
fix(replay-vision): bill vision action summaries through posthog ai

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4385,6 +4385,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
             ("product_analytics",),
             ("surveys",),
             ("subscriptions",),
+            ("replay_vision",),
         ]
     )
     @patch("posthog.tasks.usage_report.get_instance_region")

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1287,6 +1287,7 @@ POSTHOG_AI_PRODUCTS = [
     "alert_investigation_agent",
     "product_analytics",
     "surveys",
+    "replay_vision",
 ]
 
 # ai_product values billed as PostHog Code credits.

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -341,7 +341,7 @@ def _run_synthesis(team: Team, action: VisionAction, lines: list[str]) -> str:
     # the LLM gateway (settings.OPENAI_BASE_URL), so the generation lands in LLM analytics tagged to
     # Replay Vision AND bills the team's AI credits ($ai_billable) — the same budget
     # is_team_over_ai_credit_budget gates on above.
-    client = OpenAI(posthog_client=posthoganalytics, base_url=settings.OPENAI_BASE_URL, max_retries=3)
+    client = OpenAI(posthog_client=posthoganalytics, base_url=settings.OPENAI_BASE_URL, max_retries=3)  # type: ignore[arg-type]
     distinct_id = replay_vision_distinct_id(team.id)
     response = client.chat.completions.create(  # type: ignore[call-overload]
         model=SYNTHESIS_MODEL,

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -11,11 +11,14 @@ from datetime import UTC, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, Any, NamedTuple
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
+
 import structlog
-from google.genai import types
-from posthoganalytics.ai.gemini import genai
+import posthoganalytics
+from posthoganalytics.ai.openai import OpenAI
 from temporalio import activity
 
+from posthog.event_usage import groups
 from posthog.helpers.markdown_safety import strip_external_links_markdown
 from posthog.models.team import Team
 from posthog.rbac.user_access_control import UserAccessControl
@@ -23,11 +26,10 @@ from posthog.sync import database_sync_to_async
 
 from products.replay_vision.backend.max_tools import _EVENT_ID_CITATION_RE, _as_untrusted_data, describe_scanner_outcome
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
-from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel
+from products.replay_vision.backend.models.replay_scanner import ReplayScanner
 from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun, VisionActionRunStatus
 from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
 from products.replay_vision.backend.temporal.decorators import track_activity
-from products.replay_vision.backend.temporal.gemini import gemini_api_key
 from products.replay_vision.backend.temporal.vision_actions.types import (
     SynthesisStatus,
     SynthesizeGroupSummaryInputs,
@@ -41,10 +43,10 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-# Track the scanners' default Gemini model so synthesis and scanning move together. Runs through the
-# PostHog-instrumented client so the generation lands in LLM analytics attributed to Replay Vision
+# Matches how insight AI summaries synthesize: PostHog AI through the LLM gateway
+# (settings.OPENAI_BASE_URL), billed to the team's AI credits via the $ai_billable generation event
 # (see `_run_synthesis`).
-SYNTHESIS_MODEL = ScannerModel.GEMINI_3_FLASH.value
+SYNTHESIS_MODEL = "gpt-4.1-mini"
 # Cap how many observations feed one group summary — bounds context size and cost.
 MAX_OBSERVATIONS = 100
 # Upper bound on how many ids the sampling path pulls into memory. A very busy window (the case the
@@ -335,19 +337,33 @@ def _run_synthesis(team: Team, action: VisionAction, lines: list[str]) -> str:
     # thing the model reads — nothing instruction-shaped trails it for injected text to blend into.
     human = prompt_guide + _as_untrusted_data("observations", lines)
 
-    # Same PostHog-instrumented Gemini client + Replay Vision tagging the scanners use, so the
-    # generation is captured in LLM analytics attributed to Replay Vision. The enclosing activity's
-    # start-to-close timeout bounds the call.
-    client = genai.Client(api_key=gemini_api_key())
-    response = client.models.generate_content(
-        model=f"models/{SYNTHESIS_MODEL}",
-        contents=human,
-        config=types.GenerateContentConfig(system_instruction=_SYSTEM_PROMPT),
-        posthog_distinct_id=replay_vision_distinct_id(team.id),
-        posthog_groups={"project": str(team.id)},
-        posthog_properties={"ai_product": "replay_vision", "feature": "vision_action_group_summary"},
+    # PostHog AI, matching insight AI summaries: the PostHog-instrumented OpenAI client pointed at
+    # the LLM gateway (settings.OPENAI_BASE_URL), so the generation lands in LLM analytics tagged to
+    # Replay Vision AND bills the team's AI credits ($ai_billable) — the same budget
+    # is_team_over_ai_credit_budget gates on above.
+    client = OpenAI(posthog_client=posthoganalytics, base_url=settings.OPENAI_BASE_URL, max_retries=3)
+    distinct_id = replay_vision_distinct_id(team.id)
+    response = client.chat.completions.create(  # type: ignore[call-overload]
+        model=SYNTHESIS_MODEL,
+        temperature=0.3,
+        timeout=120,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": human},
+        ],
+        user=distinct_id,
+        posthog_distinct_id=distinct_id,
+        posthog_properties={
+            "ai_product": "replay_vision",
+            "feature": "vision_action_group_summary",
+            "$ai_billable": True,
+            "team_id": team.id,
+        },
+        posthog_groups={**groups(team=team), "project": str(team.id)},
     )
-    return (response.text or "").strip()
+    if not response.choices:
+        return ""
+    return (response.choices[0].message.content or "").strip()
 
 
 def _markdown_to_slack(markdown: str) -> str:

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -19,22 +19,23 @@ from products.replay_vision.backend.tests.helpers import snapshot_for
 _SYNTH_PATH = "products.replay_vision.backend.temporal.vision_actions.synthesis"
 
 
-def _mock_genai(content: str, captured: list[str] | None = None):
-    # genai.Client(...).models.generate_content(...) → object with .text
-    def _generate(**kwargs) -> SimpleNamespace:
-        if captured is not None:
-            captured.append(kwargs.get("contents", ""))
-        return SimpleNamespace(text=content)
+def _user_message(kwargs: dict) -> str:
+    return next((m["content"] for m in kwargs.get("messages", []) if m["role"] == "user"), "")
 
-    client = SimpleNamespace(models=SimpleNamespace(generate_content=_generate))
-    return SimpleNamespace(Client=lambda **_kwargs: client)
+
+def _mock_openai(content: str, captured: list[str] | None = None):
+    # OpenAI(...).chat.completions.create(...) → object with .choices[0].message.content
+    def _create(**kwargs) -> SimpleNamespace:
+        if captured is not None:
+            captured.append(_user_message(kwargs))
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+    return lambda **_kwargs: client
 
 
 def _no_llm_client(**_kwargs):
     raise AssertionError("LLM should not be called")
-
-
-_NO_LLM = SimpleNamespace(Client=_no_llm_client)
 
 
 class TestVisionActionSynthesis(BaseTest):
@@ -92,7 +93,7 @@ class TestVisionActionSynthesis(BaseTest):
     ):
         with (
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
-            patch(f"{_SYNTH_PATH}.genai", _mock_genai(llm_content, captured_prompts)),
+            patch(f"{_SYNTH_PATH}.OpenAI", _mock_openai(llm_content, captured_prompts)),
         ):
             return _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
@@ -249,10 +250,10 @@ class TestVisionActionSynthesis(BaseTest):
         run.observation_count = 5
         run.save()
 
-        # If the LLM were called, this would raise (genai client patched to blow up).
+        # If the LLM were called, this would raise (OpenAI client patched to blow up).
         with (
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
-            patch(f"{_SYNTH_PATH}.genai", _NO_LLM),
+            patch(f"{_SYNTH_PATH}.OpenAI", _no_llm_client),
         ):
             result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
@@ -286,7 +287,7 @@ class TestVisionActionSynthesis(BaseTest):
 
         with (
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=(gate == "over_budget")),
-            patch(f"{_SYNTH_PATH}.genai", _NO_LLM),
+            patch(f"{_SYNTH_PATH}.OpenAI", _no_llm_client),
         ):
             result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
@@ -461,15 +462,15 @@ class TestVisionActionSynthesis(BaseTest):
         captured: dict = {}
 
         def _capturing_client(**_kwargs):
-            def generate_content(**kwargs):
-                captured["human"] = kwargs["contents"]
-                return SimpleNamespace(text="ok")
+            def create(**kwargs):
+                captured["human"] = _user_message(kwargs)
+                return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
 
-            return SimpleNamespace(models=SimpleNamespace(generate_content=generate_content))
+            return SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
 
         with (
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
-            patch(f"{_SYNTH_PATH}.genai", SimpleNamespace(Client=_capturing_client)),
+            patch(f"{_SYNTH_PATH}.OpenAI", _capturing_client),
         ):
             _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 


### PR DESCRIPTION
## Problem

Vision action summary synthesis gates on the team's PostHog AI-credit budget (`is_team_over_ai_credit_budget`) but then calls Gemini directly with our own API key. The generation was instrumented for LLM analytics, but it never carried `$ai_billable`, so token usage never actually drew from the budget we gate on — teams were being quota-checked against a meter their usage never moved.

Standalone on master, independent of the vision-action feature stack.

## Changes

Synthesis now runs through PostHog AI, matching how insight AI summaries are generated in Temporal (`products/exports/backend/temporal/subscriptions/llm_change_summary.py`):

- `posthoganalytics.ai.openai.OpenAI(posthog_client=..., base_url=settings.OPENAI_BASE_URL)` — the LLM gateway in production.
- Model: `gpt-4.1-mini` (same as insight summaries), replacing Gemini 3 Flash.
- The generation event carries `$ai_billable: true`, `team_id`, and project/org groups, so token usage charges the team's AI credits — the same budget the pre-flight gate checks.
- Tagged `ai_product: replay_vision`, `feature: vision_action_group_summary` for LLM analytics attribution.
- System prompt, prompt-guide-leads/untrusted-observations-last ordering, empty-output handling, and the budget gate are unchanged.

## How did you test this code?

- `test_vision_action_synthesis.py` (27 tests, all green): mocks reshaped from the Gemini client to the OpenAI chat-completions client; the existing behavioral assertions (prompt ordering, injection fencing, RBAC exclusion, empty-window skip, budget skip, markdown/Slack output) all still pass against the new call shape. No new tests: the billing tagging is declarative kwargs on the wrapper, and asserting them would be a change-detector test.
- Not manually tested against a live gateway by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal billing plumbing behind the `replay-vision-actions` flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), directed by Kim after her TL pointed at the insight-AI-summaries Temporal path as the reference for charging token usage. Skills invoked: /writing-tests. The subscriptions `llm_change_summary.py` client construction and billing property shape were ported as-is; the replay-vision distinct-id convention (`replay_vision_distinct_id`) was kept over the subscriptions-style region user tag for consistency with the product's other generations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
