### PR TITLE
feat(logs): promote group to a third view in the logs/patterns bar

### DIFF
--- a/products/logs/frontend/components/LogsGroupBy/LogsGroupByResults.tsx
+++ b/products/logs/frontend/components/LogsGroupBy/LogsGroupByResults.tsx
@@ -34,9 +34,19 @@ export function LogsGroupByResults({ id }: { id: string }): JSX.Element {
     const { setOrderGroupsBy } = useActions(logsGroupByLogic({ id }))
     const { groupBy } = useValues(logsViewerConfigLogic({ id }))
 
+    // The Group view with no key chosen: prompt for one instead of showing an empty table.
+    // No query runs in this state (the logic's loader guards on a null key).
+    if (!groupBy) {
+        return (
+            <div className="flex-1 min-h-0 flex items-center justify-center text-muted" data-attr="logs-group-by-empty">
+                Pick an attribute to group by
+            </div>
+        )
+    }
+
     const columns: LemonTableColumns<_LogsGroupByGroupApi> = [
         {
-            title: groupBy?.key,
+            title: groupBy.key,
             dataIndex: 'value',
             render: (_, row) => <span className="font-mono text-xs">{row.value}</span>,
         },

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -8,6 +8,7 @@ import { TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/Taxonomi
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
+import { logsGroupByLogic } from 'products/logs/frontend/components/LogsGroupBy/logsGroupByLogic'
 import { logsPatternsLogic } from 'products/logs/frontend/components/LogsPatterns/logsPatternsLogic'
 import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
@@ -31,12 +32,14 @@ export interface LogsDisplayBarProps {
 /**
  * The bar above the results, grouped by scope rather than by widget kind:
  *
- *  - persistent-left "frame": controls that belong to the results region in *both* lenses —
- *    the filters toggle, the Logs⇄Patterns switch, and a lens-aware count indicator.
- *  - contextual-right: the Logs-only presentation tools (sort, wrap, timezone, export, shortcuts),
- *    hidden entirely in Patterns mode where none of them apply.
+ *  - persistent-left "frame": controls that belong to the results region in *every* lens —
+ *    the filters toggle, the Logs⇄Patterns⇄Group switch, and a lens-aware count indicator.
+ *  - lens configuration: the group-by key picker, shown only in Group mode (the mode lives
+ *    in the segmented bar; the key is that mode's setting, like Patterns owns its mining).
+ *  - contextual-right: the Logs-only presentation tools (sort, wrap, timezone, export,
+ *    shortcuts), hidden in Patterns/Group modes where none of them apply.
  *
- * Sits below the sparkline, next to the table it affects. None of these re-run the query.
+ * Sits below the sparkline, next to the table it affects.
  */
 export const LogsDisplayBar = ({
     id,
@@ -49,8 +52,16 @@ export const LogsDisplayBar = ({
     const showGroupBy = useFeatureFlag('LOGS_GROUP_BY')
 
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
-    // Grouping applies to the Logs lens only; Patterns has its own aggregation.
-    const inGroupByMode = showGroupBy && !inPatternsMode && groupBy !== null
+    // Group is a third view like Patterns: the mode lives in the segmented bar; the key
+    // picker below is the mode's configuration. Double-gated so it's unreachable flag-off.
+    const inGroupByMode = showGroupBy && viewMode === 'group'
+
+    // Each lens joins the bar behind its own flag; the bar renders once any non-Logs lens exists.
+    const viewModeOptions = [
+        { value: 'logs' as const, label: 'Logs' },
+        ...(showPatternsView ? [{ value: 'patterns' as const, label: 'Patterns' }] : []),
+        ...(showGroupBy ? [{ value: 'group' as const, label: 'Group' }] : []),
+    ]
 
     return (
         <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -65,18 +76,15 @@ export const LogsDisplayBar = ({
                         {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
                     </LemonButton>
                 )}
-                {showPatternsView && (
+                {viewModeOptions.length > 1 && (
                     <LemonSegmentedButton
                         size="small"
                         value={viewMode}
                         onChange={setViewMode}
-                        options={[
-                            { value: 'logs', label: 'Logs' },
-                            { value: 'patterns', label: 'Patterns' },
-                        ]}
+                        options={viewModeOptions}
                     />
                 )}
-                {showGroupBy && !inPatternsMode && (
+                {inGroupByMode && (
                     <TaxonomicStringPopover
                         size="small"
                         groupType={TaxonomicFilterGroupType.Logs}
@@ -90,6 +98,8 @@ export const LogsDisplayBar = ({
                         excludedProperties={{ [TaxonomicFilterGroupType.Logs]: ['message'] }}
                         value={groupBy?.key}
                         onChange={(value, groupType) =>
+                            // Clearing the key keeps you in the Group view (empty state) — leaving
+                            // the view is the segmented bar's job, not the picker's.
                             setGroupBy(
                                 value ? { key: value, source: TAXONOMIC_GROUP_TO_SOURCE[groupType] ?? 'log' } : null
                             )
@@ -107,8 +117,9 @@ export const LogsDisplayBar = ({
                 )}
                 {inPatternsMode ? (
                     <PatternsCountIndicator id={id} />
+                ) : inGroupByMode ? (
+                    <GroupsCountIndicator id={id} />
                 ) : (
-                    !inGroupByMode &&
                     totalLogsCount !== undefined &&
                     totalLogsCount > 0 && (
                         <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
@@ -132,4 +143,18 @@ const PatternsCountIndicator = ({ id }: { id: string }): JSX.Element | null => {
     }
 
     return <span className="text-muted text-xs">{humanFriendlyNumber(patterns.length)} patterns</span>
+}
+
+/**
+ * Lens-aware count for Group mode, mirroring PatternsCountIndicator: mounted only while the
+ * Group view is active so `logsGroupByLogic` (and its query) stays down otherwise.
+ */
+const GroupsCountIndicator = ({ id }: { id: string }): JSX.Element | null => {
+    const { groupByResponse } = useValues(logsGroupByLogic({ id }))
+
+    if (groupByResponse.total_groups === 0) {
+        return null
+    }
+
+    return <span className="text-muted text-xs">{humanFriendlyNumber(groupByResponse.total_groups)} groups</span>
 }

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -99,7 +99,7 @@ function LogsViewerContent({
         clearSelection,
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
-    const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed, viewMode, groupBy } =
+    const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed, viewMode } =
         useValues(logsViewerConfigLogic)
     const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
     const {
@@ -339,17 +339,15 @@ function LogsViewerContent({
         </>
     )
 
-    // Patterns is a mode of the Viewer, not a separate tab: it swaps only the results region
-    // and reuses the same filter bar / FacetRail / date range (shared via logsViewerFiltersLogic).
-    // Gate on the flag too, so the patterns query stays unreachable when the flag is off regardless
-    // of the (non-persisted) viewMode state.
+    // Patterns and Group are modes of the Viewer, not separate tabs: they swap only the results
+    // region and reuse the same filter bar / FacetRail / date range (shared via
+    // logsViewerFiltersLogic). Each gates on its flag too, so its query stays unreachable when
+    // the flag is off regardless of the (non-persisted) viewMode state.
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
-    // Group-by (logs-group-by flag): an active grouping swaps the Logs lens's results
-    // for the grouped table. Double-gated like Patterns so it's unreachable with the flag off.
-    const inGroupByMode = showGroupBy && !inPatternsMode && groupBy !== null
+    const inGroupByMode = showGroupBy && viewMode === 'group'
     const resultsRegion = inPatternsMode ? (
         <LogsPatterns id={id} />
-    ) : inGroupByMode && groupBy ? (
+    ) : inGroupByMode ? (
         <LogsGroupByResults id={id} />
     ) : (
         logList

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -23,7 +23,7 @@ export const DEFAULT_SPARKLINE_BREAKDOWN_BY: LogsSparklineBreakdownBy = 'severit
 
 export const DEFAULT_ORDER_BY: LogsOrderBy = 'latest'
 
-export type LogsViewerViewMode = 'logs' | 'patterns'
+export type LogsViewerViewMode = 'logs' | 'patterns' | 'group'
 export const DEFAULT_VIEW_MODE: LogsViewerViewMode = 'logs'
 
 export interface LogsViewerGroupBy {
@@ -101,8 +101,10 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
                 setViewMode: (_, { viewMode }) => viewMode,
             },
         ],
-        // The attribute to group results by (behind the logs-group-by flag); null = ungrouped.
-        // Not persisted — grouping is an explicit, per-visit exploration like Patterns.
+        // The Group view's configuration: which key to group by (behind the logs-group-by flag).
+        // Kept separate from viewMode so the key survives switching lenses within a visit —
+        // Logs and back returns to the same grouping. null = no key chosen yet (empty state).
+        // Not persisted across visits — grouping is an explicit, per-visit exploration like Patterns.
         groupBy: [
             null as LogsViewerGroupBy | null,
             {


### PR DESCRIPTION
## Problem

The group-by lens (behind `logs-group-by`, wired to real data in #68878) currently activates via a picker sitting next to the Logs/Patterns segmented button. But an active grouping swaps the entire results region: its own query, its own table, the logs count and toolbar hidden. It behaves like a view, so surfacing it as a setting on the Logs lens is dishonest UI - you're "in Logs" while looking at something that isn't logs.

## Changes

The segmented bar becomes **Logs | Patterns | Group**, splitting mode from configuration:

- `LogsViewerViewMode` gains `'group'`. The Group option renders only with the `logs-group-by` flag on, and the results region double-gates on flag + mode (same pattern as Patterns), so the state is unreachable flag-off.
- Each lens joins the bar behind its own flag (previously the whole bar was gated on the patterns flag, which would have made Group unreachable with patterns off). The bar renders once any non-Logs lens exists.
- The key picker moves inside the Group view: shown in the display bar only when that mode is active. It's the view's configuration, the way Patterns owns its mining - this is what resolves the earlier "group-by settings don't fit a segmented button" concern.
- Group with no key chosen shows a prompt ("Pick an attribute to group by") and fires no query (the logic's loader already guards on a null key).
- Clearing the key keeps you in the Group view's empty state; leaving the view is the segmented bar's job, not the picker's.
- The chosen key survives switching lenses within a visit (Logs and back returns to the same grouping) but stays non-persisted across visits, same rationale as Patterns.
- The count indicator is now lens-aware for Group too: a `GroupsCountIndicator` mirroring the patterns one, mounted only while the view is active so the aggregation never runs from Logs mode.

## How did you test this code?

Automated (ran locally, all green):

- Full TypeScript check clean for all touched files; oxlint/oxfmt clean.
- Existing `logsPatternsLogic.test.ts` suite (9 tests) passes - it exercises the shared `viewMode` state this PR extends.

No new tests: the change is view wiring over already-tested state (the reducer is a one-line union extension; the query-guard behavior it relies on is covered by the group-by endpoint tests from #68878).

Not done: no live UI verification against a running stack. The `logs-group-by` flag needs to exist to see the lens.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Flag-gated, unreleased feature - no docs update needed yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked earlier in the session and applied here: `/writing-kea-logics`, `/writing-tests` (gate applied - concluded no new tests earn their place).

Design decision worth knowing: the group-by lens originally shipped as a picker-activated state on the Logs lens because "group-by settings don't fit a segmented button". This PR resolves that tension by splitting it: the mode goes in the bar, the settings (key picker) stay in the view. Follow-up planned: clicking a group row pivots back to the Logs view filtered to that group's value.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*