### PR TITLE
fix(tasks): stream Slack agent-design relay from the agent-proxy leg

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -130,6 +130,12 @@ TASKS_AGENT_PROXY_INGEST_URL: str | None = os.getenv("TASKS_AGENT_PROXY_INGEST_U
 # is set AND the read-via-proxy flag is enabled for the user; unset means clients read from Django.
 TASKS_AGENT_PROXY_PUBLIC_URL: str | None = os.getenv("TASKS_AGENT_PROXY_PUBLIC_URL") or None
 
+# In-cluster base URL of the agent-proxy for backend consumers (e.g. the Temporal worker relaying a
+# run's live stream to Slack) that read the stream leg without going through the ingress/CDN. Points
+# at the ClusterIP service (e.g. http://agent-proxy.agent-proxy.svc.cluster.local:8003). Unset falls
+# back to TASKS_AGENT_PROXY_PUBLIC_URL, then to reading the Django-side Redis stream directly.
+TASKS_AGENT_PROXY_INTERNAL_URL: str | None = os.getenv("TASKS_AGENT_PROXY_INTERNAL_URL") or None
+
 # Shared service-to-service secret proving a call to the agent-proxy side-effect callback came from the
 # agent-proxy and not directly from a sandbox (which also holds the event-ingest JWT). When set, the
 # callback requires a matching X-Agent-Proxy-Secret header. Provision the same value to Django and the

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -98,10 +98,17 @@ class RelayAgentDesignSignalsInput:
 def _agent_proxy_base_url() -> str | None:
     """Base URL for the agent-proxy stream read leg, or ``None`` to read Redis directly.
 
-    Prefer the in-cluster URL: it skips the ingress/CDN round-trip and exists on environments
-    that have no public proxy FQDN yet. Fall back to the public URL the browser uses.
+    Prefer the in-cluster URL (skips the ingress/CDN round-trip, and exists on envs without a
+    public proxy FQDN), then the public URL the browser uses, then the ingest URL. The ingest URL
+    is the single local opt-in — ``_is_sandbox_event_ingest_enabled`` keys off it and mprocs runs
+    the proxy on :8003 — and the proxy serves ingest and stream on the same host, so it doubles as
+    a read base locally.
     """
-    return settings.TASKS_AGENT_PROXY_INTERNAL_URL or settings.TASKS_AGENT_PROXY_PUBLIC_URL
+    return (
+        settings.TASKS_AGENT_PROXY_INTERNAL_URL
+        or settings.TASKS_AGENT_PROXY_PUBLIC_URL
+        or settings.TASKS_AGENT_PROXY_INGEST_URL
+    )
 
 
 def _stream_via_proxy_enabled(task_run: TaskRunModel) -> bool:

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -164,10 +164,23 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
     base_url = _agent_proxy_base_url()
     if base_url:
         task_run = await TaskRunModel.objects.select_related("task__created_by", "team").aget(id=input.run_id)
-        if _stream_via_proxy_enabled(task_run):
+        # feature_enabled can block on a cold flag cache — off the event loop, this is an async activity.
+        if await asyncio.to_thread(_stream_via_proxy_enabled, task_run):
             await _relay_from_agent_proxy(base_url, task_run, input, emitter, workflow_handle)
             return
     await _relay_from_redis(input, emitter, workflow_handle)
+
+
+async def _heartbeat_periodically(stop: asyncio.Event) -> None:
+    """Emit an activity heartbeat on a fixed interval. A quiet turn keeps the SSE connection alive
+    with keepalive comments (which httpx_sse drops, yielding no events), so relying on event-driven
+    heartbeats alone would let the activity's heartbeat timeout fire mid-run."""
+    while not stop.is_set():
+        activity.heartbeat()
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS)
+        except TimeoutError:
+            pass
 
 
 async def _relay_from_agent_proxy(
@@ -184,66 +197,71 @@ async def _relay_from_agent_proxy(
     """
     events_url = f"{base_url.rstrip('/')}/v1/runs/{input.run_id}/stream"
 
-    last_event_id: str | None = None
-    reconnect_count = 0
-    while True:
-        # Re-mint per connection: the read token is short-lived and a run can outlast it.
-        headers = {
-            "Authorization": f"Bearer {create_stream_read_token(task_run)}",
-            "Accept": "text/event-stream",
-        }
-        if last_event_id:
-            headers["Last-Event-ID"] = last_event_id
+    stop_heartbeat = asyncio.Event()
+    heartbeat_task = asyncio.create_task(_heartbeat_periodically(stop_heartbeat))
+    try:
+        last_event_id: str | None = None
+        reconnect_count = 0
+        while True:
+            # Re-mint per connection: the read token is short-lived and a run can outlast it.
+            headers = {
+                "Authorization": f"Bearer {create_stream_read_token(task_run)}",
+                "Accept": "text/event-stream",
+            }
+            if last_event_id:
+                headers["Last-Event-ID"] = last_event_id
 
-        made_progress = False
-        error: Exception | None = None
-        try:
-            async with httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    connect=SSE_CONNECT_TIMEOUT_SECONDS,
-                    read=SSE_READ_TIMEOUT_SECONDS,
-                    write=30.0,
-                    pool=30.0,
+            made_progress = False
+            error: Exception | None = None
+            try:
+                async with httpx.AsyncClient(
+                    timeout=httpx.Timeout(
+                        connect=SSE_CONNECT_TIMEOUT_SECONDS,
+                        read=SSE_READ_TIMEOUT_SECONDS,
+                        write=30.0,
+                        pool=30.0,
+                    )
+                ) as client:
+                    async with httpx_sse.aconnect_sse(client, "GET", events_url, headers=headers) as event_source:
+                        event_source.response.raise_for_status()
+                        async for sse_event in event_source.aiter_sse():
+                            made_progress = True
+                            if sse_event.id:
+                                last_event_id = sse_event.id
+                            if sse_event.event == STREAM_END_EVENT_NAME:
+                                logger.info(
+                                    "relay_agent_design_signals_stream_ended", run_id=input.run_id, reason="stream-end"
+                                )
+                                return
+                            if not sse_event.data:
+                                continue
+                            try:
+                                event_data = json.loads(sse_event.data)
+                            except json.JSONDecodeError:
+                                continue
+                            for signal_name, arg in emitter.process(event_data):
+                                await _signal_safely(workflow_handle, signal_name, arg)
+            except (httpx.TransportError, httpx.HTTPStatusError, httpx_sse.SSEError) as e:
+                error = e
+
+            # A clean close without a stream-end frame is a proxy stream rotation — resume immediately.
+            # Only consecutive no-progress attempts back off and eventually give up, so a healthy
+            # long-lived stream reconnects without delay while a genuinely broken one stops.
+            if made_progress:
+                reconnect_count = 0
+                continue
+            reconnect_count += 1
+            if reconnect_count > MAX_RECONNECT_ATTEMPTS:
+                logger.warning(
+                    "relay_agent_design_signals_proxy_gave_up",
+                    run_id=input.run_id,
+                    error=str(error) if error else "clean close with no events",
                 )
-            ) as client:
-                async with httpx_sse.aconnect_sse(client, "GET", events_url, headers=headers) as event_source:
-                    event_source.response.raise_for_status()
-                    async for sse_event in event_source.aiter_sse():
-                        activity.heartbeat()
-                        made_progress = True
-                        if sse_event.id:
-                            last_event_id = sse_event.id
-                        if sse_event.event == STREAM_END_EVENT_NAME:
-                            logger.info(
-                                "relay_agent_design_signals_stream_ended", run_id=input.run_id, reason="stream-end"
-                            )
-                            return
-                        if not sse_event.data:
-                            continue
-                        try:
-                            event_data = json.loads(sse_event.data)
-                        except json.JSONDecodeError:
-                            continue
-                        for signal_name, arg in emitter.process(event_data):
-                            await _signal_safely(workflow_handle, signal_name, arg)
-        except (httpx.TransportError, httpx.HTTPStatusError, httpx_sse.SSEError) as e:
-            error = e
-
-        # A clean close without a stream-end frame is a proxy stream rotation — resume immediately.
-        # Only consecutive no-progress attempts back off and eventually give up, so a healthy
-        # long-lived stream reconnects without delay while a genuinely broken one stops.
-        if made_progress:
-            reconnect_count = 0
-            continue
-        reconnect_count += 1
-        if reconnect_count > MAX_RECONNECT_ATTEMPTS:
-            logger.warning(
-                "relay_agent_design_signals_proxy_gave_up",
-                run_id=input.run_id,
-                error=str(error) if error else "clean close with no events",
-            )
-            return
-        await asyncio.sleep(min(2**reconnect_count, 30))
+                return
+            await asyncio.sleep(min(2**reconnect_count, 30))
+    finally:
+        stop_heartbeat.set()
+        await heartbeat_task
 
 
 async def _relay_from_redis(

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -10,10 +10,12 @@ from django.conf import settings
 import httpx
 import httpx_sse
 import structlog
+import posthoganalytics
 from temporalio import activity
 
 from posthog.temporal.common.utils import close_db_connections
 
+from products.tasks.backend.constants import STREAM_VIA_PROXY_FEATURE_FLAG
 from products.tasks.backend.logic.services.connection_token import create_stream_read_token
 from products.tasks.backend.logic.stream.redis_stream import (
     TaskRunRedisStream,
@@ -102,6 +104,34 @@ def _agent_proxy_base_url() -> str | None:
     return settings.TASKS_AGENT_PROXY_INTERNAL_URL or settings.TASKS_AGENT_PROXY_PUBLIC_URL
 
 
+def _stream_via_proxy_enabled(task_run: TaskRunModel) -> bool:
+    """Whether the read-via-proxy flag is on for this run.
+
+    Mirrors the UI's ``resolve_stream_base_url`` and event_ingest's push gate so the relay reads
+    the proxy leg only when the browser would too — keeping ``tasks-stream-via-proxy`` a runtime
+    kill-switch for both. Local dev disables the analytics SDK, so DEBUG is the opt-in. Fails closed.
+    """
+    if settings.DEBUG:
+        return True
+    user = task_run.task.created_by
+    if user is None:
+        return False
+    organization_id = str(task_run.team.organization_id)
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                STREAM_VIA_PROXY_FEATURE_FLAG,
+                user.distinct_id or f"user_{user.id}",
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        return False
+
+
 @activity.defn
 @close_db_connections
 async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> None:
@@ -124,15 +154,20 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
 
     emitter = SlackAgentDesignSignalEmitter(input.slack_thread_context)
 
+    # Read the live proxy leg only when a proxy is configured AND the read-via-proxy flag is on for
+    # the run — the same decision the task UI makes — so the flag stays a runtime kill-switch for
+    # both. Otherwise tail the Django-side Redis stream.
+    task_run = await TaskRunModel.objects.select_related("task__created_by", "team").aget(id=input.run_id)
     base_url = _agent_proxy_base_url()
-    if base_url:
-        await _relay_from_agent_proxy(base_url, input, emitter, workflow_handle)
+    if base_url and await asyncio.to_thread(_stream_via_proxy_enabled, task_run):
+        await _relay_from_agent_proxy(base_url, task_run, input, emitter, workflow_handle)
     else:
         await _relay_from_redis(input, emitter, workflow_handle)
 
 
 async def _relay_from_agent_proxy(
     base_url: str,
+    task_run: TaskRunModel,
     input: RelayAgentDesignSignalsInput,
     emitter: SlackAgentDesignSignalEmitter,
     workflow_handle: Any,
@@ -142,7 +177,6 @@ async def _relay_from_agent_proxy(
     Reconnects with ``Last-Event-ID`` on transient drops and proxy stream rotations, and stops on
     the terminal ``stream-end`` frame. Failures are non-fatal — the relay is best-effort.
     """
-    task_run = await TaskRunModel.objects.aget(id=input.run_id)
     events_url = f"{base_url.rstrip('/')}/v1/runs/{input.run_id}/stream"
 
     last_event_id: str | None = None

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -26,9 +26,12 @@ from products.tasks.backend.models import TaskRun as TaskRunModel
 
 from ee.hogai.sandbox import is_turn_complete
 
-# Reuse the ACP event helpers and signal dispatcher from relay_sandbox_events so the SSE relay
-# and this relay derive and emit signals from identical logic. Only the event source differs.
+# Reuse the ACP event helpers, signal dispatcher, and SSE reconnect tuning from relay_sandbox_events
+# so the two relays derive/emit signals and drive their SSE transport from identical logic.
 from .relay_sandbox_events import (
+    MAX_RECONNECT_ATTEMPTS,
+    SSE_CONNECT_TIMEOUT_SECONDS,
+    SSE_READ_TIMEOUT_SECONDS,
     _extract_agent_message_text,
     _extract_tool_call_step,
     _is_session_update,
@@ -38,12 +41,6 @@ from .relay_sandbox_events import (
 logger = structlog.get_logger(__name__)
 
 HEARTBEAT_INTERVAL_SECONDS = 30
-
-# agent-proxy SSE leg tuning. Its ingress route disables Envoy's request-body buffer, so events
-# arrive per-turn — unlike the Django/Redis leg, which fills in a burst at turn-end.
-SSE_CONNECT_TIMEOUT_SECONDS = 30
-SSE_READ_TIMEOUT_SECONDS = 300
-MAX_RECONNECT_ATTEMPTS = 5
 # Terminal SSE frame name emitted when the run's stream is complete (matches the stream endpoints).
 STREAM_END_EVENT_NAME = "stream-end"
 
@@ -162,14 +159,15 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
     emitter = SlackAgentDesignSignalEmitter(input.slack_thread_context)
 
     # Read the live proxy leg only when a proxy is configured AND the read-via-proxy flag is on for
-    # the run — the same decision the task UI makes — so the flag stays a runtime kill-switch for
-    # both. Otherwise tail the Django-side Redis stream.
-    task_run = await TaskRunModel.objects.select_related("task__created_by", "team").aget(id=input.run_id)
+    # the run — the same decision the task UI makes — so the flag stays a runtime kill-switch. Load
+    # the run only on that path; the Redis fallback doesn't need it. Otherwise tail the Redis stream.
     base_url = _agent_proxy_base_url()
-    if base_url and await asyncio.to_thread(_stream_via_proxy_enabled, task_run):
-        await _relay_from_agent_proxy(base_url, task_run, input, emitter, workflow_handle)
-    else:
-        await _relay_from_redis(input, emitter, workflow_handle)
+    if base_url:
+        task_run = await TaskRunModel.objects.select_related("task__created_by", "team").aget(id=input.run_id)
+        if _stream_via_proxy_enabled(task_run):
+            await _relay_from_agent_proxy(base_url, task_run, input, emitter, workflow_handle)
+            return
+    await _relay_from_redis(input, emitter, workflow_handle)
 
 
 async def _relay_from_agent_proxy(
@@ -231,20 +229,20 @@ async def _relay_from_agent_proxy(
         except (httpx.TransportError, httpx.HTTPStatusError, httpx_sse.SSEError) as e:
             error = e
 
-        # A clean close without a stream-end frame is a proxy stream rotation — reconnect and
-        # resume. Only consecutive no-progress attempts count toward giving up, so a healthy
-        # long-lived stream reconnects indefinitely while a genuinely broken one stops.
+        # A clean close without a stream-end frame is a proxy stream rotation — resume immediately.
+        # Only consecutive no-progress attempts back off and eventually give up, so a healthy
+        # long-lived stream reconnects without delay while a genuinely broken one stops.
         if made_progress:
             reconnect_count = 0
-        else:
-            reconnect_count += 1
-            if reconnect_count > MAX_RECONNECT_ATTEMPTS:
-                logger.warning(
-                    "relay_agent_design_signals_proxy_gave_up",
-                    run_id=input.run_id,
-                    error=str(error) if error else "clean close with no events",
-                )
-                return
+            continue
+        reconnect_count += 1
+        if reconnect_count > MAX_RECONNECT_ATTEMPTS:
+            logger.warning(
+                "relay_agent_design_signals_proxy_gave_up",
+                run_id=input.run_id,
+                error=str(error) if error else "clean close with no events",
+            )
+            return
         await asyncio.sleep(min(2**reconnect_count, 30))
 
 

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import json
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
+from django.conf import settings
+
+import httpx
+import httpx_sse
 import structlog
 from temporalio import activity
 
 from posthog.temporal.common.utils import close_db_connections
 
+from products.tasks.backend.logic.services.connection_token import create_stream_read_token
 from products.tasks.backend.logic.stream.redis_stream import (
     TaskRunRedisStream,
     TaskRunStreamError,
@@ -18,8 +25,7 @@ from products.tasks.backend.models import TaskRun as TaskRunModel
 from ee.hogai.sandbox import is_turn_complete
 
 # Reuse the ACP event helpers and signal dispatcher from relay_sandbox_events so the SSE relay
-# and this stream-tailing relay derive and emit signals from identical logic. Only the event
-# source differs.
+# and this relay derive and emit signals from identical logic. Only the event source differs.
 from .relay_sandbox_events import (
     _extract_agent_message_text,
     _extract_tool_call_step,
@@ -30,6 +36,14 @@ from .relay_sandbox_events import (
 logger = structlog.get_logger(__name__)
 
 HEARTBEAT_INTERVAL_SECONDS = 30
+
+# agent-proxy SSE leg tuning. Its ingress route disables Envoy's request-body buffer, so events
+# arrive per-turn — unlike the Django/Redis leg, which fills in a burst at turn-end.
+SSE_CONNECT_TIMEOUT_SECONDS = 30
+SSE_READ_TIMEOUT_SECONDS = 300
+MAX_RECONNECT_ATTEMPTS = 5
+# Terminal SSE frame name emitted when the run's stream is complete (matches the stream endpoints).
+STREAM_END_EVENT_NAME = "stream-end"
 
 
 class SlackAgentDesignSignalEmitter:
@@ -79,16 +93,24 @@ class RelayAgentDesignSignalsInput:
     slack_thread_context: dict[str, Any] | None = None
 
 
+def _agent_proxy_base_url() -> str | None:
+    """Base URL for the agent-proxy stream read leg, or ``None`` to read Redis directly.
+
+    Prefer the in-cluster URL: it skips the ingress/CDN round-trip and exists on environments
+    that have no public proxy FQDN yet. Fall back to the public URL the browser uses.
+    """
+    return settings.TASKS_AGENT_PROXY_INTERNAL_URL or settings.TASKS_AGENT_PROXY_PUBLIC_URL
+
+
 @activity.defn
 @close_db_connections
 async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> None:
-    """Tail the run's Redis event stream and emit the Slack agent-design per-turn signals.
+    """Relay a run's event stream into the Slack agent-design per-turn signals.
 
-    This is the sequenced-ingest counterpart to the agent-design fan-out in
-    ``relay_sandbox_events``: when ``sandbox_event_ingest_enabled`` is on, the sandbox POSTs
-    its events to the Django ingest endpoint (which writes them to this Redis stream) instead
-    of holding an SSE connection open for the relay. Here we read that stream and drive the
-    same signals, so the Slack thread streams turns on DEV/PROD just as it does locally.
+    Prefers the agent-proxy SSE leg (the live stream the task UI reads) so the Slack thread
+    streams turns as they happen. When no proxy is configured — local dev, or an environment
+    without a proxy FQDN — it falls back to tailing the Django-side Redis stream, which still
+    works but arrives batched at turn-end behind the buffering ingress.
     """
     try:
         from posthog.temporal.common.client import async_connect
@@ -101,10 +123,97 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
         return
 
     emitter = SlackAgentDesignSignalEmitter(input.slack_thread_context)
-    # Match the ingest endpoint's stream construction (default, non-dedicated client) so we
-    # read from exactly the key the sandbox events are written to.
-    redis_stream = TaskRunRedisStream(get_task_run_stream_key(input.run_id))
 
+    base_url = _agent_proxy_base_url()
+    if base_url:
+        await _relay_from_agent_proxy(base_url, input, emitter, workflow_handle)
+    else:
+        await _relay_from_redis(input, emitter, workflow_handle)
+
+
+async def _relay_from_agent_proxy(
+    base_url: str,
+    input: RelayAgentDesignSignalsInput,
+    emitter: SlackAgentDesignSignalEmitter,
+    workflow_handle: Any,
+) -> None:
+    """Consume the run's live agent-proxy SSE stream and drive the Slack signals.
+
+    Reconnects with ``Last-Event-ID`` on transient drops and proxy stream rotations, and stops on
+    the terminal ``stream-end`` frame. Failures are non-fatal — the relay is best-effort.
+    """
+    task_run = await TaskRunModel.objects.aget(id=input.run_id)
+    events_url = f"{base_url.rstrip('/')}/v1/runs/{input.run_id}/stream"
+
+    last_event_id: str | None = None
+    reconnect_count = 0
+    while True:
+        # Re-mint per connection: the read token is short-lived and a run can outlast it.
+        headers = {
+            "Authorization": f"Bearer {create_stream_read_token(task_run)}",
+            "Accept": "text/event-stream",
+        }
+        if last_event_id:
+            headers["Last-Event-ID"] = last_event_id
+
+        made_progress = False
+        error: Exception | None = None
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    connect=SSE_CONNECT_TIMEOUT_SECONDS,
+                    read=SSE_READ_TIMEOUT_SECONDS,
+                    write=30.0,
+                    pool=30.0,
+                )
+            ) as client:
+                async with httpx_sse.aconnect_sse(client, "GET", events_url, headers=headers) as event_source:
+                    event_source.response.raise_for_status()
+                    async for sse_event in event_source.aiter_sse():
+                        activity.heartbeat()
+                        made_progress = True
+                        if sse_event.id:
+                            last_event_id = sse_event.id
+                        if sse_event.event == STREAM_END_EVENT_NAME:
+                            logger.info(
+                                "relay_agent_design_signals_stream_ended", run_id=input.run_id, reason="stream-end"
+                            )
+                            return
+                        if not sse_event.data:
+                            continue
+                        try:
+                            event_data = json.loads(sse_event.data)
+                        except json.JSONDecodeError:
+                            continue
+                        for signal_name, arg in emitter.process(event_data):
+                            await _signal_safely(workflow_handle, signal_name, arg)
+        except (httpx.TransportError, httpx.HTTPStatusError, httpx_sse.SSEError) as e:
+            error = e
+
+        # A clean close without a stream-end frame is a proxy stream rotation — reconnect and
+        # resume. Only consecutive no-progress attempts count toward giving up, so a healthy
+        # long-lived stream reconnects indefinitely while a genuinely broken one stops.
+        if made_progress:
+            reconnect_count = 0
+        else:
+            reconnect_count += 1
+            if reconnect_count > MAX_RECONNECT_ATTEMPTS:
+                logger.warning(
+                    "relay_agent_design_signals_proxy_gave_up",
+                    run_id=input.run_id,
+                    error=str(error) if error else "clean close with no events",
+                )
+                return
+        await asyncio.sleep(min(2**reconnect_count, 30))
+
+
+async def _relay_from_redis(
+    input: RelayAgentDesignSignalsInput,
+    emitter: SlackAgentDesignSignalEmitter,
+    workflow_handle: Any,
+) -> None:
+    """Fallback: tail the Django-side Redis stream. Works without a proxy, but arrives batched."""
+    redis_stream = TaskRunRedisStream(get_task_run_stream_key(input.run_id))
     try:
         async for item in redis_stream.read_stream_entries(
             start_id="0",

--- a/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
+++ b/products/tasks/backend/temporal/process_task/activities/slack_agent_design_signals.py
@@ -13,6 +13,7 @@ import structlog
 import posthoganalytics
 from temporalio import activity
 
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.constants import STREAM_VIA_PROXY_FEATURE_FLAG
@@ -171,18 +172,6 @@ async def relay_agent_design_signals(input: RelayAgentDesignSignalsInput) -> Non
     await _relay_from_redis(input, emitter, workflow_handle)
 
 
-async def _heartbeat_periodically(stop: asyncio.Event) -> None:
-    """Emit an activity heartbeat on a fixed interval. A quiet turn keeps the SSE connection alive
-    with keepalive comments (which httpx_sse drops, yielding no events), so relying on event-driven
-    heartbeats alone would let the activity's heartbeat timeout fire mid-run."""
-    while not stop.is_set():
-        activity.heartbeat()
-        try:
-            await asyncio.wait_for(stop.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS)
-        except TimeoutError:
-            pass
-
-
 async def _relay_from_agent_proxy(
     base_url: str,
     task_run: TaskRunModel,
@@ -193,13 +182,12 @@ async def _relay_from_agent_proxy(
     """Consume the run's live agent-proxy SSE stream and drive the Slack signals.
 
     Reconnects with ``Last-Event-ID`` on transient drops and proxy stream rotations, and stops on
-    the terminal ``stream-end`` frame. Failures are non-fatal — the relay is best-effort.
+    the terminal ``stream-end`` frame. ``Heartbeater`` keeps the activity alive through quiet turns,
+    where the proxy's keepalive comments yield no SSE events to heartbeat on. Best-effort.
     """
     events_url = f"{base_url.rstrip('/')}/v1/runs/{input.run_id}/stream"
 
-    stop_heartbeat = asyncio.Event()
-    heartbeat_task = asyncio.create_task(_heartbeat_periodically(stop_heartbeat))
-    try:
+    async with Heartbeater():
         last_event_id: str | None = None
         reconnect_count = 0
         while True:
@@ -259,9 +247,6 @@ async def _relay_from_agent_proxy(
                 )
                 return
             await asyncio.sleep(min(2**reconnect_count, 30))
-    finally:
-        stop_heartbeat.set()
-        await heartbeat_task
 
 
 async def _relay_from_redis(


### PR DESCRIPTION
## Problem

The Slack agent-design relay read the Django/Redis leg, which fills in a burst at turn-end behind the buffering ingress, so the thread didn't stream per-turn. The agent-proxy stream leg (what the task UI reads) is live.

## Changes

Relay now reads the agent-proxy SSE leg (`/v1/runs/<id>/stream`) — the same live stream the UI uses — and falls back to the Redis leg when no proxy is configured. Prefers an in-cluster URL (new `TASKS_AGENT_PROXY_INTERNAL_URL`), mints the run-scoped read token from the worker, and gates on `tasks-stream-via-proxy` so the flag stays a runtime kill-switch.

Pairs with PostHog/charts#12970.

## How did you test this code?

Validated end-to-end **locally**: sandbox → agent-proxy ingest → relay reads the proxy leg → Slack streams per-turn. Confirmed via proxy logs (relay `GET /v1/runs/<id>/stream` → `200` + `stream:first-event`, not the Redis fallback). Plus emitter unit tests + `ruff`/`ty` green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Model: Claude Opus 4.8.
