### PR TITLE
chore(metrics): adopt generated API functions in the metrics frontend

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -752,19 +752,6 @@ export class ApiRequest {
         return this.logs(projectId).addPathComponent('export')
     }
 
-    // # Metrics
-    public metrics(projectId?: ProjectType['id']): ApiRequest {
-        return this.environmentsDetail(projectId).addPathComponent('metrics')
-    }
-
-    public metricsHasMetrics(projectId?: ProjectType['id']): ApiRequest {
-        return this.metrics(projectId).addPathComponent('has_metrics')
-    }
-
-    public metricsValues(projectId?: ProjectType['id']): ApiRequest {
-        return this.metrics(projectId).addPathComponent('values')
-    }
-
     // # Tracing
     public tracingSpans(): ApiRequest {
         return this.environmentsDetail().addPathComponent('tracing').addPathComponent('spans')
@@ -2898,29 +2885,6 @@ const api = {
             filename: string
         }> {
             return new ApiRequest().logsExport().create({ data: { query, columns } })
-        },
-    },
-
-    metrics: {
-        async hasMetrics(): Promise<boolean> {
-            return new ApiRequest()
-                .metricsHasMetrics()
-                .get()
-                .then((response) => Boolean(response.hasMetrics))
-        },
-        async values({
-            search,
-            limit,
-            signal,
-        }: {
-            search?: string
-            limit?: number
-            signal?: AbortSignal
-        } = {}): Promise<{ results: { name: string; metric_type: string }[] }> {
-            return new ApiRequest()
-                .metricsValues()
-                .withQueryString({ value: search ?? '', limit: limit ?? 100 })
-                .get({ signal })
         },
     },
 

--- a/products/metrics/frontend/components/metricNamePickerLogic.ts
+++ b/products/metrics/frontend/components/metricNamePickerLogic.ts
@@ -1,17 +1,20 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { metricsValuesRetrieve } from 'products/metrics/frontend/generated/api'
+import type { _MetricNameApi } from 'products/metrics/frontend/generated/api.schemas'
 
 import type { metricNamePickerLogicType } from './metricNamePickerLogicType'
 
-export interface MetricNameItem {
-    name: string
-    metric_type: string
-}
+export type MetricNameItem = _MetricNameApi
 
 export const metricNamePickerLogic = kea<metricNamePickerLogicType>([
     path(['products', 'metrics', 'frontend', 'components', 'metricNamePickerLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
     actions({
         setSearch: (search: string) => ({ search }),
     }),
@@ -26,7 +29,10 @@ export const metricNamePickerLogic = kea<metricNamePickerLogicType>([
                     // Debounce — match the 300ms cadence used in the viewer logic so
                     // both fetches feel cohesive.
                     await breakpoint(300)
-                    const response = await api.metrics.values({ search: values.search, limit: 100 })
+                    const response = await metricsValuesRetrieve(String(values.currentTeamId), {
+                        value: values.search,
+                        limit: 100,
+                    })
                     breakpoint()
                     return response.results
                 },

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -1,9 +1,14 @@
-import api from 'lib/api'
-
 import { initKeaTests } from '~/test/init'
+
+import { metricsValuesRetrieve } from 'products/metrics/frontend/generated/api'
 
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { metricsViewerLogic } from './metricsViewerLogic'
+
+jest.mock('products/metrics/frontend/generated/api', () => ({
+    ...jest.requireActual('products/metrics/frontend/generated/api'),
+    metricsValuesRetrieve: jest.fn(),
+}))
 
 const PICKER_ITEMS = [
     { name: 'requests_total', metric_type: 'sum' },
@@ -17,7 +22,7 @@ describe('metricsViewerLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        jest.spyOn(api.metrics, 'values').mockResolvedValue({ results: PICKER_ITEMS })
+        jest.mocked(metricsValuesRetrieve).mockResolvedValue({ results: PICKER_ITEMS })
         logic = metricsViewerLogic()
         logic.mount()
         metricNamePickerLogic.actions.loadItemsSuccess(PICKER_ITEMS)

--- a/products/metrics/frontend/metricsIngestionLogic.tsx
+++ b/products/metrics/frontend/metricsIngestionLogic.tsx
@@ -1,23 +1,30 @@
-import { afterMount, kea, path, reducers, selectors } from 'kea'
+import { afterMount, connect, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
 import { retryWithBackoff } from 'lib/utils/async'
+import { teamLogic } from 'scenes/teamLogic'
 
+import { metricsHasMetricsRetrieve } from './generated/api'
 import type { metricsIngestionLogicType } from './metricsIngestionLogicType'
 
 const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
 
 export const metricsIngestionLogic = kea<metricsIngestionLogicType>([
     path(['products', 'metrics', 'frontend', 'metricsIngestionLogic']),
-    loaders({
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    loaders(({ values }) => ({
         teamHasMetrics: {
             __default: undefined as boolean | undefined,
             loadTeamHasMetrics: async (): Promise<boolean> => {
-                return await retryWithBackoff(() => api.metrics.hasMetrics(), { maxAttempts: 3 })
+                const response = await retryWithBackoff(() => metricsHasMetricsRetrieve(String(values.currentTeamId)), {
+                    maxAttempts: 3,
+                })
+                return Boolean(response.hasMetrics)
             },
         },
-    }),
+    })),
 
     reducers({
         teamHasMetricsCheckFailed: [


### PR DESCRIPTION
## Problem

The metrics frontend still goes through the handwritten `api.metrics.*` wrapper in `frontend/src/lib/api.ts` and duplicates the backend serializer with a handwritten `MetricNameItem` interface.
Generated, typed equivalents already exist in `products/metrics/frontend/generated/` (`metricsHasMetricsRetrieve`, `metricsValuesRetrieve`, `_MetricNameApi`), and the frontend convention is to use those instead of hand-rolled API clients and mirrored types.

## Changes

- `metricsIngestionLogic` now calls the generated `metricsHasMetricsRetrieve` (still wrapped in `retryWithBackoff`), getting `currentTeamId` from `teamLogic` like `metricsViewerLogic` already does.
- `metricNamePickerLogic` now calls the generated `metricsValuesRetrieve`; the handwritten `MetricNameItem` interface is now a type alias for the generated `_MetricNameApi`, so the picker's item shape tracks the backend serializer automatically.
- Deleted the now-unused `api.metrics` block and the `metrics`/`metricsHasMetrics`/`metricsValues` `ApiRequest` path helpers from `lib/api.ts` (those two logics were the only consumers).
- Updated `metricsViewerLogic.test.ts` to mock the generated `metricsValuesRetrieve` instead of spying on the deleted wrapper.

Generated functions wrap the same `api` module via `api-orval-mutator`, so HTTP behavior (cookies, CSRF, error handling) is unchanged. One behavior note: the wrapper hit `/api/environments/:id/metrics/`, the generated functions hit the canonical `/api/projects/:id/metrics/` alias of the same viewset.

## How did you test this code?

- `hogli test products/metrics/frontend/components/metricsViewerLogic.test.ts` passes (5/5).
- No type errors in the changed files (`tsgo --noEmit` filtered to the touched paths; the repo-wide check doesn't pass locally without a full kea typegen pass).
- `hogli ci:preflight --fix` passes.
- Test changes are mock plumbing only, no new tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Frank's direction to find small concrete improvements in the metrics product.
Skills invoked: /adopting-generated-api-types.
The `hasMetrics` response is still coerced with `Boolean(...)` because its generated type is untyped until #69190 (which types the `has_metrics` response schema) merges; after that the coercion can go.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
