### PR TITLE
fix(metrics): surface query errors instead of a misleading empty state

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -269,6 +269,12 @@ export const MetricsViewer = (): JSX.Element => {
                     <div className="h-full flex items-center justify-center text-secondary text-sm">
                         Pick a metric to see its time series.
                     </div>
+                ) : queryError ? (
+                    <div className="h-full flex items-center justify-center">
+                        <LemonBanner type="error" className="max-w-md">
+                            {queryError}
+                        </LemonBanner>
+                    </div>
                 ) : hasResults && viewMode === 'stat' ? (
                     <MetricStatPanel
                         title={metricName}
@@ -289,17 +295,9 @@ export const MetricsViewer = (): JSX.Element => {
                         renderLabel={renderLabel}
                     />
                 ) : !queryResultsLoading ? (
-                    queryError ? (
-                        <div className="h-full flex items-center justify-center">
-                            <LemonBanner type="error" className="max-w-md">
-                                {queryError}
-                            </LemonBanner>
-                        </div>
-                    ) : (
-                        <div className="h-full flex items-center justify-center text-secondary text-sm">
-                            No data for this metric in the selected range.
-                        </div>
-                    )
+                    <div className="h-full flex items-center justify-center text-secondary text-sm">
+                        No data for this metric in the selected range.
+                    </div>
                 ) : null}
                 {queryResultsLoading && <SpinnerOverlay />}
             </div>

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,7 +1,14 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonInputSelect, LemonSegmentedButton, LemonSelect, LemonSwitch, SpinnerOverlay } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonInputSelect,
+    LemonSegmentedButton,
+    LemonSelect,
+    LemonSwitch,
+    SpinnerOverlay,
+} from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
@@ -101,6 +108,7 @@ export const MetricsViewer = (): JSX.Element => {
         anomalyBadge,
         liveRefresh,
         queryResultsLoading,
+        queryError,
         hasMetricName,
     } = useValues(logic)
     const {
@@ -281,9 +289,17 @@ export const MetricsViewer = (): JSX.Element => {
                         renderLabel={renderLabel}
                     />
                 ) : !queryResultsLoading ? (
-                    <div className="h-full flex items-center justify-center text-secondary text-sm">
-                        No data for this metric in the selected range.
-                    </div>
+                    queryError ? (
+                        <div className="h-full flex items-center justify-center">
+                            <LemonBanner type="error" className="max-w-md">
+                                {queryError}
+                            </LemonBanner>
+                        </div>
+                    ) : (
+                        <div className="h-full flex items-center justify-center text-secondary text-sm">
+                            No data for this metric in the selected range.
+                        </div>
+                    )
                 ) : null}
                 {queryResultsLoading && <SpinnerOverlay />}
             </div>

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import { initKeaTests } from '~/test/init'
 
 import { metricNamePickerLogic } from './metricNamePickerLogic'
-import { metricsViewerLogic } from './metricsViewerLogic'
+import { metricsViewerLogic, NEW_QUERY_STARTED_ERROR_MESSAGE } from './metricsViewerLogic'
 
 const PICKER_ITEMS = [
     { name: 'requests_total', metric_type: 'sum' },
@@ -51,5 +51,23 @@ describe('metricsViewerLogic', () => {
         logic.actions.setMetricName('requests_total')
         logic.actions.setMetricName('mystery_metric')
         expect(logic.values.aggregation).toBe('increase')
+    })
+
+    // A failed query (bad regex, 500) used to render the same "No data" empty state as a genuinely
+    // empty result. The failure records the message so the viewer can show a real error instead.
+    // kea-loaders dispatches `<key>Failure(error.message, error)`, so the reducer reads the message.
+    it('records a real query failure in queryError', () => {
+        logic.actions.fetchQueryResultsFailure('Invalid regex pattern', new Error('Invalid regex pattern'))
+        expect(logic.values.queryError).toBe('Invalid regex pattern')
+    })
+
+    // The debounced viewer aborts the in-flight query on every change; that cancellation rejects with
+    // NEW_QUERY_STARTED_ERROR_MESSAGE (whose text has no "abort"), and must not become an error banner.
+    it('does not record an aborted (superseded) query as an error', () => {
+        logic.actions.fetchQueryResultsFailure(
+            NEW_QUERY_STARTED_ERROR_MESSAGE,
+            new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError')
+        )
+        expect(logic.values.queryError).toBeNull()
     })
 })

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -50,7 +50,15 @@ export const RECOMMENDED_AGGREGATION_BY_TYPE: Record<string, MetricAggregation> 
     exponential_histogram: 'p95',
 }
 const DEFAULT_DATE_FROM = '-1h'
