### PR TITLE
feat(tasks): ship rtk in the cloud sandbox image, on by default

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -41,6 +41,10 @@ MAX_CUSTOM_IMAGES_PER_USER = 10
 MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG = "tasks-modal-directory-resume-snapshots"
 STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
 OVERLAP_CLONE_BOOT_FEATURE_FLAG = "tasks-overlap-clone-boot"
+# Kill switch: rtk command-output compression is on by default in cloud sandboxes;
+# enabling this flag disables it fleet-wide — over any per-run override — without
+# an image rebuild.
+RTK_DISABLED_FEATURE_FLAG = "tasks-rtk-disabled"
 
 SnapshotKind = Literal["filesystem", "directory"]
 SNAPSHOT_KIND_FILESYSTEM: SnapshotKind = "filesystem"

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2492,6 +2492,7 @@ def bootstrap_task_run(
         "model": model,
         "reasoning_effort": reasoning_effort,
         "home_quick_action": home_quick_action,
+        "rtk_enabled": validated_data.get("rtk_enabled"),
     }.items():
         if value is not None:
             extra_state = extra_state or {}
@@ -3717,6 +3718,10 @@ def run_task(
     if initial_permission_mode is not None:
         extra_state = extra_state or {}
         extra_state["initial_permission_mode"] = initial_permission_mode
+    rtk_enabled = validated_data.get("rtk_enabled")
+    if rtk_enabled is not None:
+        extra_state = extra_state or {}
+        extra_state["rtk_enabled"] = rtk_enabled
 
     if resume_from_run_id:
         previous_run = task.runs.filter(id=resume_from_run_id).first()

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -759,6 +759,7 @@ class DockerSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        rtk_enabled: bool = True,
     ) -> str:
         # The host proxy URL (e.g. localhost:8003) is unreachable from inside the container;
         # rewrite it the same way POSTHOG_API_URL is for Docker sandboxes.
