### PR TITLE
feat(metrics): persist viewer state in the URL for shareable links

### DIFF
--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -1,3 +1,5 @@
+import { router } from 'kea-router'
+
 import api from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
@@ -51,5 +53,37 @@ describe('metricsViewerLogic', () => {
         logic.actions.setMetricName('requests_total')
         logic.actions.setMetricName('mystery_metric')
         expect(logic.values.aggregation).toBe('increase')
+    })
+
+    // Non-default viewer state must reach the URL (so a link is shareable) while defaults stay out of it.
+    // Filters are an array param — this guards the kea-router JSON round-trip that the restore relies on.
+    it('writes non-default viewer state to the URL and omits defaults', () => {
+        logic.actions.setMetricName('queue_depth')
+        logic.actions.setAggregation('rate')
+        logic.actions.setFilterStrings(['env=prod'])
+        expect(router.values.searchParams).toMatchObject({
+            metric: 'queue_depth',
+            agg: 'rate',
+            filters: ['env=prod'],
+        })
+        // Defaults are omitted, keeping shared URLs clean.
+        expect(router.values.searchParams.view).toBeUndefined()
+        expect(router.values.searchParams.dateFrom).toBeUndefined()
+    })
+
+    // A reloaded or shared link must restore the reducers. The URL aggregation has to win over the
+    // type-based default that setMetricName applies (requests_total is a counter -> 'increase'), and the
+    // array params (filters, groupBy) must survive the JSON round-trip as string arrays.
+    it('restores viewer state from the URL', () => {
+        router.actions.push('/metrics', {
+            metric: 'requests_total',
+            agg: 'rate',
+            filters: ['env=prod'],
+            groupBy: ['service.name'],
+        })
+        expect(logic.values.metricName).toBe('requests_total')
+        expect(logic.values.aggregation).toBe('rate')
+        expect(logic.values.filterStrings).toEqual(['env=prod'])
+        expect(logic.values.groupByKeys).toEqual(['service.name'])
     })
 })

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -1,10 +1,16 @@
+import equal from 'fast-deep-equal'
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router, urlToAction } from 'kea-router'
+
+import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
 import { type MetricSummary } from 'lib/components/Metric/metricSummary'
 import { type SparklineTimeSeries } from 'lib/components/Sparkline'
 import { dayjs } from 'lib/dayjs'
+import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
+import { Params } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
@@ -56,6 +62,29 @@ const ANOMALY_WINDOW_FRACTION = 0.2
 export const LIVE_REFRESH_MS = 15_000
 const LIVE_REFRESH_KEY = 'metricsLiveRefresh'
 
