### PR TITLE
feat(lemon-ui): add indeterminate state to LemonSwitch

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3936,6 +3936,10 @@ snapshots:
         hash: v1.k794b7964.0dda5edf3c90441a3314fb162be33ba02438c6236899a15673c258cd02fd9447.Q-Dyq1OyDT8kuUH8dn5lwkGdpRnj_yqZU767KP9sgL8
     lemon-ui-lemon-switch--disabled--light:
         hash: v1.k794b7964.7a07f77443205915d54f15c9102b12f487814d755721bd132fa64f3b0e6371f0.PLzcpvxsLOxEGRAa-G28ZvpeNWk78NTxLZDWAYQ9nnQ
+    lemon-ui-lemon-switch--indeterminate--dark:
+        hash: v1.k794b7964.54e2b4f8325923115070f4493d3fd9043f9bbc7e4d49d49978fdd7418930bf72.TP6egk8otVWsZ2lnGdGirO1Yq1PeihCUt_eTC-kVSS8
+    lemon-ui-lemon-switch--indeterminate--light:
+        hash: v1.k794b7964.db207d14bbd34afcc50b0c8a38cf9aad5199fe0e683aaf9b822d4636bcf72b50.aFxgqsJsNz7GHYQwowEn6jiqS4yrUvmvScBMK9xTt8A
     lemon-ui-lemon-switch--overview--dark:
         hash: v1.k794b7964.872600c303709874583784febe9bad9aef0bb87f9843af9591bfff07058120cc.wimmvYiBqy4yV_njLni26wTERdJq0rnLFYWTIZH-y44
     lemon-ui-lemon-switch--overview--light:

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
@@ -124,6 +124,9 @@
     --lemon-switch-active-translate: translateX(
         calc(var(--lemon-switch-width) - var(--lemon-switch-handle-width) - 2 * var(--lemon-switch-handle-gutter))
     );
+    --lemon-switch-indeterminate-translate: translateX(
+        calc((var(--lemon-switch-width) - var(--lemon-switch-handle-width) - 2 * var(--lemon-switch-handle-gutter)) / 2)
+    );
 
     position: relative;
     width: var(--lemon-switch-handle-width);
@@ -145,6 +148,24 @@
         transform: var(--lemon-switch-active-translate);
     }
 
+    // Indeterminate: the handle parks mid-track on the neutral track, carrying a gray dash
+    .LemonSwitch--indeterminate & {
+        transform: var(--lemon-switch-indeterminate-translate);
+    }
+
+    // The spinner replaces the dash while loading
+    .LemonSwitch--indeterminate:not(.LemonSwitch--loading) &::after {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 55%;
+        height: 2px;
+        content: '';
+        background-color: var(--color-text-secondary);
+        border-radius: 1px;
+        transform: translate(-50%, -50%);
+    }
+
     .LemonSwitch--active & {
         --lemon-switch-handle-width: calc(var(--lemon-switch-handle-size) * 1.2);
 
@@ -153,6 +174,10 @@
 
     .LemonSwitch--active.LemonSwitch--checked & {
         transform: var(--lemon-switch-active-translate);
+    }
+
+    .LemonSwitch--active.LemonSwitch--indeterminate & {
+        transform: var(--lemon-switch-indeterminate-translate);
     }
 }
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.stories.tsx
@@ -67,6 +67,22 @@ export const Standalone: Story = {
     args: { label: undefined },
 }
 
