### PR TITLE
fix(engineering-analytics): show loading state on cost section during overview fetch

### DIFF
--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
@@ -5,7 +5,7 @@ import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
 import { IconBox } from '@posthog/icons'
-import { LemonCard, LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonCard, LemonSkeleton, LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -246,6 +246,7 @@ export function RepoOverviewScene(): JSX.Element {
         defaultBranch,
         notConnected,
         overviewFailed,
+        overviewLoading,
         failingWorkflowCount,
         masterFailuresLoading,
     } = useValues(repoOverviewLogic)
@@ -260,6 +261,10 @@ export function RepoOverviewScene(): JSX.Element {
     } = useValues(engineeringAnalyticsLogic)
     const { loadOverview, loadMasterFailures, loadRepoActivity } = useActions(repoOverviewLogic)
     const { searchParams } = useValues(router)
+
+    // jobsAvailable reads false until the overview payload lands, so "not synced" messaging
+    // during the initial fetch would misread as a broken setup — hold it back while loading.
+    const overviewPending = overviewLoading && !overview
 
     if (notConnected) {
         return <ConnectGitHubSource />
@@ -311,7 +316,9 @@ export function RepoOverviewScene(): JSX.Element {
                     tooltip={
                         jobsAvailable
                             ? `Estimated: ${compactMinutes(overview?.billable_minutes)} billable × runner-tier rate.`
-                            : 'Available once the job-level source is synced.'
+                            : overviewPending
+                              ? undefined
+                              : 'Available once the job-level source is synced.'
                     }
                     value={jobsAvailable ? compactUsd(overview?.estimated_cost_usd) : '—'}
                     delta={
@@ -322,7 +329,7 @@ export function RepoOverviewScene(): JSX.Element {
                             />
                         ) : undefined
                     }
-                    sub={jobsAvailable ? undefined : 'Job-level source not synced'}
+                    sub={jobsAvailable || overviewPending ? undefined : 'Job-level source not synced'}
                 />
                 <MetricTile
                     label="Median PR open→merge"
@@ -465,7 +472,12 @@ export function RepoOverviewScene(): JSX.Element {
             </Section>
 
             <Section id="cost" title="Cost">
-                {jobsAvailable && costPerMergeSeries ? (
+                {overviewPending ? (
+                    <LemonCard hoverEffect={false} className="p-4">
+                        <LemonSkeleton className="mb-3 h-4 w-40" />
+                        <LemonSkeleton className="h-24 w-full" />
+                    </LemonCard>
+                ) : jobsAvailable && costPerMergeSeries ? (
                     <LemonCard hoverEffect={false} className="mb-2 p-4">
                         <h3 className="mb-1 text-xs font-semibold text-secondary">Cost per merged PR</h3>
                         <Sparkline
@@ -485,7 +497,7 @@ export function RepoOverviewScene(): JSX.Element {
                         </div>
                     </LemonCard>
                 ) : null}
-                {jobsAvailable && costByWorkflow.length > 0 ? (
+                {overviewPending ? null : jobsAvailable && costByWorkflow.length > 0 ? (
                     <LemonCard hoverEffect={false} className="p-4">
                         <h3 className="mb-1 text-xs font-semibold text-secondary">By workflow</h3>
                         {costByWorkflow.map((row, i) => (


### PR DESCRIPTION
## Problem

On the engineering analytics repo hub, the Cost section has no loading state. While the overview request is in flight, `jobsAvailable` (derived from the not-yet-loaded overview payload) reads `false`, so the page shows "Cost data will appear once the job-level source (github_workflow_jobs) is synced." and the CI cost tile captions "Job-level source not synced". Users see this on every page load and think the setup is broken, when the data is simply still loading.

## Changes

All in `products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx`:

- Pull `overviewLoading` from `repoOverviewLogic` (kea-loaders provides it) and derive `overviewPending = overviewLoading && !overview`, so it only covers the initial fetch. Refreshes keep showing the previous data.
- Cost section renders a `LemonSkeleton` card while pending instead of the not-synced empty state.
- CI cost stat tile suppresses the "Job-level source not synced" caption and its tooltip while pending (the value already renders as a dash).

Other tiles and tables on the page already have their own `loading` props or just hide the cost column, so no other surface misleads during load.

## How did you test this code?

- `oxlint` and `oxfmt --check` on the touched file: clean.
- Full frontend typecheck (`tsgo --noEmit` after kea typegen): no errors in `products/engineering_analytics`.
- No manual browser testing was done in this session. No new tests: this is a render-gating change on a loader flag with no logic worth pinning that an existing test doesn't cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, UI loading-state fix only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code cloud task) directed by Paul D'Ambra. The fix traces the misleading empty state to `jobsAvailable` defaulting to `false` while the overview loader is in flight, and gates the not-synced messaging on the loader instead. No skills were invoked. Considered adding a `loading` prop to `MetricTile` but the tile's dash value was already fine, only the caption and tooltip misled, so the gating stays local to the scene.
