### PR TITLE
fix(flags): use evaluate_flags in python snippet

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5975,7 +5975,7 @@ snapshots:
     scenes-app-feature-flags-code-examples--code-instructions-overview--light:
         hash: v1.k794b7964.181fee2de309458241649ba0b7b64c8ba9e3dd1b92e23afc08fb9f7922fd50b4.JCNNjcMuzmrKK8oh11XjLWJI5JB43gml6OImSTtV0OA
     scenes-app-feature-flags-code-examples--code-instructions-python-with-local-evaluation--dark:
-        hash: v1.k794b7964.8316fda4c3668ec781d727e2dbd9b0f1918e3a1b3a8d4fcf4fadebc3f12496e9.XWksz8gdp2OvMNulTvkVnEEDnxC0t6NGHlZD8YIH-EI
+        hash: v1.k794b7964.ae82e0deaa34c7ed40c69c8970c41f49e39f214f8d561195b88eb1ee568a5b64.2RiZwm6EtAf04-GExngtPt9VGyCe77N0QWpFWEVssoE
     scenes-app-feature-flags-code-examples--code-instructions-python-with-local-evaluation--light:
         hash: v1.k794b7964.38588818dde5174e7dee4d5921b4b5f0f1c0ea09284b224ac6fb42ae46945818.CiDEgwKNzWdBDkYVs8ZP9QH6c8sBcr__0K-kWaeNGfQ
     scenes-app-feature-flags-code-examples--code-instructions-react-native-with-bootstrap--dark:
@@ -6245,7 +6245,7 @@ snapshots:
     scenes-app-inbox-scene--self-driving-paused--dark:
         hash: v1.k794b7964.00929b96e59e35796acfc2f8d5f9f48e148c499b2932c227e1a4cf02c488bde0.0kZ4s9sfw8uPHzO2KT7GZ6vL6y-2qA4qzRoZW7n-bcU
     scenes-app-inbox-scene--self-driving-paused--light:
-        hash: v1.k794b7964.e2ed5feaafcc219cbecaedafed11618a60e0b39911f54121ae02acbf68270238.v1MEVslQu-332g2PB_trr6JIb-knUHeoA42roLiGQRI
+        hash: v1.k794b7964.3801adf5236e9dcea0f1fa5eeffddd6826efb30725b70760369e486db3567e82.UPOnHRPFkJ4uMMemIpHngMRSjylkumiXVWPnADLiBF4
     scenes-app-inbox-tabs--pull-requests--dark:
         hash: v1.k794b7964.dad4d6e7b9f1f68f8eaf4b31187c798dfab1631bb6bf20432ce9746f7df1de73.cqSvLKv0E6PFhnMnbn4FS6yIypKYMUKzoKniwrRI4WM
     scenes-app-inbox-tabs--pull-requests--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5975,9 +5975,9 @@ snapshots:
     scenes-app-feature-flags-code-examples--code-instructions-overview--light:
         hash: v1.k794b7964.181fee2de309458241649ba0b7b64c8ba9e3dd1b92e23afc08fb9f7922fd50b4.JCNNjcMuzmrKK8oh11XjLWJI5JB43gml6OImSTtV0OA
     scenes-app-feature-flags-code-examples--code-instructions-python-with-local-evaluation--dark:
-        hash: v1.k794b7964.46946f802bff06024f069e04ba61b1eb4f07b9692c347b062c5d0f1bc552876e.Ee2U7zY4Myf4PCjHB6vA8AHz25ShhvMqI-D8ldktjaE
+        hash: v1.k794b7964.8316fda4c3668ec781d727e2dbd9b0f1918e3a1b3a8d4fcf4fadebc3f12496e9.XWksz8gdp2OvMNulTvkVnEEDnxC0t6NGHlZD8YIH-EI
     scenes-app-feature-flags-code-examples--code-instructions-python-with-local-evaluation--light:
-        hash: v1.k794b7964.149de39d149c0edda501ec6ba47d15735ac17a767feef1dad874534a55c635fd.4vj3WfZXxE-BSohhgh1FwBdgE31_5RRws0aJiXRcnoA
+        hash: v1.k794b7964.38588818dde5174e7dee4d5921b4b5f0f1c0ea09284b224ac6fb42ae46945818.CiDEgwKNzWdBDkYVs8ZP9QH6c8sBcr__0K-kWaeNGfQ
     scenes-app-feature-flags-code-examples--code-instructions-react-native-with-bootstrap--dark:
         hash: v1.k794b7964.3440d2db4a0a5ab4057d5fe610e30285f872fd1d29ee7033885ab630e5e19865.5XAr0iN2N5213U-PObvEbro61694r_CdMq6g_2zkSRc
     scenes-app-feature-flags-code-examples--code-instructions-react-native-with-bootstrap--light:

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -349,7 +349,7 @@ remote_config_payload = posthog.get_remote_config_payload('${flagKey}')`}
             ? `
     # add group properties used in the flag to ensure the flag
     # is evaluated locally, vs. going to our servers
