### PR TITLE
fix(experiments): use the global analytics client in recalc activities

### DIFF
--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -13,6 +13,7 @@ from django.db import close_old_connections, transaction
 from django.utils import timezone
 
 import structlog
+import posthoganalytics
 from temporalio.exceptions import ApplicationError
 
 from posthog.schema import ExperimentQuery
@@ -23,7 +24,6 @@ from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.scoping import team_scope
-from posthog.ph_client import ph_scoped_capture
 from posthog.sync import database_sync_to_async
 
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window_end
@@ -263,38 +263,39 @@ def _capture_results_refresh_completed(update: RecalculationProgressUpdate) -> N
         )
         primary_metrics_count = len(experiment.metrics or [])
         secondary_metrics_count = len(experiment.metrics_secondary or [])
-        with ph_scoped_capture() as capture:
-            capture(
-                distinct_id=distinct_id,
-                event="experiment results refresh completed",
-                properties={
-                    "experiment_id": experiment.id,
-                    "team_id": team.id,
-                    "recalculation_id": str(recalc.id),
-                    "status": recalc.status,
-                    "total_metrics": recalc.total_metrics,
-                    "succeeded_metrics": update.succeeded_metrics,
-                    "failed_metrics": update.failed_metrics,
-                    "total_duration_ms": total_duration_ms,
-                    "execution_duration_ms": execution_duration_ms,
-                    "queue_duration_ms": queue_duration_ms,
-                    "trigger": recalc.trigger,
-                    "execution_mode": "recalculation",
-                    # Legacy-named aliases + missing properties for parity with the frontend
-                    # 'experiment results refresh completed' event, so the original experiments
-                    # dashboards work against workflow runs with the same property names.
-                    "triggered_by": recalc.trigger,
-                    "successful_count": update.succeeded_metrics,
-                    "errored_count": update.failed_metrics,
-                    "cached_count": 0,
-                    "total_metrics_count": recalc.total_metrics,
-                    "primary_metrics_count": primary_metrics_count,
-                    "secondary_metrics_count": secondary_metrics_count,
-                    "experiment_status": experiment.status or experiment.computed_status,
-                    "experiment_duration_hours": experiment_duration_hours,
-                },
-                groups=groups(organization=team.organization, team=team),
-            )
+        # Global client, like most Temporal workflows: the worker is long-lived, so its background flush
+        # runs fine, and a scoped client's synchronous shutdown stalls the activity (~2x flush_interval).
+        posthoganalytics.capture(
+            distinct_id=distinct_id,
+            event="experiment results refresh completed",
+            properties={
+                "experiment_id": experiment.id,
+                "team_id": team.id,
+                "recalculation_id": str(recalc.id),
+                "status": recalc.status,
+                "total_metrics": recalc.total_metrics,
+                "succeeded_metrics": update.succeeded_metrics,
+                "failed_metrics": update.failed_metrics,
+                "total_duration_ms": total_duration_ms,
+                "execution_duration_ms": execution_duration_ms,
+                "queue_duration_ms": queue_duration_ms,
+                "trigger": recalc.trigger,
+                "execution_mode": "recalculation",
+                # Legacy-named aliases + missing properties for parity with the frontend
+                # 'experiment results refresh completed' event, so the original experiments
+                # dashboards work against workflow runs with the same property names.
+                "triggered_by": recalc.trigger,
+                "successful_count": update.succeeded_metrics,
+                "errored_count": update.failed_metrics,
+                "cached_count": 0,
+                "total_metrics_count": recalc.total_metrics,
+                "primary_metrics_count": primary_metrics_count,
+                "secondary_metrics_count": secondary_metrics_count,
+                "experiment_status": experiment.status or experiment.computed_status,
+                "experiment_duration_hours": experiment_duration_hours,
+            },
+            groups=groups(organization=team.organization, team=team),
+        )
     except Exception:
         logger.warning(
             "experiment_results_refresh_completed_capture_failed",
@@ -397,24 +398,23 @@ def _capture_experiment_metric_event(
             if experiment.created_by and experiment.created_by.distinct_id
             else f"team_{team.id}"
         )
-        with ph_scoped_capture() as capture:
-            capture(
-                distinct_id=distinct_id,
-                event=event,
-                properties={
-                    "experiment_id": experiment.id,
-                    "team_id": team.id,
-                    "metric_uuid": metric_uuid,
-                    "metric_kind": (metric_dict or {}).get("metric_type"),
-                    "is_primary": metric_type == "primary",
-                    "execution_mode": "recalculation",
-                    "context": "ui",
-                    "mechanism": "orchestrated",
-                    "trigger": trigger,
-                    **extra_properties,
-                },
-                groups=groups(organization=team.organization, team=team),
-            )
+        posthoganalytics.capture(
+            distinct_id=distinct_id,
+            event=event,
+            properties={
+                "experiment_id": experiment.id,
+                "team_id": team.id,
+                "metric_uuid": metric_uuid,
+                "metric_kind": (metric_dict or {}).get("metric_type"),
+                "is_primary": metric_type == "primary",
+                "execution_mode": "recalculation",
+                "context": "ui",
+                "mechanism": "orchestrated",
+                "trigger": trigger,
+                **extra_properties,
+            },
+            groups=groups(organization=team.organization, team=team),
+        )
     except Exception:
         logger.warning(
             "experiment_metric_event_capture_failed",

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -756,20 +756,16 @@ class TestMissingRecalcRow:
 
 @contextmanager
 def _record_captures():
-    """Patch ph_scoped_capture so the analytics tests can assert the exact event name + properties
-    without standing up a real PostHog client. Yields the list of captured capture(...) kwargs."""
+    """Patch the global posthoganalytics client so the analytics tests can assert the exact event
+    name + properties without sending anything. Yields the list of captured capture(...) kwargs."""
     captured: list[dict] = []
 
     def _fake_capture(*args, **kwargs) -> None:
         captured.append(kwargs)
 
-    @contextmanager
-    def _fake_scoped():
-        yield _fake_capture
-
     with patch(
-        "products.experiments.backend.temporal.recalculation_logic.ph_scoped_capture",
-        _fake_scoped,
+        "products.experiments.backend.temporal.recalculation_logic.posthoganalytics.capture",
+        _fake_capture,
     ):
         yield captured
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The final `update_recalculation_progress` activity of the metrics recalculation workflow took ~10s in production, so after every metric finished the UI still burned two or three polling cycles waiting for the run to reach its terminal state.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Both capture sites in the recalculation activities now call the global `posthoganalytics` singleton directly instead of `ph_scoped_capture`. This is what most Temporal workflows already do (signals, tasks, warehouse imports): the worker is long-lived, so the client's background consumer flushes events fine without a synchronous drain per activity. The final activity drops to milliseconds and each metric calc sheds its ~10s tail, so the terminal state lands within one polling cycle.

> [!NOTE]
> Delivery semantics change from "flushed before the activity returns" to best-effort background flush; a hard worker kill can drop a few seconds of buffered events. That is the same trade every other singleton-using Temporal workflow makes for product analytics. Event gating also moves from the scoped helper's `is_cloud()` check to the global client's `apps.py` configuration (disabled under TEST/opt-out), matching `event_usage.py`.

`ph_scoped_capture` itself is untouched and keeps its guaranteed-drain semantics for its remaining callers.

- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/temporal/test_recalculation_activities.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/57705dc0-b6c0-4984-bfe6-cce4a1791c89)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Fable 5
Manually refactored: **no**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Root cause was pinned with the `database_sync_to_async_thread_sensitive_execution_time_seconds` histogram (via the Grafana MCP): a perfectly bimodal distribution for the progress activity ruled out Postgres lookups and executor-thread contention, and the calc activities' uniform >10s floor pointed at the shared capture path.
- Two fixes were tried and rejected before this one: passing `flush_interval=0.1` to the scoped client (works, but adds a tuning knob no other caller uses) and `sync_mode=True` as in the weekly digest activities (moves the HTTP POST inline with the capture call). The global singleton matches the dominant existing pattern across Temporal workflows.
- Other `ph_scoped_capture` users in Temporal (error tracking embeddings, exports subscriptions, web analytics digest notification) pay the same stall but are latency-insensitive; intentionally left for a follow-up.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, with the before diagram first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->