### PR TITLE
feat(metrics): raw samples explorer tab with trace links

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3719,6 +3719,9 @@ importers:
       '@posthog/products-error-tracking':
         specifier: workspace:*
         version: link:../error_tracking
+      '@posthog/products-tracing':
+        specifier: workspace:*
+        version: link:../tracing
       '@posthog/quill-charts':
         specifier: workspace:*
         version: link:../../packages/quill/packages/charts

--- a/products/metrics/frontend/MetricsScene.tsx
+++ b/products/metrics/frontend/MetricsScene.tsx
@@ -9,6 +9,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { MetricsSamples } from './components/MetricsSamples'
 import { MetricsSetupPrompt } from './components/MetricsSetupPrompt'
 import { MetricsSqlEditor } from './components/MetricsSqlEditor'
 import { MetricsViewer } from './components/MetricsViewer'
@@ -19,6 +20,7 @@ export const METRICS_LOGIC_KEY = 'metrics'
 
 const TABS: { key: MetricsSceneActiveTab; label: string }[] = [
     { key: 'viewer', label: 'Viewer' },
+    { key: 'samples', label: 'Samples' },
     { key: 'sql', label: 'SQL' },
 ]
 
@@ -67,6 +69,7 @@ const MetricsSceneContent = (): JSX.Element => {
             <MetricsSetupPrompt>
                 <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
                     {activeTab === 'viewer' && <MetricsViewer />}
+                    {activeTab === 'samples' && <MetricsSamples />}
                     {activeTab === 'sql' && <MetricsSqlEditor />}
                 </div>
             </MetricsSetupPrompt>

--- a/products/metrics/frontend/components/MetricSampleAttributes.tsx
+++ b/products/metrics/frontend/components/MetricSampleAttributes.tsx
@@ -1,0 +1,61 @@
+import { LemonTable } from '@posthog/lemon-ui'
+
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+
+export interface MetricSampleAttributesProps {
+    title: string
+    attributes: Record<string, string>
+}
+
+export function MetricSampleAttributes({ title, attributes }: MetricSampleAttributesProps): JSX.Element | null {
+    const rows = Object.entries(attributes).map(([key, value]) => ({ key, value }))
+    if (rows.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="bg-primary overflow-hidden rounded border border-border">
+            <div className="px-3 py-2 bg-bg-light border-b border-border">
+                <span className="text-xs font-semibold text-muted uppercase">{title}</span>
+            </div>
+            <LemonTable
+                embedded
+                showHeader={false}
+                size="small"
+                rowKey="key"
+                columns={[
+                    {
+                        title: 'Key',
+                        key: 'key',
+                        dataIndex: 'key',
+                        width: 0,
+                        render: (_, record) => (
+                            <span className="font-mono text-xs text-muted whitespace-nowrap">{record.key}</span>
+                        ),
+                    },
+                    {
+                        title: 'Value',
+                        key: 'value',
+                        dataIndex: 'value',
+                        render: (_, record) =>
+                            record.value === '' ? (
+                                <span className="font-mono text-xs text-muted italic">(empty)</span>
+                            ) : (
+                                <CopyToClipboardInline
+                                    explicitValue={record.value}
+                                    description="attribute value"
+                                    iconSize="xsmall"
+                                    iconPosition="start"
+                                    selectable
+                                    className="gap-1 font-mono text-xs"
+                                >
+                                    <span>{record.value}</span>
+                                </CopyToClipboardInline>
+                            ),
+                    },
+                ]}
+                dataSource={rows}
+            />
+        </div>
+    )
+}

--- a/products/metrics/frontend/components/MetricsSamples.tsx
+++ b/products/metrics/frontend/components/MetricsSamples.tsx
@@ -1,0 +1,191 @@
+import { useActions, useValues } from 'kea'
+
+import { IconFilter } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonInputSelect, LemonSelect, LemonTable, Link } from '@posthog/lemon-ui'
+import { traceUrl } from '@posthog/products-tracing/frontend/traceLinks'
+
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { TZLabel } from 'lib/components/TZLabel'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+
+import { MetricNameFilter } from './MetricNameFilter'
+import { MetricSampleAttributes } from './MetricSampleAttributes'
+import { METRICS_DATE_OPTIONS } from './metricsDates'
+import { metricsSamplesLogic } from './metricsSamplesLogic'
+
+const LIMIT_OPTIONS = [100, 250, 500, 1000].map((value) => ({ value, label: `${value} samples` }))
+
+const ATTRIBUTE_PREVIEW_COUNT = 3
+
+function attributePreview(attributes: Record<string, string>): string {
+    const entries = Object.entries(attributes)
+    const preview = entries
+        .slice(0, ATTRIBUTE_PREVIEW_COUNT)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(', ')
+    return entries.length > ATTRIBUTE_PREVIEW_COUNT ? `${preview}, …` : preview
+}
+
+export function MetricsSamples(): JSX.Element {
+    const {
+        metricName,
+        dateFrom,
+        dateTo,
+        traceId,
+        limit,
+        serviceFilter,
+        serviceOptions,
+        filteredSamples,
+        samplesLoading,
+    } = useValues(metricsSamplesLogic)
+    const { setMetricName, setDateFrom, setDateTo, setTraceId, setLimit, setServiceFilter } =
+        useActions(metricsSamplesLogic)
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <MetricNameFilter value={metricName} onChange={setMetricName} />
+                <DateFilter
+                    size="small"
+                    dateFrom={dateFrom}
+                    dateTo={dateTo}
+                    dateOptions={METRICS_DATE_OPTIONS}
+                    onChange={(changedDateFrom, changedDateTo) => {
+                        setDateFrom(changedDateFrom)
+                        setDateTo(changedDateTo)
+                    }}
+                    allowTimePrecision
+                    allowFixedRangeWithTime
+                    allowedRollingDateOptions={['minutes', 'hours', 'days', 'weeks']}
+                    use24HourFormat
+                />
+                <LemonInputSelect
+                    mode="multiple"
+                    size="small"
+                    value={serviceFilter}
+                    onChange={setServiceFilter}
+                    options={serviceOptions.map((service) => ({ key: service, label: service }))}
+                    placeholder="Filter by service…"
+                    className="min-w-[12rem]"
+                />
+                <LemonInput
+                    size="small"
+                    value={traceId}
+                    onChange={setTraceId}
+                    placeholder="Filter by trace ID…"
+                    className="min-w-[14rem] font-mono"
+                    allowClear
+                />
+                <LemonSelect size="small" value={limit} options={LIMIT_OPTIONS} onChange={setLimit} />
+            </div>
+            {!metricName.trim() ? (
+                <div className="border rounded p-8 flex items-center justify-center text-secondary text-sm">
+                    Pick a metric to see its raw emissions.
+                </div>
+            ) : (
+                <LemonTable<_MetricEventSampleApi>
+                    dataSource={filteredSamples}
+                    loading={samplesLoading}
+                    rowKey={(sample) => `${sample.timestamp}/${sample.span_id}/${sample.value}`}
+                    columns={[
+                        {
+                            title: 'Timestamp',
+                            key: 'timestamp',
+                            width: 0,
+                            render: (_, sample) => (
+                                <span className="whitespace-nowrap">
+                                    <TZLabel time={sample.timestamp} timestampStyle="absolute" />
+                                </span>
+                            ),
+                        },
+                        {
+                            title: 'Value',
+                            key: 'value',
+                            align: 'right',
+                            width: 0,
+                            render: (_, sample) => (
+                                <span className="font-mono whitespace-nowrap">
+                                    {humanFriendlyNumber(sample.value)}
+                                    {sample.unit ? ` ${sample.unit}` : ''}
+                                </span>
+                            ),
+                        },
+                        {
+                            title: 'Count',
+                            key: 'count',
+                            align: 'right',
+                            width: 0,
+                            render: (_, sample) => (
+                                <span className="font-mono">{humanFriendlyNumber(sample.count)}</span>
+                            ),
+                        },
+                        {
+                            title: 'Service',
+                            key: 'service',
+                            width: 0,
+                            render: (_, sample) => (
+                                <span className="whitespace-nowrap">{sample.service_name || '—'}</span>
+                            ),
+                        },
+                        {
+                            title: 'Attributes',
+                            key: 'attributes',
+                            render: (_, sample) => (
+                                <span className="font-mono text-xs text-muted">
+                                    {attributePreview(sample.attributes)}
+                                </span>
+                            ),
+                        },
+                        {
+                            title: 'Trace',
+                            key: 'trace',
+                            width: 0,
+                            render: (_, sample) =>
+                                sample.trace_id ? (
+                                    <div className="flex items-center gap-1 whitespace-nowrap">
+                                        <Link
+                                            to={traceUrl({
+                                                traceId: sample.trace_id,
+                                                spanId: sample.span_id || undefined,
+                                                ts: sample.timestamp,
+                                            })}
+                                            className="font-mono text-xs"
+                                        >
+                                            {sample.trace_id.slice(0, 8)}…
+                                        </Link>
+                                        <LemonButton
+                                            size="xsmall"
+                                            icon={<IconFilter />}
+                                            tooltip="Only show emissions on this trace"
+                                            onClick={() => setTraceId(sample.trace_id)}
+                                        />
+                                    </div>
+                                ) : (
+                                    <span className="text-muted">—</span>
+                                ),
+                        },
+                    ]}
+                    expandable={{
+                        noIndent: true,
+                        expandedRowRender: (sample) => (
+                            <div className="flex flex-col gap-2 p-2">
+                                <MetricSampleAttributes title="Attributes" attributes={sample.attributes} />
+                                <MetricSampleAttributes
+                                    title="Resource attributes"
+                                    attributes={sample.resource_attributes}
+                                />
+                                {Object.keys(sample.attributes).length === 0 &&
+                                    Object.keys(sample.resource_attributes).length === 0 && (
+                                        <span className="text-secondary text-sm">This emission has no attributes.</span>
+                                    )}
+                            </div>
+                        ),
+                    }}
+                    emptyState="No emissions for this metric in the selected range."
+                />
+            )}
+        </div>
+    )
+}

