### PR TITLE
fix(data-warehouse): clarify unparseable SSH tunnel private key errors

### DIFF
--- a/products/data_warehouse/backend/models/test/test_ssh_tunnel.py
+++ b/products/data_warehouse/backend/models/test/test_ssh_tunnel.py
@@ -1,6 +1,22 @@
 import pytest
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
 from products.warehouse_sources.backend.facade.models import SSHTunnel
+
+
+def _keypair_tunnel(private_key: str | None, passphrase: str | None) -> SSHTunnel:
+    return SSHTunnel(
+        enabled=True,
+        host="host.com",
+        port=5432,
+        auth_type="keypair",
+        username=None,
+        password=None,
+        private_key=private_key,
+        passphrase=passphrase,
+    )
 
 
 @pytest.mark.parametrize("port,expected", [(5432, True), (80, False), (443, False)])
@@ -74,6 +90,27 @@ def test_is_auth_valid_key_pair(private_key, passphrase, expected):
     res, error = ssh_tunnel.is_auth_valid()
 
     assert res is expected
+
+
+def test_is_auth_valid_unparseable_key_suggests_format():
+    res, error = _keypair_tunnel(private_key="not a private key", passphrase=None).is_auth_valid()
+
+    assert res is False
+    assert "OpenSSH or PEM" in error
+
+
+def test_is_auth_valid_wrong_passphrase_suggests_passphrase():
+    key = ed25519.Ed25519PrivateKey.generate()
+    encrypted = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.BestAvailableEncryption(b"correct-passphrase"),
+    ).decode()
+
+    res, error = _keypair_tunnel(private_key=encrypted, passphrase="wrong-passphrase").is_auth_valid()
+
+    assert res is False
+    assert "passphrase" in error.lower()
 
 
 def test_get_tunnel_invalid_auth():

--- a/products/warehouse_sources/backend/models/ssh_tunnel.py
+++ b/products/warehouse_sources/backend/models/ssh_tunnel.py
@@ -22,7 +22,12 @@ def from_private_key(file_obj: IO[str], passphrase: str | None = None) -> PKey:
             password=password,
         )
         file_obj.seek(0)
