### PR TITLE
fix(wizard): make forbidden-file checkpoint exit-code unambiguous

### DIFF
--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -78,7 +78,8 @@ contains neither reference file:
 ```bash
 git rev-parse --abbrev-ref HEAD          # prints: posthog/instrumentation-<random-short-sha>
 git show --stat HEAD                     # lists the wizard's files
-git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' # prints NOTHING
+git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: forbidden files committed" || echo "OK: no forbidden files"
+# expected: OK: no forbidden files (the grep finding nothing is the pass case)
 ```
 
 ## Step 3 - Configure environment variables for production


### PR DESCRIPTION
## Problem

A follow-up to #69039. That PR merged before this one-line fix landed, so the wizard PR-agent prompt in `products/tasks/backend/prompts.py` still ships a checkpoint with inverted exit-code semantics.

The Step 2 checkpoint runs:

```bash
git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' # prints NOTHING
```

The intent is "pass when no forbidden files are in the commit". But `grep` inverts that:

- Clean commit (good) → grep matches nothing → prints nothing but **exits 1**
- Dirty commit (bad) → grep matches → prints the files and **exits 0**

An agent gating on exit code reads the good outcome as a failure and the bad outcome as a pass. The `# prints NOTHING` note only described stdout, which hid the trap.

## Changes

Normalize both branches so the check always exits 0 and prints an explicit message the agent can read:

```diff
-git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' # prints NOTHING
+git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: forbidden files committed" || echo "OK: no forbidden files"
+# expected: OK: no forbidden files (the grep finding nothing is the pass case)
```

## How did you test this code?

This is prompt text, not executable product code. I ran `ruff check` and `ruff format --check` on the file (both pass). I did not run the wizard agent end to end. I verified the shell logic by reasoning through both branches: on a match, `grep` succeeds and the `&&` echoes `FAIL`; on no match, `grep` fails and the `||` echoes `OK` — both exit 0.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael flagged Graphite's review comment on #69039 about the inverted `grep` checkpoint and asked me (Claude) to verify it and split the fix into its own PR after #69039 merged without it. I confirmed the exit-code inversion is real, branched from latest master, and applied only that single change. No skills were needed for a one-line prompt fix.
