### PR TITLE
fix(flags): don't redirect the staff tools page to a project url

### DIFF
--- a/frontend/src/lib/utils/kea-router.test.ts
+++ b/frontend/src/lib/utils/kea-router.test.ts
@@ -17,6 +17,14 @@ describe('router-utils', () => {
         const altered = addProjectIdIfMissing('/feature_flags/staff', 123)
         expect(altered).toEqual('/feature_flags/staff')
     })
+    it('does not redirect the staff tools URL when it carries a query string', () => {
+        const altered = addProjectIdIfMissing('/feature_flags/staff?team_id=456', 123)
+        expect(altered).toEqual('/feature_flags/staff?team_id=456')
+    })
+    it('does not redirect the staff tools URL when it carries a hash', () => {
+        const altered = addProjectIdIfMissing('/feature_flags/staff#cache', 123)
+        expect(altered).toEqual('/feature_flags/staff#cache')
+    })
     it('still adds a project id to other feature flags URLs', () => {
         const altered = addProjectIdIfMissing('/feature_flags/123', 123)
         expect(altered).toEqual('/project/123/feature_flags/123')

--- a/frontend/src/lib/utils/kea-router.test.ts
+++ b/frontend/src/lib/utils/kea-router.test.ts
@@ -13,6 +13,14 @@ describe('router-utils', () => {
         const altered = addProjectIdIfMissing('/project/phc_gE7SWBNBgFbA4eQ154KPXebyB8KyLJuypR8jg1DSo9Z/replay', 123)
         expect(altered).toEqual('/project/phc_gE7SWBNBgFbA4eQ154KPXebyB8KyLJuypR8jg1DSo9Z/replay')
     })
+    it('does not redirect the instance-level feature flags staff tools URL to a project URL', () => {
+        const altered = addProjectIdIfMissing('/feature_flags/staff', 123)
+        expect(altered).toEqual('/feature_flags/staff')
+    })
+    it('still adds a project id to other feature flags URLs', () => {
+        const altered = addProjectIdIfMissing('/feature_flags/123', 123)
+        expect(altered).toEqual('/project/123/feature_flags/123')
+    })
 
     describe('relative path normalization', () => {
         it('normalizes ../ prefix to absolute path with project id', () => {

--- a/frontend/src/lib/utils/kea-router.ts
+++ b/frontend/src/lib/utils/kea-router.ts
@@ -27,10 +27,13 @@ const exactPathsWithoutProjectId = ['/feature_flags/staff']
 const projectIdentifierInUrlRegex = /^\/project\/(\d+|phc_)/
 
 function isPathWithoutProjectId(path: string): boolean {
-    if (exactPathsWithoutProjectId.some((exactPath) => path === exactPath || path.startsWith(exactPath + '/'))) {
+    const pathname = path.split(/[?#]/)[0]
+    if (
+        exactPathsWithoutProjectId.some((exactPath) => pathname === exactPath || pathname.startsWith(exactPath + '/'))
+    ) {
         return true
     }
-    const firstPart = path.split('/')[1]
+    const firstPart = pathname.split('/')[1]
     return pathsWithoutProjectId.includes(firstPart)
 }
 

--- a/frontend/src/lib/utils/kea-router.ts
+++ b/frontend/src/lib/utils/kea-router.ts
@@ -20,9 +20,16 @@ const pathsWithoutProjectId = [
     'render_query',
 ]
 
+// Instance-level pages that live under a product's own path prefix rather than
+// under `/instance/*`, so they need an exact (rather than first-segment) exemption.
+const exactPathsWithoutProjectId = ['/feature_flags/staff']
+
 const projectIdentifierInUrlRegex = /^\/project\/(\d+|phc_)/
 
 function isPathWithoutProjectId(path: string): boolean {
+    if (exactPathsWithoutProjectId.some((exactPath) => path === exactPath || path.startsWith(exactPath + '/'))) {
+        return true
+    }
     const firstPart = path.split('/')[1]
     return pathsWithoutProjectId.includes(firstPart)
 }


### PR DESCRIPTION
## Problem

/feature_flags/staff redirects to /project/{id}/feature_flags/staff, even though the flags staff tools page isn't project scoped.

## Changes

`addProjectIdIfMissing` decides whether a route needs a project id prefix by checking only the first path segment against a hardcoded list (`instance`, `account`, `oauth`, etc). The flags staff tools page lives under `/feature_flags/staff` instead of `/instance/*`, so it fell through and got a project id prepended like a normal project scoped route. Added an exact path exemption for `/feature_flags/staff` alongside the existing first segment list.

## How did you test this code?

Added a test in `kea-router.test.ts` that reproduces the redirect: `addProjectIdIfMissing('/feature_flags/staff', 123)` now stays unprefixed, plus a companion case confirming `/feature_flags/123` still gets a project id. I verified the new test fails without the fix (asserting the exact `/project/123/feature_flags/staff` output the reported bug produces) and passes with it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc update needed, this is a routing bug fix with no user-facing behavior change beyond the redirect no longer happening.