### PR TITLE
feat(workflows): surface email_bounce_prevented in the email metrics breakdown

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
@@ -90,6 +90,23 @@ export function WorkflowMetricsSummary({
                     ),
             },
             {
+                title: 'Bounce prevented',
+                dataIndex: 'bouncePrevented',
+                key: 'bouncePrevented',
+                align: 'right',
+                render: (_, row) =>
+                    onMetricClick && row.bouncePrevented > 0 ? (
+                        <span
+                            className="cursor-pointer text-link"
+                            onClick={() => onMetricClick('email_bounce_prevented')}
+                        >
+                            {row.bouncePrevented.toLocaleString()}
+                        </span>
+                    ) : (
+                        row.bouncePrevented.toLocaleString()
+                    ),
+            },
+            {
                 title: 'Blocked',
                 dataIndex: 'blocked',
                 key: 'blocked',

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -39,6 +39,7 @@ export type EmailMetric =
     | 'email_opened'
     | 'email_link_clicked'
     | 'email_bounced'
+    | 'email_bounce_prevented'
     | 'email_blocked'
     | 'email_spam'
 
@@ -50,6 +51,7 @@ export type EmailMetricRow = {
     opened: number
     linkClicked: number
     bounced: number
+    bouncePrevented: number
     blocked: number
 }
 
@@ -138,6 +140,13 @@ export const WORKFLOW_EMAIL_METRICS: Record<
         color: getColorVar('orange'),
         metricNames: ['email_bounced'],
     },
+    email_bounce_prevented: {
+        name: 'Bounce prevented',
+        description:
+            'Total number of emails that were not sent because pre-send validation predicted a hard bounce: the address was malformed or its domain has no mail servers. These sends are skipped before they can hurt deliverability and are not billed.',
+        color: getColorVar('purple'),
+        metricNames: ['email_bounce_prevented'],
+    },
     email_blocked: {
         name: 'Blocked',
         description: 'Total number of emails that were blocked by the recipient server',
@@ -158,6 +167,8 @@ export const WORKFLOW_EMAIL_METRICS: Record<
 // bounce to …"), so it surfaces every invocation that logged that failure in the timeframe.
 export const EMAIL_METRIC_LOG_FILTERS: Partial<Record<EmailMetric, { search: string; levels: LogEntryLevel[] }>> = {
     email_bounced: { search: 'bounce', levels: ['WARN', 'ERROR'] },
+    // MX-validation skips log "Skipping send: …" at INFO (see HogFunctionHandler in the plugin server).
+    email_bounce_prevented: { search: 'Skipping send', levels: ['INFO'] },
     email_blocked: { search: 'Complaint', levels: ['WARN', 'ERROR'] },
     // email_failed (RenderingFailure + Reject) is intentionally omitted: its two SES events emit
     // differently-worded messages ("Rendering failure …" vs "Message rejected by SES …") with no
@@ -195,6 +206,7 @@ const EMAIL_METRICS: EmailMetric[] = [
     'email_failed',
     'email_link_clicked',
     'email_bounced',
+    'email_bounce_prevented',
     'email_blocked',
     'email_spam',
 ]
@@ -471,6 +483,7 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                         opened: totals.email_opened ?? 0,
                         linkClicked: totals.email_link_clicked ?? 0,
                         bounced,
+                        bouncePrevented: totals.email_bounce_prevented ?? 0,
                         blocked,
                     }
                 }),


### PR DESCRIPTION
## Problem

The `email_bounce_prevented` app metric (emitted when pre-send email MX validation skips a predicted hard bounce) lands in `app_metrics2` but isn't in the workflow frontend's curated email metric lists. It only shows up as a raw name in the generic `metric_name` breakdown — no tile, no friendly label, no column in the per-email table, no drill-down to the skip logs.

## Changes

All driven from `workflowMetricsSummaryLogic.ts`, plus one new table column:

- Added `email_bounce_prevented` to the `EmailMetric` type, `WORKFLOW_EMAIL_METRICS` (label "Bounce prevented", purple, with a description explaining the skip is pre-send and unbilled), and the `EMAIL_METRICS` query list so totals/trends fetch it.
- Added a log drill-down entry in `EMAIL_METRIC_LOG_FILTERS` matching the `Skipping send` INFO log the skip writes, so clicking the tile/count jumps to the matching invocations.
- Added a "Bounce prevented" column to the per-email table in `WorkflowMetricsSummary.tsx` (between Bounced and Blocked), with the same click-to-drill-down pattern as Bounced, and the `bouncePrevented` field on `EmailMetricRow`.
- The per-action breakdown panel (`HogFlowEditorPanelMetrics`) and the email metric tiles/trends (`EmailMetricsSummary`) pick the metric up automatically since they iterate `WORKFLOW_EMAIL_METRICS`.

## How did you test this code?

Automated checks only — I did not verify against a running stack:

- Kea typegen ran clean; `tsgo --noEmit` reports zero errors under `products/workflows` (the repo-wide run has pre-existing errors elsewhere, untouched).
- oxlint and oxfmt clean on both changed files.
- Verified the drill-down search term and level against the log line the plugin-server skip path emits (`Skipping send: …` at INFO).

Note the tile/table will show real numbers wherever sends are actually skipped. During the current shadow-only phase nothing emits `email_bounce_prevented` yet, so surfaces render 0 until enforcement (PostHog/posthog#69179) is deployed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact — new metric surfaces in an existing metrics view.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a PostHog Code session (Claude), human-directed. Decisions:

- Based on master rather than stacking on PostHog/posthog#69179: the `email_bounce_prevented` app metric already exists on master (shipped with the original MX validation PR), so the frontend change is independently shippable.
- Placed the table column between Bounced and Blocked and reused the exact drill-down pattern of the Bounced column rather than inventing a new interaction.
- The log filter matches `Skipping send` at INFO because that is the literal prefix and level of the skip log entry in the hogflow email handler; the existing bounced/blocked filters use the same message-prefix convention.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*