### PR TITLE
feat(hogql): default to rust-py only in tests, drop the cpp shadow leg

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -181,13 +181,15 @@ _PARSER_MODE_BACKENDS: dict[ParserMode, tuple[HogQLParserBackend, HogQLParserBac
 
 # Fraction of `*_shadow` parses in PROD that also run the shadow backend. With rust-py promoted to the default primary,
 # the shadow leg now runs the cpp parser on ~0.1% of requests purely as a divergence canary. Bump if a fresh regression
-# surfaces and tighter coverage is needed. Tests always sample 100%.
+# surfaces and tighter coverage is needed. Tests default to no shadow at all (see `_resolve_parser_mode`); an
+# explicitly requested `*_shadow` mode samples 100% there so parity tests are deterministic.
 _SHADOW_SAMPLE_RATE = 0.001
 
 
 def _shadow_sample_rate() -> float:
-    """Shadow sampling fraction: 100% in tests (every parse compared, regressions fail loud), `_SHADOW_SAMPLE_RATE` in
-    prod. Divergence behavior also differs by env (TEST raises, prod records) in `_run_shadow_comparison`."""
+    """Shadow sampling fraction: 100% in tests (only reached via an explicit `*_shadow` parser_mode, compared on every
+    parse so regressions fail loud), `_SHADOW_SAMPLE_RATE` in prod. Divergence behavior also differs by env (TEST
+    raises, prod records) in `_run_shadow_comparison`."""
     return 1.0 if settings.TEST else _SHADOW_SAMPLE_RATE
 
 
@@ -196,12 +198,13 @@ def _resolve_parser_mode(
 ) -> tuple[HogQLParserBackend, HogQLParserBackend | None]:
     """Resolve a `parserMode` modifier to `(primary, shadow)` backends.
 
-    With neither `parser_mode` nor an explicit `backend=` set, the default is
-    `RUST_PY_WITH_CPP_SHADOW`: rust-py is the primary (its result is always
-    returned) and cpp runs as the shadow, sampled per `_shadow_sample_rate`
-    (100% in test, 0.1% in prod). The divergence behavior differs by
-    environment downstream (`_run_shadow_comparison`): TEST raises on any
-    mismatch, prod only reports it (never failing the request).
+    With neither `parser_mode` nor an explicit `backend=` set, the default
+    depends on the environment. In prod it is `RUST_PY_WITH_CPP_SHADOW`:
+    rust-py is the primary (its result is always returned) and cpp runs as
+    the shadow, sampled per `_shadow_sample_rate` (0.1%), with divergences
+    reported but never failing the request. In TEST it is `RUST_PY_ONLY` —
+    rust-py is the source of truth and the cpp parser never runs unless a
+    test opts into it explicitly via `parser_mode` or `backend=`.
 
     If the rust wheel failed to import (`_RUST_PARSER_AVAILABLE` is False)
     the default falls back to cpp-only, so a broken wheel can't take the
@@ -227,9 +230,11 @@ def _resolve_parser_mode(
         return _PARSER_MODE_BACKENDS[parser_mode]
     if backend is not None:
         return backend, None
-    if _RUST_PARSER_AVAILABLE:
-        return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_WITH_CPP_SHADOW]
-    return DEFAULT_BACKEND, None
+    if not _RUST_PARSER_AVAILABLE:
+        return DEFAULT_BACKEND, None
+    if settings.TEST:
+        return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_ONLY]
+    return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_WITH_CPP_SHADOW]
 
 
 class HogQLParserShadowMismatch(Exception):

--- a/posthog/hogql/test/test_parser_mode.py
+++ b/posthog/hogql/test/test_parser_mode.py
@@ -16,8 +16,8 @@ from posthog.hogql.parser import HogQLParserShadowMismatch, _resolve_parser_mode
 class TestParserMode(BaseTest):
     @parameterized.expand(
         [
-            # No mode + no explicit backend → new shadow default (rust-py primary, cpp shadow).
-            (None, None, ("rust-py", "cpp-json")),
+            # No mode + no explicit backend under TEST → rust-py only, cpp never runs.
+            (None, None, ("rust-py", None)),
             # No mode + explicit backend → honour the explicit backend, no shadow.
             (None, "cpp-json", ("cpp-json", None)),
             (None, "rust-json", ("rust-json", None)),
@@ -34,7 +34,7 @@ class TestParserMode(BaseTest):
     def test_resolve_parser_mode(self, mode, backend, expected):
         self.assertEqual(_resolve_parser_mode(mode, backend), expected)
 
-    def test_resolve_parser_mode_default_shadows_in_prod_not_only_in_test(self):
+    def test_resolve_parser_mode_default_shadows_in_prod(self):
         with patch("posthog.hogql.parser.settings") as mock_settings:
             mock_settings.TEST = False
             self.assertEqual(_resolve_parser_mode(None, None), ("rust-py", "cpp-json"))


### PR DESCRIPTION
## Problem

The HogQL parser's default mode runs rust-py as the primary with the cpp parser as a shadow. In tests the shadow sampled at 100%, so every parse in the test suite ran both parsers and cross-compared the ASTs. Now that rust-py is the established source of truth, that test-time cpp shadow is no longer needed and just adds parse-time overhead and a dependency on the cpp wheel for every test.

## Changes

- `_resolve_parser_mode` now defaults to `RUST_PY_ONLY` when `settings.TEST` is set, so tests only ever run the rust-py parser unless they explicitly opt into another backend via `parser_mode` or `backend=`.
- Production behavior is unchanged: the default stays `RUST_PY_WITH_CPP_SHADOW` (rust-py primary, cpp reverse shadow sampled at 0.1% as a divergence canary), and the cpp-only fallback when the rust wheel fails to import is untouched.
- The 100% shadow sampling in TEST remains, but it's now only reachable through explicitly requested `*_shadow` modes, keeping the shadow-machinery parity tests deterministic.

## How did you test this code?

- `posthog/hogql/test/test_parser_mode.py` (26 passed) - updated the default-resolution expectation under TEST to `("rust-py", None)`; the prod-default case still asserts the shadow pair with `settings.TEST` patched off, which is the regression guard for accidentally dropping the production reverse shadow.
- `posthog/hogql/test/test_parser_cache.py`, `test_parser_rust_py.py`, `test_diagnostic_common.py` (504 passed) as a sweep for anything depending on the test-time shadow default.

No new tests: existing tests cover both environments' defaults; only expectations changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal parser plumbing, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked PostHog Code (Claude) to remove the cpp shadow leg from the TEST default while keeping the production reverse shadow. It made the change in `_resolve_parser_mode`, updated the two affected tests (invoking the repo's /writing-tests skill first), and ran the hogql parser test suites locally. The only real decision: keep `_shadow_sample_rate` returning 1.0 in TEST rather than deleting it, since the shadow parity tests still request shadow modes explicitly and rely on deterministic sampling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
