### PR TITLE
feat(agent-platform): seed example bundles on hogli start

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -281,6 +281,19 @@ procs:
         env:
             AGENT_LOG_FILE: '/tmp/posthog-agent-logs/agent-janitor.log'
 
+    agent-seed:
+        # One-shot idempotent seeder: waits for Django + agent-ingress +
+        # agent-janitor healthchecks then deploys the curated example bundles
+        # (default: agent-builder + agent-approval-demo) so the Agent Builder
+        # panel works out of the box. Set AGENT_SEED_SLUGS to override or "all".
+        shell: 'bin/wait-for-docker && bin/seed-agent-examples'
+        capability: agent_runtime
+        ready_pattern: 'seeding complete'
+        autorestart: false
+        groups:
+            layer: Tools
+            tech: Python
+
     ai-gateway:
         shell: 'bin/wait-for-docker && bin/start-ai-gateway'
         capability: ai_gateway

--- a/bin/seed-agent-examples
+++ b/bin/seed-agent-examples
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# One-shot seeder wired into the `agent_runtime` capability. Waits for Django +
+# agent-ingress + agent-janitor healthchecks, then runs the Python seeder in
+# products/agent_platform/services/agent-tests/src/examples/seed.py.
+#
+# Idempotent: bundles whose live revision already matches (per-file sha AND
+# spec) are a no-op; drifted bundles branch a new draft and re-promote.
+#
+# Env vars:
+#   AGENT_SEED_SLUGS  Comma-separated slugs to seed. Default:
+#                     "agent-builder,agent-approval-demo" — the two most useful
+#                     examples for platform dev. "all" seeds every discovered
+#                     bundle (see the examples dir). Empty string skips seeding.
+#   POSTHOG_API       Django base URL. Default http://localhost:8010.
+#   AGENT_INGRESS_URL Ingress URL for readiness. Default http://localhost:3030.
+#   AGENT_JANITOR_URL Janitor URL for readiness. Default http://localhost:3031.
+#   AGENT_SEED_TIMEOUT_SECONDS
+#                     Per-service readiness timeout. Default 180.
+#
+# Seed uses SEED_DUMMY_SECRETS=1 so secret-gated bundles (slack) can promote
+# with obviously-fake placeholders. Never overwrites a real value.
+#
+# `PAT` for the seeder: unset here — seed.py self-mints the deterministic dev
+# key via `manage.py setup_local_api_key` in flox environments. If you're
+# outside flox, export `PAT=phx_...` before invoking.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DJANGO_URL="${POSTHOG_API:-http://localhost:8010}"
+INGRESS_URL="${AGENT_INGRESS_URL:-http://localhost:3030}"
+JANITOR_URL="${AGENT_JANITOR_URL:-http://localhost:3031}"
+SLUG_SPEC="${AGENT_SEED_SLUGS-agent-builder,agent-approval-demo}"
+TIMEOUT_S="${AGENT_SEED_TIMEOUT_SECONDS:-180}"
+
+log() { printf '[seed-agent-examples] %s\n' "$*"; }
+
+if [ -z "$SLUG_SPEC" ]; then
+    log "AGENT_SEED_SLUGS is empty — skipping"
+    log "seeding complete"
+    exit 0
+fi
+
+wait_for() {
+    local label="$1" url="$2"
+    log "waiting for $label at $url"
+    for _ in $(seq 1 "$TIMEOUT_S"); do
+        if curl -sf "$url" >/dev/null 2>&1; then
+            log "  $label ready"
+            return 0
+        fi
+        sleep 1
+    done
+    log "  WARNING: $label never became ready after ${TIMEOUT_S}s — attempting seed anyway"
+    return 0
+}
+
+wait_for "Django"        "$DJANGO_URL/_health/"
+wait_for "agent-ingress" "$INGRESS_URL/healthz"
+wait_for "agent-janitor" "$JANITOR_URL/healthz"
+
+SEED_SCRIPT="$REPO_ROOT/products/agent_platform/services/agent-tests/src/examples/seed.py"
+
+# Slug selection: "all" -> no positional args (seed.py's default is every
+# discovered bundle). Otherwise comma-split into positional selectors.
+args=()
+if [ "$SLUG_SPEC" != "all" ]; then
+    IFS=',' read -r -a args <<<"$SLUG_SPEC"
+fi
+
+log "seeding: ${args[*]:-<all discovered bundles>}"
+
+SEED_DUMMY_SECRETS=1 POSTHOG_API="$DJANGO_URL" \
+    python "$SEED_SCRIPT" "${args[@]}"
+
+log "seeding complete"

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1141,3 +1141,7 @@ environment:
         bin_script: ensure-local-setup
         description: Idempotent local-dev bootstrap (e.g. the wizard OAuth app); runs automatically on hogli start
         hidden: true
