### PR TITLE
fix(agent-platform): unwrap cjs default export in sandbox dispatcher

### DIFF
--- a/products/agent_platform/services/agent-sandbox-host/README.md
+++ b/products/agent_platform/services/agent-sandbox-host/README.md
@@ -93,7 +93,9 @@ or
 { "ok": false, "error": { "code": "tool_not_found", "message": "..." } }
 ```
 
-Tool contract (`/workdir/tools/<id>/compiled.js`):
+Tool contract (`/workdir/tools/<id>/compiled.js`) — two accepted shapes:
+
+1. Plain CJS:
 
 ```js
 module.exports = {
@@ -107,6 +109,12 @@ module.exports = {
   },
 }
 ```
+
+2. A `default` property on `module.exports` (esbuild's `__toCommonJS` CJS
+   interop for the typed pipeline's mandated `export default {}` source).
+   The dispatcher applies the same unwrap rule as the in-process pool
+   (`agent-shared/src/sandbox/sandbox-inprocess.ts`): `module.exports.default`
+   when present, else `module.exports` itself.
 
 `ctx.secrets.ref(name)` returns the nonce the runner-side `SecretBroker`
 minted for this session. The sandbox never sees raw secret values; the

--- a/products/agent_platform/services/agent-sandbox-host/scripts/smoke-test-image.sh
+++ b/products/agent_platform/services/agent-sandbox-host/scripts/smoke-test-image.sh
@@ -34,6 +34,34 @@ ECHO_TOOL='module.exports = {
     },
 }'
 
+# This fixture IS the repo's esbuild output for the typed pipeline's mandated
+# `export default {}` source shape (format:"cjs", loader:"ts", target:"node20")
+# — the compiled.js production tools ship. It exposes the tool object as
+# `.default` via a __toCommonJS getter on module.exports.
+ECHO_DEFAULT_TOOL='var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var stdin_exports = {};
+__export(stdin_exports, {
+  default: () => stdin_default
+});
+module.exports = __toCommonJS(stdin_exports);
+var stdin_default = { id: "echo-default", actions: { default: (args, ctx) => ({ doubled: args.n * 2 }) } };'
+
 # Run a single dispatch scenario:
 #   $1 — request JSON
 #   $2 — node assertion script (reads response.json from $1 argument)
@@ -48,6 +76,9 @@ run_scenario() {
     mkdir -p "$workdir/tools/echo"
     printf '%s' "$ECHO_TOOL" > "$workdir/tools/echo/compiled.js"
     echo '{ "type": "object" }' > "$workdir/tools/echo/schema.json"
+    mkdir -p "$workdir/tools/echo-default"
+    printf '%s' "$ECHO_DEFAULT_TOOL" > "$workdir/tools/echo-default/compiled.js"
+    echo '{ "type": "object" }' > "$workdir/tools/echo-default/schema.json"
     echo '{ "TEST_SECRET": "nonce_smoke_abc" }' > "$workdir/nonces.json"
     printf '%s' "$request_json" > "$workdir/request.json"
     # Bind-mounted dirs keep the host's UID/GID; the in-container `sandbox`
@@ -106,5 +137,13 @@ run_scenario \
 const res = JSON.parse(require("node:fs").readFileSync(process.argv[2], "utf-8"))
 assert.equal(res.ok, false, `expected ok=false, got ${JSON.stringify(res)}`)
 assert.equal(res.error.code, "tool_not_found", `wrong code: ${JSON.stringify(res)}`)'
+
+echo "smoke: scenario 4 — esbuild-CJS default-export tool (typed pipeline shape)" >&2
+run_scenario \
+    '{"toolId":"echo-default","action":"default","args":{"n":21},"timeoutMs":10000}' \
+    'const assert = require("node:assert/strict")
+const res = JSON.parse(require("node:fs").readFileSync(process.argv[2], "utf-8"))
+assert.equal(res.ok, true, `expected ok=true, got ${JSON.stringify(res)}`)
+assert.deepEqual(res.result, { doubled: 42 })'
 
 echo "smoke: PASS — image $IMAGE works end-to-end" >&2

--- a/products/agent_platform/services/agent-sandbox-host/src/dispatch.js
+++ b/products/agent_platform/services/agent-sandbox-host/src/dispatch.js
@@ -12,13 +12,12 @@
  *     { "ok": true, "result": unknown }
  *   | { "ok": false, "error": { "code": string, "message": string } }
  *
- * Compiled-tool contract:
- *   module.exports = {
- *     id: "<tool-id>",
- *     actions: {
- *       <name>: (args, ctx) => any | Promise<any>
- *     }
- *   }
+ * Compiled-tool contract — two accepted shapes:
+ *   1. Plain CJS:
+ *      module.exports = { id: "<tool-id>", actions: { <name>: (args, ctx) => any | Promise<any> } }
+ *   2. A `default` property on `module.exports` (esbuild's `__toCommonJS` CJS
+ *      interop for the typed pipeline's mandated `export default {}` source).
+ *   Sibling loader applying the same unwrap rule: agent-shared/src/sandbox/sandbox-inprocess.ts.
  *
  * `ctx` exposes:
  *   - secrets.ref(name)  → opaque per-session nonce string. The raw secret
@@ -67,7 +66,9 @@ function loadTool(toolId) {
     // Clear require cache so a re-published bundle is picked up — sandboxes
     // are per-session so cache reuse is fine within one session.
     delete require.cache[require.resolve(compiledPath)]
-    return require(compiledPath)
+    const mod = require(compiledPath)
+    // Same rule as the in-process pool (agent-shared/src/sandbox/sandbox-inprocess.ts).
+    return mod.default ?? mod
 }
 
 function buildContext(nonces) {

--- a/products/agent_platform/services/agent-sandbox-host/src/dispatch.test.js
+++ b/products/agent_platform/services/agent-sandbox-host/src/dispatch.test.js
@@ -46,6 +46,45 @@ test('dispatch returns the action result for a known tool + action', async () =>
     assert.deepEqual(out.result, { got: { hi: 'world' } })
 })
 
+test('dispatch unwraps an esbuild-CJS default export (typed-pipeline compiled.js)', async () => {
+    setupToolsDir()
+    // This fixture IS the repo's esbuild output: the janitor's typed pipeline
+    // mandates `export default {...}` source and compiles with esbuild
+    // format:"cjs" (loader:"ts", target:"node20"), which exposes the tool
+    // object as `.default` via a __toCommonJS getter on module.exports — not
+    // a bare `module.exports = {...}` like the fixtures above.
+    writeTool(
+        'typed-echo',
+        `var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var stdin_exports = {};
+__export(stdin_exports, {
+  default: () => stdin_default
+});
+module.exports = __toCommonJS(stdin_exports);
+var stdin_default = { id: "typed-echo", actions: { default: async (args) => ({ ok: true, echo: args.x }) } };
+`
+    )
+    const { dispatch } = freshRequire()
+    const out = await dispatch({ toolId: 'typed-echo', action: 'default', args: { x: 42 } })
+    assert.deepEqual(out.result, { ok: true, echo: 42 })
+})
+
 test('dispatch surfaces a tool-not-found error code', async () => {
     setupToolsDir()
     const { dispatch } = freshRequire()


### PR DESCRIPTION
## Problem

**Every custom tool authored through the typed pipeline fails at dispatch on the docker and modal sandbox pools** with `action_not_found`. The pipeline's AST check requires tool source to be `export default { actions: ... }` and esbuild compiles it to CJS whose interop exposes the tool object as a `default` property on `module.exports` — but `dispatch.js` reads `.actions` off the raw module exports, finds nothing, and rejects the call:

```
{ "ok": false, "error": { "code": "action_not_found", "message": "action not found: default" } }
```

CI stayed green because the e2e suite substitutes the in-process sandbox pool, which normalizes the default export (`sandbox-inprocess.ts`) — the tests exercised a proxy for the real dispatch path rather than the path itself. The dry-run endpoint from #66584 executes persisted `compiled.js` through this dispatcher, so the mismatch is reachable from the authoring loop's "test this tool" flow on both real pools.

## Changes

- `dispatch.js` `loadTool()` now applies the same rule as the in-process pool: `mod.default ?? mod`. This is the direct fix — and reader-side is the one placement that also heals already-frozen bundles, since freeze makes their `compiled.js` immutable.
- `smoke-test-image.sh` gains a scenario whose fixture is the repo's actual esbuild output for a default-export tool — this closes the door: the image gate that runs before every GHCR push now covers the shape the pipeline actually produces, so the two loaders can't silently disagree again.
- The compiled-tool contract docblock and the package README document both accepted shapes (plain `module.exports` and the esbuild `__toCommonJS` default-property interop), pointing at the sibling loader.

The alternative was fixing the producer (make the compiler emit the original documented shape), but frozen bundles are immutable, so that strands every existing revision and adds no correctness once readers normalize. Deliberately not in this PR: a cross-package janitor→dispatcher contract test in agent-tests — good follow-up, doubles the review surface here.

Sibling fix in the same authoring loop: #69202.

## How did you test this code?

Ran locally against a full dev stack (all four agent services + Postgres/Redis/Kafka/SeaweedFS, docker sandbox pool with a locally built image):

- New regression test `dispatch unwraps an esbuild-CJS default export (typed-pipeline compiled.js)` in `dispatch.test.js` — the fixture is the repo's actual esbuild 0.28.0 output (`format:'cjs'`, `loader:'ts'`, `target:'node20'`), not a hand-written approximation. With the fix reverted it fails with the exact production error above — the regression no existing test caught, because the unit fixtures hand-wrote `module.exports` and e2e substitutes the in-process pool.
- `pnpm --filter=@posthog/agent-sandbox-host test` → **8 passed**; `typescript:check`, `oxlint`, `oxfmt --check` → clean.
- `scripts/smoke-test-image.sh` against a locally built image → **all 4 scenarios pass**, including the new real-esbuild default-export dispatch.
- End-to-end (janitor-compiled tool, real model, docker pool): before the fix the session's tool result is `action_not_found`; with it, the tool executes and returns results. Reproduced both directions.

A reviewer with deploy visibility may want to confirm the image digest rolls through `ci-agent-container` → chart as usual; nothing in that path changes here. (Note: the image build+smoke job skips on fork PRs by design — the smoke run above was executed locally against a locally built image.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Contract documentation updated in-place (`dispatch.js` docblock + the package README's tool-contract section).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I found this while running the platform locally and driving custom tools through the real docker pool; diagnosis, fix, and tests were developed in a Claude Code session (Fable 5) under my direction, and I verified every claim above by execution, including the fail/fix A/B. Key decision: fix the reader, not the compiler — freeze makes existing bundles immutable, so only a reader-side normalization heals revisions that already shipped, and it applies the same rule the in-process pool has used since day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
