### PR TITLE
fix(dashboards): create inline text tile at the chosen slot

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
@@ -9,6 +9,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { DialogClose, DialogPrimitive, DialogPrimitiveTitle } from 'lib/ui/DialogPrimitive/DialogPrimitive'
 import { cn } from 'lib/utils/css-classes'
+import type { PendingInsertion } from 'scenes/dashboard/dashboardLogic'
 
 import { DashboardType, QueryBasedInsightModel } from '~/types'
 
@@ -17,14 +18,16 @@ export function TextCardModal({
     onClose,
     dashboard,
     textTileId,
+    pendingInsertion,
 }: {
     isOpen: boolean
     onClose: () => void
     dashboard: DashboardType<QueryBasedInsightModel>
     textTileId: number | 'new' | null
+    pendingInsertion?: PendingInsertion | null
 }): JSX.Element {
     const resolvedTileId = textTileId ?? 'new'
-    const modalLogicProps = { dashboard, textTileId: resolvedTileId, onClose }
+    const modalLogicProps = { dashboard, textTileId: resolvedTileId, onClose, pendingInsertion }
     const modalLogic = textCardModalLogic(modalLogicProps)
     // Form `body` + validation drive updates while typing; splitting useValues does not reduce rerenders.
     const { isTextTileSubmitting, textTileValidationErrors, textTile } = useValues(modalLogic)

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
@@ -3,9 +3,8 @@ import { expectLogic } from 'kea-test-utils'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import type { PendingInsertion } from 'scenes/dashboard/dashboardLogic'
 
-import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AccessControlLevel, DashboardType, QueryBasedInsightModel } from '~/types'
 
