### PR TITLE
chore(ci): move hobby deploy smoke test comment into shared CI report

### DIFF
--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -10,10 +10,14 @@
 # ruff: noqa: T201 allow print statements
 
 import os
+import re
 import sys
+import json
 import time
 import shlex
+import base64
 import datetime
+import subprocess
 from dataclasses import dataclass
 
 import urllib3
@@ -1170,7 +1174,15 @@ runcmd:
         self.export_droplet()
 
 
+# Legacy standalone comment marker. New runs post into the shared CI report comment
+# instead, and delete-legacy-comments.mjs cleans up any leftover standalone comment.
 COMMENT_MARKER = "<!-- hobby-smoke-test -->"
+CI_REPORT_MARKER = "<!-- posthog-ci-report -->"
+CI_REPORT_SECTION_ID = "hobby-deploy"
+CI_REPORT_SECTION_RE = re.compile(
+    rf"<!-- ci-report:section:{CI_REPORT_SECTION_ID}:([A-Za-z0-9+/=]*) -->\n"
+    rf"([\s\S]*?)\n<!-- ci-report:section-end:{CI_REPORT_SECTION_ID} -->"
+)
 
 
 @dataclass(frozen=True)
@@ -1194,49 +1206,80 @@ class PRCommentContext:
         )
 
 
-def update_smoke_test_comment(
-    ctx: PRCommentContext,
-    success: bool,
-    failure_details: dict,
-) -> None:
-    """Update or create a smoke test comment on the PR.
+def _previous_smoke_test_state(ctx: PRCommentContext) -> tuple[bool, int]:
+    """Read the previous smoke test outcome for flap detection.
 
