### PR TITLE
fix(postgres): retry CDC slot recreation on transient connection drops

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
@@ -7,6 +7,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal
 
+import structlog
+
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import cdc_error_info
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.config import PostgresCDCConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.errors import (
@@ -29,7 +31,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.c
     remove_table_from_publication,
     slot_exists,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import source_requires_ssl
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import (
+    _retry_on_connection_dropped,
+    source_requires_ssl,
+)
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -37,6 +42,7 @@ if TYPE_CHECKING:
     from products.warehouse_sources.backend.temporal.data_imports.cdc.types import CDCStreamReader
 
 logger = logging.getLogger(__name__)
+_retry_logger = structlog.get_logger(__name__)
 
 
 def _split_qualified_table(qualified: str, default_schema: str) -> tuple[str, str]:
@@ -135,22 +141,31 @@ class PostgresCDCAdapter:
             raise RuntimeError("Cannot recreate CDC replication slot: no slot name configured for this source")
 
         default_schema = self._resolve_schema(source)
-        with cdc_pg_connection(source) as conn:
-            drop_slot(conn, cdc_config.slot_name)
-            if cdc_config.publication_name and not publication_exists(conn, cdc_config.publication_name):
-                if cdc_config.management_mode != "posthog":
-                    raise RuntimeError(
-                        f"Publication '{cdc_config.publication_name}' does not exist on the source database. "
-                        "Recreate it (see the CDC setup instructions), then resync the source."
+
+        def _recreate() -> str:
+            with cdc_pg_connection(source) as conn:
+                drop_slot(conn, cdc_config.slot_name)
+                if cdc_config.publication_name and not publication_exists(conn, cdc_config.publication_name):
+                    if cdc_config.management_mode != "posthog":
+                        raise RuntimeError(
+                            f"Publication '{cdc_config.publication_name}' does not exist on the source database. "
+                            "Recreate it (see the CDC setup instructions), then resync the source."
+                        )
+                    return create_slot_and_publication(
+                        conn,
+                        cdc_config.slot_name,
+                        cdc_config.publication_name,
+                        tables=[_split_qualified_table(t, default_schema) for t in tables],
                     )
-                consistent_point = create_slot_and_publication(
-                    conn,
-                    cdc_config.slot_name,
-                    cdc_config.publication_name,
-                    tables=[_split_qualified_table(t, default_schema) for t in tables],
-                )
-            else:
-                consistent_point = create_slot(conn, cdc_config.slot_name)
+                return create_slot(conn, cdc_config.slot_name)
+
+        # Recovery reconnects and reruns DDL on a source that just dropped our streaming
+        # connection (the slot invalidation that triggered recovery), so a transient drop
+        # mid-recreate — the server terminating our backend on a deploy/failover, an idle cull —
+        # is likely. drop_slot runs first on every attempt, so retrying is idempotent; absorb the
+        # drop in-process instead of failing the whole recovery. Permanent errors (auth, a missing
+        # customer-owned publication) don't match the predicate and re-raise immediately.
+        consistent_point = _retry_on_connection_dropped(_recreate, _retry_logger)
 
         return {"cdc_consistent_point": consistent_point}
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
@@ -3,9 +3,12 @@ import uuid
 import pytest
 from unittest.mock import MagicMock, patch
 
+import psycopg.errors
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter import PostgresCDCAdapter
 
 _ADAPTER = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter"
+_POSTGRES = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"
 
 
 def _source(**cdc_overrides):
@@ -249,6 +252,33 @@ class TestRecreateSlot:
         source = _source(cdc_enabled=True)
         with pytest.raises(RuntimeError, match="no slot name"):
             PostgresCDCAdapter().recreate_slot(source, tables=[])
+
+    @patch(f"{_POSTGRES}.time.sleep")
+    @patch(f"{_ADAPTER}.create_slot")
+    @patch(f"{_ADAPTER}.publication_exists", return_value=True)
+    @patch(f"{_ADAPTER}.drop_slot")
+    @patch(f"{_ADAPTER}.cdc_pg_connection", new_callable=_fake_conn)
+    def test_retries_recreation_after_transient_connection_drop(
+        self, _conn, mock_drop, _pub_exists, mock_create_slot, _sleep
+    ) -> None:
+        # The source terminates our backend mid-recreate (deploy/failover); recovery must reconnect
+        # and retry rather than fail the whole run. drop-before-create keeps the retry idempotent.
+        mock_create_slot.side_effect = [
+            psycopg.errors.AdminShutdown("terminating connection due to administrator command"),
+            "0/CC",
+        ]
+        source = _source(
+            cdc_enabled=True,
+            cdc_management_mode="posthog",
+            cdc_slot_name="posthog_slot",
+            cdc_publication_name="posthog_pub",
+        )
+
+        fields = PostgresCDCAdapter().recreate_slot(source, tables=["users"])
+
+        assert fields == {"cdc_consistent_point": "0/CC"}
+        assert mock_create_slot.call_count == 2
+        assert mock_drop.call_count == 2
 
 
 class TestAlterPublicationMembership:


### PR DESCRIPTION
## Problem

Error tracking surfaced a CDC extraction failure on a Postgres data-warehouse source:

`ObjectNotInPrerequisiteState: can no longer get changes from replication slot "<redacted>"` / `This slot has been invalidated because it exceeded the maximum reserved size` (issue [019f3e84-3619-7f42-84eb-e5190d2312d4](https://us.posthog.com/project/2/error_tracking/019f3e84-3619-7f42-84eb-e5190d2312d4)).

The slot invalidation itself is already handled: `read_changes` raises it, the extraction activity detects it via `is_slot_invalidation_error`, and `_recover_from_slot_invalidation` recreates the slot and re-snapshots. That part works as designed.

What actually surfaced is the **recovery attempt failing**. The captured exception chains the slot invalidation with a second, real error raised while recreating the slot:

`AdminShutdown: terminating connection due to administrator command` (Postgres SQLSTATE `57P01`), thrown from `create_slot` during `recreate_slot`.

That is a transient, server-initiated connection termination (a deploy, failover, or the backend being killed). It is correctly classified as retryable, so Temporal re-runs the activity and recovery eventually succeeds. But the recovery run failed once and generated a customer-visible failed sync plus an error-tracking event.

The gap: `recreate_slot` reconnects and reruns DDL on a source that *just* dropped our streaming connection (that is literally why we are recovering), yet unlike the rest of the postgres import/CDC code, which invests heavily in absorbing transient drops via `_retry_on_connection_dropped`, the recovery path does not. A transient drop there takes down the whole recovery.

> [!NOTE]
> This is a transient infra error, not a user/upstream one, so it is deliberately **not** added to any non-retryable list. Making it non-retryable would permanently stop a recoverable sync.

## Changes

Wrap the connect-and-recreate block in `PostgresCDCAdapter.recreate_slot` with the existing `_retry_on_connection_dropped` helper.

- `drop_slot` runs first on every attempt (it already tolerates a missing slot), so re-running the whole block is idempotent even if a prior attempt partially created the slot.
- Only errors matching the transient connection-dropped predicate are retried. Permanent errors (auth failures, a missing customer-owned publication `RuntimeError`) don't match and re-raise immediately.

This is complementary to two in-flight PRs, not a duplicate of either:

- [#68383](https://github.com/PostHog/posthog/pull/68383) suppresses `AdminShutdown`/class-57 reporting at the Temporal interceptor layer (stops the noise). It does not make the recovery survive the drop.
- [#69049](https://github.com/PostHog/posthog/pull/69049) adds a manual "repair CDC" action for the broken-slot state. Different flow.

## How did you test this code?

Added one case to `TestRecreateSlot` in `test_adapter.py`: `test_retries_recreation_after_transient_connection_drop`. It makes `create_slot` raise `AdminShutdown("terminating connection due to administrator command")` on the first call and succeed on the second, then asserts recreation retried (drop + create called twice) and returned the new consistent point. The regression it guards: if the retry wrapper is removed or the transient-drop predicate stops matching, slot-invalidation recovery again fails the whole run on a transient drop. No existing test covered retry in `recreate_slot`.

The backoff `time.sleep` is patched so the test stays fast; no sleeps or network.

```
19 passed in 4.18s
```

Ran the full `test_adapter.py` file plus ruff check/format on the two changed files. I (Claude) could not exercise a live Postgres/Temporal run in the sandbox.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage started from the error-tracking issue via the PostHog MCP tools: pulled the full stack trace and confirmed the failing frame lives under `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/` (`read_changes` for the slot invalidation, `create_slot` for the recovery-time `AdminShutdown`).

Decision path: the slot invalidation is already handled on master, and the surfaced `AdminShutdown` is transient, so neither a non-retryable-list entry nor a change to global retry policy is appropriate. The real, scoped fix is making the recovery's slot recreation resilient to the transient drop, mirroring the `_retry_on_connection_dropped` pattern used throughout the postgres code. Checked open PRs (including the maintainer's own) for duplicates and found #68383 and #69049 as related-but-distinct work, noted above.

Skills invoked: `/writing-tests` (to gate the regression test).