+// Viewer state persisted in the URL so a reloaded or shared /metrics link restores the same view.
+// These defaults are the single source of truth for both the reducers below and the URL round-trip:
+// updateSearchParams omits a param when it equals its default, keeping default URLs clean.
+const DEFAULT_METRIC_NAME = ''
+const DEFAULT_VIEW_MODE: MetricsViewMode = 'chart'
+const DEFAULT_DATE_TO: string | null = null
+const DEFAULT_GROUP_BY_KEYS: string[] = []
+const DEFAULT_FILTER_STRINGS: string[] = []
+const VALID_AGGREGATIONS: MetricAggregation[] = ['sum', 'avg', 'count', 'p95', 'rate', 'increase']
+
+// kea-router coerces numeric- and boolean-looking values on decode, so normalize scalar params back
+// to the string we stored and ignore anything that isn't a plain scalar (e.g. a hand-crafted array).
+const asParamString = (value: unknown): string | undefined =>
+    typeof value === 'string'
+        ? value
+        : typeof value === 'number' || typeof value === 'boolean'
+          ? String(value)
+          : undefined
+
+// Array params round-trip as real arrays (kea-router JSON-encodes them); accept only string arrays.
+const asParamStringArray = (value: unknown): string[] | undefined =>
+    Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : undefined
+
 // Parse a "key=value" chip into an equality filter. Returns null for malformed input (no key before '=').
 const parseFilter = (raw: string): _MetricFilterApi | null => {
     const eq = raw.indexOf('=')
@@ -94,21 +123,24 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         cancelInProgressQuery: (controller: AbortController | null) => ({ controller }),
     }),
     reducers({
-        metricName: ['' as string, { setMetricName: (_, { metricName }) => metricName }],
+        metricName: [DEFAULT_METRIC_NAME as string, { setMetricName: (_, { metricName }) => metricName }],
         aggregation: [
             DEFAULT_AGGREGATION as MetricAggregation,
             { setAggregation: (_, { aggregation }) => aggregation },
         ],
         dateFrom: [DEFAULT_DATE_FROM as string | null, { setDateFrom: (_, { dateFrom }) => dateFrom }],
-        dateTo: [null as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
-        viewMode: ['chart' as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
+        dateTo: [DEFAULT_DATE_TO as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
+        viewMode: [DEFAULT_VIEW_MODE as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
         // 'latest' (current value) is the natural default for a live single-metric stat.
         statSummary: ['latest' as MetricSummary, { setStatSummary: (_, { statSummary }) => statSummary }],
         liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
         // Attribute keys to split the metric into one series each (e.g. ['service.name', 'env']).
-        groupByKeys: [[] as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
+        groupByKeys: [DEFAULT_GROUP_BY_KEYS as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
         // Raw "key=value" filter chips; parsed into query filters by the `queryFilters` selector.
-        filterStrings: [[] as string[], { setFilterStrings: (_, { filterStrings }) => filterStrings }],
+        filterStrings: [
+            DEFAULT_FILTER_STRINGS as string[],
+            { setFilterStrings: (_, { filterStrings }) => filterStrings },
+        ],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
@@ -267,5 +299,78 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                       }
                     : null,
         ],
+    }),
+    // Round-trip the viewer state through the URL so a reload or shared link restores it. The scene
+    // logic owns `activeTab`; these keys are disjoint and syncSearchParams merges into existing params,
+    // so the two coexist. `cache.isSyncingUrl` breaks the write -> read feedback loop (same guard as
+    // metricsSceneLogic).
+    urlToAction(({ actions, values, cache }) => {
+        const syncFromUrl = (_: any, params: Params): void => {
+            if (cache.isSyncingUrl) {
+                return
+            }
+            const metricName = asParamString(params.metric)
+            if (metricName !== undefined && metricName !== values.metricName) {
+                actions.setMetricName(metricName)
+            }
+            // After metricName so a restored aggregation wins over the type-based default its listener applies.
+            const aggregation = asParamString(params.agg)
+            if (
+                aggregation !== undefined &&
+                VALID_AGGREGATIONS.includes(aggregation as MetricAggregation) &&
+                aggregation !== values.aggregation
+            ) {
+                actions.setAggregation(aggregation as MetricAggregation)
+            }
+            const dateFrom = asParamString(params.dateFrom)
+            if (dateFrom !== undefined && dateFrom !== values.dateFrom) {
+                actions.setDateFrom(dateFrom)
+            }
+            const dateTo = asParamString(params.dateTo)
+            if (dateTo !== undefined && dateTo !== values.dateTo) {
+                actions.setDateTo(dateTo)
+            }
+            const viewMode = asParamString(params.view)
+            if ((viewMode === 'chart' || viewMode === 'stat') && viewMode !== values.viewMode) {
+                actions.setViewMode(viewMode)
+            }
+            const groupByKeys = asParamStringArray(params.groupBy)
+            if (groupByKeys && !equal(groupByKeys, values.groupByKeys)) {
+                actions.setGroupByKeys(groupByKeys)
+            }
+            const filterStrings = asParamStringArray(params.filters)
+            if (filterStrings && !equal(filterStrings, values.filterStrings)) {
+                actions.setFilterStrings(filterStrings)
+            }
+        }
+        return { '*': syncFromUrl }
+    }),
+    trackedActionToUrl(({ values, cache }) => {
+        const syncUrl = (): [string, Params, Record<string, any>, { replace: boolean }] => {
+            cache.isSyncingUrl = true
+            const result = syncSearchParams(router, (params: Params) => {
+                updateSearchParams(params, 'metric', values.metricName, DEFAULT_METRIC_NAME)
+                updateSearchParams(params, 'agg', values.aggregation, DEFAULT_AGGREGATION)
+                updateSearchParams(params, 'dateFrom', values.dateFrom, DEFAULT_DATE_FROM)
+                updateSearchParams(params, 'dateTo', values.dateTo, DEFAULT_DATE_TO)
+                updateSearchParams(params, 'view', values.viewMode, DEFAULT_VIEW_MODE)
+                updateSearchParams(params, 'groupBy', values.groupByKeys, DEFAULT_GROUP_BY_KEYS)
+                updateSearchParams(params, 'filters', values.filterStrings, DEFAULT_FILTER_STRINGS)
+                return params
+            })
+            queueMicrotask(() => {
+                cache.isSyncingUrl = false
+            })
+            return result
+        }
+        return {
+            setMetricName: () => syncUrl(),
+            setAggregation: () => syncUrl(),
+            setDateFrom: () => syncUrl(),
+            setDateTo: () => syncUrl(),
+            setViewMode: () => syncUrl(),
+            setGroupByKeys: () => syncUrl(),
+            setFilterStrings: () => syncUrl(),
+        }
     }),
 ])


### PR DESCRIPTION
## Problem

Only the scene tab lived in the URL. The Viewer's own state - selected metric, aggregation, date range, view mode, group-by, and filters - lived only in `metricsViewerLogic` reducers. Reloading `/metrics` or sharing a link dropped everything back to defaults, so you couldn't hand someone a link to a specific chart.

## Changes

Round-trip the viewer state through the URL, reusing the `syncSearchParams` / `updateSearchParams` / `trackedActionToUrl` pattern already used by `metricsSceneLogic` and error tracking.

- `trackedActionToUrl` maps each `set*` action to a shared writer; `updateSearchParams` omits a param when it equals its default, so a fresh view stays clean.
- `urlToAction('*')` reads each param back and dispatches the matching `set*` only when it differs, guarded by a `cache.isSyncingUrl` flag that breaks the write → read feedback loop (same guard `metricsSceneLogic` uses).
- The scene logic owns `activeTab`; the viewer's keys (`metric`, `agg`, `dateFrom`, `dateTo`, `view`, `groupBy`, `filters`) are disjoint and `syncSearchParams` merges into existing params, so the two coexist.
- Array params (`groupBy`, `filters`) round-trip as JSON via kea-router. Scalar params are validated on read because kea-router coerces numeric- and boolean-looking values on decode.
- Pulled the reducer defaults into named consts so the URL comparison and the reducers share one source of truth.

Frontend only. No backend or generated-type changes.

## How did you test this code?

Automated only. I (Claude) ran:

- The Jest suite for `metricsViewerLogic` - 5 existing + 2 new cases pass. One asserts non-default state (metric, aggregation, a filter) reaches `router.values.searchParams` while defaults stay out of it; the other pushes a URL carrying those params and asserts the reducers restore, including that the URL aggregation wins over the type-based default `setMetricName` applies, and that array params survive the JSON round-trip as string arrays. These guard the collision/feedback-loop and the array serialization, which are the parts most likely to break.
- `tsgo --noEmit` (zero errors in `products/metrics`) and oxlint/oxfmt clean.

I did not run the app, so I have not manually confirmed the browser back/forward behavior or copy-link-into-new-tab flow.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No in-repo user doc for this alpha product, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - directed by @frankh, authored by Claude Code (Claude Opus 4.8).

The main risk was array-param round-tripping, so I checked kea-router's encoder first and confirmed it JSON-encodes arrays/objects and JSON-parses them back on decode, which is why no manual serialization is needed. The read-side validation exists because the same decoder coerces numeric/boolean-looking strings. One snag: moving the `dateTo`/`viewMode` reducer defaults into consts made kea-typegen narrow their types (to `null` and `"chart"`), so I kept the widening `as` casts at the reducer site exactly as the original inline code did. Invoked the `/writing-tests` skill before adding the round-trip tests, and used `router` from kea-router (already a metrics dependency) rather than `kea-test-utils` to keep the test dependency-clean.

One of three related metrics-viewer PRs that touch overlapping lines; this is the deepest change, so it rebases most cleanly last.