-    group_properties={ ${groupType.group_type}: {'${propertyName}': 'value', 'name': 'xyz'}}`
+    group_properties={ '${groupType.group_type}': {'${propertyName}': 'value', 'name': 'xyz'}}`
             : `
     # add person properties used in the flag to ensure the flag
     # is evaluated locally, vs. going to our servers

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -327,8 +327,7 @@ export function PythonSnippet({
     encryptedPayload,
     samplePropertyName,
 }: FeatureFlagSnippet): JSX.Element {
-    const clientSuffix = 'posthog.'
-    const flagFunction = payload ? 'get_feature_flag_payload' : multivariant ? 'get_feature_flag' : 'feature_enabled'
+    const snapshotMethod = payload ? 'get_flag_payload' : multivariant ? 'get_flag' : 'is_enabled'
 
     const propertyName = samplePropertyName || 'is_authorized'
 
@@ -357,18 +356,16 @@ remote_config_payload = posthog.get_remote_config_payload('${flagKey}')`}
     person_properties={'${propertyName}': 'value'}`
         : ''
 
-    const flagSnippet = groupType
-        ? `${clientSuffix}${flagFunction}(
-    '${flagKey}',
+    const evaluateSnippet = groupType
+        ? `posthog.evaluate_flags(
     'user distinct id',
     groups={ '${groupType.group_type}': '<${groupType.name_singular || 'group'} ID>' },${localEvalAddition}
 )`
         : localEvalAddition
-          ? `${clientSuffix}${flagFunction}(
-    '${flagKey}',
+          ? `posthog.evaluate_flags(
     'user distinct id',${localEvalAddition}
 )`
-          : `${clientSuffix}${flagFunction}('${flagKey}', 'user distinct id')`
+          : `posthog.evaluate_flags('user distinct id')`
     const variableName = payload ? 'matched_flag_payload' : multivariant ? 'enabled_variant' : 'is_my_flag_enabled'
 
     const conditional = multivariant ? `${variableName} == 'example-variant'` : `${variableName}`
@@ -381,10 +378,14 @@ if ${conditional}:
     # Do something differently for this ${groupType ? groupType.name_singular || 'group' : 'user'}
 `
 
+    const reminderPrefix = localEvaluation ? '# ' + LOCAL_EVAL_REMINDER : ''
+
     return (
         <>
             <CodeSnippet language={Language.Python} wrap>
-                {`${localEvaluation ? '# ' + LOCAL_EVAL_REMINDER : ''}${variableName} = ${flagSnippet}${followUpCode}`}
+                {`${reminderPrefix}flags = ${evaluateSnippet}
+
+${variableName} = flags.${snapshotMethod}('${flagKey}')${followUpCode}`}
             </CodeSnippet>
         </>
     )


### PR DESCRIPTION
## Problem

Someone setting up a new project noticed the docs call `posthog.feature_enabled()` deprecated in the Python library, yet it is exactly what our in-app copy-paste snippet hands to brand-new flags. In current `posthog-python`, `feature_enabled()`, `get_feature_flag()`, and `get_feature_flag_payload()` all emit a `DeprecationWarning` and steer users to `evaluate_flags()`. So we were recommending a deprecated API on day one.

From: https://posthoghelp.zendesk.com/agent/tickets/61952 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/62078)

## Changes

Updated the Python `PythonSnippet` in `FeatureFlagSnippets.tsx` to the recommended `evaluate_flags()` snapshot pattern: evaluate once per user, then read the flag off the returned snapshot.

Boolean:

```python
flags = posthog.evaluate_flags('user distinct id')

is_my_flag_enabled = flags.is_enabled('flag-key')

if is_my_flag_enabled:
    # Do something differently for this user
```

Multivariate uses `flags.get_flag('flag-key')` and payloads use `flags.get_flag_payload('flag-key')`. Group and local-evaluation variants keep the same `groups=` / `person_properties=` / `group_properties=` kwargs, which now pass to `evaluate_flags()` instead of the flag call. The old methods still work during the migration period, so this is a recommendation change, not a break.

## How did you test this code?

I (an agent) confirmed against the current `posthog-python` source that `feature_enabled`/`get_feature_flag`/`get_feature_flag_payload` emit deprecation warnings and that `evaluate_flags(distinct_id, *, groups, person_properties, group_properties)` returns a snapshot exposing `is_enabled`, `get_flag`, and `get_flag_payload`, matching the pattern in the Python docs. I traced every branch of the snippet generator by reading the code. I could not run the frontend formatter or typecheck locally because `node_modules` is not installed in this environment; the edit was written to match the surrounding style.

## Docs update

No docs change needed; the docs already recommend `evaluate_flags()`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread where a user hit the deprecated-vs-recommended mismatch during Python setup. I verified the deprecation in the library source and docs, then rewrote `PythonSnippet` to emit `evaluate_flags()` across the boolean, multivariate, payload, group, and local-evaluation cases. Remote-config snippet (`get_remote_config_payload`) was left untouched since it is not deprecated.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1783459138899909)*