+    seed:agent:examples:
+        bin_script: seed-agent-examples
+        description: Idempotent seeder for the example agent bundles; runs automatically on hogli start when the agent_runtime capability is enabled
+        hidden: true

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -11,6 +11,7 @@ __all__ = [
     "generate_rsa_private_key_pem",
     "get_from_env",
     "get_list",
+    "load_or_mint_dev_oidc_rsa_key",
     "str_to_bool",
 ]
 
@@ -46,6 +47,30 @@ def generate_rsa_private_key_pem() -> str:
         encryption_algorithm=serialization.NoEncryption(),
     )
     return pem.decode("utf-8")
+
+
+def load_or_mint_dev_oidc_rsa_key() -> str:
+    """Return a persistent RSA private key for local dev OIDC signing.
+
+    First launch mints an ephemeral key and writes it to disk; subsequent Django
+    restarts read the same key back. Keeps client OAuth sessions valid across
+    dev-server reloads. Path defaults to ~/.posthog/dev-oidc-rsa.pem; override
+    with DEV_OIDC_RSA_KEY_PATH.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    path = Path(os.getenv("DEV_OIDC_RSA_KEY_PATH", "~/.posthog/dev-oidc-rsa.pem")).expanduser()
+    try:
+        if path.is_file():
+            return path.read_text()
+    except OSError:
+        # Unreadable path (perms, symlink loop) — fall through to mint + write.
+        pass
+    pem = generate_rsa_private_key_pem()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(pem)
+    path.chmod(0o600)
+    return pem
 
 
 def get_from_env(

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -54,12 +54,18 @@ def load_or_mint_dev_oidc_rsa_key() -> str:
 
     First launch mints an ephemeral key and writes it to disk; subsequent Django
     restarts read the same key back. Keeps client OAuth sessions valid across
-    dev-server reloads. Path defaults to ~/.posthog/dev-oidc-rsa.pem; override
+    dev-server reloads. Path defaults to ~/.posthog-dev/oidc-rsa.pem (a
+    dedicated dir so it doesn't collide with the CLI's ~/.posthog/); override
     with DEV_OIDC_RSA_KEY_PATH.
+
+    Any I/O failure (unwriteable HOME, weird ACL, race with a sibling worker)
+    falls back to an ephemeral key with a stderr warning. That trades OAuth
+    session stability for keeping Django bootable — the alternative is a
+    crash-loop that blocks all local dev.
     """
     from pathlib import Path  # noqa: PLC0415
 
-    path = Path(os.getenv("DEV_OIDC_RSA_KEY_PATH", "~/.posthog/dev-oidc-rsa.pem")).expanduser()
+    path = Path(os.getenv("DEV_OIDC_RSA_KEY_PATH", "~/.posthog-dev/oidc-rsa.pem")).expanduser()
     try:
         if path.is_file():
             return path.read_text()
@@ -67,9 +73,18 @@ def load_or_mint_dev_oidc_rsa_key() -> str:
         # Unreadable path (perms, symlink loop) — fall through to mint + write.
         pass
     pem = generate_rsa_private_key_pem()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(pem)
