### PR TITLE
feat(metrics): multi-metric query clauses and formulas in the viewer

### DIFF
--- a/products/metrics/frontend/components/MetricsClauseRow.tsx
+++ b/products/metrics/frontend/components/MetricsClauseRow.tsx
@@ -1,0 +1,91 @@
+import { useActions, useValues } from 'kea'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInputSelect, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+
+import { MetricNameFilter } from './MetricNameFilter'
+import { metricNamePickerLogic } from './metricNamePickerLogic'
+import {
+    clauseLabel,
+    MetricAggregation,
+    metricsViewerLogic,
+    RECOMMENDED_AGGREGATION_BY_TYPE,
+} from './metricsViewerLogic'
+
+export const AGGREGATION_OPTIONS: { value: MetricAggregation; label: string }[] = [
+    { value: 'sum', label: 'Sum' },
+    { value: 'avg', label: 'Average' },
+    { value: 'count', label: 'Count' },
+    { value: 'p95', label: 'p95' },
+    { value: 'rate', label: 'Rate (/s)' },
+    { value: 'increase', label: 'Increase' },
+]
+
+export function MetricsClauseRow({ index }: { index: number }): JSX.Element | null {
+    const { clauses } = useValues(metricsViewerLogic)
+    const { updateClause, removeClause } = useActions(metricsViewerLogic)
+    const { items: pickerItems } = useValues(metricNamePickerLogic)
+
+    const clause = clauses[index]
+    if (!clause) {
+        return null
+    }
+    const multiClause = clauses.length > 1
+    const selectedMetricType = pickerItems.find((item) => item.name === clause.metricName)?.metric_type
+    const recommendedAggregation = selectedMetricType ? RECOMMENDED_AGGREGATION_BY_TYPE[selectedMetricType] : undefined
+
+    return (
+        <div className="flex flex-wrap items-end gap-2">
+            {multiClause && (
+                <LemonTag type="muted" className="mb-1.5 font-mono">
+                    {clauseLabel(index)}
+                </LemonTag>
+            )}
+            <div className="flex flex-col gap-1">
+                <MetricNameFilter
+                    value={clause.metricName}
+                    onChange={(metricName) => updateClause(index, { metricName })}
+                />
+                {selectedMetricType && recommendedAggregation && clause.aggregation !== recommendedAggregation && (
+                    <span className="text-xs text-secondary">
+                        {selectedMetricType} — {recommendedAggregation} recommended
+                    </span>
+                )}
+            </div>
+            <LemonSelect
+                size="small"
+                value={clause.aggregation}
+                options={AGGREGATION_OPTIONS}
+                onChange={(value) => updateClause(index, { aggregation: value as MetricAggregation })}
+            />
+            <LemonInputSelect
+                mode="multiple"
+                size="small"
+                allowCustomValues
+                value={clause.groupByKeys}
+                onChange={(groupByKeys) => updateClause(index, { groupByKeys })}
+                options={[]}
+                placeholder="Group by attribute…"
+                className="min-w-[12rem]"
+            />
+            <LemonInputSelect
+                mode="multiple"
+                size="small"
+                allowCustomValues
+                value={clause.filterStrings}
+                onChange={(filterStrings) => updateClause(index, { filterStrings })}
+                options={[]}
+                placeholder="Filter attribute=value…"
+                className="min-w-[14rem]"
+            />
+            {multiClause && (
+                <LemonButton
+                    size="small"
+                    icon={<IconTrash />}
+                    onClick={() => removeClause(index)}
+                    tooltip="Remove metric"
+                />
+            )}
+        </div>
+    )
+}

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,7 +1,15 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonInputSelect, LemonSegmentedButton, LemonSelect, LemonSwitch, SpinnerOverlay } from '@posthog/lemon-ui'
+import { IconPlusSmall, IconX } from '@posthog/icons'
+import {
+    LemonButton,
+    LemonInput,
+    LemonSegmentedButton,
+    LemonSelect,
+    LemonSwitch,
+    SpinnerOverlay,
+} from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
@@ -12,17 +20,11 @@ import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils/datetime'
 
 import { DateMappingOption } from '~/types'
 
-import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { MetricsChartLegend } from './MetricsChartLegend'
+import { MetricsClauseRow } from './MetricsClauseRow'
 import { MetricStatPanel } from './MetricStatPanel'
