### PR TITLE
feat(slack): confirm and polish onboarding channel setup

### DIFF
--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -523,7 +523,7 @@ def provision_persona_scouts(
                 created = False
             else:
                 # `for_team()` filters don't propagate into row creation — pass team explicitly.
-                config = SignalScoutConfig.objects.create(
+                config = SignalScoutConfig.objects.for_team(team.id).create(
                     team=team,
                     skill_name=skill_name,
                     enabled=True,

--- a/products/signals/backend/test/test_persona_scout_provisioning.py
+++ b/products/signals/backend/test/test_persona_scout_provisioning.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
+from posthog.models.scoping import unscoped
+
 from products.signals.backend.facade.api import collect_scout_run_digests, provision_persona_scouts
 from products.signals.backend.models import SignalScoutConfig
 from products.signals.backend.test.test_scout_harness_api import _make_run
@@ -34,7 +36,10 @@ class TestProvisionPersonaScouts(BaseTest):
             "skill_names": CSM_SKILLS,
         }
         kwargs.update(overrides)
-        return provision_persona_scouts(**kwargs)
+        # The real caller is Slack's background interactivity thread, where no team scope is
+        # set — clear the suite's autouse team_scope so bare fail-closed manager calls surface.
+        with unscoped():
+            return provision_persona_scouts(**kwargs)
 
     @patch(FIRE_PATH, side_effect=_fire_all)
     def test_fresh_team_gets_seeded_enabled_fleet_with_delivery_and_first_runs(self, fire_mock) -> None:

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -54,8 +54,12 @@ START_ACTION_ID = "persona_onboarding_start"
 PERSONA_SELECT_ACTION_ID = "persona_onboarding_select"  # values: "csm" | "engineer" | "other"
 SKIP_ACTION_ID = "persona_onboarding_skip"
 CHANNEL_SELECT_ACTION_ID = "persona_onboarding_channel_select"
+CHANNEL_CONFIRM_ACTION_ID = "persona_onboarding_channel_confirm"
 CHANNEL_CREATE_ACTION_ID = "persona_onboarding_channel_create"
 CHANNEL_VERIFY_ACTION_ID = "persona_onboarding_channel_verify"
+# The confirm button reads the dropdown's current selection out of payload["state"]["values"],
+# which Slack keys by block_id — so the selector's block needs a stable one.
+CHANNEL_SELECT_BLOCK_ID = "persona_onboarding_channel_block"
 # URL buttons — clicks open the browser but still emit a block_action that must be acked.
 CONNECT_SOURCE_ACTION_ID = "persona_onboarding_connect_source"
 
@@ -272,7 +276,7 @@ PERSONA_SCOUT_CATALOG: dict[str, tuple[ScoutSpec, ...]] = {
             ),
             readiness_key="account_pulse",
             recommended_servers=("Salesforce", "HubSpot"),
-            gap_line="works best with account data — PostHog customer analytics accounts or a connected CRM.",
+            gap_line="works best with account data like PostHog customer analytics accounts or a connected CRM.",
         ),
         ScoutSpec(
             skill_name="signals-scout-csm-support-watch",
@@ -293,7 +297,7 @@ PERSONA_SCOUT_CATALOG: dict[str, tuple[ScoutSpec, ...]] = {
             ),
             readiness_key="revenue_watch",
             recommended_servers=("Stripe",),
-            gap_line="works best with billing data — connect Stripe or PostHog revenue analytics.",
+            gap_line="works best with billing data like Stripe or PostHog revenue analytics.",
         ),
     ),
 }
@@ -308,6 +312,9 @@ class CsmDataReadiness:
     support_watch: bool
     revenue_watch: bool
     accounts_count: int
+    # readiness_key -> human phrase for the data source that made the scout ready (e.g. "your
+    # PostHog customer analytics accounts"), so the reveal can say what's used by default.
+    ready_details: dict[str, str] = dataclasses.field(default_factory=dict)
 
     def as_dict(self) -> dict:
         return dataclasses.asdict(self)
@@ -335,8 +342,8 @@ def _connected_mcp_server_names(team_id: int, posthog_user_id: int | None) -> se
     return names
 
 
-def _recommended_server_connected(spec: ScoutSpec, connected_names: set[str]) -> bool:
-    return any(name.lower() in connected_names for name in spec.recommended_servers)
+def _first_connected_recommended(spec: ScoutSpec, connected_names: set[str]) -> str | None:
+    return next((name for name in spec.recommended_servers if name.lower() in connected_names), None)
 
 
 def check_csm_data_readiness(team_id: int, posthog_user_id: int | None = None) -> CsmDataReadiness:
