### PR TITLE
feat(insights): restore insight error message telemetry

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -152,7 +152,14 @@ describe('query', () => {
 
         const queryFailedCalls = captureSpy.mock.calls.filter((call) => call[0] === 'query failed')
         expect(queryFailedCalls).toHaveLength(1)
-        expect(queryFailedCalls[0][1]).toMatchObject({ query: q, duration: expect.any(Number) })
+        expect(queryFailedCalls[0][1]).toMatchObject({
+            query: q,
+            duration: expect.any(Number),
+            error_status: 500,
+            error_code: null,
+        })
+        // Raw error text must stay out of telemetry
+        expect(queryFailedCalls[0][1]).not.toHaveProperty('error_message')
     })
 
     describe('waitForPageVisible', () => {

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -273,10 +273,14 @@ export async function performQuery<N extends DataNode>(
         })
         return response
     } catch (e) {
+        // Raw error detail/message can echo query fragments, so telemetry only gets status and code
+        const error = e as (Error & { status?: number; code?: string | null }) | null
         posthog.capture('query failed', {
             query: queryNode,
             queryId,
             duration: performance.now() - startTime,
+            error_status: error?.status ?? null,
+            error_code: error?.code ?? null,
             ...logParams,
         })
         throw e

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -15,11 +15,13 @@ import { MCPUseCaseCard } from 'lib/components/MCPHint/MCPUseCaseCard'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { dayjs } from 'lib/dayjs'
 import { holidaysMatcher, isChristmas } from 'lib/holidays'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { IconChristmasOrnament, IconErrorOutline, IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { Link } from 'lib/lemon-ui/Link'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
+import posthog from 'lib/posthog-typed'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { humanFriendlyNumber, humanizeBytes } from 'lib/utils/numbers'
 import { isTrustedPostHogUrl } from 'lib/utils/trustedUrl'
@@ -547,6 +549,12 @@ export function renderDetailWithLinks(detail: string): (string | JSX.Element)[] 
     )
 }
 
