### PR TITLE
fix(navigation): stop scenePanelElement selector cache pinning departed scene trees

### DIFF
--- a/frontend/src/@types/memlab-lens.d.ts
+++ b/frontend/src/@types/memlab-lens.d.ts
@@ -1,5 +1,5 @@
 declare module '@memlab/lens/dist/memlens.lib.bundle.js' {
-    interface MemLensScanResult {
+    export interface MemLensScanResult {
         totalElements: number
         totalDetachedElements: number
         detachedComponentToFiberNodeCount: Map<string, number>
@@ -8,14 +8,21 @@ declare module '@memlab/lens/dist/memlens.lib.bundle.js' {
         end: number
     }
 
-    interface MemLensScanner {
+    export interface MemLensDOMElementInfo {
+        element: WeakRef<Element>
+        componentStack: string[] | null | undefined
+    }
+
+    export interface MemLensScanner {
         subscribe: (callback: (result: MemLensScanResult) => void) => () => void
         start: () => void
         stop: () => void
         dispose: () => void
+        scan: () => Omit<MemLensScanResult, 'start' | 'end'>
+        getDetachedDOMInfo: () => MemLensDOMElementInfo[]
     }
 
-    interface MemLensScanOptions {
+    export interface MemLensScanOptions {
         scanIntervalMs?: number
         trackEventListenerLeaks?: boolean
     }

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -134,8 +134,9 @@ export function startDetachedElementTracking(posthog: Capturable): void {
     }, IDLE_TIMEOUT_MS)
 }
 
-// Dev-only console helpers for hunting detached-DOM retainers. Holds no strong
-// element refs itself — `el(i)` derefs on demand so the hook can't become a leak.
+// Dev-only console helpers for hunting detached-DOM retainers. The convenience
+// accessors (`el(i)`, `detached()`) deref WeakRefs on demand rather than holding
+// elements; `scanner` is the raw MemLens instance and keeps its own tracking state.
 function exposeLeakHunterDevHelpers(scan: MemLensScanner): void {
     const leakHunter = {
         scanner: scan,

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -1,3 +1,5 @@
+import { getAppContext } from 'lib/utils/getAppContext'
+
 const SCAN_INTERVAL_MS = 30_000
 const TOP_N = 10
 const IDLE_TIMEOUT_MS = 5_000
@@ -15,11 +17,18 @@ interface MemLensScanResult {
     end: number
 }
 
+interface MemLensDOMElementInfo {
+    element: WeakRef<Element>
+    componentStack: string[] | null | undefined
+}
+
 interface MemLensScanner {
     subscribe: (callback: (result: MemLensScanResult) => void) => () => void
     start: () => void
     stop: () => void
     dispose: () => void
+    scan: () => Omit<MemLensScanResult, 'start' | 'end'>
+    getDetachedDOMInfo: () => MemLensDOMElementInfo[]
 }
 
 export function shouldCaptureDetachedElements(currentCount: number, previousCount: number | null): boolean {
@@ -105,6 +114,10 @@ export function startDetachedElementTracking(posthog: Capturable): void {
 
             document.addEventListener('visibilitychange', onVisibilityChange)
 
+            if (getAppContext()?.preflight?.is_debug) {
+                exposeLeakHunterDevHelpers(scan)
+            }
+
             if (!document.hidden) {
                 scan.start()
             }
@@ -119,4 +132,43 @@ export function startDetachedElementTracking(posthog: Capturable): void {
             console.warn('[detachedElementTracker] Failed to load MemLens, detached element tracking disabled')
         }
     }, IDLE_TIMEOUT_MS)
+}
+
+// Dev-only console helpers for hunting detached-DOM retainers. Holds no strong
+// element refs itself — `el(i)` derefs on demand so the hook can't become a leak.
+function exposeLeakHunterDevHelpers(scan: MemLensScanner): void {
+    const leakHunter = {
+        scanner: scan,
+        scan: (): {
+            totalElements: number
+            totalDetachedElements: number
+            detachedComponents: Record<string, number>
+        } => {
+            const result = scan.scan()
+            return {
+                totalElements: result.totalElements,
+                totalDetachedElements: result.totalDetachedElements,
+                detachedComponents: mapToTopN(result.detachedComponentToFiberNodeCount, 50),
+            }
+        },
+        detached: (
+            limit: number = 50
+        ): { i: number; tag?: string; id?: string; classes?: string | null; components?: string[] }[] =>
+            scan
+                .getDetachedDOMInfo()
+                .slice(0, limit)
+                .map((info, i) => {
+                    const el = info.element.deref()
+                    return {
+                        i,
+                        tag: el?.tagName,
+                        id: el?.id,
+                        classes: el?.getAttribute('class'),
+                        components: info.componentStack?.slice(0, 10) ?? undefined,
+                    }
+                }),
+        el: (i: number): Element | undefined => scan.getDetachedDOMInfo()[i]?.element.deref(),
+    }
+    ;(window as unknown as { __leakHunter?: typeof leakHunter }).__leakHunter = leakHunter
+    console.info('[leak-hunter] window.__leakHunter ready')
 }

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -1,3 +1,5 @@
+import type { MemLensScanner } from '@memlab/lens/dist/memlens.lib.bundle.js'
+
 import { getAppContext } from 'lib/utils/getAppContext'
 
 const SCAN_INTERVAL_MS = 30_000
@@ -6,29 +8,6 @@ const IDLE_TIMEOUT_MS = 5_000
 
 interface Capturable {
     capture: (event: string, properties?: Record<string, unknown>) => void
-}
-
-interface MemLensScanResult {
-    totalElements: number
-    totalDetachedElements: number
-    detachedComponentToFiberNodeCount: Map<string, number>
-    componentToFiberNodeCount: Map<string, number>
-    start: number
-    end: number
-}
-
-interface MemLensDOMElementInfo {
-    element: WeakRef<Element>
-    componentStack: string[] | null | undefined
-}
-
-interface MemLensScanner {
-    subscribe: (callback: (result: MemLensScanResult) => void) => () => void
-    start: () => void
-    stop: () => void
-    dispose: () => void
-    scan: () => Omit<MemLensScanResult, 'start' | 'end'>
-    getDetachedDOMInfo: () => MemLensDOMElementInfo[]
 }
 
 export function shouldCaptureDetachedElements(currentCount: number, previousCount: number | null): boolean {
@@ -79,7 +58,7 @@ export function startDetachedElementTracking(posthog: Capturable): void {
 
             state = 'ready'
 
-            const scan: MemLensScanner = createReactMemoryScan({
+            const scan = createReactMemoryScan({
                 scanIntervalMs: SCAN_INTERVAL_MS,
                 trackEventListenerLeaks: false,
             })

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -125,6 +125,7 @@ export function startDetachedElementTracking(posthog: Capturable): void {
             window.addEventListener('beforeunload', () => {
                 scan.stop()
                 scan.dispose()
+                delete (window as unknown as { __leakHunter?: unknown }).__leakHunter
                 document.removeEventListener('visibilitychange', onVisibilityChange)
             })
         } catch {

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -134,17 +134,27 @@ export function startDetachedElementTracking(posthog: Capturable): void {
     }, IDLE_TIMEOUT_MS)
 }
 
+interface LeakHunterScanSummary {
+    totalElements: number
+    totalDetachedElements: number
+    detachedComponents: Record<string, number>
+}
+
+interface LeakHunterDetachedElementSummary {
+    i: number
+    tag?: string
+    id?: string
+    classes?: string | null
+    components?: string[]
+}
+
 // Dev-only console helpers for hunting detached-DOM retainers. The convenience
 // accessors (`el(i)`, `detached()`) deref WeakRefs on demand rather than holding
 // elements; `scanner` is the raw MemLens instance and keeps its own tracking state.
 function exposeLeakHunterDevHelpers(scan: MemLensScanner): void {
     const leakHunter = {
         scanner: scan,
-        scan: (): {
-            totalElements: number
-            totalDetachedElements: number
-            detachedComponents: Record<string, number>
-        } => {
+        scan: (): LeakHunterScanSummary => {
             const result = scan.scan()
             return {
                 totalElements: result.totalElements,
@@ -152,9 +162,7 @@ function exposeLeakHunterDevHelpers(scan: MemLensScanner): void {
                 detachedComponents: mapToTopN(result.detachedComponentToFiberNodeCount, 50),
             }
         },
-        detached: (
-            limit: number = 50
-        ): { i: number; tag?: string; id?: string; classes?: string | null; components?: string[] }[] =>
+        detached: (limit: number = 50): LeakHunterDetachedElementSummary[] =>
             scan
                 .getDetachedDOMInfo()
                 .slice(0, limit)

--- a/frontend/src/layout/scenes/sceneLayoutLogic.test.ts
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.test.ts
@@ -1,0 +1,29 @@
+import { initKeaTests } from '~/test/init'
+
+import { sceneLayoutLogic } from './sceneLayoutLogic'
+
+describe('sceneLayoutLogic', () => {
+    let logic: ReturnType<typeof sceneLayoutLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = sceneLayoutLogic()
+        logic.mount()
+    })
+
+    it('releases the previous panel element from the memoized selector cache', () => {
+        // Regression guard for detached-DOM retention: with no ScenePanel
+        // subscribed, the reselect cache is only refreshed by the
+        // registerScenePanelElement listener. If that listener is removed, the
+        // stale cached element pins the departed scene's whole fiber/DOM tree.
+        const element = document.createElement('div')
+        logic.actions.registerScenePanelElement(element)
+        expect(logic.values.scenePanelElement).toBe(element)
+
+        logic.actions.registerScenePanelElement(null)
+
+        const lastResult = (logic.selectors.scenePanelElement as unknown as { lastResult: () => HTMLElement | null })
+            .lastResult
+        expect(lastResult()).toBe(null)
+    })
+})

--- a/frontend/src/layout/scenes/sceneLayoutLogic.test.ts
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.test.ts
@@ -22,6 +22,9 @@ describe('sceneLayoutLogic', () => {
 
         logic.actions.registerScenePanelElement(null)
 
+        // `lastResult` is a reselect 5 internal, not a public API — if a future
+        // kea/reselect upgrade renames it, this cast fails mechanically (TypeError),
+        // it isn't a behavioural regression in the fix itself.
         const lastResult = (logic.selectors.scenePanelElement as unknown as { lastResult: () => HTMLElement | null })
             .lastResult
         expect(lastResult()).toBe(null)

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
 import React from 'react'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -54,4 +54,14 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
             },
         ],
     }),
+    listeners(({ values }) => ({
+        registerScenePanelElement: () => {
+            // The memoized selector only recomputes when evaluated, and once the
+            // last ScenePanel unmounts nothing subscribes to it — so without this
+            // read its cached result keeps the previous (now detached) panel
+            // container alive, which pins the departed scene's entire fiber and
+            // DOM tree via the element's React fiber expandos.
+            void values.scenePanelElement
+        },
+    })),
 ])

--- a/frontend/src/layout/scenes/sceneLayoutLogic.tsx
+++ b/frontend/src/layout/scenes/sceneLayoutLogic.tsx
@@ -56,12 +56,15 @@ export const sceneLayoutLogic = kea<sceneLayoutLogicType>([
     }),
     listeners(({ values }) => ({
         registerScenePanelElement: () => {
-            // The memoized selector only recomputes when evaluated, and once the
-            // last ScenePanel unmounts nothing subscribes to it — so without this
-            // read its cached result keeps the previous (now detached) panel
-            // container alive, which pins the departed scene's entire fiber and
-            // DOM tree via the element's React fiber expandos.
-            void values.scenePanelElement
+            refreshScenePanelElementSelectorCache(values)
         },
     })),
 ])
+
+// The memoized `scenePanelElement` selector only recomputes when evaluated, and once
+// the last ScenePanel unmounts nothing subscribes to it — so without this read its
+// cached result keeps the previous (now detached) panel container alive, which pins
+// the departed scene's entire fiber and DOM tree via the element's React fiber expandos.
+function refreshScenePanelElementSelectorCache(values: sceneLayoutLogicType['values']): void {
+    void values.scenePanelElement
+}


### PR DESCRIPTION
## Problem

Production `detached_elements` telemetry shows whole unmounted scene trees retained as detached DOM after SPA navigation. Worst scans report detached ~= total fiber-tracked elements (e.g. 57,019 of 58,097 on `/error_tracking`), stable across consecutive scans, with the same generic chrome (`LemonButton`, `LinkPrimitive`, `ButtonPrimitive`, Radix primitives) topping the detached-component buckets on every affected path.

Heap-snapshot retainer tracing against a local repro found a single signature on every sampled detached DOM node:

```
kea builtLogic -> selectors -> scenePanelElement -> (reselect memoized closure) -> lastResult -> Detached <div> -> ...
```

The mechanism: leaving a scene that renders a `ScenePanel` unmounts it, which flips `scenePanelIsPresent` off, so Navigation removes the inline panel container div. The ref callback correctly nulls the `scenePanelElement` reducer, but kea selectors are reselect-memoized and only recompute when evaluated. With the last `ScenePanel` unmounted, nothing subscribes to the selector, so its cached `lastResult` keeps the detached container alive indefinitely. The container's `__reactFiber$` expando then pins the previous render generation's fiber tree via return/child/sibling pointers, and every fiber's `stateNode` pins every DOM node of the departed scene. One stale element ~= a whole detached scene, held until the user next visits a scene with a panel (possibly never).

> [!NOTE]
> Session recording (rrweb) was a suspect and is exonerated: recording was active in every trial and detached counts still dropped to zero with this fix.

## Changes

- `sceneLayoutLogic`: a listener on `registerScenePanelElement` reads `values.scenePanelElement` after the reducer updates, forcing the memoized selector to recompute and release the previous (now detached) element. Smallest possible fix at the retention mechanism itself, and it covers both writers (Navigation's inline panel div and `SidePanelInfo`'s override).
- `detachedElementTracker`: exposes dev-only `window.__leakHunter` helpers (`scan()`, `detached()`, `el(i)`) on the existing MemLens tracker, gated on `preflight.is_debug`. On-demand scans instead of waiting for the 30s interval; holds no strong element refs itself (`el(i)` derefs a `WeakRef` on demand). This is how the retainer was found and how the fix was verified.

## How did you test this code?

Automated: new jest test `sceneLayoutLogic.test.ts` asserts the memoized selector's cached result is released after `registerScenePanelElement(null)`. It catches the realistic regression of someone deleting the seemingly pointless `void values.scenePanelElement` read: verified red without the listener, green with it. No existing test covers selector-cache retention.

Instrumented repro (Claude drove this, headed Chrome + CDP against a devbox stack with demo data): 8 cycles of error tracking -> dashboard -> insight -> activity navigation via real link clicks, double forced GC + MemLens scan per cycle, heap snapshot at the end.

| Arm | Post-GC detached elements per cycle | Detached DOM nodes in heap snapshot |
| --- | --- | --- |
| Without fix | stable plateau of 14 | 5, all retained via `scenePanelElement -> lastResult` (5/5 sampled paths) |
| With fix | 0 (three runs) | 0 |

The residual difference between arms is exactly the panel-container cluster. The stable plateau shape matches the production telemetry signature (constant detached count across consecutive scans).

### Navigation behaviour check (recorded)

The fix is a pure cache read, so it shouldn't change navigation behaviour — the video below (Playwright driving headed Chrome against a devbox stack at this PR's HEAD, `bd54e7c`) shows a full round trip via real link clicks: error tracking, opening an issue (a `ScenePanel` scene), a dashboard, insights, activity, back to error tracking, then away again. It ends with a double forced GC and an on-camera `__leakHunter.scan()`: 9 detached of 1392 tracked elements, which is exactly the pre-existing stuck-Tooltip residue noted in the agent context below (present with and without the fix — the departed scene trees themselves are released).


https://github.com/user-attachments/assets/018f229b-39bb-4d5a-8f3c-4306783a896e


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code (Claude) session, driven by Paul. Skills used: a personal `hunt-detached-elements` skill (methodology: post-GC-only readings, linear-growth-vs-plateau interpretation, retainer-path tracing), plus `/writing-tests` before adding the jest test.
- Approach: ran the app on a devbox with Hedgebox demo data, drove a scripted headed Chrome via Playwright + CDP (forced GC twice before every reading), captured heap snapshots, and traced shortest retainer paths to GC roots with @memlab/heap-analysis. All sampled detached nodes converged on the `scenePanelElement` selector cache in both control snapshots.
- Fix shapes considered and rejected: always-mounting the panel container (does not cover the `SidePanelInfo` override path), storing a `WeakRef` in state (pushes deref subtleties onto readers), moving the element out of kea into a module-level store (fights kea conventions for a two-writer/one-reader value). The listener touch is the smallest change that kills the retention at its mechanism.
- A small, flat residue of 3 stuck `Tooltip` popups (9 detached nodes, non-cumulative, present in both arms) was observed and left out of scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
