### PR TITLE
feat(stamphog): derive size-gate limits from denial outcomes

### DIFF
--- a/.stamphog/policy.yml
+++ b/.stamphog/policy.yml
@@ -159,8 +159,8 @@ allow:
         - '.yaml'
         - '.yml'
 size_gate:
-    max_lines: 500
-    max_files: 20
+    max_lines: 800
+    max_files: 30
 tiers:
     t1_subclasses:
         T1a-trivial:

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -62,10 +62,14 @@ Deny-list (hard gate)
   │
   ▼
 Size ceiling (hard gate)
-  - >500 substantive lines or >20 substantive files → too large for auto-review
+  - >800 substantive lines or >30 substantive files → too large for auto-review
+    (limits derived from 90 days of denial outcomes: the friction cluster of
+    denied-yet-merged-unchanged PRs sits at 500-750 substantive lines, and past
+    ~800 the merged-unchanged rate collapses, so escalation is genuinely right)
   - Docs (.md/.txt/.rst anywhere; artifact-extension files under docs/),
     snapshots (.snap/.ambr, __snapshots__/), images,
-    `.lock`-extension files (e.g. `yarn.lock`), and generated/ artifacts
+    `.lock`-extension files (e.g. `yarn.lock`), tests (test dirs and
+    .test/.spec/_test files), and generated/ artifacts
     (regenerated-artifact extensions only: .ts/.tsx/.js/.jsx/.json/.md/.snap/.pyi/.txt)
     don't count toward the ceiling — they inflate diffs without adding review
     surface. Note: `pnpm-lock.yaml` and `package-lock.json` are not `.lock`-extension

--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -474,7 +474,7 @@ def parse_conventional_commit(subject: str) -> dict:
 
 
 _TEST_FILE_RE = re.compile(
-    r"(?:^|/)(?:__tests__|tests?)/|[_.](?:test|spec)\.[^/]+$|_test\.py$",
+    r"(?:^|/)(?:__tests__|tests?|[^/]*_tests?)/|(?:^|/)test_[^/]+\.py$|[_.](?:test|spec)\.[^/]+$|_test\.py$",
     re.IGNORECASE,
 )
 
@@ -653,9 +653,9 @@ MAX_LINES = POLICY.size_gate.max_lines
 MAX_FILES = POLICY.size_gate.max_files
 
 # Files that inflate a diff without raising auto-approval risk: prose docs,
-# regenerated artifacts, test snapshots, and tests (which cannot break
-# production; counting them punished exactly the well-tested PRs the review
-# philosophy waves through). The size ceiling counts only the substantive
+# regenerated artifacts, test snapshots, and tests (which cannot change
+# production runtime behavior; counting them punished exactly the well-tested
+# PRs the review philosophy waves through). The size ceiling counts only the substantive
 # remainder, so a 2000-line docs rewrite, a type regen, or a fix arriving with
 # extensive tests isn't auto-denied. Exempt files still count toward
 # tier/subclass classification (which calibrates LLM scrutiny) and still

--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -473,8 +473,13 @@ def parse_conventional_commit(subject: str) -> dict:
 # ── File classification ──────────────────────────────────────────
 
 
+# Directory matching is exact-segment only (__tests__/, test/, tests/, _tests/):
+# suffix matching like `*_tests/` catches runtime packages that merely end in
+# the word (destination_tests/ is API code, ingestion_acceptance_test/ is a
+# Temporal worker). Files inside looser test-tree layouts are still covered by
+# the filename branches (test_*.py, *.test.*, *_test.py).
 _TEST_FILE_RE = re.compile(
-    r"(?:^|/)(?:__tests__|tests?|[^/]*_tests?)/|(?:^|/)test_[^/]+\.py$|[_.](?:test|spec)\.[^/]+$|_test\.py$",
+    r"(?:^|/)(?:__tests__|tests?|_tests?)/|(?:^|/)test_[^/]+\.py$|[_.](?:test|spec)\.[^/]+$|_test\.py$",
     re.IGNORECASE,
 )
 

--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -652,11 +652,14 @@ def is_allow_listed_only(files: list[str]) -> bool:
 MAX_LINES = POLICY.size_gate.max_lines
 MAX_FILES = POLICY.size_gate.max_files
 
