### PR TITLE
feat(cdp): make email MX validation always-on and remove the rollout gates

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -32,6 +32,19 @@ import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/postho
 import { BASE_REDIS_KEY, HogWatcherState } from './services/monitoring/hog-watcher.service'
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 
+// Email MX validation runs on every email send, so without a mock the test-panel
+// email tests would do live DNS lookups for their fixture recipients (and
+// example.com publishes a null MX, which validation correctly blocks). Resolve
+// everything as deliverable — validation behavior is covered by
+// email-validation.service.test.ts.
+jest.mock('node:dns/promises', () => ({
+    Resolver: jest.fn().mockImplementation(() => ({
+        resolveMx: jest.fn().mockResolvedValue([{ exchange: 'mx.example.com', priority: 10 }]),
+        resolve4: jest.fn().mockResolvedValue(['1.2.3.4']),
+        resolve6: jest.fn().mockResolvedValue([]),
+    })),
+}))
+
 describe('CDP API', () => {
     let hub: Hub
     let cdpDeps: CdpConsumerBaseDeps

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -149,8 +149,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_FETCH_BACKOFF_MAX_MS'
         | 'CDP_SELF_LOOP_GUARD_MODE'
         | 'CDP_EMAIL_TRACKING_URL'
-        | 'CDP_EMAIL_MX_VALIDATION_ENABLED'
-        | 'CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER'
         | 'HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC'
@@ -439,7 +437,7 @@ export function createCdpCoreServices(
     // limiter, separate pool). The pool is created by the server only on pods
     // whose capabilities execute email actions; everywhere else this is null
     // and EmailValidationService degrades to the local cache + DNS.
-    const emailValidationService = new EmailValidationService(config, deps.emailValidationValkey)
+    const emailValidationService = new EmailValidationService(deps.emailValidationValkey)
     // Observer mirrors writes to Valkey (load-only); only the primary path drives metrics.
     const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow?.writer ?? null)
     const hogFlowExecutor = new HogFlowExecutorService(

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -52,18 +52,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueSource
     CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: string
 
-    // Master switch for pre-send email MX validation, off by default. When true,
-    // every email send is validated (syntax + MX lookup, cached per domain) and
-    // would-skip outcomes are recorded in Prometheus — shadow mode unless the team
-    // is also matched by CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS, which controls
-    // actual skipping.
-    CDP_EMAIL_MX_VALIDATION_ENABLED: boolean
-    // Teams whose predicted hard bounces are actually skipped (same string format as
-    // the other team matchers: '' = none, '*' = all, '2,7' = exact set). Teams not
-    // matched here are observe-only: validation runs and metrics are recorded, but
-    // the send always proceeds.
-    CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: string
-
     CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
     CDP_LEGACY_EVENT_CONSUMER_INCLUDE_WEBHOOKS: boolean
@@ -189,8 +177,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: 'hog',
         CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'kafka',
         CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: '',
-        CDP_EMAIL_MX_VALIDATION_ENABLED: false,
-        CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '',
 
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -100,11 +100,12 @@ describe('Hogflow Executor', () => {
         )
         const recipientsManager = new RecipientsManagerService(hub.postgres)
         const recipientPreferencesService = new RecipientPreferencesService(recipientsManager)
-        // Kill switch off — getSkipReason short-circuits to null, so email validation never does real DNS here.
-        const emailValidationService = new EmailValidationService(
-            { CDP_EMAIL_MX_VALIDATION_ENABLED: false, CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '' },
-            null
-        )
+        // Stubbed to always allow: this suite covers executor routing and flow control,
+        // not MX validation (email-validation.service.test.ts does), and the real
+        // service would fire live DNS lookups for the fixture recipients here.
+        const emailValidationService = {
+            getSkipReason: () => Promise.resolve(null),
+        } as unknown as EmailValidationService
 
         await insertHogFunctionTemplate(hub.postgres, {
             id: 'template-test-hogflow-executor',

--- a/nodejs/src/cdp/services/messaging/email-validation.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-validation.service.test.ts
@@ -59,7 +59,7 @@ describe('EmailValidationService', () => {
             const reason = await service.getSkipReason(emailInvocation('x@dead.invalid', 3), emailAction)
 
             expect(reason).toContain('no reachable mail servers')
-            const metric = await register.getSingleMetric('cdp_email_mx_would_skip_total')!.get()
+            const metric = await register.getSingleMetric('cdp_email_mx_skipped_total')!.get()
             expect(metric.values).toContainEqual(
                 expect.objectContaining({ labels: { team_id: '3', reason: 'invalid_domain' } })
             )

--- a/nodejs/src/cdp/services/messaging/email-validation.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-validation.service.test.ts
@@ -38,13 +38,10 @@ describe('EmailValidationService', () => {
         mockResolveMx.mockResolvedValue([{ exchange: 'mx.example.com', priority: 10 }])
         mockResolve4.mockResolvedValue(['1.2.3.4'])
         mockResolve6.mockResolvedValue([])
-        service = new EmailValidationService(
-            { CDP_EMAIL_MX_VALIDATION_ENABLED: true, CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '2' },
-            null
-        )
+        service = new EmailValidationService(null)
     })
 
-    describe('gating and shadow mode', () => {
+    describe('gating', () => {
         it('does not validate (returns null, no DNS) for non-email actions', async () => {
             const reason = await service.getSkipReason(emailInvocation('x@dead.invalid'), {
                 type: 'function_sms',
@@ -54,42 +51,18 @@ describe('EmailValidationService', () => {
             expect(mockResolveMx).not.toHaveBeenCalled()
         })
 
-        it('does nothing when the kill switch is off, even for a dead domain', async () => {
-            const disabled = new EmailValidationService(
-                { CDP_EMAIL_MX_VALIDATION_ENABLED: false, CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '*' },
-                null
-            )
-            expect(await disabled.getSkipReason(emailInvocation('x@dead.invalid'), emailAction)).toBeNull()
-            expect(mockResolveMx).not.toHaveBeenCalled()
-        })
-
-        it('shadow mode: validates and records the would-skip, but lets the send proceed', async () => {
+        it('records the per-team skip metric when blocking', async () => {
             mockResolveMx.mockRejectedValue(dnsError('ENOTFOUND'))
             mockResolve4.mockRejectedValue(dnsError('ENOTFOUND'))
             mockResolve6.mockRejectedValue(dnsError('ENOTFOUND'))
 
-            // Team 3 is not in the enforce list ('2') — observe-only.
             const reason = await service.getSkipReason(emailInvocation('x@dead.invalid', 3), emailAction)
 
-            expect(reason).toBeNull()
-            expect(mockResolveMx).toHaveBeenCalled()
+            expect(reason).toContain('no reachable mail servers')
             const metric = await register.getSingleMetric('cdp_email_mx_would_skip_total')!.get()
             expect(metric.values).toContainEqual(
                 expect.objectContaining({ labels: { team_id: '3', reason: 'invalid_domain' } })
             )
-        })
-
-        it('enforces skips for all teams when configured with "*"', async () => {
-            const wildcard = new EmailValidationService(
-                { CDP_EMAIL_MX_VALIDATION_ENABLED: true, CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '*' },
-                null
-            )
-            mockResolveMx.mockRejectedValue(dnsError('ENOTFOUND'))
-            mockResolve4.mockRejectedValue(dnsError('ENOTFOUND'))
-            mockResolve6.mockRejectedValue(dnsError('ENOTFOUND'))
-
-            const reason = await wildcard.getSkipReason(emailInvocation('x@dead.invalid', 999), emailAction)
-            expect(reason).toContain('no reachable mail servers')
         })
     })
 
@@ -257,10 +230,7 @@ describe('EmailValidationService', () => {
                 useClient: jest.fn().mockResolvedValue('0'), // '0' = domain previously found undeliverable
                 usePipeline: jest.fn(),
             }
-            const withValkey = new EmailValidationService(
-                { CDP_EMAIL_MX_VALIDATION_ENABLED: true, CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS: '2' },
-                valkey
-            )
+            const withValkey = new EmailValidationService(valkey)
 
             const reason = await withValkey.getSkipReason(emailInvocation('user@known-dead.example'), emailAction)
             expect(reason).toContain('no reachable mail servers')

--- a/nodejs/src/cdp/services/messaging/email-validation.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-validation.service.ts
@@ -14,9 +14,9 @@ const cdpEmailMxValidationTotal = new Counter({
     labelNames: ['result'],
 })
 
-const cdpEmailMxWouldSkipTotal = new Counter({
-    name: 'cdp_email_mx_would_skip_total',
-    help: 'Sends skipped by pre-send email validation as predicted hard bounces, per team. (Name kept from the shadow rollout for dashboard continuity — every increment is now an actual skip.)',
+const cdpEmailMxSkippedTotal = new Counter({
+    name: 'cdp_email_mx_skipped_total',
+    help: 'Sends skipped by pre-send email validation as predicted hard bounces, per team.',
     labelNames: ['team_id', 'reason'],
 })
 
@@ -133,7 +133,7 @@ export class EmailValidationService {
     }
 
     private skip(teamId: number, reason: 'invalid_syntax' | 'invalid_domain', message: string): string {
-        cdpEmailMxWouldSkipTotal.inc({ team_id: String(teamId), reason })
+        cdpEmailMxSkippedTotal.inc({ team_id: String(teamId), reason })
         return message
     }
 

--- a/nodejs/src/cdp/services/messaging/email-validation.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-validation.service.ts
@@ -4,11 +4,8 @@ import { domainToASCII } from 'node:url'
 import { Counter } from 'prom-client'
 
 import { HogFlowAction } from '~/cdp/schema/hogflow'
-import { buildIntegerMatcher } from '~/common/config/config'
 import { RedisV2 } from '~/common/redis/redis-v2'
-import { ValueMatcher } from '~/types'
 
-import { CdpConfig } from '../../config'
 import { CyclotronJobInvocationHogFunction } from '../../types'
 
 const cdpEmailMxValidationTotal = new Counter({
@@ -19,7 +16,7 @@ const cdpEmailMxValidationTotal = new Counter({
 
 const cdpEmailMxWouldSkipTotal = new Counter({
     name: 'cdp_email_mx_would_skip_total',
-    help: 'Sends that pre-send email validation would skip as predicted hard bounces, per team. Increments in both shadow and enforce mode so the series is continuous across the enforce rollout; whether the send was actually skipped depends on CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS.',
+    help: 'Sends skipped by pre-send email validation as predicted hard bounces, per team. (Name kept from the shadow rollout for dashboard continuity — every increment is now an actual skip.)',
     labelNames: ['team_id', 'reason'],
 })
 
@@ -78,39 +75,26 @@ function classifyDnsError(error: unknown): 'none' | 'transient' {
  *
  * Fail-open by design: only a definitive "this domain has no mail exchange"
  * blocks a send. A DNS hiccup must never nuke a batch of legitimate mail.
- *
- * Rollout is shadow-first: when enabled, every team is validated and would-skip
- * outcomes are recorded per team in Prometheus, but only teams matched by
- * CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS actually get their sends skipped.
  */
 export class EmailValidationService {
-    private readonly enabled: boolean
-    private readonly enforceMatcher: ValueMatcher<number>
     private readonly resolver: Resolver
     private readonly localCache = new Map<string, CacheEntry>()
     private readonly inFlight = new Map<string, Promise<boolean>>()
 
-    constructor(
-        config: Pick<CdpConfig, 'CDP_EMAIL_MX_VALIDATION_ENABLED' | 'CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS'>,
-        private valkey: RedisV2 | null
-    ) {
-        this.enabled = config.CDP_EMAIL_MX_VALIDATION_ENABLED
-        this.enforceMatcher = buildIntegerMatcher(config.CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS, true)
+    constructor(private valkey: RedisV2 | null) {
         this.resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: DNS_TRIES })
     }
 
     /**
      * Returns a human-readable reason to skip the send, or null to proceed.
-     * Only acts on `function_email` actions; anything else (kill switch off,
-     * missing recipient, non-email action) returns null so the existing send
-     * path is untouched. Teams outside the enforce list are observe-only:
-     * validation runs and metrics are recorded, but null is returned.
+     * Only acts on `function_email` actions; anything else (missing recipient,
+     * non-email action) returns null so the existing send path is untouched.
      */
     public async getSkipReason(
         invocation: CyclotronJobInvocationHogFunction,
         action: HogFlowAction
     ): Promise<string | null> {
-        if (!this.enabled || action.type !== 'function_email') {
+        if (action.type !== 'function_email') {
             return null
         }
 
@@ -123,7 +107,7 @@ export class EmailValidationService {
 
         if (!EMAIL_SYNTAX_RE.test(email)) {
             cdpEmailMxValidationTotal.inc({ result: 'invalid_syntax' })
-            return this.skipOrObserve(
+            return this.skip(
                 invocation.teamId,
                 'invalid_syntax',
                 `Skipping send: "${email}" is not a valid email address, so it would hard bounce.`
@@ -139,7 +123,7 @@ export class EmailValidationService {
         const domain = domainToASCII(rawDomain) || rawDomain.toLowerCase()
         const deliverable = await this.resolveDeliverability(domain)
         if (!deliverable) {
-            return this.skipOrObserve(
+            return this.skip(
                 invocation.teamId,
                 'invalid_domain',
                 `Skipping send: the domain "${domain}" has no reachable mail servers, so this message would hard bounce.`
@@ -148,9 +132,9 @@ export class EmailValidationService {
         return null
     }
 
-    private skipOrObserve(teamId: number, reason: 'invalid_syntax' | 'invalid_domain', message: string): string | null {
+    private skip(teamId: number, reason: 'invalid_syntax' | 'invalid_domain', message: string): string {
         cdpEmailMxWouldSkipTotal.inc({ team_id: String(teamId), reason })
-        return this.enforceMatcher(teamId) ? message : null
+        return message
     }
 
     private async resolveDeliverability(domain: string): Promise<boolean> {

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1730,11 +1730,6 @@ describe('Workflows E2E (email queue)', () => {
         hub = await createHub()
         hub.CDP_CYCLOTRON_BATCH_DELAY_MS = 50
 
-        // Enforce mode for the whole block: existing tests prove deliverable recipients
-        // pass validation untouched; the skip test proves dead domains never reach the queue.
-        hub.CDP_EMAIL_MX_VALIDATION_ENABLED = true
-        hub.CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS = '*'
-
         // `.invalid` domains are NXDOMAIN, everything else resolves as deliverable.
         const nxdomain = () => Promise.reject(Object.assign(new Error('queryMx ENOTFOUND'), { code: 'ENOTFOUND' }))
         mockDnsResolveMx.mockImplementation((domain: string) =>

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -437,13 +437,10 @@ export class PluginServer implements NodeServer {
      * deps. Only the cyclotron workers that run the hogflow email action call this, so
      * the pool is never opened on other CDP consumers or cdp-api — an idle Valkey sized
      * for the SES rate limiter shouldn't hold connections from pods that never validate.
-     * Null (the shared-deps default) when the kill switch is off, in which case
+     * Null when no SES Valkey host is configured (local dev), in which case
      * EmailValidationService degrades to its local cache + DNS.
      */
     private withEmailValidationValkey(deps: CdpConsumerBaseDeps): CdpConsumerBaseDeps {
-        if (!this.config.CDP_EMAIL_MX_VALIDATION_ENABLED) {
-            return deps
-        }
         return { ...deps, emailValidationValkey: createSesRateLimiterValkeyPool(this.config, 'email-mx-validation') }
     }
 

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -64,8 +64,6 @@ export function createCdpConsumerDeps(hub: Hub, kafkaProducer?: KafkaProducerWra
         geoipService: hub.geoipService,
         groupRepository: noopGroupReadRepository,
         quotaLimiting: hub.quotaLimiting,
-        emailValidationValkey: hub.CDP_EMAIL_MX_VALIDATION_ENABLED
-            ? createSesRateLimiterValkeyPool(hub, 'email-mx-validation')
-            : null,
+        emailValidationValkey: createSesRateLimiterValkeyPool(hub, 'email-mx-validation'),
     }
 }


### PR DESCRIPTION
## Problem

Email MX validation shipped behind a shadow-first rollout: a `CDP_EMAIL_MX_VALIDATION_ENABLED` kill switch plus a `CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS` shadow/enforce gate. The rollout is done — validation has been running fleet-wide and we're keeping it — so the two env vars and their gating code are now dead weight: extra config surface, extra constructor plumbing, and a shadow mode nothing uses.

## Changes

- `EmailValidationService` no longer takes config: the `enabled` kill switch and the `enforceMatcher` (shadow vs enforce) are gone. Every `function_email` send is validated, and a predicted hard bounce (bad syntax or dead domain) is always skipped. Fail-open behavior on DNS trouble is unchanged.
- Removed `CDP_EMAIL_MX_VALIDATION_ENABLED` and `CDP_EMAIL_MX_VALIDATION_ENFORCE_TEAMS` from `CdpConfig` and the core-services config pick.
- `server.ts`: the SES Valkey pool for the shared MX cache is created unconditionally on the email-executing cyclotron workers (it still resolves to `null` when no `SES_RATE_LIMITER_VALKEY_HOST` is configured, e.g. local dev, and the service degrades to local cache + DNS).
- The `cdp_email_mx_would_skip_total` metric keeps its name for dashboard continuity; its help text now notes every increment is an actual skip.

Companion charts PR removing the now-dead env var from the shared CDP config: PostHog/charts#12956 — **must merge only after this PR is deployed** (on the old code the default is `false`, so removing the var early would turn validation off).

## How did you test this code?

Automated only — I did not manually test against a running stack.

- `email-validation.service.test.ts` (26 tests, pass): removed the kill-switch/shadow/enforce-wildcard tests (dead behavior); constructors updated; the per-team skip-metric assertion moved into an always-on block test. All fail-open, caching, IDN, null-MX, and implicit-MX coverage unchanged.
- `hog_function.test.ts` (13 tests, pass): the blocked-send skip path (log + `email_bounce_prevented` + no billing) is unchanged.
- `hogflow-executor.service.test.ts` (39 tests, pass): the real `EmailValidationService` there relied on the kill switch to avoid live DNS; it is now a null stub since that suite covers executor routing, not validation.
- `workflows-e2e.test.ts`: removed the two `hub.CDP_EMAIL_MX_VALIDATION_*` lines — the block's enforce-mode setup is now simply the default. Could not run locally (`@posthog/cyclotron` fails to build in my environment on an SSL cert issue); CI runs it.
- Typecheck clean on all touched files; oxlint findings on touched files are pre-existing (config.ts import cycle, jest expect-in-try quirk).

## Does this require an infrastructure change?

Yes, in ordering only: the companion charts PR (PostHog/charts#12956) removes the env var and must merge after this deploys. No new infrastructure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact — removal of internal env-var gating.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a PostHog Code session (Claude), human-directed. Decisions:

- Kept the `cdp_email_mx_would_skip_total` metric name despite "would" now being literal — the rollout dashboard queries it, and the owner plans to replace it separately.
- Replaced the executor test's real validation service with a null stub instead of mocking `node:dns/promises` there: that suite asserts routing/flow control, and with the kill switch gone the real service would fire live DNS for fixture recipients.
- Kept the SES Valkey pool scoped to the email-executing worker loaders (`withEmailValidationValkey`) rather than opening it fleet-wide, dropping only the env-var gate inside it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*