-    except ValueError:
+    except ValueError as ssh_error:
+        # A wrong passphrase on an OpenSSH key surfaces as a checksum/decrypt failure. Falling
+        # through to the PEM loader masks it with a misleading "no BEGIN/END" error, so re-raise
+        # the original — the caller uses it to point the user at the passphrase.
+        if any(term in str(ssh_error).lower() for term in ("checksum", "decrypt", "password", "passphrase")):
+            raise
         key = crypto_serialization.load_pem_private_key(  # type: ignore
             file_bytes,
             password=password if passphrase is not None else None,
@@ -140,9 +145,20 @@ class SSHTunnel:
 
             try:
                 self.parse_private_key()
-            except:
-                # TODO: More helpful error messages
-                return False, "Private key could not be parsed"
+            except Exception as e:
+                # A wrong/missing passphrase and an unsupported key format both land here but need
+                # different fixes, so point the user at the likely cause. cryptography's message
+                # mentions the password/checksum only for passphrase mismatches.
+                detail = str(e).lower()
+                if any(term in detail for term in ("passphrase", "password", "decrypt", "checksum")):
+                    return False, (
+                        "Private key could not be parsed. Check the passphrase: an encrypted key needs the "
+                        "correct passphrase, and an unencrypted key needs the passphrase field left blank."
+                    )
+                return False, (
+                    "Private key could not be parsed. Paste the full key in OpenSSH or PEM format "
+                    "(RSA, Ed25519, ECDSA, or DSA), including the BEGIN and END lines."
+                )
 
             return True, ""
 

--- a/products/warehouse_sources/backend/models/ssh_tunnel.py
+++ b/products/warehouse_sources/backend/models/ssh_tunnel.py
@@ -10,6 +10,10 @@ from sshtunnel import SSHTunnelForwarder
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common import config
 
+# Substrings that mark a private-key parse failure as a wrong/missing passphrase rather than a
+# format problem, so both the parser and the validator give the same passphrase-specific guidance.
+_PASSPHRASE_ERROR_TERMS = ("checksum", "decrypt", "password", "passphrase")
+
 
 # Taken from https://stackoverflow.com/questions/60660919/paramiko-ssh-client-is-unable-to-unpack-ed25519-key
 def from_private_key(file_obj: IO[str], passphrase: str | None = None) -> PKey:
@@ -26,7 +30,7 @@ def from_private_key(file_obj: IO[str], passphrase: str | None = None) -> PKey:
         # A wrong passphrase on an OpenSSH key surfaces as a checksum/decrypt failure. Falling
         # through to the PEM loader masks it with a misleading "no BEGIN/END" error, so re-raise
         # the original — the caller uses it to point the user at the passphrase.
-        if any(term in str(ssh_error).lower() for term in ("checksum", "decrypt", "password", "passphrase")):
+        if any(term in str(ssh_error).lower() for term in _PASSPHRASE_ERROR_TERMS):
             raise
         key = crypto_serialization.load_pem_private_key(  # type: ignore
             file_bytes,
@@ -150,7 +154,7 @@ class SSHTunnel:
                 # different fixes, so point the user at the likely cause. cryptography's message
                 # mentions the password/checksum only for passphrase mismatches.
                 detail = str(e).lower()
-                if any(term in detail for term in ("passphrase", "password", "decrypt", "checksum")):
+                if any(term in detail for term in _PASSPHRASE_ERROR_TERMS):
                     return False, (
                         "Private key could not be parsed. Check the passphrase: an encrypted key needs the "
                         "correct passphrase, and an unencrypted key needs the passphrase field left blank."


### PR DESCRIPTION
## Problem

Setting up a Postgres source (or any SSH-tunnelled DB source) with a private key that PostHog couldn't parse returned a single terse message for every cause: "Private key could not be parsed". The code even carried a `# TODO: More helpful error messages`. A wrong passphrase, an encrypted key with the passphrase field left blank, and an unsupported key format all looked identical, so users had nothing to act on and often just retried the same thing.

Two things conspired to make this worse for the common case. The key parser tries the OpenSSH loader first and falls back to the PEM loader. An encrypted OpenSSH key parsed with the wrong passphrase fails the OpenSSH loader with a decryption/checksum error, but the PEM fallback swallowed that and re-raised a misleading "no BEGIN/END delimiters" error. So even the raw underlying signal pointed the wrong way.

## Changes

- `from_private_key` stops masking wrong-passphrase failures. When the OpenSSH loader raises something that looks like a decryption failure (checksum/decrypt/password), re-raise it instead of falling through to the PEM loader (which can't help and reports a confusing format error). The happy path and genuine PEM keys are unaffected.
- `is_auth_valid` now returns two distinct messages: a passphrase hint when the failure looks like a decryption problem, and a format hint (accepted key types plus the reminder to include the BEGIN/END lines) otherwise.

This lives in the shared SSH tunnel model, so it improves the setup error for every DB source that supports SSH tunnels, not just Postgres.

## How did you test this code?

Added two unit tests in `test_ssh_tunnel.py`:

- an unparseable key returns the format guidance
- a real encrypted Ed25519 key parsed with the wrong passphrase returns the passphrase guidance (this is the case the old code got backwards)

Together they lock in the branch split that is the whole point of the change. Ran the full `test_ssh_tunnel.py` file locally (18 passed) and verified out of band that a wrong passphrase on both OpenSSH-format and PEM/PKCS8-format encrypted keys now routes to the passphrase branch. Ran `ruff check`/`ruff format` over the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude while triaging real DB source-creation failures where the private key couldn't be parsed. I found the message was a catch-all with an existing TODO, then traced why a wrong-passphrase case didn't surface a passphrase-shaped error and discovered the PEM fallback was masking the OpenSSH loader's checksum error. Fixed both the masking and the message split. Considered a single combined message but chose two branches because the fixes differ (passphrase vs format) and it gives a testable behavioral distinction. Invoked the `/writing-tests` skill before adding the tests.