--- a/products/metrics/frontend/components/metricsDates.ts
+++ b/products/metrics/frontend/components/metricsDates.ts
@@ -1,0 +1,51 @@
+import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
+import { dayjs } from 'lib/dayjs'
+import { dateStringToDayJs } from 'lib/utils/dateFilters'
+import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils/datetime'
+
+import { DateMappingOption } from '~/types'
+
+export const DEFAULT_METRICS_DATE_FROM = '-1h'
+
+// Mirrors the curated set used by `LogsViewer/Filters/DateRangeFilter`.
+export const METRICS_DATE_OPTIONS: DateMappingOption[] = [
+    { key: CUSTOM_OPTION_KEY, values: [] },
+    {
+        key: 'Last 5 minutes',
+        values: ['-5M'],
+        getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(5, 'minute').format(DATE_TIME_FORMAT),
+        defaultInterval: 'minute',
+    },
+    {
+        key: 'Last 30 minutes',
+        values: ['-30M'],
+        getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(30, 'minute').format(DATE_TIME_FORMAT),
+        defaultInterval: 'minute',
+    },
+    {
+        key: 'Last 1 hour',
+        values: ['-1h'],
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(1, 'h'), date.endOf('d')),
+        defaultInterval: 'hour',
+    },
+    {
+        key: 'Last 24 hours',
+        values: ['-24h'],
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(24, 'h'), date.endOf('d')),
+        defaultInterval: 'hour',
+    },
+    {
+        key: 'Last 7 days',
+        values: ['-7d'],
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(7, 'd'), date.endOf('d')),
+        defaultInterval: 'day',
+    },
+]
+
+export const resolveMetricsDate = (value: string | null | undefined): string | null => {
+    if (!value) {
+        return null
+    }
+    const dj = dateStringToDayJs(value) ?? dayjs(value)
+    return dj.isValid() ? dj.toISOString() : null
+}

