### PR TITLE
feat(ingestion): centralize ingestion warning types in a registry

### DIFF
--- a/.agents/skills/adding-ingestion-warnings/SKILL.md
+++ b/.agents/skills/adding-ingestion-warnings/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: adding-ingestion-warnings
+description: >
+  How to add a new ingestion warning type to the event ingestion pipeline.
+  Use when emitting a new warning from nodejs ingestion code (emitIngestionWarning, captureIngestionWarning, pipeline `warnings` arrays, `drop()` with warnings), when adding a warning type, category, or severity, or when a typecheck error says a string is not assignable to IngestionWarningType.
+  Covers the INGESTION_WARNING_TYPES registry (the single source of truth for type, category, and severity), the details-key conventions that ClickHouse v2 materializes into columns, debouncing, and the downstream surfaces to keep in sync (v1 UI map, docs, v2 API).
+---
+
+# Adding ingestion warnings
+
+Ingestion warnings tell customers their events were ingested with problems (or dropped).
+They are produced to the `clickhouse_ingestion_warnings` Kafka topic and land in two ClickHouse tables: v1 (`ingestion_warnings`) and v2 (`ingestion_warnings_v2`, which materializes structured columns from the details JSON).
+
+## The registry is the source of truth
+
+Every warning type must be registered in `INGESTION_WARNING_TYPES` in
+[nodejs/src/ingestion/common/ingestion-warnings.ts](../../../nodejs/src/ingestion/common/ingestion-warnings.ts).
+The registry fixes the type's `category` and `severity`; they are resolved at serialization time, so callsites cannot drift or forget them.
+An unregistered type is a compile error (`IngestionWarningType` is the registry's key union).
+
+To add a new warning:
+
+1. **Register the type** in `INGESTION_WARNING_TYPES`, inside the matching group comment block. Pick:
+   - `category` — one of `size`, `merge`, `event`, `transformation`, `replay`. Extend `IngestionWarningCategory` only when the warning genuinely doesn't fit an existing group; new categories flow into API filters and agent-facing docs, so keep the vocabulary small.
+   - `severity` — follow the convention: `error` = the event or message was dropped, `warning` = ingested but modified or partially rejected, `info` = informational or an intentional, team-configured drop.
+2. **Emit it** (see below), passing only per-occurrence fields: `details`, `pipelineStep`, optional `key` / `alwaysSend`.
+3. **Update downstream surfaces** (see checklist).
+
+## Emitting
+
+Two paths, both end at `serializeIngestionWarning`:
+
+- **Pipeline steps** (preferred): return warnings on the result — `ok(value, sideEffects, warnings)` or `drop(reason, [], warnings)`. They accumulate in `context.warnings` and are sent by `handleIngestionWarnings()`, which requires a `teamAware()` block. See the framework doc test [09-ingestion-warnings](../../../nodejs/src/ingestion/framework/docs/09-ingestion-warnings.test.ts).
+- **Direct emit**: `emitIngestionWarning(outputs, teamId, warning)` (outputs-based, preferred) or `captureIngestionWarning(kafkaProducer, teamId, warning)` (legacy) for code outside the pipeline result flow.
+
+### Details keys ClickHouse v2 materializes
+
+`ingestion_warnings_v2` derives columns from these exact JSON key names (see `posthog/models/ingestion_warnings/sql_v2.py`) — use them, don't invent variants:
+
+| details key  | v2 column     |
+| ------------ | ------------- |
+| `eventUuid`  | `event_uuid`  |
+| `distinctId` | `distinct_id` |
+| `personId`   | `person_id`   |
+| `groupKey`   | `group_key`   |
+
+`category`, `severity`, and `pipelineStep` are appended to details by the serializer — never set them in `details` yourself; a stray key cannot override them (structured fields are spread last).
+
+### Debouncing
+
+Warnings are rate-limited per `team:type:key`. Set `key` to the entity you want to debounce by (e.g. a distinct ID) and `alwaysSend: true` only for warnings that must never be dropped by the limiter.
+
+## Rust
+
+No Rust service emits ingestion warnings today — the Rust capture service only routes `$$client_ingestion_warning` events to Kafka; the nodejs pipeline turns them into warnings.
+If a Rust service ever needs to produce to `clickhouse_ingestion_warnings` directly, mirror the nodejs registry in a Rust module (type enum with `category()` / `severity()`), keep the JSON shape identical to `serializeIngestionWarning`, and update this skill to point at it.
+
+## Downstream checklist
+
+When adding a type, also update:
+
+- **v1 UI map** — `WARNING_TYPE_TO_DESCRIPTION` (and `WARNING_TYPE_TO_DOCS_ANCHOR` if documented) in `frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx`.
+- **posthog.com docs** — the ingestion warnings page (`https://posthog.com/docs/data/ingestion-warnings`) if the warning is user-actionable.
+- **v2 API / MCP descriptions** — only if you added a new category or severity value; the example vocabularies live in the `ingestion_warnings_v2` serializer help texts (`posthog/api/ingestion_warnings_v2.py`).
+
+## Related
+
+- Warning-fixing skills (`fixing-<warning-type>`) that teach agents how to resolve each warning are planned under the ingestion warnings v2 effort; authoring one per new warning type will become part of this checklist.

--- a/nodejs/src/ingestion/common/cookieless/cookieless-manager.ts
+++ b/nodejs/src/ingestion/common/cookieless/cookieless-manager.ts
@@ -16,6 +16,7 @@ import { ConcurrencyController } from '~/common/utils/concurrencyController'
 import { RedisOperationError } from '~/common/utils/db/error'
 import { logger } from '~/common/utils/logger'
 import { UUID7, bufferToUint32ArrayLE, uint32ArrayLEToBuffer } from '~/common/utils/utils'
+import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
 import { toStartOfDayInTimezone, toYearMonthDayInTimezone } from '~/ingestion/common/timestamps'
 import { IngestionConsumerConfig } from '~/ingestion/config'
 import { PipelineResult, dlq, drop, isOkResult, ok } from '~/ingestion/framework/results'
@@ -397,7 +398,7 @@ export class CookielessManager {
             } = getProperties(event, timestamp)
             if (!userAgent || !ip || !host) {
                 let reason: string
-                let type: string
+                let type: IngestionWarningType
                 let missingProperty: string
 
                 if (!userAgent) {

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
@@ -318,8 +318,6 @@ describe('BatchWritingGroupStore', () => {
                 groupKey: 'test',
                 distinctId: `${teamId}:test`,
             },
-            category: 'size',
-            severity: 'error',
             pipelineStep: 'group-store',
         })
     })

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
@@ -380,8 +380,6 @@ export class BatchWritingGroupStore implements GroupStore {
                     groupKey: update.group_key,
                     distinctId: distinctId,
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'group-store',
             })
             return
@@ -768,8 +766,6 @@ export class BatchWritingGroupStore implements GroupStore {
                     groupTypeIndex,
                     groupKey,
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'group-store',
             })
             return

