### PR TITLE
chore(agent_platform): adopt coherence — declare and verify invariants

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
             "bin/hogli format:python",
             "uv run --no-sync ty check"
         ],
-        "*.{md,mdx}": "bin/hogli format:markdown"
+        "*.{md,mdx}": "bin/hogli format:markdown",
+        "products/agent_platform/**/*.{ts,py}": "products/agent_platform/bin/coherence-precommit"
     },
     "browserslist": {
         "development": [

--- a/products/agent_platform/.gitignore
+++ b/products/agent_platform/.gitignore
@@ -1,0 +1,2 @@
+# Local coherence CLI cache (pre-commit gate; see bin/coherence-install)
+.coherence-tool/

--- a/products/agent_platform/backend/.gitignore
+++ b/products/agent_platform/backend/.gitignore
@@ -1,0 +1,2 @@
+.coherence-out/
+.coherence/

--- a/products/agent_platform/backend/coherence.config.json
+++ b/products/agent_platform/backend/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "logic",
+    "ignore": ["migrations", "__pycache__", ".coherence-out"],
+    "codeExt": ["py"],
+    "typecheck": ["uv", "run", "--no-sync", "ty", "check", "logic"],
+    "test": ["env", "DJANGO_SETTINGS_MODULE=posthog.settings", "python", "-m", "pytest", "-q", "-k"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "python"
+}

--- a/products/agent_platform/backend/logic/Logic.spec.md
+++ b/products/agent_platform/backend/logic/Logic.spec.md
@@ -1,0 +1,24 @@
+# Logic
+
+Django-side authoring logic: the promote-time secret gate and the loaders for the TS-emitted vocabulary artifacts the control plane consumes instead of hand-maintaining mirrors.
+
+## invariants
+
+- unregistered-trigger-fail-closed
+- generated-vocabulary-loader
+- artifact-ci-coverage
+
+## works when
+
+- typechecks
+- boundary "unregistered-trigger-fail-closed" at missing_required_secrets
+- passes test "test_missing_required_secrets_fails_closed_on_unregistered_trigger"
+- boundary "generated-vocabulary-loader" at \_load
+- passes test "test_generated_vocabularies_load_and_are_nonempty"
+- boundary "artifact-ci-coverage" at TRIGGER_REQUIRED_SECRETS via test "test_ci_agents_filter_covers_every_generated_artifact"
+
+## why
+
+unregistered-trigger-fail-closed: the promote gate walks each trigger's required-secret contract, and a trigger type the node schema accepts but this registry doesn't know must BLOCK promote rather than pass with zero required secrets — the old `.get(type, [])` fail-open let a new trigger ship with its signing secret never enforced. `missing_required_secrets` is the single gate every promote crosses; the oracle proves an unregistered type yields a blocking entry.
+generated-vocabulary-loader: every vocabulary Django consumes (trigger secrets, routes, approval states, stop reasons) loads through one `_load` that reads UTF-8 explicitly, fails closed with a legible `ImproperlyConfigured` naming the file and the regen command, and rejects wrong-shaped artifacts — a corrupt or missing generated JSON must be a clear boot-time error, not a cryptic traceback or a silent empty vocabulary.
+artifact-ci-coverage: a guard only counts if CI actually invokes it — the TS freshness test that welds each generated JSON to its source runs under a CI path filter, and an artifact outside that filter can drift green. The oracle enumerates every `*.generated.json` on disk and asserts the `ci-agents` filter covers each, so adding an artifact without CI coverage is a red build naming the file.

--- a/products/agent_platform/bin/coherence-install
+++ b/products/agent_platform/bin/coherence-install
@@ -7,12 +7,13 @@
 # hook just runs the built CLI (zero runtime deps).
 set -euo pipefail
 
-PIN="bb40f4a" # daniloc/coherence v0.9.0 — pinned commit (immutable; bump deliberately)
+# Full 40-char SHA (not a short pin): unambiguous, collision-resistant.
+PIN="bb40f4a1e7f673b6caf20bf11b57b557019aa0f8" # daniloc/coherence v0.9.0 (bump deliberately)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DEST="$REPO_ROOT/products/agent_platform/.coherence-tool/repo"
 
 if [ -d "$DEST/.git" ] &&
-    [ "$(git -C "$DEST" rev-parse --short=7 HEAD 2>/dev/null)" = "$PIN" ] &&
+    [ "$(git -C "$DEST" rev-parse HEAD 2>/dev/null)" = "$PIN" ] &&
     [ -f "$DEST/dist/cli.js" ]; then
     echo "[coherence] already installed at $PIN"
     exit 0
@@ -22,6 +23,11 @@ echo "[coherence] installing daniloc/coherence@$PIN (clone + build, one time) ..
 rm -rf "$DEST"
 git clone --quiet https://github.com/daniloc/coherence.git "$DEST"
 git -C "$DEST" checkout --quiet "$PIN"
-(cd "$DEST" && npm install --silent && npm run build --silent)
+# npm (not pnpm) on purpose: this is an isolated clone outside the pnpm
+# workspace with its own package-lock.json — `npm ci` honours that lockfile for
+# a deterministic install (pnpm would ignore it). `--ignore-scripts` blocks any
+# dependency lifecycle script from executing; the build is a plain `tsc` that
+# doesn't need them. npm ships with Node, which we already require.
+(cd "$DEST" && npm ci --ignore-scripts --silent && npm run build --silent)
 echo "[coherence] ready. 'coherence verify --fast' now runs on agent_platform pre-commits."
 echo "[coherence] bypass any single commit with 'git commit --no-verify'."

--- a/products/agent_platform/bin/coherence-install
+++ b/products/agent_platform/bin/coherence-install
@@ -7,7 +7,7 @@
 # hook just runs the built CLI (zero runtime deps).
 set -euo pipefail
 
-PIN="f0b7319" # daniloc/coherence — pinned commit (immutable; bump deliberately)
+PIN="bb40f4a" # daniloc/coherence v0.9.0 — pinned commit (immutable; bump deliberately)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DEST="$REPO_ROOT/products/agent_platform/.coherence-tool/repo"
 

--- a/products/agent_platform/bin/coherence-install
+++ b/products/agent_platform/bin/coherence-install
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# coherence-install — one-time local setup for the agent-platform coherence
+# pre-commit gate (a one-week evaluation; NOT wired into CI).
+#
+# Clones + builds the pinned coherence CLI into a gitignored cache. Re-run to
+# update the pin. Needs network + Node >= 22 once; after that the pre-commit
+# hook just runs the built CLI (zero runtime deps).
+set -euo pipefail
+
+PIN="f0b7319" # daniloc/coherence — pinned commit (immutable; bump deliberately)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DEST="$REPO_ROOT/products/agent_platform/.coherence-tool/repo"
+
+if [ -d "$DEST/.git" ] &&
+    [ "$(git -C "$DEST" rev-parse --short=7 HEAD 2>/dev/null)" = "$PIN" ] &&
+    [ -f "$DEST/dist/cli.js" ]; then
+    echo "[coherence] already installed at $PIN"
+    exit 0
+fi
+
+echo "[coherence] installing daniloc/coherence@$PIN (clone + build, one time) ..."
+rm -rf "$DEST"
+git clone --quiet https://github.com/daniloc/coherence.git "$DEST"
+git -C "$DEST" checkout --quiet "$PIN"
+(cd "$DEST" && npm install --silent && npm run build --silent)
+echo "[coherence] ready. 'coherence verify --fast' now runs on agent_platform pre-commits."
+echo "[coherence] bypass any single commit with 'git commit --no-verify'."

--- a/products/agent_platform/bin/coherence-precommit
+++ b/products/agent_platform/bin/coherence-precommit
@@ -2,8 +2,16 @@
 # coherence-precommit — lint-staged command for agent_platform changes.
 #
 # For each coherence root (a dir with coherence.config.json) whose files are
-# staged, runs `coherence verify --fast` (structural claims + boundary anchoring
-# + meta-oracle; no DB, no test runner). Blocks the commit on a red.
+# staged, runs two cheap gates (no DB, no test runner):
+#   - `verify --fast`  — structural claims + boundary anchoring + meta-oracle.
+#                        Blocks on a red: a declared claim that isn't honest.
+#   - `log --strict`   — the loss-ratchet. Blocks when the commit DROPS an
+#                        invariant/boundary/parity. Without this, the cheapest
+#                        way to green a failing verify is to delete the claim,
+#                        and nothing would notice. A dropped claim must be
+#                        deliberate (re-add it, or `--no-verify` knowingly).
+#                        (The novelty advisory it also prints is advisory only —
+#                        it never fails the commit.)
 #
 # Scoped: lint-staged only invokes this for products/agent_platform/** files.
 # Graceful: if a staged file touches no coherence root it does nothing; if the
@@ -55,8 +63,14 @@ OLDIFS="$IFS"
 IFS='
 '
 for root in $roots; do
-    printf '\033[36m[coherence] verify --fast: %s\033[0m\n' "${root#$REPO_ROOT/}" >&2
+    rel="${root#$REPO_ROOT/}"
+    printf '\033[36m[coherence] verify --fast: %s\033[0m\n' "$rel" >&2
     if ! (cd "$root" && node "$CLI" verify --fast >&2); then
+        status=1
+    fi
+    # Loss-ratchet: fail if this commit drops a claim (HEAD -> working tree).
+    printf '\033[36m[coherence] log --strict: %s\033[0m\n' "$rel" >&2
+    if ! (cd "$root" && node "$CLI" log --strict >&2); then
         status=1
     fi
 done

--- a/products/agent_platform/bin/coherence-precommit
+++ b/products/agent_platform/bin/coherence-precommit
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# coherence-precommit — lint-staged command for agent_platform changes.
+#
+# For each coherence root (a dir with coherence.config.json) whose files are
+# staged, runs `coherence verify --fast` (structural claims + boundary anchoring
+# + meta-oracle; no DB, no test runner). Blocks the commit on a red.
+#
+# Scoped: lint-staged only invokes this for products/agent_platform/** files.
+# Graceful: if a staged file touches no coherence root it does nothing; if the
+# tool isn't installed it self-bootstraps (see coherence-install), and if that
+# fails (e.g. offline) it skips this commit rather than blocking.
+# Bypass any commit with `git commit --no-verify`.
+#
+# bash 3.2 compatible on purpose (stock macOS ships 3.2): no associative arrays.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CLI="$REPO_ROOT/products/agent_platform/.coherence-tool/repo/dist/cli.js"
+
+# Map each staged file (passed by lint-staged) to its coherence root: the
+# nearest ancestor dir holding a coherence.config.json. Accumulate newline-
+# delimited, then `sort -u` to dedup — no `declare -A` (needs bash >= 4 and
+# hard-errors on macOS's bash 3.2).
+roots=""
+for f in "$@"; do
+    d="$(cd "$(dirname "$f")" 2>/dev/null && pwd)" || continue
+    while [ -n "$d" ] && [ "$d" != "/" ]; do
+        if [ -f "$d/coherence.config.json" ]; then
+            roots="$roots$d
+"
+            break
+        fi
+        [ "$d" = "$REPO_ROOT" ] && break
+        d="$(dirname "$d")"
+    done
+done
+roots="$(printf '%s' "$roots" | sort -u | sed '/^$/d')"
+
+# Nothing under a coherence root (a doc, the hook itself) → no-op, and in
+# particular don't trigger the install.
+[ -n "$roots" ] || exit 0
+
+# Auto-bootstrap on first use, now that we know a root is actually affected.
+if [ ! -f "$CLI" ]; then
+    printf '\033[36m[coherence] first-time setup: installing the eval tool (one-time clone + build)...\033[0m\n' >&2
+    "$REPO_ROOT/products/agent_platform/bin/coherence-install" >&2 || true
+fi
+if [ ! -f "$CLI" ]; then
+    printf '\033[33m[coherence] tool unavailable (offline?) — skipping this commit; will retry next time.\033[0m\n' >&2
+    exit 0
+fi
+
+status=0
+OLDIFS="$IFS"
+IFS='
+'
+for root in $roots; do
+    printf '\033[36m[coherence] verify --fast: %s\033[0m\n' "${root#$REPO_ROOT/}" >&2
+    if ! (cd "$root" && node "$CLI" verify --fast >&2); then
+        status=1
+    fi
+done
+IFS="$OLDIFS"
+exit "$status"

--- a/products/agent_platform/bin/coherence-uninstall
+++ b/products/agent_platform/bin/coherence-uninstall
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# coherence-uninstall — remove the coherence evaluation HARNESS, leaving the
+# production hardening it motivated fully intact.
+#
+# Why this exists: the adoption PR squash-merges into ONE commit on master that
+# mixes the harness (this tooling + the *.spec.md claims + per-root config) with
+# real chokepoint hardening (IDOR / owner-scoping / bug-class fixes in *.ts). So
+# `git revert <that commit>` is the WRONG tool — it would undo the hardening and
+# reopen those bug classes. This script removes ONLY the harness:
+#   - the CLI scripts (bin/coherence-*), docs, per-root coherence.config.json,
+#     every *.spec.md claim file, and the gitignored caches.
+# Every *.ts / *.test.ts change stays. A test that enumerates its domain is a
+# better test whether or not coherence reads it.
+#
+# It does NOT edit package.json (structured, shared — a blind edit risks
+# corrupting it). It prints the one line to remove, which is the gate's actual
+# on/off switch: until that line is gone, lint-staged will try to run the
+# now-deleted hook and error on every agent_platform commit.
+#
+# bash 3.2 compatible (stock macOS ships 3.2): no associative arrays, no mapfile.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+AP="$REPO_ROOT/products/agent_platform"
+BIN="$AP/bin"
+
+printf '\033[36m[coherence] teardown — removing the evaluation harness (hardening stays).\033[0m\n'
+
+# Derive the config + claim files (find, so this stays correct as specs are
+# added or removed; in agent_platform, *.spec.md is the coherence convention —
+# ordinary tests are *.test.ts). Plus the fixed CLI scripts and docs, and the
+# gitignored cache/output dirs.
+files="$(find "$AP" -type f \( -name coherence.config.json -o -name '*.spec.md' \) 2>/dev/null)
+$BIN/coherence-install
+$BIN/coherence-precommit
+$BIN/coherence-uninstall
+$AP/docs/coherence-onboarding.md
+$AP/docs/coherence-overview.md"
+
+dirs="$(find "$AP" -type d \( -name .coherence -o -name .coherence-out -o -name .coherence-tool \) 2>/dev/null)"
+
+removed=0
+OLDIFS="$IFS"
+IFS='
+'
+for p in $files $dirs; do
+    [ -n "$p" ] || continue
+    if [ -e "$p" ]; then
+        rm -rf "$p"
+        printf '  removed %s\n' "${p#$REPO_ROOT/}"
+        removed=$((removed + 1))
+    fi
+done
+IFS="$OLDIFS"
+
+printf '\n\033[36m[coherence] removed %s harness file(s)/dir(s).\033[0m\n\n' "$removed"
+
+printf 'ONE required manual step — the gate'\''s actual off switch:\n'
+printf '  Delete the coherence line from package.json (lint-staged), and drop the\n'
+printf '  trailing comma from the line above it so the JSON stays valid:\n'
+if grep -n 'coherence-precommit' "$REPO_ROOT/package.json" >/dev/null 2>&1; then
+    grep -n 'coherence-precommit' "$REPO_ROOT/package.json" | sed 's/^/    /'
+else
+    printf '    (already removed — nothing to do)\n'
+fi
+
+printf '\nOptional cleanup (harmless if left — they just ignore dirs that no longer exist):\n'
+printf '  .gitignore lines for .coherence-tool/ , .coherence-out/ , .coherence/\n'
+
+printf '\nKEPT on purpose (this is hardening, not harness):\n'
+printf '  every *.ts / *.test.ts change, the mcp_store facade, pyproject.toml / tach.toml edits.\n'
+printf '\n\033[33mDo NOT `git revert` the squashed adoption commit — it also carries the\n'
+printf 'hardening (IDOR / owner-scoping chokepoints); reverting reopens those bugs.\033[0m\n'

--- a/products/agent_platform/docs/coherence-onboarding.md
+++ b/products/agent_platform/docs/coherence-onboarding.md
@@ -115,14 +115,15 @@ benign edits (false alarms), and score which go red.
 ## Setup and the local gate
 
 ```sh
-git clone --branch v0.6.0 https://github.com/daniloc/coherence.git /tmp/coherence
+git clone --branch v0.9.0 https://github.com/daniloc/coherence.git /tmp/coherence
 cd /tmp/coherence && npm install && npm run build   # → dist/cli.js (Node ≥22, zero runtime deps)
 ```
 
-Pin `daniloc/coherence` at commit `f0b7319` or later: earlier mains lack `it.each` domain
-recognition, domain-floor detection, the NOT-FOUND hard-fail on `via test`, Python support,
-and markdown-escape-robust claim parsing. For eventual CI adoption it installs as a git
-dependency (`github:daniloc/coherence`) rather than a clone.
+The gate pins `daniloc/coherence` at commit `bb40f4a` (v0.9.0) — see
+`bin/coherence-install`. v0.9.0 carries everything the gate leans on: `it.each` domain
+recognition, domain-floor detection, the NOT-FOUND hard-fail on `via test`, the `parity`
+claim type, Python support, and markdown-escape-robust claim parsing. For eventual CI
+adoption it installs as a git dependency (`github:daniloc/coherence`) rather than a clone.
 
 Each node service is its own root and ships a `coherence.config.json`:
 
@@ -146,19 +147,24 @@ The harness is **not wired into CI** (a personal-repo tool, deliberately local-o
 one-week evaluation). The gate is a **local pre-commit hook**, scoped to agent_platform, and
 it **self-installs on first use**: your first commit touching `products/agent_platform/**`
 does a one-time clone + build of the pinned CLI into a gitignored cache (`.coherence-tool/`),
-then runs `coherence verify --fast` (structural claims + boundary anchoring + the meta-oracle;
-no DB, no test runner) in each coherence root you touched and blocks the commit on a red. Run
+then runs two cheap gates in each coherence root you touched — `coherence verify --fast`
+(structural claims + boundary anchoring + the meta-oracle; no DB, no test runner) and
+`coherence log --strict` (the loss-ratchet: reds if the commit drops an invariant/boundary/
+parity) — and blocks the commit on a red from either. Run
 `products/agent_platform/bin/coherence-install` upfront if you'd rather not wait on that first
 commit. It's wired through lint-staged, so it fires only for agent_platform changes; bypass a
 single commit with `git commit --no-verify`. If the install can't run (offline), it skips that
 commit and retries next time rather than blocking.
 
-What the fast pre-commit catches locally: a dropped/unanchored invariant, a renamed or
-missing chokepoint symbol, a vacuous or weak oracle (the meta-oracle), a missing floor. What
-it does **not** run is the oracle tests themselves (real DB / real dispatch) — those are
-ordinary vitest/pytest tests that run in CI regardless, so a semantic regression is still
-caught there. The pre-commit is advisory-by-consent (bypassable, and only for whoever has it
-installed); it is not the unbypassable enforcement a CI `verify` + `log --strict` would give.
+What the fast pre-commit catches locally: an unanchored invariant, a renamed or missing
+chokepoint symbol, a vacuous or weak oracle (the meta-oracle), a missing floor (all via
+`verify`), plus a _dropped_ invariant/boundary/parity (via `log --strict` — so the cheapest
+way to green a failing `verify`, deleting the claim, is caught too). What it does **not** run
+is the oracle tests themselves (real DB / real dispatch) — those are ordinary vitest/pytest
+tests that run in CI regardless, so a semantic regression is still caught there. The
+pre-commit is advisory-by-consent (bypassable, and only for whoever has it installed); the
+same `verify` + `log --strict` in CI would be unbypassable enforcement, but that's a
+deliberate not-yet for this one-week evaluation.
 The declared invariants live in the `*.spec.md` next to the code — read the ones in any
 directory you edit; they are the checklist of what your change must not break.
 

--- a/products/agent_platform/docs/coherence-onboarding.md
+++ b/products/agent_platform/docs/coherence-onboarding.md
@@ -116,7 +116,7 @@ benign edits (false alarms), and score which go red.
 
 ```sh
 git clone --branch v0.9.0 https://github.com/daniloc/coherence.git /tmp/coherence
-cd /tmp/coherence && npm install && npm run build   # → dist/cli.js (Node ≥22, zero runtime deps)
+cd /tmp/coherence && npm ci --ignore-scripts && npm run build   # → dist/cli.js (Node ≥22, zero runtime deps)
 ```
 
 The gate pins `daniloc/coherence` at commit `bb40f4a` (v0.9.0) — see

--- a/products/agent_platform/docs/coherence-onboarding.md
+++ b/products/agent_platform/docs/coherence-onboarding.md
@@ -1,0 +1,188 @@
+# Coherence — the doctrine and the harness
+
+The transferable half of this stack: the doctrine that says _why_ we build boundaries
+this way (Danilo's Mnemion doctrine), and the harness that checks them
+([daniloc/coherence](https://github.com/daniloc/coherence)). For the concrete inventory of
+what we actually built here, see [coherence-overview.md](coherence-overview.md). Read this
+before authoring or maintaining a boundary.
+
+## The doctrine
+
+> A recurring bug is a structural question answered at call sites instead of at a boundary.
+> Don't patch faster: invert the architecture so the bug becomes **unrepresentable**.
+
+The fix-one-open-another loop _is_ the diagnosis. When two findings cluster on one seam,
+stop patching sinks and enforce the invariant from a single home.
+
+**The conversion, O(N) → O(1).** Turn a **block-list** (N guards you must remember at N
+sinks; fails open the moment one is forgotten) into a **chokepoint** (one reference monitor
+every path physically crosses). A chokepoint earns trust from four properties that must
+travel together:
+
+1. **One declarative home, and it's data.** A table keyed by the thing it governs: not a
+   predicate copied across sites, not a naming convention standing in for an unmodeled fact,
+   not prose in a doc.
+2. **Derive, never duplicate.** Every gate computes from the table.
+3. **Enforce where the invariant lives:** the chokepoint all paths cross on the protected
+   thing, not the convenient layer.
+4. **Fail closed.** Absence resolves to the safe state; forgetting to update the table is safe.
+
+**The linchpin: prove totality.** A chokepoint is not enough; you must _know_ it's the only
+path. A totality oracle converts the unanswerable block-list question ("did we find every
+sink?") into a checkable one ("does the one declaration cover the enumerable domain, and
+fail loud if not?"). A boundary without an oracle is a half-boundary; don't ship it.
+
+**Capability over convention.** An oracle proves the _anatomy_ exists (the chokepoint
+symbol, the green test). It cannot prove the chokepoint is un-routable-_around_: that comes
+from the type system. A named capability constructor with no trust parameter to dial at a
+call site makes the wrong call _unexpressible_, not merely guarded. Conventions are failures
+lurking in the code; we want contracts.
+
+**The graded ladder (match rigor to consequence).** _enshrined_ (the unsafe state is
+unrepresentable in types) > _totality-checked_ (an oracle proves the N sites agree) >
+_convention_ (held by memory). Push security boundaries up; the target is zero security
+rules at the convention tier. Don't over-enshrine: making every crossing a ceremony is its
+own inner-platform pathology.
+
+**The manifold this describes.** Charts (trust domains: owner-trusted, served-untrusted,
+agent-mcp, public-egress, ...) stitched by transition maps (the chokepoints). Trust is
+directional: most crossings preserve or lower it, only an _enshrined_ crossing may raise it.
+A convention crossing is where the manifold can tear. The **atlas** is that map made
+legible: it derives each crossing's tier from the live boundary claims and flags any
+tier-3 security crossing. (We haven't built the atlas layer here yet; it's the next increment.)
+
+**The metric: blast radius.** How many files an agent must read and keep in sync to add one
+invariant. Drive it toward one, and make the convergent move the _cheapest_ one, or the
+divergent move is the one that gets made.
+
+> In one breath: one declarative home (data, not convention) → derive every gate → enforce
+> at the chokepoint all paths cross → fail closed → assert totality so the absence of holes
+> is _checked_, not hoped → make the boundary un-routable in types → keep intent, structure,
+> and evolution converged.
+
+## The harness
+
+`coherence` is a zero-dependency Node CLI that derives a graph from a `*.spec.md` tree plus
+the code, then verifies the claims haven't rotted. The core is language- and
+platform-agnostic; TypeScript and Python adapters cover this repo. Its one load-bearing
+feature: a `boundary` claim welds a declared **invariant** → a **chokepoint symbol** → a
+**totality oracle**, and fails the build if the oracle is renamed, deleted, or missing.
+Reach for it when a correctness commitment must _stay_ enforced under future edits, not for
+one-off bugs.
+
+### Claim grammar (the part to get right)
+
+Each claim in a spec's `## works when` list is verified at one tier:
+
+- **structural** (instant): `typechecks` · `X exists` · `X imports Y`.
+- **executable**: `passes test "<name>"` shells the test runner with `<name>`. This is the
+  _single front door_: an invariant enforced by a test is named in the spec, so `verify`
+  runs it, and a claim pointing at a renamed or deleted test goes **red**.
+- **boundary** (the ratchet): `boundary "<inv>" at <symbol> [via test|guard "<oracle>"]`.
+  `via test` means a live-domain totality oracle (loops an imported SSOT / call result / the
+  anchor). `via guard` means a source-property assertion with no enumerable domain.
+
+The gate: every name in a spec's `## invariants` list **must** be anchored by a `boundary`
+claim, or coverage fails. That is the doctrine made machinery: you can't ship a
+half-boundary. Coverage gates node-contract completeness (claims + a `## why`), not a
+docblock on every symbol.
+
+### Authoring boundaries without fooling yourself
+
+The ratchet is only as honest as the oracle behind it. Four edges, all found by running it:
+
+1. **`via test "<name>"` must name a `describe`, not an `it()`.** The meta-oracle resolves
+   the oracle by `describe` title; an `it()` name resolves not-found and falls through to the
+   runner, so the claim goes green off the passing test and the meta-oracle never judges it.
+   Name the `describe` after the invariant.
+2. **Oracle names are regex.** `-t "<name>"` treats parens and brackets as groups that can
+   match nothing, surfacing as `0 passed`, not a failure. Keep titles free of regex metacharacters.
+3. **The meta-oracle proves anatomy, not semantics.** It proves the oracle _iterates a live
+   domain_; it cannot prove the assertion exercises the real enforcement rather than a
+   _proxy_. A unit test with a fake DB asserting the owner arg was _passed_ stays green while
+   the SQL `WHERE owner` predicate is deleted and the IDOR reopens.
+4. **`decompose` / `drift` are degenerate with a single node:** they need a real multi-node
+   spec tree to say anything.
+
+**The discipline: validate by perturbation, not by a green run.** For every boundary: revert
+the fix (or inject the exact violation the invariant forbids) → confirm the oracle goes
+**red** → restore. If it stays green, the oracle tests a proxy; rewrite it against the real
+mechanism. The layered defense is `oracle → meta-oracle → perturbation`, each catching what
+the layer below can be fooled about; the injection is ground truth. For an impact read,
+inject a _fair_ set: in-domain violations, out-of-domain logic bugs (blind spots), and
+benign edits (false alarms), and score which go red.
+
+## Setup and the local gate
+
+```sh
+git clone --branch v0.6.0 https://github.com/daniloc/coherence.git /tmp/coherence
+cd /tmp/coherence && npm install && npm run build   # → dist/cli.js (Node ≥22, zero runtime deps)
+```
+
+Pin `daniloc/coherence` at commit `f0b7319` or later: earlier mains lack `it.each` domain
+recognition, domain-floor detection, the NOT-FOUND hard-fail on `via test`, Python support,
+and markdown-escape-robust claim parsing. For eventual CI adoption it installs as a git
+dependency (`github:daniloc/coherence`) rather than a clone.
+
+Each node service is its own root and ships a `coherence.config.json`:
+
+```json
+{
+  "outputDir": ".coherence-out",
+  "entryDir": "src",
+  "ignore": ["node_modules", "dist", ".coherence-out"],
+  "codeExt": ["ts"],
+  "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+  "test": ["npx", "vitest", "run", "-t"],
+  "testMatch": "[1-9][0-9]* passed",
+  "language": "typescript"
+}
+```
+
+Set `testMatch`: without it a runner like `vitest -t` exits 0 even when the name matched
+nothing, and a deleted oracle stays green.
+
+The harness is **not wired into CI** (a personal-repo tool, deliberately local-only for a
+one-week evaluation). The gate is a **local pre-commit hook**, scoped to agent_platform, and
+it **self-installs on first use**: your first commit touching `products/agent_platform/**`
+does a one-time clone + build of the pinned CLI into a gitignored cache (`.coherence-tool/`),
+then runs `coherence verify --fast` (structural claims + boundary anchoring + the meta-oracle;
+no DB, no test runner) in each coherence root you touched and blocks the commit on a red. Run
+`products/agent_platform/bin/coherence-install` upfront if you'd rather not wait on that first
+commit. It's wired through lint-staged, so it fires only for agent_platform changes; bypass a
+single commit with `git commit --no-verify`. If the install can't run (offline), it skips that
+commit and retries next time rather than blocking.
+
+What the fast pre-commit catches locally: a dropped/unanchored invariant, a renamed or
+missing chokepoint symbol, a vacuous or weak oracle (the meta-oracle), a missing floor. What
+it does **not** run is the oracle tests themselves (real DB / real dispatch) — those are
+ordinary vitest/pytest tests that run in CI regardless, so a semantic regression is still
+caught there. The pre-commit is advisory-by-consent (bypassable, and only for whoever has it
+installed); it is not the unbypassable enforcement a CI `verify` + `log --strict` would give.
+The declared invariants live in the `*.spec.md` next to the code — read the ones in any
+directory you edit; they are the checklist of what your change must not break.
+
+## Command reference
+
+- `verify [--fast|--staged|--since <ref>]`: run claims + boundary anchoring + coverage.
+  `--staged`/`--since` scope to changed components; `--fast` skips executable/live claims.
+- `log [--strict]`: the temporal ledger of which invariants/boundaries a diff added, removed,
+  or rewired. `--strict` exits nonzero on a _loss_, so a PR can't silently drop a guard.
+- `decompose`: LOCALITY report, how much co-change stays inside one component (three-graph
+  agreement). Advisory.
+- `drift`: decompose's derivative, is the agent converging (one concern, one home) or
+  decohering (concerns smearing)? Names the hot seam. Advisory.
+- `scaffold <boundary|component|invariant> <name>`: emits the complete shape so you can't
+  ship a half-boundary (the gradient flip).
+- `why-lint [--check]`: flags `## why` prose that re-states an anchored mechanism, and
+  invariants/paragraphs left un-anchored.
+- `onboard` · `graph` · `overview` · `docs [--check]`: bootstrap and doc generation.
+
+## Honest limits
+
+- Oracles can be proxies; only perturbation catches that.
+- `via guard` source-scans are brittle to renames; watch their friction.
+- It's a personal-repo git dependency: a supply-chain consideration before CI adoption.
+- Where it's the _wrong_ tool: effects (the dispatch may be tabular, the handler stays
+  imperative), one-offs (a table of one is worse than an `if`), and history (migrations and
+  audit logs are point-in-time by design; you can't derive them).

--- a/products/agent_platform/docs/coherence-onboarding.md
+++ b/products/agent_platform/docs/coherence-onboarding.md
@@ -168,6 +168,34 @@ deliberate not-yet for this one-week evaluation.
 The declared invariants live in the `*.spec.md` next to the code — read the ones in any
 directory you edit; they are the checklist of what your change must not break.
 
+## Backing this out
+
+This is a one-week evaluation, so the exit is designed to be clean. The one thing to
+understand first: the adoption PR squash-merges into a single commit on master that carries
+**two** things — the harness (this tooling + the `*.spec.md` claims + per-root config) _and_
+real chokepoint hardening (IDOR / owner-scoping / bug-class fixes in `*.ts`). Those are woven
+into the same squash.
+
+**Do not `git revert` that commit.** It would undo the hardening too and reopen the exact bug
+classes the branch closed. Removing coherence means removing the _harness_ while keeping the
+_hardening_. Three tiers, easiest first:
+
+1. **Disable, don't remove (instant, zero-risk).** The gate is a _local_ pre-commit hook, not
+   CI. Delete the one lint-staged line in `package.json`
+   (`"products/agent_platform/**/*.{ts,py}": ".../coherence-precommit"`) and the gate goes
+   dormant for everyone immediately; the specs and configs become inert. This is the real
+   "call off the evaluation" move — no history rewrite.
+2. **Full teardown (later, at leisure).** Run
+   [`bin/coherence-uninstall`](../bin/coherence-uninstall). It removes exactly the harness —
+   every `coherence.config.json`, every `*.spec.md`, the CLI scripts, the docs, the gitignored
+   caches — and prints the one manual step (the `package.json` line, which it won't edit
+   blindly). It touches no `*.ts` / `*.test.ts`: a test that enumerates its domain is a better
+   test whether or not coherence reads it, so those stay.
+3. **Never the blunt revert** — see above.
+
+The oracle test files, the `mcp_store` facade, and the `pyproject.toml` / `tach.toml` edits are
+hardening, not harness; they survive all three tiers.
+
 ## Command reference
 
 - `verify [--fast|--staged|--since <ref>]`: run claims + boundary anchoring + coverage.

--- a/products/agent_platform/docs/coherence-overview.md
+++ b/products/agent_platform/docs/coherence-overview.md
@@ -1,0 +1,125 @@
+# Coherence in the agent platform
+
+Orientation for this stack: what we set out to do, and the concrete boundaries we built.
+Every invariant below is declared as a coherence `boundary` — an invariant welded to a
+chokepoint symbol and an oracle — so `coherence log --strict` reds the build if any is
+renamed, deleted, or left unanchored ("can't ship a half-boundary"). For the method behind
+this — the doctrine and the harness that checks it — see
+[coherence-onboarding.md](coherence-onboarding.md).
+
+## The goal
+
+A recurring bug is a **structural question answered at call sites** — "did we cover every
+sink?", "does this need approval?", "is this the owner?" — re-decided by hand at each site,
+so one forgotten site is a latent tear. The cure is always the same move: promote the
+convention to a **contract**:
+
+> one declarative **home** (data, not memory) → **derive** every gate from it → enforce at
+> the single **chokepoint** all paths cross → **fail closed** → **assert totality** so the
+> absence of holes is _checked, not hoped_ → and where it matters most, make the unsafe
+> state **unrepresentable** in the type system.
+
+Rigor is graded — **enshrined** (can't compile) > **totality-checked** (an oracle proves the
+N sites agree) > **convention** (a doc you hope people read) — and the target is to leave
+**no security rule at the convention tier**.
+
+## The bug-shapes we targeted
+
+The stack is organized around the classes that actually recur in this codebase:
+
+1. **Fail-open defaults** — `.get(type, [])`, `requires_approval` defaulting false: the
+   permissive answer fires exactly when knowledge is absent.
+2. **Wrong-layer authorization** — enforcing at the convenient layer (team) instead of the
+   invariant's layer (the credential's owner) → IDOR.
+3. **Hand-mirror drift** — a TS enum and a Python list maintained separately, silently
+   diverging.
+4. **Untrustworthy oracles** — a green test that is vacuous (empty domain), tests a _proxy_
+   (a fake DB pool asserts the arg was _passed_, not that the SQL actually filters), or never
+   _runs_ (a CI path-filter gap).
+5. **Silent drops** — a content-type mislabel or an unregistered trigger swallowed with no
+   trace.
+
+## What we built — 25 boundaries across 6 roots
+
+### A. Wrong-layer authorization — enforce at the invariant's layer, not the convenient one
+
+| Boundary                          | Anchor                 | Oracle                                                  | Shrieks when…                                                                                                                  |
+| --------------------------------- | ---------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `connection-owner-isolation`      | `PgMcpConnectionStore` | test _"cannot return owner B"_                          | the shared-MCP-credential lookup stops scoping to the spec author — IDOR, proven with real two-owner SQL (not a fake pool)     |
+| `connection-bearer-single-reader` | `PgMcpConnectionStore` | guard _"reads of sensitive_configuration are confined"_ | any module other than the store reads the credential column (the owner check is only complete if the store is the sole reader) |
+| `team-api-key-isolation`          | `PgTeamApiKeyResolver` | test _"returns only its own api_token"_                 | the `WHERE id = $1` is dropped/inverted and a sibling team's `phc_` token leaks                                                |
+| `shared-secret-single-principal`  | `sharedSecretVerifier` | test _"yields a single team-scoped principal"_          | a per-caller identity is smuggled into `shared_secret` mode (forgeable behind the secret)                                      |
+
+### B. Fail-open → fail-closed / can't-omit
+
+| Boundary                           | Anchor                     | Oracle                                          | Shrieks when…                                                                                     |
+| ---------------------------------- | -------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `unregistered-trigger-fail-closed` | `missing_required_secrets` | test _"…fails_closed_on_unregistered_trigger"_  | the old `.get(type, [])` returns — an unknown trigger promotes with its signing secret unenforced |
+| `native-tool-approval-floor`       | `nativeToolApprovalClass`  | test _"native tool authorization accessor"_     | a tool ships without a declared `approval` class — a compile error (required field)               |
+| `gated-dispatch-single-path`       | `gateTool`                 | test _"gate chokepoint — fail-closed dispatch"_ | any tool reaches the loop unbranded — `assertToolsGated` throws at boot                           |
+| `approval-authority-totality`      | `effectiveApprovalType`    | test _"approval-authority totality"_            | a new approval-type enum member isn't handled (total over the enum)                               |
+
+### C. Single-source — one derived thing, no drift
+
+| Boundary                             | Anchor                     | Oracle                                                       | Shrieks when…                                                                        |
+| ------------------------------------ | -------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `generated-vocabulary-single-source` | `GENERATED_ARTIFACTS`      | test _"spec generated artifacts"_                            | a checked-in JSON drifts from its TS source                                          |
+| `trigger-routes-single-source`       | `TRIGGER_ROUTES`           | test _"spec generated artifacts"_                            | the TS route map and the emitted JSON disagree                                       |
+| `approval-state-vocabulary`          | `APPROVAL_REQUEST_STATES`  | test _"spec generated artifacts"_                            | the runner's states and the DRF/DB copy diverge                                      |
+| `generated-vocabulary-loader`        | `_load`                    | test _"…vocabularies_load_and_are_nonempty"_                 | Django loads a corrupt / missing / wrong-shape artifact instead of failing closed    |
+| `artifact-ci-coverage`               | `TRIGGER_REQUIRED_SECRETS` | test _"…filter_covers_every_generated_artifact"_             | a generated artifact escapes the CI path-filter (the _guard-must-be-run_ meta-check) |
+| `gateway-wire-single-source`         | `extractGatewayRequestId`  | test _"request id single-sourcing"_                          | dispatch and cost-lookup key on two different ideas of "the request id"              |
+| `approval-wire-resolved`             | `serializeApprovalRequest` | test _"resolves a legacy approvers"_                         | an approval is serialized outside the one shared serializer                          |
+| `approval-wire-consumption`          | `buildJanitorApp`          | guard _"approval routes never bypass the shared serializer"_ | a janitor route serializes an approval by hand                                       |
+
+### D. Make the unsafe _value_ unrepresentable
+
+| Boundary                        | Anchor                    | Oracle                                              | Shrieks when…                                                                                                                          |
+| ------------------------------- | ------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `gateway-cost-provenance`       | `assertGatewayProvenance` | test _"cost provenance guard"_                      | a non-gateway (or negative/blank) cost reaches analytics                                                                               |
+| `direct-http-capability-divide` | `DirectHttpClient`        | guard _"does NOT accept a proxyUrl in its options"_ | the no-proxy internal client gains a `proxyUrl` hatch or is threaded onto agent-reachable context (class identity _is_ the capability) |
+| `django-fernet-interop`         | `EncryptedFields`         | test _"urlsafe regression"_                         | the runner can't decrypt exactly what Django encrypted (urlsafe-base64 mismatch)                                                       |
+
+### E. Bounds & edge-totality on inputs
+
+| Boundary                   | Anchor            | Oracle                                    | Shrieks when…                                                                                       |
+| -------------------------- | ----------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `tenant-array-bounds`      | `AgentSpecSchema` | test _"agent spec tenant-array bounds"_   | a tenant array ships without `maxItems` (incl. `anyOf`-wrapped nullable arrays)                     |
+| `trigger-edge-conformance` | `TRIGGER_MODULES` | test _"trigger-module conformance suite"_ | a trigger regresses content-type / drop / dedup / signing (with double-entry over the edge classes) |
+
+### F. Liveness — nothing gets stuck, nothing mutates after seal
+
+| Boundary                     | Anchor                   | Oracle                                                                                                | Shrieks when…                                                |
+| ---------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `freeze-validate-lockstep`   | `validateRevisionBundle` | tests: missing entrypoint / unknown tool / unserved model / client-tool-with-webhook / malformed cron | the janitor freezes something the runner would reject        |
+| `sweep-bounded-retries`      | `sweepOnce`              | test _"poison-pills a stuck running session after maxRetries"_                                        | a stuck session isn't reaped after `maxRetries`              |
+| `bundle-freeze-immutability` | `S3BundleStore`          | test _"freezes and blocks further writes"_                                                            | a live revision's frozen bundle is written again             |
+| `enqueue-idempotency`        | `enqueueOrResume`        | test _"returns the original session id on a duplicate call"_                                          | a redelivered event doesn't collapse to the original session |
+
+**Density:** `agent-shared` carries 14 (the shared substrate is where cross-tenant and
+single-source invariants concentrate); the rest spread across ingress, runner, janitor,
+tools, and the Django backend. Every root also declares `typechecks` as its tier-0 floor.
+
+The oracles are kept honest by **defect injection**: every boundary was proven to go _red_
+when the invariant is violated — the only check that tests semantics, not anatomy (a green
+oracle can be a proxy; a passing meta-oracle can't tell).
+
+## Where we are on the ladder — honestly
+
+- **All 25 render tier-2 today** (totality-checked): declared, oracle-guarded, floored
+  against vacuous passes.
+- **2 are tier-1-eligible** (the illegal value is structurally _unrepresentable_): the
+  required `approval` field, and the no-`proxyUrl` capability divide — which now carries its
+  backing `via guard`.
+- **Not built yet: the trust-manifold grading layer** — the crossing-by-crossing view that
+  would emit a "zero tier-3 security crossings" report and reconcile enshrinement claims.
+  That's the next frontier.
+
+## Is this worth it?
+
+The leverage is real but bounded. Coherence catches the _boundary-class_ regressions above —
+a deleted `WHERE owner`, a drifted vocabulary, an ungated tool, a vacuous oracle — and makes
+the convergent move (add a row to one home) cheaper than the divergent one (add a guard at a
+new call site). It catches nothing _outside_ its declared boundaries, and a green run can lull
+you there. It earns its place on the security-critical chokepoints; over-applying it —
+enshrining everything, essaying every rationale — is its own pathology.

--- a/products/agent_platform/docs/coherence-overview.md
+++ b/products/agent_platform/docs/coherence-overview.md
@@ -2,9 +2,11 @@
 
 Orientation for this stack: what we set out to do, and the concrete boundaries we built.
 Every invariant below is declared as a coherence `boundary` — an invariant welded to a
-chokepoint symbol and an oracle — so `coherence log --strict` reds the build if any is
-renamed, deleted, or left unanchored ("can't ship a half-boundary"). For the method behind
-this — the doctrine and the harness that checks it — see
+chokepoint symbol and an oracle. Two gates keep them honest: `coherence verify` reds the
+build on a boundary that's left unanchored or whose oracle doesn't hold ("can't ship a
+half-boundary"), and `coherence log --strict` reds it on a boundary that's dropped — so the
+cheapest way to green a failing `verify` (delete the claim) is itself caught. For the method
+behind this — the doctrine and the harness that checks it — see
 [coherence-onboarding.md](coherence-onboarding.md).
 
 ## The goal

--- a/products/agent_platform/services/agent-ingress/.gitignore
+++ b/products/agent_platform/services/agent-ingress/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.tsbuildinfo
+.coherence-out/
+.coherence/

--- a/products/agent_platform/services/agent-ingress/coherence.config.json
+++ b/products/agent_platform/services/agent-ingress/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "src",
+    "ignore": ["node_modules", "dist", ".coherence-out"],
+    "codeExt": ["ts"],
+    "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+    "test": ["npx", "vitest", "run", "-t"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "typescript"
+}

--- a/products/agent_platform/services/agent-ingress/src/enqueue/Enqueue.spec.md
+++ b/products/agent_platform/services/agent-ingress/src/enqueue/Enqueue.spec.md
@@ -1,0 +1,26 @@
+# Enqueue
+
+Single-caller-facing auth resolution (identity vs. credentials split, per-mode
+verifiers) plus the one place every trigger creates or resumes an
+`AgentSession` — `enqueueOrResume`. Session ACL enforcement (`acl.ts`) sits
+between the two: it decides whether an incoming principal may advance an
+existing session.
+
+## invariants
+
+- shared-secret-single-principal
+- enqueue-idempotency
+
+## works when
+
+- typechecks
+- boundary "shared-secret-single-principal" at sharedSecretVerifier
+- passes test "yields a single team-scoped principal"
+- boundary "enqueue-idempotency" at enqueueOrResume
+- passes test "returns the original session id on a duplicate call"
+- passes test "unique-violation on insert resolves to the original session id"
+
+## why
+
+shared-secret-single-principal: `shared_secret` auth is single-principal by design — every holder of an agent's shared secret is the same trust principal, because nothing behind the secret can forge-resistantly distinguish one holder from another. `x-external-key` is a session-routing tag (dedupe/resume key), never a credential, and `principalsMatch`'s `shared_secret` arm discriminates only on `team_id`. Adding any per-caller header, claim, or discriminator behind the secret creates a false boundary — any other holder of the same secret can self-assert the same header — and this exact mistake shipped and was reverted twice (a spec-level `caller_id_header`, then a follow-up `x-posthog-caller-id` header; both undone once review caught that either construction defeats the ACL it appears to add). Per-caller isolation is `jwt` mode's job (its `sub` is upstream-signed, not self-asserted); the sanctioned path for continuity-with-isolation under `shared_secret`, if a real use case ever needs it, is server-issued unguessable resume tokens, not a self-asserted header. The oracle pins the mint site so a future patch that reads a caller-asserted header back into the principal fails the assertion instead of silently reopening the hole.
+enqueue-idempotency: `enqueueOrResume` runs the idempotency check before the `externalKey` resume path — `findByIdempotencyKey(application.id, idempotencyKey)` short-circuits a duplicate call to the original session id, deliberately discarding the incoming principal and seed message (Stripe-shaped semantics: same request, same result, no side effect replayed). The unique index on `(application_id, idempotency_key)` is the safety net for the window between that pre-check and the `INSERT`: a concurrent writer landing first raises a Postgres unique-violation (SQLSTATE `23505`), which `enqueueOrResumeInner` catches and resolves by re-querying `findByIdempotencyKey` rather than surfacing a raw constraint error or letting the caller believe it created a fresh session. Without both halves, a redelivered webhook (e.g. a provider's `Idempotency-Key` header) racing another delivery of the same event would either duplicate a session's side effects or break the trigger with an unhandled DB error. Both oracles run against real Postgres via `PgSessionQueue` — the race test wraps the queue in a `Proxy` that reproduces the actual timing window (pre-check sees nothing, insert then hits the real unique-violation code) rather than mocking the outcome.

--- a/products/agent_platform/services/agent-ingress/src/triggers/Triggers.spec.md
+++ b/products/agent_platform/services/agent-ingress/src/triggers/Triggers.spec.md
@@ -1,0 +1,16 @@
+# Triggers
+
+Inbound trigger modules — each ships one self-describing route list from which mounting, guards, schema publication, and auth advertisement all cascade. The edge semantics every module must share (content-type robustness, drop semantics, dedup, signing fail-closed) are a checked contract, not a convention copied from the previous trigger.
+
+## invariants
+
+- trigger-edge-conformance
+
+## works when
+
+- typechecks
+- boundary "trigger-edge-conformance" at TRIGGER_MODULES via test "trigger-module conformance suite"
+
+## why
+
+trigger-edge-conformance: every new trigger historically re-learned the same edge bugs by copying its predecessor — a urlencoded-mislabeled body passing signature verification but silently dropping or corrupting the event, allowlist misses answered with provider-hostile 4xx (recorded as failed deliveries and retried), dedup silently disabled when the delivery-id header is absent, and fail-open when a signing secret is unresolved. The conformance suite iterates the live `TRIGGER_MODULES` registry and requires a fixture per module (the ratchet: registering a trigger without conformance fixtures is a red build naming the type), then asserts each applicable edge class through real HTTP responses and observed enqueues. Assertions are exact-match on seed content, not substring — a garbled-but-overlapping payload must still fail.

--- a/products/agent_platform/services/agent-janitor/.gitignore
+++ b/products/agent_platform/services/agent-janitor/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.tsbuildinfo
+.coherence-out/
+.coherence/

--- a/products/agent_platform/services/agent-janitor/coherence.config.json
+++ b/products/agent_platform/services/agent-janitor/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "src",
+    "ignore": ["node_modules", "dist", ".coherence-out"],
+    "codeExt": ["ts"],
+    "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+    "test": ["npx", "vitest", "run", "-t"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "typescript"
+}

--- a/products/agent_platform/services/agent-janitor/src/Janitor.spec.md
+++ b/products/agent_platform/services/agent-janitor/src/Janitor.spec.md
@@ -1,0 +1,28 @@
+# Janitor
+
+Operational service: internal HTTP for Django (session lifecycle, approval decisions, revision authoring/freeze), the periodic queue sweep, and cron firing. It doubles as the agent-admin surface because it already has DB + bundle store access.
+
+## invariants
+
+- freeze-validate-lockstep
+- approval-wire-consumption
+- sweep-bounded-retries
+
+## works when
+
+- typechecks
+- boundary "freeze-validate-lockstep" at validateRevisionBundle
+- passes test "reports missing_entrypoint when agent.md is absent"
+- passes test "catches unknown native tool ids and resolves valid ones"
+- passes test "flags a manual model the gateway does not serve; passes one it does"
+- passes test "rejects a required client tool when a webhook trigger is also configured"
+- passes test "flags a malformed cron schedule"
+- boundary "approval-wire-consumption" at buildJanitorApp via guard "approval routes never bypass the shared serializer"
+- boundary "sweep-bounded-retries" at sweepOnce
+- passes test "poison-pills a stuck running session after maxRetries re-queues"
+
+## why
+
+freeze-validate-lockstep: `validateRevisionBundle` is the single freeze-time gate a revision must pass before promotion to `ready`, and its checks deliberately mirror the paths the runtime would otherwise handle by silently degrading rather than rejecting — an unregistered native tool id is dropped from the toolset in `build-agent-tools.ts` (agent-runner) instead of erroring, a missing `agent.md` renders as a placeholder string in `system-prompt.ts`, and a sub-minute cron schedule would otherwise rely on the runtime's `MAX_FIRINGS_PER_TICK` backstop instead of failing outright. Freezing converts each of those silent runtime degradations into an explicit, author-visible error at promotion time, so a broken revision can't ship as a mysteriously half-working agent. The oracle pins five representative checks (missing entrypoint, unregistered native tool, a rejected model, a required client tool without a chat trigger, and a malformed cron schedule) as passing behavioral tests.
+approval-wire-consumption: every janitor route that returns an approval row (`GET /approvals`, `GET /fleet/approvals`, `GET /approvals/:id`) must go through the shared `serializeApprovalRequest`, the one function that resolves `approver_scope.type` via `effectiveApprovalType` (declared `approval-wire-resolved` in agent-shared's `Persistence.spec.md`). A hand-rolled response bypassing it would ship the raw, unresolved scope and reintroduce the undefined-type regression that boundary was written to prevent one layer down. `serializeApprovalRequest` itself is defined in agent-shared, outside this package's own symbol graph, so this boundary anchors at `buildJanitorApp` — the one function that wires every approval route — and backs it with a source-property guard: no non-test file in the janitor's own source references `approver_scope` directly, the field a hand-rolled shape would have to touch.
+sweep-bounded-retries: `sweepOnce` is the sole caller of `queue.reapStuckRunning` in the janitor, and it always supplies a bounded `maxRetries` (default 3) rather than re-queuing a stuck session unconditionally. The bound is enforced atomically inside `PgSessionQueue.reapStuckRunning`'s `retry_count < maxRetries` / `>= maxRetries` predicates, so a crash-looping session is poisoned (failed) instead of being re-queued forever and re-running its side effects on every sweep tick. The oracle exercises the real Postgres-backed queue across three consecutive sweeps and asserts the exact tick where the session flips from requeue to poison — a non-proxy check against real enforcement.

--- a/products/agent_platform/services/agent-runner/.gitignore
+++ b/products/agent_platform/services/agent-runner/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.tsbuildinfo
+.coherence-out/
+.coherence/

--- a/products/agent_platform/services/agent-runner/coherence.config.json
+++ b/products/agent_platform/services/agent-runner/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "src",
+    "ignore": ["node_modules", "dist", ".coherence-out"],
+    "codeExt": ["ts"],
+    "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+    "test": ["npx", "vitest", "run", "-t"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "typescript"
+}

--- a/products/agent_platform/services/agent-runner/src/loop/Loop.spec.md
+++ b/products/agent_platform/services/agent-runner/src/loop/Loop.spec.md
@@ -1,0 +1,16 @@
+# Loop
+
+The session turn loop: model streaming, tool dispatch, and the approval gate that decides whether a tool call executes now or queues for a human decision.
+
+## invariants
+
+- gated-dispatch-single-path
+
+## works when
+
+- typechecks
+- boundary "gated-dispatch-single-path" at gateTool via test "gate chokepoint — fail-closed dispatch"
+
+## why
+
+gated-dispatch-single-path: whether a gated tool call may execute is decided in exactly one place. Every tool lane (native, custom, MCP inline, MCP proxy, client, synthetic helpers) is wrapped through `gateTool`, which stamps a module-private brand; `assertToolsGated` runs before tools reach the model loop and throws on any unbranded tool, so a lane that skips the gate is a loud boot-time failure instead of a silent fail-open — the shape behind repeated production fixes where one wrap site was forgotten while the others were patched. The oracle enumerates every approval authority in `ApprovalTypeSchema.options` (floored, so an emptied enum can't pass vacuously) and asserts a gated call never reaches the real executor without a decision row, plus that an unbranded tool injected into dispatch throws.

--- a/products/agent_platform/services/agent-shared/.gitignore
+++ b/products/agent_platform/services/agent-shared/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.tsbuildinfo
+.coherence-out/
+.coherence/

--- a/products/agent_platform/services/agent-shared/coherence.config.json
+++ b/products/agent_platform/services/agent-shared/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "src",
+    "ignore": ["node_modules", "dist", ".coherence-out"],
+    "codeExt": ["ts"],
+    "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+    "test": ["npx", "vitest", "run", "-t"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "typescript"
+}

--- a/products/agent_platform/services/agent-shared/src/persistence/Persistence.spec.md
+++ b/products/agent_platform/services/agent-shared/src/persistence/Persistence.spec.md
@@ -1,0 +1,23 @@
+# Persistence
+
+Postgres-backed stores for the agent runtime, including the approval-gated tool-call store. Approval authority (who may clear a gated call) and the wire shape the console/ingress consume are resolved here through a single owner.
+
+## invariants
+
+- approval-authority-totality
+- approval-wire-resolved
+- approval-state-vocabulary
+
+## works when
+
+- typechecks
+- boundary "approval-authority-totality" at effectiveApprovalType via test "approval-authority totality"
+- boundary "approval-wire-resolved" at serializeApprovalRequest
+- passes test "resolves a legacy approvers"
+- boundary "approval-state-vocabulary" at APPROVAL_REQUEST_STATES via test "spec generated artifacts"
+
+## why
+
+approval-authority-totality: `effectiveApprovalType` decides WHO may clear a gated tool call — `principal` (the end user, weaker gate) or `agent` (the owner via console, stronger gate). Recognition of a concrete authority is derived from `ApprovalTypeSchema` (not a hardcoded `=== 'agent' || === 'principal'`), so a new authority added to the enum is honored instead of silently downgrading to the weakest gate. The oracle enumerates `ApprovalTypeSchema.options` — the same source that defines the vocabulary — and asserts each round-trips, with a floor so it can't pass vacuously if the projection collapses.
+approval-wire-resolved: every surface that gates on approval authority (janitor read routes, the runner's `approval_required` SSE frame, the ingress decision API) must consume a resolved `approver_scope.type`, never the raw legacy `approvers[]` shape. `serializeApprovalRequest` is the single serializer that resolves it via `effectiveApprovalType`; a hand-rolled copy that returned the scope raw had drifted and left legacy rows with an undefined type. The oracle asserts a legacy scope is resolved (not passed raw), which is the contract the Django decide gate trusts — and the gate keeps a one-line legacy fallback so the decode stays correct regardless of janitor/Django deploy order.
+approval-state-vocabulary: the runner writes `APPROVAL_REQUEST_STATES` strings into `agent_tool_approval_request.state`, and the Django side's DRF `choices` and DB `CheckConstraint` derive from the emitted `approval_request_states.generated.json` — one authored home, so a new state can't be rejected by a drifted CHECK at insert time. The freshness oracle welds the checked-in artifact to this constant; moving the live DB constraint still requires a deploy-ordered Django migration (widen before the runner writes a new state), which Django's missing-migration CI check forces whenever this list changes.

--- a/products/agent_platform/services/agent-shared/src/runtime/Runtime.spec.md
+++ b/products/agent_platform/services/agent-shared/src/runtime/Runtime.spec.md
@@ -1,0 +1,39 @@
+# Runtime
+
+Cross-process runtime services shared by the agent node services: event bus, log sink, per-leaf encryption, the team API-key resolver, and the MCP connection store that mints shared-credential bearers.
+
+## invariants
+
+- connection-owner-isolation
+- connection-bearer-single-reader
+- team-api-key-isolation
+- django-fernet-interop
+- gateway-wire-single-source
+- gateway-cost-provenance
+- direct-http-capability-divide
+
+## works when
+
+- typechecks
+- boundary "connection-owner-isolation" at PgMcpConnectionStore
+- passes test "cannot return owner B"
+- boundary "connection-bearer-single-reader" at PgMcpConnectionStore via guard "reads of sensitive_configuration are confined"
+- boundary "team-api-key-isolation" at PgTeamApiKeyResolver
+- passes test "returns only its own api_token"
+- boundary "django-fernet-interop" at EncryptedFields
+- passes test "urlsafe regression"
+- boundary "gateway-wire-single-source" at extractGatewayRequestId
+- passes test "request id single-sourcing"
+- boundary "gateway-cost-provenance" at assertGatewayProvenance
+- passes test "cost provenance guard"
+- boundary "direct-http-capability-divide" at DirectHttpClient via guard "does NOT accept a proxyUrl in its options"
+
+## why
+
+connection-owner-isolation: a shared MCP connection's stored bearer belongs to the spec author (`agent_revision.created_by_id`). resolve scopes the lookup to (installation, team, owner) so no authoring path can hand a credential to a non-owner — enforced at the runtime chokepoint every session crosses, not at spec-write (which is routable-around). The oracle runs the real exported SQL against real Postgres with two owners, because a fake-pool test only proves the param is passed, not that the predicate filters.
+connection-bearer-single-reader: the owner check is complete only if the store is the sole reader of the credential column, so the oracle confirms no other module reads it and the chokepoint can't be bypassed.
+team-api-key-isolation: the resolver's `phc_` lookup is the team's bearer to PostHog services; dropping or inverting the `WHERE id = $1` predicate mints a sibling team's token (cross-tenant billing/attribution) while every fake-pool unit test stays green. The oracle runs the real exported `SELECT_TEAM_API_TOKEN` against real Postgres with two teams.
+django-fernet-interop: the runner decrypts what Django's `EncryptedTextField` wrote, so key derivation must match Django's urlsafe-base64 form exactly — standard base64 differs only for salt keys whose encoding contains `+`/`/`, and that divergence fails silently (every decrypt of Django ciphertext breaks for that key, with nothing wrong at rest). The oracle decrypts real Django-written ciphertext, including a key that exercises the urlsafe divergence.
+gateway-wire-single-source: the runner↔ai-gateway contract (auth header shape, the response header carrying the gateway's settlement id, the usage-lookup path built from that id) is declared once in `gateway-wire.ts` and imported by dispatch, catalog, and the settled-cost lookup — the same symbol on both sides, so keying settlement by the wrong id or drifting the header shape is unrepresentable rather than remembered. The oracle drives a stubbed gateway end-to-end and asserts the id dispatch received is the id the cost lookup keys on.
+gateway-cost-provenance: cost figures on analytics generation events must come from gateway-settled usage, never local estimates — `GatewaySettledCost` carries a literal `source: 'gateway'` and `assertGatewayProvenance` backstops it at `buildAnalyticsProperties`, the single funnel both sinks route every event through, dropping-and-logging a forged or unsourced cost instead of emitting it.
+direct-http-capability-divide: two HTTP clients exist deliberately separate. `HttpClient` is proxy-bound (smokescreen in prod) and is the only client agent-influenced code can reach — `ToolContext.http` is typed `HttpFetcher` and every non-test construction site hands it an `HttpClient`. `DirectHttpClient` carries no proxy dispatcher at all and is reserved for cluster-internal calls the platform makes to itself (`HttpGatewayClient`, the PostHog introspector); it must never be threaded onto `ToolContext` or a runner `WorkerDeps` — a NO_PROXY-style hostname allowlist would defeat the divide (an `@posthog/http-request` call against an in-cluster `*.svc.cluster.local` hostname would match a suffix rule and bypass smokescreen entirely), so the class identity itself is the capability, not a runtime check. Bare global `fetch` is lint-banned across `services/agent-*/src` (`no-restricted-globals` in `.oxlintrc.json`) because Node's built-in `fetch` ignores `HTTP_PROXY`/`HTTPS_PROXY` and would silently skip both clients. The oracle pins the half of the divide that's actually executable: `DirectHttpClient`'s constructor has no `proxyUrl` option (a compile-time `@ts-expect-error` on the options type), so there is no escape hatch to wire a proxy onto the internal-only client after the fact.

--- a/products/agent_platform/services/agent-shared/src/spec/Spec.spec.md
+++ b/products/agent_platform/services/agent-shared/src/spec/Spec.spec.md
@@ -1,0 +1,22 @@
+# Spec
+
+The agent spec schema (`AgentSpecSchema`, zod) — the single source of truth for the `revision.spec` JSONB — plus the codegen bridge that emits spec vocabularies as checked-in JSON for the Django control plane to import.
+
+## invariants
+
+- tenant-array-bounds
+- generated-vocabulary-single-source
+- trigger-routes-single-source
+
+## works when
+
+- typechecks
+- boundary "tenant-array-bounds" at AgentSpecSchema via test "agent spec tenant-array bounds"
+- boundary "generated-vocabulary-single-source" at GENERATED_ARTIFACTS via test "spec generated artifacts"
+- boundary "trigger-routes-single-source" at TRIGGER_ROUTES via test "spec generated artifacts"
+
+## why
+
+tenant-array-bounds: every top-level array in the spec is author-controlled and flows into a loop/query at freeze/promote/run, so an unbounded one is a resource lever (the confirmed case: `identity_providers` fanning out into per-entry OAuthApplication creation + org-row locks at promote). The oracle reads the schema's own JSON-Schema projection, resolves `$ref` and walks `anyOf`/`oneOf`/`allOf` so a `nullable`/union array can't slip through undetected, and asserts a FLOOR on how many array fields it finds — if the projection shape ever changes so it detects fewer, the floor fails loud instead of the oracle passing vacuously (the false-green class this exists to prevent).
+generated-vocabulary-single-source: the vocabularies Django needs as data (per-trigger required secrets, approval-request states, assistant stop reasons) are authored once here and emitted as checked-in JSON that Django imports, so there is no hand-maintained Python copy to keep in lockstep. The freshness oracle welds each checked-in artifact to its TS source (parsed comparison, formatter-immune); a registry-non-empty floor keeps the guard from passing vacuously if the artifact list ever collapses. Coverage that the guard actually runs on artifact edits is enforced CI-side (`test_ci_guard_coverage.py`).
+trigger-routes-single-source: the per-trigger ingress route catalogue is authored once in `TRIGGER_ROUTES` (total over `TriggerType`; `cron` explicitly empty — janitor-fired, no inbound route). The ingress trigger modules import their `path:` values from it and Django's preview-endpoint builder reads the emitted artifact, so the routes the ingress actually serves, the paths previews advertise, and the trigger-kind enumeration strings cannot drift — retiring a hand-mirror that its own comment asked readers to "keep in sync" and that contributors measurably missed.

--- a/products/agent_platform/services/agent-shared/src/storage/Storage.spec.md
+++ b/products/agent_platform/services/agent-shared/src/storage/Storage.spec.md
@@ -1,0 +1,21 @@
+# Storage
+
+Content-addressed bundle storage for agent revisions — the file-tree layer
+backing `AgentRevision.bundle_uri`. `S3BundleStore` is the prod backend
+(SeaweedFS locally); a draft's bundle is a mutable key prefix until `freeze`
+stamps a `.frozen` marker and a content hash, after which every write and
+delete against that revision id must refuse.
+
+## invariants
+
+- bundle-freeze-immutability
+
+## works when
+
+- typechecks
+- boundary "bundle-freeze-immutability" at S3BundleStore
+- passes test "freezes and blocks further writes"
+
+## why
+
+bundle-freeze-immutability: `write` and `delete` both check `isFrozen(rev)` before touching S3 and throw `bundle ${rev} is frozen` when the `.frozen` marker object exists; `freeze` writes that marker holding a hash recomputed from each file's actual bytes rather than the writer-supplied `Metadata.sha256` that `list` trusts, so the frozen hash can't be spoofed by an in-cluster writer setting object metadata independently of content. This matters because `agent_revision.bundle_sha256` and every downstream consumer that reads a promoted bundle (the runner at session start, `readTypedBundle`) trust that a given revision id names one immutable set of bytes forever — without the write/delete refusal, a later write to an already-frozen revision id would silently swap content behind a promoted (and possibly already-executing) revision, breaking that promise for anyone who already has the id. `isFrozen` is also the authoritative cross-process signal ahead of `agent_revision.state` (Django stamps `state` _after_ the janitor returns), so the guard can't be raced by an in-flight promote reading a stale `draft` state. The oracle runs against a real S3-compatible backend (SeaweedFS): write, freeze, attempt a second write, assert it throws.

--- a/products/agent_platform/services/agent-tools/.gitignore
+++ b/products/agent_platform/services/agent-tools/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 *.tsbuildinfo
+.coherence-out/
+.coherence/

--- a/products/agent_platform/services/agent-tools/coherence.config.json
+++ b/products/agent_platform/services/agent-tools/coherence.config.json
@@ -1,0 +1,10 @@
+{
+    "outputDir": ".coherence-out",
+    "entryDir": "src",
+    "ignore": ["node_modules", "dist", ".coherence-out"],
+    "codeExt": ["ts"],
+    "typecheck": ["npx", "tsc", "--noEmit", "-p", "."],
+    "test": ["npx", "vitest", "run", "-t"],
+    "testMatch": "[1-9][0-9]* passed",
+    "language": "typescript"
+}

--- a/products/agent_platform/services/agent-tools/src/Tools.spec.md
+++ b/products/agent_platform/services/agent-tools/src/Tools.spec.md
@@ -1,0 +1,16 @@
+# Tools
+
+Native `@posthog/*` tools the runner can dispatch, plus the intrinsic approval classification that floors how dangerous each one is allowed to be.
+
+## invariants
+
+- native-tool-approval-floor
+
+## works when
+
+- typechecks
+- boundary "native-tool-approval-floor" at nativeToolApprovalClass via test "native tool authorization accessor"
+
+## why
+
+native-tool-approval-floor: whether a native tool needs human approval is an intrinsic property of the tool (mutating/external-effect vs read-only), not something each spec author must remember — a forgotten `requires_approval` flag used to dispatch mutating tools ungated. The class is now a REQUIRED field on every tool's definition (`NativeToolSchema.approval`), so `typechecks` makes an unclassified tool a compile error — totality enforced by the type system, not a parallel map plus a runtime test. `nativeToolApprovalClass` is the single read point: it returns each tool's co-located class and fails closed to `approve` on an id no tool declares; authors may tighten an individual ref via `requires_approval` but the resolver never loosens below the intrinsic class. The `via test` oracle iterates the live registry asserting the accessor never drifts from a tool's declared class (floored so an emptied registry can't pass vacuously).


### PR DESCRIPTION
## Problem

The platform-hardening PR below this one (#69107) closes several bug-classes, but nothing keeps them closed. A future edit can silently reopen a fail-open default or drop a `WHERE owner` predicate, and a prose review can miss it.

## Changes

Adopts the `coherence` harness, a spec/invariant-verification tool, as a declarative layer over the hardening in #69107. No production behavior changes here.

- Per-service `*.spec.md` files declare each invariant as a `boundary` welded to its chokepoint symbol and a totality oracle.
- One `coherence.config.json` per root (five node services plus the Django backend).
- Overview and onboarding docs under `docs/coherence-*.md`.
- `.gitignore` entries for the harness's generated output.

`coherence verify` fails if a declared invariant loses its chokepoint or oracle, so you cannot ship a half-boundary. The oracles it points at are the tests in #69107.

> [!NOTE]
> The harness is not wired into CI yet. It runs locally against a pinned clone today. Making it enforce (a CI job plus resolving the tool as a real dependency) is a deliberate follow-up, not part of this PR.

## How did you test this code?

`coherence verify --fast` reports 0 red across all six roots. This PR is declarative (specs, configs, docs); the behavior it describes is tested in #69107.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Danilo) directed this; Claude (Claude Code, Opus 4.8) did the work. This is the coherence-adoption half of a two-PR compression of a longer evaluation stack. An earlier "trust atlas" layer was built and then dropped after two independent subagent reviews found it to be mostly a re-presentation of the boundary claims rather than added enforcement. What remains is the boundary layer that carries the real leverage.

Skills invoked: /writing-tests.
