### PR TITLE
chore(lint): suppress exhaustive-deps where the dangerous autofix breaks code

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -360,6 +360,7 @@ export function DashboardItems(): JSX.Element {
                 setContainerHeight(containerRef.current.clientHeight)
             }
         })
+        // oxlint-disable-next-line react-hooks/exhaustive-deps -- ref reads inside requestAnimationFrame aren't valid deps
     }, [updateLayouts])
 
     const handleWidthChange = useCallback(

--- a/frontend/src/scenes/max/useMaxTool.ts
+++ b/frontend/src/scenes/max/useMaxTool.ts
@@ -79,6 +79,7 @@ export function useMaxTool({
             callback,
             clientExecution,
         })
+        // oxlint-disable-next-line react-hooks/exhaustive-deps -- context is tracked via contextKey (serialized) so identity churn doesn't re-register the tool
     }, [
         active,
         identifier,


### PR DESCRIPTION
## Problem

Running `pnpm --filter=@posthog/frontend format` (which invokes `oxlint --fix --fix-suggestions --fix-dangerously`) corrupts two files on every run:

- `frontend/src/scenes/max/useMaxTool.ts`: the react-hooks `exhaustive-deps` autofix inserts `context` into the deps array **without a comma**, producing a syntax error that fails the entire format run until the file is manually reverted.
- `frontend/src/scenes/dashboard/DashboardItems.tsx`: the same autofix adds `containerRef.current` and `containerRef.current.clientHeight` as deps — a behavior change, and refs aren't valid deps in the first place.

Anyone (human or agent) running format hits this repeatedly.

## Changes

Line-level `oxlint-disable-next-line react-hooks/exhaustive-deps` suppressions on the two offending hooks, each with a reason: both dep omissions are intentional (`useMaxTool` tracks `context` through the serialized `contextKey`; the dashboard callback reads a ref inside `requestAnimationFrame`).

This sits at the bottom of the toolbar-migration stack (#69045 and up are restacked onto it) so it can merge first and stop the corruption for everyone.

## How did you test this code?

- `oxlint` on both files: 0 warnings, 0 errors
- `oxlint --fix --fix-suggestions --fix-dangerously` over the whole repo: no files modified besides the two intentional suppression lines (previously both files came out broken)
- The underlying autofix bug was reported to the devex team via `hogli devex:feedback`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: lint suppression only, no behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) under Rafael's direction after the corruption bit twice while producing the toolbar-migration stack. Suppression comments rather than a config-level rule disable, so the rule keeps protecting every other hook in the repo.