### PR TITLE
feat(metrics): support !=, =~, !~ operators in filter chips

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -217,7 +217,7 @@ export const MetricsViewer = (): JSX.Element => {
                     value={filterStrings}
                     onChange={setFilterStrings}
                     options={[]}
-                    placeholder="Filter attribute=value…"
+                    placeholder="Filter e.g. env=prod, path!~/health…"
                     className="min-w-[14rem]"
                 />
                 <DateFilter

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -52,4 +52,22 @@ describe('metricsViewerLogic', () => {
         logic.actions.setMetricName('mystery_metric')
         expect(logic.values.aggregation).toBe('increase')
     })
+
+    // The chip parser must match the two-char operators before the bare '=', and never let the
+    // value slice swallow the operator characters.
+    it.each([
+        ['env=prod', { key: 'env', op: 'eq', value: 'prod' }],
+        ['env!=prod', { key: 'env', op: 'neq', value: 'prod' }],
+        ['svc=~checkout.*', { key: 'svc', op: 'regex', value: 'checkout.*' }],
+        ['path!~/health', { key: 'path', op: 'not_regex', value: '/health' }],
+        ['  env = prod ', { key: 'env', op: 'eq', value: 'prod' }],
+    ])('parses filter chip %s into the right operator', (chip, expected) => {
+        logic.actions.setFilterStrings([chip])
+        expect(logic.values.queryFilters).toEqual([expected])
+    })
+
+    it('drops malformed filter chips with no operator or empty key', () => {
+        logic.actions.setFilterStrings(['noop', '=orphan', 'env=prod'])
+        expect(logic.values.queryFilters).toEqual([{ key: 'env', op: 'eq', value: 'prod' }])
+    })
 })

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -56,13 +56,30 @@ const ANOMALY_WINDOW_FRACTION = 0.2
 export const LIVE_REFRESH_MS = 15_000
 const LIVE_REFRESH_KEY = 'metricsLiveRefresh'
 
-// Parse a "key=value" chip into an equality filter. Returns null for malformed input (no key before '=').
+// Chip operators map to the backend FilterOp values. Two-char operators are matched
+// before the bare '=' so "path!~/health" and "svc=~checkout.*" parse the way PromQL users expect.
+const FILTER_OPERATORS: { token: string; op: _MetricFilterApi['op'] }[] = [
+    { token: '!~', op: 'not_regex' },
+    { token: '=~', op: 'regex' },
+    { token: '!=', op: 'neq' },
+    { token: '=', op: 'eq' },
+]
+
+// Parse a filter chip ("key=value", "key!=value", "key=~pattern", "key!~pattern") into a filter,
+// scanning left to right for the first operator. Returns null for malformed input (no operator, or empty key).
 const parseFilter = (raw: string): _MetricFilterApi | null => {
-    const eq = raw.indexOf('=')
-    if (eq <= 0) {
-        return null
+    for (let i = 0; i < raw.length; i++) {
+        const match = FILTER_OPERATORS.find((o) => raw.startsWith(o.token, i))
+        if (!match) {
+            continue
+        }
+        const key = raw.slice(0, i).trim()
+        if (!key) {
+            return null
+        }
+        return { key, op: match.op, value: raw.slice(i + match.token.length).trim() }
     }
-    return { key: raw.slice(0, eq).trim(), op: 'eq', value: raw.slice(eq + 1).trim() }
+    return null
 }
 
 const resolveDate = (value: string | null | undefined): string | null => {


### PR DESCRIPTION
## Problem

The metrics Viewer's filter chips only parsed `key=value` into an equality filter. The backend already accepts `neq`, `regex`, and `not_regex` (and negative operators even match rows missing the key, Prometheus-style), so the capability existed end to end. Only the chip parser was behind, which meant observability users couldn't exclude or pattern-match from the UI.

## Changes

Rewrote `parseFilter` in `metricsViewerLogic.tsx` to recognize PromQL-style operators, scanning left to right and matching the two-char operators before the bare `=`:

- `key!~value` → `not_regex`
- `key=~value` → `regex`
- `key!=value` → `neq`
- `key=value` → `eq` (unchanged)
- no operator or empty key → dropped (unchanged)

Also updated the filter input placeholder to hint the new operators (`Filter e.g. env=prod, path!~/health…`).

No backend, serializer, or generated-type changes, so no `hogli build:openapi` run was needed.

## How did you test this code?

Automated only. I (Claude) ran:

- The Jest suite for `metricsViewerLogic` (`products/metrics/frontend/components/metricsViewerLogic.test.ts`) - 6 existing + 2 new cases pass. Added a parameterized test asserting each operator form (`eq`/`neq`/`regex`/`not_regex`, plus whitespace trimming) maps to the right `{ key, op, value }` through the public `queryFilters` selector, and a case that malformed chips (no operator, empty key) are dropped. This guards operator precedence and off-by-one slicing of the value - the realistic regression nothing else caught.
- `tsgo --noEmit` (zero errors in `products/metrics`) and oxlint/oxfmt clean.

I did not run the app or manually exercise the UI, so no screenshots.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No in-repo user doc exists for this alpha product (its setup guide links to external posthog.com/docs), so nothing to update here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - directed by @frankh, authored by Claude Code (Claude Opus 4.8).

I mapped the metrics product first and found that the filter operators were the cleanest of several small gaps: the backend `FilterOp` enum and `_MetricFilterSerializer` already accepted all four operators, so this is purely a frontend parser catch-up. I invoked the `/writing-tests` skill before adding the test and kept it at the cheapest rung (a pure selector assertion driven by `setFilterStrings`) rather than a component render.

This is one of three related metrics-viewer PRs; they touch overlapping lines in `metricsViewerLogic.tsx`, so expect trivial rebase conflicts if merged out of order.
