### PR TITLE
feat(slack): add onboarding conversation flow and first-patrol digest

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -13,6 +13,7 @@ from posthog.temporal.ai.slack_app.posthog_code_slack_interactivity import (
 )
 from posthog.temporal.ai.slack_app.posthog_code_slack_mention import PostHogCodeSlackMentionWorkflow
 from posthog.temporal.ai.slack_app.posthog_code_slack_mention_command import PostHogCodeSlackMentionCommandWorkflow
+from posthog.temporal.ai.slack_app.posthog_slack_first_patrol import PostHogSlackFirstPatrolWorkflow
 from posthog.temporal.ai.slack_app.posthog_slack_inbox_onboarding import PostHogSlackInboxOnboardingWorkflow
 
 from .llm_traces_summaries.summarize_traces import (
@@ -37,6 +38,7 @@ POSTHOG_CODE_SLACK_WORKFLOWS = [
     PostHogCodeSlackMentionCommandWorkflow,
     PostHogCodeSlackTerminateTaskWorkflow,
     PostHogSlackInboxOnboardingWorkflow,
+    PostHogSlackFirstPatrolWorkflow,
 ]
 
 POSTHOG_CODE_SLACK_ACTIVITIES = [

--- a/posthog/temporal/ai/slack_app/__init__.py
+++ b/posthog/temporal/ai/slack_app/__init__.py
@@ -14,6 +14,7 @@ from posthog.temporal.ai.slack_app.activities import (
     classify_message_is_agent_directed,
     classify_posthog_code_task_needs_repo_activity,
     classify_untagged_followup_activity,
+    collect_first_patrol_digest_activity,
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
     create_posthog_code_task_for_repo_activity,
@@ -23,6 +24,7 @@ from posthog.temporal.ai.slack_app.activities import (
     forward_posthog_code_followup_activity,
     handle_posthog_code_rules_command_activity,
     handle_posthog_code_slack_mention_command_activity,
+    post_first_patrol_digest_activity,
     post_posthog_code_internal_error_activity,
     post_posthog_code_no_repos_activity,
     post_posthog_code_picker_timeout_activity,
@@ -61,6 +63,8 @@ SLACK_APP_ACTIVITIES = [
     create_posthog_code_routing_rule_activity,
     handle_posthog_code_slack_mention_command_activity,
     run_posthog_slack_inbox_onboarding_activity,
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
 ]
 
 __all__ = [

--- a/posthog/temporal/ai/slack_app/activities/__init__.py
+++ b/posthog/temporal/ai/slack_app/activities/__init__.py
@@ -6,6 +6,10 @@ from posthog.temporal.ai.slack_app.activities.classifiers import (
     classify_task_needs_repo,
     classify_untagged_followup_activity,
 )
+from posthog.temporal.ai.slack_app.activities.first_patrol import (
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
+)
 from posthog.temporal.ai.slack_app.activities.messaging import (
     POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE,
     POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
@@ -64,6 +68,8 @@ __all__ = [
     "post_posthog_code_repo_picker_activity",
     "resolve_posthog_code_slack_command_user_activity",
     "resolve_posthog_code_slack_user_activity",
+    "collect_first_patrol_digest_activity",
+    "post_first_patrol_digest_activity",
     "run_posthog_slack_inbox_onboarding",
     "run_posthog_slack_inbox_onboarding_activity",
 ]

--- a/posthog/temporal/ai/slack_app/activities/first_patrol.py
+++ b/posthog/temporal/ai/slack_app/activities/first_patrol.py
@@ -1,0 +1,35 @@
+import structlog
+from temporalio import activity
+
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+
+logger = structlog.get_logger(__name__)
+
+
+@activity.defn
+def collect_first_patrol_digest_activity(inputs: PostHogSlackFirstPatrolInputs) -> dict | None:
+    from products.slack_app.backend.first_patrol import (
+        collect_first_patrol_digest,  # noqa: PLC0415 — Django app import deferred to activity runtime
+    )
+
+    return collect_first_patrol_digest(
+        team_id=inputs.team_id,
+        channel_name=inputs.channel_name,
+        scout_config_ids=inputs.scout_config_ids,
+        provisioned_at_iso=inputs.provisioned_at_iso,
+    )
+
+
+@activity.defn
+def post_first_patrol_digest_activity(inputs: PostHogSlackFirstPatrolInputs, digest: dict) -> None:
+    from products.slack_app.backend.first_patrol import (
+        post_first_patrol_digest,  # noqa: PLC0415 — Django app import deferred to activity runtime
+    )
+
+    post_first_patrol_digest(
+        integration_id=inputs.integration_id,
+        slack_user_id=inputs.slack_user_id,
+        dm_channel_id=inputs.dm_channel_id,
+        thread_ts=inputs.thread_ts,
+        digest=digest,
+    )

--- a/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
+++ b/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
@@ -1,0 +1,58 @@
+import json
+from datetime import timedelta
+
+import structlog
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.ai.slack_app.activities.first_patrol import (
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
+)
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+from posthog.temporal.common.base import PostHogWorkflow
+
+# Give the immediate first runs (dispatched at provisioning, ~15 min ceiling each) time to
+# finish before the first check; retry once for coordinator/queue lag, then give up silently.
+FIRST_PATROL_INITIAL_DELAY_SECONDS = 45 * 60
+FIRST_PATROL_RETRY_DELAY_SECONDS = 30 * 60
+FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS = 2 * 60
+
+logger = structlog.get_logger(__name__)
+
+
+@workflow.defn(name="posthog-slack-first-patrol")
+class PostHogSlackFirstPatrolWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> PostHogSlackFirstPatrolInputs:
+        loaded = json.loads(inputs[0])
+        return PostHogSlackFirstPatrolInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: PostHogSlackFirstPatrolInputs) -> None:
+        await workflow.sleep(timedelta(seconds=FIRST_PATROL_INITIAL_DELAY_SECONDS))
+        digest = await workflow.execute_activity(
+            collect_first_patrol_digest_activity,
+            args=(inputs,),
+            start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        if digest is None:
+            # No completed runs yet (queue lag, quota skip) — one more chance, then silence.
+            await workflow.sleep(timedelta(seconds=FIRST_PATROL_RETRY_DELAY_SECONDS))
+            digest = await workflow.execute_activity(
+                collect_first_patrol_digest_activity,
+                args=(inputs,),
+                start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+        if digest is None:
+            return
+        await workflow.execute_activity(
+            post_first_patrol_digest_activity,
+            args=(inputs, digest),
+            start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+            # Single attempt: the DM isn't idempotent — a retry after a post-then-crash
+            # would double-message the user. Best-effort over duplicates.
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )

--- a/posthog/temporal/ai/slack_app/types.py
+++ b/posthog/temporal/ai/slack_app/types.py
@@ -110,3 +110,15 @@ class PostHogCodeSlackMentionCommandResult:
     status: str  # "done" | "needs_picker"
     pending_rule_text: str | None = None
     target_integration_id: int | None = None
+
+
+@dataclass
+class PostHogSlackFirstPatrolInputs:
+    team_id: int
+    integration_id: int
+    slack_user_id: str
+    dm_channel_id: str
+    thread_ts: str | None
+    channel_name: str
+    scout_config_ids: list[str]
+    provisioned_at_iso: str

--- a/posthog/temporal/tests/ai/test_first_patrol_workflow.py
+++ b/posthog/temporal/tests/ai/test_first_patrol_workflow.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from posthog.temporal.ai.slack_app import posthog_slack_first_patrol as wf_module
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+
+DIGEST = {"text": "t", "variant": "all_clear", "runs_completed": 1}
+
+
+def _inputs() -> PostHogSlackFirstPatrolInputs:
+    return PostHogSlackFirstPatrolInputs(
+        team_id=1,
+        integration_id=2,
+        slack_user_id="U1",
+        dm_channel_id="D1",
+        thread_ts=None,
+        channel_name="posthog-inbox",
+        scout_config_ids=["c1"],
+        provisioned_at_iso="2026-07-02T00:00:00",
+    )
+
+
+async def _run_with(collect_results: list) -> tuple[list[str], AsyncMock]:
+    calls: list[str] = []
+    remaining = list(collect_results)
+
+    async def fake_execute(activity_fn, *, args, **kwargs):
+        calls.append(activity_fn.__name__)
+        if activity_fn.__name__ == "collect_first_patrol_digest_activity":
+            return remaining.pop(0)
+        return None
+
+    sleep_mock = AsyncMock()
+    with (
+        patch.object(wf_module.workflow, "sleep", new=sleep_mock),
+        patch.object(wf_module.workflow, "execute_activity", new=fake_execute),
+    ):
+        await wf_module.PostHogSlackFirstPatrolWorkflow().run(_inputs())
+    return calls, sleep_mock
+
+
+@pytest.mark.asyncio
+async def test_digest_on_first_check_posts_after_initial_delay():
+    calls, sleep_mock = await _run_with([DIGEST])
+    assert calls == ["collect_first_patrol_digest_activity", "post_first_patrol_digest_activity"]
+    assert sleep_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_first_check_retries_once_then_posts():
+    calls, sleep_mock = await _run_with([None, DIGEST])
+    assert calls == [
+        "collect_first_patrol_digest_activity",
+        "collect_first_patrol_digest_activity",
+        "post_first_patrol_digest_activity",
+    ]
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_completed_runs_after_retry_exits_silently():
+    calls, sleep_mock = await _run_with([None, None])
+    assert calls == ["collect_first_patrol_digest_activity", "collect_first_patrol_digest_activity"]
+    assert sleep_mock.await_count == 2

--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -516,6 +516,7 @@ Per-scout binding for the headless **Signals agent**: one row per `(team, skill_
 | `emit`                 | Boolean              | Dry-run vs emit. Defaults `True`: a freshly authored scout is live from its first tick. Flip to `False` for dry-run — the scout runs and logs but `emit_finding` writes nothing — to validate it on a team before its findings reach the inbox. |
 | `run_interval_minutes` | PositiveSmallInt     | Minutes between runs. The coordinator dispatches when `last_run_at is None or now - last_run_at >= run_interval_minutes`. Default `1440` (daily). Validated `30 <= N <= 43200`.                                                                 |
 | `last_run_at`          | DateTime (nullable)  | Stamped after each dispatch; drives the due-check. Excluded from activity logging (written every run).                                                                                                                                          |
+| `delivery_config`      | JSONField (nullable) | Optional per-scout Slack delivery target: `{"slack": {"integration_id", "channel_id", "channel_name", "configured_by_user_id"}}`. Written only by the provisioning facade (`provision_persona_scouts`) — never accepted through the public config API, so channel changes go through the owning flow — and read server-side by the `notify` run tool, which is what keeps the agent from choosing its own channel. |
 | `created_by`           | FK → User (nullable) | Audit pointer                                                                                                                                                                                                                                   |
 | `enabled_by`           | FK → User (nullable) | Who last flipped `enabled` — tracked because enablement drives spend.                                                                                                                                                                           |
 
@@ -531,6 +532,7 @@ Thin bridge from a Tasks `TaskRun` to the scout skill that ran inside it: one sc
 | `skill_name`    | CharField(200)                    | The `signals-scout-*` skill the run executed.                                                                                                                      |
 | `skill_version` | Int                               | The `LLMSkill.version` snapshot at run start.                                                                                                                      |
 | `summary`       | TextField                         | One-paragraph close-out the agent writes at end-of-run. Searchable via ILIKE on the list endpoint so future runs can dedupe even when no `Signal` row was emitted. |
+| `notifications` | JSONField                         | Append-only audit of Slack alerts delivered via the `notify` run tool — one entry per delivered alert (`{channel_id, ts, account_name, owner_email, owner_tagged, report_id, sent_at}`). Doubles as the per-run delivery cap counter (`MAX_SLACK_NOTIFICATIONS_PER_RUN`).       |
 | `created_at`    | DateTime                          | Auto-set on creation.                                                                                                                                              |
 
 **Status, timing, and chat log live on the linked `TaskRun`.** The bridge row carries no `status` / `started_at` / `completed_at` / `findings` / `run_metrics` / `metadata` of its own — those moved to `tasks.TaskRun` so the LLM-analytics token / cost roll-up, the Tasks UI, and the harness all see one canonical record. `MultiTurnSession` owns the `TaskRun` lifecycle; the `on_task_run_created` hook attaches the `TaskRun` to the bridge row before the agent's first turn.
@@ -679,6 +681,15 @@ The canonical helper lives in `backend/temporal/signal_queries.py` (with a compa
 
 It soft-deletes report signals by re-emitting them with `metadata.deleted = true` while preserving original timestamps so rows replace originals via `ReplacingMergeTree`. It intentionally includes already-deleted rows for idempotency, but currently fetches at most 5000 signals per report.
 
+### Facade (`backend/facade/api.py`)
+
+The facade module is the surface other products import instead of reaching into Signals internals — it carries `emit_signal()`, the Slack report-dismissal and default-channel helpers, the inbox-onboarding source catalog, and the persona-scout provisioning pair:
+
+- **`provision_persona_scouts(team, created_by, slack_integration_id, channel_id, channel_name, skill_names, fire_first_runs=True)`** — seeds + enables a persona's canonical scouts with a Slack delivery target. Per skill: a targeted canonical seed (`sync_canonical_skills` with every other canonical withheld), an upsert of the `SignalScoutConfig` (enabled, emitting, daily) carrying `delivery_config`, and an immediate manual first run via `start_manual_signals_scout_run` so the user's first finding doesn't wait for the next coordinator tick (dispatched outside the transaction — a dispatch failure never rolls back the config; the coordinator picks the scout up at its next tick). An existing config already delivering to a **different** channel is left untouched: the result's `channel_conflict` reports where alerts already go, and no first run fires for it. A skill the team explicitly tombstoned is skipped (`skipped_reason="skill_tombstoned"`), never resurrected. Raises `ValueError` on an unknown skill name or when enabling would exceed `MAX_ENABLED_SCOUTS_PER_TEAM`.
+- **`collect_scout_run_digests(team_id, scout_config_ids, since_iso)`** — per-skill digest rows (`summary`, `notifications_sent`, `reports_filed`) for COMPLETED runs on the given configs since the provisioning moment, newest run per skill. Returns `None` while no run has completed yet so the caller can retry later rather than reporting on nothing. Feeds the Slack first-patrol digest.
+
+Consumers: the Slack app's persona onboarding (`products/slack_app/backend/persona_onboarding.py`) provisions the CSM fleet — the three canonical `signals-scout-csm-*` scouts — against the channel the user picked, then a delayed Temporal workflow (`posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py`) collects the digest and DMs the user the first runs' outcome.
+
 ### REST Endpoints
 
 All signals endpoints live under the `projects/:team_id/signals/` path, registered on the `projects_router` in `posthog/api/__init__.py`.
@@ -803,7 +814,7 @@ View + control API for the v2 grouping pipeline. Uses scope object `INTERNAL`.
 
 The harness exposes three viewsets routed under `environment_signals_scout_*` basenames in `posthog/api/__init__.py`. They are surfaced to MCP callers as `signals-scout-*` tools via `products/signals/mcp/tools.yaml`. Reads are scoped to the team; writes (scratchpad remember / forget, signal emit) require the matching MCP scope.
 
-- **`SignalScoutRunViewSet`** — list / retrieve scout run rows; nested action `runs/{id}/emit-signal/` for the harness to push findings during a run.
+- **`SignalScoutRunViewSet`** — list / retrieve scout run rows; nested actions on `runs/{id}/` for the run-scoped writes: `emit-signal/` for the harness to push findings during a run, and `notify/` for opted-in scouts to deliver Slack alerts (see below).
 - **`SignalScratchpadViewSet`** — search / remember / forget `SignalScratchpad` rows for the team. The `signals-scout-scratchpad-search` tool is the agent's primary "what do I already know" read at prompt-assembly time.
 - **`SignalProjectProfileViewSet`** — `GET .../current/` returns the freshest non-expired `SignalProjectProfile` row for the team (recomputes if the cache is stale).
 
@@ -814,10 +825,17 @@ Generated MCP tool names:
 | `signals-scout-runs-list`           | List scout runs (filterable by skill / status / time)                          |
 | `signals-scout-runs-retrieve`       | Fetch a single run row including the full findings payload                     |
 | `signals-scout-emit-signal`         | Push a finding from inside a run (used by the harness's `emit_signal_*` tools) |
+| `signals-scout-notify`              | Deliver a confirmed finding to the scout's configured Slack delivery channel   |
 | `signals-scout-scratchpad-search`   | Search durable scratchpad entries for the team                                 |
 | `signals-scout-scratchpad-remember` | Create or update a scratchpad entry                                            |
 | `signals-scout-scratchpad-forget`   | Remove a scratchpad entry                                                      |
 | `signals-scout-project-profile-get` | Read the current `SignalProjectProfile` snapshot                               |
+
+##### The `notify` run tool (Slack delivery)
+
+`signals-scout-notify` (`runs/{id}/notify/`) is opt-in: it works only during an in-progress run whose skill lists `send_slack_message` in its `allowed_tools`. The destination always comes from the scout config's `delivery_config` — never from the request — so the agent cannot choose its own channel. The alert tags the account owner when `owner_email` resolves via Slack `users.lookupByEmail` (best-effort — a lookup miss falls back to the plain label and never blocks delivery), and links back to the inbox report when a `report_id` this run emitted or edited is passed. Deliveries are capped at `MAX_SLACK_NOTIFICATIONS_PER_RUN` (`scout_harness/limits.py`, 5) per run and audited append-only on `SignalScoutRun.notifications`. Failures return machine-readable error codes that are terminal for the run — `no_delivery_config`, `notification_cap_reached`, `unknown_report_id` (the `report_id` is not one this run emitted or edited), `slack_integration_missing`, `channel_unavailable` — the prompt instructs the scout to note them in its run summary and never retry.
+
+This is distinct from the inbox Slack notifications in `backend/slack_inbox_notifications.py`: those route a READY report to each suggested **reviewer's** configured (or team-default) channel, while the `notify` run tool is per-scout channel delivery with account-owner tagging, driven by the scout itself mid-run.
 
 ### Serializers (`backend/serializers.py`)
 

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -535,28 +535,36 @@ def provision_persona_scouts(
                 )
                 created = True
 
-        # Outside the atomic block: Temporal dispatch is a side effect that must not sit
-        # inside the transaction, and a dispatch failure must not roll back the config.
-        first_run_started = False
-        if fire_first_runs and channel_conflict is None:
-            first_run_started = _fire_first_scout_run(team.id, skill_name)
-
         results.append(
             ScoutProvisionResult(
                 skill_name=skill_name,
                 config_id=str(config.id),
                 created=created,
                 channel_conflict=channel_conflict,
-                first_run_started=first_run_started,
+                first_run_started=False,
             )
         )
+
+    # Fire first runs after the config loop, sharing ONE Temporal connection across all of them —
+    # this runs on the synchronous Slack interactivity path, so a fresh connect per skill (each a
+    # TLS handshake) risks blowing Slack's ~3s ack budget. Temporal dispatch is a deliberate
+    # side effect kept outside every config's transaction: a dispatch failure never rolls back a
+    # config, and the coordinator picks the scout up at its next tick.
+    if fire_first_runs:
+        fired = _fire_first_scout_runs(
+            team.id, [result.skill_name for result in results if result.channel_conflict is None]
+        )
+        results = [dataclasses.replace(result, first_run_started=result.skill_name in fired) for result in results]
     return results
 
 
-def _fire_first_scout_run(team_id: int, skill_name: str) -> bool:
-    """Best-effort immediate dispatch through the existing manual-run path — every guard it
-    carries (quota, withheld skills, single-flight) stays intact. Failure never breaks
-    provisioning; the coordinator picks the scout up at its next tick."""
+def _fire_first_scout_runs(team_id: int, skill_names: list[str]) -> set[str]:
+    """Best-effort immediate dispatch of each skill through the existing manual-run path — every
+    guard it carries (quota, withheld skills, single-flight) stays intact. Returns the set of
+    skills whose dispatch succeeded; a failure never breaks provisioning. One shared Temporal
+    client for the whole batch to keep the synchronous caller off repeated connects."""
+    if not skill_names:
+        return set()
     from posthog.temporal.common.client import (
         sync_connect,  # noqa: PLC0415 — keeps the temporal graph off the facade import path
     )
@@ -566,11 +574,20 @@ def _fire_first_scout_run(team_id: int, skill_name: str) -> bool:
     )
 
     try:
-        start_manual_signals_scout_run(sync_connect(), team_id=team_id, skill_name=skill_name)
-        return True
+        client = sync_connect()
     except Exception:
-        logger.warning("persona_scout_first_run_dispatch_failed", team_id=team_id, skill_name=skill_name, exc_info=True)
-        return False
+        logger.warning("persona_scout_first_run_connect_failed", team_id=team_id, exc_info=True)
+        return set()
+    fired: set[str] = set()
+    for skill_name in skill_names:
+        try:
+            start_manual_signals_scout_run(client, team_id=team_id, skill_name=skill_name)
+            fired.add(skill_name)
+        except Exception:
+            logger.warning(
+                "persona_scout_first_run_dispatch_failed", team_id=team_id, skill_name=skill_name, exc_info=True
+            )
+    return fired
 
 
 @dataclasses.dataclass(frozen=True)

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -1,6 +1,6 @@
 import enum
 import dataclasses
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import get_args
 
 from django.conf import settings
@@ -571,3 +571,52 @@ def _fire_first_scout_run(team_id: int, skill_name: str) -> bool:
     except Exception:
         logger.warning("persona_scout_first_run_dispatch_failed", team_id=team_id, skill_name=skill_name, exc_info=True)
         return False
+
+
+@dataclasses.dataclass(frozen=True)
+class ScoutRunDigest:
+    """Per-scout outcome of the runs since a provisioning moment — feeds the Slack
+    first-patrol digest."""
+
+    skill_name: str
+    summary: str
+    notifications_sent: int
+    reports_filed: int
+
+
+def collect_scout_run_digests(
+    *, team_id: int, scout_config_ids: list[str], since_iso: str
+) -> list[ScoutRunDigest] | None:
+    """Digest rows for COMPLETED scout runs on the given configs since ``since_iso`` — one per
+    skill (newest run wins). ``None`` when no run has completed yet, so the caller can retry
+    later rather than reporting on nothing."""
+    from products.signals.backend.models import (
+        SignalScoutRun,  # noqa: PLC0415 — keeps the scout stack off the facade import path
+    )
+    from products.tasks.backend.facade import api as tasks_facade  # noqa: PLC0415 — same
+
+    since = datetime.fromisoformat(since_iso)
+    runs = list(
+        SignalScoutRun.objects.for_team(team_id)
+        .select_related("task_run")
+        .filter(scout_config_id__in=scout_config_ids, created_at__gte=since)
+        .order_by("created_at")
+    )
+    completed = [run for run in runs if run.task_run.status == tasks_facade.TaskRunStatus.COMPLETED]
+    if not completed:
+        return None
+    digests: list[ScoutRunDigest] = []
+    seen: set[str] = set()
+    for run in reversed(completed):
+        if run.skill_name in seen:
+            continue
+        seen.add(run.skill_name)
+        digests.append(
+            ScoutRunDigest(
+                skill_name=run.skill_name,
+                summary=run.summary or "",
+                notifications_sent=len(run.notifications or []),
+                reports_filed=len(run.emitted_report_ids or []) + len(run.edited_report_ids or []),
+            )
+        )
+    return list(reversed(digests))

--- a/products/signals/backend/scout_harness/AGENTS.md
+++ b/products/signals/backend/scout_harness/AGENTS.md
@@ -85,7 +85,9 @@ it is exercised via the `run_signals_scout` management command (see `../manageme
   Runtime ceilings as module constants: `DEFAULT_MAX_RUNTIME_S` (per-run budget),
   `ACTIVITY_SLACK_S`, and `WORKFLOW_HARD_CEILING_S` (`= DEFAULT_MAX_RUNTIME_S +
 ACTIVITY_SLACK_S`, the activity-level ceiling that gates the workflow's
-  `start_to_close_timeout`).
+  `start_to_close_timeout`), plus `MAX_ENABLED_SCOUTS_PER_TEAM` (per-team enabled-config
+  cap) and `MAX_SLACK_NOTIFICATIONS_PER_RUN` (Slack alerts one run may deliver via the
+  `notify` tool).
 - `team_limits.py`
   Single source of truth for a team's effective scout caps + metadata, resolved from the
   `signals-scout` flag payload in one read. The same three-layer cap resolution
@@ -127,6 +129,12 @@ ACTIVITY_SLACK_S`, the activity-level ceiling that gates the workflow's
   mints config rows. The metadata viewset is the read-only `scout/metadata/current/`
   endpoint that reports enrollment + banner + enforced limits via
   `team_limits.resolve_team_metadata`.
+  `SignalScoutRunViewSet` also carries the run-scoped `notify` action (`signals-scout-notify`):
+  it delivers a confirmed finding to the scout config's `delivery_config` Slack channel — opt-in
+  via `send_slack_message` in the skill's `allowed_tools` (gated by the shared `_assert_tool_opted_in`
+  that also gates the report tools), destination taken from config not the request, owner tagged via
+  `users.lookupByEmail`, capped at `MAX_SLACK_NOTIFICATIONS_PER_RUN` and audited on
+  `SignalScoutRun.notifications`.
 
 ## Mental model
 

--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -536,7 +536,7 @@ def _report_tail_sections(*, can_emit: bool, can_edit: bool) -> list[str]:
     """Report-channel tail, tailored to the report tools the scout actually opted into.
 
     A scout can list `emit_report`, `edit_report`, or both in `allowed_tools`. The report endpoints
-    fail closed on the *exact* tool (`views._assert_report_tool_opted_in`), so the prompt must never
+    fail closed on the *exact* tool (`views._assert_tool_opted_in`), so the prompt must never
     steer a scout toward a tool it lacks — an edit-only scout pointed at `emit_report` just earns a
     PermissionDenied. We therefore pick the run-step / authoring guidance to match, and include the
     standalone author-time sections (the suggested-reviewers deep-dive, writing a report) only when the

--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -48,7 +48,7 @@ SIGNALS_SCOUT_SANDBOX_ENV_NAME = SIGNALS_REPORT_RESEARCH_ENV_NAME
 # carries the report-write scope ONLY when its skill listed one of these in `allowed_tools` (see
 # the posture selection where the sandbox context is built). A baseline scout never carries that
 # scope, so the MCP server strips the report tools from its toolset — they can't bleed into a run
-# that didn't opt in. `views._assert_report_tool_opted_in` is the matching fail-closed gate on the
+# that didn't opt in. `views._assert_tool_opted_in` is the matching fail-closed gate on the
 # write itself. `REPORT_CHANNEL_TOOLS` / `skill_uses_report_channel` live in `skill_loader` so the
 # runner, prompt builder, and viewset all resolve the same opt-in set.
 

--- a/products/signals/backend/scout_harness/skill_loader.py
+++ b/products/signals/backend/scout_harness/skill_loader.py
@@ -45,7 +45,7 @@ class LoadedSkill:
     # `signal_scout_report:write` — the scope the report tools require. A scout that doesn't list them
     # gets no report scope, so the MCP server strips those tools from its toolset (exposure is
     # scope-level at the OAuth/MCP boundary). The `emit-report` / `edit-report` viewset actions also
-    # re-check this list server-side (`views.SignalScoutRunViewSet._assert_report_tool_opted_in`) as a
+    # re-check this list server-side (`views.SignalScoutRunViewSet._assert_tool_opted_in`) as a
     # fail-closed gate on the write. Downstream consumers (e.g. Claude Code) may also read it.
     allowed_tools: list[str]
     files: list[LoadedSkillFile]

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
 
 import structlog
@@ -1077,8 +1078,15 @@ class SignalScoutRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             "report_id": str(report_id) if report_id is not None else None,
             "sent_at": timezone.now().isoformat(),
         }
-        run.notifications = [*sent_notifications, entry]
-        run.save(update_fields=["notifications"])
+        # Re-read the row under lock before appending: concurrent `notify` tool calls within one
+        # run otherwise read the same `notifications` snapshot and the last save clobbers the
+        # other's entry (and the cap check above). The lock serializes the append so no audit
+        # entry is lost — the same pattern `scout_report/persistence._record_report_emit` uses.
+        # (The message is already posted, so we never hold the lock across the Slack call.)
+        with transaction.atomic():
+            locked = SignalScoutRun.objects.select_for_update().get(pk=run.pk)
+            locked.notifications = [*(locked.notifications or []), entry]
+            locked.save(update_fields=["notifications"])
 
         return Response(
             ScoutNotifyResponseSerializer(

--- a/products/signals/backend/test/test_persona_scout_provisioning.py
+++ b/products/signals/backend/test/test_persona_scout_provisioning.py
@@ -1,9 +1,14 @@
+from datetime import timedelta
+
 import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
-from products.signals.backend.facade.api import provision_persona_scouts
+from django.utils import timezone
+
+from products.signals.backend.facade.api import collect_scout_run_digests, provision_persona_scouts
 from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.test.test_scout_harness_api import _make_run
 from products.skills.backend.models.skills import LLMSkill
 
 CSM_SKILLS = [
@@ -93,3 +98,35 @@ class TestProvisionPersonaScouts(BaseTest):
         assert results[0].config_id is None
         assert not LLMSkill.objects.filter(team=self.team, name=skill, deleted=False).exists()
         assert not SignalScoutConfig.objects.for_team(self.team.id).filter(skill_name=skill).exists()
+
+
+class TestCollectScoutRunDigests(BaseTest):
+    def _digests(self, config_ids, since="2020-01-01T00:00:00"):
+        return collect_scout_run_digests(team_id=self.team.id, scout_config_ids=config_ids, since_iso=since)
+
+    def test_returns_none_until_a_run_completes(self):
+        run = _make_run(self.team, task_run_status="in_progress")
+        assert self._digests([str(run.scout_config_id)]) is None
+
+    def test_completed_runs_digest_with_newest_per_skill(self):
+        older = _make_run(self.team, task_run_status="completed", summary="old sweep")
+        newer = _make_run(
+            self.team,
+            task_run_status="completed",
+            summary="fresh sweep, all clear",
+            scout_config=older.scout_config,
+            notifications=[{"ts": "1"}],
+            emitted_report_ids=["r1"],
+        )
+        digests = self._digests([str(older.scout_config_id)])
+        assert digests is not None
+        assert len(digests) == 1
+        assert digests[0].summary == "fresh sweep, all clear"
+        assert digests[0].notifications_sent == 1
+        assert digests[0].reports_filed == 1
+        assert newer.skill_name == digests[0].skill_name
+
+    def test_runs_before_provisioning_are_excluded(self):
+        run = _make_run(self.team, task_run_status="completed", summary="pre-existing run")
+        future = (timezone.now() + timedelta(hours=1)).isoformat()
+        assert self._digests([str(run.scout_config_id)], since=future) is None

--- a/products/signals/backend/test/test_persona_scout_provisioning.py
+++ b/products/signals/backend/test/test_persona_scout_provisioning.py
@@ -16,7 +16,11 @@ CSM_SKILLS = [
     "signals-scout-csm-support-watch",
     "signals-scout-csm-revenue-watch",
 ]
-FIRE_PATH = "products.signals.backend.facade.api._fire_first_scout_run"
+FIRE_PATH = "products.signals.backend.facade.api._fire_first_scout_runs"
+
+
+def _fire_all(team_id, skill_names):
+    return set(skill_names)
 
 
 class TestProvisionPersonaScouts(BaseTest):
@@ -32,7 +36,7 @@ class TestProvisionPersonaScouts(BaseTest):
         kwargs.update(overrides)
         return provision_persona_scouts(**kwargs)
 
-    @patch(FIRE_PATH, return_value=True)
+    @patch(FIRE_PATH, side_effect=_fire_all)
     def test_fresh_team_gets_seeded_enabled_fleet_with_delivery_and_first_runs(self, fire_mock) -> None:
         results = self._provision()
         assert [r.skill_name for r in results] == CSM_SKILLS
@@ -45,9 +49,11 @@ class TestProvisionPersonaScouts(BaseTest):
             assert config.run_interval_minutes == 1440
             assert config.delivery_config["slack"]["channel_id"] == "C_ALERTS"
             assert config.delivery_config["slack"]["integration_id"] == 42
-        assert fire_mock.call_count == len(CSM_SKILLS)
+        # One shared-connection batch dispatch for the whole fleet, not one connect per skill.
+        assert fire_mock.call_count == 1
+        assert sorted(fire_mock.call_args.args[1]) == sorted(CSM_SKILLS)
 
-    @patch(FIRE_PATH, return_value=True)
+    @patch(FIRE_PATH, side_effect=_fire_all)
     def test_existing_config_with_other_channel_is_not_overwritten(self, fire_mock) -> None:
         skill = CSM_SKILLS[0]
         SignalScoutConfig.objects.create(
@@ -63,9 +69,10 @@ class TestProvisionPersonaScouts(BaseTest):
         config = SignalScoutConfig.objects.for_team(self.team.id).get(skill_name=skill)
         assert config.delivery_config["slack"]["channel_id"] == "C_OLD"
         assert config.enabled is True
-        fire_mock.assert_not_called()
+        # A conflicting scout is excluded from the first-run batch.
+        assert fire_mock.call_args.args[1] == []
 
-    @patch(FIRE_PATH, return_value=True)
+    @patch(FIRE_PATH, side_effect=_fire_all)
     def test_existing_config_without_delivery_is_adopted(self, fire_mock) -> None:
         skill = CSM_SKILLS[0]
         SignalScoutConfig.objects.create(team=self.team, skill_name=skill, enabled=False)
@@ -80,14 +87,14 @@ class TestProvisionPersonaScouts(BaseTest):
         with pytest.raises(ValueError, match="Unknown canonical scout skill"):
             self._provision(skill_names=["signals-scout-does-not-exist"])
 
-    @patch(FIRE_PATH, return_value=False)
+    @patch(FIRE_PATH, return_value=set())
     def test_first_run_dispatch_failure_does_not_fail_provisioning(self, fire_mock) -> None:
         results = self._provision(skill_names=[CSM_SKILLS[0]])
         assert results[0].created is True
         assert results[0].first_run_started is False
         assert SignalScoutConfig.objects.for_team(self.team.id).filter(skill_name=CSM_SKILLS[0]).exists()
 
-    @patch(FIRE_PATH, return_value=True)
+    @patch(FIRE_PATH, side_effect=_fire_all)
     def test_tombstoned_skill_is_skipped_not_resurrected(self, fire_mock) -> None:
         skill = CSM_SKILLS[0]
         self._provision(skill_names=[skill])

--- a/products/signals/backend/test/test_scout_notify_api.py
+++ b/products/signals/backend/test/test_scout_notify_api.py
@@ -60,6 +60,15 @@ class TestScoutNotifyAPI(APIBaseTest):
         return client
 
     @patch(WEBCLIENT_PATH)
+    def test_successive_notifications_accumulate_in_the_audit(self, webclient_cls) -> None:
+        self._client_mock(webclient_cls)
+        run = self._run_with_delivery()
+        self.client.post(self._url(str(run.id)), self._payload(account_name="Acme"), format="json")
+        self.client.post(self._url(str(run.id)), self._payload(account_name="Initech"), format="json")
+        run.refresh_from_db()
+        assert [entry["account_name"] for entry in run.notifications] == ["Acme", "Initech"]
+
+    @patch(WEBCLIENT_PATH)
     def test_notify_posts_only_to_configured_channel(self, webclient_cls) -> None:
         client = self._client_mock(webclient_cls)
         run = self._run_with_delivery()

--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -233,6 +233,18 @@ agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see
   `revenue-analytics` watches the lagging revenue/MRR signal; neither scores an
   individual account's engagement trajectory. Acquisition is the web-analytics
   scout's territory.
+- `signals-scout-csm-*/` — the customer-success fleet, provisioned per-team by the Slack
+  co-worker's persona onboarding rather than the general enrollment path, and the first scouts
+  to use the **Slack delivery** channel: each lists `send_slack_message` in `allowed_tools` and,
+  after filing an inbox report, calls `signals-scout-notify` to ping the scout config's Slack
+  channel tagging the account owner. `-account-pulse` watches per-account product engagement
+  (the CS delivery counterpart to `customer-analytics` — it relays/edits that scout's reports
+  when it is enabled rather than re-deriving); `-support-watch` watches support-ticket movement
+  (native conversations tickets or synced Zendesk / Intercom / Linear / Jira / Freshdesk); and
+  `-revenue-watch` watches billing/renewal risk (revenue-analytics views or synced Stripe),
+  deferring aggregate MRR movement to `revenue-analytics`. All three are report-channel scouts
+  whose findings are requires-human-input (a CSM acts on them; there is no code fix), and are
+  excluded from the `signals-scout` flag's `enabled_skills` so only onboarding enables them.
 - `signals-scout-mcp-tool-calls/` — tool-quality watcher for PostHog MCP usage. Reads
   `$mcp_tool_call` telemetry for tools that need improvement: high, broad-reach failure
   rates, per-session retry/hammering that betrays a confusing schema, slow or

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -51,7 +51,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
 from posthog.utils import get_instance_region
 
-from products.slack_app.backend import inbox_channel, onboarding
+from products.slack_app.backend import inbox_channel, onboarding, persona_onboarding
 from products.slack_app.backend.feature_flags import (
     is_slack_app_assistant_enabled,
     is_slack_app_oauth_enabled,
@@ -1634,6 +1634,17 @@ def _route_assistant_event(
     posthog_user = resolution.user
 
     if event_type == "assistant_thread_started":
+        if persona_onboarding.maybe_intercept_assistant_surface(
+            probe,
+            posthog_user_id=posthog_user.id,
+            workspace_id=slack_team_id,
+            slack_user_id=slack_user_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            accessible_integration_ids=[integration.id for integration in resolution.candidates],
+            entry_point="thread_started",
+        ):
+            return ROUTE_HANDLED_LOCALLY
         return _handle_assistant_thread_started(SlackIntegration(probe), channel_id, thread_ts)
     if event_type == "assistant_thread_context_changed":
         _store_assistant_channel_context(probe.id, channel_id, thread_ts, ctx_channel)
@@ -1644,6 +1655,17 @@ def _route_assistant_event(
     mention_target = resolution.integration or (accessible[0] if len(accessible) == 1 else None)
     if mention_target is None:
         _post_pick_a_project_hint(SlackIntegration(accessible[0]), accessible, event)
+        return ROUTE_HANDLED_LOCALLY
+    if persona_onboarding.maybe_intercept_assistant_surface(
+        mention_target,
+        posthog_user_id=posthog_user.id,
+        workspace_id=slack_team_id,
+        slack_user_id=slack_user_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        accessible_integration_ids=[integration.id for integration in accessible],
+        entry_point="first_dm",
+    ):
         return ROUTE_HANDLED_LOCALLY
     return _handle_assistant_dm_message(
         event, mention_target, slack_team_id, event_id, channel_id, thread_ts, posthog_user=posthog_user
@@ -2575,6 +2597,18 @@ _AI_PREFERENCES_ACTION_IDS = frozenset(
     }
 )
 _AI_PREFERENCES_CALLBACK_IDS = frozenset({EDIT_MODAL_PERSONAL_CALLBACK_ID, EDIT_MODAL_WORKSPACE_CALLBACK_ID})
+
+
+def _is_persona_onboarding_interactivity(payload: dict, payload_type: str) -> bool:
+    """True when the payload is a persona-onboarding interaction (home card or DM steps).
+    Like the AI-settings actions, these are workspace-scoped and carry no per-row hint, so
+    the cross-region router claims locality on the workspace integration alone."""
+    if payload_type != "block_actions":
+        return False
+    for action in payload.get("actions", []) or ():
+        if str(action.get("action_id") or "").startswith(persona_onboarding.ACTION_PREFIX):
+            return True
+    return False
 
 
 def _is_ai_preferences_interactivity(payload: dict, payload_type: str) -> bool:
@@ -3623,6 +3657,13 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
             kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
+    elif slack_team_id and _is_persona_onboarding_interactivity(payload, payload_type):
+        # Persona-onboarding buttons (home card + DM steps) are workspace-scoped like the
+        # AI-settings actions above — claim locality on the workspace integration alone.
+        local = Integration.objects.filter(
+            kind=SLACK_INTEGRATION_KIND,
+            integration_id=slack_team_id,
+        ).exists()
 
     proxied = was_proxied(request)
     incoming_host = request.get_host()
@@ -3726,6 +3767,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
                 return inbox_interactivity.handle_inbox_sources(payload)
             if action_id == onboarding.INBOX_AI_APPROVAL_ACTION_ID:
                 return inbox_interactivity.handle_inbox_ai_approval(payload)
+            if action_id and action_id.startswith(persona_onboarding.ACTION_PREFIX):
+                return persona_onboarding.handle_block_action(payload, action)
             if action_id in _AI_PREFERENCES_ACTION_IDS:
                 return _handle_ai_preferences_block_action(payload, action)
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1634,8 +1634,15 @@ def _route_assistant_event(
     posthog_user = resolution.user
 
     if event_type == "assistant_thread_started":
+        # Land onboarding on the same project the first-DM path resolves to, so the CSM fleet
+        # doesn't depend on which entry point fired first. Fall back to the workspace probe when
+        # the user's target is ambiguous (multi-project, no default) — the picker resolves that on
+        # the first DM.
+        onboarding_target = (
+            resolution.integration or (resolution.candidates[0] if len(resolution.candidates) == 1 else None) or probe
+        )
         if persona_onboarding.maybe_intercept_assistant_surface(
-            probe,
+            onboarding_target,
             posthog_user_id=posthog_user.id,
             workspace_id=slack_team_id,
             slack_user_id=slack_user_id,

--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -153,3 +153,26 @@ def is_slack_app_assistant_enabled(team: Team) -> bool:
     except Exception:
         logger.exception("assistant_feature_flag_eval_failed")
         return False
+
+
+SLACK_APP_PERSONA_ONBOARDING_FLAG = "slack-app-persona-onboarding"
+
+
+def is_persona_onboarding_enabled(team: Team) -> bool:
+    """Gate for the persona onboarding flow: the DM conversation, the DM/thread
+    intercepts, and the App Home "Start onboarding" card. Evaluated on the
+    workspace's team so the whole surface stays dark when off."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                SLACK_APP_PERSONA_ONBOARDING_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("persona_onboarding_feature_flag_eval_failed")
+        return False

--- a/products/slack_app/backend/first_patrol.py
+++ b/products/slack_app/backend/first_patrol.py
@@ -76,7 +76,8 @@ def _first_sentence(summary: str, limit: int = 140) -> str:
         return ""
     sentence = text.split(". ")[0].rstrip(".")
     if len(sentence) > limit:
-        sentence = sentence[: limit - 1].rstrip() + "…"
+        # Truncated → the ellipsis is the terminal punctuation; don't also append a period.
+        return sentence[: limit - 1].rstrip() + "…"
     return sentence + "."
 
 

--- a/products/slack_app/backend/first_patrol.py
+++ b/products/slack_app/backend/first_patrol.py
@@ -1,0 +1,145 @@
+"""First-patrol digest: after CSM onboarding provisions the scout fleet and fires immediate
+first runs, a delayed Temporal workflow checks the outcomes and DMs the user a digest — the
+finding, or an explicit all-clear — so the first scout touch lands within the first hour
+even when the data is healthy.
+
+The Temporal workflow/activities live in ``posthog/temporal/ai/slack_app/``; this module
+holds the plain functions they delegate to (dispatch, collection, copy, delivery) so the
+behavior is unit-testable without a Temporal environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+
+from posthog.models.integration import Integration, SlackIntegration
+
+from products.slack_app.backend.analytics import capture_slack_event
+from products.slack_app.backend.persona_onboarding import PERSONA_CSM, PERSONA_SCOUT_CATALOG, inbox_url
+
+logger = structlog.get_logger(__name__)
+
+EVENT_DIGEST_SENT = "slack_persona_onboarding_first_patrol_digest_sent"
+
+_TITLE_BY_SKILL = {spec.skill_name: spec.title for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]}
+
+
+def start_first_patrol_digest_workflow(
+    *,
+    team_id: int,
+    integration_id: int,
+    slack_user_id: str,
+    dm_channel_id: str,
+    thread_ts: str | None,
+    channel_name: str,
+    scout_config_ids: list[str],
+    provisioned_at_iso: str,
+) -> None:
+    """Enqueue the delayed digest workflow. Raises on dispatch failure — the caller
+    (persona onboarding) treats it as best-effort."""
+    from django.conf import settings  # noqa: PLC0415 — keeps the temporal graph off the slack import path
+
+    from temporalio.common import WorkflowIDReusePolicy  # noqa: PLC0415 — same
+
+    from posthog.temporal.ai.slack_app.posthog_slack_first_patrol import (  # noqa: PLC0415 — same
+        PostHogSlackFirstPatrolWorkflow,
+    )
+    from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs  # noqa: PLC0415 — same
+    from posthog.temporal.common.client import sync_connect  # noqa: PLC0415 — same
+
+    client = sync_connect()
+    asyncio.run(
+        client.start_workflow(
+            PostHogSlackFirstPatrolWorkflow.run,
+            PostHogSlackFirstPatrolInputs(
+                team_id=team_id,
+                integration_id=integration_id,
+                slack_user_id=slack_user_id,
+                dm_channel_id=dm_channel_id,
+                thread_ts=thread_ts,
+                channel_name=channel_name,
+                scout_config_ids=scout_config_ids,
+                provisioned_at_iso=provisioned_at_iso,
+            ),
+            id=f"posthog-slack-first-patrol-{integration_id}-{slack_user_id}",
+            task_queue=settings.TASKS_TASK_QUEUE,
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+        )
+    )
+
+
+def _first_sentence(summary: str, limit: int = 140) -> str:
+    text = " ".join((summary or "").split())
+    if not text:
+        return ""
+    sentence = text.split(". ")[0].rstrip(".")
+    if len(sentence) > limit:
+        sentence = sentence[: limit - 1].rstrip() + "…"
+    return sentence + "."
+
+
+def _clause(summary: str, max_words: int = 12) -> str:
+    words = " ".join((summary or "").split()).rstrip(".").split()
+    if not words:
+        return "checked in clean"
+    if len(words) <= max_words:
+        return " ".join(words)
+    return " ".join(words[:max_words]) + "…"
+
+
+def collect_first_patrol_digest(
+    *, team_id: int, channel_name: str, scout_config_ids: list[str], provisioned_at_iso: str
+) -> dict | None:
+    """Compose the digest from the first runs' outcomes. ``None`` when no run has completed
+    yet — the workflow retries once, then gives up silently (never nag)."""
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off the slack import path
+        collect_scout_run_digests,
+    )
+
+    digests = collect_scout_run_digests(
+        team_id=team_id, scout_config_ids=scout_config_ids, since_iso=provisioned_at_iso
+    )
+    if digests is None:
+        return None
+    found = [digest for digest in digests if digest.notifications_sent or digest.reports_filed]
+    if found:
+        first = found[0]
+        title = _TITLE_BY_SKILL.get(first.skill_name, first.skill_name)
+        headline = _first_sentence(first.summary) or "it flagged an account that needs attention."
+        text = (
+            f"Your scouts just finished their first patrol — *{title}* found something: {headline} "
+            f"Full details in #{channel_name} and your <{inbox_url(team_id)}|PostHog inbox>."
+        )
+        if len(found) > 1:
+            extra = len(found) - 1
+            text += f" ({extra} more scout{'s' if extra > 1 else ''} reported findings too.)"
+        return {"text": text, "variant": "finding", "runs_completed": len(digests)}
+    clauses = "; ".join(
+        f"{_TITLE_BY_SKILL.get(digest.skill_name, digest.skill_name)}: {_clause(digest.summary)}" for digest in digests
+    )
+    text = (
+        f"First patrol done ✅ — {clauses}. Nothing to worry about right now. "
+        f"I'll keep watching daily and ping #{channel_name} the moment that changes."
+    )
+    return {"text": text, "variant": "all_clear", "runs_completed": len(digests)}
+
+
+def post_first_patrol_digest(
+    *, integration_id: int, slack_user_id: str, dm_channel_id: str, thread_ts: str | None, digest: dict
+) -> None:
+    integration = Integration.objects.filter(id=integration_id, kind="slack").first()
+    if integration is None:
+        logger.info("first_patrol_integration_gone", integration_id=integration_id)
+        return
+    SlackIntegration(integration).client.chat_postMessage(
+        channel=dm_channel_id, thread_ts=thread_ts, text=digest["text"]
+    )
+    capture_slack_event(
+        integration,
+        EVENT_DIGEST_SENT,
+        slack_user_id=slack_user_id,
+        variant=digest.get("variant"),
+        runs_completed=digest.get("runs_completed"),
+    )

--- a/products/slack_app/backend/migrations/0012_slacksettings_persona_onboarding.py
+++ b/products/slack_app/backend/migrations/0012_slacksettings_persona_onboarding.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("slack_app", "0011_slacksettings_permission_mode"),
     ]

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -12,12 +12,26 @@ from __future__ import annotations
 
 import dataclasses
 
+from django.http import HttpResponse
+from django.utils import timezone
+
 import structlog
+from slack_sdk.errors import SlackApiError
 
-from posthog.models.integration import SlackIntegration
+from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.user import User
 
+from products.slack_app.backend.analytics import capture_slack_event
+from products.slack_app.backend.feature_flags import is_persona_onboarding_enabled
+from products.slack_app.backend.inbox_channel import (
+    INBOX_CHANNEL_REQUIRED_SCOPES,
+    ensure_inbox_channel,
+    invite_user_to_inbox,
+)
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
 from products.slack_app.backend.onboarding import _public_url
 from products.slack_app.backend.services import slack_search
+from products.slack_app.backend.services.integration_resolver import load_integrations, resolve_user_for_workspace
 
 logger = structlog.get_logger(__name__)
 
@@ -197,3 +211,859 @@ def sources_catalog_url(team_id: int) -> str:
 
 def inbox_url(team_id: int) -> str:
     return _public_url(f"/project/{team_id}/inbox")
+
+
+# ============================================================================
+# Persona scout catalog + data readiness
+# ============================================================================
+
+PERSONA_CSM = "csm"
+PERSONA_ENGINEER = "engineer"
+PERSONA_OTHER = "other"
+
+STEP_AWAITING_PERSONA = "awaiting_persona"
+STEP_AWAITING_CHANNEL = "awaiting_channel"
+
+
+@dataclasses.dataclass(frozen=True)
+class ScoutSpec:
+    skill_name: str
+    title: str
+    description: str
+    readiness_key: str
+    connectable_sources: tuple[str, ...]  # ExternalDataSourceType values that would feed it
+    gap_line: str  # "works best with …" copy when readiness is False
+
+
+PERSONA_SCOUT_CATALOG: dict[str, tuple[ScoutSpec, ...]] = {
+    PERSONA_CSM: (
+        ScoutSpec(
+            skill_name="signals-scout-csm-account-pulse",
+            title="Account pulse",
+            description=(
+                "Watches each account's product usage and flags the ones sliding toward churn or "
+                "heating up toward expansion, tagging the account owner."
+            ),
+            readiness_key="account_pulse",
+            connectable_sources=("Salesforce", "Hubspot"),
+            gap_line="works best with account data — PostHog customer analytics accounts or a synced CRM.",
+        ),
+        ScoutSpec(
+            skill_name="signals-scout-csm-support-watch",
+            title="Support watch",
+            description=(
+                "Watches support tickets for spikes, escalations, and accounts going loud (or silent) "
+                "right before renewal."
+            ),
+            readiness_key="support_watch",
+            connectable_sources=("Zendesk", "Intercom", "Linear", "Jira", "Freshdesk"),
+            gap_line="works best with a ticketing tool.",
+        ),
+        ScoutSpec(
+            skill_name="signals-scout-csm-revenue-watch",
+            title="Renewal & billing watch",
+            description=(
+                "Watches billing data for failed payments, cancellations, and contraction on the accounts you own."
+            ),
+            readiness_key="revenue_watch",
+            connectable_sources=("Stripe",),
+            gap_line="works best with billing data — connect Stripe or PostHog revenue analytics.",
+        ),
+    ),
+}
+
+_TOOL_LABEL_BY_KIND = {tool.source_kind: tool.label for tool in _CONNECTABLE_TOOLS}
+
+_SUPPORT_SOURCE_KINDS = ("Zendesk", "Intercom", "Linear", "Jira", "Freshdesk")
+_CRM_SOURCE_KINDS = ("Salesforce", "Hubspot")
+
+
+@dataclasses.dataclass(frozen=True)
+class CsmDataReadiness:
+    account_pulse: bool
+    support_watch: bool
+    revenue_watch: bool
+    accounts_count: int
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def _active_source_kinds(team_id: int) -> set[str]:
+    from products.warehouse_sources.backend.models.external_data_source import (  # noqa: PLC0415 — keeps the warehouse stack off the slack import path
+        ExternalDataSource,
+    )
+
+    return set(
+        ExternalDataSource.objects.filter(team_id=team_id).exclude(deleted=True).values_list("source_type", flat=True)
+    )
+
+
+def check_csm_data_readiness(team_id: int) -> CsmDataReadiness:
+    """Per-scout data probes for the fleet reveal + completion copy. Presentation only —
+    a probe failure renders as "no data yet", never blocks onboarding."""
+    accounts_count = 0
+    try:
+        from products.customer_analytics.backend.models.account import (  # noqa: PLC0415 — keeps the customer-analytics stack off the slack import path
+            Account,
+        )
+
+        accounts_count = Account.objects.for_team(team_id).count()
+    except Exception:
+        logger.warning("persona_onboarding_accounts_probe_failed", exc_info=True)
+
+    tickets_exist = False
+    try:
+        from products.conversations.backend.models.ticket import (  # noqa: PLC0415 — keeps the conversations stack off the slack import path
+            Ticket,
+        )
+
+        tickets_exist = Ticket.objects.filter(team_id=team_id).exists()
+    except Exception:
+        logger.warning("persona_onboarding_tickets_probe_failed", exc_info=True)
+
+    source_kinds: set[str] = set()
+    try:
+        source_kinds = _active_source_kinds(team_id)
+    except Exception:
+        logger.warning("persona_onboarding_sources_probe_failed", exc_info=True)
+
+    return CsmDataReadiness(
+        account_pulse=accounts_count > 0 or any(kind in source_kinds for kind in _CRM_SOURCE_KINDS),
+        support_watch=tickets_exist or any(kind in source_kinds for kind in _SUPPORT_SOURCE_KINDS),
+        revenue_watch="Stripe" in source_kinds,
+        accounts_count=accounts_count,
+    )
+
+
+# ============================================================================
+# Settings-row state helpers
+# ============================================================================
+
+
+def get_or_create_settings_row(workspace_id: str, slack_user_id: str) -> SlackSettings:
+    row, _ = SlackSettings.objects.get_or_create(slack_workspace_id=workspace_id, slack_user_id=slack_user_id)
+    return row
+
+
+def is_onboarded(row: SlackSettings | None) -> bool:
+    return row is not None and row.onboarded_at is not None
+
+
+def has_prior_slack_activity(integration_ids: list[int], slack_user_id: str) -> bool:
+    if not integration_ids:
+        return False
+    return SlackThreadTaskMapping.objects.filter(
+        integration_id__in=integration_ids, latest_actor_slack_user_id=slack_user_id
+    ).exists()
+
+
+def _grandfather(integration: Integration, row: SlackSettings, slack_user_id: str) -> None:
+    row.onboarded_at = timezone.now()
+    row.onboarding_state = None
+    row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
+    capture_slack_event(integration, EVENT_GRANDFATHERED, slack_user_id=slack_user_id)
+
+
+def compute_home_onboarding_status(integration: Integration, workspace_id: str, slack_user_id: str) -> str:
+    """ "hidden" | "start" | "in_progress" — drives the App Home onboarding card."""
+    if not is_persona_onboarding_enabled(integration.team):
+        return "hidden"
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    if is_onboarded(row):
+        return "hidden"
+    if row is not None and isinstance(row.onboarding_state, dict):
+        return "in_progress"
+    return "start"
+
+
+# ============================================================================
+# Block builders
+# ============================================================================
+
+
+def _section(text: str) -> dict:
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def _context(text: str) -> dict:
+    return {"type": "context", "elements": [{"type": "mrkdwn", "text": text}]}
+
+
+def _button(label: str, action_id: str, value: str = "", *, style: str | None = None, url: str | None = None) -> dict:
+    button: dict = {"type": "button", "text": {"type": "plain_text", "text": label}, "action_id": action_id}
+    if value:
+        button["value"] = value
+    if style:
+        button["style"] = style
+    if url:
+        button["url"] = url
+    return button
+
+
+def build_kickoff_blocks(display_name: str, candidate: str | None) -> list[dict]:
+    hey = f"👋 Hey {display_name}! I'm PostHog's AI co-worker."
+    skip = _button("Skip setup", SKIP_ACTION_ID)
+    if candidate == PERSONA_CSM:
+        intro = f"{hey} Before we get going, let me set things up right for you.\n\nIt looks like you're a CSM — is that right?"
+        buttons = [
+            _button("Yes — set me up as a CSM", PERSONA_SELECT_ACTION_ID, PERSONA_CSM, style="primary"),
+            _button("I'm an engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    elif candidate == PERSONA_ENGINEER:
+        intro = (
+            f"{hey} Before we get going, let me set things up right for you.\n\nLooks like you're an engineer — right?"
+        )
+        buttons = [
+            _button("Yep, engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER, style="primary"),
+            _button("I'm in customer success", PERSONA_SELECT_ACTION_ID, PERSONA_CSM),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    else:
+        intro = f"{hey} Quick question so I can set things up right for you — which best describes what you do?"
+        buttons = [
+            _button("Engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER),
+            _button("Customer success (CSM)", PERSONA_SELECT_ACTION_ID, PERSONA_CSM),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    return [_section(intro), {"type": "actions", "elements": buttons}]
+
+
+def build_fleet_reveal_blocks(team_id: int, readiness: dict, detected_tools: list[str]) -> list[dict]:
+    blocks: list[dict] = [
+        _section(
+            "Great — I'm going to create a few scouts for you. Scouts are little agents that patrol "
+            "your data on a schedule and ping you whenever there's something to worry about "
+            f"(<{SCOUTS_DOC_URL}|here's how they work>)."
+        )
+    ]
+    for index, spec in enumerate(PERSONA_SCOUT_CATALOG[PERSONA_CSM], start=1):
+        blocks.append(_section(f"*{index}. {spec.title}*\n{spec.description}"))
+        if readiness.get(spec.readiness_key):
+            blocks.append(_context("✅ Ready — I can see the data this needs."))
+            continue
+        detected_kind = next((kind for kind in detected_tools if kind in spec.connectable_sources), None)
+        if detected_kind:
+            label = _TOOL_LABEL_BY_KIND.get(detected_kind, detected_kind)
+            blocks.append(
+                _section(f"⚠️ {spec.title} {spec.gap_line} I see you're using {label} — want to connect it now?")
+            )
+            blocks.append(
+                {
+                    "type": "actions",
+                    "elements": [
+                        _button(
+                            f"Connect {label}",
+                            CONNECT_SOURCE_ACTION_ID,
+                            detected_kind,
+                            url=source_connect_url(team_id, detected_kind),
+                        )
+                    ],
+                }
+            )
+        else:
+            blocks.append(_context(f"⚠️ {spec.gap_line} Connect one any time — this scout picks it up automatically."))
+            blocks.append(
+                {
+                    "type": "actions",
+                    "elements": [
+                        _button("Browse sources", CONNECT_SOURCE_ACTION_ID, "catalog", url=sources_catalog_url(team_id))
+                    ],
+                }
+            )
+    blocks.append(_context("Don't worry — I'll create these now and they activate themselves as data shows up."))
+    return blocks
+
+
+def build_channel_prompt_blocks(can_create_channel: bool) -> list[dict]:
+    elements: list[dict] = [
+        {
+            "type": "conversations_select",
+            "action_id": CHANNEL_SELECT_ACTION_ID,
+            "placeholder": {"type": "plain_text", "text": "Pick a channel"},
+            # Never offer external-shared channels — these alerts carry account intel.
+            "filter": {"include": ["public"], "exclude_external_shared_channels": True, "exclude_bot_users": True},
+        }
+    ]
+    if can_create_channel:
+        elements.append(_button("Create #posthog-inbox", CHANNEL_CREATE_ACTION_ID))
+    return [
+        _section(
+            "One more thing: this works best if you add me to a channel where I can post findings. "
+            "Pick one, or I can create #posthog-inbox for you."
+            if can_create_channel
+            else "One more thing: this works best if you add me to a channel where I can post findings. Pick one below."
+        ),
+        {"type": "actions", "elements": elements},
+    ]
+
+
+def build_invite_needed_blocks(channel_id: str, channel_name: str) -> list[dict]:
+    return [
+        _section(
+            f"I can't post in #{channel_name} yet — I'm not a member. Type `/invite @PostHog` in that "
+            "channel, then tap Verify."
+        ),
+        {"type": "actions", "elements": [_button("Verify", CHANNEL_VERIFY_ACTION_ID, channel_id, style="primary")]},
+    ]
+
+
+def build_locked_in_blocks(
+    team_id: int, channel_name: str, readiness: dict, channel_conflict: str | None
+) -> list[dict]:
+    if channel_conflict:
+        first = (
+            f"Your scouts are already running for this project and posting to #{channel_conflict} — "
+            "I've left that as-is. You're onboarded! 🎉"
+        )
+    else:
+        first = (
+            "🎉 You're locked in. I've already sent your scouts on their first patrol — I'll message "
+            f"you when a scout finds something, and findings land in #{channel_name} with the account "
+            "owner tagged when I can find them."
+        )
+    blocks = [_section(first)]
+    gap_titles = [spec.title for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM] if not readiness.get(spec.readiness_key)]
+    if gap_titles:
+        names = ", ".join(gap_titles)
+        verb = "is" if len(gap_titles) == 1 else "are"
+        blocks.append(
+            _context(
+                f"Heads-up: {names} {verb} waiting on data — connect a source from the list above and "
+                "they wake up on their own."
+            )
+        )
+    blocks.append(
+        _section(
+            f"Manage your scouts (pause, cadence, run history) any time from your <{inbox_url(team_id)}|PostHog inbox>."
+            "\n\nIn the meantime, do you want to work on anything? You can ask me things like:\n"
+            "• _Which of my accounts had the biggest usage drop this month?_\n"
+            "• _Summarize what Acme did last week._"
+        )
+    )
+    return blocks
+
+
+ENGINEER_COMPLETION_TEXT = (
+    "Got it — engineer it is. 🛠️ Mention `@PostHog` in a channel or message me here to hand me a "
+    "task — I can investigate your data, dig through errors, and open PRs. If you haven't yet, "
+    "connect GitHub and pick your sources from the setup message I send when the app is installed."
+)
+OTHER_COMPLETION_TEXT = (
+    "Thanks! Message me here any time — ask about your product data, dashboards, or anything PostHog."
+)
+SKIP_TEXT = "No problem — skipping setup. Message me whenever; settings live in my Home tab."
+NUDGE_PERSONA_TEXT = "One quick thing first — tap one of the buttons above (or Skip) and then I'm all yours."
+NUDGE_CHANNEL_TEXT = (
+    "Almost there — pick a channel for account alerts above (or Skip), then send me that message again."
+)
+ERROR_TEXT = "Something went wrong on my end — tap the button again, or skip setup and message me anytime."
+
+
+# ============================================================================
+# Flow entry points (called from api.py) + interactivity handlers
+# ============================================================================
+
+
+@dataclasses.dataclass
+class _FlowContext:
+    integration: Integration
+    slack: SlackIntegration
+    row: SlackSettings
+    workspace_id: str
+    slack_user_id: str
+    state: dict
+
+
+def _load_context(payload: dict) -> _FlowContext | None:
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if not workspace_id or not slack_user_id:
+        return None
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    if row is None or not isinstance(row.onboarding_state, dict):
+        return None
+    state = row.onboarding_state
+    integration = Integration.objects.filter(id=state.get("integration_id"), kind="slack").first()
+    # Defensive: the stored integration must still belong to the clicking workspace.
+    if integration is None or integration.integration_id != workspace_id:
+        return None
+    return _FlowContext(integration, SlackIntegration(integration), row, workspace_id, slack_user_id, state)
+
+
+def _display_name(slack: SlackIntegration, slack_user_id: str) -> str:
+    try:
+        info = slack.client.users_info(user=slack_user_id)
+        profile = (info.get("user") or {}).get("profile") or {}
+        name = profile.get("display_name") or profile.get("real_name") or ""
+        return name.split()[0] if name else "there"
+    except Exception:
+        return "there"
+
+
+def _post(ctx: _FlowContext, blocks: list[dict], text: str) -> None:
+    ctx.slack.client.chat_postMessage(
+        channel=ctx.state.get("dm_channel_id"),
+        thread_ts=ctx.state.get("thread_ts"),
+        text=text,
+        blocks=blocks,
+    )
+
+
+def _save_state(row: SlackSettings, state: dict | None) -> None:
+    row.onboarding_state = state
+    row.save(update_fields=["onboarding_state", "updated_at"])
+
+
+def _freeze_buttons(ctx: _FlowContext, payload: dict, note: str) -> None:
+    """Replace the clicked message's action blocks with a note, so stale buttons can't
+    double-fire. Best-effort — a failure here never blocks the step itself."""
+    channel_id = (payload.get("channel") or {}).get("id")
+    message = payload.get("message") or {}
+    ts = message.get("ts")
+    if not channel_id or not ts:
+        return
+    blocks = [block for block in (message.get("blocks") or []) if block.get("type") != "actions"]
+    blocks.append(_context(note))
+    try:
+        ctx.slack.client.chat_update(channel=channel_id, ts=ts, text=note, blocks=blocks)
+    except Exception:
+        logger.warning("persona_onboarding_freeze_buttons_failed", exc_info=True)
+
+
+def _republish_home(integration: Integration, slack_user_id: str) -> None:
+    # Deferred: slack_app_home imports this module for the onboarding card, so a module-level
+    # import here would be a true circular import.
+    from products.slack_app.backend.services.slack_app_home import republish_home_for_user  # noqa: PLC0415
+
+    try:
+        republish_home_for_user(integration, slack_user_id)
+    except Exception:
+        logger.warning("persona_onboarding_home_republish_failed", exc_info=True)
+
+
+def start_onboarding_dm(
+    integration: Integration,
+    slack_user_id: str,
+    *,
+    posthog_user_id: int,
+    entry_point: str,
+    channel_id: str | None = None,
+    thread_ts: str | None = None,
+) -> None:
+    """Open (or reuse) the DM and post the kickoff question; idempotent — an in-flight
+    onboarding reposts its current step instead of resetting."""
+    slack = SlackIntegration(integration)
+    workspace_id = integration.integration_id
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if isinstance(row.onboarding_state, dict):
+        ctx = _FlowContext(integration, slack, row, workspace_id, slack_user_id, row.onboarding_state)
+        _repost_current_step(ctx)
+        return
+    candidate, source = detect_persona(slack, workspace_id, slack_user_id)
+    display_name = _display_name(slack, slack_user_id)
+    if channel_id is None:
+        opened = slack.client.conversations_open(users=slack_user_id)
+        channel_id = (opened.get("channel") or {}).get("id")
+        if not channel_id:
+            logger.warning("persona_onboarding_dm_open_failed", slack_user_id=slack_user_id)
+            return
+    blocks = build_kickoff_blocks(display_name, candidate)
+    posted = slack.client.chat_postMessage(
+        channel=channel_id, thread_ts=thread_ts, text="Quick setup — which best describes what you do?", blocks=blocks
+    )
+    row.onboarding_state = {
+        "step": STEP_AWAITING_PERSONA,
+        "persona_candidate": candidate,
+        "detection_source": source,
+        "team_id": integration.team_id,
+        "integration_id": integration.id,
+        "posthog_user_id": posthog_user_id,
+        "dm_channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "kickoff_ts": posted.get("ts"),
+        "started_at": timezone.now().isoformat(),
+    }
+    row.save(update_fields=["onboarding_state", "updated_at"])
+    capture_slack_event(
+        integration,
+        EVENT_STARTED,
+        slack_user_id=slack_user_id,
+        entry_point=entry_point,
+        persona_candidate=candidate,
+        detection_source=source or "none",
+        search_available=slack_search.search_available(slack, workspace_id, slack_user_id),
+    )
+
+
+def maybe_intercept_assistant_surface(
+    integration: Integration,
+    *,
+    posthog_user_id: int,
+    workspace_id: str,
+    slack_user_id: str,
+    channel_id: str,
+    thread_ts: str | None,
+    accessible_integration_ids: list[int],
+    entry_point: str,
+) -> bool:
+    """The DM / assistant-container gate. Returns True when the event was consumed by
+    onboarding (caller must not start an agent task or post the default welcome)."""
+    if not is_persona_onboarding_enabled(integration.team):
+        return False
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if is_onboarded(row):
+        return False
+    if has_prior_slack_activity(accessible_integration_ids, slack_user_id):
+        # An established user predating this flow — never ambush them with onboarding.
+        _grandfather(integration, row, slack_user_id)
+        return False
+    if isinstance(row.onboarding_state, dict):
+        ctx = _FlowContext(
+            integration, SlackIntegration(integration), row, workspace_id, slack_user_id, row.onboarding_state
+        )
+        if entry_point == "first_dm":
+            _post_nudge(ctx)
+        else:
+            _repost_current_step(ctx)
+        return True
+    start_onboarding_dm(
+        integration,
+        slack_user_id,
+        posthog_user_id=posthog_user_id,
+        entry_point=entry_point,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+    )
+    return True
+
+
+def handle_home_start(payload: dict) -> HttpResponse:
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if not workspace_id or not slack_user_id:
+        return HttpResponse(status=200)
+    result = load_integrations(slack_team_id=workspace_id, kinds=["slack"], slack_user_id=slack_user_id)
+    if not result.candidates:
+        return HttpResponse(status=200)
+    probe = result.integration if result.integration in result.candidates else result.candidates[0]
+    if not is_persona_onboarding_enabled(probe.team):
+        return HttpResponse(status=200)
+    resolution = resolve_user_for_workspace(
+        workspace_result=result, slack_team_id=workspace_id, slack_user_id=slack_user_id
+    )
+    if resolution.user is None:
+        return HttpResponse(status=200)
+    target = resolution.integration or (resolution.candidates[0] if resolution.candidates else probe)
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if is_onboarded(row):
+        _republish_home(target, slack_user_id)
+        return HttpResponse(status=200)
+    start_onboarding_dm(target, slack_user_id, posthog_user_id=resolution.user.id, entry_point="home_button")
+    _republish_home(target, slack_user_id)
+    return HttpResponse(status=200)
+
+
+def handle_block_action(payload: dict, action: dict) -> HttpResponse:
+    action_id = str(action.get("action_id") or "")
+    try:
+        if action_id == START_ACTION_ID:
+            return handle_home_start(payload)
+        if action_id == CONNECT_SOURCE_ACTION_ID:
+            _handle_connect_click(payload, action)
+        elif action_id == PERSONA_SELECT_ACTION_ID:
+            _handle_persona_select(payload, action)
+        elif action_id == SKIP_ACTION_ID:
+            _handle_skip(payload)
+        elif action_id == CHANNEL_SELECT_ACTION_ID:
+            _handle_channel_select(payload, action)
+        elif action_id == CHANNEL_CREATE_ACTION_ID:
+            _handle_channel_create(payload)
+        elif action_id == CHANNEL_VERIFY_ACTION_ID:
+            _handle_channel_verify(payload, action)
+    except Exception:
+        logger.exception("persona_onboarding_action_failed", action_id=action_id)
+        ctx = _load_context(payload)
+        if ctx is not None:
+            try:
+                _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+            except Exception:
+                logger.warning("persona_onboarding_error_post_failed", exc_info=True)
+    return HttpResponse(status=200)
+
+
+def _post_nudge(ctx: _FlowContext) -> None:
+    step = ctx.state.get("step")
+    text = NUDGE_CHANNEL_TEXT if step == STEP_AWAITING_CHANNEL else NUDGE_PERSONA_TEXT
+    _post(ctx, [_section(text)], text)
+    _repost_current_step(ctx)
+
+
+def _repost_current_step(ctx: _FlowContext) -> None:
+    step = ctx.state.get("step")
+    if step == STEP_AWAITING_CHANNEL:
+        pending_channel = ctx.state.get("pending_channel_id")
+        if pending_channel:
+            blocks = build_invite_needed_blocks(
+                pending_channel, ctx.state.get("pending_channel_name") or pending_channel
+            )
+        else:
+            blocks = build_channel_prompt_blocks(_can_create_channel(ctx.slack))
+        _post(ctx, blocks, "Pick a channel for scout findings.")
+        return
+    display_name = _display_name(ctx.slack, ctx.slack_user_id)
+    blocks = build_kickoff_blocks(display_name, ctx.state.get("persona_candidate"))
+    _post(ctx, blocks, "Quick setup — which best describes what you do?")
+
+
+def _can_create_channel(slack: SlackIntegration) -> bool:
+    try:
+        return not slack.missing_scopes(INBOX_CHANNEL_REQUIRED_SCOPES)
+    except Exception:
+        return False
+
+
+def _handle_connect_click(payload: dict, action: dict) -> None:
+    # URL button — the browser already navigated; just ack + record the click.
+    ctx = _load_context(payload)
+    if ctx is not None:
+        capture_slack_event(
+            ctx.integration,
+            EVENT_CONNECT_CLICKED,
+            slack_user_id=ctx.slack_user_id,
+            source_kind=str(action.get("value") or ""),
+        )
+
+
+def _handle_persona_select(payload: dict, action: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_PERSONA:
+        _repost_current_step(ctx)
+        return
+    persona = str(action.get("value") or "")
+    if persona not in (PERSONA_CSM, PERSONA_ENGINEER, PERSONA_OTHER):
+        return
+    labels = {PERSONA_CSM: "Customer success (CSM)", PERSONA_ENGINEER: "Engineer", PERSONA_OTHER: "Something else"}
+    _freeze_buttons(ctx, payload, f"You picked: {labels[persona]}")
+    capture_slack_event(
+        ctx.integration,
+        EVENT_PERSONA_SELECTED,
+        slack_user_id=ctx.slack_user_id,
+        persona=persona,
+        persona_candidate=ctx.state.get("persona_candidate"),
+        matched_detection=persona == ctx.state.get("persona_candidate"),
+    )
+
+    if persona in (PERSONA_ENGINEER, PERSONA_OTHER):
+        ctx.row.persona = persona
+        ctx.row.onboarded_at = timezone.now()
+        ctx.row.onboarding_state = None
+        ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+        text = ENGINEER_COMPLETION_TEXT if persona == PERSONA_ENGINEER else OTHER_COMPLETION_TEXT
+        _post(ctx, [_section(text)], text)
+        capture_slack_event(
+            ctx.integration, EVENT_COMPLETED, slack_user_id=ctx.slack_user_id, persona=persona, scouts_provisioned=0
+        )
+        _republish_home(ctx.integration, ctx.slack_user_id)
+        return
+
+    # CSM: reveal the fleet (with per-scout readiness + connect offers), then ask for a channel.
+    ctx.row.persona = PERSONA_CSM
+    readiness = check_csm_data_readiness(ctx.integration.team_id)
+    detected_tools = detect_workspace_tools(ctx.slack, ctx.workspace_id, ctx.slack_user_id)
+    ctx.state.update(
+        {"step": STEP_AWAITING_CHANNEL, "readiness": readiness.as_dict(), "detected_tools": detected_tools}
+    )
+    ctx.row.onboarding_state = ctx.state
+    ctx.row.save(update_fields=["persona", "onboarding_state", "updated_at"])
+    _post(
+        ctx,
+        build_fleet_reveal_blocks(ctx.integration.team_id, readiness.as_dict(), detected_tools),
+        "I'm going to create a few scouts for you.",
+    )
+    _post(ctx, build_channel_prompt_blocks(_can_create_channel(ctx.slack)), "Pick a channel for scout findings.")
+    capture_slack_event(
+        ctx.integration,
+        EVENT_FLEET_SHOWN,
+        slack_user_id=ctx.slack_user_id,
+        detected_tools=detected_tools,
+        **readiness.as_dict(),
+    )
+
+
+def _handle_skip(payload: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    step = ctx.state.get("step")
+    _freeze_buttons(ctx, payload, "Setup skipped.")
+    ctx.row.onboarded_at = timezone.now()
+    ctx.row.onboarding_state = None
+    ctx.row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
+    _post(ctx, [_section(SKIP_TEXT)], SKIP_TEXT)
+    capture_slack_event(ctx.integration, EVENT_SKIPPED, slack_user_id=ctx.slack_user_id, step=step)
+    _republish_home(ctx.integration, ctx.slack_user_id)
+
+
+def _channel_name_best_effort(slack: SlackIntegration, channel_id: str) -> str:
+    try:
+        info = slack.client.conversations_info(channel=channel_id)
+        return (info.get("channel") or {}).get("name") or channel_id
+    except Exception:
+        return channel_id
+
+
+def _handle_channel_select(payload: dict, action: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    channel_id = str(action.get("selected_conversation") or "")
+    if not channel_id:
+        return
+    channel_name = _channel_name_best_effort(ctx.slack, channel_id)
+    _attempt_channel_setup(ctx, channel_id, channel_name, method="selected")
+
+
+def _handle_channel_create(payload: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    if not _can_create_channel(ctx.slack):
+        _post(ctx, build_channel_prompt_blocks(False), "Pick a channel for scout findings.")
+        return
+    ensured = ensure_inbox_channel(ctx.integration)
+    if ensured is None:
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        return
+    channel_id, channel_target_name = ensured
+    invite_user_to_inbox(ctx.integration, channel_id, ctx.slack_user_id)
+    _attempt_channel_setup(ctx, channel_id, channel_target_name.lstrip("#"), method="created")
+
+
+def _handle_channel_verify(payload: dict, action: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    channel_id = str(action.get("value") or ctx.state.get("pending_channel_id") or "")
+    if not channel_id:
+        return
+    channel_name = ctx.state.get("pending_channel_name") or _channel_name_best_effort(ctx.slack, channel_id)
+    _attempt_channel_setup(ctx, channel_id, channel_name, method="selected", invite_required=True)
+
+
+def _attempt_channel_setup(
+    ctx: _FlowContext, channel_id: str, channel_name: str, *, method: str, invite_required: bool = False
+) -> None:
+    # The hello post doubles as the membership probe — the only check that works with the
+    # scopes we actually hold (no channels:read / channels:join / chat:write.public).
+    try:
+        ctx.slack.client.chat_postMessage(
+            channel=channel_id,
+            text=(
+                f"👋 I'll post scout findings here — set up by <@{ctx.slack_user_id}>. "
+                "First patrol is already underway."
+            ),
+        )
+    except SlackApiError as exc:
+        error = (getattr(exc, "response", None) or {}).get("error", "")
+        if error in ("not_in_channel", "channel_not_found", "is_archived", "restricted_action"):
+            ctx.state.update({"pending_channel_id": channel_id, "pending_channel_name": channel_name})
+            _save_state(ctx.row, ctx.state)
+            _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
+            return
+        raise
+    capture_slack_event(
+        ctx.integration,
+        EVENT_CHANNEL_CONFIGURED,
+        slack_user_id=ctx.slack_user_id,
+        method=method,
+        invite_required=invite_required,
+    )
+    _provision_and_complete(ctx, channel_id, channel_name)
+
+
+def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: str) -> None:
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off the slack import path
+        provision_persona_scouts,
+    )
+
+    user = User.objects.filter(id=ctx.state.get("posthog_user_id")).first()
+    if user is None:
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        return
+    try:
+        results = provision_persona_scouts(
+            team=ctx.integration.team,
+            created_by=user,
+            slack_integration_id=ctx.integration.id,
+            channel_id=channel_id,
+            channel_name=channel_name,
+            skill_names=[spec.skill_name for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]],
+        )
+    except Exception:
+        logger.exception("persona_onboarding_provisioning_failed", team_id=ctx.integration.team_id)
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        return
+
+    readiness = ctx.state.get("readiness") or {}
+    channel_conflict = next((result.channel_conflict for result in results if result.channel_conflict), None)
+    _post(
+        ctx,
+        build_locked_in_blocks(ctx.integration.team_id, channel_name, readiness, channel_conflict),
+        "You're locked in — your scouts are on their first patrol.",
+    )
+    ctx.row.persona = PERSONA_CSM
+    ctx.row.onboarded_at = timezone.now()
+    ctx.row.onboarding_state = None
+    ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+    capture_slack_event(
+        ctx.integration,
+        EVENT_COMPLETED,
+        slack_user_id=ctx.slack_user_id,
+        persona=PERSONA_CSM,
+        scouts_provisioned=len([result for result in results if result.config_id]),
+        first_runs_fired=len([result for result in results if result.first_run_started]),
+        channel_conflict=bool(channel_conflict),
+        **readiness,
+    )
+    _republish_home(ctx.integration, ctx.slack_user_id)
+    _start_first_patrol_digest(ctx, results, channel_name)
+
+
+def _start_first_patrol_digest(ctx: _FlowContext, results: list, channel_name: str) -> None:
+    """Kick the delayed first-patrol digest workflow — best-effort, never user-visible on failure."""
+    config_ids = [result.config_id for result in results if result.config_id and not result.channel_conflict]
+    if not config_ids:
+        return
+    try:
+        from products.slack_app.backend.first_patrol import (  # noqa: PLC0415 — keeps the temporal graph off the slack import path
+            start_first_patrol_digest_workflow,
+        )
+
+        start_first_patrol_digest_workflow(
+            team_id=ctx.integration.team_id,
+            integration_id=ctx.integration.id,
+            slack_user_id=ctx.slack_user_id,
+            dm_channel_id=str(ctx.state.get("dm_channel_id") or ""),
+            thread_ts=ctx.state.get("thread_ts"),
+            channel_name=channel_name,
+            scout_config_ids=config_ids,
+            provisioned_at_iso=timezone.now().isoformat(),
+        )
+    except Exception:
+        logger.warning("persona_onboarding_digest_dispatch_failed", exc_info=True)

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -619,7 +619,24 @@ def _load_context(payload: dict) -> _FlowContext | None:
     # Defensive: the stored integration must still belong to the clicking workspace.
     if integration is None or integration.integration_id != workspace_id:
         return None
-    return _FlowContext(integration, SlackIntegration(integration), row, workspace_id, slack_user_id, state)
+    ctx = _FlowContext(integration, SlackIntegration(integration), row, workspace_id, slack_user_id, state)
+    _retarget_to_click(ctx, payload)
+    return ctx
+
+
+def _retarget_to_click(ctx: _FlowContext, payload: dict) -> None:
+    """Point follow-up posts at the thread hosting the clicked button. In the assistant surface
+    every top-level DM message roots its own conversation, so replying anywhere else opens a
+    brand-new History entry instead of continuing inline."""
+    channel_id = (payload.get("channel") or {}).get("id")
+    message = payload.get("message") or {}
+    anchor = message.get("thread_ts") or message.get("ts")
+    if not channel_id or not anchor:
+        return
+    if channel_id != ctx.state.get("dm_channel_id") or anchor != ctx.state.get("thread_ts"):
+        ctx.state["dm_channel_id"] = channel_id
+        ctx.state["thread_ts"] = anchor
+        _save_state(ctx.row, ctx.state)
 
 
 def _display_name(slack: SlackIntegration, slack_user_id: str) -> str:
@@ -711,7 +728,9 @@ def start_onboarding_dm(
         "integration_id": integration.id,
         "posthog_user_id": posthog_user_id,
         "dm_channel_id": channel_id,
-        "thread_ts": thread_ts,
+        # A top-level kickoff roots its own conversation in the assistant surface — anchor
+        # follow-ups under it so the whole flow stays in that one thread.
+        "thread_ts": thread_ts or posted.get("ts"),
         "kickoff_ts": posted.get("ts"),
         "started_at": timezone.now().isoformat(),
     }

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -391,7 +391,13 @@ def _context(text: str) -> dict:
 
 
 def _button(label: str, action_id: str, value: str = "", *, style: str | None = None, url: str | None = None) -> dict:
-    button: dict = {"type": "button", "text": {"type": "plain_text", "text": label}, "action_id": action_id}
+    # Slack rejects a message whose interactive elements share an action_id, so a button's value
+    # doubles as an id suffix; `handle_block_action` dispatches on the base id before the ":".
+    button: dict = {
+        "type": "button",
+        "text": {"type": "plain_text", "text": label},
+        "action_id": f"{action_id}:{value}" if value else action_id,
+    }
     if value:
         button["value"] = value
     if style:
@@ -447,6 +453,8 @@ def build_fleet_reveal_blocks(team_id: int, readiness: dict, detected_tools: lis
             blocks.append(_context("✅ Ready — I can see the data this needs."))
             continue
         detected_kind = next((kind for kind in detected_tools if kind in spec.connectable_sources), None)
+        # Button values are "<readiness_key>:<kind|catalog>": sibling connect buttons must not
+        # collide on value (it doubles as the action_id suffix), and telemetry gets the scout.
         if detected_kind:
             label = _TOOL_LABEL_BY_KIND.get(detected_kind, detected_kind)
             blocks.append(
@@ -459,7 +467,7 @@ def build_fleet_reveal_blocks(team_id: int, readiness: dict, detected_tools: lis
                         _button(
                             f"Connect {label}",
                             CONNECT_SOURCE_ACTION_ID,
-                            detected_kind,
+                            f"{spec.readiness_key}:{detected_kind}",
                             url=source_connect_url(team_id, detected_kind),
                         )
                     ],
@@ -471,7 +479,12 @@ def build_fleet_reveal_blocks(team_id: int, readiness: dict, detected_tools: lis
                 {
                     "type": "actions",
                     "elements": [
-                        _button("Browse sources", CONNECT_SOURCE_ACTION_ID, "catalog", url=sources_catalog_url(team_id))
+                        _button(
+                            "Browse sources",
+                            CONNECT_SOURCE_ACTION_ID,
+                            f"{spec.readiness_key}:catalog",
+                            url=sources_catalog_url(team_id),
+                        )
                     ],
                 }
             )
@@ -786,7 +799,9 @@ def handle_home_start(payload: dict) -> HttpResponse:
 
 
 def handle_block_action(payload: dict, action: dict) -> HttpResponse:
-    action_id = str(action.get("action_id") or "")
+    # Valued buttons carry their value as an ":<value>" action_id suffix (see `_button`);
+    # routing happens on the base id.
+    action_id = str(action.get("action_id") or "").split(":", 1)[0]
     try:
         if action_id == START_ACTION_ID:
             return handle_home_start(payload)
@@ -848,11 +863,13 @@ def _handle_connect_click(payload: dict, action: dict) -> None:
     # URL button — the browser already navigated; just ack + record the click.
     ctx = _load_context(payload)
     if ctx is not None:
+        scout_key, _, source_kind = str(action.get("value") or "").rpartition(":")
         capture_slack_event(
             ctx.integration,
             EVENT_CONNECT_CLICKED,
             slack_user_id=ctx.slack_user_id,
-            source_kind=str(action.get("value") or ""),
+            source_kind=source_kind,
+            scout_readiness_key=scout_key or None,
         )
 
 

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -491,6 +491,9 @@ def build_channel_prompt_blocks(can_create_channel: bool) -> list[dict]:
     ]
     if can_create_channel:
         elements.append(_button("Create #posthog-inbox", CHANNEL_CREATE_ACTION_ID))
+    # Skip is a bail-out at every step: without it a CSM who can't (or won't) pick a channel
+    # is wedged, since the DM intercept hijacks every message while onboarding_state is set.
+    elements.append(_button("Skip for now", SKIP_ACTION_ID))
     return [
         _section(
             "One more thing: this works best if you add me to a channel where I can post findings. "
@@ -508,23 +511,31 @@ def build_invite_needed_blocks(channel_id: str, channel_name: str) -> list[dict]
             f"I can't post in #{channel_name} yet — I'm not a member. Type `/invite @PostHog` in that "
             "channel, then tap Verify."
         ),
-        {"type": "actions", "elements": [_button("Verify", CHANNEL_VERIFY_ACTION_ID, channel_id, style="primary")]},
+        {
+            "type": "actions",
+            "elements": [
+                _button("Verify", CHANNEL_VERIFY_ACTION_ID, channel_id, style="primary"),
+                _button("Skip for now", SKIP_ACTION_ID),
+            ],
+        },
     ]
 
 
 def build_locked_in_blocks(
-    team_id: int, channel_name: str, readiness: dict, channel_conflict: str | None
+    team_name: str, channel_name: str, readiness: dict, channel_conflict: str | None, team_id: int
 ) -> list[dict]:
+    # Name the project: a Slack workspace can map to several PostHog projects and the fleet lands
+    # in the one that resolved for this user, so say which so a multi-project CSM isn't guessing.
     if channel_conflict:
         first = (
-            f"Your scouts are already running for this project and posting to #{channel_conflict} — "
+            f"Your scouts are already running for *{team_name}* and posting to #{channel_conflict} — "
             "I've left that as-is. You're onboarded! 🎉"
         )
     else:
         first = (
-            "🎉 You're locked in. I've already sent your scouts on their first patrol — I'll message "
-            f"you when a scout finds something, and findings land in #{channel_name} with the account "
-            "owner tagged when I can find them."
+            f"🎉 You're locked in for *{team_name}*. I've already sent your scouts on their first "
+            f"patrol — I'll message you when a scout finds something, and findings land in "
+            f"#{channel_name} with the account owner tagged when I can find them."
         )
     blocks = [_section(first)]
     gap_titles = [spec.title for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM] if not readiness.get(spec.readiness_key)]
@@ -729,6 +740,12 @@ def maybe_intercept_assistant_surface(
         if entry_point == "first_dm":
             _post_nudge(ctx)
         else:
+            # A re-opened assistant container is a fresh thread — retarget the stored pointer so the
+            # repost lands where the user is looking, not in the (now hidden) original thread.
+            if channel_id and (channel_id != ctx.state.get("dm_channel_id") or thread_ts != ctx.state.get("thread_ts")):
+                ctx.state["dm_channel_id"] = channel_id
+                ctx.state["thread_ts"] = thread_ts
+                _save_state(ctx.row, ctx.state)
             _repost_current_step(ctx)
         return True
     start_onboarding_dm(
@@ -1022,15 +1039,20 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
 
     readiness = ctx.state.get("readiness") or {}
     channel_conflict = next((result.channel_conflict for result in results if result.channel_conflict), None)
-    _post(
-        ctx,
-        build_locked_in_blocks(ctx.integration.team_id, channel_name, readiness, channel_conflict),
-        "You're locked in — your scouts are on their first patrol.",
-    )
+    # Mark onboarded BEFORE the celebratory post: provisioning + first runs already happened, so a
+    # transient post failure must not leave the user un-onboarded with live scouts (which would
+    # re-fire all three first runs and re-post the channel hello on the next retry).
     ctx.row.persona = PERSONA_CSM
     ctx.row.onboarded_at = timezone.now()
     ctx.row.onboarding_state = None
     ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+    _post(
+        ctx,
+        build_locked_in_blocks(
+            ctx.integration.team.name, channel_name, readiness, channel_conflict, ctx.integration.team_id
+        ),
+        "You're locked in — your scouts are on their first patrol.",
+    )
     capture_slack_event(
         ctx.integration,
         EVENT_COMPLETED,

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -10,8 +10,11 @@ only thin wiring.
 
 from __future__ import annotations
 
+import threading
 import dataclasses
+from collections.abc import Callable
 
+from django.db import close_old_connections
 from django.http import HttpResponse
 from django.utils import timezone
 
@@ -772,30 +775,49 @@ def maybe_intercept_assistant_surface(
     return True
 
 
+def _run_in_background(fn: Callable[[], None], *, task: str) -> None:
+    """Run best-effort work off the interactivity request thread. Slack voids a block action
+    after 3s and shows a warning on the clicked button; the kickoff path makes far too many
+    Slack API calls to fit, and every step of it is idempotent + user-retryable."""
+
+    def runner() -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("persona_onboarding_background_task_failed", task=task)
+        finally:
+            close_old_connections()
+
+    threading.Thread(target=runner, name=f"persona-onboarding-{task}", daemon=True).start()
+
+
 def handle_home_start(payload: dict) -> HttpResponse:
     workspace_id = str((payload.get("team") or {}).get("id") or "")
     slack_user_id = str((payload.get("user") or {}).get("id") or "")
-    if not workspace_id or not slack_user_id:
-        return HttpResponse(status=200)
+    if workspace_id and slack_user_id:
+        _run_in_background(lambda: _run_home_start(workspace_id, slack_user_id), task="home_start")
+    return HttpResponse(status=200)
+
+
+def _run_home_start(workspace_id: str, slack_user_id: str) -> None:
     result = load_integrations(slack_team_id=workspace_id, kinds=["slack"], slack_user_id=slack_user_id)
     if not result.candidates:
-        return HttpResponse(status=200)
+        return
     probe = result.integration if result.integration in result.candidates else result.candidates[0]
     if not is_persona_onboarding_enabled(probe.team):
-        return HttpResponse(status=200)
+        return
     resolution = resolve_user_for_workspace(
         workspace_result=result, slack_team_id=workspace_id, slack_user_id=slack_user_id
     )
     if resolution.user is None:
-        return HttpResponse(status=200)
+        return
     target = resolution.integration or (resolution.candidates[0] if resolution.candidates else probe)
     row = get_or_create_settings_row(workspace_id, slack_user_id)
     if is_onboarded(row):
         _republish_home(target, slack_user_id)
-        return HttpResponse(status=200)
+        return
     start_onboarding_dm(target, slack_user_id, posthog_user_id=resolution.user.id, entry_point="home_button")
     _republish_home(target, slack_user_id)
-    return HttpResponse(status=200)
 
 
 def handle_block_action(payload: dict, action: dict) -> HttpResponse:

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -1038,7 +1038,7 @@ def _handle_channel_verify(payload: dict, action: dict) -> None:
     if not channel_id:
         return
     channel_name = ctx.state.get("pending_channel_name") or _channel_name_best_effort(ctx.slack, channel_id)
-    _attempt_channel_setup(ctx, channel_id, channel_name, method="selected", invite_required=True)
+    _attempt_channel_setup(ctx, channel_id, channel_name, method="verified", invite_required=True)
 
 
 def _attempt_channel_setup(

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -33,6 +33,7 @@ from posthog.user_permissions import UserPermissions
 from products.slack_app.backend import persona_onboarding
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
+from products.slack_app.backend.services.slack_auth import check_integrations_auth_and_filter
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
     build_ai_preferences_payload,
@@ -421,29 +422,21 @@ def _header_blocks() -> list[dict]:
 
 def _onboarding_card_blocks(status: str) -> list[dict]:
     if status == "in_progress":
-        return [
-            {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": "✨ *Onboarding in progress* — check your DMs from me."},
-                "accessory": {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "Restart"},
-                    "action_id": persona_onboarding.START_ACTION_ID,
-                },
-            }
-        ]
-    return [
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "✨ *New here?* Let me set things up for you — takes under a minute."},
-            "accessory": {
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Start onboarding"},
-                "action_id": persona_onboarding.START_ACTION_ID,
-                "style": "primary",
-            },
+        button: dict = {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Resume in DMs"},
+            "action_id": persona_onboarding.START_ACTION_ID,
         }
-    ]
+        text = "✨ *Onboarding in progress* — check your DMs from me."
+    else:
+        button = {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Start onboarding"},
+            "action_id": persona_onboarding.START_ACTION_ID,
+            "style": "primary",
+        }
+        text = "✨ *New here?* Let me set things up for you — takes under a minute."
+    return [{"type": "section", "text": {"type": "mrkdwn", "text": text}, "accessory": button}]
 
 
 def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> list[dict]:
@@ -1262,14 +1255,20 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 
 
 def _get_slack_integration(slack_team_id: str) -> Integration | None:
-
+    # A workspace can carry several installs and stale ones keep dead tokens (re-installs,
+    # revoked projects), so prefer a candidate whose bot token passes the cached auth check —
+    # blindly taking `.first()` routed every home publish through a dead token.
     if not slack_team_id:
         return None
-    return (
+    candidates = list(
         Integration.objects.select_related("team", "team__organization")
         .filter(kind="slack", integration_id=slack_team_id)
-        .first()
+        .order_by("id")
     )
+    if not candidates:
+        return None
+    healthy = check_integrations_auth_and_filter(candidates)
+    return healthy[0] if healthy else candidates[0]
 
 
 def _load_rows(integration: Integration, slack_user_id: str) -> tuple[SlackSettings | None, SlackSettings | None]:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -30,6 +30,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
+from products.slack_app.backend import persona_onboarding
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.slack_app.backend.services.slack_settings import (
@@ -349,6 +350,7 @@ def render_home_view(
     account_state: AccountState | None = None,
     project_state: ProjectState | None = None,
     tasks_state: TasksState | None = None,
+    onboarding_status: str = "hidden",
 ) -> dict:
     """Render the Block Kit payload for `views.publish` on the App Home tab."""
 
@@ -356,6 +358,12 @@ def render_home_view(
     blocks: list[dict] = []
 
     blocks.extend(_header_blocks())
+
+    # Persona onboarding card — shown only while the user is un-onboarded (flag-gated by the
+    # caller). Once onboarding completes, the card disappears and home reverts to settings.
+    if onboarding_status != "hidden":
+        blocks.append({"type": "divider"})
+        blocks.extend(_onboarding_card_blocks(onboarding_status))
 
     # Section 1 — project routing. Personal pick on top; admins get an
     # editable workspace default below, others see it as read-only context.
@@ -408,6 +416,33 @@ def _header_blocks() -> list[dict]:
             "Welcome to PostHog! 👋",
             "Tune how @PostHog mentions get routed and answered from this Slack workspace.",
         ),
+    ]
+
+
+def _onboarding_card_blocks(status: str) -> list[dict]:
+    if status == "in_progress":
+        return [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "✨ *Onboarding in progress* — check your DMs from me."},
+                "accessory": {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Restart"},
+                    "action_id": persona_onboarding.START_ACTION_ID,
+                },
+            }
+        ]
+    return [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "✨ *New here?* Let me set things up for you — takes under a minute."},
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Start onboarding"},
+                "action_id": persona_onboarding.START_ACTION_ID,
+                "style": "primary",
+            },
+        }
     ]
 
 
@@ -1037,6 +1072,12 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     if not is_slack_app_home_enabled(integration):
         return
 
+    republish_home_for_user(integration, slack_user_id)
+
+
+def republish_home_for_user(integration: Integration, slack_user_id: str) -> None:
+    """Recompute and publish the Home tab for one user — the shared publish path for
+    `app_home_opened` and for flows (persona onboarding) that change what home shows."""
     effective = resolve_ai_preferences(integration, slack_user_id)
     user_row, workspace_row = _load_rows(integration, slack_user_id)
 
@@ -1045,6 +1086,9 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     account_state = _resolve_account_state(integration, slack_user_id)
     project_state = _resolve_project_state(integration, slack_user_id)
     tasks_state = _resolve_tasks_state(integration, slack_user_id)
+    onboarding_status = persona_onboarding.compute_home_onboarding_status(
+        integration, integration.integration_id, slack_user_id
+    )
 
     view = render_home_view(
         effective=effective,
@@ -1054,6 +1098,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
         account_state=account_state,
         project_state=project_state,
         tasks_state=tasks_state,
+        onboarding_status=onboarding_status,
     )
     try:
         slack.client.views_publish(user_id=slack_user_id, view=view)
@@ -1061,7 +1106,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
         logger.exception(
             "slack_app_home_publish_failed",
             slack_user_id=slack_user_id,
-            slack_team_id=slack_team_id,
+            slack_team_id=integration.integration_id,
         )
 
 

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -39,6 +39,7 @@ from products.slack_app.backend.services.slack_app_home import (
     PreferenceSource,
     TaskItem,
     TasksState,
+    _get_slack_integration,
     handle_ai_preferences_block_action,
     handle_app_home_opened,
     handle_app_home_view_submission,
@@ -102,6 +103,18 @@ def non_admin_user():
     with patch(
         "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
         return_value=False,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _all_candidates_healthy():
+    # `_get_slack_integration` auth-checks candidates through slack_auth, which builds its own
+    # WebClient (a real network call in tests). Default every candidate to healthy; the picker
+    # tests override this with their own patch.
+    with patch(
+        "products.slack_app.backend.services.slack_app_home.check_integrations_auth_and_filter",
+        side_effect=lambda candidates, **kwargs: candidates,
     ):
         yield
 
@@ -887,3 +900,36 @@ class TestWorkspaceSubmitAdminGate:
         body = json.loads(response.content)
         assert body["response_action"] == "errors"
         assert not SlackSettings.objects.filter(slack_user_id__isnull=True).exists()
+
+
+class TestGetSlackIntegration:
+    # A workspace with a stale install kept a dead token at the lowest id; `.first()` routed
+    # every home publish through it (`invalid_auth`), so the picker must prefer a candidate
+    # that passes the auth check and only fall back to id order when none do.
+    AUTH_FILTER = "products.slack_app.backend.services.slack_app_home.check_integrations_auth_and_filter"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        organization = Organization.objects.create(name="Org")
+        self.dead = Integration.objects.create(
+            team=Team.objects.create(organization=organization, name="Stale"),
+            kind="slack",
+            integration_id=SLACK_WORKSPACE_ID,
+            sensitive_config={"access_token": "xoxb-dead"},
+        )
+        self.live = Integration.objects.create(
+            team=Team.objects.create(organization=organization, name="Live"),
+            kind="slack",
+            integration_id=SLACK_WORKSPACE_ID,
+            sensitive_config={"access_token": "xoxb-live"},
+        )
+
+    def test_prefers_auth_healthy_integration(self):
+        with patch(self.AUTH_FILTER, side_effect=lambda candidates, **kwargs: [self.live]):
+            picked = _get_slack_integration(SLACK_WORKSPACE_ID)
+        assert picked is not None and picked.id == self.live.id
+
+    def test_falls_back_to_first_when_none_healthy(self):
+        with patch(self.AUTH_FILTER, return_value=[]):
+            picked = _get_slack_integration(SLACK_WORKSPACE_ID)
+        assert picked is not None and picked.id == self.dead.id

--- a/products/slack_app/backend/tests/test_first_patrol.py
+++ b/products/slack_app/backend/tests/test_first_patrol.py
@@ -59,6 +59,21 @@ class TestFirstPatrolDigestComposition:
         assert "Renewal & billing watch: checked in clean" in digest["text"]
         assert "Nothing to worry about right now" in digest["text"]
 
+    def test_long_finding_headline_has_no_doubled_punctuation(self):
+        long_summary = "The account " + "very " * 60 + "quietly slid this week."
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-account-pulse",
+                    summary=long_summary,
+                    notifications_sent=1,
+                    reports_filed=1,
+                )
+            ]
+        )
+        assert "…." not in digest["text"]
+        assert "…" in digest["text"]
+
     def test_multiple_finders_counted_beyond_the_headline(self):
         digest = _collect(
             [

--- a/products/slack_app/backend/tests/test_first_patrol.py
+++ b/products/slack_app/backend/tests/test_first_patrol.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+from products.signals.backend.facade.api import ScoutRunDigest
+from products.slack_app.backend import first_patrol
+
+COLLECT_PATH = "products.signals.backend.facade.api.collect_scout_run_digests"
+
+
+def _collect(digests):
+    with patch(COLLECT_PATH, return_value=digests):
+        return first_patrol.collect_first_patrol_digest(
+            team_id=1, channel_name="posthog-inbox", scout_config_ids=["c1"], provisioned_at_iso="2026-07-02T00:00:00"
+        )
+
+
+class TestFirstPatrolDigestComposition:
+    def test_no_completed_runs_returns_none_for_retry(self):
+        assert _collect(None) is None
+
+    def test_finding_variant_leads_with_the_finding_and_links_channel(self):
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-account-pulse",
+                    summary="Initech's weekly active users dropped 60% vs baseline. Fleet otherwise steady.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-support-watch",
+                    summary="Queue quiet.",
+                    notifications_sent=0,
+                    reports_filed=0,
+                ),
+            ]
+        )
+        assert digest["variant"] == "finding"
+        assert "Account pulse" in digest["text"]
+        assert "Initech's weekly active users dropped 60% vs baseline." in digest["text"]
+        assert "#posthog-inbox" in digest["text"]
+        assert digest["runs_completed"] == 2
+
+    def test_all_clear_variant_quotes_run_summaries_with_fallback(self):
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-account-pulse",
+                    summary="Checked 214 accounts, all within baseline.",
+                    notifications_sent=0,
+                    reports_filed=0,
+                ),
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-revenue-watch", summary="", notifications_sent=0, reports_filed=0
+                ),
+            ]
+        )
+        assert digest["variant"] == "all_clear"
+        assert "Account pulse: Checked 214 accounts, all within baseline" in digest["text"]
+        assert "Renewal & billing watch: checked in clean" in digest["text"]
+        assert "Nothing to worry about right now" in digest["text"]
+
+    def test_multiple_finders_counted_beyond_the_headline(self):
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-account-pulse",
+                    summary="A slid.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+                ScoutRunDigest(
+                    skill_name="signals-scout-csm-support-watch",
+                    summary="B spiked.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+            ]
+        )
+        assert digest["variant"] == "finding"
+        assert "1 more scout reported findings too" in digest["text"]

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -297,6 +297,27 @@ class TestPersonaSelection(_FlowTestBase):
             for element in block.get("elements", [])
         )
 
+    @parameterized.expand(
+        [
+            ("top_level_click", {"ts": "555.1", "blocks": []}, "555.1"),
+            ("threaded_click", {"ts": "555.2", "thread_ts": "555.1", "blocks": []}, "555.1"),
+        ]
+    )
+    @patch(WEBCLIENT)
+    def test_reply_threads_under_clicked_message(self, _name, message, expected_anchor, mock_webclient):
+        # A reply outside the clicked message's thread opens a brand-new conversation in the
+        # assistant surface — the click location must win over the stored (here: None) pointer.
+        client = self._client(mock_webclient)
+        self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": "engineer"}
+        payload = self._payload(action)
+        payload["message"] = message
+
+        persona_onboarding.handle_block_action(payload, action)
+
+        assert client.chat_postMessage.call_count >= 1
+        assert all(call.kwargs["thread_ts"] == expected_anchor for call in client.chat_postMessage.call_args_list)
+
     @patch(WEBCLIENT)
     def test_skip_marks_onboarded_without_persona(self, mock_webclient):
         client = self._client(mock_webclient)
@@ -561,4 +582,7 @@ class TestHomeStartFlow(_FlowTestBase):
         client.chat_postMessage.assert_called_once()
         row = self._row()
         assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_PERSONA
+        # Follow-ups must thread under the kickoff — an unthreaded reply roots a brand-new
+        # conversation in the assistant surface instead of continuing this one.
+        assert row.onboarding_state["thread_ts"] == "111.222"
         republish.assert_called_once()

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -535,3 +535,30 @@ class TestBlockKitActionIdUniqueness:
         ]
         assert action_ids, "builder emitted no interactive elements — extractor or builder is broken"
         assert len(action_ids) == len(set(action_ids)), f"duplicate action_ids in one message: {action_ids}"
+
+
+class TestHomeStartFlow(_FlowTestBase):
+    # The Start button must ack inside Slack's 3s budget, so the kickoff work runs in a
+    # background task; this pins the wiring end to end — click → kickoff DM posted, state row
+    # created, home republished — with the background seam collapsed to inline.
+    @patch(WEBCLIENT)
+    def test_click_posts_kickoff_and_republishes_home(self, mock_webclient_class):
+        client = self._client(mock_webclient_class)
+        workspace_result = MagicMock(candidates=[self.integration], integration=self.integration)
+        user_resolution = MagicMock(user=self.user, integration=self.integration, candidates=[self.integration])
+        action = {"action_id": persona_onboarding.START_ACTION_ID}
+        with (
+            patch(FLAG, return_value=True),
+            patch.object(persona_onboarding, "_run_in_background", side_effect=lambda fn, task: fn()),
+            patch.object(persona_onboarding, "load_integrations", return_value=workspace_result),
+            patch.object(persona_onboarding, "resolve_user_for_workspace", return_value=user_resolution),
+            patch.object(persona_onboarding, "_republish_home") as republish,
+        ):
+            response = persona_onboarding.handle_block_action(
+                {"team": {"id": WORKSPACE}, "user": {"id": SLACK_USER}, "actions": [action]}, action
+            )
+        assert response.status_code == 200
+        client.chat_postMessage.assert_called_once()
+        row = self._row()
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_PERSONA
+        republish.assert_called_once()

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -209,6 +209,28 @@ class TestInterceptAssistantSurface(_FlowTestBase):
         assert persona_onboarding.NUDGE_PERSONA_TEXT in self._posted_text(client)
         assert self._row().onboarding_state["kickoff_ts"] == original_kickoff_ts
 
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_reopened_pane_retargets_the_thread_pointer(self, mock_webclient, _flag):
+        # Kickoff in the original thread, then re-open the assistant container (fresh thread):
+        # the repost must land in the new thread, not the stale one.
+        client = self._client(mock_webclient)
+        assert self._intercept(entry_point="thread_started") is True
+        persona_onboarding.maybe_intercept_assistant_surface(
+            self.integration,
+            posthog_user_id=self.user.id,
+            workspace_id=WORKSPACE,
+            slack_user_id=SLACK_USER,
+            channel_id="D_NEW",
+            thread_ts="new-thread-ts",
+            accessible_integration_ids=[self.integration.id],
+            entry_point="thread_started",
+        )
+        state = self._row().onboarding_state
+        assert state["dm_channel_id"] == "D_NEW"
+        assert state["thread_ts"] == "new-thread-ts"
+        assert client.chat_postMessage.call_args.kwargs["channel"] == "D_NEW"
+
 
 class TestPersonaSelection(_FlowTestBase):
     def _select(self, value: str) -> None:
@@ -339,6 +361,47 @@ class TestChannelStep(_FlowTestBase):
         assert row.onboarded_at is not None
         assert row.onboarding_state is None
         assert "locked in" in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_skip_at_channel_step_onboards_without_provisioning(self, mock_webclient, mock_provision):
+        # A CSM who can't/won't pick a channel must be able to bail — otherwise the DM intercept
+        # wedges them out of the assistant entirely.
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+        action = {"action_id": persona_onboarding.SKIP_ACTION_ID}
+        persona_onboarding.handle_block_action(self._payload(action), action)
+        mock_provision.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        assert "skipping setup" in self._posted_text(client).lower()
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_prompt_and_invite_offer_a_skip(self, mock_webclient, mock_provision):
+        assert any(
+            element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
+            for block in persona_onboarding.build_channel_prompt_blocks(True)
+            for element in block.get("elements", [])
+        )
+        assert any(
+            element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
+            for block in persona_onboarding.build_invite_needed_blocks("C1", "alerts")
+            for element in block.get("elements", [])
+        )
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_provisioning_failure_leaves_user_unonboarded_and_retryable(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.side_effect = RuntimeError("temporal down")
+        row = self._seed_channel_state()
+        self._select_channel()
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert "something went wrong" in self._posted_text(client).lower()
 
     @patch(PROVISION)
     @patch(WEBCLIENT)

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -500,3 +500,38 @@ class TestPersonaOnboardingInteractivityRouting:
 
     def test_payload_without_actions_is_not_claimed(self):
         assert api._is_persona_onboarding_interactivity({}, "block_actions") is False
+
+
+class TestBlockKitActionIdUniqueness:
+    # Slack rejects any message whose interactive elements share an action_id (`invalid_blocks`),
+    # so every builder that can emit sibling buttons is exercised in its busiest configuration.
+    @parameterized.expand(
+        [
+            ("kickoff_ask", lambda: persona_onboarding.build_kickoff_blocks("Pat", None)),
+            (
+                "kickoff_csm_candidate",
+                lambda: persona_onboarding.build_kickoff_blocks("Pat", persona_onboarding.PERSONA_CSM),
+            ),
+            (
+                "kickoff_engineer_candidate",
+                lambda: persona_onboarding.build_kickoff_blocks("Pat", persona_onboarding.PERSONA_ENGINEER),
+            ),
+            ("fleet_reveal_all_gaps_no_tools", lambda: persona_onboarding.build_fleet_reveal_blocks(1, {}, [])),
+            (
+                "fleet_reveal_all_gaps_tools_detected",
+                lambda: persona_onboarding.build_fleet_reveal_blocks(1, {}, ["Salesforce", "Linear", "Stripe"]),
+            ),
+            ("channel_prompt_with_create", lambda: persona_onboarding.build_channel_prompt_blocks(True)),
+            ("invite_needed", lambda: persona_onboarding.build_invite_needed_blocks("C1", "posthog-inbox")),
+        ]
+    )
+    def test_action_ids_unique_within_message(self, _name, build):
+        blocks = build()
+        action_ids = [
+            element["action_id"]
+            for block in blocks
+            for element in block.get("elements", [])
+            if isinstance(element, dict) and "action_id" in element
+        ]
+        assert action_ids, "builder emitted no interactive elements — extractor or builder is broken"
+        assert len(action_ids) == len(set(action_ids)), f"duplicate action_ids in one message: {action_ids}"

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -447,10 +447,15 @@ class TestChannelStep(_FlowTestBase):
 
         client.chat_postMessage.side_effect = None
         verify_action = {"action_id": persona_onboarding.CHANNEL_VERIFY_ACTION_ID, "value": PICKED_CHANNEL}
-        persona_onboarding.handle_block_action(self._payload(verify_action), verify_action)
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.handle_block_action(self._payload(verify_action), verify_action)
 
         mock_provision.assert_called_once()
         assert mock_provision.call_args.kwargs["channel_id"] == PICKED_CHANNEL
+        # The /invite-then-verify path must carry its own funnel label so it stays distinct from
+        # the dropdown path in the channel-configured conversion.
+        configured = [c for c in capture.call_args_list if c.args[1] == persona_onboarding.EVENT_CHANNEL_CONFIGURED]
+        assert [c.kwargs["method"] for c in configured] == ["verified"]
         row.refresh_from_db()
         assert row.onboarded_at is not None
         assert row.onboarding_state is None

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -1,0 +1,439 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.utils import timezone
+
+from parameterized import parameterized
+from slack_sdk.errors import SlackApiError
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+from products.signals.backend.facade.api import ScoutProvisionResult
+from products.slack_app.backend import api, persona_onboarding
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
+from products.tasks.backend.models import Task, TaskRun
+
+WORKSPACE = "T1"
+SLACK_USER = "U1"
+DM_CHANNEL = "D1"
+PICKED_CHANNEL = "C9"
+
+FLAG = "products.slack_app.backend.persona_onboarding.is_persona_onboarding_enabled"
+PROVISION = "products.signals.backend.facade.api.provision_persona_scouts"
+WEBCLIENT = "posthog.models.integration.WebClient"
+
+CSM_SKILL_NAMES = [spec.skill_name for spec in persona_onboarding.PERSONA_SCOUT_CATALOG[persona_onboarding.PERSONA_CSM]]
+DIGEST_START = "products.slack_app.backend.first_patrol.start_first_patrol_digest_workflow"
+
+
+@pytest.fixture(autouse=True)
+def _no_temporal_digest_dispatch():
+    # The completion path enqueues the first-patrol digest workflow; without this patch the
+    # tests wait out a real Temporal connection attempt (~80s of timeout across the module).
+    with patch(DIGEST_START) as mock_start:
+        yield mock_start
+
+
+@pytest.fixture(autouse=True)
+def _mute_analytics():
+    # Every handler fires capture_slack_event, whose ph_scoped_capture flushes on a blocking
+    # network shutdown — no flow test asserts analytics, so mock it to keep the suite fast.
+    with patch("products.slack_app.backend.persona_onboarding.capture_slack_event"):
+        yield
+
+
+class _FlowTestBase:
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        cache.clear()
+        self.organization = Organization.objects.create(name="Org")
+        self.team = Team.objects.create(organization=self.organization, name="Team")
+        self.user = User.objects.create(email="csm@example.com", first_name="Pat")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=WORKSPACE,
+            config={"scope": "chat:write,channels:manage"},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    def _client(self, mock_webclient_class: MagicMock) -> MagicMock:
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ok": True, "ts": "111.222"}
+        client.chat_update.return_value = {"ok": True}
+        client.conversations_open.return_value = {"channel": {"id": DM_CHANNEL}}
+        client.conversations_info.return_value = {"channel": {"id": PICKED_CHANNEL, "name": "cs-alerts"}}
+        client.users_info.return_value = {"user": {"profile": {"title": "", "display_name": "Pat"}}}
+        client.views_publish.return_value = {"ok": True}
+        mock_webclient_class.return_value = client
+        return client
+
+    def _row(self) -> SlackSettings:
+        return SlackSettings.objects.get(slack_workspace_id=WORKSPACE, slack_user_id=SLACK_USER)
+
+    def _seed_state(self, step: str, **extra: object) -> SlackSettings:
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        state: dict = {
+            "step": step,
+            "persona_candidate": None,
+            "detection_source": None,
+            "team_id": self.team.id,
+            "integration_id": self.integration.id,
+            "posthog_user_id": self.user.id,
+            "dm_channel_id": DM_CHANNEL,
+            "thread_ts": None,
+            "kickoff_ts": "111.222",
+            "started_at": "2026-07-02T00:00:00+00:00",
+        }
+        state.update(extra)
+        row.onboarding_state = state
+        row.save(update_fields=["onboarding_state", "updated_at"])
+        return row
+
+    def _payload(self, action: dict) -> dict:
+        return {
+            "team": {"id": WORKSPACE},
+            "user": {"id": SLACK_USER},
+            "channel": {"id": DM_CHANNEL},
+            "message": {"ts": "1.2", "blocks": []},
+            "actions": [action],
+        }
+
+    def _posted_text(self, client: MagicMock) -> str:
+        parts: list[str] = []
+        for call in client.chat_postMessage.call_args_list:
+            parts.append(str(call.kwargs.get("text") or ""))
+            for block in call.kwargs.get("blocks") or []:
+                text = (block.get("text") or {}).get("text", "")
+                if isinstance(text, str):
+                    parts.append(text)
+                for element in block.get("elements", []):
+                    element_text = element.get("text")
+                    parts.append(
+                        element_text if isinstance(element_text, str) else (element_text or {}).get("text", "")
+                    )
+        return " ".join(parts)
+
+
+class TestInterceptAssistantSurface(_FlowTestBase):
+    def _intercept(self, entry_point: str = "first_dm") -> bool:
+        return persona_onboarding.maybe_intercept_assistant_surface(
+            self.integration,
+            posthog_user_id=self.user.id,
+            workspace_id=WORKSPACE,
+            slack_user_id=SLACK_USER,
+            channel_id=DM_CHANNEL,
+            thread_ts=None,
+            accessible_integration_ids=[self.integration.id],
+            entry_point=entry_point,
+        )
+
+    @patch(FLAG, return_value=False)
+    @patch(WEBCLIENT)
+    def test_flag_off_is_inert(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+
+        assert self._intercept() is False
+
+        client.chat_postMessage.assert_not_called()
+        assert not SlackSettings.objects.filter(slack_workspace_id=WORKSPACE, slack_user_id=SLACK_USER).exists()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_new_user_gets_kickoff_dm_and_state(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+
+        assert self._intercept() is True
+
+        client.chat_postMessage.assert_called_once()
+        row = self._row()
+        assert row.onboarded_at is None
+        state = row.onboarding_state
+        assert state["step"] == persona_onboarding.STEP_AWAITING_PERSONA
+        assert state["team_id"] == self.team.id
+        assert state["integration_id"] == self.integration.id
+        assert state["posthog_user_id"] == self.user.id
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_prior_activity_grandfathers_without_onboarding(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        task = Task.objects.create(team=self.team, title="t")
+        task_run = TaskRun.objects.create(team=self.team, task=task)
+        SlackThreadTaskMapping.objects.create(
+            team=self.team,
+            integration=self.integration,
+            slack_workspace_id=WORKSPACE,
+            channel="C0",
+            thread_ts="1.0",
+            task=task,
+            task_run=task_run,
+            mentioning_slack_user_id=SLACK_USER,
+            latest_actor_slack_user_id=SLACK_USER,
+        )
+
+        assert self._intercept() is False
+
+        row = self._row()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        client.chat_postMessage.assert_not_called()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_onboarded_row_is_never_intercepted(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        row.onboarded_at = timezone.now()
+        row.save(update_fields=["onboarded_at", "updated_at"])
+
+        assert self._intercept() is False
+
+        client.chat_postMessage.assert_not_called()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_dm_during_in_flight_onboarding_nudges_without_reset(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        assert self._intercept() is True
+        original_kickoff_ts = self._row().onboarding_state["kickoff_ts"]
+        client.chat_postMessage.reset_mock()
+        client.chat_postMessage.return_value = {"ok": True, "ts": "999.999"}
+
+        assert self._intercept(entry_point="first_dm") is True
+
+        assert persona_onboarding.NUDGE_PERSONA_TEXT in self._posted_text(client)
+        assert self._row().onboarding_state["kickoff_ts"] == original_kickoff_ts
+
+
+class TestPersonaSelection(_FlowTestBase):
+    def _select(self, value: str) -> None:
+        action = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": value}
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+    @patch(WEBCLIENT)
+    def test_engineer_select_completes_onboarding(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+
+        self._select("engineer")
+
+        row.refresh_from_db()
+        assert row.persona == "engineer"
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        assert persona_onboarding.ENGINEER_COMPLETION_TEXT in self._posted_text(client)
+
+    @patch(WEBCLIENT)
+    def test_csm_select_reveals_fleet_then_asks_for_channel(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+
+        self._select("csm")
+
+        row.refresh_from_db()
+        assert row.persona == "csm"
+        assert row.onboarded_at is None
+        state = row.onboarding_state
+        assert state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert set(state["readiness"]) == {"account_pulse", "support_watch", "revenue_watch", "accounts_count"}
+        assert state["detected_tools"] == []
+        assert client.chat_postMessage.call_count == 2
+        reveal_blocks, prompt_blocks = (call.kwargs["blocks"] for call in client.chat_postMessage.call_args_list)
+        assert persona_onboarding.SCOUTS_DOC_URL in str(reveal_blocks)
+        assert any(
+            element.get("action_id") == persona_onboarding.CHANNEL_SELECT_ACTION_ID
+            for block in prompt_blocks
+            for element in block.get("elements", [])
+        )
+
+    @patch(WEBCLIENT)
+    def test_replayed_csm_click_reposts_channel_step_without_double_transition(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(
+            persona_onboarding.STEP_AWAITING_CHANNEL,
+            readiness={"account_pulse": False, "support_watch": False, "revenue_watch": False, "accounts_count": 0},
+            detected_tools=[],
+        )
+        row.persona = persona_onboarding.PERSONA_CSM
+        row.save(update_fields=["persona"])
+
+        self._select("csm")
+
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert client.chat_postMessage.call_count == 1
+        assert persona_onboarding.SCOUTS_DOC_URL not in self._posted_text(client)
+        assert any(
+            element.get("action_id") == persona_onboarding.CHANNEL_SELECT_ACTION_ID
+            for block in client.chat_postMessage.call_args.kwargs["blocks"]
+            for element in block.get("elements", [])
+        )
+
+    @patch(WEBCLIENT)
+    def test_skip_marks_onboarded_without_persona(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": persona_onboarding.SKIP_ACTION_ID}
+
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.persona is None
+        assert row.onboarding_state is None
+        assert persona_onboarding.SKIP_TEXT in self._posted_text(client)
+
+
+class TestChannelStep(_FlowTestBase):
+    def _seed_channel_state(self) -> SlackSettings:
+        row = self._seed_state(
+            persona_onboarding.STEP_AWAITING_CHANNEL,
+            readiness={"account_pulse": False, "support_watch": False, "revenue_watch": False, "accounts_count": 0},
+            detected_tools=[],
+        )
+        row.persona = persona_onboarding.PERSONA_CSM
+        row.save(update_fields=["persona"])
+        return row
+
+    def _results(self, channel_conflict: str | None = None) -> list[ScoutProvisionResult]:
+        return [
+            ScoutProvisionResult(
+                skill_name=skill_name,
+                config_id=f"cfg-{index}",
+                created=True,
+                channel_conflict=channel_conflict if index == 0 else None,
+                first_run_started=True,
+            )
+            for index, skill_name in enumerate(CSM_SKILL_NAMES)
+        ]
+
+    def _select_channel(self) -> None:
+        action = {"action_id": persona_onboarding.CHANNEL_SELECT_ACTION_ID, "selected_conversation": PICKED_CHANNEL}
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_select_provisions_fleet_and_finalizes_row(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        mock_provision.assert_called_once()
+        kwargs = mock_provision.call_args.kwargs
+        assert kwargs["team"] == self.team
+        assert kwargs["created_by"] == self.user
+        assert kwargs["slack_integration_id"] == self.integration.id
+        assert kwargs["channel_id"] == PICKED_CHANNEL
+        assert kwargs["channel_name"] == "cs-alerts"
+        assert kwargs["skill_names"] == CSM_SKILL_NAMES
+        row.refresh_from_db()
+        assert row.persona == persona_onboarding.PERSONA_CSM
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        assert "locked in" in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_not_in_channel_defers_provisioning_until_verify(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+
+        def reject_picked_channel(channel=None, **kwargs):
+            if channel == PICKED_CHANNEL:
+                raise SlackApiError("not_in_channel", {"error": "not_in_channel"})
+            return {"ok": True, "ts": "1.3"}
+
+        client.chat_postMessage.side_effect = reject_picked_channel
+        self._select_channel()
+
+        mock_provision.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["pending_channel_id"] == PICKED_CHANNEL
+        assert "/invite" in self._posted_text(client)
+
+        client.chat_postMessage.side_effect = None
+        verify_action = {"action_id": persona_onboarding.CHANNEL_VERIFY_ACTION_ID, "value": PICKED_CHANNEL}
+        persona_onboarding.handle_block_action(self._payload(verify_action), verify_action)
+
+        mock_provision.assert_called_once()
+        assert mock_provision.call_args.kwargs["channel_id"] == PICKED_CHANNEL
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+
+    @patch(PROVISION, side_effect=RuntimeError("enabled cap reached"))
+    @patch(WEBCLIENT)
+    def test_provisioning_failure_keeps_flow_retryable(self, mock_webclient, _mock_provision):
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert persona_onboarding.ERROR_TEXT in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_conflict_uses_already_running_copy(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results(channel_conflict="scout-hq")
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        text = self._posted_text(client)
+        assert "already running" in text
+        assert "#scout-hq" in text
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+
+
+class TestHomeOnboardingStatus(_FlowTestBase):
+    @parameterized.expand(
+        [
+            ("flag_off", False, "in_flight", "hidden"),
+            ("no_row", True, None, "start"),
+            ("in_flight", True, "in_flight", "in_progress"),
+            ("onboarded", True, "onboarded", "hidden"),
+        ]
+    )
+    @patch(FLAG)
+    def test_home_card_status_matrix(self, _name, flag_on, row_state, expected, mock_flag):
+        mock_flag.return_value = flag_on
+        if row_state == "in_flight":
+            self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        elif row_state == "onboarded":
+            row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+            row.onboarded_at = timezone.now()
+            row.save(update_fields=["onboarded_at", "updated_at"])
+
+        assert persona_onboarding.compute_home_onboarding_status(self.integration, WORKSPACE, SLACK_USER) == expected
+
+
+class TestPersonaOnboardingInteractivityRouting:
+    @parameterized.expand(
+        [
+            ("persona_step_action", "block_actions", persona_onboarding.PERSONA_SELECT_ACTION_ID, True),
+            ("home_start_action", "block_actions", persona_onboarding.START_ACTION_ID, True),
+            ("unrelated_action", "block_actions", "posthog_code_repo_select", False),
+            ("view_submission", "view_submission", persona_onboarding.PERSONA_SELECT_ACTION_ID, False),
+        ]
+    )
+    def test_is_persona_onboarding_interactivity(self, _name, payload_type, action_id, expected):
+        payload = {"actions": [{"action_id": action_id}]}
+        assert api._is_persona_onboarding_interactivity(payload, payload_type) is expected
+
+    def test_payload_without_actions_is_not_claimed(self):
+        assert api._is_persona_onboarding_interactivity({}, "block_actions") is False

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -1143,6 +1143,55 @@ class TestAssistantEvents(TestCase):
             )
             slack_cls.return_value.client.assistant_threads_setSuggestedPrompts.assert_not_called()
 
+    def test_thread_started_onboarding_targets_resolved_project_not_probe(self):
+        # In a multi-project workspace the workspace probe and the user's resolved default can
+        # differ; the thread-started entry point must land onboarding on the resolved project (as
+        # the first-DM path does) so the fleet doesn't depend on which entry point fired first.
+        from products.slack_app.backend.services.integration_resolver import (
+            ResolutionResult,
+            UserAndIntegrationsResolution,
+        )
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        resolved = Integration.objects.create(
+            team=other_team,
+            kind="slack",
+            integration_id="T12345",
+            config={"scope": "chat:write"},
+            sensitive_config={"access_token": "xoxb-other"},
+        )
+        load = patch(
+            "products.slack_app.backend.api.load_integrations",
+            return_value=ResolutionResult(
+                integration=self.integration, source="workspace_default", candidates=[self.integration, resolved]
+            ),
+        )
+        resolve = patch(
+            "products.slack_app.backend.api.resolve_user_for_workspace",
+            return_value=UserAndIntegrationsResolution(
+                user=self.user,
+                integration=resolved,
+                candidates=[self.integration, resolved],
+                source="user_default",
+            ),
+        )
+        enabled_p = patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+        usp = patch("products.slack_app.backend.api._us_should_handle_instead", return_value=False)
+        slack = patch("products.slack_app.backend.api.SlackIntegration")
+        intercept = patch(
+            "products.slack_app.backend.persona_onboarding.maybe_intercept_assistant_surface", return_value=True
+        )
+        with load, resolve, enabled_p, usp, slack, intercept as mock_intercept:
+            self._route(
+                {
+                    "type": "assistant_thread_started",
+                    "assistant_thread": {"user_id": "U123", "channel_id": "D001", "thread_ts": "111.222"},
+                }
+            )
+
+        mock_intercept.assert_called_once()
+        assert mock_intercept.call_args.args[0] == resolved
+
     def test_context_changed_caches_viewed_channel(self):
         from products.slack_app.backend.api import _get_assistant_channel_context
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "account_name": {
+            "description": "Display name of the account the finding is about (headline of the alert).",
+            "maxLength": 300,
+            "type": "string"
+        },
+        "owner_email": {
+            "anyOf": [
+                {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "The account owner's email as resolved from the data (`system.accounts` roles or CRM owner join). The server resolves it to a Slack mention via `users.lookupByEmail`; on a miss the alert falls back to plain text. Omit when no owner was resolvable."
+        },
+        "owner_label": {
+            "anyOf": [
+                {
+                    "maxLength": 200,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable owner fallback (e.g. `Jane Doe (Salesforce)` or `HubSpot owner 1234`) used when `owner_email` is absent or doesn't resolve to a Slack user."
+        },
+        "report_id": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "UUID of the inbox `SignalReport` this run emitted or edited for the same finding. Must be one of this run's report ids; the alert links to it. Always file the report first, then notify."
+        },
+        "run_id": {
+            "description": "UUID of the `SignalScoutRun` bridge row.",
+            "type": "string"
+        },
+        "severity": {
+            "anyOf": [
+                {
+                    "description": "* `high` - high\n* `medium` - medium\n* `low` - low",
+                    "enum": ["high", "medium", "low"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Severity steer for the alert's visual treatment. Omit for a neutral alert.\n\n* `low` - low\n* `medium` - medium\n* `high` - high"
+        },
+        "text": {
+            "description": "The finding summary, in Slack mrkdwn, written for the account owner: what changed, the magnitude and window, and the one thing to check. 2–4 sentences. Do NOT include an owner mention — the server prepends it.",
+            "maxLength": 2500,
+            "type": "string"
+        }
+    },
+    "required": ["run_id", "text", "account_name"],
+    "type": "object"
+}


### PR DESCRIPTION
> Part 3 of the CSM persona onboarding stack (8 PRs), based on #69079.

## Problem

With state, detection, and the scout fleet in place (parts 1 and 2), this wires the actual conversation: a new user DMs the bot (or clicks the App Home card) and walks a short flow that confirms their persona, reveals the fleet, picks a findings channel, provisions the scouts, and guarantees a first scout touch within the hour.

## Changes

- Deterministic Block Kit state machine in `persona_onboarding.py`: kickoff with confirm buttons, fleet reveal with per-scout readiness lines, channel step (picker or create `#posthog-inbox`, hello-post as the membership probe, `/invite` + Verify fallback), locked-in completion. No LLM anywhere in the interactive path.
- Entry points gated by the `slack-app-persona-onboarding` flag: first DM, assistant container open, App Home card. Established users are silently grandfathered.
- First-patrol digest: a delayed Temporal workflow (`posthog/temporal/ai/slack_app/`) collects the first runs' outcomes and DMs the user.
- Five follow-up fix commits from adversarial review ride in this PR: provisioning hardening, per-message-unique action ids, fast Start ack via background execution, migration formatting, and keeping replies in the thread the user is actually looking at. The first of those also patches small signals-side bits from part 2 (worth a look when reviewing that commit).

## How did you test this code?

`hogli test products/slack_app/backend/tests/ posthog/temporal/tests/ai/test_first_patrol_workflow.py` (708 passed). The flow tests drive the state machine end to end through the public handlers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Covered by part 6 of this stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code from a reviewed design doc, then hardened via an adversarial review pass whose fixes are the trailing commits here. `/writing-tests` was invoked for the suites. A later session split the feature branch into this stack, this PR is an unmodified slice of the original commits. Reviewing commit by commit is recommended, the commits follow the module plan.
