### PR TITLE
fix(surveys): stop double-scaling survey rates in MCP stats view

### DIFF
--- a/products/surveys/mcp/apps/SurveyStatsView.tsx
+++ b/products/surveys/mcp/apps/SurveyStatsView.tsx
@@ -49,9 +49,7 @@ export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
                                     <div>
                                         <div className="flex justify-between text-sm mb-1">
                                             <span className="text-muted-foreground">Response rate</span>
-                                            <span className="tabular-nums">
-                                                {data.rates.response_rate.toFixed(1)}%
-                                            </span>
+                                            <span className="tabular-nums">{data.rates.response_rate.toFixed(1)}%</span>
                                         </div>
                                         <Progress value={data.rates.response_rate} variant="success" />
                                     </div>
@@ -60,9 +58,7 @@ export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
                                     <div>
                                         <div className="flex justify-between text-sm mb-1">
                                             <span className="text-muted-foreground">Dismissal rate</span>
-                                            <span className="tabular-nums">
-                                                {data.rates.dismissal_rate.toFixed(1)}%
-                                            </span>
+                                            <span className="tabular-nums">{data.rates.dismissal_rate.toFixed(1)}%</span>
                                         </div>
                                         <Progress value={data.rates.dismissal_rate} variant="warning" />
                                     </div>

--- a/products/surveys/mcp/apps/SurveyStatsView.tsx
+++ b/products/surveys/mcp/apps/SurveyStatsView.tsx
@@ -12,6 +12,7 @@ export interface SurveyStatEntry {
 export interface SurveyStatsData {
     survey_id?: string
     stats?: Record<string, { total_count: number; unique_persons: number }>
+    // Rates come from the API already scaled to a percentage (0-100), e.g. 21.7 means 21.7%.
     rates?: { response_rate?: number; dismissal_rate?: number }
     _posthogUrl?: string
 }
@@ -49,10 +50,10 @@ export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
                                         <div className="flex justify-between text-sm mb-1">
                                             <span className="text-muted-foreground">Response rate</span>
                                             <span className="tabular-nums">
-                                                {(data.rates.response_rate * 100).toFixed(1)}%
+                                                {data.rates.response_rate.toFixed(1)}%
                                             </span>
                                         </div>
-                                        <Progress value={data.rates.response_rate * 100} variant="success" />
+                                        <Progress value={data.rates.response_rate} variant="success" />
                                     </div>
                                 )}
                                 {data.rates.dismissal_rate != null && (
@@ -60,10 +61,10 @@ export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
                                         <div className="flex justify-between text-sm mb-1">
                                             <span className="text-muted-foreground">Dismissal rate</span>
                                             <span className="tabular-nums">
-                                                {(data.rates.dismissal_rate * 100).toFixed(1)}%
+                                                {data.rates.dismissal_rate.toFixed(1)}%
                                             </span>
                                         </div>
-                                        <Progress value={data.rates.dismissal_rate * 100} variant="warning" />
+                                        <Progress value={data.rates.dismissal_rate} variant="warning" />
                                     </div>
                                 )}
                             </div>

--- a/products/surveys/mcp/apps/SurveyStatsView.tsx
+++ b/products/surveys/mcp/apps/SurveyStatsView.tsx
@@ -58,7 +58,9 @@ export function SurveyStatsView({ data }: SurveyStatsViewProps): ReactElement {
                                     <div>
                                         <div className="flex justify-between text-sm mb-1">
                                             <span className="text-muted-foreground">Dismissal rate</span>
-                                            <span className="tabular-nums">{data.rates.dismissal_rate.toFixed(1)}%</span>
+                                            <span className="tabular-nums">
+                                                {data.rates.dismissal_rate.toFixed(1)}%
+                                            </span>
                                         </div>
                                         <Progress value={data.rates.dismissal_rate} variant="warning" />
                                     </div>

--- a/products/surveys/mcp/apps/Surveys.stories.tsx
+++ b/products/surveys/mcp/apps/Surveys.stories.tsx
@@ -126,8 +126,8 @@ const sampleStats: SurveyStatsData = {
         'survey dismissed': { total_count: 1830, unique_persons: 1700 },
     },
     rates: {
-        response_rate: 0.255,
-        dismissal_rate: 0.217,
+        response_rate: 25.5,
+        dismissal_rate: 21.7,
     },
     _posthogUrl: 'https://us.posthog.com/project/1/surveys/survey-1',
 }


### PR DESCRIPTION
## Problem

The Surveys MCP stats app displayed wildly inflated dismissal / response rates — a survey dismissed ~46% of the time showed as "over 4000%". Reported from a Slack thread.

## Changes

The surveys stats API returns `response_rate` / `dismissal_rate` already scaled to a percentage (0-100) — e.g. `21.7` means 21.7%. `SurveyStatsView` multiplied them by 100 again for both the label and the `Progress` bar, so real API values rendered as thousands of percent.

- Render the rate values directly instead of `* 100` (they're already percentages).
- Fix the Storybook fixture, which had encoded the rates as 0-1 fractions (`0.255` / `0.217`). That second mistake cancelled the first out in the story, hiding the bug from snapshot review — the fixture now uses real percentage values (`25.5` / `21.7`) matching the API contract.

## How did you test this code?

No manual/browser testing was performed by the agent. Verified by reading the backend rate calculation (`products/surveys/backend/responses/stats.py` computes `sent/shown * 100`, i.e. a 0-100 percentage) and confirming a live `survey-stats` response returns e.g. `dismissal_rate: 60`. Another consumer of the same payload (`products/dashboards/.../widgetOverviewStoryFixtures.ts`) already treats these as percentages, corroborating the contract. No existing snapshot/unit tests cover this component's rate rendering.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced from the MCP `survey-stats` output back to the shared stats endpoint, ruling out the backend (`calculate_rates` correctly returns 0-100) and the MCP server (passes the value through untouched). The double-scaling was isolated to `SurveyStatsView.tsx`. The misleading Storybook fixture is fixed in the same change so the story now reflects the true API contract.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783506581065509?thread_ts=1783506581.065509&cid=C0ACRAMJUAG)*