--- a/products/metrics/frontend/components/metricsSamplesLogic.test.ts
+++ b/products/metrics/frontend/components/metricsSamplesLogic.test.ts
@@ -1,0 +1,92 @@
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { metricsSamplesCreate } from 'products/metrics/frontend/generated/api'
+import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+
+import { metricsSamplesLogic } from './metricsSamplesLogic'
+import { metricsViewerLogic } from './metricsViewerLogic'
+
+jest.mock('products/metrics/frontend/generated/api', () => ({
+    metricsSamplesCreate: jest.fn(async () => ({ results: [] })),
+    metricsQueryCreate: jest.fn(async () => ({ results: [] })),
+    metricsCharacterizeCreate: jest.fn(async () => ({ direction: 'flat' })),
+}))
+
+const mockedSamplesCreate = metricsSamplesCreate as jest.Mock
+
+const sample = (service: string): _MetricEventSampleApi => ({
+    timestamp: '2026-01-01T00:00:00Z',
+    metric_name: 'requests_total',
+    metric_type: 'sum',
+    value: 1,
+    count: 1,
+    unit: '',
+    aggregation_temporality: 'cumulative',
+    is_monotonic: true,
+    service_name: service,
+    trace_id: '',
+    span_id: '',
+    attributes: {},
+    resource_attributes: {},
+})
+
+describe('metricsSamplesLogic', () => {
+    let logic: ReturnType<typeof metricsSamplesLogic.build>
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        initKeaTests()
+        jest.spyOn(api.metrics, 'values').mockResolvedValue({ results: [] })
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('does not query without a metric name', async () => {
+        logic = metricsSamplesLogic()
+        logic.mount()
+        await logic.asyncActions.fetchSamples({})
+        expect(mockedSamplesCreate).not.toHaveBeenCalled()
+    })
+
+    it.each([
+        ['', false],
+        ['abc123', true],
+    ])('trace id %p in the request body: %p', async (traceId, included) => {
+        logic = metricsSamplesLogic()
+        logic.mount()
+        logic.actions.setMetricName('requests_total')
+        logic.actions.setTraceId(traceId)
+        await logic.asyncActions.fetchSamples({})
+        const body = mockedSamplesCreate.mock.calls.at(-1)[1].query
+        expect(body.metricName).toBe('requests_total')
+        expect('traceId' in body).toBe(included)
+        expect(body.traceId).toBe(included ? traceId : undefined)
+    })
+
+    it('filters loaded samples by service client-side', () => {
+        logic = metricsSamplesLogic()
+        logic.mount()
+        logic.actions.fetchSamplesSuccess([sample('web'), sample('worker'), sample('web')])
+        expect(logic.values.serviceOptions).toEqual(['web', 'worker'])
+        logic.actions.setServiceFilter(['worker'])
+        expect(logic.values.filteredSamples.map((s) => s.service_name)).toEqual(['worker'])
+        logic.actions.setServiceFilter([])
+        expect(logic.values.filteredSamples).toHaveLength(3)
+    })
+
+    it('seeds the metric and date range from the viewer on first open', () => {
+        const viewerLogic = metricsViewerLogic()
+        viewerLogic.mount()
+        viewerLogic.actions.setMetricName('queue_depth')
+        viewerLogic.actions.setDateFrom('-24h')
+        logic = metricsSamplesLogic()
+        logic.mount()
+        expect(logic.values.metricName).toBe('queue_depth')
+        expect(logic.values.dateFrom).toBe('-24h')
+        viewerLogic.unmount()
+    })
+})

