### PR TITLE
feat(flags): expose minimalFlagCalledEvents in the flags response

### DIFF
--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -64,6 +64,8 @@ from posthog.storage.hypercache_manager import (
     get_cache_stats as get_cache_stats_generic,
 )
 
+from products.feature_flags.backend.models.team_feature_flags_config import TeamFeatureFlagsConfig
+
 logger = structlog.get_logger(__name__)
 
 
@@ -153,12 +155,14 @@ def _serialize_team_field(field: str, value: Any) -> Any:
     return value
 
 
-def _serialize_team_to_metadata(team: Team) -> dict[str, Any]:
+def _serialize_team_to_metadata(team: Team, minimal_flag_called_events: bool | None = None) -> dict[str, Any]:
     """
     Serialize a Team object to metadata dictionary.
 
     Args:
         team: Team object with organization and project already loaded
+        minimal_flag_called_events: Pre-fetched value from TeamFeatureFlagsConfig, to let
+            batch callers avoid an N+1 query. If None, this looks it up itself.
 
     Returns:
         Dictionary containing full team metadata
@@ -170,6 +174,20 @@ def _serialize_team_to_metadata(team: Team) -> dict[str, Any]:
 
     metadata["organization_name"] = team.organization.name if team.organization else None
     metadata["project_name"] = team.project.name if team.project else None
+
+    if minimal_flag_called_events is None:
+        # Deliberately not team.teamfeatureflagsconfig: the reverse O2O accessor gets
+        # cache-populated as a side effect of register_team_extension_signal's
+        # get_or_create(team=instance, ...) at team-creation time, so an already-loaded
+        # Team object can carry a stale cached value if the config row changes after
+        # the Team was loaded. An explicit query is always fresh.
+        minimal_flag_called_events = (
+            TeamFeatureFlagsConfig.objects.filter(team_id=team.id)
+            .values_list("minimal_flag_called_events", flat=True)
+            .first()
+            or False
+        )
+    metadata["minimal_flag_called_events"] = minimal_flag_called_events
 
     return metadata
 
@@ -188,7 +206,17 @@ def _batch_load_team_metadata(teams: list[Team]) -> dict[int, dict[str, Any]]:
     Returns:
         Dict mapping team_id -> metadata dict
     """
-    return {team.id: _serialize_team_to_metadata(team) for team in teams}
+    minimal_flag_called_events_by_team = dict(
+        TeamFeatureFlagsConfig.objects.filter(team_id__in=[team.id for team in teams]).values_list(
+            "team_id", "minimal_flag_called_events"
+        )
+    )
+    return {
+        team.id: _serialize_team_to_metadata(
+            team, minimal_flag_called_events=minimal_flag_called_events_by_team.get(team.id, False)
+        )
+        for team in teams
+    }
 
 
 def _load_team_metadata(team_key: KeyType) -> dict[str, Any] | HyperCacheStoreMissing:
@@ -303,7 +331,7 @@ def verify_team_metadata(
 
     # Compare only fields we care about (defined in TEAM_METADATA_FIELDS + derived fields).
     # This allows removing fields from the cache without triggering unnecessary fixes.
-    fields_to_check = set(TEAM_METADATA_FIELDS) | {"organization_name", "project_name"}
+    fields_to_check = set(TEAM_METADATA_FIELDS) | {"organization_name", "project_name", "minimal_flag_called_events"}
     diffs = []
     for key in fields_to_check:
         db_val = db_data.get(key)

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -25,6 +25,8 @@ from posthog.storage.team_metadata_cache import (
 )
 from posthog.tasks.team_metadata import update_team_metadata_cache_task
 
+from products.feature_flags.backend.models.team_feature_flags_config import TeamFeatureFlagsConfig
+
 
 class TestTeamMetadataCache(BaseTest):
     """Test basic team metadata cache functionality."""
@@ -392,24 +394,29 @@ class TestVerifyTeamMetadata(BaseTest):
 
         self.assertEqual(result["status"], "match", f"Expected match but got {result}")
 
+    @parameterized.expand(
+        [
+            ("name", "Wrong Name"),
+            # minimal_flag_called_events isn't in TEAM_METADATA_FIELDS — it's added to
+            # fields_to_check separately, so it needs its own mismatch case.
+            ("minimal_flag_called_events", True),
+        ]
+    )
     @patch("posthog.storage.team_metadata_cache.get_team_metadata")
-    def test_verify_detects_mismatch_in_tracked_fields(self, mock_get_metadata):
-        """Verify that mismatches in TEAM_METADATA_FIELDS are still detected."""
+    def test_verify_detects_mismatch_in_tracked_fields(self, field, wrong_value, mock_get_metadata):
         from posthog.storage.team_metadata_cache import _serialize_team_to_metadata
 
-        # Get the actual serialized data for this team
         db_data = _serialize_team_to_metadata(self.team)
 
-        # Create cached data with a mismatch in a tracked field
         cached_data = db_data.copy()
-        cached_data["name"] = "Wrong Name"  # Mismatch in a tracked field
+        cached_data[field] = wrong_value
         mock_get_metadata.return_value = cached_data
 
         result = verify_team_metadata(self.team)
 
         self.assertEqual(result["status"], "mismatch")
         self.assertEqual(result["issue"], "DATA_MISMATCH")
-        self.assertIn("name", result["diff_fields"])
+        self.assertIn(field, result["diff_fields"])
 
     @patch("posthog.storage.team_metadata_cache.get_team_metadata")
     def test_verify_returns_miss_when_no_cached_data(self, mock_get_metadata):
@@ -420,6 +427,51 @@ class TestVerifyTeamMetadata(BaseTest):
 
         self.assertEqual(result["status"], "miss")
         self.assertEqual(result["issue"], "CACHE_MISS")
+
+
+class TestMinimalFlagCalledEventsInMetadata(BaseTest):
+    """
+    minimal_flag_called_events lives on TeamFeatureFlagsConfig, not on Team, so it's
+    derived rather than pulled from TEAM_METADATA_FIELDS. Guards against the derivation
+    defaulting to the wrong value or the batch path (used by cache warming) drifting
+    from the single-team path (used by cache miss lookups).
+    """
+
+    def test_defaults_to_false_for_ungated_team(self):
+        from posthog.storage.team_metadata_cache import _serialize_team_to_metadata
+
+        metadata = _serialize_team_to_metadata(self.team)
+
+        self.assertIs(metadata["minimal_flag_called_events"], False)
+
+    def test_reflects_gated_config_row(self):
+        from posthog.storage.team_metadata_cache import _serialize_team_to_metadata
+
+        TeamFeatureFlagsConfig.objects.update_or_create(team=self.team, defaults={"minimal_flag_called_events": True})
+
+        metadata = _serialize_team_to_metadata(self.team)
+
+        self.assertIs(metadata["minimal_flag_called_events"], True)
+
+    def test_batch_load_matches_single_team_load(self):
+        from posthog.storage.team_metadata_cache import _batch_load_team_metadata, _serialize_team_to_metadata
+
+        gated_team = self.organization.teams.create(name="Gated team")
+        TeamFeatureFlagsConfig.objects.update_or_create(team=gated_team, defaults={"minimal_flag_called_events": True})
+        ungated_team = self.organization.teams.create(name="Ungated team")
+
+        batch_result = _batch_load_team_metadata([gated_team, ungated_team])
+
+        self.assertEqual(
+            batch_result[gated_team.id]["minimal_flag_called_events"],
+            _serialize_team_to_metadata(gated_team)["minimal_flag_called_events"],
+        )
+        self.assertEqual(
+            batch_result[ungated_team.id]["minimal_flag_called_events"],
+            _serialize_team_to_metadata(ungated_team)["minimal_flag_called_events"],
+        )
+        self.assertIs(batch_result[gated_team.id]["minimal_flag_called_events"], True)
+        self.assertIs(batch_result[ungated_team.id]["minimal_flag_called_events"], False)
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test:6379/0")

--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -213,12 +213,23 @@ pub struct FlagsResponse {
     pub request_id: Uuid,
     /// Timestamp when flags were evaluated, in milliseconds since Unix epoch
     pub evaluated_at: i64,
+    /// Set to `true` when the team is gated into slim `$feature_flag_called` events
+    /// (TeamFeatureFlagsConfig.minimal_flag_called_events). Omitted otherwise, so SDKs
+    /// that see no field at all fall back to full events, same as legacy teams.
+    /// Only reaches the wire on this v2 shape: `LegacyFlagsResponse`, `DecideV1Response`,
+    /// and `DecideV2Response` intentionally never carry it over. SDKs old enough to hit
+    /// those response shapes predate this field and have no code path that reads it, so
+    /// there's nothing gained by sending it to them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimal_flag_called_events: Option<bool>,
 
     /// Additional configuration data merged into the response at the top level
     #[serde(flatten)]
     pub config: ConfigResponse,
 }
 
+/// Legacy `/flags` response shape. This and the two decide response shapes below never
+/// carry `minimal_flag_called_events`: see the field's doc on `FlagsResponse` for why.
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LegacyFlagsResponse {
@@ -343,6 +354,7 @@ impl FlagsResponse {
             quota_limited,
             request_id,
             evaluated_at: chrono::Utc::now().timestamp_millis(),
+            minimal_flag_called_events: None,
             config: ConfigResponse::default(),
         }
     }
@@ -362,6 +374,7 @@ impl FlagsResponse {
             quota_limited,
             request_id,
             evaluated_at,
+            minimal_flag_called_events: None,
             config: ConfigResponse::default(),
         }
     }