@@ -376,18 +383,38 @@ def check_csm_data_readiness(team_id: int, posthog_user_id: int | None = None) -
 
     specs_by_key = {spec.readiness_key: spec for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]}
 
-    def mcp_ready(readiness_key: str) -> bool:
-        return _recommended_server_connected(specs_by_key[readiness_key], mcp_connected)
+    def resolve(readiness_key: str, posthog_detail: str | None, source_matches: tuple[str, ...]) -> str | None:
+        """First data source that makes the scout ready, as a human phrase — PostHog-native data
+        wins so users see they don't need to connect anything."""
+        if posthog_detail:
+            return posthog_detail
+        source_kind = next((kind for kind in source_matches if kind in source_kinds), None)
+        if source_kind:
+            return f"your {source_kind} data synced into PostHog"
+        server_name = _first_connected_recommended(specs_by_key[readiness_key], mcp_connected)
+        if server_name:
+            return f"your connected {server_name} MCP server"
+        return None
 
+    details = {
+        "account_pulse": resolve(
+            "account_pulse",
+            "your PostHog customer analytics accounts" if accounts_count > 0 else None,
+            _CRM_SOURCE_KINDS,
+        ),
+        "support_watch": resolve(
+            "support_watch",
+            "your PostHog conversations tickets" if tickets_exist else None,
+            _SUPPORT_SOURCE_KINDS,
+        ),
+        "revenue_watch": resolve("revenue_watch", None, ("Stripe",)),
+    }
     return CsmDataReadiness(
-        account_pulse=accounts_count > 0
-        or any(kind in source_kinds for kind in _CRM_SOURCE_KINDS)
-        or mcp_ready("account_pulse"),
-        support_watch=tickets_exist
-        or any(kind in source_kinds for kind in _SUPPORT_SOURCE_KINDS)
-        or mcp_ready("support_watch"),
-        revenue_watch="Stripe" in source_kinds or mcp_ready("revenue_watch"),
+        account_pulse=details["account_pulse"] is not None,
+        support_watch=details["support_watch"] is not None,
+        revenue_watch=details["revenue_watch"] is not None,
         accounts_count=accounts_count,
+        ready_details={key: detail for key, detail in details.items() if detail},
     )
 
 
@@ -523,6 +550,7 @@ def build_fleet_reveal_blocks(
     slack_user_id: str,
 ) -> list[dict]:
     templates_by_name = {template.name.lower(): template for template in templates}
+    ready_details = readiness.get("ready_details") or {}
     blocks: list[dict] = [
         _section(
             "Great — I'm going to create a few scouts for you. Scouts are little agents that patrol "
@@ -530,10 +558,21 @@ def build_fleet_reveal_blocks(
             f"(<{SCOUTS_DOC_URL}|here's how they work>)."
         )
     ]
+    if any(not readiness.get(spec.readiness_key) for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]):
+        blocks.append(
+            _context(
+                "Scouts use your PostHog data by default — product usage, revenue analytics, and "
+                "customer analytics are already in reach. Connecting a tool below is optional; it "
+                "just gives them more signal."
+            )
+        )
     for index, spec in enumerate(PERSONA_SCOUT_CATALOG[PERSONA_CSM], start=1):
         blocks.append(_section(f"*{index}. {spec.title}*\n{spec.description}"))
         if readiness.get(spec.readiness_key):
-            blocks.append(_context("✅ Ready — I can see the data this needs."))
+            detail = ready_details.get(spec.readiness_key)
+            blocks.append(
+                _context(f"✅ Ready — I'll use {detail}." if detail else "✅ Ready — I can see the data this needs.")
+            )
             continue
         candidates = [
             templates_by_name[name.lower()] for name in spec.recommended_servers if name.lower() in templates_by_name
@@ -573,33 +612,39 @@ def build_fleet_reveal_blocks(
                     ],
                 }
             )
-    blocks.append(_context("Don't worry — I'll create these now and they activate themselves as data shows up."))
+    blocks.append(_context("Don't worry, I'll create these now and they activate themselves as data shows up."))
     return blocks
 
 
 def build_channel_prompt_blocks(can_create_channel: bool) -> list[dict]:
-    elements: list[dict] = [
+    # Picking from the dropdown is easy to fat-finger, so it does nothing on its own —
+    # the explicit Add PostHog button next to it is what commits the choice.
+    select_row: list[dict] = [
         {
             "type": "conversations_select",
             "action_id": CHANNEL_SELECT_ACTION_ID,
             "placeholder": {"type": "plain_text", "text": "Pick a channel"},
             # Never offer external-shared channels — these alerts carry account intel.
             "filter": {"include": ["public"], "exclude_external_shared_channels": True, "exclude_bot_users": True},
-        }
+        },
+        _button("Add PostHog", CHANNEL_CONFIRM_ACTION_ID, style="primary"),
     ]