@@ -773,6 +774,7 @@ class DockerSandbox(SandboxBase):
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
+            rtk_enabled=rtk_enabled,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         # Only append when opted in: agent-server builds without the option reject unknown
@@ -845,6 +847,7 @@ class DockerSandbox(SandboxBase):
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
+        rtk_enabled: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -899,6 +902,7 @@ class DockerSandbox(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
+            rtk_enabled=rtk_enabled,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
@@ -946,6 +950,7 @@ class DockerSandbox(SandboxBase):
                 event_ingest_url=event_ingest_url,
                 event_ingest_keep_stream_open=event_ingest_keep_stream_open,
                 repo_ready_file=repo_ready_file,
+                rtk_enabled=rtk_enabled,
             )
             if self._launch_and_check(command):
                 logger.info(f"Agent-server started on port {self._host_port} (without --baseBranch)")

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -845,6 +845,7 @@ class ModalSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        rtk_enabled: bool = True,
     ) -> str:
         env_prefix = build_agent_runtime_env_prefix(
             interaction_origin=interaction_origin,
@@ -855,6 +856,7 @@ class ModalSandbox(SandboxBase):
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
+            rtk_enabled=rtk_enabled,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         # Only append when opted in: agent-server builds without the option reject unknown
@@ -954,6 +956,7 @@ class ModalSandbox(SandboxBase):
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
+        rtk_enabled: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -1007,6 +1010,7 @@ class ModalSandbox(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
+            rtk_enabled=rtk_enabled,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -170,6 +170,7 @@ def build_agent_runtime_env_prefix(
     event_ingest_token: str | None = None,
     event_ingest_url: str | None = None,
     event_ingest_keep_stream_open: bool = False,
+    rtk_enabled: bool = True,
 ) -> str:
     env_vars = {
         "POSTHOG_CODE_INTERACTION_ORIGIN": interaction_origin,
@@ -180,6 +181,9 @@ def build_agent_runtime_env_prefix(
         "POSTHOG_TASK_RUN_EVENT_INGEST_TOKEN": event_ingest_token,
         "POSTHOG_TASK_RUN_EVENT_INGEST_URL": event_ingest_url,
         "POSTHOG_TASK_RUN_EVENT_INGEST_KEEP_STREAM_OPEN": "true" if event_ingest_keep_stream_open else None,
+        # Set explicitly in both states: "0" opts the run out, "1" pins auto-detection on
+        # even if a stale env value survives in a resumed sandbox.
+        "POSTHOG_RTK": "1" if rtk_enabled else "0",
     }
     assignments = " ".join(
         f"{name}={shlex.quote(value)}" for name, value in env_vars.items() if value is not None and value != ""
@@ -301,6 +305,7 @@ class SandboxBase(ABC):
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
+        rtk_enabled: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -448,6 +448,30 @@ class TestModalSandboxAgentServer:
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_TOKEN=ingest-token" in command
         # Modal sandboxes reach the proxy by its real URL, no Docker-host rewrite.
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_URL=https://agent-proxy.example.com" in command
+        assert "POSTHOG_RTK=1" in command
+
+    @pytest.mark.parametrize(
+        "rtk_enabled, expected_env",
+        [
+            (True, "POSTHOG_RTK=1"),
+            (False, "POSTHOG_RTK=0"),
+        ],
+    )
+    def test_start_agent_server_rtk_env(self, mock_sandbox: Any, rtk_enabled, expected_env):
+        mock_sandbox.execute = MagicMock(
+            return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+        )
+
+        mock_sandbox.start_agent_server(
+            repository="posthog/posthog",
+            task_id="task-123",
+            run_id="run-456",
+            mode="background",
+            rtk_enabled=rtk_enabled,
+        )
+
+        command = _agent_server_launch_command(mock_sandbox.execute)
+        assert expected_env in command
 
     @pytest.mark.parametrize(
         "keep_stream_open, expected_env_present",

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1317,6 +1317,15 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
             "Codex runtimes accept 'auto', 'read-only', and 'full-access'."
         ),
     )
+    rtk_enabled = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Whether rtk command-output compression is enabled for this run. Omitted or null "
+            "follows the server-side default (enabled); false opts this run out."
+        ),
+    )
 
     def validate(self, attrs):
         errors: dict[str, str] = {}
@@ -1478,6 +1487,15 @@ class TaskRunBootstrapCreateRequestSerializer(serializers.Serializer):
             "Initial permission mode for the agent session. Claude runtimes accept PostHog permission "
             "presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and "
             "'read-only'."
+        ),
+    )
+    rtk_enabled = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Whether rtk command-output compression is enabled for this run. Omitted or null "
+            "follows the server-side default (enabled); false opts this run out."
         ),
     )
     home_quick_action = serializers.CharField(

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -102,6 +102,27 @@ RUN set -eux; \
 
 ENV AGENTSH_SERVER=http://127.0.0.1:18080
 
+# Install rtk (https://github.com/rtk-ai/rtk), a proxy that compresses the output of
+# common dev commands before it reaches the model. The agent auto-detects it on PATH
+# and routes eligible Bash commands through it; POSTHOG_RTK=0 (set per run from the
+# task processing context) opts a run out.
+ARG RTK_VERSION=0.43.0
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) rtk_asset="rtk-x86_64-unknown-linux-musl.tar.gz"; \
+             rtk_sha256="ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609" ;; \
+      arm64) rtk_asset="rtk-aarch64-unknown-linux-gnu.tar.gz"; \
+             rtk_sha256="5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8731" ;; \
+      *) echo "Unsupported architecture for rtk: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/rtk.tar.gz \
+      "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/${rtk_asset}" && \
+    echo "${rtk_sha256}  /tmp/rtk.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk && \
+    rm /tmp/rtk.tar.gz && \
+    rtk --version
+
 ###
 # Agent SDK
 ###

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -15,6 +15,7 @@ from products.tasks.backend.constants import (
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
+    RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
     vm_sandbox_allowed_origins,
 )
@@ -85,6 +86,10 @@ class TaskProcessingContext:
     agent_proxy_keep_stream_open: bool = False
     # Set only when the run resolved to the VM runtime — custom images layer on the VM base.
     custom_image_name: str | None = None
+    # rtk command-output compression is on by default (the sandbox image ships the binary).
+    # The kill-switch flag wins over everything; otherwise a per-run state override
+    # (the user's toggle) applies. Captured at workflow start so it's stable across retries.
+    rtk_enabled: bool = True
 
     @property
     def mode(self) -> str:
