### PR TITLE
feat(error-tracking): format weekly digest counts as compact numbers

### DIFF
--- a/products/error_tracking/backend/test/test_weekly_digest.py
+++ b/products/error_tracking/backend/test/test_weekly_digest.py
@@ -614,8 +614,13 @@ class TestWeeklyDigestWorkflowDelivery(ClickhouseTestMixin, APIBaseTest):
             assert digest["org_name"] == self.organization.name
             section = digest["project_sections"][0]
             assert section["team_name"] == self.team.name
-            assert section["exception_count"] == 1
+            assert section["exception_count"] == "1"
             assert section["top_issues"][0]["id"] == str(issue.id)
+            assert section["top_issues"][0]["occurrence_count"] == "1"
+            # The email template branches on `ingestion_failure_count > 0`, so it
+            # must stay numeric; the formatted value ships as the display twin.
+            assert section["ingestion_failure_count"] == 0
+            assert section["ingestion_failure_count_display"] == "0"
             assert "team" not in section
 
             # Retry of the org task must not send the same campaign twice (MessagingRecord dedupe)

--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -12,6 +12,7 @@ from posthog.schema import HogQLFilters
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
 from posthog.schema_enums import ProductKey
+from posthog.utils import compact_number
 
 logger = structlog.get_logger(__name__)
 
@@ -443,13 +444,26 @@ def build_team_digest_data(team: Team) -> dict[str, Any] | None:
 
 
 def build_team_section_payload(data: dict[str, Any]) -> dict[str, Any]:
-    """JSON-safe project section for the digest workflow webhook payload."""
+    """JSON-safe project section for the digest workflow webhook payload.
+
+    Big counts are pre-formatted here because the email template (Liquid) has no
+    number formatting filter. ingestion_failure_count must stay numeric — the
+    template branches on `> 0` — so it gets a display twin instead. Copies, not
+    in-place mutation: the same data dict is reused across recipients.
+    """
 
     def serialize_issue(issue: dict[str, Any]) -> dict[str, Any]:
-        return {**issue, "id": str(issue["id"])}
+        return {**issue, "id": str(issue["id"]), "occurrence_count": compact_number(issue["occurrence_count"])}
 
     section = {k: v for k, v in data.items() if k != "team"}
     section["team_name"] = data["team"].name
+    section["exception_count"] = compact_number(data["exception_count"])
+    section["ingestion_failure_count_display"] = compact_number(data["ingestion_failure_count"])
+    if data["crash_free"]:
+        section["crash_free"] = {
+            **data["crash_free"],
+            "total_sessions": compact_number(data["crash_free"]["total_sessions"]),
+        }
     section["top_issues"] = [serialize_issue(i) for i in data["top_issues"]]
     section["new_issues"] = [serialize_issue(i) for i in data["new_issues"]]
     return section


### PR DESCRIPTION
## Problem

Big counts in the error tracking weekly digest email render raw: "Total exceptions: 18393368", "Total sessions: 8752503".
The delivery workflow's email template is Liquid (stock LiquidJS, no custom filters), so there is no number formatting filter available at render time.

## Changes

- `build_team_section_payload` now formats big counts server-side with the existing `posthog.utils.compact_number` (3 significant figures, K/M/B/T - same semantics as the frontend's `compactNumber`): `exception_count`, `crash_free.total_sessions`, and `occurrence_count` on top/new issues become strings like `18.4M` / `278K`.
- `ingestion_failure_count` stays numeric because the email template branches on `> 0`. A new `ingestion_failure_count_display` twin carries the formatted value, and the workflow template renders it with a `| default: section.ingestion_failure_count` fallback so template and backend can deploy in either order.
- Formatting happens only at the webhook payload boundary. Internal digest data keeps raw ints, so per-user sorting by `exception_count` in `posthog/tasks/email.py` is unaffected, and the payload builder copies nested dicts instead of mutating data shared across recipients.

> [!NOTE]
> The "[Error tracking] Weekly digest email" workflow template was already updated to read the display twin, with a backward-compatible fallback. Everything else needs no template change since values arrive pre-formatted.

## How did you test this code?

- `products/error_tracking/backend/test/test_weekly_digest.py::TestWeeklyDigestWorkflowDelivery` passes. Extended the existing payload test to assert the formatted string fields and, critically, that `ingestion_failure_count` stays an int with a string display twin - that numeric/string contract is what the Liquid `> 0` conditional depends on, and no existing test covered it.
- No new test for `compact_number` itself: it already exists and is covered by `posthog/test/test_templatetags.py`.
- End-to-end: ran the `send_error_tracking_weekly_digest` management command against a locally seeded dataset (about 1.16M exceptions, 452K sessions, five issues across mixed magnitudes) delivering through the real workflow webhook - the email rendered `1.16M`, `451K`, `780K`/`11.2K`/`940`, and `45K` failed-to-ingest as expected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while debugging why digest numbers rendered unformatted.
I (well, Claude) first wrote a new compact-number helper, then replaced it with the existing `posthog.utils.compact_number` after I pointed out we already had one - no new formatting code ships.
Considered formatting in the Liquid template instead, rejected because the engine registers no custom filters and per-field `divided_by`/`round` chains would repeat ugly logic across the template.
Skills invoked: /writing-tests (gate for the test changes).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)