--- a/nodejs/src/ingestion/common/ingestion-warnings.test.ts
+++ b/nodejs/src/ingestion/common/ingestion-warnings.test.ts
@@ -26,16 +26,15 @@ describe('captureIngestionWarning()', () => {
 
     it('can read own writes', async () => {
         await captureIngestionWarning(kafkaProducer, 2, {
-            type: 'some_type',
-            // severity inside details must lose to the structured field below
+            // registered as size/error in INGESTION_WARNING_TYPES
+            type: 'message_size_too_large',
+            // severity inside details must lose to the registry-derived field
             details: {
                 foo: 'bar',
                 distinctId: 'user-1',
                 personId: '019831c9-6491-7000-8000-000000000000',
                 severity: 'from-details',
             },
-            category: 'size',
-            severity: 'error',
             pipelineStep: 'emit-event',
         })
 
@@ -47,7 +46,7 @@ describe('captureIngestionWarning()', () => {
             expect.objectContaining({
                 team_id: 2,
                 source: 'plugin-server',
-                type: 'some_type',
+                type: 'message_size_too_large',
                 details: expect.any(String),
                 timestamp: expect.any(String),
                 _timestamp: expect.any(String),
@@ -75,7 +74,7 @@ describe('captureIngestionWarning()', () => {
         expect(v2Warnings).toEqual([
             {
                 team_id: 2,
-                type: 'some_type',
+                type: 'message_size_too_large',
                 category: 'size',
                 severity: 'error',
                 pipeline_step: 'emit-event',

--- a/nodejs/src/ingestion/common/ingestion-warnings.ts
+++ b/nodejs/src/ingestion/common/ingestion-warnings.ts
@@ -15,36 +15,90 @@ export const ingestionWarningCounter = new Counter({
     labelNames: ['type', 'emitted'],
 })
 
+export type IngestionWarningCategory = 'size' | 'merge' | 'event' | 'transformation' | 'replay'
+export type IngestionWarningSeverity = 'info' | 'warning' | 'error'
+
+/**
+ * Central registry of every ingestion warning type this service can emit.
+ * Category and severity are fixed attributes of the type, resolved here at
+ * serialization time so callsites cannot drift or forget them. Adding a new
+ * warning requires registering it here, which keeps the ClickHouse v2
+ * structured columns, the API filters, and agent-facing docs in sync.
+ *
+ * Severity convention: 'error' = the event (or message) was dropped,
+ * 'warning' = ingested but modified or partially rejected,
+ * 'info' = informational or an intentional, team-configured drop.
+ */
+export const INGESTION_WARNING_TYPES = {
+    // Size limits — payload or property blobs exceeding Kafka/Postgres limits
+    message_size_too_large: { category: 'size', severity: 'error' },
+    person_properties_size_violation: { category: 'size', severity: 'error' },
+    person_upsert_message_size_too_large: { category: 'size', severity: 'error' },
+    group_upsert_message_size_too_large: { category: 'size', severity: 'error' },
+    group_key_too_long: { category: 'size', severity: 'error' },
+
+    // Person merges — rejected $identify / $create_alias / $merge_dangerously operations
+    cannot_merge_already_identified: { category: 'merge', severity: 'warning' },
+    cannot_merge_with_illegal_distinct_id: { category: 'merge', severity: 'warning' },
+    merge_race_condition: { category: 'merge', severity: 'error' },
+
+    // Event validation — malformed or rejected event data
+    client_ingestion_warning: { category: 'event', severity: 'info' },
+    ignored_invalid_timestamp: { category: 'event', severity: 'warning' },
+    schema_validation_failed: { category: 'event', severity: 'error' },
+    skipping_event_invalid_distinct_id: { category: 'event', severity: 'error' },
+    invalid_ai_token_property: { category: 'event', severity: 'warning' },
+    invalid_process_person_profile: { category: 'event', severity: 'warning' },
+    invalid_event_when_process_person_profile_is_false: { category: 'event', severity: 'error' },
+    event_dropped_too_old: { category: 'event', severity: 'info' },
+
+    // Cookieless mode — events missing the data required to compute a cookieless distinct id
+    cookieless_missing_timestamp: { category: 'event', severity: 'error' },
+    cookieless_timestamp_out_of_range: { category: 'event', severity: 'error' },
+    cookieless_missing_user_agent: { category: 'event', severity: 'error' },
+    cookieless_missing_ip: { category: 'event', severity: 'error' },
+    cookieless_missing_host: { category: 'event', severity: 'error' },
+
+    // Heatmaps — rejected $heatmap_data payloads
+    invalid_heatmap_data: { category: 'event', severity: 'warning' },
+    rejecting_heatmap_data_with_invalid_url: { category: 'event', severity: 'warning' },
+    rejecting_heatmap_data_with_invalid_items: { category: 'event', severity: 'warning' },
+
+    // Error tracking — exception event processing
+    error_tracking_exception_processing_errors: { category: 'event', severity: 'warning' },
+
+    // Transformations — user-configured hog transformations
+    event_dropped_by_transformation: { category: 'transformation', severity: 'info' },
+
+    // Session replay — rejected or suspicious replay messages
+    replay_lib_version_too_old: { category: 'replay', severity: 'info' },
+    message_contained_no_valid_rrweb_events: { category: 'replay', severity: 'warning' },
+    message_timestamp_diff_too_large: { category: 'replay', severity: 'warning' },
+} as const satisfies Record<string, { category: IngestionWarningCategory; severity: IngestionWarningSeverity }>
+
+export type IngestionWarningType = keyof typeof INGESTION_WARNING_TYPES
+
 /**
  * Unified ingestion warning structure used across pipeline warnings and direct producer calls.
+ * Category and severity come from INGESTION_WARNING_TYPES; only the per-occurrence
+ * fields (pipelineStep, details) are set by callsites.
  */
 export interface IngestionWarning {
-    type: string
+    type: IngestionWarningType
     details: Record<string, any>
-    category?: string
-    severity?: 'info' | 'warning' | 'error'
     pipelineStep?: string
     key?: string
     alwaysSend?: boolean
 }
 
-/**
- * Structured warning fields for direct producer calls.
- * Subset of IngestionWarning focusing on enrichment metadata.
- */
-export interface StructuredWarningFields {
-    category?: string
-    severity?: 'info' | 'warning' | 'error'
-    pipelineStep?: string
-}
-
 function serializeIngestionWarning(teamId: TeamId, warning: IngestionWarning): string {
+    const { category, severity } = INGESTION_WARNING_TYPES[warning.type]
     // Structured fields are spread last so a stray key in details cannot override them.
     // ClickHouse v2 materializes columns from these exact key names (see sql_v2.py).
     const fullDetails = {
         ...warning.details,
-        ...(warning.category && { category: warning.category }),
-        ...(warning.severity && { severity: warning.severity }),
+        category,
+        severity,
         ...(warning.pipelineStep && { pipelineStep: warning.pipelineStep }),
     }
     return JSON.stringify({

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -730,8 +730,6 @@ describe('BatchWritingPersonStore', () => {
                 personId: person.uuid,
                 distinctId: 'test',
             },
-            category: 'size',
-            severity: 'error',
             pipelineStep: 'person-store',
         })
     })
@@ -915,8 +913,6 @@ describe('BatchWritingPersonStore', () => {
                         personId: person.uuid,
                         distinctId: 'test',
                     },
-                    category: 'size',
-                    severity: 'error',
                     pipelineStep: 'person-store',
                 })
                 expect(mockRepo.updatePerson).not.toHaveBeenCalled() // No fallback for MessageSizeTooLarge

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -796,8 +796,6 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                             teamId: update.team_id,
                             message: 'Person properties exceeds size limit and was rejected',
                         },
-                        category: 'size',
-                        severity: 'error',
                         pipelineStep: 'person-store',
                     })
                     personWriteMethodAttemptCounter.inc({
@@ -1006,8 +1004,6 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                     personId: update.uuid,
                     distinctId: update.distinct_id,
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'person-store',
             })
             personWriteMethodAttemptCounter.inc({
@@ -1027,8 +1023,6 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                     teamId: update.team_id,
                     message: 'Person properties exceeds size limit and was rejected',
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'person-store',
             })
             personWriteMethodAttemptCounter.inc({

--- a/nodejs/src/ingestion/common/persons/person-create-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.test.ts
@@ -146,8 +146,6 @@ describe('PersonCreateService', () => {
                     teamId: teamId,
                     message: 'Person properties exceeds size limit and was rejected',
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'person-store',
             })
         })

--- a/nodejs/src/ingestion/common/persons/person-create-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.ts
@@ -96,8 +96,6 @@ export class PersonCreateService {
                         eventUuid: creatorEventUuid,
                         message: 'Person properties exceeds size limit and was rejected',
                     },
-                    category: 'size',
-                    severity: 'error',
                     pipelineStep: 'person-store',
                 })
                 throw error

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -178,6 +178,7 @@ export class PersonMergeService {
                 details: {
                     illegalDistinctId: mergeIntoDistinctId,
                     otherDistinctId: otherPersonDistinctId,
+                    distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                 },
                 category: 'merge',
@@ -193,6 +194,7 @@ export class PersonMergeService {
                 details: {
                     illegalDistinctId: otherPersonDistinctId,
                     otherDistinctId: mergeIntoDistinctId,
+                    distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                 },
                 category: 'merge',
@@ -366,6 +368,7 @@ export class PersonMergeService {
                 details: {
                     sourcePersonDistinctId: otherPersonDistinctId,
                     targetPersonDistinctId: mergeIntoDistinctId,
+                    distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                     personId: mergeInto.uuid,
                     otherPersonId: otherPerson.uuid,
@@ -427,6 +430,7 @@ export class PersonMergeService {
                 details: {
                     sourcePersonDistinctId: otherPersonDistinctId,
                     targetPersonDistinctId: mergeIntoDistinctId,
+                    distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                     personId: mergeInto.uuid,
                     otherPersonId: otherPerson.uuid,

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -181,8 +181,6 @@ export class PersonMergeService {
                     distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                 },
-                category: 'merge',
-                severity: 'warning',
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
             })
@@ -197,8 +195,6 @@ export class PersonMergeService {
                     distinctId: mergeIntoDistinctId,
                     eventUuid: this.context.event.uuid,
                 },
-                category: 'merge',
-                severity: 'warning',
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
             })
@@ -373,8 +369,6 @@ export class PersonMergeService {
                     personId: mergeInto.uuid,
                     otherPersonId: otherPerson.uuid,
                 },
-                category: 'merge',
-                severity: 'warning',
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
             })
@@ -435,8 +429,6 @@ export class PersonMergeService {
                     personId: mergeInto.uuid,
                     otherPersonId: otherPerson.uuid,
                 },
-                category: 'merge',
-                severity: 'error',
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
             })

--- a/nodejs/src/ingestion/common/steps/event-processing/emit-event-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/emit-event-step.test.ts
@@ -136,8 +136,6 @@ describe('emit-event-step', () => {
                     distinctId: 'test-distinct-id',
                     personId: 'person-uuid',
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'emit-event',
             })
             // Metric should not be incremented when there's an error

--- a/nodejs/src/ingestion/common/steps/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/emit-event-step.ts
@@ -97,8 +97,6 @@ export function createEmitEventStep<O extends string, T extends EmitEventStepInp
                                 distinctId: serialized.distinct_id,
                                 personId: serialized.person_id,
                             },
-                            category: 'size',
-                            severity: 'error',
                             pipelineStep: 'emit-event',
                         })
                         // The event was not ingested, so there is no info to resolve with

--- a/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.test.ts
@@ -299,8 +299,6 @@ describe('flush-batch-stores-step', () => {
                     distinctId: 'user1',
                     step: 'flushBatchStoresStep',
                 },
-                category: 'size',
-                severity: 'error',
                 pipelineStep: 'flush',
             })
         })