@@ -1157,6 +1170,21 @@ mod tests {
         assert!(obj.contains_key("errorsWhileComputingFlags"));
         assert!(obj.contains_key("flags"));
         assert!(obj.contains_key("requestId"));
+    }
+
+    #[test]
+    fn test_minimal_flag_called_events_round_trips_through_serde() {
+        let mut response = FlagsResponse::new(false, HashMap::new(), None, Uuid::new_v4());
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(
+            !json.as_object().unwrap().contains_key("minimalFlagCalledEvents"),
+            "absence must mean full events — SDKs treat a missing key the same as an old cache entry"
+        );
+
+        response.minimal_flag_called_events = Some(true);
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json.get("minimalFlagCalledEvents"), Some(&json!(true)));
     }
 
     #[test]

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     flags::{flag_matching::EvaluationType, flag_service::FlagService},
     handler::phases::{Phase, PhaseGuard},
     metrics::consts::{FLAG_REQUESTS_COUNTER, FLAG_REQUESTS_LATENCY, FLAG_REQUEST_FAULTS_COUNTER},
+    team::team_models::Team,
 };
 use std::collections::HashMap;
 use tracing::{instrument, warn};
@@ -281,11 +282,13 @@ async fn process_request_inner(
         // Build the rest of the FlagsResponse with config from HyperCache.
         // When config=true, reads pre-computed config from Python's RemoteConfig.
         // On cache miss, returns fallback config.
-        let response = {
+        let mut response = {
             let _phase = PhaseGuard::enter(Phase::ConfigResponse);
             config_response_builder::build_response_from_cache(flags_response, &context, &team)
                 .await?
         };
+
+        apply_minimal_flag_called_events(&mut response, &team);
 
         // Populate canonical log with flag evaluation results and read back evaluation_type.
         // If an earlier step errored (? above), we skip this and evaluation_type stays
@@ -304,6 +307,15 @@ async fn process_request_inner(
     .await;
 
     (result, metrics_data)
+}
+
+/// Sets `minimal_flag_called_events: Some(true)` when the team is gated into slim
+/// `$feature_flag_called` events. Never sets `Some(false)` — absence is the "full events"
+/// signal for SDKs (see [`crate::api::types::FlagsResponse::minimal_flag_called_events`]).
+fn apply_minimal_flag_called_events(response: &mut FlagsResponse, team: &Team) {
+    if team.minimal_flag_called_events {
+        response.minimal_flag_called_events = Some(true);
+    }
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -4,7 +4,7 @@ use crate::{
         errors::FlagError,
         types::{
             Compression, FlagDetails, FlagDetailsMetadata, FlagEvaluationReason, FlagValue,
-            FlagsQueryParams, LegacyFlagsResponse,
+            FlagsQueryParams, FlagsResponse, LegacyFlagsResponse,
         },
     },
     cohorts::cohort_cache_manager::CohortCacheManager,
@@ -23,11 +23,12 @@ use crate::{
         flag_service::FlagService,
     },
     handler::{
-        decoding, evaluation::evaluate_feature_flags, flags::fetch_and_filter, properties,
-        FeatureFlagEvaluationContext,
+        apply_minimal_flag_called_events, decoding, evaluation::evaluate_feature_flags,
+        flags::fetch_and_filter, properties, FeatureFlagEvaluationContext,
     },
     mock,
     properties::property_models::PropertyType,
+    team::team_models::Team,
     utils::{
         mock::MockInto,
         test_utils::{
@@ -1814,5 +1815,31 @@ async fn test_realtime_cohort_evaluation_setting_behavior() {
         provider_disabled.call_count(),
         0,
         "Provider should not be called when flags have no cohort dependencies"
+    );
+}
+
+#[test]
+fn test_apply_minimal_flag_called_events_sets_true_when_team_gated() {
+    let mut response = FlagsResponse::new(false, HashMap::new(), None, Uuid::new_v4());
+    let team = Team {
+        minimal_flag_called_events: true,
+        ..Default::default()
+    };
+
+    apply_minimal_flag_called_events(&mut response, &team);
+
+    assert_eq!(response.minimal_flag_called_events, Some(true));
+}
+
+#[test]
+fn test_apply_minimal_flag_called_events_leaves_none_when_team_ungated() {
+    let mut response = FlagsResponse::new(false, HashMap::new(), None, Uuid::new_v4());
+    let team = Team::default();
+
+    apply_minimal_flag_called_events(&mut response, &team);
+
+    assert_eq!(
+        response.minimal_flag_called_events, None,
+        "absence, not Some(false), is the full-events signal SDKs rely on"
     );
 }

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -50,6 +50,11 @@ pub struct Team {
     pub cookieless_server_hash_mode: Option<i16>,
     #[serde(default = "default_timezone")]
     pub timezone: String,
+    // Sourced from the internal-only TeamFeatureFlagsConfig extension, not a posthog_team
+    // column. #[serde(default)] keeps cache entries written before this field existed
+    // deserializing to `false` (full events), fail-safe.
+    #[serde(default)]
+    pub minimal_flag_called_events: bool,
 }
 
 fn default_timezone() -> String {
@@ -81,5 +86,28 @@ impl TeamIdentifier for Team {
 
     fn api_token(&self) -> &str {
         &self.api_token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_minimal_flag_called_events_defaults_false_on_legacy_cache_blob() {
+        // A HyperCache JSON blob written before this field existed has no
+        // minimal_flag_called_events key. #[serde(default)] must make that
+        // deserialize to `false` (full events) rather than erroring.
+        let legacy_json = serde_json::json!({
+            "id": 1,
+            "name": "test team",
+            "api_token": "test_token",
+            "uuid": Uuid::new_v4().to_string(),
+        });
+
+        let team: Team =
+            serde_json::from_value(legacy_json).expect("legacy blob must still deserialize");
+
+        assert!(!team.minimal_flag_called_events);
     }
 }

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -43,7 +43,11 @@ const TEAM_COLUMNS: &str = "
     session_recording_url_blocklist_config,
     session_recording_event_trigger_config,
     session_recording_trigger_match_type_config,
-    recording_domains
+    recording_domains,
+    COALESCE(
+        (SELECT minimal_flag_called_events FROM feature_flags_teamfeatureflagsconfig WHERE team_id = posthog_team.id),
+        false
+    ) AS minimal_flag_called_events
 ";
 
 impl Team {
@@ -297,5 +301,51 @@ mod tests {
         let config = team_from_pg.extra_settings.unwrap();
         let recorder_script = config.get("recorder_script").and_then(|v| v.as_str());
         assert_eq!(recorder_script, Some(""));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_defaults_minimal_flag_called_events_false_without_config_row() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        let team_from_pg = Team::from_pg(context.non_persons_reader.clone(), &team.api_token)
+            .await
+            .expect("Failed to fetch team from pg");
+
+        assert!(!team_from_pg.minimal_flag_called_events);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_reflects_gated_minimal_flag_called_events() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        let mut conn = get_connection_with_metrics(
+            &context.non_persons_reader,
+            "non_persons_reader",
+            "test_insert_team_feature_flags_config",
+        )
+        .await
+        .expect("Failed to get connection");
+
+        sqlx::query(
+            "INSERT INTO feature_flags_teamfeatureflagsconfig (team_id, minimal_flag_called_events) VALUES ($1, true)",
+        )
+        .bind(team.id)
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert TeamFeatureFlagsConfig row");
+
+        let team_from_pg = Team::from_pg(context.non_persons_reader.clone(), &team.api_token)
+            .await
+            .expect("Failed to fetch team from pg");
+
+        assert!(team_from_pg.minimal_flag_called_events);
     }
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -17,7 +17,7 @@ use feature_flags::config::DEFAULT_TEST_CONFIG;
 use feature_flags::utils::test_utils::{
     insert_config_in_hypercache, insert_flags_for_team_in_redis,
     insert_flags_with_metadata_for_team_in_redis, insert_new_team_in_redis, setup_pg_reader_client,
-    setup_redis_client, TestContext,
+    setup_redis_client, update_team_in_hypercache, TestContext,
 };
 
 pub mod common;
@@ -1736,6 +1736,47 @@ async fn it_sets_quota_limited_in_legacy_and_v2() -> Result<()> {
         v2.quota_limited,
         Some(vec![ServiceName::FeatureFlags.as_string()])
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_minimal_flag_called_events_reaches_v2_but_not_legacy_response() -> Result<()> {
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let distinct_id = "user1".to_string();
+
+    let client = setup_redis_client(Some(config.redis_url.clone())).await;
+    let mut team = insert_new_team_in_redis(client.clone()).await.unwrap();
+    team.minimal_flag_called_events = true;
+    update_team_in_hypercache(client.clone(), &team).await?;
+    let token = team.api_token.clone();
+
+    let context = TestContext::new(None).await;
+    context.insert_new_team(Some(team.id)).await.unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let payload = json!({
+        "token": token,
+        "distinct_id": distinct_id,
+    });
+
+    // V2 response: the gated team's signal is present and true.
+    let res = server
+        .send_flags_request(payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+    let v2: FlagsResponse = res.json().await?;
+    assert_eq!(v2.minimal_flag_called_events, Some(true));
+
+    // Legacy response (no version param): LegacyFlagsResponse doesn't carry the field at
+    // all, so a gated team's v1 clients never see the signal and keep sending full events.
+    let res = server
+        .send_flags_request(payload.to_string(), Some("1"), None)
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+    let json_data = res.json::<Value>().await?;
+    assert!(json_data.get("minimalFlagCalledEvents").is_none());
 
     Ok(())
 }

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -1769,8 +1769,8 @@ async fn test_minimal_flag_called_events_reaches_v2_but_not_legacy_response() ->
     let v2: FlagsResponse = res.json().await?;
     assert_eq!(v2.minimal_flag_called_events, Some(true));
 
-    // Legacy response (no version param): LegacyFlagsResponse doesn't carry the field at
-    // all, so a gated team's v1 clients never see the signal and keep sending full events.
+    // Legacy response (v=1): LegacyFlagsResponse doesn't carry the field at all, so a
+    // gated team's v1 clients never see the signal and keep sending full events.
     let res = server
         .send_flags_request(payload.to_string(), Some("1"), None)
         .await;


### PR DESCRIPTION
## Problem

`TeamFeatureFlagsConfig.minimal_flag_called_events` already exists to gate teams into slim `$feature_flag_called` events, but the `/flags` response never told SDKs whether a team is gated in. This PR wires that field through to the response so SDKs know which event shape to send.

## Changes

- `FlagsResponse` (the v2 response shape) gets a new `minimalFlagCalledEvents` field. It's `Option<bool>` and only serialized when `true`, so absence means full events, same as the behavior SDKs already have for teams that predate this field or cache entries written before it existed. `LegacyFlagsResponse` and the two decide response shapes intentionally don't carry it, since SDKs old enough to hit those shapes have no code that reads it.
- `Team` (Rust) picks up a `minimal_flag_called_events` field, sourced via a `COALESCE` subquery against `feature_flags_teamfeatureflagsconfig` in `Team::from_pg`. `#[serde(default)]` keeps HyperCache entries written before this field existed deserializing to `false`.
- `posthog/storage/team_metadata_cache.py` now serializes `minimal_flag_called_events` too, so the Postgres-backed team metadata cache and its verify path agree with what the Rust reader does. The batch loader fetches all teams' config rows in one query to avoid N+1s during cache warming.

## How did you test this code?

Added unit and integration tests:

- Rust: serde round-trip test confirming the field is omitted when `None` and present when `Some(true)`.
- Rust: handler unit tests for `apply_minimal_flag_called_events`, covering both the gated and ungated team cases.
- Rust: `Team::from_pg` tests confirming it defaults to `false` without a config row and reflects a gated row.
- Rust: end-to-end test confirming the v2 `/flags` response carries the field for a gated team while the legacy (v1) response omits it.
- Python: tests confirming `_serialize_team_to_metadata` defaults to `false`, reflects a gated config row, and that the batch loader matches the single-team loader.

I ran all of the above locally: `hogli test posthog/storage/test/test_team_metadata_cache.py` (36 passed) and the Rust unit and integration tests covering the new field (15 passed). I didn't exercise this against a live SDK.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?