+    secondary_row: list[dict] = []
     if can_create_channel:
-        elements.append(_button("Create #posthog-inbox", CHANNEL_CREATE_ACTION_ID))
+        secondary_row.append(_button("Create #posthog-inbox", CHANNEL_CREATE_ACTION_ID))
     # Skip is a bail-out at every step: without it a CSM who can't (or won't) pick a channel
     # is wedged, since the DM intercept hijacks every message while onboarding_state is set.
-    elements.append(_button("Skip for now", SKIP_ACTION_ID))
+    secondary_row.append(_button("Skip for now", SKIP_ACTION_ID))
     return [
         _section(
             "One more thing: this works best if you add me to a channel where I can post findings. "
-            "Pick one, or I can create #posthog-inbox for you."
+            "Pick one and tap Add PostHog, or I can create #posthog-inbox for you."
             if can_create_channel
-            else "One more thing: this works best if you add me to a channel where I can post findings. Pick one below."
+            else "One more thing: this works best if you add me to a channel where I can post findings. "
+            "Pick one below and tap Add PostHog."
         ),
-        {"type": "actions", "elements": elements},
+        {"type": "actions", "block_id": CHANNEL_SELECT_BLOCK_ID, "elements": select_row},
+        {"type": "actions", "elements": secondary_row},
     ]
 
 
@@ -667,6 +712,7 @@ OTHER_COMPLETION_TEXT = (
     "Thanks! Message me here any time — ask about your product data, dashboards, or anything PostHog."
 )
 SKIP_TEXT = "No problem — skipping setup. Message me whenever; settings live in my Home tab."