@@ -41,9 +40,6 @@ const makeDashboard = (body: string = 'existing text'): DashboardType<QueryBased
 
 describe('textCardModalLogic', () => {
     beforeEach(() => {
-        useMocks({
-            get: { '/api/environments/:team_id/dashboards/123/': () => [200, makeDashboard()] },
-        })
         initKeaTests()
         jest.spyOn(lemonToast, 'error').mockImplementation(jest.fn())
     })
@@ -52,39 +48,31 @@ describe('textCardModalLogic', () => {
         jest.restoreAllMocks()
     })
 
-    it('creates a new text tile at the pending insertion slot instead of an empty column', async () => {
+    // A new tile carries the inline "+" slot as its layout (so the grid doesn't float it to an empty
+    // column), and carries none when added without a slot (header "Add", which appends normally).
+    it.each([
+        {
+            scenario: 'with a pending insertion slot',
+            pendingInsertion: { x: 6, y: 4, w: null } as PendingInsertion,
+            expectedLayouts: { sm: { x: 6, y: 4, w: 2, h: 2 } },
+        },
+        {
+            scenario: 'without a pending insertion slot',
+            pendingInsertion: null,
+            expectedLayouts: undefined,
+        },
+    ])('creates a new text tile $scenario', async ({ pendingInsertion, expectedLayouts }) => {
         const dashboard = makeDashboard('')
-        // the inline "+" bar records where the tile should land before opening the modal
-        const dashLogic = dashboardLogic({ id: dashboard.id, dashboard })
-        dashLogic.mount()
-        dashLogic.actions.setPendingInsertion({ x: 6, y: 4, w: null })
-
         const updateSpy = jest.spyOn(api, 'update').mockResolvedValue(dashboard as any)
 
-        const logic = textCardModalLogic({ dashboard, textTileId: 'new', onClose: jest.fn() })
+        const logic = textCardModalLogic({ dashboard, textTileId: 'new', onClose: jest.fn(), pendingInsertion })
         logic.mount()
         logic.actions.setTextTileValue('body', 'hello')
         logic.actions.submitTextTile()
         await expectLogic(logic).toFinishAllListeners()
 
         const patchBody = updateSpy.mock.calls[0][1] as { tiles: { layouts?: unknown }[] }
-        expect(patchBody.tiles[0].layouts).toEqual({ sm: { x: 6, y: 4, w: 2, h: 2 } })
-    })
-
-    it('omits layouts when there is no pending insertion (header add appends normally)', async () => {
-        const dashboard = makeDashboard('')
-        dashboardLogic({ id: dashboard.id, dashboard }).mount()
-
-        const updateSpy = jest.spyOn(api, 'update').mockResolvedValue(dashboard as any)
-
-        const logic = textCardModalLogic({ dashboard, textTileId: 'new', onClose: jest.fn() })
-        logic.mount()
-        logic.actions.setTextTileValue('body', 'hello')
-        logic.actions.submitTextTile()
-        await expectLogic(logic).toFinishAllListeners()
-
-        const patchBody = updateSpy.mock.calls[0][1] as { tiles: { layouts?: unknown }[] }
-        expect(patchBody.tiles[0].layouts).toBeUndefined()
+        expect(patchBody.tiles[0].layouts).toEqual(expectedLayouts)
     })
 
     it('does not show toast for expected form validation errors', async () => {

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
@@ -2,6 +2,10 @@ import { expectLogic } from 'kea-test-utils'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import api from 'lib/api'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AccessControlLevel, DashboardType, QueryBasedInsightModel } from '~/types'
 
@@ -37,12 +41,50 @@ const makeDashboard = (body: string = 'existing text'): DashboardType<QueryBased
 
 describe('textCardModalLogic', () => {
     beforeEach(() => {
+        useMocks({
+            get: { '/api/environments/:team_id/dashboards/123/': () => [200, makeDashboard()] },
+        })
         initKeaTests()
         jest.spyOn(lemonToast, 'error').mockImplementation(jest.fn())
     })
 
     afterEach(() => {
         jest.restoreAllMocks()
+    })
+
+    it('creates a new text tile at the pending insertion slot instead of an empty column', async () => {
+        const dashboard = makeDashboard('')
+        // the inline "+" bar records where the tile should land before opening the modal
+        const dashLogic = dashboardLogic({ id: dashboard.id, dashboard })
+        dashLogic.mount()
+        dashLogic.actions.setPendingInsertion({ x: 6, y: 4, w: null })
+
+        const updateSpy = jest.spyOn(api, 'update').mockResolvedValue(dashboard as any)
+
+        const logic = textCardModalLogic({ dashboard, textTileId: 'new', onClose: jest.fn() })
+        logic.mount()
+        logic.actions.setTextTileValue('body', 'hello')
+        logic.actions.submitTextTile()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const patchBody = updateSpy.mock.calls[0][1] as { tiles: { layouts?: unknown }[] }
+        expect(patchBody.tiles[0].layouts).toEqual({ sm: { x: 6, y: 4, w: 2, h: 2 } })
+    })
+
+    it('omits layouts when there is no pending insertion (header add appends normally)', async () => {
+        const dashboard = makeDashboard('')
+        dashboardLogic({ id: dashboard.id, dashboard }).mount()
+
+        const updateSpy = jest.spyOn(api, 'update').mockResolvedValue(dashboard as any)
+
+        const logic = textCardModalLogic({ dashboard, textTileId: 'new', onClose: jest.fn() })
+        logic.mount()
+        logic.actions.setTextTileValue('body', 'hello')
+        logic.actions.submitTextTile()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const patchBody = updateSpy.mock.calls[0][1] as { tiles: { layouts?: unknown }[] }
+        expect(patchBody.tiles[0].layouts).toBeUndefined()
     })
 
     it('does not show toast for expected form validation errors', async () => {

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.test.ts
@@ -48,8 +48,6 @@ describe('textCardModalLogic', () => {
         jest.restoreAllMocks()
     })
 
-    // A new tile carries the inline "+" slot as its layout (so the grid doesn't float it to an empty
-    // column), and carries none when added without a slot (header "Add", which appends normally).
     it.each([
         {
             scenario: 'with a pending insertion slot',

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
@@ -4,10 +4,17 @@ import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardTile, DashboardType, QueryBasedInsightModel } from '~/types'
 
 import type { textCardModalLogicType } from './textCardModalLogicType'
+
+// Matches the text-tile defaults in `calculateLayouts` (tileLayouts.ts) so the tile is created at the
+// size the grid would give it anyway.
+const NEW_TEXT_TILE_WIDTH = 2
+const NEW_TEXT_TILE_HEIGHT = 2
 
 export interface TextTileForm {
     body: string
@@ -34,7 +41,10 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardTextTileModal', 'logic']),
     props({} as TextCardModalProps),
     key((props) => `textCardModalLogic-${props.dashboard.id}-${props.textTileId}`),
-    connect(() => ({ actions: [dashboardsModel, ['updateDashboard']] })),
+    connect((props: TextCardModalProps) => ({
+        actions: [dashboardsModel, ['updateDashboard']],
+        values: [dashboardLogic({ id: props.dashboard.id }), ['pendingInsertion']],
+    })),
     listeners(({ props, actions, values }) => ({
         submitTextTileFailure: (error) => {
             if (props.dashboard && props.textTileId) {
@@ -79,7 +89,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
             })
         },
     })),
-    forms(({ props, actions }) => ({
+    forms(({ props, actions, values }) => ({
         textTile: {
             defaults: (props.textTileId && props.textTileId !== 'new'
                 ? getExistingTextTile(props.dashboard, props.textTileId)
@@ -102,12 +112,28 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
                 }))
 
                 if (props.textTileId === 'new') {
+                    // When inserted via the inline "+" bar, create the tile at the chosen slot instead of
+                    // letting the backend default it to an empty column (which the grid floats to the top).
+                    // Existing tiles are shifted down afterwards by dashboardLogic's applyPendingInsertion.
+                    const slot = values.pendingInsertion
+                    const layouts = slot
+                        ? {
+                              sm: {
+                                  x: slot.x,
+                                  y: slot.y,
+                                  w: slot.w ?? NEW_TEXT_TILE_WIDTH,
+                                  h: NEW_TEXT_TILE_HEIGHT,
+                              },
+                          }
+                        : undefined
+
                     actions.updateDashboard({
                         id: props.dashboard.id,
                         tiles: [
                             {
                                 text: { body: formValues.body },
                                 transparent_background: formValues.transparent_background,
+                                ...(layouts ? { layouts } : {}),
                             },
                         ],
                     })

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
@@ -4,17 +4,13 @@ import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import type { PendingInsertion } from 'scenes/dashboard/dashboardLogic'
+import { DEFAULT_TEXT_TILE_SIZE } from 'scenes/dashboard/tileLayouts'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { DashboardTile, DashboardType, QueryBasedInsightModel } from '~/types'
 
 import type { textCardModalLogicType } from './textCardModalLogicType'
-
-// Matches the text-tile defaults in `calculateLayouts` (tileLayouts.ts) so the tile is created at the
-// size the grid would give it anyway.
-const NEW_TEXT_TILE_WIDTH = 2
-const NEW_TEXT_TILE_HEIGHT = 2
 
 export interface TextTileForm {
     body: string
@@ -25,6 +21,8 @@ export interface TextCardModalProps {
     dashboard: DashboardType<QueryBasedInsightModel>
     textTileId: number | 'new'
     onClose: () => void
+    // Set when opened from the inline "+" bar, so a new tile is created at the chosen slot.
+    pendingInsertion?: PendingInsertion | null
 }
 
 const MAX_TEXT_CARD_BODY_LENGTH = 4000
@@ -41,10 +39,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardTextTileModal', 'logic']),
     props({} as TextCardModalProps),
     key((props) => `textCardModalLogic-${props.dashboard.id}-${props.textTileId}`),
-    connect((props: TextCardModalProps) => ({
-        actions: [dashboardsModel, ['updateDashboard']],
-        values: [dashboardLogic({ id: props.dashboard.id }), ['pendingInsertion']],
-    })),
+    connect(() => ({ actions: [dashboardsModel, ['updateDashboard']] })),
     listeners(({ props, actions, values }) => ({
         submitTextTileFailure: (error) => {
             if (props.dashboard && props.textTileId) {
@@ -89,7 +84,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
             })
         },
     })),
-    forms(({ props, actions, values }) => ({
+    forms(({ props, actions }) => ({
         textTile: {
             defaults: (props.textTileId && props.textTileId !== 'new'
                 ? getExistingTextTile(props.dashboard, props.textTileId)
@@ -115,14 +110,14 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
                     // When inserted via the inline "+" bar, create the tile at the chosen slot instead of
                     // letting the backend default it to an empty column (which the grid floats to the top).
                     // Existing tiles are shifted down afterwards by dashboardLogic's applyPendingInsertion.
-                    const slot = values.pendingInsertion
+                    const slot = props.pendingInsertion
                     const layouts = slot
                         ? {
                               sm: {
                                   x: slot.x,
                                   y: slot.y,
-                                  w: slot.w ?? NEW_TEXT_TILE_WIDTH,
-                                  h: NEW_TEXT_TILE_HEIGHT,
+                                  w: slot.w ?? DEFAULT_TEXT_TILE_SIZE.w,
+                                  h: DEFAULT_TEXT_TILE_SIZE.h,
                               },
                           }
                         : undefined

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
@@ -21,7 +21,6 @@ export interface TextCardModalProps {
     dashboard: DashboardType<QueryBasedInsightModel>
     textTileId: number | 'new'
     onClose: () => void
-    // Set when opened from the inline "+" bar, so a new tile is created at the chosen slot.
     pendingInsertion?: PendingInsertion | null
 }
 
@@ -107,8 +106,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
                 }))
 
                 if (props.textTileId === 'new') {
-                    // When inserted via the inline "+" bar, create the tile at the chosen slot instead of
-                    // letting the backend default it to an empty column (which the grid floats to the top).
+                    // Create at the chosen slot; without a layout the grid floats the tile to the top.
                     // Existing tiles are shifted down afterwards by dashboardLogic's applyPendingInsertion.
                     const slot = props.pendingInsertion
                     const layouts = slot

--- a/frontend/src/scenes/dashboard/DashboardModals.tsx
+++ b/frontend/src/scenes/dashboard/DashboardModals.tsx
@@ -28,6 +28,7 @@ export function DashboardModals({ dashboard }: { dashboard: DashboardType<QueryB
         subscriptionId,
         showTextTileModal,
         textTileId,
+        pendingInsertion,
         showButtonTileModal,
         buttonTileId,
         terraformModalOpen,
@@ -63,6 +64,7 @@ export function DashboardModals({ dashboard }: { dashboard: DashboardType<QueryB
                         onClose={() => push(urls.dashboard(dashboard.id))}
                         dashboard={dashboard}
                         textTileId={textTileId}
+                        pendingInsertion={pendingInsertion}
                     />
                     <ButtonTileCardModal
                         isOpen={showButtonTileModal}

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1778,6 +1778,78 @@ describe('dashboardLogic', () => {
         })
     })
 
+    describe('inline insertion follow-up', () => {
+        // Two insight tiles stacked in the left column (0-6); the right column is free.
+        const leftColumnDashboard = (
+            extraTiles: DashboardTile<QueryBasedInsightModel>[] = []
+        ): DashboardType<QueryBasedInsightModel> => {
+            const top = {
+                ...tileFromInsight(insightOnDashboard(172, [12]), 301),
+                layouts: { sm: { i: '301', x: 0, y: 0, w: 6, h: 5 } },
+            } as DashboardTile<QueryBasedInsightModel>
+            const bottom = {
+                ...tileFromInsight(insightOnDashboard(175, [12]), 302),
+                layouts: { sm: { i: '302', x: 0, y: 5, w: 6, h: 5 } },
+            } as DashboardTile<QueryBasedInsightModel>
+            return { ...dashboardResult(12, [top, bottom, ...extraTiles]), id: 12 }
+        }
+
+        // The tile the add flow created and the dashboard returns. When it already carries the slot layout
+        // (text/widget), the follow-up should only shift the displaced tile; when it has none (insight added
+        // via reload), the follow-up must position it too.
+        it.each([
+            {
+                scenario: 'tile created at the slot — new tile is not re-patched',
+                createdTile: {
+                    id: 999,
+                    text: { body: 'note', last_modified_at: '2021-01-01T00:00:00Z' },
+                    layouts: { sm: { i: '999', x: 0, y: 5, w: 2, h: 2 } },
+                    color: null,
+                } as unknown as DashboardTile<QueryBasedInsightModel>,
+                newTileId: 999,
+                expectNewTileInPatch: false,
+            },
+            {
+                scenario: 'tile arrived without a layout — new tile is positioned by the follow-up',
+                createdTile: {
+                    ...tileFromInsight(insightOnDashboard(666, [12]), 998),
+                    layouts: {},
+                } as DashboardTile<QueryBasedInsightModel>,
+                newTileId: 998,
+                expectNewTileInPatch: true,
+            },
+        ])(
+            'applyPendingInsertion shifts displaced tiles ($scenario)',
+            async ({ createdTile, newTileId, expectNewTileInPatch }) => {
+                const updateSpy = jest.spyOn(api, 'update').mockResolvedValue(leftColumnDashboard() as any)
+                logic = dashboardLogic({ id: 12, dashboard: leftColumnDashboard() })
+                logic.mount()
+                await expectLogic(logic).toFinishAllListeners()
+
+                logic.actions.setPendingInsertion({ x: 0, y: 5, w: null })
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    dashboardsModel.actions.updateDashboardSuccess(leftColumnDashboard([createdTile]) as any)
+                }).toFinishAllListeners()
+
+                const patchCall = updateSpy.mock.calls.filter(
+                    ([url, body]) =>
+                        typeof url === 'string' &&
+                        url.includes('/dashboards/12') &&
+                        !!(body as { tiles?: unknown })?.tiles
+                )
+                const lastPatchBody = patchCall.at(-1)?.[1] as { tiles?: { id: number }[] } | undefined
+                const patchedIds = (lastPatchBody?.tiles || []).map((t) => t.id)
+
+                expect(patchedIds).toContain(302) // the displaced tile is always shifted down
+                expect(patchedIds.includes(newTileId)).toBe(expectNewTileInPatch)
+
+                updateSpy.mockRestore()
+            }
+        )
+    })
+
     describe('widget tiles', () => {
         let lemonToastInfoSpy: jest.SpiedFunction<typeof lemonToast.info>
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1698,7 +1698,9 @@ describe('dashboardLogic', () => {
             expect(logic.values.textTiles).toEqual([])
         })
 
-        it('optimistically shows a new text tile before the save resolves', async () => {
+        it('optimistically shows a new text tile before the save resolves, alongside existing tiles', async () => {
+            const idsBeforeAdd = logic.values.tiles.map((t) => t.id)
+
             await expectLogic(logic, () => {
                 dashboardsModel.actions.updateDashboard({
                     id: 5,
@@ -1706,15 +1708,19 @@ describe('dashboardLogic', () => {
                 })
             }).toDispatchActions([logic.actionTypes.addOptimisticTiles])
 
-            // the tile is in state (with a temporary negative id) without waiting for the server
+            // the tile is in state (with a temporary negative id) without waiting for the server,
+            // and the reducer appended it rather than replacing the existing tiles
             const optimistic = logic.values.tiles.find((t) => t.text?.body === 'brand new')
             expect(optimistic).not.toBeUndefined()
             expect(optimistic!.id).toBeLessThan(0)
+            expect(logic.values.tiles.map((t) => t.id)).toEqual(expect.arrayContaining(idsBeforeAdd))
         })
 
-        it('rolls the optimistic tile back if the save fails', async () => {
+        it('rolls the optimistic tile back if the save fails, without touching persisted tiles', async () => {
             silenceKeaLoadersErrors()
             jest.spyOn(api, 'update').mockRejectedValueOnce(new Error('boom'))
+
+            const idsBeforeAdd = logic.values.tiles.map((t) => t.id)
 
             await expectLogic(logic, () => {
                 dashboardsModel.actions.updateDashboard({
@@ -1728,6 +1734,8 @@ describe('dashboardLogic', () => {
             ])
 
             expect(logic.values.tiles.some((t) => t.text?.body === 'doomed')).toBe(false)
+            // the rollback removed only the optimistic tile, not the tiles that were already there
+            expect(logic.values.tiles.map((t) => t.id)).toEqual(idsBeforeAdd)
             resumeKeaLoadersErrors()
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1698,6 +1698,39 @@ describe('dashboardLogic', () => {
             expect(logic.values.textTiles).toEqual([])
         })
 
+        it('optimistically shows a new text tile before the save resolves', async () => {
+            await expectLogic(logic, () => {
+                dashboardsModel.actions.updateDashboard({
+                    id: 5,
+                    tiles: [{ text: { body: 'brand new' } }] as any,
+                })
+            }).toDispatchActions([logic.actionTypes.addOptimisticTiles])
+
+            // the tile is in state (with a temporary negative id) without waiting for the server
+            const optimistic = logic.values.tiles.find((t) => t.text?.body === 'brand new')
+            expect(optimistic).not.toBeUndefined()
+            expect(optimistic!.id).toBeLessThan(0)
+        })
+
+        it('rolls the optimistic tile back if the save fails', async () => {
+            silenceKeaLoadersErrors()
+            jest.spyOn(api, 'update').mockRejectedValueOnce(new Error('boom'))
+
+            await expectLogic(logic, () => {
+                dashboardsModel.actions.updateDashboard({
+                    id: 5,
+                    tiles: [{ text: { body: 'doomed' } }] as any,
+                })
+            }).toDispatchActions([
+                logic.actionTypes.addOptimisticTiles,
+                dashboardsModel.actionTypes.updateDashboardFailure,
+                logic.actionTypes.removeOptimisticTiles,
+            ])
+
+            expect(logic.values.tiles.some((t) => t.text?.body === 'doomed')).toBe(false)
+            resumeKeaLoadersErrors()
+        })
+
         it('shows undo toast when removing a text tile', async () => {
             const { render } = await import('@testing-library/react')
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -401,7 +401,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         duplicateTile: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
         removeTile: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
         addOptimisticTiles: (tiles: DashboardTile<QueryBasedInsightModel>[]) => ({ tiles }),
-        removeOptimisticTiles: (tileIds: number[]) => ({ tileIds }),
+        removeOptimisticTiles: true,
         moveToDashboard: (
             tile: DashboardTile<QueryBasedInsightModel>,
             fromDashboard: number,
@@ -920,6 +920,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 },
                 addOptimisticTiles: (state, { tiles }) => {
                     // Show freshly-added tiles before the save round-trips; the server response replaces them.
+                    // Optimistic tiles carry a negative id (see the updateDashboard listener) until then.
                     return state
                         ? ({
                               ...state,
@@ -927,11 +928,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                           } as DashboardType<QueryBasedInsightModel>)
                         : state
                 },
-                removeOptimisticTiles: (state, { tileIds }) => {
+                removeOptimisticTiles: (state) => {
+                    // Roll back every not-yet-persisted tile (negative id) when a save fails.
                     return state
                         ? ({
                               ...state,
-                              tiles: (state.tiles || []).filter((t) => !tileIds.includes(t.id)),
+                              tiles: (state.tiles || []).filter((t) => t.id >= 0),
                           } as DashboardType<QueryBasedInsightModel>)
                         : state
                 },
@@ -2186,6 +2188,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return
             }
             const optimisticTiles = newTextTiles.map((tile) => {
+                // Negative id marks the tile as optimistic until the server response replaces it.
                 cache.nextOptimisticTileId = (cache.nextOptimisticTileId ?? 0) - 1
                 return {
                     id: cache.nextOptimisticTileId,
@@ -2195,14 +2198,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     color: null,
                 } as DashboardTile<QueryBasedInsightModel>
             })
-            cache.optimisticTileIds = [...(cache.optimisticTileIds || []), ...optimisticTiles.map((t) => t.id)]
             actions.addOptimisticTiles(optimisticTiles)
         },
         [dashboardsModel.actionTypes.updateDashboardFailure]: () => {
-            if (cache.optimisticTileIds?.length) {
-                actions.removeOptimisticTiles(cache.optimisticTileIds)
-                cache.optimisticTileIds = []
-            }
+            actions.removeOptimisticTiles()
         },
         setPendingInsertion: ({ pendingInsertion }) => {
             // Snapshot current tile ids so we can identify the tile the add flow appends afterwards.
@@ -2290,7 +2289,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             // Text/button (via updateDashboard) and widget (client-merged) tiles arrive through here.
             if (dashboard?.id === props.id) {
                 // The server response already replaced any optimistic tiles with their saved equivalents.
-                cache.optimisticTileIds = []
                 actions.applyPendingInsertion()
             }
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2245,7 +2245,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 h
             )
 
-            // The inline insert has landed at the line — report it (outcome, vs the option-clicked intent).
             const insertedTileType = newTile.text
                 ? 'text_card'
                 : newTile.button_tile
@@ -2255,7 +2254,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     : 'insight'
             eventUsageLogic.actions.reportDashboardTileInsertedInline(insertedTileType, slot.x, slot.y, slot.w != null)
 
-            // Already at the slot with nothing to displace — the created position stands, no follow-up needed.
             if (newTileAlreadyAtSlot && tilesToUpdate.length === 0) {
                 return
             }
@@ -2276,8 +2274,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return
             }
 
-            // Persist the reflow (same raw-PATCH shape as duplicateTile / saveEditModeChanges). The new tile's
-            // own layout only rides along when we had to place it (insights); text/widget tiles already carry it.
             const tilesToPersist = newTileAlreadyAtSlot
                 ? tilesToUpdate
                 : [...tilesToUpdate, { id: newTile.id, layouts: newTileLayout }]

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2232,6 +2232,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const w = slot.w ?? newTileLayoutEntry?.w ?? DEFAULT_INSERTED_TILE_SIZE.w
             const h = newTileLayoutEntry?.h ?? DEFAULT_INSERTED_TILE_SIZE.h
 
+            // Text/widget tiles are created at the slot, so only the tiles they displace need moving.
+            // Insights arrive with no layout (added via a reload) and still need positioning here.
+            const newTileAlreadyAtSlot = newTileLayoutEntry?.x === slot.x && newTileLayoutEntry?.y === slot.y
+
             const { newTileLayout, tilesToUpdate } = calculateInsertionLayout(
                 smLayout,
                 newTile.id,
@@ -2241,18 +2245,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 h
             )
 
-            // Apply optimistically so the grid reflows immediately.
-            const shiftById = new Map(tilesToUpdate.map((t) => [t.id, t.layouts.sm]))
-            const newSmLayout = (smLayout || []).map((l) => {
-                if (String(l.i) === String(newTile.id)) {
-                    return { ...l, ...newTileLayout.sm }
-                }
-                const shifted = shiftById.get(parseInt(l.i))
-                return shifted ? { ...l, ...shifted } : l
-            })
-            actions.updateLayouts({ ...values.layouts, sm: newSmLayout })
-
-            // The inline insert has now landed at the line — report it (outcome, vs the option-clicked intent).
+            // The inline insert has landed at the line — report it (outcome, vs the option-clicked intent).
             const insertedTileType = newTile.text
                 ? 'text_card'
                 : newTile.button_tile
@@ -2262,19 +2255,37 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     : 'insight'
             eventUsageLogic.actions.reportDashboardTileInsertedInline(insertedTileType, slot.x, slot.y, slot.w != null)
 
+            // Already at the slot with nothing to displace — the created position stands, no follow-up needed.
+            if (newTileAlreadyAtSlot && tilesToUpdate.length === 0) {
+                return
+            }
+
+            // Apply optimistically so the grid reflows immediately.
+            const shiftById = new Map(tilesToUpdate.map((t) => [t.id, t.layouts.sm]))
+            const newSmLayout = (smLayout || []).map((l) => {
+                if (!newTileAlreadyAtSlot && String(l.i) === String(newTile.id)) {
+                    return { ...l, ...newTileLayout.sm }
+                }
+                const shifted = shiftById.get(parseInt(l.i))
+                return shifted ? { ...l, ...shifted } : l
+            })
+            actions.updateLayouts({ ...values.layouts, sm: newSmLayout })
+
             // In edit mode the change is saved with the rest of the edit session.
             if (values.layoutEditMode) {
                 return
             }
 
-            // Persist the repositioning (same raw-PATCH shape as duplicateTile / saveEditModeChanges).
-            // TODO: drop this follow-up request once the tile-create endpoints can insert at a position
-            // (and reflow the displaced tiles) server-side, so an inline insert is a single round trip.
+            // Persist the reflow (same raw-PATCH shape as duplicateTile / saveEditModeChanges). The new tile's
+            // own layout only rides along when we had to place it (insights); text/widget tiles already carry it.
+            const tilesToPersist = newTileAlreadyAtSlot
+                ? tilesToUpdate
+                : [...tilesToUpdate, { id: newTile.id, layouts: newTileLayout }]
             try {
                 const response: DashboardType<InsightModel> = await api.update(
                     `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                     {
-                        tiles: [...tilesToUpdate, { id: newTile.id, layouts: newTileLayout }],
+                        tiles: tilesToPersist,
                     }
                 )
                 const updated = getQueryBasedDashboard(response)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -47,6 +47,7 @@ import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic
 import { objectsEqual } from 'lib/utils/objects'
 import { shouldCancelQuery } from 'lib/utils/requests'
 import { toParams } from 'lib/utils/url'
+import type { DashboardAddTileType } from 'scenes/dashboard/dashboardAddTileTypes'
 import { BREAKPOINTS, dashboardToSaveableTemplate, getDashboardTileDisplayName } from 'scenes/dashboard/dashboardUtils'
 import {
     calculateDuplicateLayout,
@@ -193,6 +194,19 @@ const tileLayoutsFromDashboard = (
         tileIdToLayouts[tile.id] = tile.layouts
     })
     return tileIdToLayouts
+}
+
+function tileTypeOf(tile: DashboardTile<QueryBasedInsightModel>): DashboardAddTileType {
+    if (tile.text) {
+        return 'text_card'
+    }
+    if (tile.button_tile) {
+        return 'button'
+    }
+    if (tile.widget) {
+        return 'widget'
+    }
+    return 'insight'
 }
 
 function mergeUpdatedWidgetTileIntoDashboard(
@@ -2245,14 +2259,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 h
             )
 
-            const insertedTileType = newTile.text
-                ? 'text_card'
-                : newTile.button_tile
-                  ? 'button'
-                  : newTile.widget
-                    ? 'widget'
-                    : 'insight'
-            eventUsageLogic.actions.reportDashboardTileInsertedInline(insertedTileType, slot.x, slot.y, slot.w != null)
+            eventUsageLogic.actions.reportDashboardTileInsertedInline(
+                tileTypeOf(newTile),
+                slot.x,
+                slot.y,
+                slot.w != null
+            )
 
             if (newTileAlreadyAtSlot && tilesToUpdate.length === 0) {
                 return

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -400,6 +400,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         }),
         duplicateTile: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
         removeTile: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
+        addOptimisticTiles: (tiles: DashboardTile<QueryBasedInsightModel>[]) => ({ tiles }),
+        removeOptimisticTiles: (tileIds: number[]) => ({ tileIds }),
         moveToDashboard: (
             tile: DashboardTile<QueryBasedInsightModel>,
             fromDashboard: number,
@@ -915,6 +917,23 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         ...state,
                         tiles: state?.tiles?.filter((t) => t.id !== tile.id),
                     } as DashboardType<QueryBasedInsightModel>
+                },
+                addOptimisticTiles: (state, { tiles }) => {
+                    // Show freshly-added tiles before the save round-trips; the server response replaces them.
+                    return state
+                        ? ({
+                              ...state,
+                              tiles: [...(state.tiles || []), ...tiles],
+                          } as DashboardType<QueryBasedInsightModel>)
+                        : state
+                },
+                removeOptimisticTiles: (state, { tileIds }) => {
+                    return state
+                        ? ({
+                              ...state,
+                              tiles: (state.tiles || []).filter((t) => !tileIds.includes(t.id)),
+                          } as DashboardType<QueryBasedInsightModel>)
+                        : state
                 },
                 [dashboardsModel.actionTypes.tileMovedToDashboard]: (state, { tile, dashboardId }) => {
                     if (state?.id === dashboardId) {
@@ -2157,6 +2176,34 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
             }
         },
+        [dashboardsModel.actionTypes.updateDashboard]: ({ id, tiles }) => {
+            // Render newly-created text tiles right away; the save response replaces them, failure rolls them back.
+            if (id !== props.id || !Array.isArray(tiles)) {
+                return
+            }
+            const newTextTiles = tiles.filter((tile) => !!tile?.text && tile?.id == null)
+            if (!newTextTiles.length) {
+                return
+            }
+            const optimisticTiles = newTextTiles.map((tile) => {
+                cache.nextOptimisticTileId = (cache.nextOptimisticTileId ?? 0) - 1
+                return {
+                    id: cache.nextOptimisticTileId,
+                    text: tile.text,
+                    transparent_background: tile.transparent_background,
+                    layouts: tile.layouts || {},
+                    color: null,
+                } as DashboardTile<QueryBasedInsightModel>
+            })
+            cache.optimisticTileIds = [...(cache.optimisticTileIds || []), ...optimisticTiles.map((t) => t.id)]
+            actions.addOptimisticTiles(optimisticTiles)
+        },
+        [dashboardsModel.actionTypes.updateDashboardFailure]: () => {
+            if (cache.optimisticTileIds?.length) {
+                actions.removeOptimisticTiles(cache.optimisticTileIds)
+                cache.optimisticTileIds = []
+            }
+        },
         setPendingInsertion: ({ pendingInsertion }) => {
             // Snapshot current tile ids so we can identify the tile the add flow appends afterwards.
             cache.tileIdsBeforeInsertion = pendingInsertion ? new Set((values.tiles || []).map((t) => t.id)) : undefined
@@ -2242,6 +2289,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         [dashboardsModel.actionTypes.updateDashboardSuccess]: ({ dashboard }) => {
             // Text/button (via updateDashboard) and widget (client-merged) tiles arrive through here.
             if (dashboard?.id === props.id) {
+                // The server response already replaced any optimistic tiles with their saved equivalents.
+                cache.optimisticTileIds = []
                 actions.applyPendingInsertion()
             }
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2299,7 +2299,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
         [dashboardsModel.actionTypes.updateDashboardSuccess]: ({ dashboard }) => {
             // Text/button (via updateDashboard) and widget (client-merged) tiles arrive through here.
             if (dashboard?.id === props.id) {
-                // The server response already replaced any optimistic tiles with their saved equivalents.
                 actions.applyPendingInsertion()
             }
         },

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -27,6 +27,9 @@ const MIN_WIDGET_TILE_HEIGHT_ROWS = 4
 /** Fallback tile dimensions (half-width, standard height) when a tile has no known layout yet. */
 export const DEFAULT_INSERTED_TILE_SIZE = { w: 6, h: 5 } as const
 
+/** Default text-tile dimensions the grid assigns when a text tile has no stored layout. */
+export const DEFAULT_TEXT_TILE_SIZE = { w: 2, h: 2 } as const
+
 type WidgetCatalogLayout = DashboardWidgetCatalogEntry['defaultLayout']
 
 /**
@@ -242,8 +245,8 @@ export const calculateLayouts = (
             let defaultH = 5
             // Content-adjusted constraints (note that widths should be factors of 12)
             if (tile.text) {
-                defaultW = 2
-                defaultH = 2
+                defaultW = DEFAULT_TEXT_TILE_SIZE.w
+                defaultH = DEFAULT_TEXT_TILE_SIZE.h
             } else if (isFunnelsQuery(query)) {
                 defaultW = 4
                 defaultH = 4

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -27,7 +27,6 @@ const MIN_WIDGET_TILE_HEIGHT_ROWS = 4
 /** Fallback tile dimensions (half-width, standard height) when a tile has no known layout yet. */
 export const DEFAULT_INSERTED_TILE_SIZE = { w: 6, h: 5 } as const
 
-/** Default text-tile dimensions the grid assigns when a text tile has no stored layout. */
 export const DEFAULT_TEXT_TILE_SIZE = { w: 2, h: 2 } as const
 
 type WidgetCatalogLayout = DashboardWidgetCatalogEntry['defaultLayout']


### PR DESCRIPTION
## Problem

Adding a tile via the inline "+" bar on a dashboard made the new tile flash up to the top before settling, and it didn't appear until the save round-tripped. On dashboards with an empty column the jump was very visible.

Root cause: text/widget tiles were created with no layout, so the grid floated them to the first free slot (the top). A follow-up request then repositioned them, which is what you saw flash - and it was intermittent because that second request could lose a race to a reload.

## Changes

- **Text/widget tiles** embed the chosen slot layout in their create request, so they're born at the slot (no flash). The slot is passed to the text modal as a prop, keeping the modal logic decoupled from `dashboardLogic`.
- **Optimistic render** for new text tiles - they appear the moment you save, before the request returns; rolled back if the save fails.
- **Slimmed the follow-up** (`applyPendingInsertion`): when a tile is already at its slot it only shifts the tiles it displaces instead of re-positioning itself. When nothing is displaced, the follow-up request is skipped entirely.

> [!NOTE]
> Insight parity (making inline-inserted insights land at the slot too) is split into a stacked follow-up: #69343. It needed a backend serializer change, so it lives on its own.

## How did you test this code?

Automated (Jest), run locally by me (Claude):

- `textCardModalLogic.test.ts` - create payload carries the slot layout when a slot is set, none otherwise.
- `dashboardLogic.test.ts` - optimistic text tile appears before save and rolls back on failure; `applyPendingInsertion` shifts displaced tiles and only re-patches the new tile when it lacks a slot.

Full dashboard Jest suite: 79 passed / 1 skipped. I did not manually click through the running app, so the on-screen reflow is verified at the state level, not visually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) built this with Matt across several rounds. Traced the text-tile flash to create-then-reposition and matched the widget pattern (embed layout at create). Ran the shared `xp-reviewer` skill twice and applied its feedback (prop-drill the slot, share the default-size constant, parameterize tests, drop redundant optimistic bookkeeping in favour of the negative-id sentinel). Insight parity was split into stacked PR #69343.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
