### PR TITLE
chore(frontend): steer agents away from localStorage for durable state

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -44,6 +44,12 @@ When touching `lib/api`, `api.get<`, `api.create<`, or any handwritten API inter
 
 Covered by the root `AGENTS.md` (Code Style → Frontend). The discovery hint for this tree: if a scene/component has a `*Logic.ts`, that's where actions/reducers/selectors/listeners belong. See `/writing-kea-logics` and `/using-kea-disposables`.
 
+## Rule 4 — Persist durable state to the backend, not `localStorage`
+
+`localStorage` is the path of least resistance — one line, no model/migration/serializer/endpoint — so agents reach for it by default. It's the **right** choice for device-local ephemeral UI state (collapsed panels, dismissed hints, view toggles; often via kea's `persist`). It's the **wrong** choice for anything a user expects to follow their account.
+
+Before persisting to `localStorage`, ask: should this survive a device switch, or be authoritative/shared? If yes — user settings, saved configs, preferences, anything a user would be upset to lose when they open PostHog on another machine — persist it to the backend (model + API), even though it's more work. Don't default to `localStorage` just because this tree is frontend-heavy; the repo has a database. When the backend route is the right call, that means a Django model, serializer, and endpoint — see the root `AGENTS.md` and `/improving-drf-endpoints`.
+
 ## Typecheck & typegen cadence (don't over-run these)
 
 These are slow; run them at the right moment, not after every edit.


### PR DESCRIPTION
## Problem

Agents building frontend features default to `localStorage` for persistence because it's a single line, with no model/migration/serializer/endpoint to write. That's fine for ephemeral device-local UI state, but it's the wrong home for anything a user expects to follow their account. State that should sync across a user's devices ends up trapped on one machine, and the user is surprised when it vanishes on another. This was raised in a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783459196822899?thread_ts=1783459196.822899&cid=C09G8Q32R6F) alongside the related "custom instructions should live in the cloud" complaint.

## Changes

Adds "Rule 4" to `frontend/src/AGENTS.md` (its `CLAUDE.md` is a symlink, so both are covered). It's a decision rule, not a blanket ban: `localStorage` stays correct for collapsed panels, dismissed hints, view toggles, and similar. The rule asks the agent to persist to the backend when state should survive a device switch or be authoritative/shared, and points at `/improving-drf-endpoints` for the model + serializer + endpoint path.

## How did you test this code?

Docs-only change. No automated tests run; nothing to execute.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raquel raised that agents lean on `localStorage` by default and asked whether AGENTS.md should say something about it. I (the PostHog Slack app) pushed back on the original framing — "there's no db attached to the repo" isn't the real cause, and a blanket "always save to PostHog" would be wrong given ~340 legit `localStorage` usages, many via kea's `persist`. We settled on a decision rule that distinguishes device-local ephemeral state from account-durable state. No skills were needed for a docs-only edit.