@@ -235,6 +240,44 @@ def _is_agent_proxy_keep_stream_open_enabled(
         agent_proxy_keep_stream_open=enabled,
     )
     return enabled
+
+
+def _is_rtk_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    """rtk compression is on by default. The kill-switch flag wins over everything —
+    a fleet-wide disable must not be pinned back on by a per-run override — and
+    otherwise the per-run state override (the user's toggle in PostHog Code settings)
+    applies. Fails open (enabled, override honored) on flag-service errors so the
+    default posture is preserved."""
+    try:
+        disabled = bool(
+            posthoganalytics.feature_enabled(
+                RTK_DISABLED_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("rtk_disabled_flag_check_failed", run_id=run_id, error=str(e))
+        disabled = False
+
+    if disabled:
+        log_with_activity_context("rtk_disabled_flag_checked", run_id=run_id, rtk_enabled=False)
+        return False
+
+    state_override = (state or {}).get("rtk_enabled")
+    if isinstance(state_override, bool):
+        return state_override
+
+    return True
 
 
 def _is_sandbox_event_ingest_enabled(
@@ -669,6 +712,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"agent_proxy_keep_stream_open: {agent_proxy_keep_stream_open} for this task run",
     )
+    rtk_enabled = _is_rtk_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"rtk_enabled: {rtk_enabled} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -705,4 +759,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         overlap_clone_boot_enabled=overlap_clone_boot_enabled,
         agent_proxy_keep_stream_open=agent_proxy_keep_stream_open,
         custom_image_name=custom_image_name,
+        rtk_enabled=rtk_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -299,6 +299,7 @@ def _invoke_start_agent_server(
             event_ingest_keep_stream_open=params.event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
             wait_for_health=wait_for_health,
+            rtk_enabled=ctx.rtk_enabled,
         )
 
         # Mark startup-time token issuance so follow-ups within the next

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -13,6 +13,7 @@ from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
+    RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
     vm_sandbox_allowed_origin_products,
 )
@@ -24,6 +25,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_agent_proxy_keep_stream_open_enabled,
     _is_burstable_sandbox_resources_enabled,
     _is_modal_vm_sandbox_enabled,
+    _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
     get_task_processing_context,
 )
@@ -425,6 +427,98 @@ class TestGetTaskProcessingContextActivity:
             )
 
         feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "kill_switch_value, expected",
