### PR TITLE
feat(slack): onboarding funnel analytics and quieter first patrol

### DIFF
--- a/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
+++ b/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
@@ -38,7 +38,8 @@ class PostHogSlackFirstPatrolWorkflow(PostHogWorkflow):
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
         if digest is None:
-            # No completed runs yet (queue lag, quota skip) — one more chance, then silence.
+            # Nothing to DM yet — no completed runs (queue lag, quota skip) or a clean patrol
+            # so far. One more chance for a late finding, then silence.
             await workflow.sleep(timedelta(seconds=FIRST_PATROL_RETRY_DELAY_SECONDS))
             digest = await workflow.execute_activity(
                 collect_first_patrol_digest_activity,

--- a/posthog/temporal/tests/ai/test_first_patrol_workflow.py
+++ b/posthog/temporal/tests/ai/test_first_patrol_workflow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from posthog.temporal.ai.slack_app import posthog_slack_first_patrol as wf_module
 from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
 
-DIGEST = {"text": "t", "variant": "all_clear", "runs_completed": 1}
+DIGEST = {"text": "t", "variant": "finding", "runs_completed": 1}
 
 
 def _inputs() -> PostHogSlackFirstPatrolInputs:
@@ -58,7 +58,7 @@ async def test_empty_first_check_retries_once_then_posts():
 
 
 @pytest.mark.asyncio
-async def test_no_completed_runs_after_retry_exits_silently():
+async def test_nothing_to_report_after_retry_exits_silently():
     calls, sleep_mock = await _run_with([None, None])
     assert calls == ["collect_first_patrol_digest_activity", "collect_first_patrol_digest_activity"]
     assert sleep_mock.await_count == 2

--- a/products/slack_app/backend/analytics.py
+++ b/products/slack_app/backend/analytics.py
@@ -29,16 +29,32 @@ def slack_event_props(integration: Integration, *, slack_user_id: str | None = N
     return props
 
 
+def slack_user_distinct_id(workspace_id: str, slack_user_id: str) -> str:
+    """Stable per-Slack-user distinct_id for events that must chain into per-user funnels.
+    Deliberately synthetic (not the linked PostHog user's distinct_id): it is computable at
+    every capture site — interactivity handlers, home opens before user resolution, Temporal
+    activities — so every step of a flow lands on the same person."""
+    return f"slack:{workspace_id}:{slack_user_id}"
+
+
 def capture_slack_event(
-    integration: Integration, event: str, *, slack_user_id: str | None = None, **props: object
+    integration: Integration,
+    event: str,
+    *,
+    slack_user_id: str | None = None,
+    distinct_id: str | None = None,
+    **props: object,
 ) -> None:
-    """Capture a Slack app event, keyed on the team (``distinct_id`` = team uuid) with org/team groups.
-    Best-effort: analytics never breaks the flow."""
+    """Capture a Slack app event with org/team groups. Best-effort: analytics never breaks the flow.
+
+    ``distinct_id`` defaults to the team uuid, which collapses every user in a workspace into one
+    person — fine for volume counts, useless for funnels. Flows that need per-user conversion
+    tracking must pass ``slack_user_distinct_id(...)``."""
     try:
         team = integration.team
         with ph_scoped_capture() as capture:
             capture(
-                distinct_id=str(team.uuid),
+                distinct_id=distinct_id or str(team.uuid),
                 event=event,
                 properties=slack_event_props(integration, slack_user_id=slack_user_id, **props),
                 groups=groups(team.organization, team),

--- a/products/slack_app/backend/first_patrol.py
+++ b/products/slack_app/backend/first_patrol.py
@@ -16,7 +16,7 @@ import structlog
 
 from posthog.models.integration import Integration, SlackIntegration
 
-from products.slack_app.backend.analytics import capture_slack_event
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
 from products.slack_app.backend.persona_onboarding import PERSONA_CSM, PERSONA_SCOUT_CATALOG, inbox_url
 
 logger = structlog.get_logger(__name__)
@@ -141,6 +141,9 @@ def post_first_patrol_digest(
         integration,
         EVENT_DIGEST_SENT,
         slack_user_id=slack_user_id,
+        # Same per-user person as the onboarding funnel, so the digest chains as its final step.
+        distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
         variant=digest.get("variant"),
         runs_completed=digest.get("runs_completed"),
+        persona=PERSONA_CSM,
     )

--- a/products/slack_app/backend/first_patrol.py
+++ b/products/slack_app/backend/first_patrol.py
@@ -1,7 +1,7 @@
 """First-patrol digest: after CSM onboarding provisions the scout fleet and fires immediate
-first runs, a delayed Temporal workflow checks the outcomes and DMs the user a digest — the
-finding, or an explicit all-clear — so the first scout touch lands within the first hour
-even when the data is healthy.
+first runs, a delayed Temporal workflow checks the outcomes and DMs the user a digest — but
+only when a scout actually found something. A clean patrol stays silent: run-state DMs are
+noise, and findings already land in the delivery channel.
 
 The Temporal workflow/activities live in ``posthog/temporal/ai/slack_app/``; this module
 holds the plain functions they delegate to (dispatch, collection, copy, delivery) so the
@@ -81,20 +81,12 @@ def _first_sentence(summary: str, limit: int = 140) -> str:
     return sentence + "."
 
 
-def _clause(summary: str, max_words: int = 12) -> str:
-    words = " ".join((summary or "").split()).rstrip(".").split()
-    if not words:
-        return "checked in clean"
-    if len(words) <= max_words:
-        return " ".join(words)
-    return " ".join(words[:max_words]) + "…"
-
-
 def collect_first_patrol_digest(
     *, team_id: int, channel_name: str, scout_config_ids: list[str], provisioned_at_iso: str
 ) -> dict | None:
-    """Compose the digest from the first runs' outcomes. ``None`` when no run has completed
-    yet — the workflow retries once, then gives up silently (never nag)."""
+    """Compose the digest from the first runs' outcomes. ``None`` when there is nothing worth
+    a DM — no run has completed yet, or every completed run came back clean. The workflow
+    retries once (a still-running scout may yet report a finding), then gives up silently."""
     from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off the slack import path
         collect_scout_run_digests,
     )
@@ -105,26 +97,19 @@ def collect_first_patrol_digest(
     if digests is None:
         return None
     found = [digest for digest in digests if digest.notifications_sent or digest.reports_filed]
-    if found:
-        first = found[0]
-        title = _TITLE_BY_SKILL.get(first.skill_name, first.skill_name)
-        headline = _first_sentence(first.summary) or "it flagged an account that needs attention."
-        text = (
-            f"Your scouts just finished their first patrol — *{title}* found something: {headline} "
-            f"Full details in #{channel_name} and your <{inbox_url(team_id)}|PostHog inbox>."
-        )
-        if len(found) > 1:
-            extra = len(found) - 1
-            text += f" ({extra} more scout{'s' if extra > 1 else ''} reported findings too.)"
-        return {"text": text, "variant": "finding", "runs_completed": len(digests)}
-    clauses = "; ".join(
-        f"{_TITLE_BY_SKILL.get(digest.skill_name, digest.skill_name)}: {_clause(digest.summary)}" for digest in digests
-    )
+    if not found:
+        return None
+    first = found[0]
+    title = _TITLE_BY_SKILL.get(first.skill_name, first.skill_name)
+    headline = _first_sentence(first.summary) or "it flagged an account that needs attention."
     text = (
-        f"First patrol done ✅ — {clauses}. Nothing to worry about right now. "
-        f"I'll keep watching daily and ping #{channel_name} the moment that changes."
+        f"Your scouts just finished their first patrol — *{title}* found something: {headline} "
+        f"Full details in #{channel_name} and your <{inbox_url(team_id)}|PostHog inbox>."
     )
-    return {"text": text, "variant": "all_clear", "runs_completed": len(digests)}
+    if len(found) > 1:
+        extra = len(found) - 1
+        text += f" ({extra} more scout{'s' if extra > 1 else ''} reported findings too.)"
+    return {"text": text, "variant": "finding", "runs_completed": len(digests)}
 
 
 def post_first_patrol_digest(

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -34,7 +34,7 @@ from products.mcp_store.backend.facade.contracts import TemplateInfo
 if TYPE_CHECKING:
     from slack_sdk.web import SlackResponse
 
-from products.slack_app.backend.analytics import capture_slack_event
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
 from products.slack_app.backend.feature_flags import is_persona_onboarding_enabled
 from products.slack_app.backend.inbox_channel import (
     INBOX_CHANNEL_REQUIRED_SCOPES,
@@ -71,16 +71,24 @@ SCOUTS_DOC_URL = "https://posthog.com/docs/self-driving/scouts"
 # Single-flight window for the kickoff post (see `start_onboarding_dm`).
 _START_CLAIM_TTL_SECONDS = 60
 
+# Funnel: home_card_shown → started → persona_selected → fleet_shown → channel_configured →
+# completed (skipped/grandfathered are exits; invite_needed, nudged, and error mark friction
+# between steps). Every event shares a per-user distinct_id and carries persona context so
+# conversion can be broken down by persona at any step.
+EVENT_HOME_CARD_SHOWN = "slack_persona_onboarding_home_card_shown"
 EVENT_STARTED = "slack_persona_onboarding_started"
 EVENT_PERSONA_SELECTED = "slack_persona_onboarding_persona_selected"
 EVENT_FLEET_SHOWN = "slack_persona_onboarding_fleet_shown"
 EVENT_CONNECT_CLICKED = "slack_persona_onboarding_connect_clicked"
 EVENT_MCP_CONNECTED = "slack_persona_onboarding_mcp_connected"
 EVENT_GITHUB_CONNECTED = "slack_persona_onboarding_github_connected"
+EVENT_CHANNEL_INVITE_NEEDED = "slack_persona_onboarding_channel_invite_needed"
 EVENT_CHANNEL_CONFIGURED = "slack_persona_onboarding_channel_configured"
 EVENT_COMPLETED = "slack_persona_onboarding_completed"
 EVENT_SKIPPED = "slack_persona_onboarding_skipped"
 EVENT_GRANDFATHERED = "slack_persona_onboarding_grandfathered"
+EVENT_NUDGED = "slack_persona_onboarding_nudged"
+EVENT_ERROR = "slack_persona_onboarding_error"
 
 # Signed state carried by Connect buttons through the MCP OAuth round-trip; long-lived because
 # the fleet-reveal message can sit unread in a DM for a while before anyone clicks it.
@@ -471,11 +479,17 @@ def has_prior_slack_activity(integration_ids: list[int], slack_user_id: str) -> 
     ).exists()
 
 
-def _grandfather(integration: Integration, row: SlackSettings, slack_user_id: str) -> None:
+def _grandfather(integration: Integration, row: SlackSettings, slack_user_id: str, posthog_user_id: int) -> None:
     row.onboarded_at = timezone.now()
     row.onboarding_state = None
     row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
-    capture_slack_event(integration, EVENT_GRANDFATHERED, slack_user_id=slack_user_id)
+    capture_slack_event(
+        integration,
+        EVENT_GRANDFATHERED,
+        slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
+        posthog_user_id=posthog_user_id,
+    )
 
 
 def compute_home_onboarding_status(integration: Integration, workspace_id: str, slack_user_id: str) -> str:
@@ -811,6 +825,22 @@ def _load_context(payload: dict) -> _FlowContext | None:
     return ctx
 
 
+def _capture_flow_event(ctx: _FlowContext, event: str, **props: object) -> None:
+    """Capture a funnel event for an in-flight onboarding: per-user distinct_id (steps must
+    chain on one person) plus persona context on every step for breakdowns. Explicit props win
+    over the defaults."""
+    props.setdefault("persona", ctx.row.persona)
+    props.setdefault("persona_candidate", ctx.state.get("persona_candidate"))
+    props.setdefault("posthog_user_id", ctx.state.get("posthog_user_id"))
+    capture_slack_event(
+        ctx.integration,
+        event,
+        slack_user_id=ctx.slack_user_id,
+        distinct_id=slack_user_distinct_id(ctx.workspace_id, ctx.slack_user_id),
+        **props,
+    )
+
+
 def _retarget_to_click(ctx: _FlowContext, payload: dict) -> None:
     """Point follow-up posts at the thread hosting the clicked button. In the assistant surface
     every top-level DM message roots its own conversation, so replying anywhere else opens a
@@ -973,10 +1003,12 @@ def _post_kickoff(
         integration,
         EVENT_STARTED,
         slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
         entry_point=entry_point,
         persona_candidate=candidate,
         detection_source=source or "none",
         search_available=slack_search.search_available(slack, workspace_id, slack_user_id),
+        posthog_user_id=posthog_user_id,
     )
 
 
@@ -1000,7 +1032,7 @@ def maybe_intercept_assistant_surface(
         return False
     if has_prior_slack_activity(accessible_integration_ids, slack_user_id):
         # An established user predating this flow — never ambush them with onboarding.
-        _grandfather(integration, row, slack_user_id)
+        _grandfather(integration, row, slack_user_id, posthog_user_id)
         return False
     # The consume/pass-through decision must be made inline, but everything past it talks to
     # Slack (detection searches, posts) — run it off the event-request thread so the events API
@@ -1118,6 +1150,7 @@ def _run_action(handler: Callable[[], None], payload: dict, action_id: str) -> N
         logger.exception("persona_onboarding_action_failed", action_id=action_id)
         ctx = _load_context(payload)
         if ctx is not None:
+            _capture_flow_event(ctx, EVENT_ERROR, stage=action_id)
             try:
                 _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
             except Exception:
@@ -1129,6 +1162,8 @@ def _post_nudge(ctx: _FlowContext) -> None:
     text = NUDGE_CHANNEL_TEXT if step == STEP_AWAITING_CHANNEL else NUDGE_PERSONA_TEXT
     _post(ctx, [_section(text)], text)
     _repost_current_step(ctx)
+    # Friction signal: the user tried to talk to the bot instead of finishing the step.
+    _capture_flow_event(ctx, EVENT_NUDGED, step=step)
 
 
 def _repost_current_step(ctx: _FlowContext) -> None:
@@ -1166,16 +1201,31 @@ def _can_create_channel(slack: SlackIntegration) -> bool:
 
 def _handle_connect_click(payload: dict, action: dict) -> None:
     # URL button — the browser already navigated; just ack + record the click.
+    scout_key, _, server_name = str(action.get("value") or "").rpartition(":")
     ctx = _load_context(payload)
     if ctx is not None:
-        scout_key, _, server_name = str(action.get("value") or "").rpartition(":")
-        capture_slack_event(
-            ctx.integration,
-            EVENT_CONNECT_CLICKED,
-            slack_user_id=ctx.slack_user_id,
-            server_name=server_name,
-            scout_readiness_key=scout_key or None,
-        )
+        _capture_flow_event(ctx, EVENT_CONNECT_CLICKED, server_name=server_name, scout_readiness_key=scout_key or None)
+        return
+    # Connect buttons outlive the flow (the engineer completion's GitHub button, a finished
+    # CSM's fleet-reveal buttons), so clicks after state is cleared still need recording.
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if not workspace_id or not slack_user_id:
+        return
+    result = load_integrations(slack_team_id=workspace_id, kinds=["slack"], slack_user_id=slack_user_id)
+    integration = result.integration or (result.candidates[0] if result.candidates else None)
+    if integration is None:
+        return
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    capture_slack_event(
+        integration,
+        EVENT_CONNECT_CLICKED,
+        slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
+        server_name=server_name,
+        scout_readiness_key=scout_key or None,
+        persona=row.persona if row is not None else None,
+    )
 
 
 def handle_mcp_connect_return(
@@ -1201,10 +1251,13 @@ def handle_mcp_connect_return(
             integration,
             EVENT_MCP_CONNECTED,
             slack_user_id=slack_user_id,
+            distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
             server_name=template_name,
             scout_readiness_key=readiness_key,
             success=success,
             error=error or None,
+            persona=row.persona if row is not None else None,
+            posthog_user_id=state.get("posthog_user_id") if state else None,
         )
         if row is not None and state is not None and success:
             _refresh_fleet_reveal(integration, row, state, workspace_id, slack_user_id)
@@ -1313,6 +1366,7 @@ def _post_github_connected_followup(integration: Integration, row: SlackSettings
         integration,
         EVENT_GITHUB_CONNECTED,
         slack_user_id=row.slack_user_id,
+        distinct_id=slack_user_distinct_id(row.slack_workspace_id, row.slack_user_id or ""),
         persona=row.persona,
         posthog_user_id=followup.get("posthog_user_id"),
     )
@@ -1335,12 +1389,10 @@ def _handle_persona_select(payload: dict, action: dict) -> None:
     if persona == PERSONA_CSM:
         note += " — one sec while I look at what data you have…"
     _freeze_buttons(ctx, payload, note)
-    capture_slack_event(
-        ctx.integration,
+    _capture_flow_event(
+        ctx,
         EVENT_PERSONA_SELECTED,
-        slack_user_id=ctx.slack_user_id,
         persona=persona,
-        persona_candidate=ctx.state.get("persona_candidate"),
         matched_detection=persona == ctx.state.get("persona_candidate"),
     )
 
@@ -1364,14 +1416,7 @@ def _handle_persona_select(payload: dict, action: dict) -> None:
         posted = _post(ctx, blocks, text)
         if not github_connected:
             _remember_github_followup(ctx, posted)
-        capture_slack_event(
-            ctx.integration,
-            EVENT_COMPLETED,
-            slack_user_id=ctx.slack_user_id,
-            persona=persona,
-            scouts_provisioned=0,
-            **completion_props,
-        )
+        _capture_flow_event(ctx, EVENT_COMPLETED, persona=persona, scouts_provisioned=0, **completion_props)
         _republish_home(ctx.integration, ctx.slack_user_id)
         return
 
@@ -1401,13 +1446,7 @@ def _handle_persona_select(payload: dict, action: dict) -> None:
         ctx.state["fleet_message_ts"] = posted.get("ts")
         _save_state(ctx.row, ctx.state)
     _post_channel_prompt(ctx)
-    capture_slack_event(
-        ctx.integration,
-        EVENT_FLEET_SHOWN,
-        slack_user_id=ctx.slack_user_id,
-        detected_tools=detected_tools,
-        **readiness.as_dict(),
-    )
+    _capture_flow_event(ctx, EVENT_FLEET_SHOWN, detected_tools=detected_tools, **readiness.as_dict())
 
 
 def _handle_skip(payload: dict) -> None:
@@ -1420,7 +1459,7 @@ def _handle_skip(payload: dict) -> None:
     ctx.row.onboarding_state = None
     ctx.row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
     _post(ctx, [_section(SKIP_TEXT)], SKIP_TEXT)
-    capture_slack_event(ctx.integration, EVENT_SKIPPED, slack_user_id=ctx.slack_user_id, step=step)
+    _capture_flow_event(ctx, EVENT_SKIPPED, step=step)
     _republish_home(ctx.integration, ctx.slack_user_id)
 
 
@@ -1547,14 +1586,11 @@ def _attempt_channel_setup(
             # different channel stays possible alongside the /invite path.
             _post_channel_prompt(ctx)
         _post_invite_needed(ctx, channel_id, channel_name)
+        # Drop-off marker: users parked at /invite-then-Verify with no channel_configured after
+        # this are the ones who wedged here.
+        _capture_flow_event(ctx, EVENT_CHANNEL_INVITE_NEEDED, method=method, error=error, retry=invite_required)
         return
-    capture_slack_event(
-        ctx.integration,
-        EVENT_CHANNEL_CONFIGURED,
-        slack_user_id=ctx.slack_user_id,
-        method=method,
-        invite_required=invite_required,
-    )
+    _capture_flow_event(ctx, EVENT_CHANNEL_CONFIGURED, method=method, invite_required=invite_required)
     _provision_and_complete(ctx, channel_id, channel_name)
 
 
@@ -1585,6 +1621,7 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
     user = User.objects.filter(id=ctx.state.get("posthog_user_id")).first()
     if user is None:
         _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        _capture_flow_event(ctx, EVENT_ERROR, stage="provisioning_user_missing")
         return
     try:
         results = provision_persona_scouts(
@@ -1598,6 +1635,8 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
     except Exception:
         logger.exception("persona_onboarding_provisioning_failed", team_id=ctx.integration.team_id)
         _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        # Funnel leak between channel_configured and completed — the user stays un-onboarded.
+        _capture_flow_event(ctx, EVENT_ERROR, stage="provisioning")
         return
 
     readiness = ctx.state.get("readiness") or {}
@@ -1617,10 +1656,9 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
         ),
         "You're locked in — your scouts are on their first patrol.",
     )
-    capture_slack_event(
-        ctx.integration,
+    _capture_flow_event(
+        ctx,
         EVENT_COMPLETED,
-        slack_user_id=ctx.slack_user_id,
         persona=PERSONA_CSM,
         scouts_provisioned=len([result for result in results if result.config_id]),
         first_runs_fired=len([result for result in results if result.first_run_started]),

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -31,6 +31,7 @@ from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
 from products.slack_app.backend import persona_onboarding
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.slack_app.backend.services.slack_auth import check_integrations_auth_and_filter
@@ -1089,13 +1090,18 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     if not is_slack_app_home_enabled(integration):
         return
 
-    republish_home_for_user(integration, slack_user_id)
+    republish_home_for_user(integration, slack_user_id, track_impression=True)
 
 
-def _publish_onboarding_home_if_needed(integration: Integration, slack_user_id: str) -> bool:
+def _publish_onboarding_home_if_needed(
+    integration: Integration, slack_user_id: str, *, track_impression: bool = False
+) -> bool:
     """Publish the onboarding-only home when the user hasn't onboarded yet (flag-gated inside
     the status computation). Returns True when it published — the caller must then skip the
-    settings view, which also skips its several Slack/DB round-trips of state resolution."""
+    settings view, which also skips its several Slack/DB round-trips of state resolution.
+
+    ``track_impression`` is set only for user-initiated home opens: the card is the top of the
+    onboarding funnel, and programmatic republishes (after each flow step) aren't impressions."""
     onboarding_status = persona_onboarding.compute_home_onboarding_status(
         integration, integration.integration_id, slack_user_id
     )
@@ -1107,6 +1113,14 @@ def _publish_onboarding_home_if_needed(integration: Integration, slack_user_id: 
         else None
     )
     _publish_home_view(integration, slack_user_id, render_onboarding_home_view(onboarding_status, dm_link))
+    if track_impression:
+        capture_slack_event(
+            integration,
+            persona_onboarding.EVENT_HOME_CARD_SHOWN,
+            slack_user_id=slack_user_id,
+            distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
+            status=onboarding_status,
+        )
     return True
 
 
@@ -1127,10 +1141,11 @@ def _publish_home_view(integration: Integration, slack_user_id: str, view: dict)
         )
 
 
-def republish_home_for_user(integration: Integration, slack_user_id: str) -> None:
+def republish_home_for_user(integration: Integration, slack_user_id: str, *, track_impression: bool = False) -> None:
     """Recompute and publish the Home tab for one user — the shared publish path for
-    `app_home_opened` and for flows (persona onboarding) that change what home shows."""
-    if _publish_onboarding_home_if_needed(integration, slack_user_id):
+    `app_home_opened` (which tracks the onboarding-card impression) and for flows
+    (persona onboarding) that change what home shows."""
+    if _publish_onboarding_home_if_needed(integration, slack_user_id, track_impression=track_impression):
         return
     effective = resolve_ai_preferences(integration, slack_user_id)
     user_row, workspace_row = _load_rows(integration, slack_user_id)

--- a/products/slack_app/backend/tests/test_first_patrol.py
+++ b/products/slack_app/backend/tests/test_first_patrol.py
@@ -1,11 +1,21 @@
+import pytest
 from unittest.mock import patch
 
 from parameterized import parameterized
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
 
 from products.signals.backend.facade.api import ScoutRunDigest
 from products.slack_app.backend import first_patrol
 
 COLLECT_PATH = "products.signals.backend.facade.api.collect_scout_run_digests"
+CAPTURE_PATH = "products.slack_app.backend.first_patrol.capture_slack_event"
+WEBCLIENT = "posthog.models.integration.WebClient"
+WORKSPACE = "T1"
+SLACK_USER = "U1"
+DM_CHANNEL = "D1"
 
 
 def _collect(digests):
@@ -98,3 +108,58 @@ class TestFirstPatrolDigestComposition:
         )
         assert digest["variant"] == "finding"
         assert "1 more scout reported findings too" in digest["text"]
+
+
+class TestPostFirstPatrolDigest:
+    # The digest DM is the onboarding funnel's final step. Nothing else asserts the emitted
+    # identity — the composition tests stop at collect, and the workflow test mocks this post —
+    # so an arg-swap or a fallback to capture_slack_event's team-uuid default would silently
+    # detach the digest from per-user funnel chaining.
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.organization = Organization.objects.create(name="Org")
+        self.team = Team.objects.create(organization=self.organization, name="Team")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=WORKSPACE,
+            config={"scope": "chat:write"},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    @patch(CAPTURE_PATH)
+    @patch(WEBCLIENT)
+    def test_dm_posts_and_pins_event_to_the_per_user_person(self, mock_webclient, mock_capture):
+        digest = {"text": "Your scouts found something.", "variant": "finding", "runs_completed": 2}
+
+        first_patrol.post_first_patrol_digest(
+            integration_id=self.integration.id,
+            slack_user_id=SLACK_USER,
+            dm_channel_id=DM_CHANNEL,
+            thread_ts="111.222",
+            digest=digest,
+        )
+
+        mock_webclient.return_value.chat_postMessage.assert_called_once_with(
+            channel=DM_CHANNEL, thread_ts="111.222", text=digest["text"]
+        )
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[1] == first_patrol.EVENT_DIGEST_SENT
+        assert mock_capture.call_args.kwargs["distinct_id"] == first_patrol.slack_user_distinct_id(
+            self.integration.integration_id, SLACK_USER
+        )
+        assert mock_capture.call_args.kwargs["persona"] == first_patrol.PERSONA_CSM
+
+    @patch(CAPTURE_PATH)
+    @patch(WEBCLIENT)
+    def test_missing_integration_is_a_silent_no_op(self, mock_webclient, mock_capture):
+        first_patrol.post_first_patrol_digest(
+            integration_id=self.integration.id + 999,
+            slack_user_id=SLACK_USER,
+            dm_channel_id=DM_CHANNEL,
+            thread_ts=None,
+            digest={"text": "unused", "variant": "finding", "runs_completed": 1},
+        )
+
+        mock_webclient.assert_not_called()
+        mock_capture.assert_not_called()

--- a/products/slack_app/backend/tests/test_first_patrol.py
+++ b/products/slack_app/backend/tests/test_first_patrol.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from products.signals.backend.facade.api import ScoutRunDigest
 from products.slack_app.backend import first_patrol
 
@@ -14,8 +16,30 @@ def _collect(digests):
 
 
 class TestFirstPatrolDigestComposition:
-    def test_no_completed_runs_returns_none_for_retry(self):
-        assert _collect(None) is None
+    @parameterized.expand(
+        [
+            ("no_completed_runs", None),
+            (
+                "clean_patrol",
+                [
+                    ScoutRunDigest(
+                        skill_name="signals-scout-slack-csm-account-pulse",
+                        summary="Checked 214 accounts, all within baseline.",
+                        notifications_sent=0,
+                        reports_filed=0,
+                    ),
+                    ScoutRunDigest(
+                        skill_name="signals-scout-slack-csm-revenue-watch",
+                        summary="",
+                        notifications_sent=0,
+                        reports_filed=0,
+                    ),
+                ],
+            ),
+        ]
+    )
+    def test_returns_none_so_no_dm_is_sent(self, _name, digests):
+        assert _collect(digests) is None
 
     def test_finding_variant_leads_with_the_finding_and_links_channel(self):
         digest = _collect(
@@ -39,28 +63,6 @@ class TestFirstPatrolDigestComposition:
         assert "Initech's weekly active users dropped 60% vs baseline." in digest["text"]
         assert "#posthog-inbox" in digest["text"]
         assert digest["runs_completed"] == 2
-
-    def test_all_clear_variant_quotes_run_summaries_with_fallback(self):
-        digest = _collect(
-            [
-                ScoutRunDigest(
-                    skill_name="signals-scout-slack-csm-account-pulse",
-                    summary="Checked 214 accounts, all within baseline.",
-                    notifications_sent=0,
-                    reports_filed=0,
-                ),
-                ScoutRunDigest(
-                    skill_name="signals-scout-slack-csm-revenue-watch",
-                    summary="",
-                    notifications_sent=0,
-                    reports_filed=0,
-                ),
-            ]
-        )
-        assert digest["variant"] == "all_clear"
-        assert "Account pulse: Checked 214 accounts, all within baseline" in digest["text"]
-        assert "Renewal & billing watch: checked in clean" in digest["text"]
-        assert "Nothing to worry about right now" in digest["text"]
 
     def test_long_finding_headline_has_no_doubled_punctuation(self):
         long_summary = "The account " + "very " * 60 + "quietly slid this week."

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -995,3 +995,104 @@ class TestHomeStartFlow(_FlowTestBase):
         ):
             persona_onboarding._run_home_start(WORKSPACE, SLACK_USER)
         republish.assert_called_once()
+
+
+class TestFunnelAnalytics(_FlowTestBase):
+    # The funnel contract: every step of one user's onboarding must land on the same per-user
+    # distinct_id (else conversion collapses to team level and steps stop chaining) and carry
+    # persona for breakdowns. The other flow tests mute analytics, so nothing else guards the
+    # emitted stream.
+    DISTINCT_ID = f"slack:{WORKSPACE}:{SLACK_USER}"
+
+    @patch(PROVISION)
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_csm_flow_events_share_person_and_persona(self, mock_webclient, _flag, mock_provision):
+        self._client(mock_webclient)
+        mock_provision.return_value = [
+            ScoutProvisionResult(
+                skill_name=skill_name,
+                config_id=f"cfg-{index}",
+                created=True,
+                channel_conflict=None,
+                first_run_started=True,
+            )
+            for index, skill_name in enumerate(CSM_SKILL_NAMES)
+        ]
+        select = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": "csm"}
+        confirm = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+        confirm_payload = self._payload(confirm)
+        confirm_payload["state"] = {
+            "values": {
+                persona_onboarding.CHANNEL_SELECT_BLOCK_ID: {
+                    persona_onboarding.CHANNEL_SELECT_ACTION_ID: {"selected_conversation": PICKED_CHANNEL}
+                }
+            }
+        }
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.maybe_intercept_assistant_surface(
+                self.integration,
+                posthog_user_id=self.user.id,
+                workspace_id=WORKSPACE,
+                slack_user_id=SLACK_USER,
+                channel_id=DM_CHANNEL,
+                thread_ts=None,
+                accessible_integration_ids=[self.integration.id],
+                entry_point="first_dm",
+            )
+            persona_onboarding.handle_block_action(self._payload(select), select)
+            persona_onboarding.handle_block_action(confirm_payload, confirm)
+
+        assert [call.args[1] for call in capture.call_args_list] == [
+            persona_onboarding.EVENT_STARTED,
+            persona_onboarding.EVENT_PERSONA_SELECTED,
+            persona_onboarding.EVENT_FLEET_SHOWN,
+            persona_onboarding.EVENT_CHANNEL_CONFIGURED,
+            persona_onboarding.EVENT_COMPLETED,
+        ]
+        assert {call.kwargs["distinct_id"] for call in capture.call_args_list} == {self.DISTINCT_ID}
+        by_event = {call.args[1]: call.kwargs for call in capture.call_args_list}
+        assert by_event[persona_onboarding.EVENT_STARTED]["posthog_user_id"] == self.user.id
+        for event in (
+            persona_onboarding.EVENT_PERSONA_SELECTED,
+            persona_onboarding.EVENT_FLEET_SHOWN,
+            persona_onboarding.EVENT_CHANNEL_CONFIGURED,
+            persona_onboarding.EVENT_COMPLETED,
+        ):
+            assert by_event[event]["persona"] == persona_onboarding.PERSONA_CSM
+        assert by_event[persona_onboarding.EVENT_COMPLETED]["scouts_provisioned"] == len(CSM_SKILL_NAMES)
+
+    @patch(WEBCLIENT)
+    def test_connect_click_after_completion_still_tracked(self, mock_webclient):
+        # Connect buttons outlive the flow (the engineer completion's GitHub button); a click
+        # after onboarding_state is cleared must still record, with the persona off the row.
+        self._client(mock_webclient)
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        row.persona = persona_onboarding.PERSONA_ENGINEER
+        row.onboarded_at = timezone.now()
+        row.save(update_fields=["persona", "onboarded_at", "updated_at"])
+        action = {"action_id": f"{persona_onboarding.CONNECT_SOURCE_ACTION_ID}:github", "value": "github"}
+
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.handle_block_action(self._payload(action), action)
+
+        capture.assert_called_once()
+        assert capture.call_args.args[1] == persona_onboarding.EVENT_CONNECT_CLICKED
+        assert capture.call_args.kwargs["distinct_id"] == self.DISTINCT_ID
+        assert capture.call_args.kwargs["persona"] == persona_onboarding.PERSONA_ENGINEER
+        assert capture.call_args.kwargs["server_name"] == "github"
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_home_impression_fires_only_on_user_initiated_open(self, mock_webclient, _flag):
+        # Programmatic republishes (after every flow step) must not count as impressions, or
+        # the funnel's top inflates by a few events per onboarding.
+        self._client(mock_webclient)
+        with patch.object(slack_app_home, "capture_slack_event") as capture:
+            slack_app_home.republish_home_for_user(self.integration, SLACK_USER, track_impression=True)
+            assert capture.call_args.args[1] == persona_onboarding.EVENT_HOME_CARD_SHOWN
+            assert capture.call_args.kwargs["distinct_id"] == self.DISTINCT_ID
+            assert capture.call_args.kwargs["status"] == "start"
+            capture.reset_mock()
+            slack_app_home.republish_home_for_user(self.integration, SLACK_USER)
+            capture.assert_not_called()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-notify.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "account_name": {
+            "description": "Display name of the account the finding is about (headline of the alert).",
+            "maxLength": 300,
+            "type": "string"
+        },
+        "owner_email": {
+            "anyOf": [
+                {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "The account owner's email as resolved from the data (`system.accounts` roles or CRM owner join). The server resolves it to a Slack mention via `users.lookupByEmail`; on a miss the alert falls back to plain text. Omit when no owner was resolvable."
+        },
+        "owner_label": {
+            "anyOf": [
+                {
+                    "maxLength": 200,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Human-readable owner fallback (e.g. `Jane Doe (Salesforce)` or `HubSpot owner 1234`) used when `owner_email` is absent or doesn't resolve to a Slack user."
+        },
+        "report_id": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "UUID of the inbox `SignalReport` this run emitted or edited for the same finding. Must be one of this run's report ids; the alert links to it. Always file the report first, then notify."
+        },
+        "run_id": {
+            "description": "UUID of the `SignalScoutRun` bridge row.",
+            "type": "string"
+        },
+        "severity": {
+            "anyOf": [
+                {
+                    "description": "* `high` - high\n* `medium` - medium\n* `low` - low",
+                    "enum": ["high", "medium", "low"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Severity steer for the alert's visual treatment. Omit for a neutral alert.\n\n* `low` - low\n* `medium` - medium\n* `high` - high"
+        },
+        "text": {
+            "description": "The finding summary, in Slack mrkdwn, written for the account owner: what changed, the magnitude and window, and the one thing to check. 2–4 sentences. Do NOT include an owner mention — the server prepends it.",
+            "maxLength": 2500,
+            "type": "string"
+        }
+    },
+    "required": ["run_id", "text", "account_name"],
+    "type": "object"
+}


### PR DESCRIPTION
> Part 8 of the CSM persona onboarding stack (8 PRs), based on #69085.

## Problem

Onboarding events were keyed on the team uuid, which collapses every user in a workspace into one person. Fine for volume counts, useless for a conversion funnel. And the first-patrol digest DMed an "all clear" even when nothing happened, which is noise.

## Changes

- `slack_user_distinct_id(workspace, user)` and a `distinct_id` override on `capture_slack_event`, so every step of one user's onboarding lands on the same person: `home_card_shown → started → persona_selected → fleet_shown → channel_configured → completed`, with the first-patrol digest chaining as the final step.
- New friction and exit markers: `channel_invite_needed`, `nudged`, `error` (with stage), plus `github_connected` for the part 7 follow-up. Every in-flow event carries persona context for breakdowns.
- Home-card impressions fire only on user-initiated opens, programmatic republishes after each flow step don't inflate the funnel top.
- First-patrol digest only DMs when a scout actually found something. A clean patrol stays silent, findings already land in the delivery channel.

## How did you test this code?

`hogli test products/slack_app/backend/tests/ posthog/temporal/tests/ai/test_first_patrol_workflow.py` (732 passed). `TestFunnelAnalytics` pins the funnel contract (shared distinct_id and persona across the CSM path, post-completion connect clicks, impression vs republish), which nothing else guarded since the flow tests mute analytics.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. `/writing-tests` was invoked for `TestFunnelAnalytics`. Dropping the all-clear digest variant was a deliberate product call: run-state DMs read as noise, and the retry-then-silence workflow shape is unchanged.