-# Files that inflate a diff without adding review surface: prose docs,
-# regenerated artifacts, and test snapshots. The size ceiling counts only the
-# substantive remainder, so a 2000-line docs rewrite or type regen isn't
-# auto-denied. Exempt files still count toward tier/subclass classification
-# (which calibrates LLM scrutiny) and still appear in the diff the LLM reads.
+# Files that inflate a diff without raising auto-approval risk: prose docs,
+# regenerated artifacts, test snapshots, and tests (which cannot break
+# production; counting them punished exactly the well-tested PRs the review
+# philosophy waves through). The size ceiling counts only the substantive
+# remainder, so a 2000-line docs rewrite, a type regen, or a fix arriving with
+# extensive tests isn't auto-denied. Exempt files still count toward
+# tier/subclass classification (which calibrates LLM scrutiny) and still
+# appear in the diff the LLM reads.
 # Deliberately narrower than ALLOW_ONLY_EXTENSIONS: .json/.yaml/.toml configs
 # change runtime behavior, so they stay in the count.
 SIZE_EXEMPT_EXTENSIONS = {
@@ -692,7 +695,11 @@ _SIZE_EXEMPT_PATH_RE = re.compile(
 
 
 def is_size_exempt(path: str) -> bool:
-    return Path(path).suffix.lower() in SIZE_EXEMPT_EXTENSIONS or bool(_SIZE_EXEMPT_PATH_RE.search(path))
+    return (
+        Path(path).suffix.lower() in SIZE_EXEMPT_EXTENSIONS
+        or bool(_SIZE_EXEMPT_PATH_RE.search(path))
+        or bool(_TEST_FILE_RE.search(path))
+    )
 
 
 def substantive_size(files: list[dict]) -> tuple[int, int]:

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -371,10 +371,21 @@ def test_dwh_source_mixed_still_denies() -> None:
         pytest.param("posthog/api/test/test_insight.py", True, id="test-dir-exempt"),
         pytest.param("frontend/src/scenes/insights/Insight.test.tsx", True, id="dot-test-exempt"),
         pytest.param("posthog/personhog_client/test_interceptor.py", True, id="bare-pytest-file-exempt"),
-        pytest.param("common/ingestion/acceptance_tests/test_basic_capture.py", True, id="suffixed-test-dir-exempt"),
+        pytest.param(
+            "common/ingestion/acceptance_tests/test_basic_capture.py", True, id="test-file-in-loose-test-tree-exempt"
+        ),
         pytest.param("nodejs/src/cdp/_tests/helpers.ts", True, id="underscore-tests-dir-exempt"),
         pytest.param("posthog/tasks/protest.py", False, id="test-suffix-substring-counted"),
         pytest.param("posthog/latest/models.py", False, id="latest-dir-counted"),
+        # Runtime packages that merely end in "_test(s)" must not classify as
+        # tests: via the shared predicate that would open the T0 auto-approve
+        # path, not just the size exemption.
+        pytest.param(
+            "products/batch_exports/backend/api/destination_tests/delta.py", False, id="runtime-dir-test-suffix-counted"
+        ),
+        pytest.param(
+            "posthog/temporal/ingestion_acceptance_test/worker.py", False, id="runtime-worker-test-suffix-counted"
+        ),
     ],
 )
 def test_is_size_exempt(path: str, exempt: bool) -> None:

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -347,7 +347,12 @@ def test_dwh_source_mixed_still_denies() -> None:
         pytest.param("docs/example-snippet.ts", True, id="docs-dir-artifact-extension"),
         pytest.param("posthog/api/test/__snapshots__/test_api.ambr", True, id="ambr-snapshot"),
         pytest.param("frontend/__snapshots__/scene.storyshot", True, id="storyshot-extension"),
-        pytest.param("posthog/test/__snapshots__/helper.py", False, id="executable-under-snapshots-counted"),
+        # Outside a test dir, an executable under a snapshots dir still counts
+        # (extension-only snapshot exemption). Inside a test dir it is exempt
+        # like any test file: test-only PRs already gate-trust the same content
+        # via T0, and the LLM still reads it in the diff.
+        pytest.param("frontend/__snapshots__/helper.py", False, id="executable-under-snapshots-counted"),
+        pytest.param("posthog/test/__snapshots__/helper.py", True, id="snapshots-inside-test-dir-exempt"),
         pytest.param("frontend/src/generated/core/api.schemas.ts", True, id="generated-dir"),
         pytest.param("products/tasks/frontend/generated/api.ts", True, id="product-generated-dir"),
         pytest.param("frontend/src/queries/schema/schema-general.ts", True, id="queries-schema"),
