### PR TITLE
fix(bigquery): qualify INFORMATION_SCHEMA with the dataset project

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -996,8 +996,12 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
             # `bigquery.jobs.create`) or auth failure surfaces here rather than at `result()`.
             # Both calls must sit inside the try so a permission-denied account degrades to
             # "no new schemas" instead of crashing schema discovery.
+            # Qualify INFORMATION_SCHEMA with the project: when the dataset lives in a different
+            # project than the service account (the `dataset_project` option), the client's default
+            # project and the job's billing project diverge, and BigQuery can't resolve an unqualified
+            # `dataset.INFORMATION_SCHEMA.*` — it rejects the job with "ProjectId must be non-empty".
             query = conn.query(
-                f"SELECT table_name, column_name, data_type, is_nullable FROM `{_resolve_dataset_id(config)}.INFORMATION_SCHEMA.COLUMNS` ORDER BY table_name ASC",
+                f"SELECT table_name, column_name, data_type, is_nullable FROM `{_resolve_query_project(config)}.{_resolve_dataset_id(config)}.INFORMATION_SCHEMA.COLUMNS` ORDER BY table_name ASC",
                 project=_resolve_query_project(config),
             )
             rows = query.result()
@@ -1082,12 +1086,15 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
         # the BigQuery region / metadata version, hence the
         # `removeprefix` below — the JOIN has to tolerate both shapes or
         # half the rows get dropped.
+        # Project-qualify the dataset (see `get_columns`): an unqualified `dataset.INFORMATION_SCHEMA.*`
+        # fails with "ProjectId must be non-empty" when the dataset lives in a different project.
+        qualified_dataset = f"{project}.{dataset_id}"
         query = f"""
         SELECT tc.table_name, kcu.column_name
-        FROM `{dataset_id}`.INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-        JOIN `{dataset_id}`.INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+        FROM `{qualified_dataset}`.INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+        JOIN `{qualified_dataset}`.INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
         ON tc.constraint_name = kcu.constraint_name
-        JOIN `{dataset_id}`.INFORMATION_SCHEMA.COLUMNS c
+        JOIN `{qualified_dataset}`.INFORMATION_SCHEMA.COLUMNS c
         ON kcu.table_name = c.table_name
         AND (
             kcu.column_name = c.column_name
@@ -1136,9 +1143,11 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
 
             project = _resolve_query_project(config)
 
+            # Project-qualify the dataset (see `get_columns`): an unqualified `dataset.INFORMATION_SCHEMA.*`
+            # fails with "ProjectId must be non-empty" when the dataset lives in a different project.
             query = f"""
             SELECT table_name, column_name
