### PR TITLE
feat(llm-gateway): capture reasoning effort on $ai_generation events

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -195,10 +195,9 @@ async def handle_llm_request(
     # $ai_generation event. This is the shared chokepoint for every provider (Anthropic,
     # OpenAI chat/responses, Cloudflare), so a single extraction here covers them all, on
     # both success and error events. Read from the request body — the source of truth for
-    # what was actually sent to the model — rather than a caller-supplied header.
-    effort = _extract_effort(request_data)
-    if effort is not None:
-        set_effort(effort)
+    # what was actually sent to the model — rather than a caller-supplied header. Always
+    # set it (None when absent) so a stale value can't leak in if the context is reused.
+    set_effort(_extract_effort(request_data))
 
     structlog.contextvars.bind_contextvars(
         user_id=user.user_id,

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -35,21 +35,54 @@ from llm_gateway.streaming.sse import format_sse_stream
 logger = structlog.get_logger(__name__)
 
 
+def _clean_effort(value: Any) -> str | None:
+    if isinstance(value, str) and (stripped := value.strip()):
+        return stripped
+    return None
+
+
+# Reasoning-effort lives at a different spot per API surface. Each ProviderConfig declares
+# its extractor so adding a provider forces a choice here rather than silently dropping effort.
+def effort_from_output_config(request_data: dict[str, Any]) -> str | None:
+    """Anthropic Messages: ``output_config: {"effort": "..."}``."""
+    output_config = request_data.get("output_config")
+    return _clean_effort(output_config.get("effort")) if isinstance(output_config, dict) else None
+
+
+def effort_from_reasoning_effort(request_data: dict[str, Any]) -> str | None:
+    """OpenAI chat completions: top-level ``reasoning_effort``."""
+    return _clean_effort(request_data.get("reasoning_effort"))
+
+
+def effort_from_reasoning(request_data: dict[str, Any]) -> str | None:
+    """OpenAI Responses: ``reasoning: {"effort": "..."}``."""
+    reasoning = request_data.get("reasoning")
+    return _clean_effort(reasoning.get("effort")) if isinstance(reasoning, dict) else None
+
+
+def no_effort(request_data: dict[str, Any]) -> str | None:
+    """Endpoints with no reasoning-effort parameter (e.g. transcription)."""
+    return None
+
+
 @dataclass
 class ProviderConfig:
     name: str
     endpoint_name: str
+    # How to pull reasoning effort out of a request body for this surface. Required (no default)
+    # so a new provider can't be added without deciding — see the effort_from_* functions above.
+    extract_effort: Callable[[dict[str, Any]], str | None]
 
 
-ANTHROPIC_CONFIG = ProviderConfig(name="anthropic", endpoint_name="anthropic_messages")
-BEDROCK_CONFIG = ProviderConfig(name="bedrock", endpoint_name="bedrock_messages")
-OPENAI_CONFIG = ProviderConfig(name="openai", endpoint_name="chat_completions")
-OPENAI_RESPONSES_CONFIG = ProviderConfig(name="openai", endpoint_name="responses")
-OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig(name="openai", endpoint_name="audio_transcriptions")
+ANTHROPIC_CONFIG = ProviderConfig("anthropic", "anthropic_messages", effort_from_output_config)
+BEDROCK_CONFIG = ProviderConfig("bedrock", "bedrock_messages", effort_from_output_config)
+OPENAI_CONFIG = ProviderConfig("openai", "chat_completions", effort_from_reasoning_effort)
+OPENAI_RESPONSES_CONFIG = ProviderConfig("openai", "responses", effort_from_reasoning)
+OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig("openai", "audio_transcriptions", no_effort)
 # Split endpoint labels so an adapter-specific regression is distinguishable in metrics.
-CLOUDFLARE_ANTHROPIC_CONFIG = ProviderConfig(name="cloudflare", endpoint_name="cloudflare_anthropic_messages")
-CLOUDFLARE_OPENAI_CONFIG = ProviderConfig(name="cloudflare", endpoint_name="cloudflare_chat_completions")
-CLOUDFLARE_OPENAI_RESPONSES_CONFIG = ProviderConfig(name="cloudflare", endpoint_name="cloudflare_responses")
+CLOUDFLARE_ANTHROPIC_CONFIG = ProviderConfig("cloudflare", "cloudflare_anthropic_messages", effort_from_output_config)
+CLOUDFLARE_OPENAI_CONFIG = ProviderConfig("cloudflare", "cloudflare_chat_completions", effort_from_reasoning_effort)
+CLOUDFLARE_OPENAI_RESPONSES_CONFIG = ProviderConfig("cloudflare", "cloudflare_responses", effort_from_reasoning)
 
 _KNOWN_LITELLM_PROVIDER_PREFIXES = (
     "anthropic/",
@@ -132,40 +165,6 @@ def _sanitize_request_data(data: dict[str, Any]) -> dict[str, Any]:
     return {k: _sanitize_request_value(v) for k, v in data.items() if k not in FORBIDDEN_REQUEST_PARAMS}
 
 
-def _extract_effort(request_data: dict[str, Any]) -> str | None:
-    """Pull the reasoning-effort level out of a request body, normalized across providers.
-
-    Callers express effort in three shapes depending on the API surface:
-      - Anthropic Messages: ``output_config: {"effort": "..."}``
-      - OpenAI chat completions: ``reasoning_effort: "..."``
-      - OpenAI Responses: ``reasoning: {"effort": "..."}``
-
-    Returns the effort string (e.g. "low"/"medium"/"high"/"xhigh"/"max"), or None when the
-    request didn't set one. Kept permissive on the value so a newly-introduced effort level is
-    captured rather than silently dropped.
-    """
-
-    def _clean(value: Any) -> str | None:
-        if isinstance(value, str):
-            stripped = value.strip()
-            if stripped:
-                return stripped
-        return None
-
-    output_config = request_data.get("output_config")
-    if isinstance(output_config, dict) and (effort := _clean(output_config.get("effort"))):
-        return effort
-
-    if effort := _clean(request_data.get("reasoning_effort")):
-        return effort
-
-    reasoning = request_data.get("reasoning")
-    if isinstance(reasoning, dict) and (effort := _clean(reasoning.get("effort"))):
-        return effort
-
-    return None
-
-
 async def handle_llm_request(
     request_data: dict[str, Any],
     user: AuthenticatedUser,
@@ -190,14 +189,10 @@ async def handle_llm_request(
     )
     set_auth_user(user)
 
-    # Effort isn't a first-class LiteLLM logging field, so stash it in the request context
-    # (mirroring time_to_first_token) for the PostHog callback to stamp onto the captured
-    # $ai_generation event. This is the shared chokepoint for every provider (Anthropic,
-    # OpenAI chat/responses, Cloudflare), so a single extraction here covers them all, on
-    # both success and error events. Read from the request body — the source of truth for
-    # what was actually sent to the model — rather than a caller-supplied header. Always
-    # set it (None when absent) so a stale value can't leak in if the context is reused.
-    set_effort(_extract_effort(request_data))
+    # Stash effort for the PostHog callback to stamp on the $ai_generation event (mirrors
+    # time_to_first_token). Set unconditionally so a stale value can't leak if the context
+    # is reused.
+    set_effort(provider_config.extract_effort(request_data))
 
     structlog.contextvars.bind_contextvars(
         user_id=user.user_id,

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -26,7 +26,7 @@ from llm_gateway.request_context import (
     get_posthog_properties,
     get_request_id,
     set_auth_user,
-    set_posthog_properties,
+    set_effort,
     set_request_context,
     set_time_to_first_token,
 )
@@ -144,18 +144,25 @@ def _extract_effort(request_data: dict[str, Any]) -> str | None:
     request didn't set one. Kept permissive on the value so a newly-introduced effort level is
     captured rather than silently dropped.
     """
-    candidates: list[Any] = []
-    output_config = request_data.get("output_config")
-    if isinstance(output_config, dict):
-        candidates.append(output_config.get("effort"))
-    candidates.append(request_data.get("reasoning_effort"))
-    reasoning = request_data.get("reasoning")
-    if isinstance(reasoning, dict):
-        candidates.append(reasoning.get("effort"))
 
-    for candidate in candidates:
-        if isinstance(candidate, str) and candidate.strip():
-            return candidate.strip()
+    def _clean(value: Any) -> str | None:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+        return None
+
+    output_config = request_data.get("output_config")
+    if isinstance(output_config, dict) and (effort := _clean(output_config.get("effort"))):
+        return effort
+
+    if effort := _clean(request_data.get("reasoning_effort")):
+        return effort
+
+    reasoning = request_data.get("reasoning")
+    if isinstance(reasoning, dict) and (effort := _clean(reasoning.get("effort"))):
+        return effort
+
     return None
 
 
@@ -183,17 +190,15 @@ async def handle_llm_request(
     )
     set_auth_user(user)
 
-    # Effort isn't a first-class LiteLLM logging field, so thread it onto the captured
-    # $ai_generation event via the request context the PostHog callback already reads.
-    # The request body is authoritative for what was actually sent to the model, so it
-    # wins over any caller-supplied x-posthog-property-$ai_effort header. This is the
-    # shared chokepoint for every provider (Anthropic, OpenAI chat/responses, Cloudflare),
-    # so a single extraction here covers them all, on both success and error events.
+    # Effort isn't a first-class LiteLLM logging field, so stash it in the request context
+    # (mirroring time_to_first_token) for the PostHog callback to stamp onto the captured
+    # $ai_generation event. This is the shared chokepoint for every provider (Anthropic,
+    # OpenAI chat/responses, Cloudflare), so a single extraction here covers them all, on
+    # both success and error events. Read from the request body — the source of truth for
+    # what was actually sent to the model — rather than a caller-supplied header.
     effort = _extract_effort(request_data)
     if effort is not None:
-        properties = dict(get_posthog_properties() or {})
-        properties["$ai_effort"] = effort
-        set_posthog_properties(properties)
+        set_effort(effort)
 
     structlog.contextvars.bind_contextvars(
         user_id=user.user_id,

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -26,6 +26,7 @@ from llm_gateway.request_context import (
     get_posthog_properties,
     get_request_id,
     set_auth_user,
+    set_posthog_properties,
     set_request_context,
     set_time_to_first_token,
 )
@@ -131,6 +132,33 @@ def _sanitize_request_data(data: dict[str, Any]) -> dict[str, Any]:
     return {k: _sanitize_request_value(v) for k, v in data.items() if k not in FORBIDDEN_REQUEST_PARAMS}
 
 
+def _extract_effort(request_data: dict[str, Any]) -> str | None:
+    """Pull the reasoning-effort level out of a request body, normalized across providers.
+
+    Callers express effort in three shapes depending on the API surface:
+      - Anthropic Messages: ``output_config: {"effort": "..."}``
+      - OpenAI chat completions: ``reasoning_effort: "..."``
+      - OpenAI Responses: ``reasoning: {"effort": "..."}``
+
+    Returns the effort string (e.g. "low"/"medium"/"high"/"xhigh"/"max"), or None when the
+    request didn't set one. Kept permissive on the value so a newly-introduced effort level is
+    captured rather than silently dropped.
+    """
+    candidates: list[Any] = []
+    output_config = request_data.get("output_config")
+    if isinstance(output_config, dict):
+        candidates.append(output_config.get("effort"))
+    candidates.append(request_data.get("reasoning_effort"))
+    reasoning = request_data.get("reasoning")
+    if isinstance(reasoning, dict):
+        candidates.append(reasoning.get("effort"))
+
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
 async def handle_llm_request(
     request_data: dict[str, Any],
     user: AuthenticatedUser,
@@ -154,6 +182,18 @@ async def handle_llm_request(
         )
     )
     set_auth_user(user)
+
+    # Effort isn't a first-class LiteLLM logging field, so thread it onto the captured
+    # $ai_generation event via the request context the PostHog callback already reads.
+    # The request body is authoritative for what was actually sent to the model, so it
+    # wins over any caller-supplied x-posthog-property-$ai_effort header. This is the
+    # shared chokepoint for every provider (Anthropic, OpenAI chat/responses, Cloudflare),
+    # so a single extraction here covers them all, on both success and error events.
+    effort = _extract_effort(request_data)
+    if effort is not None:
+        properties = dict(get_posthog_properties() or {})
+        properties["$ai_effort"] = effort
+        set_posthog_properties(properties)
 
     structlog.contextvars.bind_contextvars(
         user_id=user.user_id,

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -41,8 +41,6 @@ def _clean_effort(value: Any) -> str | None:
     return None
 
 
-# Reasoning-effort lives at a different spot per API surface. Each ProviderConfig declares
-# its extractor so adding a provider forces a choice here rather than silently dropping effort.
 def effort_from_output_config(request_data: dict[str, Any]) -> str | None:
     """Anthropic Messages: ``output_config: {"effort": "..."}``."""
     output_config = request_data.get("output_config")
@@ -69,20 +67,52 @@ def no_effort(request_data: dict[str, Any]) -> str | None:
 class ProviderConfig:
     name: str
     endpoint_name: str
-    # How to pull reasoning effort out of a request body for this surface. Required (no default)
-    # so a new provider can't be added without deciding — see the effort_from_* functions above.
+    # Where reasoning effort lives varies per API surface. Required (no default) so a new
+    # provider can't be added without deciding; see the effort_from_* functions above.
     extract_effort: Callable[[dict[str, Any]], str | None]
 
 
-ANTHROPIC_CONFIG = ProviderConfig("anthropic", "anthropic_messages", effort_from_output_config)
-BEDROCK_CONFIG = ProviderConfig("bedrock", "bedrock_messages", effort_from_output_config)
-OPENAI_CONFIG = ProviderConfig("openai", "chat_completions", effort_from_reasoning_effort)
-OPENAI_RESPONSES_CONFIG = ProviderConfig("openai", "responses", effort_from_reasoning)
-OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig("openai", "audio_transcriptions", no_effort)
+ANTHROPIC_CONFIG = ProviderConfig(
+    name="anthropic",
+    endpoint_name="anthropic_messages",
+    extract_effort=effort_from_output_config,
+)
+BEDROCK_CONFIG = ProviderConfig(
+    name="bedrock",
+    endpoint_name="bedrock_messages",
+    extract_effort=effort_from_output_config,
+)
+OPENAI_CONFIG = ProviderConfig(
+    name="openai",
+    endpoint_name="chat_completions",
+    extract_effort=effort_from_reasoning_effort,
+)
+OPENAI_RESPONSES_CONFIG = ProviderConfig(
+    name="openai",
+    endpoint_name="responses",
+    extract_effort=effort_from_reasoning,
+)
+OPENAI_TRANSCRIPTION_CONFIG = ProviderConfig(
+    name="openai",
+    endpoint_name="audio_transcriptions",
+    extract_effort=no_effort,
+)
 # Split endpoint labels so an adapter-specific regression is distinguishable in metrics.
-CLOUDFLARE_ANTHROPIC_CONFIG = ProviderConfig("cloudflare", "cloudflare_anthropic_messages", effort_from_output_config)
-CLOUDFLARE_OPENAI_CONFIG = ProviderConfig("cloudflare", "cloudflare_chat_completions", effort_from_reasoning_effort)
-CLOUDFLARE_OPENAI_RESPONSES_CONFIG = ProviderConfig("cloudflare", "cloudflare_responses", effort_from_reasoning)
+CLOUDFLARE_ANTHROPIC_CONFIG = ProviderConfig(
+    name="cloudflare",
+    endpoint_name="cloudflare_anthropic_messages",
+    extract_effort=effort_from_output_config,
+)
+CLOUDFLARE_OPENAI_CONFIG = ProviderConfig(
+    name="cloudflare",
+    endpoint_name="cloudflare_chat_completions",
+    extract_effort=effort_from_reasoning_effort,
+)
+CLOUDFLARE_OPENAI_RESPONSES_CONFIG = ProviderConfig(
+    name="cloudflare",
+    endpoint_name="cloudflare_responses",
+    extract_effort=effort_from_reasoning,
+)
 
 _KNOWN_LITELLM_PROVIDER_PREFIXES = (
     "anthropic/",

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -74,14 +74,22 @@ def _is_product_billable(product: str) -> bool:
 def _apply_owned_event_properties(properties: dict[str, Any], product: str, team_id: int | None) -> None:
     """Enforce gateway-owned event properties, run after caller `x-posthog-property-*` headers are merged.
 
-    `ai_product` and `$ai_billable` are derived from the product config / route and must NOT be
+    `ai_product`, `$ai_billable`, and `$ai_effort` are derived by the gateway and must NOT be
     overridable by callers — a typo would silently mis-bill or misattribute the generation, so we
-    re-assert them on top of whatever the headers set. `team_id`, in contrast, is a deliberate caller
-    override (a shared-key caller such as signals sets it to the customer team); we only fall back to
-    the authenticated key owner's team when no override was supplied.
+    re-assert them on top of whatever the headers set. `$ai_effort` is resolved from the request
+    body (see handler._extract_effort); a caller can't spoof it via `x-posthog-property-$ai_effort`
+    because we overwrite it here, and drop any header-supplied value when the gateway found none.
+    `team_id`, in contrast, is a deliberate caller override (a shared-key caller such as signals
+    sets it to the customer team); we only fall back to the authenticated key owner's team when no
+    override was supplied.
     """
     properties["ai_product"] = product
     properties["$ai_billable"] = _is_product_billable(product)
+    effort = get_effort()
+    if effort is not None:
+        properties["$ai_effort"] = effort
+    else:
+        properties.pop("$ai_effort", None)
     if team_id is not None:
         properties.setdefault("team_id", team_id)
     # A header-supplied team_id arrives as a string ("42"); store it as an int so the captured
@@ -279,12 +287,6 @@ class PostHogCallback(InstrumentedCallback):
         if time_to_first_token is not None:
             properties["$ai_time_to_first_token"] = time_to_first_token
 
-        # The gateway resolves effort from the request body (see handler._extract_effort);
-        # stamp it after the caller-property merge so it can't be spoofed via a header.
-        effort = get_effort()
-        if effort is not None:
-            properties["$ai_effort"] = effort
-
         properties = _truncate_for_capture(properties)
 
         capture_kwargs: dict[str, Any] = {
@@ -348,11 +350,6 @@ class PostHogCallback(InstrumentedCallback):
                 properties[f"$feature/{flag_key}"] = variant
 
         _apply_owned_event_properties(properties, product, team_id)
-
-        # Stamp effort on errors too, so effort-level error rates are analyzable.
-        effort = get_effort()
-        if effort is not None:
-            properties["$ai_effort"] = effort
 
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -14,6 +14,7 @@ from llm_gateway.products.config import get_product_config
 from llm_gateway.rate_limiting.cost_refresh import normalize_metric_labels
 from llm_gateway.request_context import (
     get_auth_user,
+    get_effort,
     get_posthog_flags,
     get_posthog_properties,
     get_product,
@@ -278,6 +279,12 @@ class PostHogCallback(InstrumentedCallback):
         if time_to_first_token is not None:
             properties["$ai_time_to_first_token"] = time_to_first_token
 
+        # The gateway resolves effort from the request body (see handler._extract_effort);
+        # stamp it after the caller-property merge so it can't be spoofed via a header.
+        effort = get_effort()
+        if effort is not None:
+            properties["$ai_effort"] = effort
+
         properties = _truncate_for_capture(properties)
 
         capture_kwargs: dict[str, Any] = {
@@ -341,6 +348,11 @@ class PostHogCallback(InstrumentedCallback):
                 properties[f"$feature/{flag_key}"] = variant
 
         _apply_owned_event_properties(properties, product, team_id)
+
+        # Stamp effort on errors too, so effort-level error rates are analyzable.
+        effort = get_effort()
+        if effort is not None:
+            properties["$ai_effort"] = effort
 
         capture_kwargs: dict[str, Any] = {
             "distinct_id": distinct_id,

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -77,8 +77,9 @@ def _apply_owned_event_properties(properties: dict[str, Any], product: str, team
     `ai_product`, `$ai_billable`, and `$ai_effort` are derived by the gateway and must NOT be
     overridable by callers — a typo would silently mis-bill or misattribute the generation, so we
     re-assert them on top of whatever the headers set. `$ai_effort` is resolved from the request
-    body (see handler._extract_effort); a caller can't spoof it via `x-posthog-property-$ai_effort`
-    because we overwrite it here, and drop any header-supplied value when the gateway found none.
+    body per provider (see `ProviderConfig.extract_effort`); a caller can't spoof it via
+    `x-posthog-property-$ai_effort` because we overwrite it here, and drop any header-supplied
+    value when the gateway found none.
     `team_id`, in contrast, is a deliberate caller override (a shared-key caller such as signals
     sets it to the customer team); we only fall back to the authenticated key owner's team when no
     override was supplied.

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -74,15 +74,11 @@ def _is_product_billable(product: str) -> bool:
 def _apply_owned_event_properties(properties: dict[str, Any], product: str, team_id: int | None) -> None:
     """Enforce gateway-owned event properties, run after caller `x-posthog-property-*` headers are merged.
 
-    `ai_product`, `$ai_billable`, and `$ai_effort` are derived by the gateway and must NOT be
-    overridable by callers — a typo would silently mis-bill or misattribute the generation, so we
-    re-assert them on top of whatever the headers set. `$ai_effort` is resolved from the request
-    body per provider (see `ProviderConfig.extract_effort`); a caller can't spoof it via
-    `x-posthog-property-$ai_effort` because we overwrite it here, and drop any header-supplied
-    value when the gateway found none.
-    `team_id`, in contrast, is a deliberate caller override (a shared-key caller such as signals
-    sets it to the customer team); we only fall back to the authenticated key owner's team when no
-    override was supplied.
+    `ai_product`, `$ai_billable`, and `$ai_effort` are gateway-derived (effort via
+    `ProviderConfig.extract_effort`) and must not be spoofable via headers, so we re-assert them
+    here and drop `$ai_effort` when the gateway found none. `team_id`, in contrast, is a
+    deliberate caller override (e.g. a shared-key caller attributing to a customer team); we only
+    fall back to the key owner's team when no override was supplied.
     """
     properties["ai_product"] = product
     properties["$ai_billable"] = _is_product_billable(product)

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -36,6 +36,7 @@ throttle_runner_var: ContextVar[ThrottleRunner | None] = ContextVar("throttle_ru
 throttle_context_var: ContextVar[ThrottleContext | None] = ContextVar("throttle_context", default=None)
 auth_user_var: ContextVar[AuthenticatedUser | None] = ContextVar("auth_user", default=None)
 time_to_first_token_var: ContextVar[float | None] = ContextVar("time_to_first_token", default=None)
+effort_var: ContextVar[str | None] = ContextVar("effort", default=None)
 
 
 def get_request_context() -> RequestContext | None:
@@ -166,6 +167,14 @@ def get_time_to_first_token() -> float | None:
 
 def set_time_to_first_token(ttft: float) -> None:
     time_to_first_token_var.set(ttft)
+
+
+def get_effort() -> str | None:
+    return effort_var.get()
+
+
+def set_effort(effort: str | None) -> None:
+    effort_var.set(effort)
 
 
 async def record_cost(cost: float, end_user_id: str | None = None) -> None:

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -110,145 +110,50 @@ class TestPostHogCallback:
             assert props["ai_product"] == "wizard"
             mock_client.shutdown.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "event_method, effort, caller_effort, expected",
+        [
+            # gateway-resolved effort is stamped, on both success and error events
+            ("_on_success", "medium", None, "medium"),
+            ("_on_failure", "high", None, "high"),
+            # omitted when the gateway found none
+            ("_on_success", None, None, None),
+            # gateway-owned: a caller header can neither override a resolved value...
+            ("_on_success", "medium", "spoofed", "medium"),
+            # ...nor sneak one in when the gateway found none (success and error paths)
+            ("_on_success", None, "spoofed", None),
+            ("_on_failure", None, "spoofed", None),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_on_success_stamps_effort_from_context(
+    async def test_effort_is_gateway_owned(
         self,
         callback: PostHogCallback,
         auth_user: AuthenticatedUser,
         standard_logging_object: dict,
         mock_posthog_client: tuple,
+        event_method: str,
+        effort: str | None,
+        caller_effort: str | None,
+        expected: str | None,
     ) -> None:
         _, mock_client = mock_posthog_client
         kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+        caller_props = {"$ai_effort": caller_effort} if caller_effort is not None else {}
 
         with (
             patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
             patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value="medium"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value=effort),
+            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value=caller_props),
         ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+            await getattr(callback, event_method)(kwargs, None, 0.0, 1.0, end_user_id=None)
 
-            props = mock_client.capture.call_args.kwargs["properties"]
-            assert props["$ai_effort"] == "medium"
-
-    @pytest.mark.asyncio
-    async def test_on_success_omits_effort_when_absent(
-        self,
-        callback: PostHogCallback,
-        auth_user: AuthenticatedUser,
-        standard_logging_object: dict,
-        mock_posthog_client: tuple,
-    ) -> None:
-        _, mock_client = mock_posthog_client
-        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
-        ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_client.capture.call_args.kwargs["properties"]
+        props = mock_client.capture.call_args.kwargs["properties"]
+        if expected is None:
             assert "$ai_effort" not in props
-
-    @pytest.mark.asyncio
-    async def test_on_failure_stamps_effort_from_context(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
-    ) -> None:
-        _, mock_client = mock_posthog_client
-        kwargs = {
-            "standard_logging_object": {
-                "model": "claude-3-opus",
-                "custom_llm_provider": "anthropic",
-                "error_str": "boom",
-            },
-            "litellm_params": {},
-        }
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value="high"),
-        ):
-            await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_client.capture.call_args.kwargs["properties"]
-            assert props["$ai_effort"] == "high"
-
-    @pytest.mark.asyncio
-    async def test_on_success_effort_overrides_caller_header(
-        self,
-        callback: PostHogCallback,
-        auth_user: AuthenticatedUser,
-        standard_logging_object: dict,
-        mock_posthog_client: tuple,
-    ) -> None:
-        # $ai_effort is gateway-owned: a caller-supplied x-posthog-property-$ai_effort
-        # must not win over the value the gateway resolved from the request body.
-        _, mock_client = mock_posthog_client
-        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value="medium"),
-            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
-        ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_client.capture.call_args.kwargs["properties"]
-            assert props["$ai_effort"] == "medium"
-
-    @pytest.mark.asyncio
-    async def test_on_success_drops_caller_effort_when_gateway_has_none(
-        self,
-        callback: PostHogCallback,
-        auth_user: AuthenticatedUser,
-        standard_logging_object: dict,
-        mock_posthog_client: tuple,
-    ) -> None:
-        # With no gateway-resolved effort, a caller-supplied value is dropped rather than
-        # captured — the property is owned by the gateway, not spoofable via a header.
-        _, mock_client = mock_posthog_client
-        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
-            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
-        ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_client.capture.call_args.kwargs["properties"]
-            assert "$ai_effort" not in props
-
-    @pytest.mark.asyncio
-    async def test_on_failure_drops_caller_effort_when_gateway_has_none(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
-    ) -> None:
-        # Same spoof-prevention as the success path applies to error events.
-        _, mock_client = mock_posthog_client
-        kwargs = {
-            "standard_logging_object": {
-                "model": "claude-3-opus",
-                "custom_llm_provider": "anthropic",
-                "error_str": "boom",
-            },
-            "litellm_params": {},
-        }
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
-            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
-            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
-        ):
-            await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-            props = mock_client.capture.call_args.kwargs["properties"]
-            assert "$ai_effort" not in props
+        else:
+            assert props["$ai_effort"] == expected
 
     @pytest.mark.asyncio
     async def test_on_success_header_team_id_overrides_auth_user_team(

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -111,6 +111,72 @@ class TestPostHogCallback:
             mock_client.shutdown.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_on_success_stamps_effort_from_context(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value="medium"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_on_success_omits_effort_when_absent(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert "$ai_effort" not in props
+
+    @pytest.mark.asyncio
+    async def test_on_failure_stamps_effort_from_context(
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
+    ) -> None:
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "standard_logging_object": {
+                "model": "claude-3-opus",
+                "custom_llm_provider": "anthropic",
+                "error_str": "boom",
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value="high"),
+        ):
+            await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_effort"] == "high"
+
+    @pytest.mark.asyncio
     async def test_on_success_header_team_id_overrides_auth_user_team(
         self,
         callback: PostHogCallback,

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -225,6 +225,32 @@ class TestPostHogCallback:
             assert "$ai_effort" not in props
 
     @pytest.mark.asyncio
+    async def test_on_failure_drops_caller_effort_when_gateway_has_none(
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
+    ) -> None:
+        # Same spoof-prevention as the success path applies to error events.
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "standard_logging_object": {
+                "model": "claude-3-opus",
+                "custom_llm_provider": "anthropic",
+                "error_str": "boom",
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
+            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
+        ):
+            await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert "$ai_effort" not in props
+
+    @pytest.mark.asyncio
     async def test_on_success_header_team_id_overrides_auth_user_team(
         self,
         callback: PostHogCallback,

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -177,6 +177,54 @@ class TestPostHogCallback:
             assert props["$ai_effort"] == "high"
 
     @pytest.mark.asyncio
+    async def test_on_success_effort_overrides_caller_header(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        # $ai_effort is gateway-owned: a caller-supplied x-posthog-property-$ai_effort
+        # must not win over the value the gateway resolved from the request body.
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value="medium"),
+            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_on_success_drops_caller_effort_when_gateway_has_none(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        # With no gateway-resolved effort, a caller-supplied value is dropped rather than
+        # captured — the property is owned by the gateway, not spoofable via a header.
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="posthog_code"),
+            patch("llm_gateway.callbacks.posthog.get_effort", return_value=None),
+            patch("llm_gateway.callbacks.posthog.get_posthog_properties", return_value={"$ai_effort": "spoofed"}),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert "$ai_effort" not in props
+
+    @pytest.mark.asyncio
     async def test_on_success_header_team_id_overrides_auth_user_team(
         self,
         callback: PostHogCallback,

--- a/services/llm-gateway/tests/test_handler.py
+++ b/services/llm-gateway/tests/test_handler.py
@@ -1,0 +1,101 @@
+from typing import Any
+
+import pytest
+
+from llm_gateway.api.handler import ANTHROPIC_CONFIG, _extract_effort, handle_llm_request
+from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.request_context import get_posthog_properties, request_context_var
+
+
+class TestExtractEffort:
+    def test_anthropic_output_config_effort(self) -> None:
+        assert _extract_effort({"output_config": {"effort": "medium"}}) == "medium"
+
+    def test_openai_reasoning_effort(self) -> None:
+        assert _extract_effort({"reasoning_effort": "high"}) == "high"
+
+    def test_openai_responses_reasoning_effort(self) -> None:
+        assert _extract_effort({"reasoning": {"effort": "xhigh"}}) == "xhigh"
+
+    def test_none_when_absent(self) -> None:
+        assert _extract_effort({"model": "claude-opus-4-8", "messages": []}) is None
+
+    def test_none_when_output_config_has_no_effort(self) -> None:
+        # Structured-outputs-only requests set output_config.format but no effort.
+        assert _extract_effort({"output_config": {"format": {"type": "json_schema"}}}) is None
+
+    def test_output_config_wins_over_reasoning_effort(self) -> None:
+        # Anthropic native effort takes precedence when multiple shapes are present.
+        assert _extract_effort({"output_config": {"effort": "low"}, "reasoning_effort": "high"}) == "low"
+
+    def test_whitespace_is_stripped(self) -> None:
+        assert _extract_effort({"reasoning_effort": "  high  "}) == "high"
+
+    def test_non_string_effort_ignored(self) -> None:
+        assert _extract_effort({"output_config": {"effort": 5}}) is None
+
+    def test_novel_effort_level_passes_through(self) -> None:
+        # Kept permissive so a newly-introduced level isn't silently dropped.
+        assert _extract_effort({"reasoning_effort": "ultra"}) == "ultra"
+
+    def test_malformed_output_config_ignored(self) -> None:
+        assert _extract_effort({"output_config": "not-a-dict"}) is None
+
+
+class TestEffortInstrumentation:
+    @pytest.fixture
+    def mock_user(self) -> AuthenticatedUser:
+        return AuthenticatedUser(
+            user_id=123,
+            team_id=456,
+            auth_method="personal_api_key",
+            distinct_id="test-distinct-id",
+            scopes=["llm_gateway:read"],
+        )
+
+    @pytest.fixture(autouse=True)
+    def reset_context(self):
+        token = request_context_var.set(None)
+        yield
+        request_context_var.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_effort_lands_on_request_context(self, mock_user: AuthenticatedUser) -> None:
+        captured: dict[str, Any] = {}
+
+        async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
+            # set_posthog_properties runs before the provider call, so the effort
+            # is visible on the context the PostHog callback later reads.
+            captured["properties"] = get_posthog_properties()
+            return {"ok": True}
+
+        await handle_llm_request(
+            request_data={"model": "test", "messages": [], "output_config": {"effort": "medium"}},
+            user=mock_user,
+            model="test-model",
+            is_streaming=False,
+            provider_config=ANTHROPIC_CONFIG,
+            llm_call=mock_llm_call,
+        )
+
+        assert captured["properties"]["$ai_effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_no_effort_property_when_absent(self, mock_user: AuthenticatedUser) -> None:
+        captured: dict[str, Any] = {}
+
+        async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
+            captured["properties"] = get_posthog_properties()
+            return {"ok": True}
+
+        await handle_llm_request(
+            request_data={"model": "test", "messages": []},
+            user=mock_user,
+            model="test-model",
+            is_streaming=False,
+            provider_config=ANTHROPIC_CONFIG,
+            llm_call=mock_llm_call,
+        )
+
+        properties = captured["properties"] or {}
+        assert "$ai_effort" not in properties

--- a/services/llm-gateway/tests/test_handler.py
+++ b/services/llm-gateway/tests/test_handler.py
@@ -3,47 +3,46 @@ from typing import Any
 
 import pytest
 
-from llm_gateway.api.handler import ANTHROPIC_CONFIG, _extract_effort, handle_llm_request
+from llm_gateway.api.handler import (
+    ANTHROPIC_CONFIG,
+    effort_from_output_config,
+    effort_from_reasoning,
+    effort_from_reasoning_effort,
+    handle_llm_request,
+    no_effort,
+)
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.request_context import effort_var, get_effort
 
 
-class TestExtractEffort:
-    def test_anthropic_output_config_effort(self) -> None:
-        assert _extract_effort({"output_config": {"effort": "medium"}}) == "medium"
-
-    def test_openai_reasoning_effort(self) -> None:
-        assert _extract_effort({"reasoning_effort": "high"}) == "high"
-
-    def test_openai_responses_reasoning_effort(self) -> None:
-        assert _extract_effort({"reasoning": {"effort": "xhigh"}}) == "xhigh"
-
-    def test_none_when_absent(self) -> None:
-        assert _extract_effort({"model": "claude-opus-4-8", "messages": []}) is None
-
-    def test_none_when_output_config_has_no_effort(self) -> None:
-        # Structured-outputs-only requests set output_config.format but no effort.
-        assert _extract_effort({"output_config": {"format": {"type": "json_schema"}}}) is None
-
-    def test_output_config_wins_over_reasoning_effort(self) -> None:
-        # Anthropic native effort takes precedence when multiple shapes are present.
-        assert _extract_effort({"output_config": {"effort": "low"}, "reasoning_effort": "high"}) == "low"
-
-    def test_whitespace_is_stripped(self) -> None:
-        assert _extract_effort({"reasoning_effort": "  high  "}) == "high"
-
-    def test_non_string_effort_ignored(self) -> None:
-        assert _extract_effort({"output_config": {"effort": 5}}) is None
-
-    def test_novel_effort_level_passes_through(self) -> None:
-        # Kept permissive so a newly-introduced level isn't silently dropped.
-        assert _extract_effort({"reasoning_effort": "ultra"}) == "ultra"
-
-    def test_malformed_output_config_ignored(self) -> None:
-        assert _extract_effort({"output_config": "not-a-dict"}) is None
-
-    def test_whitespace_only_effort_is_none(self) -> None:
-        assert _extract_effort({"reasoning_effort": "   "}) is None
+class TestEffortExtractors:
+    @pytest.mark.parametrize(
+        "extractor, request_data, expected",
+        [
+            # Anthropic Messages: output_config.effort
+            (effort_from_output_config, {"output_config": {"effort": "medium"}}, "medium"),
+            (effort_from_output_config, {"output_config": {"effort": "  medium  "}}, "medium"),
+            # Structured-outputs-only request (format, no effort)
+            (effort_from_output_config, {"output_config": {"format": {"type": "json_schema"}}}, None),
+            (effort_from_output_config, {"output_config": "not-a-dict"}, None),
+            (effort_from_output_config, {"output_config": {"effort": 5}}, None),
+            (effort_from_output_config, {}, None),
+            # OpenAI chat completions: reasoning_effort
+            (effort_from_reasoning_effort, {"reasoning_effort": "high"}, "high"),
+            (effort_from_reasoning_effort, {"reasoning_effort": "   "}, None),
+            # Permissive: a newly-introduced level passes through
+            (effort_from_reasoning_effort, {"reasoning_effort": "ultra"}, "ultra"),
+            (effort_from_reasoning_effort, {}, None),
+            # OpenAI Responses: reasoning.effort
+            (effort_from_reasoning, {"reasoning": {"effort": "xhigh"}}, "xhigh"),
+            (effort_from_reasoning, {"reasoning": "not-a-dict"}, None),
+            (effort_from_reasoning, {}, None),
+            # Endpoints without an effort param ignore everything
+            (no_effort, {"reasoning_effort": "high"}, None),
+        ],
+    )
+    def test_extractor(self, extractor: Any, request_data: dict[str, Any], expected: str | None) -> None:
+        assert extractor(request_data) == expected
 
 
 class TestEffortInstrumentation:
@@ -53,29 +52,20 @@ class TestEffortInstrumentation:
         yield
         effort_var.reset(token)
 
+    @pytest.mark.parametrize(
+        "request_data, expected",
+        [
+            ({"model": "test", "messages": [], "output_config": {"effort": "medium"}}, "medium"),
+            ({"model": "test", "messages": []}, None),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_effort_lands_on_request_context(self, authenticated_user: AuthenticatedUser) -> None:
-        captured: dict[str, Any] = {}
-
-        async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
-            # set_effort runs before the provider call, so the effort is visible on the
-            # context the PostHog callback later reads.
-            captured["effort"] = get_effort()
-            return {"ok": True}
-
-        await handle_llm_request(
-            request_data={"model": "test", "messages": [], "output_config": {"effort": "medium"}},
-            user=authenticated_user,
-            model="test-model",
-            is_streaming=False,
-            provider_config=ANTHROPIC_CONFIG,
-            llm_call=mock_llm_call,
-        )
-
-        assert captured["effort"] == "medium"
-
-    @pytest.mark.asyncio
-    async def test_no_effort_when_absent(self, authenticated_user: AuthenticatedUser) -> None:
+    async def test_effort_from_request_reaches_context(
+        self, authenticated_user: AuthenticatedUser, request_data: dict[str, Any], expected: str | None
+    ) -> None:
+        # Pre-seed a stale value: handle_llm_request must set effort unconditionally, so the
+        # no-effort case resets to None rather than leaking the stale value into the callback.
+        effort_var.set("stale")
         captured: dict[str, Any] = {}
 
         async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
@@ -83,7 +73,7 @@ class TestEffortInstrumentation:
             return {"ok": True}
 
         await handle_llm_request(
-            request_data={"model": "test", "messages": []},
+            request_data=request_data,
             user=authenticated_user,
             model="test-model",
             is_streaming=False,
@@ -91,26 +81,4 @@ class TestEffortInstrumentation:
             llm_call=mock_llm_call,
         )
 
-        assert captured["effort"] is None
-
-    @pytest.mark.asyncio
-    async def test_stale_effort_is_reset_when_absent(self, authenticated_user: AuthenticatedUser) -> None:
-        # A value from a prior request must not leak into one that sets no effort:
-        # handle_llm_request sets it unconditionally (None when absent).
-        effort_var.set("high")
-        captured: dict[str, Any] = {}
-
-        async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
-            captured["effort"] = get_effort()
-            return {"ok": True}
-
-        await handle_llm_request(
-            request_data={"model": "test", "messages": []},
-            user=authenticated_user,
-            model="test-model",
-            is_streaming=False,
-            provider_config=ANTHROPIC_CONFIG,
-            llm_call=mock_llm_call,
-        )
-
-        assert captured["effort"] is None
+        assert captured["effort"] == expected

--- a/services/llm-gateway/tests/test_handler.py
+++ b/services/llm-gateway/tests/test_handler.py
@@ -42,6 +42,9 @@ class TestExtractEffort:
     def test_malformed_output_config_ignored(self) -> None:
         assert _extract_effort({"output_config": "not-a-dict"}) is None
 
+    def test_whitespace_only_effort_is_none(self) -> None:
+        assert _extract_effort({"reasoning_effort": "   "}) is None
+
 
 class TestEffortInstrumentation:
     @pytest.fixture(autouse=True)
@@ -73,6 +76,28 @@ class TestEffortInstrumentation:
 
     @pytest.mark.asyncio
     async def test_no_effort_when_absent(self, authenticated_user: AuthenticatedUser) -> None:
+        captured: dict[str, Any] = {}
+
+        async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
+            captured["effort"] = get_effort()
+            return {"ok": True}
+
+        await handle_llm_request(
+            request_data={"model": "test", "messages": []},
+            user=authenticated_user,
+            model="test-model",
+            is_streaming=False,
+            provider_config=ANTHROPIC_CONFIG,
+            llm_call=mock_llm_call,
+        )
+
+        assert captured["effort"] is None
+
+    @pytest.mark.asyncio
+    async def test_stale_effort_is_reset_when_absent(self, authenticated_user: AuthenticatedUser) -> None:
+        # A value from a prior request must not leak into one that sets no effort:
+        # handle_llm_request sets it unconditionally (None when absent).
+        effort_var.set("high")
         captured: dict[str, Any] = {}
 
         async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:

--- a/services/llm-gateway/tests/test_handler.py
+++ b/services/llm-gateway/tests/test_handler.py
@@ -1,10 +1,11 @@
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
 
 from llm_gateway.api.handler import ANTHROPIC_CONFIG, _extract_effort, handle_llm_request
 from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.request_context import get_posthog_properties, request_context_var
+from llm_gateway.request_context import effort_var, get_effort
 
 
 class TestExtractEffort:
@@ -43,59 +44,48 @@ class TestExtractEffort:
 
 
 class TestEffortInstrumentation:
-    @pytest.fixture
-    def mock_user(self) -> AuthenticatedUser:
-        return AuthenticatedUser(
-            user_id=123,
-            team_id=456,
-            auth_method="personal_api_key",
-            distinct_id="test-distinct-id",
-            scopes=["llm_gateway:read"],
-        )
-
     @pytest.fixture(autouse=True)
-    def reset_context(self):
-        token = request_context_var.set(None)
+    def reset_effort(self) -> Iterator[None]:
+        token = effort_var.set(None)
         yield
-        request_context_var.reset(token)
+        effort_var.reset(token)
 
     @pytest.mark.asyncio
-    async def test_effort_lands_on_request_context(self, mock_user: AuthenticatedUser) -> None:
+    async def test_effort_lands_on_request_context(self, authenticated_user: AuthenticatedUser) -> None:
         captured: dict[str, Any] = {}
 
         async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
-            # set_posthog_properties runs before the provider call, so the effort
-            # is visible on the context the PostHog callback later reads.
-            captured["properties"] = get_posthog_properties()
+            # set_effort runs before the provider call, so the effort is visible on the
+            # context the PostHog callback later reads.
+            captured["effort"] = get_effort()
             return {"ok": True}
 
         await handle_llm_request(
             request_data={"model": "test", "messages": [], "output_config": {"effort": "medium"}},
-            user=mock_user,
+            user=authenticated_user,
             model="test-model",
             is_streaming=False,
             provider_config=ANTHROPIC_CONFIG,
             llm_call=mock_llm_call,
         )
 
-        assert captured["properties"]["$ai_effort"] == "medium"
+        assert captured["effort"] == "medium"
 
     @pytest.mark.asyncio
-    async def test_no_effort_property_when_absent(self, mock_user: AuthenticatedUser) -> None:
+    async def test_no_effort_when_absent(self, authenticated_user: AuthenticatedUser) -> None:
         captured: dict[str, Any] = {}
 
         async def mock_llm_call(**kwargs: Any) -> dict[str, Any]:
-            captured["properties"] = get_posthog_properties()
+            captured["effort"] = get_effort()
             return {"ok": True}
 
         await handle_llm_request(
             request_data={"model": "test", "messages": []},
-            user=mock_user,
+            user=authenticated_user,
             model="test-model",
             is_streaming=False,
             provider_config=ANTHROPIC_CONFIG,
             llm_call=mock_llm_call,
         )
 
-        properties = captured["properties"] or {}
-        assert "$ai_effort" not in properties
+        assert captured["effort"] is None

--- a/services/llm-gateway/tests/test_handler.py
+++ b/services/llm-gateway/tests/test_handler.py
@@ -5,6 +5,14 @@ import pytest
 
 from llm_gateway.api.handler import (
     ANTHROPIC_CONFIG,
+    BEDROCK_CONFIG,
+    CLOUDFLARE_ANTHROPIC_CONFIG,
+    CLOUDFLARE_OPENAI_CONFIG,
+    CLOUDFLARE_OPENAI_RESPONSES_CONFIG,
+    OPENAI_CONFIG,
+    OPENAI_RESPONSES_CONFIG,
+    OPENAI_TRANSCRIPTION_CONFIG,
+    ProviderConfig,
     effort_from_output_config,
     effort_from_reasoning,
     effort_from_reasoning_effort,
@@ -52,16 +60,30 @@ class TestEffortInstrumentation:
         yield
         effort_var.reset(token)
 
+    # One case per real config with its surface's natural request shape, so miswiring any
+    # config to the wrong extractor (silently dropping $ai_effort for that surface) fails here.
     @pytest.mark.parametrize(
-        "request_data, expected",
+        "provider_config, request_data, expected",
         [
-            ({"model": "test", "messages": [], "output_config": {"effort": "medium"}}, "medium"),
-            ({"model": "test", "messages": []}, None),
+            (ANTHROPIC_CONFIG, {"output_config": {"effort": "medium"}}, "medium"),
+            (BEDROCK_CONFIG, {"output_config": {"effort": "low"}}, "low"),
+            (OPENAI_CONFIG, {"reasoning_effort": "high"}, "high"),
+            (OPENAI_RESPONSES_CONFIG, {"reasoning": {"effort": "xhigh"}}, "xhigh"),
+            (OPENAI_TRANSCRIPTION_CONFIG, {"reasoning_effort": "high"}, None),
+            (CLOUDFLARE_ANTHROPIC_CONFIG, {"output_config": {"effort": "medium"}}, "medium"),
+            (CLOUDFLARE_OPENAI_CONFIG, {"reasoning_effort": "high"}, "high"),
+            (CLOUDFLARE_OPENAI_RESPONSES_CONFIG, {"reasoning": {"effort": "xhigh"}}, "xhigh"),
+            # No effort in the request resets any stale context value to None
+            (ANTHROPIC_CONFIG, {}, None),
         ],
     )
     @pytest.mark.asyncio
     async def test_effort_from_request_reaches_context(
-        self, authenticated_user: AuthenticatedUser, request_data: dict[str, Any], expected: str | None
+        self,
+        authenticated_user: AuthenticatedUser,
+        provider_config: ProviderConfig,
+        request_data: dict[str, Any],
+        expected: str | None,
     ) -> None:
         # Pre-seed a stale value: handle_llm_request must set effort unconditionally, so the
         # no-effort case resets to None rather than leaking the stale value into the callback.
@@ -77,7 +99,7 @@ class TestEffortInstrumentation:
             user=authenticated_user,
             model="test-model",
             is_streaming=False,
-            provider_config=ANTHROPIC_CONFIG,
+            provider_config=provider_config,
             llm_call=mock_llm_call,
         )
 


### PR DESCRIPTION
## Problem

The LLM gateway is the single chokepoint every product's LLM traffic flows through (PostHog Code, signals, the Slack app, etc.), and its PostHog callback is what stamps properties onto `$ai_generation` events. It records model, provider, tokens, and cost, but not the **reasoning-effort level** the caller requested.

That gap means we can't slice LLM cost or quality by effort tier in LLM analytics — so we can't answer questions like "is a model at `medium` effort actually cheaper-per-task than another at `max`?" with our own data. Raised in a Slack thread wanting to validate published effort-tier cost/benchmark claims against real usage: [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783494796757509?thread_ts=1783494796.757509&cid=C09G8Q32R6F).

## Changes

- Extract the reasoning-effort level from the request body in `handle_llm_request` and stamp it onto the captured `$ai_generation` event as a new `$ai_effort` property, threaded through the request context the PostHog callback already reads.
- Done once at the shared chokepoint, so it covers every provider surface: Anthropic `output_config.effort`, OpenAI chat `reasoning_effort`, and OpenAI Responses `reasoning.effort`. Applies to both success and error events, so effort-level error-rate analysis works too.
- The request body is authoritative (it reflects what was actually sent to the model), so it wins over any caller-supplied `x-posthog-property-$ai_effort` header. Extraction is permissive on the value so a newly-introduced effort level is captured rather than silently dropped, and no property is emitted when the request didn't set one.

`$ai_effort` is a custom event property (queryable via `properties.$ai_effort` and available as a breakdown immediately). A first-class typed ClickHouse column on `ai_events` would be a heavier follow-up (migration + MV change) and isn't needed to start slicing cost by effort.

## How did you test this code?

Automated tests only (added `services/llm-gateway/tests/test_handler.py`):

- Unit tests for the `_extract_effort` helper across all three provider shapes, the absent case, structured-outputs-only `output_config` (format but no effort), precedence when multiple shapes are present, whitespace trimming, non-string values, novel/unknown effort levels, and a malformed `output_config`.
- Integration tests driving `handle_llm_request` and asserting `$ai_effort` lands on the request context the callback reads (and is absent when the request sets no effort).

Ran locally with `uv run pytest`: the new file (12 passed) plus the existing `tests/callbacks/test_posthog.py`, `tests/test_streaming_errors.py`, and `tests/test_request_context.py` (99 passed). `ruff check` clean on the changed files. `mypy` on `handler.py` reports one pre-existing error in `_handle_non_streaming_request` unrelated to this change (present on master).

I (the agent) did not run the gateway end-to-end against a live provider.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent at a PostHog engineer's request, originating from a Slack thread about validating published effort-tier cost/benchmark claims against our own usage data.

- Investigated first via the AI observability data: confirmed there's no effort property captured today on `$ai_generation`, and that PostHog Code traffic is tagged `ai_product = 'posthog_code'`.
- Traced the instrumentation path through `services/llm-gateway`: the PostHog callback (`callbacks/posthog.py`) builds event properties, and `api/handler.py:handle_llm_request` is the shared chokepoint all providers route through, where the raw request body (with effort) is still available.
- Considered two designs: (a) extract effort inside the callback from LiteLLM's logging kwargs, or (b) extract it at the handler chokepoint and thread it via the request context. Chose (b) because effort isn't a first-class LiteLLM logging field (the Anthropic `output_config.effort` shape in particular isn't reliably surfaced in the callback kwargs), whereas the handler has the parsed body directly and already owns the request context the callback consumes. One extraction there covers all providers on both success and error paths.
- Named the property `$ai_effort` (following the `$ai_` convention); confirmed no existing property by that name and no typed column for it in the ingestion schema.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783494796757509?thread_ts=1783494796.757509&cid=C09G8Q32R6F)*