-    path.chmod(0o600)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(pem)
+        path.chmod(0o600)
+    except OSError as e:
+        # Never crash-loop Django on a dev-only convenience: log to stderr and
+        # return the ephemeral key. OAuth sessions may rotate on the next
+        # restart until the user fixes the path.
+        print(  # noqa: T201
+            f"[settings] WARNING: could not persist dev OIDC key to {path}: {e}. "
+            f"Falling back to ephemeral — client OAuth sessions will invalidate on Django restart.",
+        )
     return pem
 
 

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -54,18 +54,30 @@ def load_or_mint_dev_oidc_rsa_key() -> str:
 
     First launch mints an ephemeral key and writes it to disk; subsequent Django
     restarts read the same key back. Keeps client OAuth sessions valid across
-    dev-server reloads. Path defaults to ~/.posthog-dev/oidc-rsa.pem (a
-    dedicated dir so it doesn't collide with the CLI's ~/.posthog/); override
-    with DEV_OIDC_RSA_KEY_PATH.
+    dev-server reloads. Path defaults to <real-home>/.posthog-dev/oidc-rsa.pem
+    (dedicated dir; doesn't collide with the CLI's ~/.posthog/). Override with
+    DEV_OIDC_RSA_KEY_PATH.
 
-    Any I/O failure (unwriteable HOME, weird ACL, race with a sibling worker)
+    Resolves the real home via `pwd.getpwuid(os.getuid())` rather than `HOME`,
+    since some launchers (debugpy from IDE debug sessions, sandboxed dev-server
+    supervisors) don't propagate HOME to the child process and `Path.expanduser`
+    would resolve `~` to the wrong place — silently minting a fresh key every
+    restart.
+
+    Any I/O failure (unwriteable path, weird ACL, race with a sibling worker)
     falls back to an ephemeral key with a stderr warning. That trades OAuth
     session stability for keeping Django bootable — the alternative is a
     crash-loop that blocks all local dev.
     """
+    import pwd  # noqa: PLC0415
     from pathlib import Path  # noqa: PLC0415
 
-    path = Path(os.getenv("DEV_OIDC_RSA_KEY_PATH", "~/.posthog-dev/oidc-rsa.pem")).expanduser()
+    override = os.getenv("DEV_OIDC_RSA_KEY_PATH")
+    if override:
+        path = Path(override).expanduser()
+    else:
+        home = pwd.getpwuid(os.getuid()).pw_dir
+        path = Path(home) / ".posthog-dev" / "oidc-rsa.pem"
     try:
         if path.is_file():
             return path.read_text()

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -922,9 +922,12 @@ WORKFLOWS_WEBHOOK_SECRET = get_from_env("WORKFLOWS_WEBHOOK_SECRET", "")
 OIDC_RSA_PRIVATE_KEY = os.getenv("OIDC_RSA_PRIVATE_KEY", "").replace("\\n", "\n")
 
 # Saving an RS256 OAuthApplication validates that this key is set, so a test run without one
-# (fork PRs, bare local environments) fails in every test that creates an OAuth app. Generate
-# an ephemeral key so tests never depend on an env-provided key.
-if TEST and not OIDC_RSA_PRIVATE_KEY:
+# (fork PRs, bare local environments) fails in every test that creates an OAuth app. The same
+# gap bites local dev: any flow that mints an OAuth app (e.g. the agent platform's
+# revision promote) 500s until the key is provisioned. Generate an ephemeral key so tests
+# and local dev never depend on an env-provided key. Cloud deployments still require the
+# real env-provided key.
+if not OIDC_RSA_PRIVATE_KEY and (TEST or (DEBUG and not CLOUD_DEPLOYMENT)):
     OIDC_RSA_PRIVATE_KEY = generate_rsa_private_key_pem()
 
 OIDC_RSA_PRIVATE_KEY_INACTIVE_1 = os.getenv("OIDC_RSA_PRIVATE_KEY_INACTIVE_1", "").replace("\\n", "\n")

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -940,7 +940,12 @@ OIDC_RSA_PRIVATE_KEY = os.getenv("OIDC_RSA_PRIVATE_KEY", "").replace("\\n", "\n"
 if not OIDC_RSA_PRIVATE_KEY:
     if TEST:
         OIDC_RSA_PRIVATE_KEY = generate_rsa_private_key_pem()
-    elif DEBUG and not CLOUD_DEPLOYMENT:
+    # Mirror the blocklist in `assert_debug_not_in_production` (posthog/settings/utils.py:26)
+    # so this covers every DEBUG-allowed env: unset (self-hosted / bare local),
+    # `LOCAL`, and `E2E`. A `not CLOUD_DEPLOYMENT` check would miss `LOCAL` and
+    # `E2E` — both are documented valid local-dev values (see
+    # `posthog/settings/base_variables.py`) and would still hit the original 500.
+    elif DEBUG and (CLOUD_DEPLOYMENT or "").upper() not in ("US", "EU", "DEV"):
         OIDC_RSA_PRIVATE_KEY = load_or_mint_dev_oidc_rsa_key()
 
 OIDC_RSA_PRIVATE_KEY_INACTIVE_1 = os.getenv("OIDC_RSA_PRIVATE_KEY_INACTIVE_1", "").replace("\\n", "\n")

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -7,7 +7,13 @@ from corsheaders.defaults import default_headers
 
 from posthog.scopes import get_scope_descriptions
 from posthog.settings.base_variables import BASE_DIR, CLOUD_DEPLOYMENT, DEBUG, TEST
-from posthog.settings.utils import generate_rsa_private_key_pem, get_from_env, get_list, str_to_bool
+from posthog.settings.utils import (
+    generate_rsa_private_key_pem,
+    get_from_env,
+    get_list,
+    load_or_mint_dev_oidc_rsa_key,
+    str_to_bool,
+)
 from posthog.utils_cors import CORS_ALLOWED_TRACING_HEADERS
 
 logger = structlog.get_logger(__name__)
@@ -924,11 +930,18 @@ OIDC_RSA_PRIVATE_KEY = os.getenv("OIDC_RSA_PRIVATE_KEY", "").replace("\\n", "\n"
 # Saving an RS256 OAuthApplication validates that this key is set, so a test run without one
 # (fork PRs, bare local environments) fails in every test that creates an OAuth app. The same
 # gap bites local dev: any flow that mints an OAuth app (e.g. the agent platform's
-# revision promote) 500s until the key is provisioned. Generate an ephemeral key so tests
-# and local dev never depend on an env-provided key. Cloud deployments still require the
+# revision promote) 500s until the key is provisioned. Self-provision a key so tests and
+# local dev never depend on an env-provided one. Cloud deployments still require the
 # real env-provided key.
-if not OIDC_RSA_PRIVATE_KEY and (TEST or (DEBUG and not CLOUD_DEPLOYMENT)):
-    OIDC_RSA_PRIVATE_KEY = generate_rsa_private_key_pem()
+#   - TEST: ephemeral key per run (tests are isolated; persistence would just be noise).
+#   - Local dev: persist the key to disk so it survives Django restarts. Otherwise every
+#     dev-server auto-reload rotates the OIDC signing key and invalidates any client OAuth
+#     session (e.g. a signed-in Claude Code session hitting the local backend).
+if not OIDC_RSA_PRIVATE_KEY:
+    if TEST:
+        OIDC_RSA_PRIVATE_KEY = generate_rsa_private_key_pem()
+    elif DEBUG and not CLOUD_DEPLOYMENT:
+        OIDC_RSA_PRIVATE_KEY = load_or_mint_dev_oidc_rsa_key()
 
 OIDC_RSA_PRIVATE_KEY_INACTIVE_1 = os.getenv("OIDC_RSA_PRIVATE_KEY_INACTIVE_1", "").replace("\\n", "\n")
 OIDC_RSA_PRIVATE_KEY_INACTIVE_2 = os.getenv("OIDC_RSA_PRIVATE_KEY_INACTIVE_2", "").replace("\\n", "\n")

--- a/products/demo/backend/logic/products/hedgebox/matrix.py
+++ b/products/demo/backend/logic/products/hedgebox/matrix.py
@@ -51,7 +51,6 @@ from posthog.constants import PAGEVIEW_EVENT
 from posthog.exceptions_capture import capture_exception
 from posthog.models.event.util import create_event
 from posthog.models.oauth import OAuthApplication
-from posthog.scopes import UNPRIVILEGED_SCOPES
 from posthog.storage import object_storage
 
 from products.actions.backend.models.action import Action
@@ -1763,14 +1762,16 @@ class HedgeboxMatrix(Matrix):
                 authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
                 algorithm="RS256",
                 is_first_party=True,
-                # An empty ceiling resolves to UNPRIVILEGED_SCOPES at /authorize, which
-                # excludes the privileged/hidden scopes the onboarding wizard requests
-                # (llm_gateway:read, wizard_session:*) — so it failed with invalid_scope.
-                # Reproduce the broad default and add those so the wizard works locally.
-                scopes=sorted(
-                    UNPRIVILEGED_SCOPES
-                    | {"llm_gateway:read", "llm_gateway:write", "wizard_session:read", "wizard_session:write"}
-                ),
+                # No explicit ceiling: an empty `scopes` resolves to `UNPRIVILEGED_SCOPES | {"*"}`
+                # at `/authorize` (see `posthog.scopes.scopes_within_ceiling`), which grandfathers
+                # the legacy `scope=*` request PostHog Code and the CLI still send. An explicit
+                # ceiling — even a broad one — is not permitted `*` (the `"*" not in to_check`
+                # guard fires unconditionally when the ceiling is non-empty), so listing scopes
+                # here breaks first-party sign-in on this app. The onboarding wizard's
+                # privileged/hidden scopes (llm_gateway:*, wizard_session:*) — the original
+                # motivation for populating this list — are served by its own app now
+                # (`WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID`, provisioned in bin/ensure-local-setup),
+                # so grafting them here is redundant.
             )
         except (IntegrityError, ValidationError):
             pass


### PR DESCRIPTION
## Problem

Fresh local envs currently show `[404] {"error":"no_agent"}` in the Agent Builder panel because the `agent-builder` bundle isn't deployed. The seeder for the example bundles exists at `products/agent_platform/services/agent-tests/src/examples/seed.py` but it's a manual step, so every platform dev has to remember to run it (and hit the same two footguns) before the panel works.

The two footguns:

1. Slack-triggered example bundles (`agent-builder`, `sre-slack-bot`) require `SLACK_SIGNING_SECRET` + `SLACK_BOT_TOKEN` in `encrypted_env` before promote will let them go live.
2. Promote mints a companion RS256 OAuth application. django-oauth-toolkit refuses to save that without `OIDC_RSA_PRIVATE_KEY`, so local envs without the env var hand-provisioned 500 with `You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm`. TEST mode already auto-generates an ephemeral key (`posthog/settings/web.py:927`); local dev did not.

## Changes

- `bin/seed-agent-examples` — new one-shot wrapper. Waits for `/​_health/` on Django and `/​healthz` on ingress + janitor, then runs the existing Python seeder with `SEED_DUMMY_SECRETS=1` (clears the Slack-secret gate with obviously-fake placeholders — never overwrites a real value). Slug selection defaults to `agent-builder,agent-approval-demo`; override via `AGENT_SEED_SLUGS=…` or `AGENT_SEED_SLUGS=all`. Empty string skips entirely.
- `bin/mprocs.yaml` — new `agent-seed` pane under the `agent_runtime` capability, `autorestart: false`, `ready_pattern: 'seeding complete'`. Fires on `hogli start` whenever agent-platform dev is selected.
- `hogli.yaml` — hogli auto-registered `seed:agent:examples`; updated the placeholder description to match sibling entries (`ensure:local:setup`, etc.).
- `posthog/settings/web.py` — extend the existing TEST-only auto-generation of `OIDC_RSA_PRIVATE_KEY` to also cover `DEBUG and not CLOUD_DEPLOYMENT`. Cloud paths still require the real env-provided key.

> [!NOTE]
> The OIDC change is what fixed the underlying promote 500 for me. The seeder wiring on top of it is what makes it invisible to future contributors.

## How did you test this code?

I (Claude) validated locally in my env:

- Reproduced the empty-DB state, ran `SEED_DUMMY_SECRETS=1 python …/seed.py` — hit the `OIDC_RSA_PRIVATE_KEY` 500 on promote against the current Django running without the env var. Traced it to `posthog/models/oauth.py:376`.
- After the settings.py edit + Django restart, the seeder completed for `agent-approval-demo` (before, it failed there — this confirms the OIDC fix unblocks the whole promote path).
- Hand-checked `bin/seed-agent-examples`: `bash -n` clean, YAML load succeeds, `wait_for` loop tolerates a slow janitor.

I (Dylan) validated locally

- Full `hogli start` cold-boot with the new pane running through — the environment is mid-session so I didn't restart the whole stack. Reviewers who want to verify: kill everything, `./bin/start` with the `agent_runtime` capability selected, watch the `agent-seed` pane report `seeding complete`, refresh the Agents page in the app, confirm the Agent Builder panel no longer 404s.
- `AGENT_SEED_SLUGS=all` end-to-end (would drag in the whole example set, `~7` bundles).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The relevant doc is `products/agent_platform/docs/local-dev.md`, which currently instructs devs to author + promote agents manually before `bin/run-agent` will do anything. It's still accurate for anyone wanting to author their own bundle, so I've left it untouched here. Happy to add a "hogli seeds these for you" note in a follow-up if reviewers want it inline.

## Related PRs

- [PostHog/code#3279](https://github.com/PostHog/code/pull/3279) — client-side sibling for the same local-dev OAuth flow. The picker being empty after sign-in was traced to the local backend minting team-scoped tokens without `scoped_organizations`; this PR unblocks the server side (OIDC RSA fallback + demo OAuth ceiling revert) while #3279 handles the client side (fall back to `@me.organization` when the token has no scoped orgs). Both together give a one-shot local-dev sign-in.
- [PostHog/posthog#69402](https://github.com/PostHog/posthog/pull/69402) — followup that prunes the on-disk example bundle set this seeder installs (`agent-approval-demo`, `agent-builder`, `sre-slack-bot`, `wake-me-up`). Land order doesn't matter — they touch disjoint files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Dylan asked me (Claude) to bring his local agent platform into a clean state after hitting the `no_agent` 404. Diagnosing the seeder failure surfaced the OIDC 500 as the actual root cause and the missing dummy-secrets flag as the surface issue. He then asked to package the fix so nobody else has to re-derive it.

- Tools: Claude Code CLI, `psql` (via the `querying-local-postgres` skill for read-only checks; mutations run outside the skill with explicit consent).
- Skills invoked: `querying-local-postgres` to inspect `agent_application` / `agent_revision` state before cleaning up an archived `sre-slack-bot` orphan from a previous session. No other repo skills triggered — no serializer/viewset/migration/DRF changes.
- Considered doing this via a Django data migration; rejected because the migration would have to call the running janitor mid-`migrate`, which breaks the `django-migrations` skill's "migrations are pure DB" contract. A mprocs pane composes with the existing stack-startup patterns (`ensure-local-setup`, `bin/start-ai-gateway`) instead.
- Settings change modeled directly on the existing `TEST and not OIDC_RSA_PRIVATE_KEY` block; the guard combines both cases into one conditional so the intent is one read, not two.