+        [
+            (True, False),
+            (False, True),
+            (None, True),
+        ],
+    )
+    def test_rtk_enabled_defaults_on_with_kill_switch(self, kill_switch_value, expected):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=kill_switch_value,
+        ) as feature_enabled_mock:
+            assert (
+                _is_rtk_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is expected
+            )
+
+        feature_enabled_mock.assert_called_once_with(
+            RTK_DISABLED_FEATURE_FLAG,
+            distinct_id="distinct-id",
+            groups={"organization": "organization-id"},
+            group_properties={"organization": {"id": "organization-id"}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def test_rtk_enabled_fails_open_on_flag_error(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _is_rtk_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is True
+            )
+
+    @pytest.mark.parametrize("state_override", [True, False])
+    def test_rtk_enabled_state_override_applies_when_kill_switch_inactive(self, state_override):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            assert (
+                _is_rtk_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"rtk_enabled": state_override},
+                )
+                is state_override
+            )
+
+    @pytest.mark.parametrize("state_override", [True, False])
+    def test_rtk_kill_switch_beats_any_state_override(self, state_override):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            assert (
+                _is_rtk_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"rtk_enabled": state_override},
+                )
+                is False
+            )
+
+    def test_rtk_flag_error_still_honors_state_override(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _is_rtk_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"rtk_enabled": False},
+                )
+                is False
+            )
 
     @pytest.mark.parametrize(
         "payload, expected",

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1915,6 +1915,33 @@ class TestTaskAPI(BaseTaskAPITest):
         assert "initial_permission_mode" not in (task_run.state or {})
         mock_workflow.assert_called_once()
 
+    @parameterized.expand([(True,), (False,)])
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_persists_rtk_enabled(self, rtk_enabled, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"rtk_enabled": rtk_enabled},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["rtk_enabled"] is rtk_enabled
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_omits_rtk_enabled_when_not_set(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert "rtk_enabled" not in (task_run.state or {})
+        mock_workflow.assert_called_once()
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_run_endpoint_rejects_invalid_initial_permission_mode(self, mock_workflow):
         task = self.create_task()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -957,6 +957,11 @@ export interface ClaudeTaskRunCreateSchemaApi {
      * * `bypassPermissions` - bypassPermissions
      * * `auto` - auto */
     initial_permission_mode?: InitialPermissionModeEnumApi
+    /**
+     * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+     * @nullable
+     */
+    rtk_enabled?: boolean | null
 }
 
 /**
@@ -1049,6 +1054,11 @@ export interface CodexTaskRunCreateSchemaApi {
      * * `read-only` - read-only
      * * `full-access` - full-access */
     initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi
+    /**
+     * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+     * @nullable
+     */
+    rtk_enabled?: boolean | null
 }
 
 export interface TaskRunResumeRequestSchemaApi {
@@ -1509,6 +1519,11 @@ export interface TaskRunBootstrapCreateRequestApi {
      * * `read-only` - read-only
      * * `full-access` - full-access */
     initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi
+    /**
+     * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+     * @nullable
+     */
+    rtk_enabled?: boolean | null
     /**
      * Label of the Home-tab quick action that started this run (e.g. 'Fix CI'), surfaced on the workstream.
      * @maxLength 120

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -831,6 +831,12 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .describe(
                     'Initial permission mode for Claude runtimes.\n\n\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto'
                 ),
+            rtk_enabled: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
+                ),
         })
         .describe('Request body for creating a new task run'),
     zod
@@ -919,6 +925,12 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .optional()
                 .describe(
                     'Initial permission mode for Codex runtimes.\n\n\* `auto` - auto\n\* `read-only` - read-only\n\* `full-access` - full-access'
+                ),
+            rtk_enabled: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
                 ),
         })
         .describe('Request body for creating a new task run'),
@@ -1262,6 +1274,12 @@ export const TasksRunsCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 "Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.\n\n\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto\n\* `read-only` - read-only\n\* `full-access` - full-access"
+            ),
+        rtk_enabled: zod
+            .boolean()
+            .nullish()
+            .describe(
+                'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
             ),
         home_quick_action: zod
             .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12968,6 +12968,11 @@ export namespace Schemas {
        * * `bypassPermissions` - bypassPermissions
        * * `auto` - auto */
       initial_permission_mode?: InitialPermissionModeEnum;
+      /**
+         * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+         * @nullable
+         */
+      rtk_enabled?: boolean | null;
     }
 
     export type ClickhouseEventProperties = { [key: string]: unknown };
@@ -13320,6 +13325,11 @@ export namespace Schemas {
        * * `read-only` - read-only
        * * `full-access` - full-access */
       initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnum;
+      /**
+         * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+         * @nullable
+         */
+      rtk_enabled?: boolean | null;
     }
 
     export type PropertyGroupOperator = typeof PropertyGroupOperator[keyof typeof PropertyGroupOperator];
@@ -54862,6 +54872,11 @@ export namespace Schemas {
        * * `read-only` - read-only
        * * `full-access` - full-access */
       initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnum;
+      /**
+         * Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.
+         * @nullable
+         */
+      rtk_enabled?: boolean | null;
       /**
          * Label of the Home-tab quick action that started this run (e.g. 'Fix CI'), surfaced on the workstream.
          * @maxLength 120


### PR DESCRIPTION
## Problem

The agent's `rtk` integration (PostHog/code#3096) compresses the output of common dev commands by 60-90% before it reaches the model, let's have it for cloud sandboxes.

## Changes

- install `rtk` v0.43.0 in `Dockerfile.sandbox-base` as a pinned, SHA256-verified GitHub release binary with a version smoke test. All sandbox variants inherit it.

- always set `POSTHOG_RTK` in the agent runtime (`1` or `0`) across both Modal and Docker sandboxes, ensuring resumed sandboxes cannot inherit stale values.

- enable RTK by default with a fleet-wide kill switch. Per-run `rtk_enabled` overrides take precedence, otherwise the `tasks-rtk-disabled` feature flag controls rollout and fails open to enabled.

- add `rtk_enabled` to task run creation, storing it in `TaskRun.state` so clients can opt individual runs out.