### PR TITLE
fix(data-warehouse): auto-heal delta tables with an orphaned _delta_log

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -236,13 +236,8 @@ class DeltaTableHelper:
             except Exception as e:
                 capture_exception(e)
                 error_text = "".join(str(arg) for arg in e.args)
-                # Unrecoverable table states: delete the table so the sync starts fresh.
-                # - "parse decimal overflow": bugged decimal data an old writer produced.
-                # - "No table metadata or protocol found": an orphaned _delta_log holding
-                #   commit files but no protocol/metadata action (e.g. a reset_table raced
-                #   an in-flight writer). Commit 0 writes protocol+metadata atomically, so
-                #   a healthy table can never produce this; no future sync can open or
-                #   repair the log, only wiping it recovers the schema.
+                # Unrecoverable tables (bugged decimals, or an orphaned _delta_log missing its
+                # metadata action — impossible on a healthy table): wipe so the sync starts fresh.
                 if "parse decimal overflow" in error_text or "No table metadata or protocol found" in error_text:
                     await self._logger.aerror(
                         f"get_delta_table: deleting unrecoverable delta table for a fresh sync: {error_text}"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -234,9 +234,19 @@ class DeltaTableHelper:
                     deltalake.DeltaTable, table_uri=delta_uri, storage_options=storage_options
                 )
             except Exception as e:
-                # Temp fix for bugged tables
                 capture_exception(e)
-                if "parse decimal overflow" in "".join(e.args):
+                error_text = "".join(str(arg) for arg in e.args)
+                # Unrecoverable table states: delete the table so the sync starts fresh.
+                # - "parse decimal overflow": bugged decimal data an old writer produced.
+                # - "No table metadata or protocol found": an orphaned _delta_log holding
+                #   commit files but no protocol/metadata action (e.g. a reset_table raced
+                #   an in-flight writer). Commit 0 writes protocol+metadata atomically, so
+                #   a healthy table can never produce this; no future sync can open or
+                #   repair the log, only wiping it recovers the schema.
+                if "parse decimal overflow" in error_text or "No table metadata or protocol found" in error_text:
+                    await self._logger.aerror(
+                        f"get_delta_table: deleting unrecoverable delta table for a fresh sync: {error_text}"
+                    )
                     async with aget_s3_client() as s3:
                         await s3._rm(delta_uri, recursive=True)
                 else:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -239,9 +239,7 @@ class TestCompactIfFragmented:
 
 
 class TestGetDeltaTableUnrecoverableErrors:
