### PR TITLE
fix(session-summary): tag video-summary Gemini calls with ai_product

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a4_analyze_video_segment.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a4_analyze_video_segment.py
@@ -120,6 +120,7 @@ async def analyze_video_segment_activity(
             posthog_distinct_id=inputs.user_distinct_id_to_log,
             posthog_trace_id=trace_id,
             posthog_properties={
+                "ai_product": "session_replay",
                 "segment_index": segment.segment_index,
             },
             posthog_groups={"project": str(inputs.team_id)},

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a6_consolidate_video_segments.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a6_consolidate_video_segments.py
@@ -175,7 +175,7 @@ async def _call_llm_to_consolidate_segments(
                 ),
                 posthog_distinct_id=inputs.user_distinct_id_to_log,
                 posthog_trace_id=trace_id,
-                posthog_properties={},
+                posthog_properties={"ai_product": "session_replay"},
                 posthog_groups={"project": str(inputs.team_id)},
             )
 
@@ -307,7 +307,7 @@ async def _call_llm_to_tag_session(
         ),
         posthog_distinct_id=inputs.user_distinct_id_to_log,
         posthog_trace_id=trace_id,
-        posthog_properties={"$session_id": inputs.session_id},
+        posthog_properties={"ai_product": "session_replay", "$session_id": inputs.session_id},
         posthog_groups={"project": str(inputs.team_id)},
     )
 


### PR DESCRIPTION
## Problem

The video-based session summary path calls Gemini directly and never sets `ai_product` on its three `generate_content` calls, so those `$ai_generation` events (~1.9M/30d) are the entire `(untagged)` bucket in the AI Gateway cutover dashboard's usage-by-product view. The OpenAI text path already sets `ai_product: "session_replay"` (`ee/hogai/session_summaries/llm/call.py`); this brings the Gemini video path to parity.

## Changes

- `a4_analyze_video_segment.py`: set `ai_product: "session_replay"` on the segment-analysis call.
- `a6_consolidate_video_segments.py`: set it on the consolidate call (was `{}`) and the tag-session call.

## How did you test this code?

Not run by the agent. The change adds a static `ai_product` property to three existing capture calls with no logic change. Grep confirms these are the only Gemini `generate_content` sites under `session_summary/`, so the tag is complete. Post-deploy check: the events group under `session_replay` in the pre-gateway usage-by-product view instead of `(untagged)`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) at Brandon Leung's direction. Requires human review.