@@ -363,6 +368,9 @@ def test_dwh_source_mixed_still_denies() -> None:
         pytest.param("frontend/src/generated/core/evil.py", False, id="generated-dir-executable-py"),
         pytest.param("frontend/src/generated/core/build.sh", False, id="generated-dir-executable-sh"),
         pytest.param("docs/generate_sidebar.py", False, id="docs-dir-executable-py"),
+        pytest.param("posthog/api/test/test_insight.py", True, id="test-dir-exempt"),
+        pytest.param("frontend/src/scenes/insights/Insight.test.tsx", True, id="dot-test-exempt"),
+        pytest.param("posthog/tasks/protest.py", False, id="test-suffix-substring-counted"),
     ],
 )
 def test_is_size_exempt(path: str, exempt: bool) -> None:
@@ -370,8 +378,9 @@ def test_is_size_exempt(path: str, exempt: bool) -> None:
 
 
 def test_substantive_size_counts_only_non_exempt_files() -> None:
-    # A docs-heavy PR must not be size-denied for its prose, and a code-heavy
-    # PR must not slip under the ceiling by padding with docs.
+    # A docs- or test-heavy PR must not be size-denied for its prose or its
+    # tests, and a code-heavy PR must not slip under the ceiling by padding
+    # with either.
     files = [
         {"filename": "docs/big-rewrite.md", "additions": 2000, "deletions": 500},
         {"filename": "frontend/src/generated/core/api.ts", "additions": 900, "deletions": 900},
@@ -381,8 +390,8 @@ def test_substantive_size_counts_only_non_exempt_files() -> None:
 
     lines, file_count = substantive_size(files)
 
-    assert lines == 90
-    assert file_count == 2
+    assert lines == 40
+    assert file_count == 1
 
 
 # ── Dependency manifests without a lockfile ──────────────────────

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -370,7 +370,11 @@ def test_dwh_source_mixed_still_denies() -> None:
         pytest.param("docs/generate_sidebar.py", False, id="docs-dir-executable-py"),
         pytest.param("posthog/api/test/test_insight.py", True, id="test-dir-exempt"),
         pytest.param("frontend/src/scenes/insights/Insight.test.tsx", True, id="dot-test-exempt"),
+        pytest.param("posthog/personhog_client/test_interceptor.py", True, id="bare-pytest-file-exempt"),
+        pytest.param("common/ingestion/acceptance_tests/test_basic_capture.py", True, id="suffixed-test-dir-exempt"),
+        pytest.param("nodejs/src/cdp/_tests/helpers.ts", True, id="underscore-tests-dir-exempt"),
         pytest.param("posthog/tasks/protest.py", False, id="test-suffix-substring-counted"),
+        pytest.param("posthog/latest/models.py", False, id="latest-dir-counted"),
     ],
 )
 def test_is_size_exempt(path: str, exempt: bool) -> None:

--- a/tools/pr-approval-agent/test_policy.py
+++ b/tools/pr-approval-agent/test_policy.py
@@ -150,8 +150,8 @@ OLD_ALLOW_PATH_PATTERNS = [
     "generated/",
     "__snapshots__/",
 ]
-OLD_MAX_LINES = 500
-OLD_MAX_FILES = 20
+OLD_MAX_LINES = 800
+OLD_MAX_FILES = 30
 OLD_DISMISS_TEST_RE = "(?:^|/)(?:__tests__|tests?|fixtures)/|(?:^|/)test_[^/]+\\.py$|_test\\.(py|go)$|\\.test\\.(ts|tsx|js|jsx)$|\\.spec\\.(ts|tsx|js|jsx)$|(?:^|/)conftest\\.py$"
 OLD_DISMISS_GENERATED_RE = "(?:^|/)generated/.*\\.(ts|tsx|js|jsx|json|md|snap|pyi|txt)$|\\.gen\\.(ts|tsx|js|jsx)$|\\.generated\\.(ts|tsx|js|jsx)$|^frontend/src/queries/schema/"
 