+/** Kind of the query that errored, unwrapping InsightVizNode/DataTableNode wrappers to the source query. */
+function queryKindForReporting(query: Record<string, any> | Node | null | undefined): string | null {
+    const record = query as Record<string, any> | null | undefined
+    return record?.source?.kind ?? record?.kind ?? null
+}
+
 export function InsightValidationError({
     detail,
     validationErrorCode,
@@ -565,6 +573,15 @@ export function InsightValidationError({
     const isMemoryLimitError = validationErrorCode === CLICKHOUSE_MEMORY_LIMIT_ERROR_CODE
     const defaultCta =
         cta ?? (onRetry ? <RetryButton onRetry={onRetry} query={query} /> : <QueryDebuggerButton query={query} />)
+
+    // Raw error detail can echo query fragments, so telemetry only gets the code and coarse metadata
+    useOnMountEffect(() => {
+        posthog.capture('insight error message shown', {
+            error_type: 'validation',
+            code: validationErrorCode ?? null,
+            query_kind: queryKindForReporting(query),
+        })
+    })
 
     return (
         <div
@@ -645,6 +662,16 @@ export function InsightErrorState({
 }: InsightErrorStateProps): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { openSupportForm } = useActions(supportLogic)
+
+    // Raw error detail can echo query fragments, so telemetry only gets coarse metadata;
+    // query_id lets staff look the actual error up server-side
+    useOnMountEffect(() => {
+        posthog.capture('insight error message shown', {
+            error_type: 'server',
+            query_kind: queryKindForReporting(query),
+            query_id: queryId ?? null,
+        })
+    })
 
     if (!preflight?.cloud) {
         excludeDetail = true // We don't provide support for self-hosted instances

--- a/frontend/src/scenes/insights/EmptyStates/InsightErrorStates.test.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/InsightErrorStates.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { InsightErrorState, InsightValidationError } from './EmptyStates'
+
+describe('insight error states', () => {
+    let captureSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        useMocks({})
+        initKeaTests()
+        captureSpy = jest.spyOn(posthog, 'capture')
+        captureSpy.mockClear()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('reports "insight error message shown" when a validation error renders', () => {
+        render(
+            <InsightValidationError
+                detail="Funnels require at least two steps."
+                validationErrorCode="funnels_require_at_least_two_steps"
+                query={{ kind: 'InsightVizNode', source: { kind: 'FunnelsQuery' } }}
+            />
+        )
+
+        const shownCalls = captureSpy.mock.calls.filter((call) => call[0] === 'insight error message shown')
+        expect(shownCalls).toHaveLength(1)
+        // Exact match: raw error detail must stay out of telemetry
+        expect(shownCalls[0][1]).toEqual({
+            error_type: 'validation',
+            code: 'funnels_require_at_least_two_steps',
+            query_kind: 'FunnelsQuery',
+        })
+    })
+
+    it('reports "insight error message shown" when a server error renders', () => {
+        render(<InsightErrorState title="A server error occurred." queryId="test-query-id" />)
+
+        const shownCalls = captureSpy.mock.calls.filter((call) => call[0] === 'insight error message shown')
+        expect(shownCalls).toHaveLength(1)
+        expect(shownCalls[0][1]).toEqual({
+            error_type: 'server',
+            query_kind: null,
+            query_id: 'test-query-id',
+        })
+    })
+})


### PR DESCRIPTION
## TL;DR

When an insight query fails or shows an error message, we now send a small telemetry event saying "a user saw error X of type Y" — using only error codes and query kinds, never the raw error text. This lets us rank which errors users actually hit, so we can prioritize fixing or improving the most common ones.

## Problem

We have no telemetry on which error messages insight users actually see:

- The `insight error message shown` event stopped being captured in July 2023, when #16305 removed the legacy filters-based load path in `insightLogic` as prep for the insight refresh fix. The query-based path never re-added it, so the event only trickles in from self-hosted instances frozen on pre-July-2023 releases.
- The `query failed` event captures the query and duration but no error status or code.

This blocks prioritizing actionable error CTAs like the one added in #68755: we can rank ClickHouse-level failures via the query log, but pre-execution validation errors and the user-facing message distribution are invisible.

## Changes

- `query failed` now includes `error_status` and `error_code`, extracted from the thrown error (covers `ApiError`, async poll errors which already carry a parsed `code`, and plain `Error`s).
- `InsightValidationError` and `InsightErrorState` capture `insight error message shown` on mount, with `error_type` (`validation`/`server`), `code`, `query_kind`, and `query_id`. Since these components render on every surface (insight scene, dashboard cards, notebooks, data table wrappers), this covers all placements.
- Per review: raw error text (`detail`/`message`) is deliberately **not** captured — backend error details can echo HogQL fragments and other user-controlled values. Telemetry only gets the status, code, and coarse query metadata; `query_id` lets staff look the actual error up server-side.
- `InsightValidationError` reuses the existing `validationErrorCode` prop (already wired from `InsightVizDisplay` and `InsightCard` on master) for the capture.

No UI changes.

## How did you test this code?

- Extended the existing `query.test.ts` error case to assert `error_status`/`error_code` on the `query failed` capture, plus an explicit assertion that `error_message` is absent. Regression guarded: dropping the error properties again (which would silently kill the telemetry) or re-introducing raw error text.
- New `InsightErrorStates.test.tsx` asserts both components emit `insight error message shown` with exactly the allowed properties on render (`toEqual`, so a stray `detail` fails). Regression guarded: the capture being removed during a refactor, which is exactly how the event died in #16305 and went unnoticed for three years.
- Both files pass locally (18 tests). oxlint/oxfmt clean on changed files. I could not run the full typecheck meaningfully in this environment (kea typegen artifacts missing tree-wide); the changed lines report no errors.
- No manual testing in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal telemetry only, no docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (PostHog Code cloud task) at Thomas's direction, following an analysis of insight error volumes that found the 2023 instrumentation gap.
- Rebased onto master (which had since gained the `validationErrorCode` prop for memory-limit errors — this PR now reuses it) and redacted raw error text from telemetry per review.
- Skills invoked: `/writing-tests`, `/adopting-generated-api-types` (no API-call migration applied, capture-only change).
- Considered typing the two events in `posthog-typed.ts` but it is a generated file, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