-    # (case_name, error_message, expect_heal)
-    # expect_heal=True: the table is wiped and get_delta_table falls back to first-sync
-    # mode instead of failing every future run on an unopenable table.
+    # (case_name, error_message, expect_heal) — heal = wipe the table and fall back to first-sync mode
     _ERROR_CASES: list[tuple[str, str, bool]] = [
         (
             "orphaned_delta_log",

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -238,6 +238,54 @@ class TestCompactIfFragmented:
             mock_compact.assert_not_called()
 
 
+class TestGetDeltaTableUnrecoverableErrors:
+    # (case_name, error_message, expect_heal)
+    # expect_heal=True: the table is wiped and get_delta_table falls back to first-sync
+    # mode instead of failing every future run on an unopenable table.
+    _ERROR_CASES: list[tuple[str, str, bool]] = [
+        (
+            "orphaned_delta_log",
+            "Kernel error: No table metadata or protocol found in delta log.",
+            True,
+        ),
+        ("bugged_decimal_data", "parse decimal overflow at column x", True),
+        ("other_errors_reraise", "Generic DeltaTable error: something else went wrong", False),
+    ]
+
+    @parameterized.expand(_ERROR_CASES)
+    @pytest.mark.asyncio
+    async def test_open_failure_handling(self, _name: str, error_message: str, expect_heal: bool):
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        delta_uri = "s3://bucket/team_id/job_id/t"
+
+        s3 = MagicMock()
+        s3._rm = AsyncMock()
+        s3_cm = MagicMock()
+        s3_cm.__aenter__ = AsyncMock(return_value=s3)
+        s3_cm.__aexit__ = AsyncMock(return_value=False)
+
+        module = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper"
+        with (
+            patch.object(helper, "_get_delta_table_uri", AsyncMock(return_value=delta_uri)),
+            patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
+            patch(f"{module}.aget_s3_client", MagicMock(return_value=s3_cm)),
+            patch(f"{module}.capture_exception"),
+        ):
+            mock_delta_table.is_deltatable.return_value = True
+            mock_delta_table.side_effect = Exception(error_message)
+
+            if expect_heal:
+                result = await helper.get_delta_table()
+                assert result is None
+                assert helper.is_first_sync is True
+                s3._rm.assert_awaited_once_with(delta_uri, recursive=True)
+            else:
+                with pytest.raises(Exception, match="something else went wrong"):
+                    await helper.get_delta_table()
+                s3._rm.assert_not_awaited()
+                assert helper.is_first_sync is False
+
+
 class TestWriteToDeltalakeCommitMetadataPassThrough:
     """Covers that commit_metadata is forwarded to deltalake.write_deltalake as CommitProperties."""
 


### PR DESCRIPTION
## Problem

A v2 warehouse sync can leave a Delta table in a permanently unopenable state: the `_delta_log` directory contains commit files but no protocol/metadata action. This happens when a table reset (which recursively deletes the table's S3 prefix) races an in-flight writer holding a stale table handle - the writer commits its next version into the now-empty log directory, so commit 0 (which writes protocol+metadata atomically) never exists.

From then on `DeltaTable.is_deltatable()` returns true (the log directory is non-empty) but opening the table raises `DeltaError: Kernel error: No table metadata or protocol found in delta log.` on every run. Nothing self-heals: `get_delta_table()` only auto-deletes on the `parse decimal overflow` carve-out and re-raises everything else, so the schema fails every scheduled sync forever. We observed one schema accumulate close to 4,000 consecutive hourly failures this way, with a handful of one-off occurrences on other schemas.

## Changes

In `DeltaTableHelper.get_delta_table()`, treat `No table metadata or protocol found` the same way as the existing `parse decimal overflow` carve-out: capture the exception, delete the table prefix, and fall through to first-sync mode so the next write recreates the table from scratch.

This is safe to auto-delete on because a healthy table can never produce this error - commit 0 writes protocol and metadata atomically with put-if-absent, so the only states that raise it are orphaned or corrupted logs that no future sync could ever open or repair.

> [!NOTE]
> This fixes the *recovery* path, not the root cause. `reset_table()` still isn't fenced against a concurrent writer on the same `(team, schema)` - that race is what corrupts the log in the first place and deserves a separate fix (per-schema write lock around reset, or rejecting resync while a job is running).

## How did you test this code?

Added `TestGetDeltaTableUnrecoverableErrors` to `test_delta_table_helper.py` - a parameterized test covering the two heal-and-continue errors (orphaned log, decimal overflow) plus the re-raise path for any other open failure. It catches the regression where the carve-out gets narrowed or reverted and corrupted tables go back to failing every scheduled run; no existing test covered the carve-out at all (including the pre-existing decimal-overflow branch). Verified the full `test_delta_table_helper.py` file passes (48 tests). No manual testing against S3 was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal error-handling change, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with PostHog Code (Claude). The session started as a production investigation of a schema failing hourly with this DeltaError; job history showed the failure began right after resync jobs raced each other (concurrent commit conflicts, then a permanently poisoned log), and code reading showed the error re-raises forever with no recovery path.
- Skills invoked: `/writing-tests` before adding the test.
- Considered auto-deleting on all open failures, rejected as too aggressive - transient S3/read errors must keep re-raising. The fix matches only this specific kernel error, which provably cannot occur on a healthy table.
- The affected production schema still needs a manual resync to recover today (this fix handles future occurrences); flagged separately to the operator.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*