### PR TITLE
fix(google-analytics): surface a clear error on OAuth token refresh failure

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -1,6 +1,7 @@
 from typing import Optional, cast
 
 import requests
+from google.auth.exceptions import RefreshError
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
@@ -145,6 +146,17 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
                     "Google Analytics admin settings.",
                 )
             return False, f"Failed to read Google Analytics property metadata: {e}"
+        except RefreshError:
+            # Raised while AuthorizedSession refreshes the OAuth access token (e.g. invalid_scope or
+            # invalid_grant): the stored token is missing the required permissions, or has expired or
+            # been revoked. Retrying can't recover it — the raw RefreshError repr is meaningless to
+            # users, so guide them to reconnect.
+            return (
+                False,
+                "PostHog could not authenticate with Google Analytics. Your connection may have "
+                "expired or is missing the required permissions. Please reconnect your Google "
+                "account and grant access to Google Analytics.",
+            )
         except Exception as e:
             return False, f"Failed to read Google Analytics property metadata: {e}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -2,6 +2,7 @@ import pytest
 from unittest import mock
 
 import requests
+from google.auth.exceptions import RefreshError
 
 from posthog.schema import ReleaseStatus, SourceFieldOauthConfig
 
@@ -176,6 +177,26 @@ def test_validate_credentials_maps_http_errors(status_code, expected_substring):
 
     assert ok is False
     assert expected_substring in (message or "")
+
+
+def test_validate_credentials_maps_token_refresh_error():
+    # google-auth raises RefreshError with (message, response_dict); its default repr is the tuple,
+    # which used to leak verbatim to users. Guard the mapping to a clean reconnect prompt.
+    refresh_error = RefreshError("invalid_scope: Bad Request", {"error": "invalid_scope"})
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.source.google_analytics_session"
+        ),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.source.get_property_metadata",
+            side_effect=refresh_error,
+        ),
+    ):
+        ok, message = GoogleAnalyticsSource().validate_credentials(_config(), team_id=1)
+
+    assert ok is False
+    assert "reconnect your Google" in (message or "")
+    assert "invalid_scope" not in (message or "")
 
 
 def test_validate_credentials_handles_session_failure():


### PR DESCRIPTION
## Problem

When someone connects a Google Analytics warehouse source whose OAuth token can't be refreshed (expired, revoked, or missing the required scope), credential validation caught the underlying `google.auth.exceptions.RefreshError` in a bare `except` and interpolated it into the message. `RefreshError` is constructed with two args (a message and the raw token-endpoint response dict), so its default repr is a `(message, response_dict)` tuple that leaked verbatim to users. The result was an error a user could do nothing with, exposing internal error shapes instead of telling them what to fix.

## Changes

Add an explicit `except RefreshError` branch in `validate_credentials` that maps the failure to an actionable reconnect prompt, mirroring how the sibling Google Search Console source already handles the same exception. The bare `except Exception` fallback stays for genuinely unexpected errors.

## How did you test this code?

Added one regression test (`test_validate_credentials_maps_token_refresh_error`) that raises a `RefreshError` with the two-arg shape and asserts the user-facing message points them to reconnect and that the raw error shape no longer appears in it. Without the fix the raw tuple leaks, so this guards the exact regression.

Ran the full Google Analytics source test file locally (22 passed) and `ruff check`/`ruff format` over the touched files. I (Claude) did not exercise the OAuth flow in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude while triaging real Google Analytics new-source failures. The observed error was a token-refresh failure whose `RefreshError` repr leaked to the user. I confirmed the sibling Google Search Console source already catches `RefreshError` and returns a clean reconnect message, and reused that wording and rationale here. Kept the change scoped to the validation path. Invoked the `/writing-tests` skill before adding the test.