-import {
-    LIVE_REFRESH_MS,
-    MetricAggregation,
-    metricsViewerLogic,
-    MetricsViewMode,
-    RECOMMENDED_AGGREGATION_BY_TYPE,
-} from './metricsViewerLogic'
+import { LIVE_REFRESH_MS, MAX_CLAUSES, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
 
 const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
     { value: 'chart', label: 'Chart' },
@@ -34,15 +36,6 @@ const SUMMARY_OPTIONS: { value: MetricSummary; label: string }[] = [
     { value: 'latest', label: 'Latest' },
     { value: 'average', label: 'Average' },
     { value: 'total', label: 'Total' },
-]
-
-const AGGREGATION_OPTIONS: { value: MetricAggregation; label: string }[] = [
-    { value: 'sum', label: 'Sum' },
-    { value: 'avg', label: 'Average' },
-    { value: 'count', label: 'Count' },
-    { value: 'p95', label: 'p95' },
-    { value: 'rate', label: 'Rate (/s)' },
-    { value: 'increase', label: 'Increase' },
 ]
 
 // Mirrors the curated set used by `LogsViewer/Filters/DateRangeFilter`.
@@ -84,16 +77,21 @@ export const MetricsViewer = (): JSX.Element => {
     const logic = metricsViewerLogic()
     // Keep the picker logic mounted alongside the viewer so the chosen metric's
     // metric_type stays available for the aggregation hint after the dropdown closes.
-    const pickerLogic = useMountedLogic(metricNamePickerLogic())
+    useMountedLogic(metricNamePickerLogic())
     const {
         metricName,
         aggregation,
+        clauses,
+        clauseLabels,
+        formula,
+        formulaEnabled,
+        isSimpleMode,
+        effectiveViewMode,
+        querySelection,
         dateFrom,
         dateTo,
         viewMode,
         statSummary,
-        groupByKeys,
-        filterStrings,
         chartSeries,
         sparklineValues,
         sparklineLabels,
@@ -102,42 +100,35 @@ export const MetricsViewer = (): JSX.Element => {
         liveRefresh,
         queryResultsLoading,
         hasMetricName,
+        filterStrings,
     } = useValues(logic)
     const {
-        setMetricName,
-        setAggregation,
+        addClause,
+        setFormula,
+        setFormulaEnabled,
         setDateFrom,
         setDateTo,
         setViewMode,
         setStatSummary,
-        setGroupByKeys,
-        setFilterStrings,
         setLiveRefresh,
         fetchQueryResults,
         fetchAnomaly,
         clearAnomaly,
     } = useActions(logic)
-    const { items: pickerItems } = useValues(pickerLogic)
 
     // Refetch the chart whenever any filter changes — the loader breakpoint debounces input.
     useEffect(() => {
         fetchQueryResults({})
-    }, [metricName, aggregation, dateFrom, dateTo, groupByKeys, filterStrings]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [querySelection, dateFrom, dateTo]) // eslint-disable-line react-hooks/exhaustive-deps
 
     // Characterize the recent window only while the stat card is visible — the badge is stat-mode only.
     useEffect(() => {
-        if (viewMode === 'stat' && hasMetricName) {
+        if (effectiveViewMode === 'stat' && hasMetricName) {
             fetchAnomaly({})
         } else {
             clearAnomaly()
         }
-    }, [metricName, aggregation, dateFrom, dateTo, viewMode, hasMetricName, filterStrings]) // eslint-disable-line react-hooks/exhaustive-deps
-
-    const selectedMetricType = useMemo(
-        () => pickerItems.find((item) => item.name === metricName)?.metric_type,
-        [pickerItems, metricName]
-    )
-    const recommendedAggregation = selectedMetricType ? RECOMMENDED_AGGREGATION_BY_TYPE[selectedMetricType] : undefined
+    }, [metricName, aggregation, dateFrom, dateTo, effectiveViewMode, hasMetricName, filterStrings]) // eslint-disable-line react-hooks/exhaustive-deps
 
     // Mirrors the format/timeUnit ladder LogsSparkline uses so the X-axis density
     // matches the selected range.
@@ -185,83 +176,92 @@ export const MetricsViewer = (): JSX.Element => {
 
     return (
         <div className="flex flex-col gap-3">
-            <div className="flex flex-wrap items-end gap-2">
-                <div className="flex flex-col gap-1">
-                    <MetricNameFilter value={metricName} onChange={setMetricName} />
-                    {selectedMetricType && recommendedAggregation && aggregation !== recommendedAggregation && (
-                        <span className="text-xs text-secondary">
-                            {selectedMetricType} — {recommendedAggregation} recommended
-                        </span>
-                    )}
-                </div>
-                <LemonSelect
-                    size="small"
-                    value={aggregation}
-                    options={AGGREGATION_OPTIONS}
-                    onChange={(value) => setAggregation(value as MetricAggregation)}
-                />
-                <LemonInputSelect
-                    mode="multiple"
-                    size="small"
-                    allowCustomValues
-                    value={groupByKeys}
-                    onChange={setGroupByKeys}
-                    options={[]}
-                    placeholder="Group by attribute…"
-                    className="min-w-[12rem]"
-                />
-                <LemonInputSelect
-                    mode="multiple"
-                    size="small"
-                    allowCustomValues
-                    value={filterStrings}
-                    onChange={setFilterStrings}
-                    options={[]}
-                    placeholder="Filter attribute=value…"
-                    className="min-w-[14rem]"
-                />
-                <DateFilter
-                    size="small"
-                    dateFrom={dateFrom}
-                    dateTo={dateTo}
-                    dateOptions={DATE_OPTIONS}
-                    onChange={(changedDateFrom, changedDateTo) => {
-                        setDateFrom(changedDateFrom)
-                        setDateTo(changedDateTo)
-                    }}
-                    allowTimePrecision
-                    allowFixedRangeWithTime
-                    allowedRollingDateOptions={['minutes', 'hours', 'days', 'weeks']}
-                    use24HourFormat
-                />
-                <LemonSegmentedButton
-                    size="small"
-                    value={viewMode}
-                    options={VIEW_MODE_OPTIONS}
-                    onChange={(value) => setViewMode(value)}
-                />
-                {viewMode === 'stat' && (
-                    <LemonSelect
+            <div className="flex flex-col gap-2">
+                {clauses.map((_, index) => (
+                    <MetricsClauseRow key={index} index={index} />
+                ))}
+                <div className="flex flex-wrap items-end gap-2">
+                    <LemonButton
                         size="small"
-                        value={statSummary}
-                        options={SUMMARY_OPTIONS}
-                        onChange={(value) => setStatSummary(value)}
+                        type="secondary"
+                        icon={<IconPlusSmall />}
+                        onClick={addClause}
+                        disabledReason={
+                            clauses.length >= MAX_CLAUSES ? `Maximum ${MAX_CLAUSES} metrics per query` : undefined
+                        }
+                    >
+                        Add metric
+                    </LemonButton>
+                    {formulaEnabled ? (
+                        <div className="flex items-end gap-1">
+                            <LemonInput
+                                size="small"
+                                value={formula}
+                                onChange={setFormula}
+                                placeholder={
+                                    clauseLabels.length > 1
+                                        ? `Formula, e.g. (${clauseLabels[0]} - ${clauseLabels[1]}) / ${clauseLabels[0]}`
+                                        : 'Formula, e.g. a * 100'
+                                }
+                                className="min-w-[14rem] font-mono"
+                            />
+                            <LemonButton
+                                size="small"
+                                icon={<IconX />}
+                                onClick={() => setFormulaEnabled(false)}
+                                tooltip="Remove formula"
+                            />
+                        </div>
+                    ) : (
+                        <LemonButton size="small" type="secondary" onClick={() => setFormulaEnabled(true)}>
+                            Enable formula
+                        </LemonButton>
+                    )}
+                    <DateFilter
+                        size="small"
+                        dateFrom={dateFrom}
+                        dateTo={dateTo}
+                        dateOptions={DATE_OPTIONS}
+                        onChange={(changedDateFrom, changedDateTo) => {
+                            setDateFrom(changedDateFrom)
+                            setDateTo(changedDateTo)
+                        }}
+                        allowTimePrecision
+                        allowFixedRangeWithTime
+                        allowedRollingDateOptions={['minutes', 'hours', 'days', 'weeks']}
+                        use24HourFormat
                     />
-                )}
-                <LemonSwitch
-                    label="Live"
-                    checked={liveRefresh}
-                    onChange={setLiveRefresh}
-                    tooltip={`Auto-refresh every ${LIVE_REFRESH_MS / 1000}s`}
-                    bordered
-                />
+                    {isSimpleMode && (
+                        <LemonSegmentedButton
+                            size="small"
+                            value={viewMode}
+                            options={VIEW_MODE_OPTIONS}
+                            onChange={(value) => setViewMode(value)}
+                        />
+                    )}
+                    {effectiveViewMode === 'stat' && (
+                        <LemonSelect
+                            size="small"
+                            value={statSummary}
+                            options={SUMMARY_OPTIONS}
+                            onChange={(value) => setStatSummary(value)}
+                        />
+                    )}
+                    <LemonSwitch
+                        label="Live"
+                        checked={liveRefresh}
+                        onChange={setLiveRefresh}
+                        tooltip={`Auto-refresh every ${LIVE_REFRESH_MS / 1000}s`}
+                        bordered
+                    />
+                </div>
             </div>
             <div className="relative h-[360px] border rounded p-3">
                 {!hasMetricName ? (
                     <div className="h-full flex items-center justify-center text-secondary text-sm">
                         Pick a metric to see its time series.
                     </div>
-                ) : hasResults && viewMode === 'stat' ? (
+                ) : hasResults && effectiveViewMode === 'stat' ? (
                     <MetricStatPanel
                         title={metricName}
                         summary={statSummary}
@@ -287,7 +287,7 @@ export const MetricsViewer = (): JSX.Element => {
                 ) : null}
                 {queryResultsLoading && <SpinnerOverlay />}
             </div>
-            {viewMode === 'chart' && hasResults && <MetricsChartLegend series={chartSeries} />}
+            {effectiveViewMode === 'chart' && hasResults && <MetricsChartLegend series={chartSeries} />}
         </div>
     )
 }

--- a/products/metrics/frontend/components/metricsSeries.ts
+++ b/products/metrics/frontend/components/metricsSeries.ts
@@ -7,10 +7,14 @@ export const seriesColor = (index: number): string => `data-color-${(index % SER
 
 // Human-readable series name from its label map (e.g. "service.name=checkout, env=prod"),
 // falling back to the metric name then a provided default for ungrouped/unlabelled series.
-export const formatSeriesName = (series: _MetricSeriesApi, fallback: string): string => {
+export const formatSeriesName = (series: _MetricSeriesApi, fallback: string, withClausePrefix = false): string => {
     const entries = Object.entries(series.labels ?? {})
-    if (entries.length > 0) {
-        return entries.map(([key, value]) => `${key}=${value}`).join(', ')
+    const base =
+        entries.length > 0
+            ? entries.map(([key, value]) => `${key}=${value}`).join(', ')
+            : (series.metric_name ?? fallback)
+    if (withClausePrefix && series.clause && series.clause !== 'formula') {
+        return `${series.clause}. ${base}`
     }
-    return series.metric_name ?? fallback
+    return base
 }

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -2,8 +2,15 @@ import api from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
 
+import { metricsCharacterizeCreate } from 'products/metrics/frontend/generated/api'
+
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { metricsViewerLogic } from './metricsViewerLogic'
+
+jest.mock('products/metrics/frontend/generated/api', () => ({
+    metricsQueryCreate: jest.fn(async () => ({ results: [] })),
+    metricsCharacterizeCreate: jest.fn(async () => ({ direction: 'flat' })),
+}))
 
 const PICKER_ITEMS = [
     { name: 'requests_total', metric_type: 'sum' },
@@ -16,6 +23,7 @@ describe('metricsViewerLogic', () => {
     let logic: ReturnType<typeof metricsViewerLogic.build>
 
     beforeEach(() => {
+        jest.clearAllMocks()
         initKeaTests()
         jest.spyOn(api.metrics, 'values').mockResolvedValue({ results: PICKER_ITEMS })
         logic = metricsViewerLogic()
@@ -51,5 +59,80 @@ describe('metricsViewerLogic', () => {
         logic.actions.setMetricName('requests_total')
         logic.actions.setMetricName('mystery_metric')
         expect(logic.values.aggregation).toBe('increase')
+    })
+
+    it('applies the type-appropriate aggregation when a later clause picks a metric', () => {
+        logic.actions.setMetricName('requests_total')
+        logic.actions.addClause()
+        logic.actions.updateClause(1, { metricName: 'request_duration' })
+        expect(logic.values.clauses[1].aggregation).toBe('p95')
+    })
+
+    it('builds the single-metric shorthand for one clause without a formula', () => {
+        logic.actions.setMetricName('queue_depth')
+        logic.actions.setGroupByKeys(['service.name'])
+        logic.actions.setFilterStrings(['env=prod'])
+        expect(logic.values.querySelection).toEqual({
+            metricName: 'queue_depth',
+            aggregation: 'avg',
+            groupBy: [{ key: 'service.name' }],
+            filters: [{ key: 'env', op: 'eq', value: 'prod' }],
+        })
+    })
+
+    it.each([
+        ['a second clause', true, ''],
+        ['a formula', false, 'a * 100'],
+    ])('switches to named clauses when %s is added', (_desc, addSecond, formula) => {
+        logic.actions.setMetricName('requests_total')
+        if (addSecond) {
+            logic.actions.addClause()
+            logic.actions.updateClause(1, { metricName: 'queue_depth' })
+        }
+        if (formula) {
+            logic.actions.setFormulaEnabled(true)
+            logic.actions.setFormula(formula)
+        }
+        expect(logic.values.querySelection).toEqual({
+            clauses: [
+                { name: 'a', metricName: 'requests_total', aggregation: 'increase' },
+                ...(addSecond ? [{ name: 'b', metricName: 'queue_depth', aggregation: 'avg' }] : []),
+            ],
+            ...(formula ? { formula } : {}),
+        })
+    })
+
+    it('returns no selection while any clause lacks a metric', () => {
+        logic.actions.setMetricName('queue_depth')
+        logic.actions.addClause()
+        expect(logic.values.querySelection).toBeNull()
+    })
+
+    it('renumbers clause names when a clause is removed', () => {
+        logic.actions.setMetricName('requests_total')
+        logic.actions.addClause()
+        logic.actions.updateClause(1, { metricName: 'queue_depth' })
+        logic.actions.addClause()
+        logic.actions.updateClause(2, { metricName: 'request_duration' })
+        logic.actions.removeClause(0)
+        expect(logic.values.querySelection).toEqual({
+            clauses: [
+                { name: 'a', metricName: 'queue_depth', aggregation: 'avg' },
+                { name: 'b', metricName: 'request_duration', aggregation: 'p95' },
+            ],
+        })
+    })
+
+    it.each([
+        ['one clause', false, true],
+        ['multiple clauses', true, false],
+    ])('anomaly characterization with %s', async (_desc, addSecond, expectCalled) => {
+        logic.actions.setMetricName('requests_total')
+        if (addSecond) {
+            logic.actions.addClause()
+            logic.actions.updateClause(1, { metricName: 'queue_depth' })
+        }
+        await logic.asyncActions.fetchAnomaly({})
+        expect(metricsCharacterizeCreate as jest.Mock).toHaveBeenCalledTimes(expectCalled ? 1 : 0)
     })
 })

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -11,6 +11,7 @@ import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/
 import type {
     _MetricAnomalyReportApi,
     _MetricFilterApi,
+    _MetricQueryBodyApi,
     _MetricSeriesApi,
     MetricAnomalyDirectionEnumApi,
 } from 'products/metrics/frontend/generated/api.schemas'
@@ -25,6 +26,15 @@ export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95' | 'rate' | 'incr
 export type MetricsViewMode = 'chart' | 'stat'
 
 export type MetricsViewerSeries = _MetricSeriesApi
+
+export interface MetricsViewerClause {
+    metricName: string
+    aggregation: MetricAggregation
+    groupByKeys: string[]
+    filterStrings: string[]
+}
+
+export type MetricsQuerySelection = Omit<_MetricQueryBodyApi, 'dateFrom' | 'dateTo'>
 
 // Display shape for the stat card's "vs baseline" anomaly badge (null = no anomaly / flat metric).
 export interface MetricsAnomalyBadge {
@@ -55,6 +65,22 @@ const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling
 const ANOMALY_WINDOW_FRACTION = 0.2
 export const LIVE_REFRESH_MS = 15_000
 const LIVE_REFRESH_KEY = 'metricsLiveRefresh'
+export const MAX_CLAUSES = 10
+
+const DEFAULT_CLAUSE: MetricsViewerClause = {
+    metricName: '',
+    aggregation: DEFAULT_AGGREGATION,
+    groupByKeys: [],
+    filterStrings: [],
+}
+
+export const clauseLabel = (index: number): string => String.fromCharCode(97 + index)
+
+const patchClause = (
+    clauses: MetricsViewerClause[],
+    index: number,
+    patch: Partial<MetricsViewerClause>
+): MetricsViewerClause[] => clauses.map((clause, i) => (i === index ? { ...clause, ...patch } : clause))
 
 // Parse a "key=value" chip into an equality filter. Returns null for malformed input (no key before '=').
 const parseFilter = (raw: string): _MetricFilterApi | null => {
@@ -64,6 +90,9 @@ const parseFilter = (raw: string): _MetricFilterApi | null => {
     }
     return { key: raw.slice(0, eq).trim(), op: 'eq', value: raw.slice(eq + 1).trim() }
 }
+
+const parseFilters = (filterStrings: string[]): _MetricFilterApi[] =>
+    filterStrings.map(parseFilter).filter((f): f is _MetricFilterApi => f !== null)
 
 const resolveDate = (value: string | null | undefined): string | null => {
     if (!value) {
@@ -81,79 +110,97 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
     actions({
         setMetricName: (metricName: string) => ({ metricName }),
         setAggregation: (aggregation: MetricAggregation) => ({ aggregation }),
+        setGroupByKeys: (groupByKeys: string[]) => ({ groupByKeys }),
+        setFilterStrings: (filterStrings: string[]) => ({ filterStrings }),
+        addClause: true,
+        removeClause: (index: number) => ({ index }),
+        updateClause: (index: number, clause: Partial<MetricsViewerClause>) => ({ index, clause }),
+        setFormula: (formula: string) => ({ formula }),
+        setFormulaEnabled: (formulaEnabled: boolean) => ({ formulaEnabled }),
         setDateFrom: (dateFrom: string | null) => ({ dateFrom }),
         setDateTo: (dateTo: string | null) => ({ dateTo }),
         setViewMode: (viewMode: MetricsViewMode) => ({ viewMode }),
         setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
         setLiveRefresh: (liveRefresh: boolean) => ({ liveRefresh }),
-        setGroupByKeys: (groupByKeys: string[]) => ({ groupByKeys }),
-        setFilterStrings: (filterStrings: string[]) => ({ filterStrings }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
         cancelInProgressQuery: (controller: AbortController | null) => ({ controller }),
     }),
     reducers({
-        metricName: ['' as string, { setMetricName: (_, { metricName }) => metricName }],
-        aggregation: [
-            DEFAULT_AGGREGATION as MetricAggregation,
-            { setAggregation: (_, { aggregation }) => aggregation },
+        clauses: [
+            [DEFAULT_CLAUSE] as MetricsViewerClause[],
+            {
+                setMetricName: (state, { metricName }) => patchClause(state, 0, { metricName }),
+                setAggregation: (state, { aggregation }) => patchClause(state, 0, { aggregation }),
+                setGroupByKeys: (state, { groupByKeys }) => patchClause(state, 0, { groupByKeys }),
+                setFilterStrings: (state, { filterStrings }) => patchClause(state, 0, { filterStrings }),
+                updateClause: (state, { index, clause }) => patchClause(state, index, clause),
+                addClause: (state) => (state.length < MAX_CLAUSES ? [...state, { ...DEFAULT_CLAUSE }] : state),
+                removeClause: (state, { index }) => (state.length > 1 ? state.filter((_, i) => i !== index) : state),
+            },
         ],
+        formula: ['', { setFormula: (_, { formula }) => formula }],
+        formulaEnabled: [false, { setFormulaEnabled: (_, { formulaEnabled }) => formulaEnabled }],
         dateFrom: [DEFAULT_DATE_FROM as string | null, { setDateFrom: (_, { dateFrom }) => dateFrom }],
         dateTo: [null as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
         viewMode: ['chart' as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
         // 'latest' (current value) is the natural default for a live single-metric stat.
         statSummary: ['latest' as MetricSummary, { setStatSummary: (_, { statSummary }) => statSummary }],
         liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
-        // Attribute keys to split the metric into one series each (e.g. ['service.name', 'env']).
-        groupByKeys: [[] as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
-        // Raw "key=value" filter chips; parsed into query filters by the `queryFilters` selector.
-        filterStrings: [[] as string[], { setFilterStrings: (_, { filterStrings }) => filterStrings }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
         ],
     }),
-    listeners(({ actions, values, cache }) => ({
-        setMetricName: ({ metricName }) => {
-            // Each metric type has one sensible default; a manual aggregation pick
-            // holds only until the next metric switch.
+    listeners(({ actions, values, cache }) => {
+        // Each metric type has one sensible default; a manual aggregation pick
+        // holds only until the next metric switch on that clause.
+        const applyRecommendedAggregation = (index: number, metricName: string): void => {
             const metricType = values.items.find((item) => item.name === metricName)?.metric_type
             const recommended = metricType ? RECOMMENDED_AGGREGATION_BY_TYPE[metricType] : undefined
-            if (recommended && recommended !== values.aggregation) {
-                actions.setAggregation(recommended)
+            if (recommended && recommended !== values.clauses[index]?.aggregation) {
+                actions.updateClause(index, { aggregation: recommended })
             }
-        },
-        cancelInProgressQuery: ({ controller }) => {
-            if (values.queryAbortController !== null) {
-                values.queryAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
-            }
-            actions.setQueryAbortController(controller)
-        },
-        setLiveRefresh: ({ liveRefresh }) => {
-            if (!liveRefresh) {
-                cache.disposables.dispose(LIVE_REFRESH_KEY)
-                return
-            }
-            // pauseOnPageHidden (default) stops polling on a hidden tab and resumes on focus.
-            cache.disposables.add(() => {
-                const intervalId = setInterval(() => {
-                    actions.fetchQueryResults({})
-                    if (values.viewMode === 'stat') {
-                        actions.fetchAnomaly({})
-                    }
-                }, LIVE_REFRESH_MS)
-                return () => clearInterval(intervalId)
-            }, LIVE_REFRESH_KEY)
-        },
-    })),
+        }
+        return {
+            setMetricName: ({ metricName }) => applyRecommendedAggregation(0, metricName),
+            updateClause: ({ index, clause }) => {
+                if (clause.metricName !== undefined) {
+                    applyRecommendedAggregation(index, clause.metricName)
+                }
+            },
+            cancelInProgressQuery: ({ controller }) => {
+                if (values.queryAbortController !== null) {
+                    values.queryAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                }
+                actions.setQueryAbortController(controller)
+            },
+            setLiveRefresh: ({ liveRefresh }) => {
+                if (!liveRefresh) {
+                    cache.disposables.dispose(LIVE_REFRESH_KEY)
+                    return
+                }
+                // pauseOnPageHidden (default) stops polling on a hidden tab and resumes on focus.
+                cache.disposables.add(() => {
+                    const intervalId = setInterval(() => {
+                        actions.fetchQueryResults({})
+                        if (values.effectiveViewMode === 'stat') {
+                            actions.fetchAnomaly({})
+                        }
+                    }, LIVE_REFRESH_MS)
+                    return () => clearInterval(intervalId)
+                }, LIVE_REFRESH_KEY)
+            },
+        }
+    }),
     loaders(({ values, actions }) => ({
         queryResults: [
             [] as MetricsViewerSeries[],
             {
                 fetchQueryResults: async (_, breakpoint) => {
-                    const trimmedName = values.metricName.trim()
-                    if (!trimmedName) {
+                    const selection = values.querySelection
+                    if (!selection) {
                         return []
                     }
                     const dateFromISO = resolveDate(values.dateFrom)
@@ -168,14 +215,9 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                         String(values.currentTeamId),
                         {
                             query: {
-                                metricName: trimmedName,
-                                aggregation: values.aggregation,
+                                ...selection,
                                 dateFrom: dateFromISO,
                                 ...(dateToISO ? { dateTo: dateToISO } : {}),
-                                ...(values.groupByKeys.length
-                                    ? { groupBy: values.groupByKeys.map((key) => ({ key })) }
-                                    : {}),
-                                ...(values.queryFilters.length ? { filters: values.queryFilters } : {}),
                             },
                         },
                         { signal: controller.signal }
@@ -191,6 +233,9 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
             {
                 clearAnomaly: () => null,
                 fetchAnomaly: async (_, breakpoint) => {
+                    if (!values.isSimpleMode) {
+                        return null
+                    }
                     const trimmedName = values.metricName.trim()
                     const fromISO = resolveDate(values.dateFrom)
                     if (!trimmedName || !fromISO) {
@@ -221,11 +266,60 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         ],
     })),
     selectors({
+        metricName: [(s) => [s.clauses], (clauses) => clauses[0]?.metricName ?? ''],
+        aggregation: [(s) => [s.clauses], (clauses) => clauses[0]?.aggregation ?? DEFAULT_AGGREGATION],
+        groupByKeys: [(s) => [s.clauses], (clauses) => clauses[0]?.groupByKeys ?? []],
+        filterStrings: [(s) => [s.clauses], (clauses) => clauses[0]?.filterStrings ?? []],
         hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
         queryFilters: [
             (s) => [s.filterStrings],
-            (filterStrings: string[]): _MetricFilterApi[] =>
-                filterStrings.map(parseFilter).filter((f): f is _MetricFilterApi => f !== null),
+            (filterStrings: string[]): _MetricFilterApi[] => parseFilters(filterStrings),
+        ],
+        clauseLabels: [(s) => [s.clauses], (clauses): string[] => clauses.map((_, index) => clauseLabel(index))],
+        activeFormula: [
+            (s) => [s.formulaEnabled, s.formula],
+            (formulaEnabled, formula): string | null => (formulaEnabled && formula.trim() ? formula.trim() : null),
+        ],
+        isSimpleMode: [
+            (s) => [s.clauses, s.activeFormula],
+            (clauses, activeFormula): boolean => clauses.length === 1 && !activeFormula,
+        ],
+        effectiveViewMode: [
+            (s) => [s.viewMode, s.isSimpleMode],
+            (viewMode, isSimpleMode): MetricsViewMode => (isSimpleMode ? viewMode : 'chart'),
+        ],
+        querySelection: [
+            (s) => [s.clauses, s.activeFormula],
+            (clauses, activeFormula): MetricsQuerySelection | null => {
+                if (clauses.some((clause) => !clause.metricName.trim())) {
+                    return null
+                }
+                if (clauses.length === 1 && !activeFormula) {
+                    const clause = clauses[0]
+                    const filters = parseFilters(clause.filterStrings)
+                    return {
+                        metricName: clause.metricName.trim(),
+                        aggregation: clause.aggregation,
+                        ...(clause.groupByKeys.length ? { groupBy: clause.groupByKeys.map((key) => ({ key })) } : {}),
+                        ...(filters.length ? { filters } : {}),
+                    }
+                }
+                return {
+                    clauses: clauses.map((clause, index) => {
+                        const filters = parseFilters(clause.filterStrings)
+                        return {
+                            name: clauseLabel(index),
+                            metricName: clause.metricName.trim(),
+                            aggregation: clause.aggregation,
+                            ...(clause.groupByKeys.length
+                                ? { groupBy: clause.groupByKeys.map((key) => ({ key })) }
+                                : {}),
+                            ...(filters.length ? { filters } : {}),
+                        }
+                    }),
+                    ...(activeFormula ? { formula: activeFormula } : {}),
+                }
+            },
         ],
         // The viewer renders the first series only for now; group-by lands
         // multi-series rendering in a later PR.
@@ -234,10 +328,19 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // All series rendered as chart lines (a group-by query returns one series per label combination).
         // The x-axis labels come from `sparklineLabels` (the backend grids every series onto one time axis).
         chartSeries: [
-            (s) => [s.queryResults, s.metricName],
-            (results: MetricsViewerSeries[], metricName: string): SparklineTimeSeries[] =>
+            (s) => [s.queryResults, s.metricName, s.formula, s.isSimpleMode],
+            (
+                results: MetricsViewerSeries[],
+                metricName: string,
+                formula: string,
+                isSimpleMode: boolean
+            ): SparklineTimeSeries[] =>
                 results.map((series, index) => ({
-                    name: formatSeriesName(series, metricName),
+                    name: formatSeriesName(
+                        series,
+                        series.clause === 'formula' ? formula.trim() || 'Formula' : metricName,
+                        !isSimpleMode
+                    ),
                     values: series.points.map((p) => p.value),
                     color: seriesColor(index),
                 })),


### PR DESCRIPTION
## Problem

The metrics query endpoint supports up to 10 named clauses and a server-side formula over them (e.g. `(a - b) / a`), but the viewer only ever sent the single-metric shorthand. There was no way to compare metrics side by side or compute ratios like error rate from the UI.

## Changes

- Viewer state is now a clause array. Each clause has its own metric, aggregation, filters, and group-by, rendered as a labelled row (a, b, ...) with an "Add metric" button (capped at the server's 10-clause limit).
- "Enable formula" reveals a formula input. Formula series render as the formula text in the legend.
- Wire behavior: one clause with no formula keeps sending the existing single-metric shorthand, anything else sends named clauses (the two forms are mutually exclusive server-side).
- Clause names are positional, so removing a clause renumbers cleanly.
- Series names get a clause prefix in multi-clause mode (`a. requests_total`).
- Stat mode and the anomaly badge stay single-clause only, since characterization is per-metric. Combined views always chart.
- The per-metric recommended aggregation auto-pick now applies per clause.

No backend changes.

## How did you test this code?

Ran `hogli test products/metrics/frontend/components/metricsViewerLogic.test.ts` (13 passed). New cases and the regression each catches:

- `querySelection` shorthand vs named clauses: catches sending both or neither wire form, which the backend rejects.
- Clause renumbering after removal: catches formula letters drifting off their metrics.
- Recommended aggregation on a later clause: covers the new per-clause listener path.
- Anomaly guard: catches characterize being called with clause-0-only info for a combined view.

I (Claude) did not test manually in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-kea-logics, /writing-tests. Kept `setMetricName`/`setAggregation`/etc. as clause-0 aliases so the simple single-metric path and existing tests stay intact, and derived clause names positionally instead of storing them (considered stored names, rejected because removal would leave gaps a formula could dangle on). Used `logic.asyncActions` in tests instead of adding a kea-test-utils dependency to the metrics package.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*