### PR TITLE
chore(ci): skip legacy backend gating on docs-only changes

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -327,6 +327,11 @@ jobs:
                         - bin/ci-wait-for-docker
                         - frontend/public/email/*
                         - 'docker/clickhouse/**'
+                        # Same rationale as the backend filter's excludes above: docs-only
+                        # changes match the broad globs but exercise no legacy backend code,
+                        # so they shouldn't trigger the Django/turbo-discover path either.
+                        - '!**/*.md'
+                        - '!**/*.mdx'
                       schema:
                         # Tracked separately from `legacy` so turbo-discover can
                         # diff schema.json and narrow the product matrix to

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -239,6 +239,11 @@ jobs:
                         - bin/ci-wait-for-docker
                         - frontend/public/email/*
                         - 'docker/clickhouse/**'
+                        # Same rationale as the backend filter's excludes above: docs-only
+                        # changes match the broad globs but exercise no legacy backend code,
+                        # so they shouldn't trigger the Django/turbo-discover path either.
+                        - '!**/*.md'
+                        - '!**/*.mdx'
                       schema:
                         # Tracked separately from `legacy` so turbo-discover can
                         # diff schema.json and narrow the product matrix to


### PR DESCRIPTION
## Problem

#67952 moved the markdown-only skip into the `backend` filter, deliberately scoped to match the old shell hack it replaced — which never touched the `legacy` filter. So a docs-only PR (say, a README under `posthog/`) still sets `legacy: true` and triggers the Django/turbo-discover gating path for nothing. This was flagged as follow-up material in that PR's description.

## Changes

Adds the same `!**/*.md` / `!**/*.mdx` excludes to the `legacy` filter in `ci-backend.yml`, with a comment pointing at the backend filter's rationale (excludes are load-bearing: an over-broad exclude silently skips a suite, so only patterns that truly never affect backend code qualify — markdown does).

`.depot/workflows/ci-backend.yml` gets the identical change, keeping the shadow drift check green and the two files apples-to-apples.

Behavior change, stated plainly: a PR whose entire diff is markdown no longer runs the legacy-gated Django/turbo-discover suites. A PR mixing markdown with any other backend-matching file is unaffected — the non-markdown file still matches, so `legacy` stays true.

## How did you test this code?

- Both files parse as YAML; actionlint 1.7.12 (CI-pinned version) clean; `hogli lint:workflows` passes all 6 checks across 96 workflows; `hogli ci:preflight --fix` reports 0 failures.
- The exclude semantics (a `!` pattern vetoes, positive globs OR) are exactly those exercised by the vendored action's test suite and already load-bearing in production for the `backend` filter since #67952 merged.
- This PR's own CI is the live check: it touches only workflow YAML, so `legacy` gating here still fires (yml isn't markdown), and reviewers can confirm the filter parses by the `changes` job succeeding.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — CI internals only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Paul, implemented by Claude (PostHog Code) — the second of two follow-ups to #67952 (the first, #69171, migrates the remaining call sites to the vendored action).

Scope decision: only the `legacy` filter gets the excludes. The other filters in the `changes` job (`migrations`, `schema`, `persons_sql`, …) enumerate specific non-markdown paths where a stray `.md` can't match, so adding excludes there would be dead weight against the "only exclude what truly never affects backend" rule.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