--- a/products/metrics/frontend/components/metricsSamplesLogic.ts
+++ b/products/metrics/frontend/components/metricsSamplesLogic.ts
@@ -1,0 +1,123 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { metricsSamplesCreate } from 'products/metrics/frontend/generated/api'
+import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+
+import { DEFAULT_METRICS_DATE_FROM, resolveMetricsDate } from './metricsDates'
+import type { metricsSamplesLogicType } from './metricsSamplesLogicType'
+import { metricsViewerLogic } from './metricsViewerLogic'
+
+export const DEFAULT_SAMPLES_LIMIT = 100
+const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metric samples query started, cancelling the previous one'
+
+export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
+    path(['products', 'metrics', 'frontend', 'components', 'metricsSamplesLogic']),
+    connect(() => ({
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            metricsViewerLogic,
+            ['metricName as viewerMetricName', 'dateFrom as viewerDateFrom', 'dateTo as viewerDateTo'],
+        ],
+    })),
+    actions({
+        setMetricName: (metricName: string) => ({ metricName }),
+        setDateFrom: (dateFrom: string | null) => ({ dateFrom }),
+        setDateTo: (dateTo: string | null) => ({ dateTo }),
+        setTraceId: (traceId: string) => ({ traceId }),
+        setLimit: (limit: number) => ({ limit }),
+        setServiceFilter: (serviceFilter: string[]) => ({ serviceFilter }),
+        setSamplesAbortController: (controller: AbortController | null) => ({ controller }),
+        cancelInProgressSamplesQuery: (controller: AbortController | null) => ({ controller }),
+    }),
+    reducers({
+        metricName: ['' as string, { setMetricName: (_, { metricName }) => metricName }],
+        dateFrom: [DEFAULT_METRICS_DATE_FROM as string | null, { setDateFrom: (_, { dateFrom }) => dateFrom }],
+        dateTo: [null as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
+        traceId: ['' as string, { setTraceId: (_, { traceId }) => traceId }],
+        limit: [DEFAULT_SAMPLES_LIMIT as number, { setLimit: (_, { limit }) => limit }],
+        serviceFilter: [[] as string[], { setServiceFilter: (_, { serviceFilter }) => serviceFilter }],
+        samplesAbortController: [
+            null as AbortController | null,
+            { setSamplesAbortController: (_, { controller }) => controller },
+        ],
+    }),
+    loaders(({ values, actions }) => ({
+        samples: [
+            [] as _MetricEventSampleApi[],
+            {
+                fetchSamples: async (_, breakpoint) => {
+                    const trimmedName = values.metricName.trim()
+                    if (!trimmedName) {
+                        return []
+                    }
+                    const dateFromISO = resolveMetricsDate(values.dateFrom)
+                    if (!dateFromISO) {
+                        return []
+                    }
+                    await breakpoint(300)
+                    const dateToISO = resolveMetricsDate(values.dateTo) ?? undefined
+                    const trimmedTraceId = values.traceId.trim()
+                    const controller = new AbortController()
+                    actions.cancelInProgressSamplesQuery(controller)
+                    const response = await metricsSamplesCreate(
+                        String(values.currentTeamId),
+                        {
+                            query: {
+                                metricName: trimmedName,
+                                dateFrom: dateFromISO,
+                                ...(dateToISO ? { dateTo: dateToISO } : {}),
+                                ...(trimmedTraceId ? { traceId: trimmedTraceId } : {}),
+                                limit: values.limit,
+                            },
+                        },
+                        { signal: controller.signal }
+                    )
+                    breakpoint()
+                    actions.setSamplesAbortController(null)
+                    return response.results
+                },
+            },
+        ],
+    })),
+    selectors({
+        hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
+        serviceOptions: [
+            (s) => [s.samples],
+            (samples): string[] =>
+                Array.from(new Set(samples.map((sample) => sample.service_name).filter(Boolean))).sort(),
+        ],
+        filteredSamples: [
+            (s) => [s.samples, s.serviceFilter],
+            (samples, serviceFilter): _MetricEventSampleApi[] =>
+                serviceFilter.length
+                    ? samples.filter((sample) => serviceFilter.includes(sample.service_name))
+                    : samples,
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        setMetricName: () => actions.fetchSamples({}),
+        setDateFrom: () => actions.fetchSamples({}),
+        setDateTo: () => actions.fetchSamples({}),
+        setTraceId: () => actions.fetchSamples({}),
+        setLimit: () => actions.fetchSamples({}),
+        cancelInProgressSamplesQuery: ({ controller }) => {
+            if (values.samplesAbortController !== null) {
+                values.samplesAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+            }
+            actions.setSamplesAbortController(controller)
+        },
+    })),
+    afterMount(({ actions, values }) => {
+        if (!values.metricName && values.viewerMetricName) {
+            actions.setDateFrom(values.viewerDateFrom)
+            actions.setDateTo(values.viewerDateTo)
+            actions.setMetricName(values.viewerMetricName)
+        } else {
+            actions.fetchSamples({})
+        }
+    }),
+])

