### PR TITLE
fix(settings): keep project and passthrough environment names in sync

### DIFF
--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -67,6 +67,8 @@ export const teamLogic = kea<teamLogicType>([
             ['loadCurrentOrganization'],
             customProductsLogic,
             ['loadCustomProducts'],
+            projectLogic,
+            ['loadCurrentProject'],
         ],
     })),
     actions({
@@ -360,6 +362,8 @@ export const teamLogic = kea<teamLogicType>([
         updateCurrentTeamSuccess: () => {
             // Reload user after team update to keep user object in sync
             actions.loadUser()
+            // Keep currentProject in sync too, so a rename is reflected without a page refresh
+            actions.loadCurrentProject()
         },
         createTeamSuccess: ({ currentTeam }) => {
             if (currentTeam) {

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -67,8 +67,6 @@ export const teamLogic = kea<teamLogicType>([
             ['loadCurrentOrganization'],
             customProductsLogic,
             ['loadCustomProducts'],
-            projectLogic,
-            ['loadCurrentProject'],
         ],
     })),
     actions({
@@ -362,8 +360,6 @@ export const teamLogic = kea<teamLogicType>([
         updateCurrentTeamSuccess: () => {
             // Reload user after team update to keep user object in sync
             actions.loadUser()
-            // Keep currentProject in sync too, so a rename is reflected without a page refresh
-            actions.loadCurrentProject()
         },
         createTeamSuccess: ({ currentTeam }) => {
             if (currentTeam) {

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1208,6 +1208,12 @@ class ProjectBackwardCompatSerializer(
                 should_team_be_saved_too = True
                 setattr(team, attr, value)
 
+        # The Project's name and its passthrough Team's name both represent "the project's name".
+        # Keep them in sync so the UI shows the same value regardless of which one it reads.
+        if "name" in validated_data:
+            should_team_be_saved_too = True
+            team.name = validated_data["name"]
+
         instance.save()
         if should_team_be_saved_too:
             team.save()

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1597,6 +1597,15 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
         updated_team = super().update(instance, validated_data)
 
+        # Renaming the passthrough environment must also rename its parent Project, since both
+        # store "the project's name". Otherwise the name reverts on refresh when the UI reads
+        # Project.name. The passthrough Team is the one whose id equals the Project's id.
+        if "name" in validated_data and instance.id == instance.project_id:
+            project = instance.project
+            if project.name != instance.name:
+                project.name = instance.name
+                project.save(update_fields=["name", "updated_at"])
+
         if "proactive_tasks_enabled" in validated_data:
             # Backward compat for old proactive tasks enabled field, remove after February 2026
             if validated_data["proactive_tasks_enabled"]:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -377,6 +377,18 @@ def team_api_test_factory():
             team.refresh_from_db()
             self.assertEqual(team.timezone, "UTC")
 
+        def test_renaming_syncs_project_and_passthrough_team_names(self):
+            # The Project's name and its passthrough Team's name both represent "the project's name".
+            # A rename through either endpoint must update both, or the name reverts on refresh
+            # depending on which model the UI reads.
+            self.assertEqual(self.team.id, self.project.id)  # the default team is the project's passthrough
+            response = self.client.patch(f"/api/environments/{self.team.id}/", {"name": "Renamed project"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.team.refresh_from_db()
+            self.project.refresh_from_db()
+            self.assertEqual(self.team.name, "Renamed project")
+            self.assertEqual(self.project.name, "Renamed project")
+
         def test_filter_permission(self):
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/",


### PR DESCRIPTION
## Problem

Renaming a project shows a success toast, but the name reverts to the old value after a page refresh.

The root cause is that a project's name is stored in two separate columns: `Project.name` and its passthrough `Team.name` (the environment whose id matches the project's). Both represent "the project's name", and they were kept in sync only by a conditional dual-write in the frontend (`teamLogic.updateCurrentTeam`) that fires one PATCH to `/api/environments/` and, only when a project is loaded, a second PATCH to `/api/projects/`. When one of those two writes doesn't happen, the two columns diverge — the toast still fires, but on refresh the UI shows whichever column it happens to read, so the name appears to revert.

## Changes

Enforce the sync on the backend so a rename through either endpoint updates both columns, regardless of the frontend path:

- `TeamSerializer.update` (`/api/environments/<id>`): when the passthrough environment is renamed, mirror the new name to its parent `Project`.
- `ProjectBackwardCompatSerializer.update` (`/api/projects/<id>`): when the project is renamed, mirror the new name to its passthrough `Team`.

## How did you test this code?

Added a backend regression test (`test_renaming_syncs_project_and_passthrough_team_names`) to the shared `team_api_test_factory`, so it runs against **both** `/api/environments/` (via `TestTeamAPI`) and `/api/projects/` (via `TestProjectAPI`, whose client rewrites the path). It renames through the endpoint and asserts that both `Project.name` and the passthrough `Team.name` are updated — catching a regression where either serializer stops keeping the two in sync. No existing test asserted cross-model name consistency (the prior update test only checked the response body).

The agent could not run the backend suite in its sandbox (no Postgres/ClickHouse); the edited files were syntax-checked and the tests are expected to run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack report that project renames don't persist. Traced the rename path from the settings UI (`TeamDisplayName` → `teamLogic.updateCurrentTeam`) through both API endpoints and confirmed that `Project.name` and the passthrough `Team.name` are distinct columns synced only by a conditional frontend dual-write. Chose to make the backend authoritative (sync in both serializers) rather than only hardening the frontend, so the fix holds for any API caller and any single-endpoint path. An initial in-session `loadCurrentProject()` tweak in `teamLogic` was reverted after it caused unmocked async in existing jest tests (shard timeout); the backend sync fixes the reported bug on its own. Skills invoked: `/improving-drf-endpoints` (serializer change — confirmed no field/schema changes, so no OpenAPI regeneration needed) and `/writing-tests` (kept a single factory test covering both endpoints instead of two near-duplicates).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1783465096422219)*
