### PR TITLE
fix(surveys): show customization tab for API surveys so whiteLabel is editable

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1307,7 +1307,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                         </>
                                     ),
                                 },
-                                ...(survey.type !== SurveyType.API
+                                ...(survey.type !== SurveyType.ExternalSurvey
                                     ? [
                                           {
                                               key: SurveyEditSection.Customization,


### PR DESCRIPTION
## Problem

Closes #53036

API-type surveys had the entire Customization tab (including the "Hide PostHog branding" toggle) hidden in the editor. The condition at `SurveyEdit.tsx:1310` guarded the section with `survey.type !== SurveyType.API`, but the intended exclusion is only for `ExternalSurvey` (hosted surveys that render outside PostHog's widget system).

API surveys can still render the PostHog survey widget — users just control when/how to show it via the API. The appearance settings, including `whiteLabel`, apply to that widget and should be editable.

## Changes

- Changed the Customization section guard from `!== SurveyType.API` to `!== SurveyType.ExternalSurvey` in `SurveyEdit.tsx`
- The `Customization` component already handles `ExternalSurvey` internally where needed (Layout and popup delay sections), so no changes needed there

## How did you test this code?

Manual testing not possible in this environment. The change is a one-word type swap in a conditional — `API` → `ExternalSurvey`. The `ExternalSurvey` exclusion is already used identically in two adjacent conditions in the same file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Root cause traced to `SurveyEdit.tsx:1310` where `SurveyType.API` was used instead of `SurveyType.ExternalSurvey` as the exclusion condition. Single-token fix. No skills invoked.