-const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling the previous one'
+export const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling the previous one'
+
+// A superseded or unmounted request rejects with an abort, not a real failure — never surface it as an error.
+// The cancel path aborts with NEW_QUERY_STARTED_ERROR_MESSAGE, whose text doesn't contain "abort", so match it
+// explicitly alongside the generic abort check (mirrors logsViewerDataLogic's isUserInitiatedError).
+const isUserInitiatedError = (error: unknown): boolean => {
+    const errorStr = String(error).toLowerCase()
+    return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
+}
 // The anomaly badge characterizes the most recent slice of the selected window against the rest.
 const ANOMALY_WINDOW_FRACTION = 0.2
 export const LIVE_REFRESH_MS = 15_000
@@ -113,6 +121,18 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
         ],
+        // A real query failure (bad regex, 500, timeout) — surfaced as a banner so it isn't mistaken
+        // for the empty-result state. Cleared when a new query starts or one succeeds; an aborted
+        // (superseded) query leaves the previous state untouched so refetches don't flash an error.
+        queryError: [
+            null as string | null,
+            {
+                fetchQueryResults: () => null,
+                fetchQueryResultsSuccess: () => null,
+                fetchQueryResultsFailure: (state, { error }) =>
+                    isUserInitiatedError(error) ? state : error || 'Something went wrong running this query.',
+            },
+        ],
     }),
     listeners(({ actions, values, cache }) => ({
         setMetricName: ({ metricName }) => {
@@ -126,7 +146,10 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         },
         cancelInProgressQuery: ({ controller }) => {
             if (values.queryAbortController !== null) {
-                values.queryAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+                // An AbortError-named DOMException (not a bare string) is what api.ts and the global
+                // loader onFailure recognize as a cancellation, so a superseded query is swallowed
+                // rather than logged/captured as a real error.
+                values.queryAbortController.abort(new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'))
             }
             actions.setQueryAbortController(controller)
         },


### PR DESCRIPTION
## Problem

When a metrics query failed (bad regex, a 500, a timeout), the results loader kept its empty value and the Viewer rendered the same "No data for this metric in the selected range" state as a genuinely empty result. A real error was indistinguishable from no data. This gets worse now that users can type regexes (see the sibling filter-operators PR), since an invalid pattern comes back as a backend `ParseError` that would silently look like "no data".

While tracing the abort path I also found a latent issue: the Viewer cancelled a superseded query with a bare string reason, which `api.ts` and the global loader `onFailure` do not recognize as a cancellation (they check for an `AbortError`-named error). So every superseded query was being logged and captured as an exception.

## Changes

- Added a `queryError` reducer off the loader's failure action. It records the message on a real failure and clears on a new request or success.
- Aborts are excluded so a superseded query never flashes an error. The cancel path now aborts with an `AbortError`-named `DOMException` instead of a bare string, which is what `api.ts` and the global `onFailure` recognize as a cancellation (this also stops superseded queries being logged/captured). The reducer additionally guards on it via an `isUserInitiatedError` helper, mirroring `logsViewerDataLogic`.
- The chart area now renders a `LemonBanner` error in place of the empty state when `queryError` is set.

Frontend only. No backend or generated-type changes.

## How did you test this code?

Automated only. I (Claude) ran:

- The Jest suite for `metricsViewerLogic` - 5 existing + 2 new cases pass. One asserts a real failure is recorded in `queryError`; the other asserts an aborted (superseded) query is not, which is the subtle regression - without the guard, a banner would flash on every debounced refetch. Both dispatch the loader's public `fetchQueryResultsFailure` action directly (kea-loaders calls `<key>Failure(error.message, error)`), so they exercise the exact reducer path cheaply, with no API mock or timers.
- `tsgo --noEmit` (zero errors in `products/metrics`) and oxlint/oxfmt clean.

I did not run the app, so no screenshots of the banner.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No in-repo user doc for this alpha product, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - directed by @frankh, authored by Claude Code (Claude Opus 4.8).

The key decision was how to detect aborts. The reference `logsViewerDataLogic` aborts with an `AbortError` `DOMException`, but metrics used a bare string, so I traced `handleFetch` in `lib/api.ts` and confirmed the string reason gets wrapped in an `ApiError` rather than recognized as a cancellation. Switching to the `DOMException` both fixes that latent capture-as-error bug and makes detection reliable, so I did that here.

I first wrote the tests using `kea-test-utils` + `expectLogic`, but that package isn't resolvable from the `products/metrics` tree (not declared there) and `tsgo` flagged it. Rather than add a workspace dependency and churn the lockfile, I rewrote the tests to dispatch the failure action directly, which is cheaper and more targeted anyway. Invoked the `/writing-tests` skill before writing them.

One of three related metrics-viewer PRs that touch overlapping lines; expect trivial rebase conflicts if merged out of order. This one reads well after the filter-operators PR since the banner makes the invalid-regex path visible.