-            FROM `{_resolve_dataset_id(config)}`.INFORMATION_SCHEMA.COLUMNS
+            FROM `{project}.{_resolve_dataset_id(config)}`.INFORMATION_SCHEMA.COLUMNS
             WHERE is_partitioning_column = 'YES'
                OR clustering_ordinal_position = 1
             """

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -1000,9 +1000,10 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
             # project than the service account (the `dataset_project` option), the client's default
             # project and the job's billing project diverge, and BigQuery can't resolve an unqualified
             # `dataset.INFORMATION_SCHEMA.*` — it rejects the job with "ProjectId must be non-empty".
+            project = _resolve_query_project(config)
             query = conn.query(
-                f"SELECT table_name, column_name, data_type, is_nullable FROM `{_resolve_query_project(config)}.{_resolve_dataset_id(config)}.INFORMATION_SCHEMA.COLUMNS` ORDER BY table_name ASC",
-                project=_resolve_query_project(config),
+                f"SELECT table_name, column_name, data_type, is_nullable FROM `{project}.{_resolve_dataset_id(config)}.INFORMATION_SCHEMA.COLUMNS` ORDER BY table_name ASC",
+                project=project,
             )
             rows = query.result()
         except Forbidden:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -833,6 +833,27 @@ def test_bigquery_get_columns_qualifies_information_schema_with_dataset_project(
     assert fake_client.query.call_args.kwargs["project"] == "dataset-project"
 
 
+@pytest.mark.parametrize("method_name", ["get_primary_keys", "get_leading_index_columns"])
+def test_bigquery_discovery_qualifies_information_schema_with_dataset_project(method_name):
+    """`get_primary_keys` and `get_leading_index_columns` share the same unqualified-reference
+    defect as `get_columns`, but swallow the error and silently lose PK/index detection. Their
+    INFORMATION_SCHEMA references must carry the dataset project too."""
+    config = _make_config(
+        project_id="service-account-project",
+        dataset_id="posthog_export",
+        dataset_project=BigQueryDatasetProjectConfig(dataset_project_id="dataset-project", enabled=True),
+    )
+
+    fake_client = mock.MagicMock()
+    fake_client.query.return_value.result.return_value = []
+
+    getattr(BigQueryImplementation(), method_name)(fake_client, config, tables=["t"])
+
+    sql = fake_client.query.call_args.args[0]
+    assert "`dataset-project.posthog_export`.INFORMATION_SCHEMA" in sql
+    assert fake_client.query.call_args.kwargs["project"] == "dataset-project"
+
+
 def test_bigquery_get_primary_keys_trims_whitespace_in_identifiers():
     fake_client = mock.MagicMock()
     fake_client.query.return_value.result.return_value = []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -808,9 +808,29 @@ def test_bigquery_get_columns_trims_whitespace_in_identifiers():
     BigQueryImplementation().get_columns(fake_client, config, names=None)
 
     sql = fake_client.query.call_args.args[0]
-    assert "`bigquery_aloalo.INFORMATION_SCHEMA.COLUMNS`" in sql
+    assert "`524098457564.bigquery_aloalo.INFORMATION_SCHEMA.COLUMNS`" in sql
     assert " bigquery_aloalo" not in sql
+    assert " 524098457564" not in sql
     assert fake_client.query.call_args.kwargs["project"] == "524098457564"
+
+
+def test_bigquery_get_columns_qualifies_information_schema_with_dataset_project():
+    """When the dataset lives in a different project (`dataset_project`), the INFORMATION_SCHEMA
+    reference must carry that project — an unqualified `dataset.INFORMATION_SCHEMA.*` makes BigQuery
+    reject the job with "ProjectId must be non-empty"."""
+    fake_client = mock.MagicMock()
+    fake_client.query.return_value.result.return_value = []
+
+    config = _make_config(
+        project_id="service-account-project",
+        dataset_id="posthog_export",
+        dataset_project=BigQueryDatasetProjectConfig(dataset_project_id="dataset-project", enabled=True),
+    )
+    BigQueryImplementation().get_columns(fake_client, config, names=None)
+
+    sql = fake_client.query.call_args.args[0]
+    assert "`dataset-project.posthog_export.INFORMATION_SCHEMA.COLUMNS`" in sql
+    assert fake_client.query.call_args.kwargs["project"] == "dataset-project"
 
 
 def test_bigquery_get_primary_keys_trims_whitespace_in_identifiers():
@@ -821,8 +841,9 @@ def test_bigquery_get_primary_keys_trims_whitespace_in_identifiers():
     BigQueryImplementation().get_primary_keys(fake_client, config, tables=["t"])
 
     sql = fake_client.query.call_args.args[0]
-    assert "`my_dataset`.INFORMATION_SCHEMA.TABLE_CONSTRAINTS" in sql
-    assert " my_dataset`" not in sql
+    assert "`my-project.my_dataset`.INFORMATION_SCHEMA.TABLE_CONSTRAINTS" in sql
+    assert " my_dataset" not in sql
+    assert " my-project" not in sql
     assert fake_client.query.call_args.kwargs["project"] == "my-project"
 
 


### PR DESCRIPTION
## Problem

A BigQuery import source surfaced this in error tracking during schema discovery:

```
BadRequest: POST https://bigquery.googleapis.com/.../jobs?prettyPrint=false: ProjectId must be non-empty
```

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f3f65-8439-7bb0-8052-5302ba150169)

The crash originates in our code, at `get_columns` in `bigquery.py`, on the `INFORMATION_SCHEMA.COLUMNS` discovery query.

The trigger is the "use a different project for the dataset" option (`dataset_project`). When that project differs from the service-account project, the BigQuery client's default project (service account) and the query job's billing project (dataset project) diverge. Our discovery queries reference the dataset **without** a project qualifier (`` `dataset.INFORMATION_SCHEMA.COLUMNS` ``), and with those two projects split, BigQuery can't resolve the INFORMATION_SCHEMA project and rejects the whole job at insert time with `ProjectId must be non-empty`.

`get_primary_keys` and `get_leading_index_columns` share the exact same defect, but they swallow the error and return empty, so they silently lose primary-key and index detection for these sources instead of crashing. Only `get_columns` lets the generic `BadRequest` propagate, so that's the one that shows up in error tracking.

This is our bug, not a user/upstream config problem. The customer configured `dataset_project` exactly as our UI intends.

## Changes

Project-qualify the INFORMATION_SCHEMA references in all three discovery queries (`get_columns`, `get_primary_keys`, `get_leading_index_columns`) using the already-resolved query project.

```diff
- FROM `posthog_export.INFORMATION_SCHEMA.COLUMNS`
+ FROM `dataset-project.posthog_export.INFORMATION_SCHEMA.COLUMNS`
```

The query project resolves to the dataset project when `dataset_project` is set, and to the service-account project otherwise, so the qualifier is a no-op for existing sources (it just spells out the project that was already the implicit default) and fixes the divergent-project case.

> [!NOTE]
> Fixing all three (not just the crashing `get_columns`) restores primary-key and index detection for `dataset_project` sources, which was silently degraded by the same root cause.

## How did you test this code?

I'm an agent (Claude). I did not run a live BigQuery sync. Automated tests only:

- Added `test_bigquery_get_columns_qualifies_information_schema_with_dataset_project` — asserts the INFORMATION_SCHEMA reference carries the dataset project when `dataset_project` is set. This is the regression the crash represents. No existing test exercised the divergent-project case, so none would have caught it.
- Updated the two existing whitespace-trimming tests (`get_columns`, `get_primary_keys`) to expect the now project-qualified references.
- Full file passes: `pytest .../bigquery/tests/test_source.py` -> 127 passed. Ruff check + format clean.

## Docs update

No user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook. Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools to confirm the failing frame (`get_columns`, `bigquery.py`) and the triggering config shape (`dataset_project` pointing at a different project than the service account).
- Invoked the `/writing-tests` skill before touching tests.
- Considered treating this as a user/upstream error (NonRetryableErrors) and rejected it: the config is valid per our UI, so retrying isn't the issue, our query construction is. Also considered fixing only the crashing `get_columns`, but the sibling INFORMATION_SCHEMA queries have the identical defect (failing closed), so I qualified all three.
- Checked open PRs for duplicates. #62831 touches `get_columns` (service-account impersonation) but only swaps a `RefreshError` import alias, it does not touch the INFORMATION_SCHEMA construction or fix this error.