+export const Indeterminate: Story = {
+    render: function IndeterminateStory() {
+        const [value, setValue] = useState<boolean | 'indeterminate'>('indeterminate')
+        return (
+            <div className="deprecated-space-y-2">
+                <RawLemonSwitch label="Interactive (click resolves to checked)" checked={value} onChange={setValue} />
+                <LemonSwitch label="Unchecked" checked={false} />
+                <RawLemonSwitch label="Indeterminate" checked="indeterminate" onChange={() => {}} />
+                <LemonSwitch label="Checked" checked />
+                <RawLemonSwitch label="Indeterminate bordered" checked="indeterminate" onChange={() => {}} bordered />
+                <RawLemonSwitch label="Indeterminate small" size="small" checked="indeterminate" onChange={() => {}} />
+            </div>
+        )
+    },
+}
+
 export const Bordered: Story = {
     args: { bordered: true },
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import { LemonSwitch } from './LemonSwitch'
 
@@ -8,6 +8,23 @@ describe('LemonSwitch', () => {
     afterEach(() => {
         cleanup()
     })
+
+    it.each([
+        { checked: false as const, ariaChecked: 'false', nextChecked: true },
+        { checked: true as const, ariaChecked: 'true', nextChecked: false },
+        { checked: 'indeterminate' as const, ariaChecked: 'mixed', nextChecked: true },
+    ])(
+        'exposes aria-checked "$ariaChecked" and resolves a click to $nextChecked',
+        ({ checked, ariaChecked, nextChecked }) => {
+            const onChange = jest.fn()
+            render(<LemonSwitch checked={checked} onChange={onChange} />)
+
+            const button = screen.getByRole('switch')
+            expect(button).toHaveAttribute('aria-checked', ariaChecked)
+            fireEvent.click(button)
+            expect(onChange).toHaveBeenCalledWith(nextChecked)
+        }
+    )
 
     it.each([
         { value: true, expected: 'true' },

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -10,7 +10,8 @@ import { cn } from 'lib/utils/css-classes'
 export interface LemonSwitchProps {
     className?: string
     onChange?: (newChecked: boolean) => void
-    checked: boolean
+    /** `'indeterminate'` shows a mixed state (centered handle with a dash); clicking it resolves to checked. */
+    checked: boolean | 'indeterminate'
     label?: string | JSX.Element
     labelClassName?: string
     id?: string
@@ -84,14 +85,15 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
                 id={id}
                 className={`LemonSwitch__button ${
                     sliderColorOverrideChecked || sliderColorOverrideUnchecked
-                        ? `bg-${checked ? sliderColorOverrideChecked : sliderColorOverrideUnchecked}`
+                        ? `bg-${checked === true ? sliderColorOverrideChecked : sliderColorOverrideUnchecked}`
                         : ''
                 }`}
                 type="button"
                 role="switch"
+                aria-checked={checked === 'indeterminate' ? 'mixed' : checked}
                 onClick={() => {
                     if (onChange && !loading) {
-                        onChange(!checked)
+                        onChange(checked !== true)
                     }
                 }}
                 onMouseDown={() => !loading && setIsActive(true)}
@@ -128,7 +130,8 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
             <div
                 ref={ref}
                 className={clsx('LemonSwitch', className, `LemonSwitch--${size}`, {
-                    'LemonSwitch--checked': checked,
+                    'LemonSwitch--checked': checked === true,
+                    'LemonSwitch--indeterminate': checked === 'indeterminate',
                     'LemonSwitch--active': isActive,
                     'LemonSwitch--bordered': bordered,
                     'LemonSwitch--disabled': isDisabled,


### PR DESCRIPTION
## Problem

LemonSwitch only knows checked and unchecked. For "some but not all children enabled" situations (bulk toggles, nested settings, filters with an unset override) we want an indeterminate state.

[#68644](https://github.com/PostHog/posthog/pull/68644) prototyped nine treatments side by side in Storybook. Variant I won: the handle parks mid-track on the neutral track and carries a gray dash.

## Changes

- `LemonSwitchProps.checked` widened to `boolean | 'indeterminate'`. Existing boolean call sites are unaffected.
- Indeterminate rendering lives in `LemonSwitch.scss` behind a `LemonSwitch--indeterminate` class: centered handle transform plus a gray dash drawn as an `::after` pseudo-element (hidden while `loading`, where the spinner takes its place).
- Clicking an indeterminate switch resolves it to checked; after that it toggles normally.
- The button now exposes `aria-checked` (`mixed` while indeterminate) - previously `role="switch"` had no checked state exposed at all.
- New `Indeterminate` Storybook story showing the interactive resolve behavior and static unchecked/indeterminate/checked comparison, including bordered and small sizes.

No screenshots included (agent session) - see the `Lemon UI/Lemon Switch/Indeterminate` Storybook story for visuals.

## How did you test this code?

- Added a parameterized case set to `LemonSwitch.test.tsx` asserting `aria-checked` and the click resolution for false/true/indeterminate. It catches the realistic regression of writing `onChange(!checked)`, which for the truthy string `'indeterminate'` would resolve to unchecked instead of checked - no existing test covered click behavior or aria state.
- `jest LemonSwitch.test.tsx` passes (7 tests).
- oxlint and oxfmt clean on the touched files. Full `typescript:check` reports the same pre-existing error count with and without this change (missing kea typegen artifacts in a fresh checkout), and none in LemonSwitch or its consumers.
- I did not visually verify the Storybook story in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - component-internal change, documented via Storybook.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code), directed by @thmsobrmlr, folding the winning variant I from the prototype PR [#68644](https://github.com/PostHog/posthog/pull/68644) into the production component. Skills invoked: /writing-tests.

Decisions: implemented the indeterminate visuals in SCSS (class + `::after` dash) rather than the prototype's inline styles, kept `LemonSwitch--checked` applied only for `checked === true` so the string value can't inherit checked styling, and guarded `sliderColorOverride*` selection against the truthy `'indeterminate'` string. Once this merges, #68644 can be closed and its prototype files discarded with it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

