### PR TITLE
feat(batch-import-worker): support cross-account IAM role auth for S3

### DIFF
--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, net::IpAddr, path::PathBuf, sync::Arc, time::Dur
 
 use anyhow::Error;
 use aws_config::{retry::RetryConfig, timeout::TimeoutConfig, BehaviorVersion, Region};
+use aws_sdk_s3::config::ProvideCredentials;
 use base64::{prelude::BASE64_URL_SAFE, Engine};
 use chrono::{DateTime, Utc};
 use fernet::MultiFernet;
@@ -14,6 +15,7 @@ use crate::{
         capture::CaptureEmitter, kafka::KafkaEmitter, Emitter, FileEmitter, NoOpEmitter,
         StdoutEmitter,
     },
+    error::{ToUserError, UserError},
     extractor::ExtractorType,
     parse::format::FormatConfig,
     source::{
@@ -72,8 +74,17 @@ pub struct FolderSourceConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3SourceConfig {
-    access_key_id_key: String,
-    secret_access_key_key: String,
+    #[serde(default)]
+    access_key_id_key: Option<String>,
+    #[serde(default)]
+    secret_access_key_key: Option<String>,
+    // Cross-account IAM role auth: the customer's role assumed via STS, with the per-team
+    // external id their trust policy conditions on (confused-deputy guard). Mutually
+    // exclusive with the access-key fields above.
+    #[serde(default)]
+    role_arn: Option<String>,
+    #[serde(default)]
+    external_id: Option<String>,
     bucket: String,
     prefix: String,
     region: String,
@@ -345,44 +356,112 @@ impl S3SourceConfig {
         Ok(())
     }
 
-    fn build_s3_config(&self, secrets: &JobSecrets) -> Result<aws_sdk_s3::config::Builder, Error> {
+    fn static_key_credentials(
+        &self,
+        secrets: &JobSecrets,
+    ) -> Result<aws_sdk_s3::config::Credentials, Error> {
+        let access_key_id_key = self
+            .access_key_id_key
+            .as_deref()
+            .ok_or(Error::msg("Missing access_key_id_key in source config"))?;
+        let secret_access_key_key = self
+            .secret_access_key_key
+            .as_deref()
+            .ok_or(Error::msg("Missing secret_access_key_key in source config"))?;
+
         let access_key_id = secrets
             .secrets
-            .get(&self.access_key_id_key)
+            .get(access_key_id_key)
             .ok_or(Error::msg(format!(
-                "Missing access key id as key {}",
-                self.access_key_id_key
+                "Missing access key id as key {access_key_id_key}"
             )))?
             .as_str()
             .ok_or(Error::msg(format!(
-                "Access key id as key {} is not a string",
-                self.access_key_id_key
+                "Access key id as key {access_key_id_key} is not a string"
             )))?;
 
         let secret_access_key = secrets
             .secrets
-            .get(&self.secret_access_key_key)
+            .get(secret_access_key_key)
             .ok_or(Error::msg(format!(
-                "Missing secret access key as key {}",
-                self.secret_access_key_key
+                "Missing secret access key as key {secret_access_key_key}"
             )))?
             .as_str()
             .ok_or(Error::msg(format!(
-                "Secret access key as key {} is not a string",
-                self.secret_access_key_key
+                "Secret access key as key {secret_access_key_key} is not a string"
             )))?;
 
-        let aws_credentials = aws_sdk_s3::config::Credentials::new(
+        Ok(aws_sdk_s3::config::Credentials::new(
             access_key_id,
             secret_access_key,
             None,
             None,
             "job_config",
-        );
+        ))
+    }
 
+    // Session policy pinning every assumed-role session to read-only access on the configured
+    // bucket/prefix, regardless of how broad the customer's role permissions are.
+    fn session_policy(&self) -> String {
+        serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket"],
+                    "Resource": format!("arn:aws:s3:::{}", self.bucket),
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject"],
+                    "Resource": format!("arn:aws:s3:::{}/{}*", self.bucket, self.prefix),
+                },
+            ],
+        })
+        .to_string()
+    }
+
+    async fn assume_role_credentials(
+        &self,
+        role_arn: &str,
+    ) -> Result<aws_config::sts::AssumeRoleProvider, Error> {
+        if self.endpoint_url.is_some() {
+            return Err(Error::from(UserError::new(
+                "IAM role authentication only works with AWS S3 - S3-compatible stores must use access keys",
+            )));
+        }
+
+        let external_id = self
+            .external_id
+            .as_deref()
+            .ok_or(Error::msg("Missing external_id in role-auth source config"))?;
+
+        let provider = aws_config::sts::AssumeRoleProvider::builder(role_arn)
+            .session_name("posthog-batch-import")
+            .external_id(external_id)
+            .region(Region::new(self.region.clone()))
+            .session_length(Duration::from_secs(3600))
+            .policy(self.session_policy())
+            .build()
+            .await;
+
+        // Fail fast so a misconfigured trust policy pauses the job with an actionable
+        // message instead of surfacing as an opaque S3 error mid-import.
+        provider.provide_credentials().await.user_error(format!(
+            "PostHog could not assume IAM role {role_arn}. Verify the role exists, its trust \
+             policy allows PostHog's import role, and the External ID matches the one shown in \
+             the migration setup."
+        ))?;
+
+        Ok(provider)
+    }
+
+    async fn build_s3_config(
+        &self,
+        secrets: &JobSecrets,
+    ) -> Result<aws_sdk_s3::config::Builder, Error> {
         let mut builder = aws_sdk_s3::config::Builder::new()
             .region(Region::new(self.region.clone()))
-            .credentials_provider(aws_credentials)
             .behavior_version(BehaviorVersion::latest())
             // S3-compatible stores (GCS) return whole-object checksums on ranged GETs, which the
             // SDK then validates against the partial body and fails. Only validate when requested.
@@ -395,6 +474,23 @@ impl S3SourceConfig {
                     .build(),
             )
             .retry_config(RetryConfig::standard());
+
+        builder = match (&self.role_arn, &self.access_key_id_key) {
+            (Some(role_arn), None) => {
+                builder.credentials_provider(self.assume_role_credentials(role_arn).await?)
+            }
+            (None, Some(_)) => builder.credentials_provider(self.static_key_credentials(secrets)?),
+            (Some(_), Some(_)) => {
+                return Err(Error::msg(
+                    "S3 source config sets both role_arn and access keys - exactly one auth method is required",
+                ))
+            }
+            (None, None) => {
+                return Err(Error::from(UserError::new(
+                    "S3 source has no authentication configured - provide an IAM role or access keys",
+                )))
+            }
+        };
 
         if let Some(ref url) = self.endpoint_url {
             Self::validate_endpoint_url(url, self.allow_internal_ips)?;
@@ -414,7 +510,7 @@ impl S3SourceConfig {
     }
 
     pub async fn create_source(&self, secrets: &JobSecrets) -> Result<S3Source, Error> {
-        let builder = self.build_s3_config(secrets)?;
+        let builder = self.build_s3_config(secrets).await?;
         let client = aws_sdk_s3::Client::from_conf(builder.build());
 
         Ok(S3Source::new(
@@ -430,7 +526,7 @@ impl S3SourceConfig {
         staging_dir: PathBuf,
         staging_max_bytes: u64,
     ) -> Result<GzipS3Source, Error> {
-        let builder = self.build_s3_config(secrets)?;
+        let builder = self.build_s3_config(secrets).await?;
         let client = aws_sdk_s3::Client::from_conf(builder.build());
 
         Ok(GzipS3Source::new(
@@ -849,6 +945,125 @@ mod tests {
         }"#;
         let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         assert!(config.allow_internal_ips);
+    }
+
+    #[test]
+    fn test_s3_source_config_legacy_key_auth_deserializes() {
+        let json = r#"{
+            "access_key_id_key": "ak",
+            "secret_access_key_key": "sk",
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1"
+        }"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.access_key_id_key.as_deref(), Some("ak"));
+        assert_eq!(config.secret_access_key_key.as_deref(), Some("sk"));
+        assert!(config.role_arn.is_none());
+        assert!(config.external_id.is_none());
+    }
+
+    #[test]
+    fn test_s3_source_config_role_auth_deserializes() {
+        let json = r#"{
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1",
+            "role_arn": "arn:aws:iam::123456789012:role/posthog-import",
+            "external_id": "posthog-us-some-team-uuid"
+        }"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.role_arn.as_deref(),
+            Some("arn:aws:iam::123456789012:role/posthog-import")
+        );
+        assert_eq!(
+            config.external_id.as_deref(),
+            Some("posthog-us-some-team-uuid")
+        );
+        assert!(config.access_key_id_key.is_none());
+        assert!(config.secret_access_key_key.is_none());
+    }
+
+    fn role_auth_config(json_patch: Value) -> S3SourceConfig {
+        let mut base = serde_json::json!({
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1",
+            "role_arn": "arn:aws:iam::123456789012:role/posthog-import",
+            "external_id": "posthog-us-some-team-uuid"
+        });
+        base.as_object_mut()
+            .unwrap()
+            .extend(json_patch.as_object().unwrap().clone());
+        serde_json::from_value(base).unwrap()
+    }
+
+    fn empty_secrets() -> JobSecrets {
+        JobSecrets {
+            secrets: HashMap::new(),
+        }
+    }
+
+    // These rejection paths all error before any credentials provider is built, so no
+    // network access happens.
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_role_with_endpoint_url() {
+        let config = role_auth_config(
+            serde_json::json!({"endpoint_url": "https://acct123.r2.cloudflarestorage.com"}),
+        );
+        let err = config
+            .build_s3_config(&empty_secrets())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("IAM role authentication only works with AWS S3"));
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_role_without_external_id() {
+        let mut config = role_auth_config(serde_json::json!({}));
+        config.external_id = None;
+        let err = config
+            .build_s3_config(&empty_secrets())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("external_id"));
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_both_auth_methods() {
+        let config = role_auth_config(
+            serde_json::json!({"access_key_id_key": "ak", "secret_access_key_key": "sk"}),
+        );
+        let err = config
+            .build_s3_config(&empty_secrets())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("exactly one auth method"));
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_missing_auth() {
+        let json = r#"{"bucket": "b", "prefix": "p", "region": "us-east-1"}"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
+        let err = config
+            .build_s3_config(&empty_secrets())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no authentication configured"));
+    }
+
+    #[test]
+    fn test_session_policy_scopes_to_bucket_and_prefix() {
+        let config = role_auth_config(serde_json::json!({}));
+        let policy: Value = serde_json::from_str(&config.session_policy()).unwrap();
+        let statements = policy["Statement"].as_array().unwrap();
+        assert_eq!(statements[0]["Resource"], "arn:aws:s3:::b");
+        assert_eq!(statements[1]["Resource"], "arn:aws:s3:::b/p*");
     }
 
     #[test]

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -427,7 +427,7 @@ impl S3SourceConfig {
     ) -> Result<aws_config::sts::AssumeRoleProvider, Error> {
         if self.endpoint_url.is_some() {
             return Err(Error::from(UserError::new(
-                "IAM role authentication only works with AWS S3 - S3-compatible stores must use access keys",
+                "IAM role authentication only works with AWS S3. S3-compatible stores must use access keys",
             )));
         }
 
@@ -482,12 +482,12 @@ impl S3SourceConfig {
             (None, Some(_)) => builder.credentials_provider(self.static_key_credentials(secrets)?),
             (Some(_), Some(_)) => {
                 return Err(Error::msg(
-                    "S3 source config sets both role_arn and access keys - exactly one auth method is required",
+                    "S3 source config sets both role_arn and access keys, but exactly one auth method is required",
                 ))
             }
             (None, None) => {
                 return Err(Error::from(UserError::new(
-                    "S3 source has no authentication configured - provide an IAM role or access keys",
+                    "S3 source has no authentication configured. Provide an IAM role or access keys",
                 )))
             }
         };

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -94,6 +94,18 @@ pub struct S3SourceConfig {
     allow_internal_ips: bool,
 }
 
+// The exactly-one auth method a valid S3SourceConfig resolves to; see S3SourceConfig::auth.
+enum S3Auth<'a> {
+    Role {
+        role_arn: &'a str,
+        external_id: &'a str,
+    },
+    Keys {
+        access_key_id_key: &'a str,
+        secret_access_key_key: &'a str,
+    },
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DateRangeExportSourceConfig {
     base_url: String,
@@ -195,6 +207,14 @@ impl JobSecrets {
         let serialized = serde_json::to_vec(&self.secrets)?;
         let encrypted = fernet.encrypt(&serialized);
         Ok(encrypted)
+    }
+
+    fn get_str(&self, key: &str, what: &str) -> Result<&str, Error> {
+        self.secrets
+            .get(key)
+            .ok_or(Error::msg(format!("Missing {what} as secret {key}")))?
+            .as_str()
+            .ok_or(Error::msg(format!("{what} secret {key} is not a string")))
     }
 }
 
@@ -356,40 +376,57 @@ impl S3SourceConfig {
         Ok(())
     }
 
+    /// The single validated auth method resolved from the config's optional field pairs.
+    fn auth(&self) -> Result<S3Auth<'_>, Error> {
+        let has_key_fields =
+            self.access_key_id_key.is_some() || self.secret_access_key_key.is_some();
+
+        match (&self.role_arn, has_key_fields) {
+            (Some(_), true) => Err(Error::msg(
+                "S3 source config sets both role_arn and access keys, but exactly one auth method is required",
+            )),
+            (Some(role_arn), false) => {
+                let external_id = self
+                    .external_id
+                    .as_deref()
+                    .ok_or(Error::msg("Missing external_id in role-auth source config"))?;
+                Ok(S3Auth::Role {
+                    role_arn,
+                    external_id,
+                })
+            }
+            (None, true) => {
+                if self.external_id.is_some() {
+                    return Err(Error::msg(
+                        "S3 source config sets external_id, which is only valid with role_arn",
+                    ));
+                }
+                let access_key_id_key = self
+                    .access_key_id_key
+                    .as_deref()
+                    .ok_or(Error::msg("Missing access_key_id_key in source config"))?;
+                let secret_access_key_key = self
+                    .secret_access_key_key
+                    .as_deref()
+                    .ok_or(Error::msg("Missing secret_access_key_key in source config"))?;
+                Ok(S3Auth::Keys {
+                    access_key_id_key,
+                    secret_access_key_key,
+                })
+            }
+            (None, false) => Err(Error::from(UserError::new(
+                "S3 source has no authentication configured. Provide an IAM role or access keys",
+            ))),
+        }
+    }
+
     fn static_key_credentials(
-        &self,
         secrets: &JobSecrets,
+        access_key_id_key: &str,
+        secret_access_key_key: &str,
     ) -> Result<aws_sdk_s3::config::Credentials, Error> {
-        let access_key_id_key = self
-            .access_key_id_key
-            .as_deref()
-            .ok_or(Error::msg("Missing access_key_id_key in source config"))?;
-        let secret_access_key_key = self
-            .secret_access_key_key
-            .as_deref()
-            .ok_or(Error::msg("Missing secret_access_key_key in source config"))?;
-
-        let access_key_id = secrets
-            .secrets
-            .get(access_key_id_key)
-            .ok_or(Error::msg(format!(
-                "Missing access key id as key {access_key_id_key}"
-            )))?
-            .as_str()
-            .ok_or(Error::msg(format!(
-                "Access key id as key {access_key_id_key} is not a string"
-            )))?;
-
-        let secret_access_key = secrets
-            .secrets
-            .get(secret_access_key_key)
-            .ok_or(Error::msg(format!(
-                "Missing secret access key as key {secret_access_key_key}"
-            )))?
-            .as_str()
-            .ok_or(Error::msg(format!(
-                "Secret access key as key {secret_access_key_key} is not a string"
-            )))?;
+        let access_key_id = secrets.get_str(access_key_id_key, "access key id")?;
+        let secret_access_key = secrets.get_str(secret_access_key_key, "secret access key")?;
 
         Ok(aws_sdk_s3::config::Credentials::new(
             access_key_id,
@@ -410,6 +447,13 @@ impl S3SourceConfig {
                     "Effect": "Allow",
                     "Action": ["s3:ListBucket"],
                     "Resource": format!("arn:aws:s3:::{}", self.bucket),
+                    // ListBucket is bucket-level, so the prefix restriction has to be a
+                    // condition on the request's prefix parameter, not part of the resource.
+                    "Condition": {
+                        "StringLike": {
+                            "s3:prefix": [format!("{}*", self.prefix)],
+                        },
+                    },
                 },
                 {
                     "Effect": "Allow",
@@ -424,17 +468,13 @@ impl S3SourceConfig {
     async fn assume_role_credentials(
         &self,
         role_arn: &str,
+        external_id: &str,
     ) -> Result<aws_config::sts::AssumeRoleProvider, Error> {
         if self.endpoint_url.is_some() {
             return Err(Error::from(UserError::new(
                 "IAM role authentication only works with AWS S3. S3-compatible stores must use access keys",
             )));
         }
-
-        let external_id = self
-            .external_id
-            .as_deref()
-            .ok_or(Error::msg("Missing external_id in role-auth source config"))?;
 
         let provider = aws_config::sts::AssumeRoleProvider::builder(role_arn)
             .session_name("posthog-batch-import")
@@ -475,21 +515,20 @@ impl S3SourceConfig {
             )
             .retry_config(RetryConfig::standard());
 
-        builder = match (&self.role_arn, &self.access_key_id_key) {
-            (Some(role_arn), None) => {
-                builder.credentials_provider(self.assume_role_credentials(role_arn).await?)
-            }
-            (None, Some(_)) => builder.credentials_provider(self.static_key_credentials(secrets)?),
-            (Some(_), Some(_)) => {
-                return Err(Error::msg(
-                    "S3 source config sets both role_arn and access keys, but exactly one auth method is required",
-                ))
-            }
-            (None, None) => {
-                return Err(Error::from(UserError::new(
-                    "S3 source has no authentication configured. Provide an IAM role or access keys",
-                )))
-            }
+        builder = match self.auth()? {
+            S3Auth::Role {
+                role_arn,
+                external_id,
+            } => builder
+                .credentials_provider(self.assume_role_credentials(role_arn, external_id).await?),
+            S3Auth::Keys {
+                access_key_id_key,
+                secret_access_key_key,
+            } => builder.credentials_provider(Self::static_key_credentials(
+                secrets,
+                access_key_id_key,
+                secret_access_key_key,
+            )?),
         };
 
         if let Some(ref url) = self.endpoint_url {
@@ -509,9 +548,13 @@ impl S3SourceConfig {
         Ok(builder)
     }
 
-    pub async fn create_source(&self, secrets: &JobSecrets) -> Result<S3Source, Error> {
+    async fn build_client(&self, secrets: &JobSecrets) -> Result<aws_sdk_s3::Client, Error> {
         let builder = self.build_s3_config(secrets).await?;
-        let client = aws_sdk_s3::Client::from_conf(builder.build());
+        Ok(aws_sdk_s3::Client::from_conf(builder.build()))
+    }
+
+    pub async fn create_source(&self, secrets: &JobSecrets) -> Result<S3Source, Error> {
+        let client = self.build_client(secrets).await?;
 
         Ok(S3Source::new(
             client,
@@ -526,8 +569,7 @@ impl S3SourceConfig {
         staging_dir: PathBuf,
         staging_max_bytes: u64,
     ) -> Result<GzipS3Source, Error> {
-        let builder = self.build_s3_config(secrets).await?;
-        let client = aws_sdk_s3::Client::from_conf(builder.build());
+        let client = self.build_client(secrets).await?;
 
         Ok(GzipS3Source::new(
             client,
@@ -551,81 +593,25 @@ impl DateRangeExportSourceConfig {
             AuthSourceConfig::ApiKey {
                 header_name,
                 key_secret,
-            } => {
-                let key = secrets
-                    .secrets
-                    .get(key_secret)
-                    .ok_or(Error::msg(format!(
-                        "Missing API key as secret {key_secret}"
-                    )))?
-                    .as_str()
-                    .ok_or(Error::msg(format!(
-                        "API key secret {key_secret} is not a string"
-                    )))?;
-                AuthConfig::ApiKey {
-                    header_name: header_name.clone(),
-                    key: key.to_string(),
-                }
-            }
-            AuthSourceConfig::BearerToken { token_secret } => {
-                let token = secrets
-                    .secrets
-                    .get(token_secret)
-                    .ok_or(Error::msg(format!(
-                        "Missing bearer token as secret {token_secret}"
-                    )))?
-                    .as_str()
-                    .ok_or(Error::msg(format!(
-                        "Bearer token secret {token_secret} is not a string"
-                    )))?;
-                AuthConfig::BearerToken {
-                    token: token.to_string(),
-                }
-            }
+            } => AuthConfig::ApiKey {
+                header_name: header_name.clone(),
+                key: secrets.get_str(key_secret, "API key")?.to_string(),
+            },
+            AuthSourceConfig::BearerToken { token_secret } => AuthConfig::BearerToken {
+                token: secrets.get_str(token_secret, "bearer token")?.to_string(),
+            },
             AuthSourceConfig::BasicAuth {
                 username_secret,
                 password_secret,
-            } => {
-                let username = secrets
-                    .secrets
-                    .get(username_secret)
-                    .ok_or(Error::msg(format!(
-                        "Missing username as secret {username_secret}",
-                    )))?
-                    .as_str()
-                    .ok_or(Error::msg(format!(
-                        "Username secret {username_secret} is not a string",
-                    )))?;
-                let password = secrets
-                    .secrets
-                    .get(password_secret)
-                    .ok_or(Error::msg(format!(
-                        "Missing password as secret {password_secret}",
-                    )))?
-                    .as_str()
-                    .ok_or(Error::msg(format!(
-                        "Password secret {password_secret} is not a string",
-                    )))?;
-                AuthConfig::BasicAuth {
-                    username: username.to_string(),
-                    password: password.to_string(),
-                }
-            }
-            AuthSourceConfig::MixpanelAuth { secret_key_secret } => {
-                let secret_key = secrets
-                    .secrets
-                    .get(secret_key_secret)
-                    .ok_or(Error::msg(format!(
-                        "Missing secret key as secret {secret_key_secret}"
-                    )))?
-                    .as_str()
-                    .ok_or(Error::msg(format!(
-                        "Secret key secret {secret_key_secret} is not a string"
-                    )))?;
-                AuthConfig::MixpanelAuth {
-                    secret_key: secret_key.to_string(),
-                }
-            }
+            } => AuthConfig::BasicAuth {
+                username: secrets.get_str(username_secret, "username")?.to_string(),
+                password: secrets.get_str(password_secret, "password")?.to_string(),
+            },
+            AuthSourceConfig::MixpanelAuth { secret_key_secret } => AuthConfig::MixpanelAuth {
+                secret_key: secrets
+                    .get_str(secret_key_secret, "secret key")?
+                    .to_string(),
+            },
         };
 
         let extractor = self.extractor_type.create_extractor();
@@ -1033,16 +1019,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_s3_config_rejects_both_auth_methods() {
-        let config = role_auth_config(
+    async fn test_build_s3_config_rejects_mixed_auth_methods() {
+        let cases = [
+            // Full key pair alongside role_arn.
             serde_json::json!({"access_key_id_key": "ak", "secret_access_key_key": "sk"}),
-        );
+            // A partial key pair must not silently win the role path either.
+            serde_json::json!({"access_key_id_key": "ak"}),
+            serde_json::json!({"secret_access_key_key": "sk"}),
+        ];
+        for patch in cases {
+            let config = role_auth_config(patch.clone());
+            let err = config
+                .build_s3_config(&empty_secrets())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("exactly one auth method"),
+                "patch {patch}: unexpected error {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_external_id_with_key_auth() {
+        let json = r#"{
+            "access_key_id_key": "ak",
+            "secret_access_key_key": "sk",
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1",
+            "external_id": "posthog-us-some-team-uuid"
+        }"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         let err = config
             .build_s3_config(&empty_secrets())
             .await
             .unwrap_err()
             .to_string();
-        assert!(err.contains("exactly one auth method"));
+        assert!(err.contains("only valid with role_arn"));
     }
 
     #[tokio::test]
@@ -1063,6 +1078,10 @@ mod tests {
         let policy: Value = serde_json::from_str(&config.session_policy()).unwrap();
         let statements = policy["Statement"].as_array().unwrap();
         assert_eq!(statements[0]["Resource"], "arn:aws:s3:::b");
+        assert_eq!(
+            statements[0]["Condition"]["StringLike"]["s3:prefix"],
+            serde_json::json!(["p*"])
+        );
         assert_eq!(statements[1]["Resource"], "arn:aws:s3:::b/p*");
     }
 

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -1019,6 +1019,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_build_s3_config_accepts_legacy_key_auth() {
+        let json = r#"{
+            "access_key_id_key": "ak",
+            "secret_access_key_key": "sk",
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1"
+        }"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
+        let mut secrets = HashMap::new();
+        secrets.insert("ak".to_string(), Value::String("key-id".to_string()));
+        secrets.insert("sk".to_string(), Value::String("key-secret".to_string()));
+        let secrets = JobSecrets { secrets };
+        assert!(config.build_s3_config(&secrets).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_errors_when_key_secret_missing() {
+        let json = r#"{
+            "access_key_id_key": "ak",
+            "secret_access_key_key": "sk",
+            "bucket": "b",
+            "prefix": "p",
+            "region": "us-east-1"
+        }"#;
+        let config: S3SourceConfig = serde_json::from_str(json).unwrap();
+        let err = config
+            .build_s3_config(&empty_secrets())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Missing access key id as secret ak"));
+    }
+
+    #[tokio::test]
     async fn test_build_s3_config_rejects_mixed_auth_methods() {
         let cases = [
             // Full key pair alongside role_arn.

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -30,7 +30,11 @@ pub(crate) fn extract_user_friendly_error(
 ) -> String {
     let error_string = format!("{error:?}");
 
-    if error_string.contains("InvalidAccessKeyId") {
+    if error_string.contains("AssumeRole") || error_string.contains("sts.amazonaws.com") {
+        "PostHog could not assume the configured IAM role - check the role's trust policy and External ID".to_string()
+    } else if error_string.contains("ExpiredToken") {
+        "Temporary AWS credentials expired and could not be refreshed - check that the IAM role still trusts PostHog".to_string()
+    } else if error_string.contains("InvalidAccessKeyId") {
         "Invalid AWS Access Key ID - please check your credentials".to_string()
     } else if error_string.contains("SignatureDoesNotMatch") {
         "Invalid AWS Secret Access Key - please check your credentials".to_string()
@@ -208,6 +212,31 @@ mod tests {
         let err = MockS3Error("Request timeout: Connection timed out".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "get object chunk");
         assert_eq!(msg, "S3 get object chunk operation timed out - check your network connection and region settings");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_assume_role_failure() {
+        for raw in [
+            "service error: AssumeRole operation failed: AccessDenied",
+            "dispatch failure connecting to https://sts.amazonaws.com/",
+        ] {
+            let err = MockS3Error(raw.to_string());
+            let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+            assert_eq!(
+                msg,
+                "PostHog could not assume the configured IAM role - check the role's trust policy and External ID"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_expired_token() {
+        let err = MockS3Error("ExpiredToken: The security token has expired".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "get object");
+        assert_eq!(
+            msg,
+            "Temporary AWS credentials expired and could not be refreshed - check that the IAM role still trusts PostHog"
+        );
     }
 
     #[test]

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -30,10 +30,12 @@ pub(crate) fn extract_user_friendly_error(
 ) -> String {
     let error_string = format!("{error:?}");
 
-    if error_string.contains("AssumeRole") || error_string.contains("sts.amazonaws.com") {
-        "PostHog could not assume the configured IAM role - check the role's trust policy and External ID".to_string()
+    // "https://sts." matches both the global (sts.amazonaws.com) and regional
+    // (sts.<region>.amazonaws.com) STS endpoints in dispatch-failure messages.
+    if error_string.contains("AssumeRole") || error_string.contains("https://sts.") {
+        "PostHog could not assume the configured IAM role. Check the role's trust policy and External ID".to_string()
     } else if error_string.contains("ExpiredToken") {
-        "Temporary AWS credentials expired and could not be refreshed - check that the IAM role still trusts PostHog".to_string()
+        "Temporary AWS credentials expired and could not be refreshed. Check that the IAM role still trusts PostHog".to_string()
     } else if error_string.contains("InvalidAccessKeyId") {
         "Invalid AWS Access Key ID - please check your credentials".to_string()
     } else if error_string.contains("SignatureDoesNotMatch") {
@@ -219,12 +221,13 @@ mod tests {
         for raw in [
             "service error: AssumeRole operation failed: AccessDenied",
             "dispatch failure connecting to https://sts.amazonaws.com/",
+            "dispatch failure connecting to https://sts.us-east-1.amazonaws.com/",
         ] {
             let err = MockS3Error(raw.to_string());
             let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
             assert_eq!(
                 msg,
-                "PostHog could not assume the configured IAM role - check the role's trust policy and External ID"
+                "PostHog could not assume the configured IAM role. Check the role's trust policy and External ID"
             );
         }
     }
@@ -235,7 +238,7 @@ mod tests {
         let msg = extract_user_friendly_error(&err, "my-bucket", "get object");
         assert_eq!(
             msg,
-            "Temporary AWS credentials expired and could not be refreshed - check that the IAM role still trusts PostHog"
+            "Temporary AWS credentials expired and could not be refreshed. Check that the IAM role still trusts PostHog"
         );
     }
 


### PR DESCRIPTION
## Problem

Managed migrations currently read customer S3 buckets with customer-provided long-lived access keys. That forces customers to create IAM user access keys (which many orgs prohibit) and forces us to store their secrets. The industry-standard alternative is cross-account IAM role assumption with an external ID, like Fivetran and Snowflake use.

This is PR 1 of 3 in posthog (worker, then backend, then frontend), plus companion changes in the charts and infra repos. It ships dormant: nothing produces role-auth job configs until the backend PR lands, and the deserialization change is backward compatible with every existing job row.

## Changes

- `S3SourceConfig` gains optional `role_arn` and `external_id` fields, and the access-key fields become optional. Existing configs (which always have the key fields) deserialize unchanged.
- `build_s3_config()` branches on auth mode:
  - **Role**: builds an `aws_config::sts::AssumeRoleProvider` (base credentials from the ambient IRSA chain) with the external ID, a 1h session length, and an inline session policy that pins every session to `s3:ListBucket` on the bucket + `s3:GetObject` on `bucket/prefix*`, no matter how broad the customer's role is. The SDK's identity cache auto-refreshes sessions, which matters for multi-day imports.
  - **Keys**: existing static-credential path, unchanged (including the `endpoint_url` + SSRF-resolver logic for R2/MinIO).
  - Role + `endpoint_url` is rejected: role auth is AWS-S3-only, and this keeps custom-endpoint SSRF surface away from our own AWS credentials.
- Eager `provide_credentials()` check on the role path, so a broken trust policy pauses the job immediately with an actionable `display_status_message` (via the existing `UserError` chain) instead of an opaque S3 failure mid-import.
- `extract_user_friendly_error()` gains STS branches so mid-job revocation (customer deletes the trust statement) also surfaces actionably.

No Cargo changes: `aws-config` already resolves to 1.8.14, which has `AssumeRoleProvider` with `.policy()` and `.external_id()`.

## How did you test this code?

Automated only (no live AWS): `cargo test -p batch-import-worker` (298 passed), `cargo fmt` + `clippy -D warnings` clean. New tests catch regressions no existing test did:

- Legacy key-auth JSON keeps deserializing after the fields became optional (breaking this bricks every in-flight import).
- Role-auth JSON round-trips; role+endpoint_url, role-without-external_id, both-auths, and no-auth configs are rejected before any network call.
- Session policy resolves to the exact bucket/prefix ARNs (this is the least-privilege guarantee).
- STS/ExpiredToken error strings map to the actionable user messages.

End-to-end verification against a real AWS account happens when the full stack is assembled (infra role grant + backend), tracked in the follow-up PRs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

User-facing setup docs land with the frontend PR (posthog.com repo); no in-repo docs cover the worker.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (planned in plan mode with Explore/Plan subagents, then implemented). Design decisions worth knowing while reviewing:

- Flat optional fields on `S3SourceConfig` instead of a tagged `auth` enum, mirroring how `endpoint_url` was added. Existing encrypted rows can't be rewritten, so a tagged shape would have meant supporting two representations forever.
- `external_id` lives in `import_config` (not the encrypted secrets blob). AWS treats ExternalId as non-secret (it appears in the customer's trust policy and CloudTrail); it only needs to be unguessable and provider-generated.
- An old worker binary that claims a new role-auth job fails deserialization and pauses the job (fail-safe), which dictates rollout order: this deploys before the backend create path is enabled.
- Skills invoked: /rust-lint conventions (fmt + clippy after every edit).