### PR TITLE
fix(dashboards): add set-to-null toggle for list variables on dashboards

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -345,12 +345,23 @@ export const VariableComponent = ({
         return (
             <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
                 <LemonSelect
-                    disabledReason={variableOverridesAreSet && 'Discard dashboard variables to change'}
+                    disabledReason={
+                        (variableOverridesAreSet && 'Discard dashboard variables to change') ||
+                        (variable.isNull && 'Set to null is enabled') ||
+                        undefined
+                    }
                     value={variable.isNull ? null : (variable.value ?? variable.default_value ?? null)}
                     onChange={(value) => onChange(variable.id, value, !value)}
                     options={getListVariableValues(variable).map((n) => ({ label: n, value: n }))}
                     size={size}
                     allowClear
+                />
+                <LemonSwitch
+                    className="mt-1"
+                    label="Set to null"
+                    checked={variable.isNull ?? false}
+                    disabledReason={variableOverridesAreSet && 'Discard dashboard variables to change'}
+                    onChange={(checked) => onChange(variable.id, null, checked)}
                 />
             </LemonField.Pure>
         )


### PR DESCRIPTION
## Problem

Closes #47202

List-type SQL variables on dashboards had no way to be set to null from the UI. Every other variable type (string, number, boolean, date) has a "Set to null" `LemonSwitch` toggle, but list variables hit an early return path in `VariableComponent` that rendered only a bare `LemonSelect`, with no null toggle.

The early return at `VariableComponent` line 343 exists to skip the popover overlay for list variables in dashboard mode (sensible — a dropdown is better UX than a popover for a list), but it accidentally skipped the null toggle too.

## Changes

- Added a `LemonSwitch` for "Set to null" below the `LemonSelect` in the list-variable dashboard path
- When null is active, the select is disabled with a hint explaining why
- Pattern matches how the null toggle behaves for all other variable types

## How did you test this code?

Manual testing not possible in this environment. The change adds a `LemonSwitch` that calls `onChange(variable.id, null, checked)` — the same call signature used by every other variable type's null toggle in the same file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Root cause traced to `Variables.tsx:344` where the early-return for list variables in dashboard mode omitted the null toggle that all other variable types include. No skills invoked.