### PR TITLE
fix(bigquery): treat missing GCP project as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -176,6 +176,15 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # rename it back, or remove it from the sync. Matched on the stable "Not found: Table"
             # wording rather than the volatile table id.
             "Not found: Table": "BigQuery couldn't find a table this source is syncing — it was deleted or renamed after the source was set up. Restore or rename the table in BigQuery, or remove it from this source's synced tables, then re-enable the source.",
+            # Raised from `bq_client.get_table(...)` in `_build_source_response` (and other calls) when
+            # the GCP project the source references no longer exists — it was deleted, or the Project ID
+            # in the service account key file (or the configured dataset project) is wrong. The google
+            # exception stringifies as "... Project <id> is not found. Make sure it references valid GCP
+            # project that hasn't been deleted.", which the table/dataset "Not found" keys don't cover, so
+            # it slips through and retries forever. Retrying can't conjure a missing project; the user
+            # must fix the project reference. Matched on the stable guidance wording rather than the
+            # volatile project id that appears earlier in the message.
+            "Make sure it references valid GCP project": "BigQuery couldn't find the Google Cloud project this source references — it may have been deleted, or the Project ID in your service account key file (or the configured dataset project) may be incorrect. Verify the project exists in Google Cloud and correct the project details in your source configuration, then reconnect the source.",
             # Raised by google-cloud-bigquery's `TableReference.from_string` when a table id has
             # more than the three `project.dataset.table` components. This happens when the
             # Dataset ID field is set to `project.dataset` instead of just `dataset` — we then

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1392,6 +1392,27 @@ def test_bigquery_table_not_found_key_does_not_match_unrelated_errors(other_erro
     assert not any(key in other_error for key in non_retryable_errors)
 
 
+def test_bigquery_project_not_found_during_sync_is_non_retryable():
+    """A source referencing a deleted or mistyped GCP project surfaces from `get_table()` at sync time
+    as a google NotFound whose str() is "... Project <id> is not found. Make sure it references valid
+    GCP project that hasn't been deleted." — distinct from the table/dataset "Not found" wording. It
+    must be recognised as non-retryable instead of retrying a project that can't reappear within the run."""
+    error = NotFound(
+        "GET https://bigquery.googleapis.com/bigquery/v2/projects/my-proj/datasets/my_dataset/"
+        "tables/my_table?prettyPrint=false: Project my-proj is not found. Make sure it references "
+        "valid GCP project that hasn't been deleted.; Project id: my-proj"
+    )
+
+    error_msg = str(error)
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in error_msg]
+
+    assert matching, "a project-not-found 404 during sync should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+    assert "Not found: Table" not in error_msg
+    assert "was not found in location" not in error_msg
+
+
 def test_bigquery_storage_read_client_disables_grpc_message_size_limit():
     """Regression: the Storage Read API streams Arrow ReadRowsResponse messages that can
     exceed gRPC's default 4 MiB client receive limit (wide rows / large string columns like


### PR DESCRIPTION
## Problem

A BigQuery data-warehouse import can reference a Google Cloud project that no longer exists, or whose Project ID in the service account key file (or the configured dataset project) is wrong. When that happens, `get_table(...)` in `_build_source_response` raises a google `NotFound` whose message is:

```
... Project <id> is not found. Make sure it references valid GCP project that hasn't been deleted.; Project id: <id>
```

None of the source's existing `get_non_retryable_errors` keys match this wording. The table-not-found key matches `Not found: Table` and the dataset-region key matches `was not found in location`, but this project-level 404 slips through both, so the sync retries forever and keeps spamming error tracking. Retrying can never conjure a missing project back into existence, so it should stop and surface an actionable message.

Surfaced by error tracking: [issue 019f3f66-a3a1-7e31-92c3-cb68a747315d](https://us.posthog.com/project/2/error_tracking/019f3f66-a3a1-7e31-92c3-cb68a747315d) (`NotFound`, raised in `bigquery.py` `_build_source_response`).

## Changes

Added a new non-retryable key to `BigQuerySource.get_non_retryable_errors` matching the stable guidance phrase `Make sure it references valid GCP project` (not the volatile project id that appears earlier in the message), mapped to a user-facing message telling the customer the project may be deleted or the Project ID may be wrong and to fix it in their source configuration.

> [!NOTE]
> This is a user/upstream configuration error (deleted or mistyped project), not a bug in our code, so the fix is to stop retrying rather than change the query path.

## How did you test this code?

Added `test_bigquery_project_not_found_during_sync_is_non_retryable`, which builds the exact `NotFound` shape and asserts the new key matches, maps to a non-null message, and does not collide with the `Not found: Table` / `was not found in location` keys. The existing `test_bigquery_table_not_found_key_does_not_match_unrelated_errors` still guards that transient 5xx errors stay retryable.

I (Claude) could not run pytest in this environment (test deps not installed), so I verified the substring match logic directly: the key matches the real error message and produces zero false positives against the transient/table/dataset error strings. `ruff check` and `ruff format` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `bigquery` import source. I confirmed the failure originates in this source (`_build_source_response`, `bigquery.py:1271`, `bq_client.get_table(...)`), read the existing non-retryable handling, and classified this as a user/upstream error (missing/mistyped GCP project) rather than a fixable bug in our code, so the fix extends `NonRetryableErrors` mirroring the existing pattern. I matched on the stable guidance wording rather than the project id to keep false positives out and avoid leaking customer values. Checked open PRs (including the maintainer's own) for an existing fix before opening this. Invoked the `/writing-tests` skill before adding the regression test.
