### PR TITLE
fix(error-tracking): handle Firefox NS_ERROR_FAILURE as browser noise

### DIFF
--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -18,9 +18,14 @@ const DOM_MUTATION_PATTERNS = [
     "Failed to execute 'appendChild' on 'Node'",
 ]
 
-function isDOMModificationError(error: Error): boolean {
-    const message = error.message || ''
-    return DOM_MUTATION_PATTERNS.some((pattern) => message.includes(pattern))
+// Errors that originate in the browser environment rather than a PostHog bug: extensions
+// mutating the DOM (the patterns above, e.g. translation / ad-blocking), and Firefox/Gecko's
+// internal `NS_ERROR_FAILURE` — thrown from DOM ops like scrollIntoView/focus that fire in a
+// layout effect inside third-party UI libraries, and which we can't fix in app code. We surface
+// these with a "likely your browser" hint instead of the full crash + report-to-us UI.
+function isLikelyBrowserError(error: Error): boolean {
+    const haystack = `${error.name || ''} ${error.message || ''}`
+    return DOM_MUTATION_PATTERNS.some((pattern) => haystack.includes(pattern)) || haystack.includes('NS_ERROR_FAILURE')
 }
 
 interface ErrorBoundaryProps {
@@ -52,7 +57,7 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
 
                 const exceptionEvent = props.exceptionEvent as SupportTicketExceptionEvent
 
-                const isBrowserExtensionError = isDOMModificationError(normalizedError)
+                const isLikelyBrowserEnvError = isLikelyBrowserError(normalizedError)
 
                 const errorDetails = [
                     exceptionEvent?.uuid ? `Exception ID: ${exceptionEvent.uuid}` : null,
@@ -64,7 +69,7 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                 return (
                     <div className={clsx('ErrorBoundary', className)}>
                         <h2>An error has occurred</h2>
-                        {isBrowserExtensionError && (
+                        {isLikelyBrowserEnvError && (
                             <LemonBanner
                                 type="warning"
                                 className="mb-2"
@@ -79,9 +84,9 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                                     },
                                 }}
                             >
-                                This error is commonly caused by browser extensions (such as translation or ad-blocking
-                                extensions) that modify the page. Try disabling your browser extension(s) and reloading
-                                the page to avoid this error in the future.
+                                This error usually comes from your browser or a browser extension (such as a translation
+                                or ad-blocking extension) rather than PostHog itself. Try reloading the page, and
+                                disabling browser extensions if it keeps happening.
                             </LemonBanner>
                         )}
                         <pre>
@@ -98,7 +103,7 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                         {exceptionEvent?.uuid && (
                             <div className="text-muted text-xs mb-2">Exception ID: {exceptionEvent.uuid}</div>
                         )}
-                        {!isBrowserExtensionError && (
+                        {!isLikelyBrowserEnvError && (
                             <>
                                 <p className="mb-2">
                                     Click below to send this to an engineer.{' '}

--- a/frontend/src/layout/navigation/SelfReadOnlyNotice/selfReadOnlyModeLogic.test.ts
+++ b/frontend/src/layout/navigation/SelfReadOnlyNotice/selfReadOnlyModeLogic.test.ts
@@ -1,56 +1,101 @@
-import { dropReadOnlyExceptions } from './selfReadOnlyModeLogic'
+import { dropBrowserNoiseExceptions, dropReadOnlyExceptions } from './selfReadOnlyModeLogic'
 
-describe('dropReadOnlyExceptions', () => {
-    it('passes non-exception events through unchanged', () => {
-        const event = { event: '$pageview', properties: { $current_url: '/foo' } }
-        expect(dropReadOnlyExceptions(event)).toBe(event)
-    })
+describe('before_send exception filters', () => {
+    describe('dropReadOnlyExceptions', () => {
+        it('passes non-exception events through unchanged', () => {
+            const event = { event: '$pageview', properties: { $current_url: '/foo' } }
+            expect(dropReadOnlyExceptions(event)).toBe(event)
+        })
 
-    it('passes $exception events without ReadOnlyModeError through', () => {
-        const event = {
-            event: '$exception',
-            properties: {
-                $exception_list: [{ type: 'TypeError', value: 'x is not a function' }],
-            },
-        }
-        expect(dropReadOnlyExceptions(event)).toBe(event)
-    })
+        it('passes $exception events without ReadOnlyModeError through', () => {
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [{ type: 'TypeError', value: 'x is not a function' }],
+                },
+            }
+            expect(dropReadOnlyExceptions(event)).toBe(event)
+        })
 
-    it('drops $exception events whose top-level type is ReadOnlyModeError', () => {
-        const event = {
-            event: '$exception',
-            properties: {
-                $exception_list: [{ type: 'ReadOnlyModeError', value: 'You are in read-only mode' }],
-            },
-        }
-        expect(dropReadOnlyExceptions(event)).toBeNull()
-    })
+        it('drops $exception events whose top-level type is ReadOnlyModeError', () => {
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [{ type: 'ReadOnlyModeError', value: 'You are in read-only mode' }],
+                },
+            }
+            expect(dropReadOnlyExceptions(event)).toBeNull()
+        })
 
-    it('drops wrapped errors where ReadOnlyModeError lives in the cause chain', () => {
-        // posthog-js serializes `new Error('wrapper', { cause: readOnlyErr })`
-        // by appending the cause to `$exception_list`. The filter walks the
-        // whole list so wrappers do not slip through.
-        const event = {
-            event: '$exception',
-            properties: {
-                $exception_list: [
-                    { type: 'Error', value: 'reverseProxyCheckerLogic: query failed' },
-                    { type: 'ReadOnlyModeError', value: 'You are in read-only mode' },
-                ],
-            },
-        }
-        expect(dropReadOnlyExceptions(event)).toBeNull()
-    })
+        it('drops wrapped errors where ReadOnlyModeError lives in the cause chain', () => {
+            // posthog-js serializes `new Error('wrapper', { cause: readOnlyErr })`
+            // by appending the cause to `$exception_list`. The filter walks the
+            // whole list so wrappers do not slip through.
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [
+                        { type: 'Error', value: 'reverseProxyCheckerLogic: query failed' },
+                        { type: 'ReadOnlyModeError', value: 'You are in read-only mode' },
+                    ],
+                },
+            }
+            expect(dropReadOnlyExceptions(event)).toBeNull()
+        })
 
-    it('tolerates missing properties and missing exception list', () => {
-        expect(dropReadOnlyExceptions({ event: '$exception' })).toEqual({ event: '$exception' })
-        expect(dropReadOnlyExceptions({ event: '$exception', properties: {} })).toEqual({
-            event: '$exception',
-            properties: {},
+        it('tolerates missing properties and missing exception list', () => {
+            expect(dropReadOnlyExceptions({ event: '$exception' })).toEqual({ event: '$exception' })
+            expect(dropReadOnlyExceptions({ event: '$exception', properties: {} })).toEqual({
+                event: '$exception',
+                properties: {},
+            })
+        })
+
+        it('returns null when handed null (matching posthog-js before_send contract)', () => {
+            expect(dropReadOnlyExceptions(null)).toBeNull()
         })
     })
 
-    it('returns null when handed null (matching posthog-js before_send contract)', () => {
-        expect(dropReadOnlyExceptions(null)).toBeNull()
+    describe('dropBrowserNoiseExceptions', () => {
+        it('passes non-exception events through unchanged', () => {
+            const event = { event: '$pageview', properties: { $current_url: '/foo' } }
+            expect(dropBrowserNoiseExceptions(event)).toBe(event)
+        })
+
+        it('passes real $exception events through unchanged', () => {
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [{ type: 'TypeError', value: 'x is not a function' }],
+                },
+            }
+            expect(dropBrowserNoiseExceptions(event)).toBe(event)
+        })
+
+        it('drops $exception events whose value is a Firefox NS_ERROR_FAILURE', () => {
+            // posthog-js captures Gecko's non-Error throw as "NS_ERROR_FAILURE" in the value.
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [{ type: 'Error', value: 'NS_ERROR_FAILURE' }],
+                },
+            }
+            expect(dropBrowserNoiseExceptions(event)).toBeNull()
+        })
+
+        it('drops $exception events whose type is NS_ERROR_FAILURE', () => {
+            const event = {
+                event: '$exception',
+                properties: {
+                    $exception_list: [{ type: 'NS_ERROR_FAILURE', value: '' }],
+                },
+            }
+            expect(dropBrowserNoiseExceptions(event)).toBeNull()
+        })
+
+        it('tolerates missing properties, missing list, and null', () => {
+            expect(dropBrowserNoiseExceptions({ event: '$exception' })).toEqual({ event: '$exception' })
+            expect(dropBrowserNoiseExceptions(null)).toBeNull()
+        })
     })
 })

--- a/frontend/src/layout/navigation/SelfReadOnlyNotice/selfReadOnlyModeLogic.ts
+++ b/frontend/src/layout/navigation/SelfReadOnlyNotice/selfReadOnlyModeLogic.ts
@@ -31,6 +31,28 @@ export function dropReadOnlyExceptions<T extends { event?: string; properties?: 
     return event
 }
 
+// Firefox/Gecko surfaces internal DOM failures — e.g. scrollIntoView/focus thrown from a
+// layout effect inside a third-party UI library — as `NS_ERROR_FAILURE`, usually with an
+// empty message. These are browser-level failures we can't fix in app code, so drop them
+// rather than let them drown out real, actionable exceptions in error tracking.
+// Exported for unit testing.
+export function dropBrowserNoiseExceptions<T extends { event?: string; properties?: Record<string, any> } | null>(
+    event: T
+): T | null {
+    if (!event || event.event !== '$exception') {
+        return event
+    }
+    const list = (event.properties?.$exception_list ?? []) as Array<{ type?: string; value?: string }>
+    if (
+        list.some(
+            (ex) => (ex?.type ?? '').includes('NS_ERROR_FAILURE') || (ex?.value ?? '').includes('NS_ERROR_FAILURE')
+        )
+    ) {
+        return null
+    }
+    return event
+}
+
 export const selfReadOnlyModeLogic = kea<selfReadOnlyModeLogicType>([
     path(['layout', 'navigation', 'SelfReadOnlyNotice', 'selfReadOnlyModeLogic']),
 
@@ -102,11 +124,13 @@ export const selfReadOnlyModeLogic = kea<selfReadOnlyModeLogicType>([
         setReadOnlyGetter(() => selfReadOnlyModeLogic.findMounted()?.values.isReadOnly ?? false)
         setReadOnlyNotifier((method) => actions.notifyBlocked(method))
 
-        // Central error-tracking filter — drops any `$exception` event whose
-        // chain contains a ReadOnlyModeError. Catches direct captures *and*
-        // wrapped errors (`new Error('...', { cause: readOnlyErr })`). No
-        // existing code sets `before_send`, so we own this config slot.
-        posthog.set_config({ before_send: dropReadOnlyExceptions })
+        // Central error-tracking filter — posthog-js applies these `before_send`
+        // functions in order and drops the event if any returns null. We drop
+        // `$exception` events for read-only blocks-by-design (`ReadOnlyModeError`,
+        // including wrapped `new Error('...', { cause: readOnlyErr })`) and for
+        // unactionable Firefox `NS_ERROR_FAILURE` browser noise. This logic owns
+        // the `before_send` slot; add further filters to this array to compose.
+        posthog.set_config({ before_send: [dropReadOnlyExceptions, dropBrowserNoiseExceptions] })
 
         // The user-facing toast for blocked writes is shown by the standard
         // `e instanceof ApiError → lemonToast.error(e.detail)` pattern that


### PR DESCRIPTION
Used the error trackings prompt to fix feature to open this PR.


## Problem

Firefox users hit an `NS_ERROR_FAILURE` while using the command-bar search. It's an empty-message Gecko error thrown from internal DOM operations (`scrollIntoView` / `focus`) that fire in a layout effect inside Base UI's `Autocomplete`. React's error boundary catches it, which produces two bad outcomes: the surrounding scene blanks out with the full "An error has occurred" crash screen, and every occurrence is reported to error tracking as if it were a PostHog bug.

The actual throw is inside Base UI plus a Firefox quirk (Chromium silently no-ops the same call), so there's no clean fix in our own code. This PR makes the app resilient to it and stops the noise, instead of pretending we can fix the throw.

Origin: https://us.posthog.com/error_tracking/019c29c4-3860-7ca0-8d56-3044472de7f4

## Changes

- **`ErrorBoundary`** already special-cases browser-extension DOM mutation errors (`removeChild` / `insertBefore` / `appendChild`) and shows a "this is likely your browser" banner instead of the crash + report-to-us UI. I extended that classification to also match `NS_ERROR_FAILURE`, and generalized the banner copy so it reads correctly for both browser and extension causes.
- **`before_send`**: added `dropBrowserNoiseExceptions` and composed it into the central `before_send` array (next to the existing `dropReadOnlyExceptions`), so `$exception` events carrying `NS_ERROR_FAILURE` are dropped before they reach error tracking.

> [!NOTE]
> This is a resilience + de-noise change, not a fix to the underlying throw. The root cause is Base UI's `useListNavigation` calling native `scrollIntoView` / `focus` in a layout effect, which Firefox rejects with `NS_ERROR_FAILURE`. Fixing that at the source would mean changing the search's `Autocomplete` config or upgrading Base UI, which is deliberately out of scope here.

## How did you test this code?

- Added 5 unit tests for `dropBrowserNoiseExceptions`: drops `NS_ERROR_FAILURE` by `type` or `value`, passes real and non-`$exception` events through, tolerates null / missing properties. The file's suite passes 11/11.
- Ran the frontend typecheck (no errors in the changed files) and oxlint (0 warnings/errors on the three files).
- I (Claude) could **not** reproduce the Firefox-only crash manually. There's no Firefox in the agent environment, so the `ErrorBoundary` banner and classification path were not exercised in a real browser. The `before_send` filter is covered by unit tests; the `ErrorBoundary` copy/classification change is not.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by @clr182. Skill invoked: `/writing-tests` before adding the filter tests.

The error-tracking stack is the error boundary's own reporting commit (`componentDidCatch` then `captureException`), so it doesn't contain the throwing component. I traced "search" to the Base UI `Autocomplete` command bar and, with a code scan, confirmed the throw is Base UI's `useListNavigation` layout effect issuing native `scrollIntoView` / `focus` on the highlighted item, which is the exact Firefox `NS_ERROR_FAILURE` pattern.

I weighed three fixes: (a) change the search's `Autocomplete` config to avoid the fragile `inline` / `autoHighlight` path, (b) upgrade `@base-ui/react`, (c) resilience + de-noise at the boundary. I chose (c): the root cause is library-internal, (a) drops a UX feature on an unverified hypothesis I can't reproduce without Firefox, and (b) is a heavy cross-app change. If this keeps recurring, (a) or (b) is the follow-up.
