### PR TITLE
fix(metrics): type the has_metrics response schema

### DIFF
--- a/products/metrics/backend/presentation/api.py
+++ b/products/metrics/backend/presentation/api.py
@@ -333,6 +333,10 @@ class _MetricAnomalyReportSerializer(serializers.Serializer):
     )
 
 
+class _HasMetricsResponseSerializer(serializers.Serializer):
+    hasMetrics = serializers.BooleanField(help_text="Whether the team has ingested any metrics.")
+
+
 class _MetricNameSerializer(serializers.Serializer):
     name = serializers.CharField(help_text="Metric name as it appears in the team's data.")
     metric_type = serializers.CharField(
@@ -419,7 +423,7 @@ class MetricsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "metrics"
     serializer_class = _FallbackSerializer
 
-    @extend_schema(responses={200: OpenApiTypes.OBJECT})
+    @extend_schema(responses={200: _HasMetricsResponseSerializer})
     @action(detail=False, methods=["GET"], required_scopes=["metrics:read"])
     def has_metrics(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.METRICS, feature=Feature.QUERY)

--- a/products/metrics/frontend/generated/api.schemas.ts
+++ b/products/metrics/frontend/generated/api.schemas.ts
@@ -241,6 +241,11 @@ export interface _MetricAnomalyReportApi {
     series: _MetricSeriesApi
 }
 
+export interface _HasMetricsResponseApi {
+    /** Whether the team has ingested any metrics. */
+    hasMetrics: boolean
+}
+
 export interface _MetricGroupByApi {
     /**
      * Attribute name to split series by (e.g. 'k8s.pod.name', 'env').
@@ -457,8 +462,6 @@ export interface _MetricNamesResponseApi {
     /** Distinct metric names ordered by recent activity. */
     results: _MetricNameApi[]
 }
-
-export type MetricsHasMetricsRetrieve200 = { [key: string]: unknown }
 
 export type MetricsValuesRetrieveParams = {
     /**

--- a/products/metrics/frontend/generated/api.ts
+++ b/products/metrics/frontend/generated/api.ts
@@ -11,8 +11,8 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
     AppMetricsResponseApi,
     AppMetricsTotalsResponseApi,
-    MetricsHasMetricsRetrieve200,
     MetricsValuesRetrieveParams,
+    _HasMetricsResponseApi,
     _MetricAnomalyReportApi,
     _MetricAnomalyRequestApi,
     _MetricNamesResponseApi,
@@ -92,8 +92,8 @@ export const getMetricsHasMetricsRetrieveUrl = (projectId: string) => {
 export const metricsHasMetricsRetrieve = async (
     projectId: string,
     options?: RequestInit
-): Promise<MetricsHasMetricsRetrieve200> => {
-    return apiMutator<MetricsHasMetricsRetrieve200>(getMetricsHasMetricsRetrieveUrl(projectId), {
+): Promise<_HasMetricsResponseApi> => {
+    return apiMutator<_HasMetricsResponseApi>(getMetricsHasMetricsRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -55965,6 +55965,11 @@ export namespace Schemas {
       detail: string;
     }
 
+    export interface _HasMetricsResponse {
+      /** Whether the team has ingested any metrics. */
+      hasMetrics: boolean;
+    }
+
     export interface _HasSpansResponse {
       /** Whether the team has ingested any tracing spans yet. Used to gate the onboarding empty state. */
       hasSpans: boolean;
@@ -60863,8 +60868,6 @@ export namespace Schemas {
      */
     offset?: number;
     };
-
-    export type EnvironmentsMetricsHasMetricsRetrieve200 = { [key: string]: unknown };
 
     export type EnvironmentsMetricsValuesRetrieveParams = {
     /**
@@ -67999,8 +68002,6 @@ export namespace Schemas {
      */
     offset?: number;
     };
-
-    export type MetricsHasMetricsRetrieve200 = { [key: string]: unknown };
 
     export type MetricsValuesRetrieveParams = {
     /**


### PR DESCRIPTION
## Problem

The `has_metrics` endpoint declares its response as `OpenApiTypes.OBJECT`, so drf-spectacular emits an untyped `{}` schema.
Downstream, the generated frontend type is `MetricsHasMetricsRetrieve200 = { [key: string]: unknown }`, so consumers of `metricsHasMetricsRetrieve` get no type safety on the `hasMetrics` field.
Every other action on `MetricsViewSet` (`query`, `samples`, `characterize`, `values`) already uses a named response serializer.

## Changes

- Added `_HasMetricsResponseSerializer` with a `hasMetrics` boolean field (same pattern as tracing's `_HasSpansResponse`) and used it in the `@extend_schema` response for `has_metrics`.
- Regenerated OpenAPI output (`hogli build:openapi`): the frontend type is now `_HasMetricsResponseApi { hasMetrics: boolean }` and the MCP schema picked up the same shape.

The response body is unchanged, this is a schema-only change.

## How did you test this code?

- `hogli test products/metrics/backend/tests/test_api.py` passes.
- `hogli ci:preflight --fix` passes (lint, format, OpenAPI drift).
- No new tests: the endpoint's behavior is unchanged, only its declared schema.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Frank's direction to find small concrete improvements in the metrics product.
Skills invoked: /improving-drf-endpoints.
The untyped response was found by auditing the generated types under `products/metrics/frontend/generated/` for `unknown` shapes, per the skill's triage step.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