--- a/tools/pr-approval-agent/version.py
+++ b/tools/pr-approval-agent/version.py
@@ -9,4 +9,4 @@ changes don't need a bump - they are tracked by the policy sha shown next to
 the version in the verdict table.
 """
 
-STAMPHOG_VERSION = "2.0.0b2"
+STAMPHOG_VERSION = "2.0.0b3"


### PR DESCRIPTION
## Problem

The size gate's ceiling (500 substantive lines / 20 files) was a folklore number, and after #69185 re-keyed the LLM layer to risky-territory-times-assurance it became the last size=risk conflation in the pipeline. It is also expensive: across 90 days of outcomes, 49% of gate-denied PRs were merged **unchanged** after a human looked — half the gate's denials bought review friction, not caught risk. Worse, test lines counted toward the ceiling, so a well-tested fix could be auto-denied *because of its tests*.

## Changes

Three small changes, no new mechanism, single ceiling kept:

- test files (test dirs, `.test`/`.spec`/`_test` files) join the existing size-exemption set (docs, snapshots, generated, lockfiles). They still appear in the diff the LLM reads and still count toward scrutiny tiers; pure-test PRs already gate-trust the same content via the T0 test-only path
- `max_lines` 500 → 800, `max_files` 20 → 30 in `.stamphog/policy.yml`
- version bumps to 2.0.0b3 so the [version dashboard](https://us.posthog.com/project/2/dashboard/1812721) segments the effect

The snapshots-hardening test case moves to a non-test-dir path (its intent — extension-only snapshot exemption — is preserved) and gains an explicit case documenting the test-dir behavior.

## How did you test this code?

Two-stage backtest, method as in #69185 (harness: #69198).

Stage 1 — deterministic counterfactual, real `gates.py` arithmetic rerun over 707 stored diffs joined with real outcomes ("friction" = size-denied, no deny-category, merged unchanged anyway):

| policy | size-denied | friction | newly passing | still caught by deny categories |
|---|---|---|---|---|
| current (500L/20F) | 74 | 20 | — | — |
| test-exempt only | 61 | 15 | 13 | 3 |
| test-exempt + 800L/30F (this PR) | 36 | 4 | 38 | 8 |
| test-exempt + 1200L/40F | 22 | 1 | 52 | 11 |

The friction cluster sits at 500–750 substantive lines and collapses past ~800 (larger denied PRs genuinely get changed by humans), so 800/30 is the knee, and the next step up shows clearly diminishing returns. 13 of 74 denies were "big because tests" (extreme case: 3836 raw lines, 106 substantive).

Stage 2 — LLM validation: the 25 clean newly-admitted PRs replayed under the current reviewer from their frozen production prompts with the denial context neutralized. 19 approve; those approvals merged unchanged at **74% vs the 71% benchmark** of ordinary gate-passing PRs. The 6 holds cite unresolved reviewer concerns, a security-bot flag, and a public-API behavior change — territory and assurance judgments, not size. (The first replay pass, before neutralizing the denial mandate, showed 25/25 compliance with "gates denied → you must refuse", confirming gates stay authoritative over the LLM.)

Unit changes: `test_substantive_size` expectations flip for the test-file row (that is the regression guard for the exemption), three new `is_size_exempt` cases including a `protest.py` false-positive guard, frozen policy constants updated per the migration-guard discipline. Full suite: 401 passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`tools/pr-approval-agent/README.md` size-ceiling section updated with the new numbers and their derivation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- built with Claude Code, continuing the #69185 / #69198 line of work. I set the constraints (no added complexity, no double ceiling); Claude ran the counterfactual sweep, proposed the exemption + numbers from the friction-cluster analysis, and validated the marginal band via prompt replay
- considered and dropped: assurance-conditioned double ceiling (complexity), deletion-weighted line counting (the test exemption captures most of its value), touching T1 sub-tier boundaries (they only calibrate scrutiny effort)
- the sweep and replay tooling is the backtest harness from #69198 plus a local gate-counterfactual script; datasets stay out of the repo