--- a/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
@@ -157,8 +157,6 @@ function createProducePromises(personsStoreMessages: FlushResult[], outputs: Per
                                 distinctId: record.distinctId,
                                 step: 'flushBatchStoresStep',
                             },
-                            category: 'size',
-                            severity: 'error',
                             pipelineStep: 'flush',
                         })
                     } else {

--- a/nodejs/src/ingestion/common/steps/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/handle-client-ingestion-warning-step.ts
@@ -49,8 +49,6 @@ export function createHandleClientIngestionWarningStep<TInput extends HandleClie
                 distinctId: event.distinct_id,
                 message: event.properties?.$$client_ingestion_warning_message,
             },
-            category: 'event',
-            severity: 'info',
             pipelineStep: 'client-emit',
             alwaysSend: true,
         }).then((emitted) => (emitted ? ingestedInfo : null))

--- a/nodejs/src/ingestion/common/steps/event-processing/hog-transform-event-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/hog-transform-event-step.test.ts
@@ -80,8 +80,6 @@ describe('createHogTransformEventStep', () => {
                         transformationId: 'hog-fn-1',
                         transformationName: 'Drop internal users',
                     },
-                    category: 'transformation',
-                    severity: 'info',
                     pipelineStep: 'hog-transform',
                     key: 'hog-fn-1',
                 },

--- a/nodejs/src/ingestion/common/steps/event-processing/hog-transform-event-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/hog-transform-event-step.ts
@@ -47,8 +47,6 @@ export function createHogTransformEventStep<T extends HogTransformEventInput>(
                     transformationId: result.droppedBy?.id,
                     transformationName: result.droppedBy?.name,
                 },
-                category: 'transformation',
-                severity: 'info',
                 pipelineStep: 'hog-transform',
                 // Debounce per transformation so each dropping transformation surfaces
                 key: result.droppedBy?.id,

