### PR TITLE
fix(google_sheets): note the header-row requirement in setup copy

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -127,7 +127,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             name=SchemaExternalDataSourceType.GOOGLE_SHEETS,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="Google Sheets",
-            caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets)",
+            caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets). The first row of each sheet must contain unique column headers, since PostHog reads it as the column names when syncing.",
             releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/Google_Sheets.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/google-sheets",


### PR DESCRIPTION
## Problem

Session-replay observations of the data-warehouse onboarding flow show users connecting a Google Sheets source, kicking off a sync, and then hitting a failure they can't explain. The root cause in these cases is the sheet's first row: PostHog reads it as the column names (via gspread's `get_all_records`), so a sheet whose first row is data, blank, or has duplicate headers either drops that row, mislabels columns, or fails outright. Nothing in the setup screen tells the user this up front, so they only discover it after a failed sync and some debugging.

## Changes

Append the header-row requirement to the Google Sheets source setup caption shown in step 2 of the wizard. This pre-empts both the missing-header and duplicate-header failure modes (the latter already surfaces a friendly error at sync time, but by then the user has already waited on a doomed sync).

No behavior change to sync logic or schema handling, copy only.

## How did you test this code?

Automated: ran `ruff check` and `ruff format` over the changed file (both clean). Verified no test snapshot or fixture references the previous caption string. I (the agent) did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) while synthesising friction themes from Replay Vision observations of the data-warehouse new-source onboarding flow. Two separate observed sessions failed a Google Sheets sync because of a missing/incorrect header row and had to diagnose it after the fact.

I checked the source config plumbing (the wizard API serves each source's `caption` from its backend `source.py`, so this is the right place to change the copy), confirmed the header-row assumption against the sync code (`get_all_records` treats row 1 as headers), and searched open PRs to rule out a duplicate. The maintainer has many in-flight PRs improving connection-error copy and setup-time validation, but none covers the Google Sheets header-row guidance.

Kept as copy-only on purpose: detecting and rejecting a bad header row at validation time would be a larger, riskier change and is left as a recommendation.