-    - Only one comment per PR (edit existing if present)
-    - Detect flapping if previous failure and now success
+    Checks the shared CI report comment's section first, falling back to the legacy
+    standalone comment while open PRs still carry one.
     """
     headers = {
         "Authorization": f"token {ctx.gh_token}",
         "Accept": "application/vnd.github.v3+json",
     }
     repo = "PostHog/posthog"
-
-    # Find existing comment and parse failure count
-    existing_comment = None
-    previous_was_failure = False
-    previous_failure_count = 0
     try:
         resp = requests.get(
             f"https://api.github.com/repos/{repo}/issues/{ctx.pr_number}/comments",
             headers=headers,
             timeout=10,
         )
-        if resp.status_code == 200:
-            for comment in resp.json():
-                body = comment.get("body", "")
-                if COMMENT_MARKER in body:
-                    existing_comment = comment
-                    previous_was_failure = "❌" in body
-                    # Parse previous failure count
-                    import re
-
-                    match = re.search(r"Consecutive failures: (\d+)", body)
-                    if match:
-                        previous_failure_count = int(match.group(1))
-                    elif previous_was_failure:
-                        previous_failure_count = 1
-                    break
+        if resp.status_code != 200:
+            return False, 0
+        for comment in resp.json():
+            body = comment.get("body", "")
+            if body.startswith(CI_REPORT_MARKER):
+                section = CI_REPORT_SECTION_RE.search(body)
+                if not section:
+                    continue
+                try:
+                    meta = json.loads(base64.b64decode(section.group(1)))
+                except Exception:
+                    meta = {}
+                was_failure = meta.get("status") == "fail"
+                count_match = re.search(r"Consecutive failures: (\d+)", section.group(2))
+                if count_match:
+                    return was_failure, int(count_match.group(1))
+                return was_failure, 1 if was_failure else 0
+            if COMMENT_MARKER in body:
+                was_failure = "❌" in body
+                count_match = re.search(r"Consecutive failures: (\d+)", body)
+                if count_match:
+                    return was_failure, int(count_match.group(1))
+                return was_failure, 1 if was_failure else 0
     except Exception as e:
         print(f"⚠️  Could not fetch existing comments: {e}", flush=True)
+    return False, 0
+
+
+def _post_ci_report_section(status: str, summary: str, body: str) -> None:
+    """Write our section of the shared CI report comment via the Node tooling that owns it."""
+    try:
+        subprocess.run(
+            ["node", ".github/scripts/post-reminder-section.mjs", CI_REPORT_SECTION_ID, status, summary],
+            env={**os.environ, "BODY": body},
+            timeout=120,
+            check=False,
+        )
+        subprocess.run(
+            ["node", "frontend/bin/ci-report/delete-legacy-comments.mjs"],
+            timeout=120,
+            check=False,
+        )
+    except Exception as e:
+        print(f"⚠️  Could not post CI report section: {e}", flush=True)
+
+
+def update_smoke_test_comment(
+    ctx: PRCommentContext,
+    success: bool,
+    failure_details: dict,
+) -> None:
+    """Post the smoke test outcome as a collapsible section in the shared CI report comment.
+
+    Detects flapping if the previous run failed and this one passed.
+    """
+    previous_was_failure, previous_failure_count = _previous_smoke_test_state(ctx)
+    repo = "PostHog/posthog"
 
     # Build run link
     run_link = ""
@@ -1244,27 +1287,27 @@ def update_smoke_test_comment(
         attempt_suffix = f"/attempts/{ctx.run_attempt}" if ctx.run_attempt and ctx.run_attempt != "1" else ""
         run_link = f"https://github.com/{repo}/actions/runs/{ctx.run_id}{attempt_suffix}"
 
-    # Build comment body
+    # Build section content
     failure_count = 0
     if success:
         if previous_was_failure:
             # Flapping: was failing, now passing
-            status_emoji = "⚠️"
-            status_text = "FLAPPING"
+            status = "warn"
+            summary = f"flapping: passed after {previous_failure_count} failure(s)"
             body_content = (
                 f"Test passed after {previous_failure_count} consecutive failure(s). This may indicate flaky behavior.\n\n"
                 "The hobby deployment smoke test is now passing, but was failing on previous runs."
             )
         else:
-            status_emoji = "✅"
-            status_text = "PASSED"
+            status = "ok"
+            summary = "passed"
             body_content = "Hobby deployment smoke test passed successfully."
     else:
-        status_emoji = "❌"
-        status_text = "FAILED"
+        status = "fail"
         failure_count = previous_failure_count + 1
         reason = failure_details.get("reason", "unknown")
         message = failure_details.get("message", "Unknown failure")
+        summary = message
 
         body_content = f"**Failing fast because:** {message}\n\n"
 
@@ -1290,41 +1333,8 @@ def update_smoke_test_comment(
         footer_parts.append(f"Consecutive failures: {failure_count}")
     footer = " | ".join(p for p in footer_parts if p)
 
-    comment_body = f"""{COMMENT_MARKER}
-## {status_emoji} Hobby deploy smoke test: {status_text}
-
-{body_content}
-
----
-<sub>{footer}</sub>
-"""
-
-    # Create or update comment
-    try:
-        if existing_comment:
-            resp = requests.patch(
-                existing_comment["url"],
-                headers=headers,
-                json={"body": comment_body},
-                timeout=10,
-            )
-            if resp.status_code == 200:
-                print(f"✅ Updated smoke test comment on PR #{ctx.pr_number}", flush=True)
-            else:
-                print(f"⚠️  Failed to update comment: {resp.status_code}", flush=True)
-        else:
-            resp = requests.post(
-                f"https://api.github.com/repos/{repo}/issues/{ctx.pr_number}/comments",
-                headers=headers,
-                json={"body": comment_body},
-                timeout=10,
-            )
-            if resp.status_code == 201:
-                print(f"✅ Created smoke test comment on PR #{ctx.pr_number}", flush=True)
-            else:
-                print(f"⚠️  Failed to create comment: {resp.status_code}", flush=True)
-    except Exception as e:
-        print(f"⚠️  Could not update PR comment: {e}", flush=True)
+    section_body = f"{body_content}\n\n---\n<sub>{footer}</sub>"
+    _post_ci_report_section(status=status, summary=summary, body=section_body)
 
 
 def main():

--- a/frontend/bin/ci-report/delete-legacy-comments.mjs
+++ b/frontend/bin/ci-report/delete-legacy-comments.mjs
@@ -16,6 +16,7 @@ const LEGACY_MARKERS = [
     'It looks like the code of ',
     '### 📄 Generated Docs Update Required',
     '### 📦 Surveys SDK Version Check Reminder',
+    '<!-- hobby-smoke-test -->',
 ]
 
 const context = resolvePrContext('cleanup')

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -29,6 +29,7 @@ export const SECTIONS = [
     { id: 'hogql-parser-npm', title: '@posthog/hogql-parser version' },
     { id: 'hogql-parser-rs', title: 'hogql-parser-rs version' },
     { id: 'generated-docs', title: 'Generated docs' },
+    { id: 'hobby-deploy', title: 'Hobby deploy smoke test' },
     { id: 'survey-sdk', title: 'Survey SDK reminder' },
 ]
 


### PR DESCRIPTION
## Problem

The hobby deploy smoke test posts its own standalone PR comment ("## ✅ Hobby deploy smoke test: PASSED"). We now have a shared, sticky CI report comment that every check joins as a collapsible section, so the smoke test should live there instead of adding another top-level comment to the PR.

## Changes

```mermaid
flowchart LR
    A[hobby-ci.py wait-for-health] --> B[requests.post/patch standalone PR comment]
```

```mermaid
flowchart LR
    A[hobby-ci.py wait-for-health] --> B[post-reminder-section.mjs hobby-deploy] --> C[shared CI report comment section]
    A --> D[delete-legacy-comments.mjs cleans up old standalone comment]
```

- Registered a `hobby-deploy` section ("Hobby deploy smoke test") in the shared report's `SECTIONS` registry, so the result renders as a collapsed `<details>` block with a status emoji and one-line summary.
- `update_smoke_test_comment` in `bin/hobby-ci.py` no longer talks to the GitHub comments API directly. It builds a status (ok, warn for flapping, fail), a one-line summary, and the same detailed body (failure reason, unhealthy containers, run link, consecutive-failure counter), then shells out to `post-reminder-section.mjs`, reusing the Node tooling that owns the report's race-safe read-merge-write logic.
- Flap detection is preserved by reading the previous outcome back from the section's encoded meta, with a fallback to the legacy standalone comment during the transition.
- Added the old `<!-- hobby-smoke-test -->` marker to `delete-legacy-comments.mjs`, and `hobby-ci.py` runs that cleanup after posting, so open PRs don't show both the old comment and the new section.

## How did you test this code?

- `ruff check` and `ruff format --check` pass on `bin/hobby-ci.py`, and both edited `.mjs` files load cleanly under Node.
- Exercised the Python-to-Node handoff locally: `_post_ci_report_section` invokes the Node scripts and they skip gracefully when there's no PR context (e.g. `release-*` branch pushes).
- The agent environment had no `node_modules`, so the `update-ci-report` jest suite couldn't run there; the registry change is a pure data addition that the existing tests don't pin. No end-to-end run against a real PR comment yet, which is what draft CI on this PR will exercise (this workflow only triggers when hobby files change, and `bin/hobby-ci.py` is on its paths filter).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, this is internal CI tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude via PostHog Code) made these changes end to end. Considered porting the section read-merge-write logic to Python, but rejected it since `update-ci-report.mjs` deliberately owns the concurrent-writer handling; shelling out to the existing `post-reminder-section.mjs` keeps one implementation. Flapping state previously lived in the standalone comment's text, so it's now recovered from the section's base64 meta plus the "Consecutive failures: N" line, matching the old behavior.