--- a/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.test.ts
@@ -180,7 +180,7 @@ describe('createPrepareEventStep', () => {
 
     it('should return timestamp parsing warnings as pipeline warnings', async () => {
         jest.mocked(parseEventTimestamp).mockImplementation((_event, callback) => {
-            callback?.('timestamp_in_the_future', { timestamp: '3000-01-01' })
+            callback?.('ignored_invalid_timestamp', { timestamp: '3000-01-01' })
             return DateTime.fromISO('2023-01-01T00:00:00.000Z')
         })
 
@@ -188,6 +188,6 @@ describe('createPrepareEventStep', () => {
         const result = await step(createInput())
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(result.warnings).toEqual([{ type: 'timestamp_in_the_future', details: { timestamp: '3000-01-01' } }])
+        expect(result.warnings).toEqual([{ type: 'ignored_invalid_timestamp', details: { timestamp: '3000-01-01' } }])
     })
 })

--- a/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prepare-event-step.ts
@@ -1,4 +1,5 @@
 import { sanitizeEventName } from '~/common/utils/db/utils'
+import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
 import { invalidTimestampCounter } from '~/ingestion/common/metrics'
 import { parseEventTimestamp } from '~/ingestion/common/timestamps'
 import { PipelineWarning } from '~/ingestion/framework/pipeline.interface'
@@ -29,7 +30,7 @@ export function createPrepareEventStep<TInput extends PrepareEventStepInput>(): 
         const { normalizedEvent, ...rest } = input
 
         const warnings: PipelineWarning[] = []
-        const invalidTimestampCallback = function (type: string, details: Record<string, any>) {
+        const invalidTimestampCallback = function (type: IngestionWarningType, details: Record<string, any>) {
             invalidTimestampCounter.labels(type).inc()
             warnings.push({ type, details })
         }

--- a/nodejs/src/ingestion/common/timestamps.ts
+++ b/nodejs/src/ingestion/common/timestamps.ts
@@ -1,8 +1,9 @@
 import { DateTime } from 'luxon'
 
+import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
 import { PluginEvent } from '~/plugin-scaffold'
 
-type IngestionWarningCallback = (type: string, details: Record<string, any>) => void
+type IngestionWarningCallback = (type: IngestionWarningType, details: Record<string, any>) => void
 
 /**
  * Parse event timestamp from plugin-server event data.

--- a/nodejs/src/ingestion/framework/base-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/base-batch-pipeline.test.ts
@@ -401,7 +401,7 @@ describe('BaseBatchPipeline', () => {
             const batch = createBatch(messages.map((message) => ({ message })))
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning = { type: 'test_warning', details: { message: 'step warning' } }
+            const stepWarning = { type: 'merge_race_condition', details: { message: 'step warning' } }
             const pipeline = new BaseBatchPipeline((items: any[]) => {
                 return Promise.resolve(items.map(() => ok({ processed: 'result' }, [], [stepWarning])))
             }, rootPipeline)
@@ -416,7 +416,7 @@ describe('BaseBatchPipeline', () => {
         it('should merge context warnings with step warnings', async () => {
             const messages: Message[] = [createTestMessage({ value: Buffer.from('test1'), offset: 1 })]
 
-            const contextWarning = { type: 'context_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
             const batch = [
                 createOkContext(
                     { message: messages[0] },
@@ -430,7 +430,7 @@ describe('BaseBatchPipeline', () => {
 
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning = { type: 'step_warning', details: { message: 'from step' } }
+            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
             const pipeline = new BaseBatchPipeline((items: any[]) => {
                 return Promise.resolve(items.map(() => ok({ processed: 'result' }, [], [stepWarning])))
             }, rootPipeline)
@@ -449,8 +449,8 @@ describe('BaseBatchPipeline', () => {
                 createTestMessage({ value: Buffer.from('item3'), offset: 3 }),
             ]
 
-            const contextWarning1 = { type: 'context_warning_1', details: { idx: 1 } }
-            const contextWarning2 = { type: 'context_warning_2', details: { idx: 2 } }
+            const contextWarning1 = { type: 'ignored_invalid_timestamp', details: { idx: 1 } }
+            const contextWarning2 = { type: 'invalid_heatmap_data', details: { idx: 2 } }
 
             const batch = [
                 createOkContext(
@@ -481,9 +481,9 @@ describe('BaseBatchPipeline', () => {
 
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning1 = { type: 'step_warning_1', details: { result: 1 } }
-            const stepWarning3a = { type: 'step_warning_3a', details: { result: 3 } }
-            const stepWarning3b = { type: 'step_warning_3b', details: { result: 3 } }
+            const stepWarning1 = { type: 'message_size_too_large', details: { result: 1 } }
+            const stepWarning3a = { type: 'group_key_too_long', details: { result: 3 } }
+            const stepWarning3b = { type: 'event_dropped_too_old', details: { result: 3 } }
             const pipeline = new BaseBatchPipeline((_: any[]) => {
                 return Promise.resolve([
                     ok({ processed: 'result1' }, [], [stepWarning1]),
@@ -513,7 +513,7 @@ describe('BaseBatchPipeline', () => {
                 createTestMessage({ value: Buffer.from('drop'), offset: 2 }),
             ]
 
-            const contextWarning = { type: 'context_warning', details: { message: 'existing' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'existing' } }
             const batch = [
                 createOkContext(
                     { message: messages[0] },

--- a/nodejs/src/ingestion/framework/base-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/base-batch-pipeline.test.ts
@@ -401,7 +401,7 @@ describe('BaseBatchPipeline', () => {
             const batch = createBatch(messages.map((message) => ({ message })))
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning = { type: 'merge_race_condition', details: { message: 'step warning' } }
+            const stepWarning = { type: 'merge_race_condition' as const, details: { message: 'step warning' } }
             const pipeline = new BaseBatchPipeline((items: any[]) => {
                 return Promise.resolve(items.map(() => ok({ processed: 'result' }, [], [stepWarning])))
             }, rootPipeline)
@@ -416,7 +416,7 @@ describe('BaseBatchPipeline', () => {
         it('should merge context warnings with step warnings', async () => {
             const messages: Message[] = [createTestMessage({ value: Buffer.from('test1'), offset: 1 })]
 
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'from context' } }
             const batch = [
                 createOkContext(
                     { message: messages[0] },
@@ -430,7 +430,7 @@ describe('BaseBatchPipeline', () => {
 
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
+            const stepWarning = { type: 'schema_validation_failed' as const, details: { message: 'from step' } }
             const pipeline = new BaseBatchPipeline((items: any[]) => {
                 return Promise.resolve(items.map(() => ok({ processed: 'result' }, [], [stepWarning])))
             }, rootPipeline)
@@ -449,8 +449,8 @@ describe('BaseBatchPipeline', () => {
                 createTestMessage({ value: Buffer.from('item3'), offset: 3 }),
             ]
 
-            const contextWarning1 = { type: 'ignored_invalid_timestamp', details: { idx: 1 } }
-            const contextWarning2 = { type: 'invalid_heatmap_data', details: { idx: 2 } }
+            const contextWarning1 = { type: 'ignored_invalid_timestamp' as const, details: { idx: 1 } }
+            const contextWarning2 = { type: 'invalid_heatmap_data' as const, details: { idx: 2 } }
 
             const batch = [
                 createOkContext(
@@ -481,9 +481,9 @@ describe('BaseBatchPipeline', () => {
 
             const rootPipeline = createNewBatchPipeline().build()
 
-            const stepWarning1 = { type: 'message_size_too_large', details: { result: 1 } }
-            const stepWarning3a = { type: 'group_key_too_long', details: { result: 3 } }
-            const stepWarning3b = { type: 'event_dropped_too_old', details: { result: 3 } }
+            const stepWarning1 = { type: 'message_size_too_large' as const, details: { result: 1 } }
+            const stepWarning3a = { type: 'group_key_too_long' as const, details: { result: 3 } }
+            const stepWarning3b = { type: 'event_dropped_too_old' as const, details: { result: 3 } }
             const pipeline = new BaseBatchPipeline((_: any[]) => {
                 return Promise.resolve([
                     ok({ processed: 'result1' }, [], [stepWarning1]),
@@ -513,7 +513,7 @@ describe('BaseBatchPipeline', () => {
                 createTestMessage({ value: Buffer.from('drop'), offset: 2 }),
             ]
 
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'existing' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'existing' } }
             const batch = [
                 createOkContext(
                     { message: messages[0] },

--- a/nodejs/src/ingestion/framework/branching-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/branching-pipeline.test.ts
@@ -95,7 +95,7 @@ describe('BranchingPipeline', () => {
             const branches = { a: branch }
 
             const existingSideEffect = Promise.resolve('existing')
-            const existingWarning = { type: 'client_ingestion_warning', details: {} }
+            const existingWarning = { type: 'client_ingestion_warning' as const, details: {} }
 
             const previousPipeline = new StartPipeline<{ type: string }, unknown>()
             const pipeline = new BranchingPipeline(decisionFn, branches, previousPipeline)
@@ -163,8 +163,8 @@ describe('BranchingPipeline', () => {
         it('should accumulate warnings from previous context and branch result', async () => {
             const decisionFn = (value: { type: string }) => value.type
 
-            const previousWarning = { type: 'schema_validation_failed', details: {} }
-            const branchWarning = { type: 'invalid_heatmap_data', details: {} }
+            const previousWarning = { type: 'schema_validation_failed' as const, details: {} }
+            const branchWarning = { type: 'invalid_heatmap_data' as const, details: {} }
 
             const branch = new StartPipeline<{ type: string }, unknown>().pipe((input) =>
                 Promise.resolve(ok({ result: input.type }, [], [branchWarning]))
@@ -186,13 +186,13 @@ describe('BranchingPipeline', () => {
             const decisionFn = (value: { type: string }) => value.type
 
             const inputSideEffect = Promise.resolve('input')
-            const inputWarning = { type: 'ignored_invalid_timestamp', details: {} }
+            const inputWarning = { type: 'ignored_invalid_timestamp' as const, details: {} }
 
             const previousSideEffect = Promise.resolve('previous')
-            const previousWarning = { type: 'schema_validation_failed', details: {} }
+            const previousWarning = { type: 'schema_validation_failed' as const, details: {} }
 
             const branchSideEffect = Promise.resolve('branch')
-            const branchWarning = { type: 'invalid_heatmap_data', details: {} }
+            const branchWarning = { type: 'invalid_heatmap_data' as const, details: {} }
 
             const branch = new StartPipeline<{ type: string }, unknown>().pipe((input) =>
                 Promise.resolve(ok({ result: input.type }, [branchSideEffect], [branchWarning]))

--- a/nodejs/src/ingestion/framework/branching-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/branching-pipeline.test.ts
@@ -95,7 +95,7 @@ describe('BranchingPipeline', () => {
             const branches = { a: branch }
 
             const existingSideEffect = Promise.resolve('existing')
-            const existingWarning = { type: 'test_warning', details: {} }
+            const existingWarning = { type: 'client_ingestion_warning', details: {} }
 
             const previousPipeline = new StartPipeline<{ type: string }, unknown>()
             const pipeline = new BranchingPipeline(decisionFn, branches, previousPipeline)
@@ -163,8 +163,8 @@ describe('BranchingPipeline', () => {
         it('should accumulate warnings from previous context and branch result', async () => {
             const decisionFn = (value: { type: string }) => value.type
 
-            const previousWarning = { type: 'previous_warning', details: {} }
-            const branchWarning = { type: 'branch_warning', details: {} }
+            const previousWarning = { type: 'schema_validation_failed', details: {} }
+            const branchWarning = { type: 'invalid_heatmap_data', details: {} }
 
             const branch = new StartPipeline<{ type: string }, unknown>().pipe((input) =>
                 Promise.resolve(ok({ result: input.type }, [], [branchWarning]))
@@ -186,13 +186,13 @@ describe('BranchingPipeline', () => {
             const decisionFn = (value: { type: string }) => value.type
 
             const inputSideEffect = Promise.resolve('input')
-            const inputWarning = { type: 'input_warning', details: {} }
+            const inputWarning = { type: 'ignored_invalid_timestamp', details: {} }
 
             const previousSideEffect = Promise.resolve('previous')
-            const previousWarning = { type: 'previous_warning', details: {} }
+            const previousWarning = { type: 'schema_validation_failed', details: {} }
 
             const branchSideEffect = Promise.resolve('branch')
-            const branchWarning = { type: 'branch_warning', details: {} }
+            const branchWarning = { type: 'invalid_heatmap_data', details: {} }
 
             const branch = new StartPipeline<{ type: string }, unknown>().pipe((input) =>
                 Promise.resolve(ok({ result: input.type }, [branchSideEffect], [branchWarning]))

--- a/nodejs/src/ingestion/framework/docs/09-ingestion-warnings.test.ts
+++ b/nodejs/src/ingestion/framework/docs/09-ingestion-warnings.test.ts
@@ -177,6 +177,7 @@ describe('Warning Basics', () => {
     it('a step can add multiple warnings', async () => {
         interface Event {
             name: string
+            timestamp?: string
             properties: Record<string, any>
         }
 
@@ -186,24 +187,26 @@ describe('Warning Basics', () => {
                     items.map((item) => {
                         const warnings: PipelineWarning[] = []
 
-                        if (item.name.length > 50) {
+                        const groupKey = item.properties['$group_key']
+                        if (groupKey && String(groupKey).length > 400) {
                             warnings.push({
                                 type: 'group_key_too_long',
-                                details: { length: item.name.length, max: 50 },
+                                details: { groupKey: String(groupKey).slice(0, 20), max: 400 },
                             })
                         }
 
-                        if (Object.keys(item.properties).length > 100) {
+                        if (item.timestamp && isNaN(Date.parse(item.timestamp))) {
                             warnings.push({
-                                type: 'person_properties_size_violation',
-                                details: { count: Object.keys(item.properties).length, max: 100 },
+                                type: 'ignored_invalid_timestamp',
+                                details: { value: item.timestamp },
                             })
                         }
 
-                        if (item.properties['$ip'] && typeof item.properties['$ip'] !== 'string') {
+                        const processPerson = item.properties['$process_person_profile']
+                        if (processPerson !== undefined && typeof processPerson !== 'boolean') {
                             warnings.push({
                                 type: 'invalid_process_person_profile',
-                                details: { received: typeof item.properties['$ip'] },
+                                details: { received: typeof processPerson },
                             })
                         }
 
@@ -219,21 +222,19 @@ describe('Warning Basics', () => {
             .build()
 
         // Create an event that triggers multiple warnings
-        const longName = 'a'.repeat(60)
-        const manyProperties: Record<string, any> = {}
-        for (let i = 0; i < 110; i++) {
-            manyProperties[`prop${i}`] = i
+        const properties: Record<string, any> = {
+            $group_key: 'g'.repeat(500),
+            $process_person_profile: 'yes', // Not a boolean
         }
-        manyProperties['$ip'] = 12345 // Wrong type
 
-        const batch = [createOkContext({ name: longName, properties: manyProperties }, { team })]
+        const batch = [createOkContext({ name: '$groupidentify', timestamp: 'not-a-date', properties }, { team })]
         pipeline.feed(batch)
 
         const results = await pipeline.next()
 
         expect(results![0].context.warnings).toHaveLength(3)
         expect(results![0].context.warnings.map((w) => w.type)).toContain('group_key_too_long')
-        expect(results![0].context.warnings.map((w) => w.type)).toContain('person_properties_size_violation')
+        expect(results![0].context.warnings.map((w) => w.type)).toContain('ignored_invalid_timestamp')
         expect(results![0].context.warnings.map((w) => w.type)).toContain('invalid_process_person_profile')
     })
 })

--- a/nodejs/src/ingestion/framework/docs/09-ingestion-warnings.test.ts
+++ b/nodejs/src/ingestion/framework/docs/09-ingestion-warnings.test.ts
@@ -20,18 +20,23 @@
  * 1. Steps add warnings to results using the third parameter of `ok()`
  * 2. Warnings accumulate through the pipeline in context
  * 3. `handleIngestionWarnings()` converts warnings to side effects
- * 4. Side effects send warnings to Kafka for display in the UI
+ * 4. Side effects send warnings to Kafka; category and severity are resolved
+ *    from `INGESTION_WARNING_TYPES` at serialization time
  *
  * ## Warning Structure
  *
  * ```typescript
  * interface PipelineWarning {
- *     type: string              // Warning category (e.g., 'missing_field')
+ *     type: IngestionWarningType    // Must be registered in INGESTION_WARNING_TYPES
+ *                                   // (ingestion/common/ingestion-warnings.ts)
  *     details: Record<string, any>  // Additional context
  *     key?: string              // Optional key for debouncing
  *     alwaysSend?: boolean      // Bypass debouncing for critical warnings
  * }
  * ```
+ *
+ * New warning types must be added to the registry first — the registry fixes the
+ * type's category and severity so every emission is consistently classified.
  *
  * ## Team Context Requirement
  *
@@ -74,7 +79,7 @@ describe('Warning Basics', () => {
 
                         if (!item.properties) {
                             warnings.push({
-                                type: 'missing_properties',
+                                type: 'schema_validation_failed',
                                 details: { eventName: item.name },
                             })
                         }
@@ -97,7 +102,7 @@ describe('Warning Basics', () => {
         expect(isOkResult(results![0].result)).toBe(true)
         expect(results![0].context.warnings).toHaveLength(1)
         expect(results![0].context.warnings[0]).toEqual({
-            type: 'missing_properties',
+            type: 'schema_validation_failed',
             details: { eventName: 'pageview' },
         })
     })
@@ -120,7 +125,7 @@ describe('Warning Basics', () => {
                         const warnings: PipelineWarning[] = []
                         if (!item.timestamp) {
                             warnings.push({
-                                type: 'missing_timestamp',
+                                type: 'ignored_invalid_timestamp',
                                 details: { eventName: item.name },
                             })
                         }
@@ -137,7 +142,7 @@ describe('Warning Basics', () => {
                         const warnings: PipelineWarning[] = []
                         if (!item.properties) {
                             warnings.push({
-                                type: 'missing_properties',
+                                type: 'schema_validation_failed',
                                 details: { eventName: item.name },
                             })
                         }
@@ -160,7 +165,10 @@ describe('Warning Basics', () => {
 
         // Both warnings from both steps are accumulated
         expect(results![0].context.warnings).toHaveLength(2)
-        expect(results![0].context.warnings.map((w) => w.type)).toEqual(['missing_timestamp', 'missing_properties'])
+        expect(results![0].context.warnings.map((w) => w.type)).toEqual([
+            'ignored_invalid_timestamp',
+            'schema_validation_failed',
+        ])
     })
 
     /**
@@ -180,21 +188,21 @@ describe('Warning Basics', () => {
 
                         if (item.name.length > 50) {
                             warnings.push({
-                                type: 'event_name_too_long',
+                                type: 'group_key_too_long',
                                 details: { length: item.name.length, max: 50 },
                             })
                         }
 
                         if (Object.keys(item.properties).length > 100) {
                             warnings.push({
-                                type: 'too_many_properties',
+                                type: 'person_properties_size_violation',
                                 details: { count: Object.keys(item.properties).length, max: 100 },
                             })
                         }
 
                         if (item.properties['$ip'] && typeof item.properties['$ip'] !== 'string') {
                             warnings.push({
-                                type: 'invalid_ip_type',
+                                type: 'invalid_process_person_profile',
                                 details: { received: typeof item.properties['$ip'] },
                             })
                         }
@@ -224,9 +232,9 @@ describe('Warning Basics', () => {
         const results = await pipeline.next()
 
         expect(results![0].context.warnings).toHaveLength(3)
-        expect(results![0].context.warnings.map((w) => w.type)).toContain('event_name_too_long')
-        expect(results![0].context.warnings.map((w) => w.type)).toContain('too_many_properties')
-        expect(results![0].context.warnings.map((w) => w.type)).toContain('invalid_ip_type')
+        expect(results![0].context.warnings.map((w) => w.type)).toContain('group_key_too_long')
+        expect(results![0].context.warnings.map((w) => w.type)).toContain('person_properties_size_violation')
+        expect(results![0].context.warnings.map((w) => w.type)).toContain('invalid_process_person_profile')
     })
 })
 
@@ -247,7 +255,9 @@ describe('Handling Ingestion Warnings', () => {
         function createWarningStep(): BatchProcessingStep<Event, Event> {
             return function warningStep(items) {
                 return Promise.resolve(
-                    items.map((item) => ok(item, [], [{ type: 'test_warning', details: { eventName: item.name } }]))
+                    items.map((item) =>
+                        ok(item, [], [{ type: 'client_ingestion_warning', details: { eventName: item.name } }])
+                    )
                 )
             }
         }
@@ -291,7 +301,7 @@ describe('Handling Ingestion Warnings', () => {
                 return Promise.resolve(
                     items.map((item) => {
                         const sideEffect = Promise.resolve().then(() => sideEffectLog.push(`processed: ${item.name}`))
-                        const warnings: PipelineWarning[] = [{ type: 'info', details: {} }]
+                        const warnings: PipelineWarning[] = [{ type: 'client_ingestion_warning', details: {} }]
                         return ok(item, [sideEffect], warnings)
                     })
                 )
@@ -338,7 +348,7 @@ describe('Warning Debouncing', () => {
                             [],
                             [
                                 {
-                                    type: 'user_rate_limited',
+                                    type: 'cannot_merge_already_identified',
                                     details: { distinctId: item.distinctId },
                                     key: item.distinctId, // Debounce by user
                                 },
@@ -358,7 +368,7 @@ describe('Warning Debouncing', () => {
         const results = await pipeline.next()
 
         expect(results![0].context.warnings[0]).toEqual({
-            type: 'user_rate_limited',
+            type: 'cannot_merge_already_identified',
             details: { distinctId: 'user-123' },
             key: 'user-123',
         })
@@ -382,7 +392,7 @@ describe('Warning Debouncing', () => {
                             [],
                             [
                                 {
-                                    type: 'quota_exceeded',
+                                    type: 'message_size_too_large',
                                     details: { eventName: item.name },
                                     key: 'quota',
                                     alwaysSend: true, // Always send, never debounce
@@ -403,7 +413,7 @@ describe('Warning Debouncing', () => {
         const results = await pipeline.next()
 
         expect(results![0].context.warnings[0]).toEqual({
-            type: 'quota_exceeded',
+            type: 'message_size_too_large',
             details: { eventName: 'important_event' },
             key: 'quota',
             alwaysSend: true,

--- a/nodejs/src/ingestion/framework/docs/12-filter-map.test.ts
+++ b/nodejs/src/ingestion/framework/docs/12-filter-map.test.ts
@@ -92,7 +92,7 @@ describe('Filter Map', () => {
                         const warnings: PipelineWarning[] = []
                         if (item.event.name === 'deprecated_event') {
                             warnings.push({
-                                type: 'deprecated_event',
+                                type: 'event_dropped_by_transformation',
                                 details: { eventName: item.event.name },
                             })
                         }
@@ -172,6 +172,6 @@ describe('Filter Map', () => {
         expect(mockWarningOutputs.queueMessages).toHaveBeenCalledTimes(1)
         expect(mockWarningOutputs.queueMessages.mock.calls[0][0]).toBe(INGESTION_WARNINGS_OUTPUT)
         const warningValue = mockWarningOutputs.queueMessages.mock.calls[0][1][0].value!.toString()
-        expect(warningValue).toContain('"type":"deprecated_event"')
+        expect(warningValue).toContain('"type":"event_dropped_by_transformation"')
     })
 })

--- a/nodejs/src/ingestion/framework/ingestion-warning-handling-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/ingestion-warning-handling-batch-pipeline.test.ts
@@ -138,8 +138,8 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                         message,
                         team,
                         warnings: [
-                            { type: 'test_warning', details: { field: 'value' } },
-                            { type: 'another_warning', details: { error: 'something' } },
+                            { type: 'client_ingestion_warning', details: { field: 'value' } },
+                            { type: 'ignored_invalid_timestamp', details: { error: 'something' } },
                         ],
                     }
                 ),
@@ -157,11 +157,11 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
 
             expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(2)
             expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, team.id, {
-                type: 'test_warning',
+                type: 'client_ingestion_warning',
                 details: { field: 'value' },
             })
             expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, team.id, {
-                type: 'another_warning',
+                type: 'ignored_invalid_timestamp',
                 details: { error: 'something' },
             })
         })
@@ -176,7 +176,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     {
                         message,
                         team,
-                        warnings: [{ type: 'critical_warning', details: { urgent: true }, alwaysSend: true }],
+                        warnings: [{ type: 'merge_race_condition', details: { urgent: true }, alwaysSend: true }],
                     }
                 ),
             ]
@@ -188,7 +188,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             const results = await pipeline.next()
 
             expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, team.id, {
-                type: 'critical_warning',
+                type: 'merge_race_condition',
                 details: { urgent: true },
                 alwaysSend: true,
             })
@@ -209,7 +209,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                         message,
                         team,
                         sideEffects: [existingSideEffect1, existingSideEffect2],
-                        warnings: [{ type: 'test_warning', details: { test: true } }],
+                        warnings: [{ type: 'client_ingestion_warning', details: { test: true } }],
                     }
                 ),
             ]
@@ -243,7 +243,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     {
                         message: messages[0],
                         team,
-                        warnings: [{ type: 'warning_1', details: { idx: 1 } }],
+                        warnings: [{ type: 'message_size_too_large', details: { idx: 1 } }],
                     }
                 ),
                 createOkContext(
@@ -260,8 +260,8 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                         message: messages[2],
                         team,
                         warnings: [
-                            { type: 'warning_3a', details: { idx: 3 } },
-                            { type: 'warning_3b', details: { idx: 3, extra: true } },
+                            { type: 'group_key_too_long', details: { idx: 3 } },
+                            { type: 'event_dropped_too_old', details: { idx: 3, extra: true } },
                         ],
                     }
                 ),
@@ -295,7 +295,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     {
                         message: messages[0],
                         team: team1,
-                        warnings: [{ type: 'warning_team1', details: { team: 1 } }],
+                        warnings: [{ type: 'cookieless_missing_ip', details: { team: 1 } }],
                     }
                 ),
                 createOkContext(
@@ -303,7 +303,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     {
                         message: messages[1],
                         team: team2,
-                        warnings: [{ type: 'warning_team2', details: { team: 2 } }],
+                        warnings: [{ type: 'cookieless_missing_host', details: { team: 2 } }],
                     }
                 ),
             ]
@@ -315,11 +315,11 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             await pipeline.next()
 
             expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, team1.id, {
-                type: 'warning_team1',
+                type: 'cookieless_missing_ip',
                 details: { team: 1 },
             })
             expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, team2.id, {
-                type: 'warning_team2',
+                type: 'cookieless_missing_host',
                 details: { team: 2 },
             })
         })
@@ -346,7 +346,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     createContext(ok({ message: messages[0], team }), {
                         message: messages[0],
                         team,
-                        warnings: [{ type: 'upstream_warning', details: { source: 'previous' } }],
+                        warnings: [{ type: 'schema_validation_failed', details: { source: 'previous' } }],
                     }),
                     createContext(ok({ message: messages[1], team }), {
                         message: messages[1],
@@ -356,7 +356,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     createContext(ok({ message: messages[2], team }), {
                         message: messages[2],
                         team,
-                        warnings: [{ type: 'another_upstream_warning', details: { source: 'previous' } }],
+                        warnings: [{ type: 'invalid_heatmap_data', details: { source: 'previous' } }],
                     }),
                 ]),
             }

--- a/nodejs/src/ingestion/framework/retrying-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/retrying-pipeline.test.ts
@@ -379,7 +379,7 @@ describe('RetryingPipeline', () => {
 
     describe('warning handling', () => {
         it('should preserve warnings from successful results', async () => {
-            const stepWarning = { type: 'test_warning', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 const value = input.message.value?.toString()
                 return Promise.resolve(ok({ processed: value }, [], [stepWarning]))
@@ -406,7 +406,7 @@ describe('RetryingPipeline', () => {
 
         it('should preserve warnings after retries succeed', async () => {
             let callCount = 0
-            const stepWarning = { type: 'test_warning', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 callCount++
                 if (callCount < 2) {
@@ -439,7 +439,7 @@ describe('RetryingPipeline', () => {
         })
 
         it('should preserve context warnings with DLQ results', async () => {
-            const contextWarning = { type: 'context_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
             const mockProcessStep = jest.fn().mockImplementation(async (_input: { message: Message }) => {
                 return Promise.resolve(dlq('DLQ reason', new Error('test error')))
             })
@@ -471,7 +471,7 @@ describe('RetryingPipeline', () => {
         })
 
         it('should preserve context warnings with non-retriable errors', async () => {
-            const contextWarning = { type: 'context_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
             const mockProcessStep = jest.fn().mockImplementation(async (_input: { message: Message }) => {
                 const error = new Error('Non-retriable error')
                 ;(error as any).isRetriable = false
@@ -505,8 +505,8 @@ describe('RetryingPipeline', () => {
         })
 
         it('should merge context and step warnings', async () => {
-            const contextWarning = { type: 'context_warning', details: { message: 'from context' } }
-            const stepWarning = { type: 'step_warning', details: { message: 'from step' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
+            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 const value = input.message.value?.toString()
                 return Promise.resolve(ok({ processed: value }, [], [stepWarning]))

--- a/nodejs/src/ingestion/framework/retrying-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/retrying-pipeline.test.ts
@@ -379,7 +379,7 @@ describe('RetryingPipeline', () => {
 
     describe('warning handling', () => {
         it('should preserve warnings from successful results', async () => {
-            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition' as const, details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 const value = input.message.value?.toString()
                 return Promise.resolve(ok({ processed: value }, [], [stepWarning]))
@@ -406,7 +406,7 @@ describe('RetryingPipeline', () => {
 
         it('should preserve warnings after retries succeed', async () => {
             let callCount = 0
-            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition' as const, details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 callCount++
                 if (callCount < 2) {
@@ -439,7 +439,7 @@ describe('RetryingPipeline', () => {
         })
 
         it('should preserve context warnings with DLQ results', async () => {
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'from context' } }
             const mockProcessStep = jest.fn().mockImplementation(async (_input: { message: Message }) => {
                 return Promise.resolve(dlq('DLQ reason', new Error('test error')))
             })
@@ -471,7 +471,7 @@ describe('RetryingPipeline', () => {
         })
 
         it('should preserve context warnings with non-retriable errors', async () => {
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'from context' } }
             const mockProcessStep = jest.fn().mockImplementation(async (_input: { message: Message }) => {
                 const error = new Error('Non-retriable error')
                 ;(error as any).isRetriable = false
@@ -505,8 +505,8 @@ describe('RetryingPipeline', () => {
         })
 
         it('should merge context and step warnings', async () => {
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
-            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'from context' } }
+            const stepWarning = { type: 'schema_validation_failed' as const, details: { message: 'from step' } }
             const mockProcessStep = jest.fn().mockImplementation(async (input: { message: Message }) => {
                 const value = input.message.value?.toString()
                 return Promise.resolve(ok({ processed: value }, [], [stepWarning]))

--- a/nodejs/src/ingestion/framework/step-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/step-pipeline.test.ts
@@ -271,7 +271,7 @@ describe('StepPipeline', () => {
         it('should accumulate warnings from step results', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition' as const, details: { message: 'from step' } }
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning]))
 
             const previous = new StartPipeline<{ data: string }, unknown>()
@@ -286,8 +286,8 @@ describe('StepPipeline', () => {
         it('should merge context warnings with step warnings', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
-            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
+            const contextWarning = { type: 'client_ingestion_warning' as const, details: { message: 'from context' } }
+            const stepWarning = { type: 'schema_validation_failed' as const, details: { message: 'from step' } }
 
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning]))
 
@@ -323,10 +323,10 @@ describe('StepPipeline', () => {
         it('should preserve order of warnings', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const contextWarning1 = { type: 'ignored_invalid_timestamp', details: { idx: 1 } }
-            const contextWarning2 = { type: 'invalid_heatmap_data', details: { idx: 2 } }
-            const stepWarning1 = { type: 'message_size_too_large', details: { idx: 3 } }
-            const stepWarning2 = { type: 'group_key_too_long', details: { idx: 4 } }
+            const contextWarning1 = { type: 'ignored_invalid_timestamp' as const, details: { idx: 1 } }
+            const contextWarning2 = { type: 'invalid_heatmap_data' as const, details: { idx: 2 } }
+            const stepWarning1 = { type: 'message_size_too_large' as const, details: { idx: 3 } }
+            const stepWarning2 = { type: 'group_key_too_long' as const, details: { idx: 4 } }
 
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning1, stepWarning2]))
 

--- a/nodejs/src/ingestion/framework/step-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/step-pipeline.test.ts
@@ -271,7 +271,7 @@ describe('StepPipeline', () => {
         it('should accumulate warnings from step results', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const stepWarning = { type: 'test_warning', details: { message: 'from step' } }
+            const stepWarning = { type: 'merge_race_condition', details: { message: 'from step' } }
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning]))
 
             const previous = new StartPipeline<{ data: string }, unknown>()
@@ -286,8 +286,8 @@ describe('StepPipeline', () => {
         it('should merge context warnings with step warnings', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const contextWarning = { type: 'context_warning', details: { message: 'from context' } }
-            const stepWarning = { type: 'step_warning', details: { message: 'from step' } }
+            const contextWarning = { type: 'client_ingestion_warning', details: { message: 'from context' } }
+            const stepWarning = { type: 'schema_validation_failed', details: { message: 'from step' } }
 
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning]))
 
@@ -323,10 +323,10 @@ describe('StepPipeline', () => {
         it('should preserve order of warnings', async () => {
             const message: Message = { value: Buffer.from('test'), topic: 'test', partition: 0, offset: 1 } as Message
 
-            const contextWarning1 = { type: 'context_warning_1', details: { idx: 1 } }
-            const contextWarning2 = { type: 'context_warning_2', details: { idx: 2 } }
-            const stepWarning1 = { type: 'step_warning_1', details: { idx: 3 } }
-            const stepWarning2 = { type: 'step_warning_2', details: { idx: 4 } }
+            const contextWarning1 = { type: 'ignored_invalid_timestamp', details: { idx: 1 } }
+            const contextWarning2 = { type: 'invalid_heatmap_data', details: { idx: 2 } }
+            const stepWarning1 = { type: 'message_size_too_large', details: { idx: 3 } }
+            const stepWarning2 = { type: 'group_key_too_long', details: { idx: 4 } }
 
             const step = jest.fn().mockResolvedValue(ok({ processed: 'result' }, [], [stepWarning1, stepWarning2]))
 

--- a/nodejs/src/ingestion/pipelines/errortracking/cymbal-processing-step.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/cymbal-processing-step.ts
@@ -1,4 +1,5 @@
 import { logger } from '~/common/utils/logger'
+import { IngestionWarningType } from '~/ingestion/common/ingestion-warnings'
 import { invalidTimestampCounter } from '~/ingestion/common/metrics'
 import { parseEventTimestamp } from '~/ingestion/common/timestamps'
 import { BatchProcessingStep } from '~/ingestion/framework/base-batch-pipeline'
@@ -23,7 +24,7 @@ export interface CymbalProcessingInput {
  */
 function validateEventTimestamp(event: PluginEvent): { timestamp: ISOTimestamp; warnings: PipelineWarning[] } {
     const warnings: PipelineWarning[] = []
-    const invalidTimestampCallback = function (type: string, details: Record<string, any>) {
+    const invalidTimestampCallback = function (type: IngestionWarningType, details: Record<string, any>) {
         invalidTimestampCounter.labels(type).inc()
         warnings.push({ type, details })
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.test.ts
@@ -905,6 +905,8 @@ describe('session-replay-pipeline', () => {
             expect(parseJSON(messageValue.details)).toEqual({
                 libVersion: '1.74.0',
                 parsedVersion: { major: 1, minor: 74 },
+                category: 'replay',
+                severity: 'info',
             })
         })
 


### PR DESCRIPTION
## Problem

Ingestion warning types were scattered string literals across ~20 files, each callsite responsible for remembering its own category and severity. In practice only the 8 directly-emitted types carried enrichment; the 18 types emitted through the pipeline framework's `warnings` arrays (cookieless, schema validation, heatmaps, replay, transformations, timestamps) landed in the v2 ClickHouse table unclassified as `unknown`/`warning`. Finding "all warning types" required a full repo sweep, and nothing stopped a new callsite from shipping a typo'd or unregistered type.

## Changes

- Adds `INGESTION_WARNING_TYPES` to `nodejs/src/ingestion/common/ingestion-warnings.ts` as the single source of truth: all 29 live warning types with a fixed category and severity, grouped by area, with a documented severity convention (`error` = dropped, `warning` = ingested but modified, `info` = informational or an intentional, team-configured drop).
- `IngestionWarning.type` is now the registry's key union, so emitting an unregistered type is a compile error; `serializeIngestionWarning` resolves category/severity from the registry, so framework-path warnings get classified in ClickHouse v2 for free.
- Callsites drop their per-callsite `category`/`severity` fields and only pass per-occurrence data (`details`, `pipelineStep`, `key`); the `StructuredWarningFields` interface is gone.
- Tightens the timestamp-warning callbacks and the cookieless warning variable from `string` to `IngestionWarningType`.
- Rewrites test fixtures that used made-up warning types to use registered ones, and updates the framework doc test to teach the registry requirement.
- Populates the `distinct_id` v2 column for merge warnings (cherry-picked).
- Adds an `adding-ingestion-warnings` skill (`.agents/skills/`) covering the registry workflow, the details keys ClickHouse v2 materializes, debouncing, and the downstream surfaces to keep in sync.

Rust is intentionally untouched: no Rust service produces ingestion warnings (capture only routes `$$client_ingestion_warning` events to Kafka); the skill documents what to mirror if one ever does.

> [!NOTE]
> Emitted data changes only for the previously-unenriched framework-path types, which gain `category`/`severity` keys in their details JSON (and therefore real values in the v2 structured columns instead of defaults). Directly-emitted types serialize byte-identically to before.

## How did you test this code?

- Typecheck (`tsgo`) is what enforces the registry — it's how the 18 unregistered types were found in the first place.
- Ran the full ingestion test scope (common steps/persons/groups/cookieless, framework, heatmaps, errortracking, sessionreplay): 3562 tests pass, including the `captureIngestionWarning` ClickHouse read-own-writes integration test, which now verifies registry-derived `category`/`severity` land in the v2 structured columns.
- Updated the replay lib-version test assertion to expect the new enrichment — that's the intended behavior change, and the test now guards it.
- No new tests: the registry is enforced at compile time, and existing integration tests cover serialization end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: /writing-tests, /writing-skills.
- The registry idea came from José after a manual sweep for "all warning types" kept missing emitters; the closed union then surfaced 18 live types the sweep had missed, plus one category mismatch (transformations ship `transformation`, not `pipeline`) before it changed emitted data.
- Framework test fixtures used descriptive fake types (`test_warning`, `warning_team1`); we mapped them onto real registered types rather than adding a test-only escape hatch, so the compile-time guarantee stays absolute.
- Severity assignments for the newly-registered types follow the dropped/modified/informational convention and are worth a close review — they're judgment calls encoded from each callsite's drop-vs-continue behavior.