+PICK_CHANNEL_FIRST_TEXT = "Pick a channel from the dropdown first, then tap Add PostHog."
 NUDGE_PERSONA_TEXT = "One quick thing first — tap one of the buttons above (or Skip) and then I'm all yours."
 NUDGE_CHANNEL_TEXT = (
     "Almost there — pick a channel for account alerts above (or Skip), then send me that message again."
@@ -936,7 +982,9 @@ def handle_block_action(payload: dict, action: dict) -> HttpResponse:
         elif action_id == SKIP_ACTION_ID:
             _handle_skip(payload)
         elif action_id == CHANNEL_SELECT_ACTION_ID:
-            _handle_channel_select(payload, action)
+            pass  # picking from the dropdown is inert — Add PostHog commits the choice
+        elif action_id == CHANNEL_CONFIRM_ACTION_ID:
+            _handle_channel_confirm(payload)
         elif action_id == CHANNEL_CREATE_ACTION_ID:
             _handle_channel_create(payload)
         elif action_id == CHANNEL_VERIFY_ACTION_ID:
@@ -1150,15 +1198,18 @@ def _channel_name_best_effort(slack: SlackIntegration, channel_id: str) -> str:
         return channel_id
 
 
-def _handle_channel_select(payload: dict, action: dict) -> None:
+def _handle_channel_confirm(payload: dict) -> None:
     ctx = _load_context(payload)
     if ctx is None:
         return
     if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
         _repost_current_step(ctx)
         return
-    channel_id = str(action.get("selected_conversation") or "")
+    values = (payload.get("state") or {}).get("values") or {}
+    select_state = (values.get(CHANNEL_SELECT_BLOCK_ID) or {}).get(CHANNEL_SELECT_ACTION_ID) or {}
+    channel_id = str(select_state.get("selected_conversation") or "")
     if not channel_id:
+        _post(ctx, [_section(PICK_CHANNEL_FIRST_TEXT)], PICK_CHANNEL_FIRST_TEXT)
         return
     channel_name = _channel_name_best_effort(ctx.slack, channel_id)
     _attempt_channel_setup(ctx, channel_id, channel_name, method="selected")
@@ -1197,11 +1248,13 @@ def _handle_channel_verify(payload: dict, action: dict) -> None:
     _attempt_channel_setup(ctx, channel_id, channel_name, method="selected", invite_required=True)
 
 
-def _attempt_channel_setup(
-    ctx: _FlowContext, channel_id: str, channel_name: str, *, method: str, invite_required: bool = False
-) -> None:
-    # The hello post doubles as the membership probe — the only check that works with the
-    # scopes we actually hold (no channels:read / channels:join / chat:write.public).
+# Membership-shaped hello failures that the /invite-then-Verify flow can recover from.
+_INVITE_FALLBACK_ERRORS = ("not_in_channel", "channel_not_found", "is_archived", "restricted_action")
+
+
+def _post_channel_hello(ctx: _FlowContext, channel_id: str) -> str | None:
+    """Post the channel hello; it doubles as the membership probe. Returns the Slack error
+    string for membership-shaped failures, None on success; anything else raises."""
     try:
         ctx.slack.client.chat_postMessage(
             channel=channel_id,
@@ -1210,14 +1263,39 @@ def _attempt_channel_setup(
                 "First patrol is already underway."
             ),
         )
+        return None
     except SlackApiError as exc:
-        error = (getattr(exc, "response", None) or {}).get("error", "")
-        if error in ("not_in_channel", "channel_not_found", "is_archived", "restricted_action"):
-            ctx.state.update({"pending_channel_id": channel_id, "pending_channel_name": channel_name})
-            _save_state(ctx.row, ctx.state)
-            _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
-            return
+        error = str((getattr(exc, "response", None) or {}).get("error", ""))
+        if error in _INVITE_FALLBACK_ERRORS:
+            return error
         raise
+
+
+def _try_join_channel(slack: SlackIntegration, channel_id: str) -> bool:
+    try:
+        slack.client.conversations_join(channel=channel_id)
+        return True
+    except SlackApiError as exc:
+        logger.warning(
+            "persona_onboarding_channel_join_failed",
+            channel_id=channel_id,
+            error=(getattr(exc, "response", None) or {}).get("error"),
+        )
+        return False
+
+
+def _attempt_channel_setup(
+    ctx: _FlowContext, channel_id: str, channel_name: str, *, method: str, invite_required: bool = False
+) -> None:
+    error = _post_channel_hello(ctx, channel_id)
+    if error == "not_in_channel" and _try_join_channel(ctx.slack, channel_id):
+        # Public channel and we hold channels:join — add ourselves instead of asking for /invite.
+        error = _post_channel_hello(ctx, channel_id)
+    if error is not None:
+        ctx.state.update({"pending_channel_id": channel_id, "pending_channel_name": channel_name})
+        _save_state(ctx.row, ctx.state)
+        _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
+        return
     capture_slack_event(
         ctx.integration,
         EVENT_CHANNEL_CONFIGURED,

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -319,6 +319,10 @@ class CsmDataReadiness:
     def as_dict(self) -> dict:
         return dataclasses.asdict(self)
 
+    def analytics_props(self) -> dict:
+        # ready_details is presentation-only with variable keys — keep it out of the flat event schema.
+        return {key: value for key, value in self.as_dict().items() if key != "ready_details"}
+
 
 def _active_source_kinds(team_id: int) -> set[str]:
     from products.warehouse_sources.backend.models.external_data_source import (  # noqa: PLC0415 — keeps the warehouse stack off the slack import path
@@ -1190,7 +1194,7 @@ def _handle_persona_select(payload: dict, action: dict) -> None:
         EVENT_FLEET_SHOWN,
         slack_user_id=ctx.slack_user_id,
         detected_tools=detected_tools,
-        **readiness.as_dict(),
+        **readiness.analytics_props(),
     )
 
 
@@ -1390,7 +1394,8 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
         scouts_provisioned=len([result for result in results if result.config_id]),
         first_runs_fired=len([result for result in results if result.first_run_started]),
         channel_conflict=bool(channel_conflict),
-        **readiness,
+        # readiness still carries ready_details for the Block Kit render above; keep it out of analytics.
+        **{key: value for key, value in readiness.items() if key != "ready_details"},
     )
     _republish_home(ctx.integration, ctx.slack_user_id)
     _start_first_patrol_digest(ctx, results, channel_name)

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -792,6 +792,15 @@ def _save_state(row: SlackSettings, state: dict | None) -> None:
     row.save(update_fields=["onboarding_state", "updated_at"])
 
 
+def _remember_message_ts(ctx: _FlowContext, key: str, posted: SlackResponse) -> None:
+    """Track a posted message so a later step can rewrite it in place (e.g. flip the channel
+    prompt to a done note once the channel is configured)."""
+    ts = posted.get("ts")
+    if ts:
+        ctx.state[key] = ts
+        _save_state(ctx.row, ctx.state)
+
+
 def _freeze_buttons(ctx: _FlowContext, payload: dict, note: str) -> None:
     """Replace the clicked message's action blocks with a note, so stale buttons can't
     double-fire. Best-effort — a failure here never blocks the step itself."""
@@ -1012,16 +1021,25 @@ def _repost_current_step(ctx: _FlowContext) -> None:
     if step == STEP_AWAITING_CHANNEL:
         pending_channel = ctx.state.get("pending_channel_id")
         if pending_channel:
-            blocks = build_invite_needed_blocks(
-                pending_channel, ctx.state.get("pending_channel_name") or pending_channel
-            )
+            _post_invite_needed(ctx, pending_channel, ctx.state.get("pending_channel_name") or pending_channel)
         else:
-            blocks = build_channel_prompt_blocks(_can_create_channel(ctx.slack))
-        _post(ctx, blocks, "Pick a channel for scout findings.")
+            _post_channel_prompt(ctx)
         return
     display_name = _display_name(ctx.slack, ctx.slack_user_id)
     blocks = build_kickoff_blocks(display_name, ctx.state.get("persona_candidate"))
     _post(ctx, blocks, "Quick setup — which best describes what you do?")
+
+
+def _post_channel_prompt(ctx: _FlowContext, can_create: bool | None = None) -> None:
+    if can_create is None:
+        can_create = _can_create_channel(ctx.slack)
+    posted = _post(ctx, build_channel_prompt_blocks(can_create), "Pick a channel for scout findings.")
+    _remember_message_ts(ctx, "channel_prompt_ts", posted)
+
+
+def _post_invite_needed(ctx: _FlowContext, channel_id: str, channel_name: str) -> None:
+    posted = _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
+    _remember_message_ts(ctx, "invite_message_ts", posted)
 
 
 def _can_create_channel(slack: SlackIntegration) -> bool:
@@ -1166,7 +1184,7 @@ def _handle_persona_select(payload: dict, action: dict) -> None:
     if posted and posted.get("ts"):
         ctx.state["fleet_message_ts"] = posted.get("ts")
         _save_state(ctx.row, ctx.state)
-    _post(ctx, build_channel_prompt_blocks(_can_create_channel(ctx.slack)), "Pick a channel for scout findings.")
+    _post_channel_prompt(ctx)
     capture_slack_event(
         ctx.integration,
         EVENT_FLEET_SHOWN,
@@ -1223,7 +1241,7 @@ def _handle_channel_create(payload: dict) -> None:
         _repost_current_step(ctx)
         return
     if not _can_create_channel(ctx.slack):
-        _post(ctx, build_channel_prompt_blocks(False), "Pick a channel for scout findings.")
+        _post_channel_prompt(ctx, can_create=False)
         return
     ensured = ensure_inbox_channel(ctx.integration)
     if ensured is None:
@@ -1294,7 +1312,7 @@ def _attempt_channel_setup(
     if error is not None:
         ctx.state.update({"pending_channel_id": channel_id, "pending_channel_name": channel_name})
         _save_state(ctx.row, ctx.state)
-        _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
+        _post_invite_needed(ctx, channel_id, channel_name)
         return
     capture_slack_event(
         ctx.integration,
@@ -1304,6 +1322,24 @@ def _attempt_channel_setup(
         invite_required=invite_required,
     )
     _provision_and_complete(ctx, channel_id, channel_name)
+
+
+def _resolve_channel_prompts(ctx: _FlowContext, channel_name: str) -> None:
+    """Rewrite the now-stale channel-setup messages (prompt with the picker, invite-then-verify
+    ask) to a done note so their controls don't linger after the channel is configured.
+    Best-effort — a failure here never blocks completion."""
+    note = f"✅ Channel set — I'll post scout findings to #{channel_name}."
+    dm_channel_id = ctx.state.get("dm_channel_id")
+    if not dm_channel_id:
+        return
+    for key in ("channel_prompt_ts", "invite_message_ts"):
+        ts = ctx.state.get(key)
+        if not ts:
+            continue
+        try:
+            ctx.slack.client.chat_update(channel=dm_channel_id, ts=ts, text=note, blocks=[_section(note)])
+        except Exception:
+            logger.warning("persona_onboarding_channel_prompt_update_failed", exc_info=True)
 
 
 def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: str) -> None:
@@ -1338,6 +1374,7 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
     ctx.row.onboarded_at = timezone.now()
     ctx.row.onboarding_state = None
     ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+    _resolve_channel_prompts(ctx, channel_name)
     _post(
         ctx,
         build_locked_in_blocks(

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -66,9 +66,9 @@ def _no_temporal_digest_dispatch():
 @pytest.fixture(autouse=True)
 def _mute_analytics():
     # Every handler fires capture_slack_event, whose ph_scoped_capture flushes on a blocking
-    # network shutdown — no flow test asserts analytics, so mock it to keep the suite fast.
-    with patch("products.slack_app.backend.persona_onboarding.capture_slack_event"):
-        yield
+    # network shutdown — mock it to keep the suite fast; the mock also lets tests inspect kwargs.
+    with patch("products.slack_app.backend.persona_onboarding.capture_slack_event") as mock_capture:
+        yield mock_capture
 
 
 class _FlowTestBase:
@@ -276,7 +276,7 @@ class TestPersonaSelection(_FlowTestBase):
         assert persona_onboarding.ENGINEER_COMPLETION_TEXT in self._posted_text(client)
 
     @patch(WEBCLIENT)
-    def test_csm_select_reveals_fleet_then_asks_for_channel(self, mock_webclient):
+    def test_csm_select_reveals_fleet_then_asks_for_channel(self, mock_webclient, _mute_analytics):
         client = self._client(mock_webclient)
         row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
 
@@ -294,6 +294,12 @@ class TestPersonaSelection(_FlowTestBase):
             "accounts_count",
             "ready_details",
         }
+        # ready_details is presentation-only — it must stay out of the flat analytics event schema.
+        fleet_shown = next(
+            call for call in _mute_analytics.call_args_list if call.args[1] == persona_onboarding.EVENT_FLEET_SHOWN
+        )
+        assert "ready_details" not in fleet_shown.kwargs
+        assert "account_pulse" in fleet_shown.kwargs
         assert state["detected_tools"] == []
         # The post-OAuth return leg needs this pointer to flip the reveal's ⚠️ lines to ✅.
         assert state["fleet_message_ts"] == "111.222"

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -297,6 +297,8 @@ class TestPersonaSelection(_FlowTestBase):
         assert state["detected_tools"] == []
         # The post-OAuth return leg needs this pointer to flip the reveal's ⚠️ lines to ✅.
         assert state["fleet_message_ts"] == "111.222"
+        # Completion needs this pointer to rewrite the channel prompt to its done note.
+        assert state["channel_prompt_ts"] == "111.222"
         assert client.chat_postMessage.call_count == 2
         reveal_blocks, prompt_blocks = (call.kwargs["blocks"] for call in client.chat_postMessage.call_args_list)
         assert persona_onboarding.SCOUTS_DOC_URL in str(reveal_blocks)
@@ -515,6 +517,25 @@ class TestChannelStep(_FlowTestBase):
 
     @patch(PROVISION)
     @patch(WEBCLIENT)
+    def test_completion_rewrites_channel_prompt_to_done_note(self, mock_webclient, mock_provision):
+        # Without the rewrite, the picker stays live after onboarding completes and a stray
+        # click re-runs channel setup against a finished flow.
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+        row.onboarding_state["channel_prompt_ts"] = "55.66"
+        row.save(update_fields=["onboarding_state"])
+
+        self._select_channel()
+
+        prompt_updates = [call for call in client.chat_update.call_args_list if call.kwargs.get("ts") == "55.66"]
+        assert len(prompt_updates) == 1
+        assert prompt_updates[0].kwargs["channel"] == DM_CHANNEL
+        assert "Channel set" in prompt_updates[0].kwargs["text"]
+        assert "#cs-alerts" in prompt_updates[0].kwargs["text"]
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
     def test_channel_prompt_and_invite_offer_a_skip(self, mock_webclient, mock_provision):
         assert any(
             element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
@@ -560,6 +581,7 @@ class TestChannelStep(_FlowTestBase):
         row.refresh_from_db()
         assert row.onboarded_at is None
         assert row.onboarding_state["pending_channel_id"] == PICKED_CHANNEL
+        assert row.onboarding_state["invite_message_ts"] == "1.3"
         assert "/invite" in self._posted_text(client)
 
         client.chat_postMessage.side_effect = None
@@ -571,6 +593,10 @@ class TestChannelStep(_FlowTestBase):
         row.refresh_from_db()
         assert row.onboarded_at is not None
         assert row.onboarding_state is None
+        # The stale invite-then-verify ask flips to the done note so Verify can't double-fire.
+        invite_updates = [call for call in client.chat_update.call_args_list if call.kwargs.get("ts") == "1.3"]
+        assert len(invite_updates) == 1
+        assert "Channel set" in invite_updates[0].kwargs["text"]
 
     @patch(PROVISION, side_effect=RuntimeError("enabled cap reached"))
     @patch(WEBCLIENT)

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -287,7 +287,13 @@ class TestPersonaSelection(_FlowTestBase):
         assert row.onboarded_at is None
         state = row.onboarding_state
         assert state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
-        assert set(state["readiness"]) == {"account_pulse", "support_watch", "revenue_watch", "accounts_count"}
+        assert set(state["readiness"]) == {
+            "account_pulse",
+            "support_watch",
+            "revenue_watch",
+            "accounts_count",
+            "ready_details",
+        }
         assert state["detected_tools"] == []
         # The post-OAuth return leg needs this pointer to flip the reveal's ⚠️ lines to ✅.
         assert state["fleet_message_ts"] == "111.222"
@@ -384,8 +390,18 @@ class TestChannelStep(_FlowTestBase):
         ]
 
     def _select_channel(self) -> None:
-        action = {"action_id": persona_onboarding.CHANNEL_SELECT_ACTION_ID, "selected_conversation": PICKED_CHANNEL}
-        persona_onboarding.handle_block_action(self._payload(action), action)
+        # Selection is committed by the Add PostHog button; the picked channel rides along in
+        # the message's input state, like Slack sends it.
+        action = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+        payload = self._payload(action)
+        payload["state"] = {
+            "values": {
+                persona_onboarding.CHANNEL_SELECT_BLOCK_ID: {
+                    persona_onboarding.CHANNEL_SELECT_ACTION_ID: {"selected_conversation": PICKED_CHANNEL}
+                }
+            }
+        }
+        persona_onboarding.handle_block_action(payload, action)
 
     @patch(PROVISION)
     @patch(WEBCLIENT)
@@ -427,6 +443,78 @@ class TestChannelStep(_FlowTestBase):
 
     @patch(PROVISION)
     @patch(WEBCLIENT)
+    def test_selecting_a_channel_alone_does_nothing(self, mock_webclient, mock_provision):
+        # The dropdown fires a block action on every selection — acting on it directly is how
+        # a mis-click used to add the bot to the wrong channel.
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+        action = {"action_id": persona_onboarding.CHANNEL_SELECT_ACTION_ID, "selected_conversation": PICKED_CHANNEL}
+
+        response = persona_onboarding.handle_block_action(self._payload(action), action)
+
+        assert response.status_code == 200
+        mock_provision.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_confirm_without_selection_asks_for_a_channel(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        self._seed_channel_state()
+        action = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        mock_provision.assert_not_called()
+        assert persona_onboarding.PICK_CHANNEL_FIRST_TEXT in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_confirm_joins_public_channel_before_asking_for_invite(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+        joined = False
+
+        def reject_until_joined(channel=None, **kwargs):
+            if channel == PICKED_CHANNEL and not joined:
+                raise SlackApiError("not_in_channel", {"error": "not_in_channel"})
+            return {"ok": True, "ts": "1.3"}
+
+        def join(channel=None, **kwargs):
+            nonlocal joined
+            joined = True
+            return {"ok": True}
+
+        client.chat_postMessage.side_effect = reject_until_joined
+        client.conversations_join.side_effect = join
+
+        self._select_channel()
+
+        client.conversations_join.assert_called_once_with(channel=PICKED_CHANNEL)
+        mock_provision.assert_called_once()
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+
+    def test_channel_prompt_keeps_confirm_next_to_selector(self):
+        blocks = persona_onboarding.build_channel_prompt_blocks(True)
+        select_row = next(
+            block for block in blocks if block.get("block_id") == persona_onboarding.CHANNEL_SELECT_BLOCK_ID
+        )
+        assert [element.get("action_id") for element in select_row["elements"]] == [
+            persona_onboarding.CHANNEL_SELECT_ACTION_ID,
+            persona_onboarding.CHANNEL_CONFIRM_ACTION_ID,
+        ]
+        other_rows = [block for block in blocks if block.get("type") == "actions" and block is not select_row]
+        assert [element.get("action_id") for row in other_rows for element in row["elements"]] == [
+            persona_onboarding.CHANNEL_CREATE_ACTION_ID,
+            persona_onboarding.SKIP_ACTION_ID,
+        ]
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
     def test_channel_prompt_and_invite_offer_a_skip(self, mock_webclient, mock_provision):
         assert any(
             element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
@@ -464,6 +552,8 @@ class TestChannelStep(_FlowTestBase):
             return {"ok": True, "ts": "1.3"}
 
         client.chat_postMessage.side_effect = reject_picked_channel
+        # Joining isn't possible either (e.g. missing channels:join) — only /invite can recover.
+        client.conversations_join.side_effect = SlackApiError("missing_scope", {"error": "missing_scope"})
         self._select_channel()
 
         mock_provision.assert_not_called()
@@ -614,6 +704,18 @@ class TestFleetRevealConnectButtons:
         intercom = buttons["Connect Intercom"]
         assert "/settings/mcp-servers?mcp=tmpl-intercom" in intercom["url"]
 
+    def test_ready_scouts_name_their_default_data_source(self):
+        # Users shouldn't feel obligated to connect a tool when PostHog already has the data —
+        # ready scouts say what they'll use, and gapped ones say connecting is optional.
+        readiness = {
+            "revenue_watch": True,
+            "ready_details": {"revenue_watch": "your Stripe data synced into PostHog"},
+        }
+        blocks = persona_onboarding.build_fleet_reveal_blocks(1, readiness, [], [], WORKSPACE, SLACK_USER)
+        text = str(blocks)
+        assert "I'll use your Stripe data synced into PostHog." in text
+        assert "Connecting a tool below is optional" in text
+
     def test_without_matching_templates_offers_store_browse(self):
         blocks = persona_onboarding.build_fleet_reveal_blocks(1, {}, [], [], WORKSPACE, SLACK_USER)
         buttons = [
@@ -640,6 +742,8 @@ class TestCsmReadinessWithMcpInstallations(_FlowTestBase):
         with patch.object(persona_onboarding, "get_active_installations", return_value=[installation]):
             readiness = persona_onboarding.check_csm_data_readiness(self.team.id, self.user.id)
         assert getattr(readiness, readiness_key) is True
+        # The reveal names the data source so users know what powers the scout by default.
+        assert server_name in readiness.ready_details[readiness_key]
         others = {"account_pulse", "support_watch", "revenue_watch"} - {readiness_key}
         assert not any(getattr(readiness, key) for key in others)
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "account_name": {
+            "description": "Display name of the account the finding is about (headline of the alert).",
+            "maxLength": 300,
+            "type": "string"
+        },
+        "owner_email": {
+            "anyOf": [
+                {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "The account owner's email as resolved from the data (`system.accounts` roles or CRM owner join). The server resolves it to a Slack mention via `users.lookupByEmail`; on a miss the alert falls back to plain text. Omit when no owner was resolvable."
+        },
+        "owner_label": {
+            "anyOf": [
+                {
+                    "maxLength": 200,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable owner fallback (e.g. `Jane Doe (Salesforce)` or `HubSpot owner 1234`) used when `owner_email` is absent or doesn't resolve to a Slack user."
+        },
+        "report_id": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "UUID of the inbox `SignalReport` this run emitted or edited for the same finding. Must be one of this run's report ids; the alert links to it. Always file the report first, then notify."
+        },
+        "run_id": {
+            "description": "UUID of the `SignalScoutRun` bridge row.",
+            "type": "string"
+        },
+        "severity": {
+            "anyOf": [
+                {
+                    "description": "* `high` - high\n* `medium` - medium\n* `low` - low",
+                    "enum": ["high", "medium", "low"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Severity steer for the alert's visual treatment. Omit for a neutral alert.\n\n* `low` - low\n* `medium` - medium\n* `high` - high"
+        },
+        "text": {
+            "description": "The finding summary, in Slack mrkdwn, written for the account owner: what changed, the magnitude and window, and the one thing to check. 2–4 sentences. Do NOT include an owner mention — the server prepends it.",
+            "maxLength": 2500,
+            "type": "string"
+        }
+    },
+    "required": ["run_id", "text", "account_name"],
+    "type": "object"
+}


### PR DESCRIPTION
> Part 5 of the CSM persona onboarding stack (8 PRs), based on #69082.

## Problem

Dogfooding the channel step surfaced friction: the picker committed on selection (easy to fat-finger), the reveal didn't say that PostHog's own data is already in reach, and provisioning could trip the fail-closed scout manager outside request context.

## Changes

- Channel choice is now explicit: pick from the dropdown, then tap Add PostHog to commit. The bot joins public channels itself when it holds `channels:join`.
- Fleet reveal surfaces posthog-default data per scout, so an empty-CRM team still sees what the scouts can watch today.
- Persona scout configs are created via `for_team` so provisioning works outside request context (Temporal-fired first runs).
- Channel-setup prompts are rewritten to a done note once the channel is configured, so stale pickers and Verify buttons don't linger.

## How did you test this code?

`hogli test products/slack_app/backend/tests/test_persona_onboarding_flow.py products/signals/backend/test/test_persona_scout_provisioning.py` (59 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Covered by part 6 of this stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code while dogfooding the flow in a local workspace. A later session split the feature branch into this stack, this PR is an unmodified slice of the original commits.