--- a/products/metrics/frontend/metricsSceneLogic.tsx
+++ b/products/metrics/frontend/metricsSceneLogic.tsx
@@ -12,8 +12,8 @@ import type { metricsSceneLogicType } from './metricsSceneLogicType'
 
 export const METRICS_SQL_EDITOR_TAB_ID = 'metrics-sql-editor'
 
-export type MetricsSceneActiveTab = 'viewer' | 'sql'
-const VALID_ACTIVE_TABS: MetricsSceneActiveTab[] = ['viewer', 'sql']
+export type MetricsSceneActiveTab = 'viewer' | 'samples' | 'sql'
+const VALID_ACTIVE_TABS: MetricsSceneActiveTab[] = ['viewer', 'samples', 'sql']
 export const DEFAULT_ACTIVE_TAB: MetricsSceneActiveTab = 'viewer'
 
 export const metricsSceneLogic = kea<metricsSceneLogicType>([

--- a/products/metrics/package.json
+++ b/products/metrics/package.json
@@ -15,6 +15,7 @@
         "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@posthog/products-error-tracking": "workspace:*",
+        "@posthog/products-tracing": "workspace:*",
         "@types/react": "*",
         "clsx": "*",
         "react": "*",


### PR DESCRIPTION
## Problem

The metrics backend has a fully built samples endpoint that returns raw per-emission rows (value, count, service, per-point attributes, resource attributes, trace and span ids) including a trace-id pivot, but nothing in the UI surfaces it. There was no way to inspect the individual emissions behind a chart or jump from a metric to the trace that produced it.

## Changes

- New Samples tab on the metrics scene, next to Viewer and SQL. Tab state URL-syncs through the existing `activeTab` param.
- The tab has its own metric picker, date range, limit select, trace-id input, and a service filter. On first open it seeds the metric and date range from the viewer so switching tabs keeps context.
- Results render in an expandable LemonTable: timestamp, value with unit, count, service, attribute preview, and a trace link. Expanding a row shows full attribute and resource-attribute tables (visual pattern borrowed from the logs product's LogAttributes, without its logic coupling).
- Trace cells link to the tracing product via its canonical `traceUrl` helper (with the timestamp hint so the cold load stays time-bounded), plus a one-click "only show emissions on this trace" pivot.
- Service filtering is client-side over the loaded page (max 1000 rows) since the endpoint has no service predicate yet.

> [!NOTE]
> Follow-up candidate: push the service filter server-side (small addition to the samples query runner and serializer).

No backend changes. The `@posthog/products-tracing` workspace peer dep is new for the metrics package (first cross-product import of tracing's trace links).

## How did you test this code?

Ran `hogli test products/metrics/frontend/components/metricsSamplesLogic.test.ts` (5 passed). What each case catches:

- No query without a metric name: the endpoint requires `metricName`, so an unguarded fetch on mount would 400.
- Trace id included only when set: sending `traceId: ""` would filter to nothing instead of everything.
- Client-side service filtering: guards `filteredSamples`/`serviceOptions` selector logic.
- Viewer seeding on first open: guards the tab opening blank despite a metric being selected in the viewer.

I (Claude) did not test manually in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-kea-logics, /writing-tests. Chose a dedicated tab over a drawer under the viewer because the endpoint requires a metric name and an independent picker keeps the tab usable on its own. Duplicated the viewer's date options into `metricsDates.ts` instead of refactoring `MetricsViewer.tsx`, to keep this PR conflict-free with the parallel multi-clause viewer PR. The pnpm-lock.yaml entry for the new workspace dep was added by hand (sandbox had no registry access for a normal install) and validated by `hogli ci:preflight`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*