### PR TITLE
feat(llma): add what-changed input to prompt publish review

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7134,7 +7134,7 @@ const api = {
 
         async update(
             promptName: string,
-            data: { prompt: LLMPrompt['prompt']; base_version: number }
+            data: { prompt: LLMPrompt['prompt']; base_version: number; version_description?: string }
         ): Promise<LLMPrompt> {
             return await new ApiRequest().llmPromptByName(promptName).update({ data })
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7660,6 +7660,7 @@ export interface LLMPrompt {
     name: string
     prompt: string
     version: number
+    version_description?: string | null
     created_by: UserBasicType
     created_at: string
     updated_at: string
@@ -7687,6 +7688,7 @@ export interface LLMPromptPublic {
 export interface LLMPromptVersionSummary {
     id: string
     version: number
+    version_description?: string | null
     created_by: UserBasicType
     created_at: string
     is_latest: boolean

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -377,10 +377,16 @@ describe('llmPromptLogic', () => {
         expect(logic.values.isPublishReviewOpen).toBe(true)
         expect(updateSpy).not.toHaveBeenCalled()
 
-        // Confirming from the review publishes and closes it
+        // Confirming from the review publishes with the typed description and closes it
+        logic.actions.setVersionDescription('Tightened the refusal criteria')
         logic.actions.submitPromptForm()
         await expectLogic(logic).toDispatchActions(['submitPromptFormSuccess'])
         expect(updateSpy).toHaveBeenCalledTimes(1)
+        expect(updateSpy).toHaveBeenCalledWith('my-test-prompt', {
+            prompt: 'My edited prompt.',
+            base_version: 2,
+            version_description: 'Tightened the refusal criteria',
+        })
         expect(logic.values.isPublishReviewOpen).toBe(false)
 
         logic.unmount()

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -125,6 +125,7 @@ function buildPromptVersionSummary(prompt: LLMPrompt, isLatest: boolean): LLMPro
     return {
         id: prompt.id,
         version: prompt.version,
+        version_description: prompt.version_description ?? null,
         created_by: prompt.created_by,
         created_at: prompt.created_at,
         is_latest: isLatest,
@@ -166,6 +167,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         requestPublish: true,
         openPublishReview: true,
         closePublishReview: true,
+        setVersionDescription: (versionDescription: string) => ({ versionDescription }),
     }),
 
     reducers(({ props }) => ({
@@ -248,6 +250,14 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 setMode: () => false,
             },
         ],
+        versionDescription: [
+            '',
+            {
+                setVersionDescription: (_, { versionDescription }) => versionDescription,
+                submitPromptFormSuccess: () => '',
+                setMode: () => '',
+            },
+        ],
     })),
 
     loaders(({ props }) => ({
@@ -303,9 +313,11 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                             throw new Error('Cannot publish prompt version: prompt data not loaded')
                         }
 
+                        const versionDescription = values.versionDescription.trim()
                         savedPrompt = await api.llmPrompts.update(props.promptName, {
                             prompt: formValues.prompt,
                             base_version: currentPrompt.latest_version,
+                            ...(versionDescription ? { version_description: versionDescription } : {}),
                         })
                         llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
                         lemonToast.success(`Published v${savedPrompt.version}`)

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -255,6 +255,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             {
                 setVersionDescription: (_, { versionDescription }) => versionDescription,
                 submitPromptFormSuccess: () => '',
+                closePublishReview: () => '',
                 setMode: () => '',
             },
         ],

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -92,6 +92,12 @@ export function PromptViewDetails(): JSX.Element {
                 </span>
             </div>
 
+            {prompt.version_description ? (
+                <p className="text-secondary m-0 text-sm italic" data-attr="llma-prompt-version-description">
+                    {prompt.version_description}
+                </p>
+            ) : null}
+
             <div>
                 <label className="text-xs font-semibold uppercase text-secondary">Name</label>
                 <p className="font-mono">{prompt.name}</p>
@@ -171,8 +177,9 @@ export function PromptViewDetails(): JSX.Element {
 }
 
 export function PublishReviewModal(): JSX.Element | null {
-    const { isPublishReviewOpen, prompt, promptForm, nextVersion, isPromptFormSubmitting } = useValues(llmPromptLogic)
-    const { closePublishReview, submitPromptForm } = useActions(llmPromptLogic)
+    const { isPublishReviewOpen, prompt, promptForm, nextVersion, isPromptFormSubmitting, versionDescription } =
+        useValues(llmPromptLogic)
+    const { closePublishReview, submitPromptForm, setVersionDescription } = useActions(llmPromptLogic)
 
     if (!isPrompt(prompt)) {
         return null
@@ -210,32 +217,43 @@ export function PublishReviewModal(): JSX.Element | null {
                 </>
             }
         >
-            <div className="overflow-hidden rounded border" data-attr="llma-prompt-publish-review-diff">
-                <Suspense
-                    fallback={
-                        <div className="space-y-2 p-4">
-                            <LemonSkeleton active className="h-4 w-full" />
-                            <LemonSkeleton active className="h-4 w-3/4" />
-                        </div>
-                    }
-                >
-                    <MonacoDiffEditor
-                        original={prompt.prompt}
-                        value={promptForm.prompt}
-                        modified={promptForm.prompt}
-                        language="markdown"
-                        options={{
-                            readOnly: true,
-                            renderSideBySide: true,
-                            minimap: { enabled: false },
-                            scrollBeyondLastLine: false,
-                            wordWrap: 'on',
-                            lineNumbers: 'off',
-                            folding: false,
-                            hideUnchangedRegions: { enabled: true },
-                        }}
+            <div className="space-y-3">
+                <div className="overflow-hidden rounded border" data-attr="llma-prompt-publish-review-diff">
+                    <Suspense
+                        fallback={
+                            <div className="space-y-2 p-4">
+                                <LemonSkeleton active className="h-4 w-full" />
+                                <LemonSkeleton active className="h-4 w-3/4" />
+                            </div>
+                        }
+                    >
+                        <MonacoDiffEditor
+                            original={prompt.prompt}
+                            value={promptForm.prompt}
+                            modified={promptForm.prompt}
+                            language="markdown"
+                            options={{
+                                readOnly: true,
+                                renderSideBySide: true,
+                                minimap: { enabled: false },
+                                scrollBeyondLastLine: false,
+                                wordWrap: 'on',
+                                lineNumbers: 'off',
+                                folding: false,
+                                hideUnchangedRegions: { enabled: true },
+                            }}
+                        />
+                    </Suspense>
+                </div>
+                <LemonField.Pure label="What changed?" help="Optional — shown in the version history.">
+                    <LemonInput
+                        value={versionDescription}
+                        onChange={setVersionDescription}
+                        placeholder="e.g. Tightened the refusal criteria"
+                        maxLength={400}
+                        data-attr="llma-prompt-version-description-input"
                     />
-                </Suspense>
+                </LemonField.Pure>
             </div>
         </LemonModal>
     )
@@ -710,6 +728,11 @@ export function PromptVersionSidebar({
                                         />
                                     )}
                                 </div>
+                                {versionPrompt.version_description ? (
+                                    <div className="mb-1 text-xs" title={versionPrompt.version_description}>
+                                        {versionPrompt.version_description}
+                                    </div>
+                                ) : null}
                                 <div className="text-xs text-secondary">
                                     {dayjs(versionPrompt.created_at).format('MMM D, YYYY h:mm A')}
                                 </div>

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -729,7 +729,10 @@ export function PromptVersionSidebar({
                                     )}
                                 </div>
                                 {versionPrompt.version_description ? (
-                                    <div className="mb-1 text-xs" title={versionPrompt.version_description}>
+                                    <div
+                                        className="mb-1 line-clamp-2 text-xs"
+                                        title={versionPrompt.version_description}
+                                    >
                                         {versionPrompt.version_description}
                                     </div>
                                 ) : null}


### PR DESCRIPTION
## Problem

Version history cards show only version number, author, and date — finding a specific change in a long history means opening diffs one by one. The backend accepts a `version_description` since #69156, but nothing in the UI writes or shows it.

## Changes

- Optional "What changed?" input in the publish review modal (below the diff, 400-char cap). Sent as `version_description` on publish; blank sends nothing.
- Version cards in the history sidebar show the description; the overview shows the current version's description under the version tags.
- Optimistic version summary after publish carries the description so the sidebar is correct before the refetch.
- Handwritten `LLMPrompt` / `LLMPromptVersionSummary` types and the `api.llmPrompts.update` body extended. Deliberately not migrated to generated `Api` types — the whole prompts frontend uses the handwritten client consistently; migrating it is its own refactor.

## How did you test this code?

<img width="882" height="405" alt="image" src="https://github.com/user-attachments/assets/ca32da80-c4b9-48b1-9328-88bd08a8742f" />

<img width="328" height="310" alt="image" src="https://github.com/user-attachments/assets/ad065c83-8ac9-4e86-b526-342cbd50f3f1" />

Extended the existing publish-review routing test with one assert: the typed description reaches the API body — catches the input being wired to state but dropped from the request. Nothing else added; rendering a string on a card doesn't earn a test. All 25 prompts-suite tests pass; oxlint and typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The pending prompt-management docs PR (PostHog/posthog.com#18157) will be reworked to cover the review modal + descriptions together once this ships.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as part of the prompt management UX pass; skills invoked: /adopting-generated-api-types (decision: extend handwritten types, note migration as follow-up), /writing-tests. Kept the field optional with zero validation friction — Humanloop's retreat from mandatory commit messages is the design reference.