### PR TITLE
chore(batch-import-worker): allow worker to handle nullable secrets

### DIFF
--- a/rust/batch-import-worker/.sqlx/query-7c4dccace778cc931a460e982d16a8aa058d6728135e358c8ba1722954e56b57.json
+++ b/rust/batch-import-worker/.sqlx/query-7c4dccace778cc931a460e982d16a8aa058d6728135e358c8ba1722954e56b57.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            WITH next_job AS (\n                SELECT *, lease_id as previous_lease_id\n                FROM posthog_batchimport\n                WHERE status = 'running' AND (leased_until IS NULL OR leased_until <= now())\n                ORDER BY created_at\n                LIMIT 1\n                FOR UPDATE SKIP LOCKED\n            )\n            UPDATE posthog_batchimport\n            SET\n                status = 'running',\n                leased_until = now() + interval '30 minutes', -- We lease for a long time because job init can be quite slow\n                lease_id = $1\n            FROM next_job\n            WHERE posthog_batchimport.id = next_job.id\n            RETURNING\n                posthog_batchimport.id,\n                posthog_batchimport.team_id,\n                posthog_batchimport.created_at,\n                posthog_batchimport.updated_at,\n                posthog_batchimport.status_message,\n                posthog_batchimport.display_status_message,\n                posthog_batchimport.state,\n                posthog_batchimport.import_config,\n                posthog_batchimport.secrets,\n                posthog_batchimport.backoff_attempt,\n                posthog_batchimport.backoff_until,\n                next_job.previous_lease_id\n            ",
+  "query": "\n            WITH next_job AS (\n                SELECT *, lease_id as previous_lease_id\n                FROM posthog_batchimport\n                WHERE status = 'running' AND (leased_until IS NULL OR leased_until <= now())\n                ORDER BY created_at\n                LIMIT 1\n                FOR UPDATE SKIP LOCKED\n            )\n            UPDATE posthog_batchimport\n            SET\n                status = 'running',\n                leased_until = now() + interval '30 minutes', -- We lease for a long time because job init can be quite slow\n                lease_id = $1\n            FROM next_job\n            WHERE posthog_batchimport.id = next_job.id\n            RETURNING\n                posthog_batchimport.id,\n                posthog_batchimport.team_id,\n                posthog_batchimport.created_at,\n                posthog_batchimport.updated_at,\n                posthog_batchimport.status_message,\n                posthog_batchimport.display_status_message,\n                posthog_batchimport.state,\n                posthog_batchimport.import_config,\n                posthog_batchimport.secrets as \"secrets?\",\n                posthog_batchimport.backoff_attempt,\n                posthog_batchimport.backoff_until,\n                next_job.previous_lease_id\n            ",
   "describe": {
     "columns": [
       {
@@ -45,7 +45,7 @@
       },
       {
         "ordinal": 8,
-        "name": "secrets",
+        "name": "secrets?",
         "type_info": "Text"
       },
       {
@@ -84,5 +84,5 @@
       true
     ]
   },
-  "hash": "bdf5288f88ee3c0d914c26d8e7c01af95c5802d8b0f703eb74df2c5084c76f00"
+  "hash": "7c4dccace778cc931a460e982d16a8aa058d6728135e358c8ba1722954e56b57"
 }

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -160,6 +160,13 @@ pub struct JobSecrets {
 
 // Jobsecrets is a json object, encrypted using fernet and then base64 urlsafe encoded.
 impl JobSecrets {
+    // Jobs using IAM role auth (rather than customer-provided keys) have no secrets at all.
+    pub fn empty() -> Self {
+        Self {
+            secrets: HashMap::new(),
+        }
+    }
+
     // Data is base64 url-safe encoded
     pub fn decrypt(data: &str, keys: &[String]) -> Result<Self, Error> {
         // Matching the plugin server, each key is 32 btyes of utf8 data, which we

--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -127,7 +127,7 @@ impl JobModel {
                 posthog_batchimport.display_status_message,
                 posthog_batchimport.state,
                 posthog_batchimport.import_config,
-                posthog_batchimport.secrets,
+                posthog_batchimport.secrets as "secrets?",
                 posthog_batchimport.backoff_attempt,
                 posthog_batchimport.backoff_until,
                 next_job.previous_lease_id
@@ -400,7 +400,7 @@ struct JobRow {
     display_status_message: Option<String>,
     state: Option<serde_json::Value>,
     import_config: serde_json::Value,
-    secrets: String,
+    secrets: Option<String>,
     backoff_attempt: Option<i32>,
     backoff_until: Option<DateTime<Utc>>,
     previous_lease_id: Option<String>,
@@ -418,7 +418,13 @@ impl TryFrom<(JobRow, &[String], String)> for JobModel {
 
         let import_config = serde_json::from_value(row.import_config).context("Parsing config")?;
 
-        let secrets = JobSecrets::decrypt(&row.secrets, keys).context("Parsing keys")?;
+        // Jobs authenticating via IAM role have no secrets — the column is NULL.
+        let secrets = match row.secrets.as_deref() {
+            Some(data) if !data.is_empty() => {
+                JobSecrets::decrypt(data, keys).context("Decrypting secrets")?
+            }
+            _ => JobSecrets::empty(),
+        };
 
         Ok(JobModel {
             id: row.id,
@@ -508,6 +514,46 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    fn make_job_row(secrets: Option<String>) -> JobRow {
+        JobRow {
+            id: Uuid::now_v7(),
+            team_id: 1,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            status_message: None,
+            display_status_message: None,
+            state: None,
+            import_config: serde_json::to_value(
+                make_dummy_job_model(Uuid::now_v7(), "lease", 1).import_config,
+            )
+            .unwrap(),
+            secrets,
+            backoff_attempt: None,
+            backoff_until: None,
+            previous_lease_id: None,
+        }
+    }
+
+    // Jobs using IAM role auth store NULL secrets - parsing must skip decryption
+    // instead of failing (a parse failure pauses the job).
+    #[test]
+    fn test_null_and_empty_secrets_parse_as_empty() {
+        let keys = vec!["0".repeat(32)];
+        for secrets in [None, Some(String::new())] {
+            let model =
+                JobModel::try_from((make_job_row(secrets), keys.as_slice(), "l".to_string()))
+                    .unwrap();
+            assert!(model.secrets.secrets.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_undecryptable_secrets_still_fail_parsing() {
+        let keys = vec!["0".repeat(32)];
+        let row = make_job_row(Some("not-a-fernet-token".to_string()));
+        assert!(JobModel::try_from((row, keys.as_slice(), "l".to_string())).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When adding the cross-account role based bucket auth method to the batch import worker, we will make the secrets field nullable on the batch import model.

the worker needs to be able to handle this field being null

## Changes

- JobRow.secrets is now `Option<string>`
- `TryFrom<JobRow>` now only calls `JobSecrets::decrypt` when secrets are present and non-empty

## How did you test this code?

- new unit tests added to test for the nullable secrets value