### PR TITLE
fix(charts): stop quill legend descenders being clipped

### DIFF
--- a/packages/quill/packages/charts/src/components/Legend/Legend.stories.tsx
+++ b/packages/quill/packages/charts/src/components/Legend/Legend.stories.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 
 import { DAYS, SERIES } from '../../charts/time-series-fixtures'
 import { TimeSeriesBarChart } from '../../charts/TimeSeriesBarChart/TimeSeriesBarChart'
+import type { Series } from '../../core/types'
 import { Stage, useReactiveTheme } from '../../story-helpers'
 import { ChartLegend } from './ChartLegend'
 import { Legend, type LegendItem } from './Legend'
@@ -92,17 +93,19 @@ export const LongLabelsTruncate: Story = {
 function ChartLegendStory({
     show = true,
     position,
+    series = SERIES,
 }: {
     show?: boolean
     position: 'top' | 'bottom' | 'left' | 'right'
+    series?: Series[]
 }): JSX.Element {
     const theme = useReactiveTheme()
-    const items = useMemo(() => legendItemsFromSeries(SERIES, theme), [theme])
+    const items = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
     return (
         <Stage width={520} height={320}>
             <ChartLegend show={show} items={items} position={position}>
                 <TimeSeriesBarChart
-                    series={SERIES}
+                    series={series}
                     labels={DAYS}
                     theme={theme}
                     config={{ yAxis: { showGrid: true } }}
@@ -114,6 +117,24 @@ function ChartLegendStory({
 
 export const LayoutTop: Story = {
     render: () => <ChartLegendStory position="top" />,
+}
+
+// A single-series insight whose series name blows well past the legend's label cap — the row
+// truncates with an ellipsis (full text on the native `title` tooltip) instead of pushing the
+// chart around, and its descenders (g, p, y) render uncut at both positions.
+const LONG_NAME_SERIES: Series[] = [
+    {
+        key: 'long',
+        label: '$pageview · United States · Chrome · organic search · returning users grouped by signup cohort (last 30 days)',
+        data: [20, 35, 28, 60, 45, 70, 52],
+    },
+]
+
+export const LongSeriesNameTop: Story = {
+    render: () => <ChartLegendStory position="top" series={LONG_NAME_SERIES} />,
+}
+export const LongSeriesNameSide: Story = {
+    render: () => <ChartLegendStory position="right" series={LONG_NAME_SERIES} />,
 }
 export const LayoutBottom: Story = {
     render: () => <ChartLegendStory position="bottom" />,

--- a/packages/quill/packages/charts/src/components/Legend/Legend.tsx
+++ b/packages/quill/packages/charts/src/components/Legend/Legend.tsx
@@ -55,7 +55,9 @@ export function Legend({
         <div className={`flex ${layout} ${className ?? ''}`} data-attr={dataAttr}>
             {items.map((item) => {
                 const dimmed = hidden?.has(item.key) ? ' opacity-40' : ''
-                const rowClass = `inline-flex items-center gap-1.5 text-xs leading-none${dimmed}`
+                // leading-4 (not leading-none): the line box must contain descenders — the layout slot
+                // wrapping the legend is a scroll container, which clips glyphs that poke below the line box.
+                const rowClass = `inline-flex items-center gap-1.5 text-xs leading-4${dimmed}`
                 const inner = (
                     <>
                         <span


### PR DESCRIPTION
## Problem

The new quill chart legend clips the bottom of its labels when positioned at the top of a chart. Descenders (the tails of g, p, y) get sliced off, e.g. "signals", "reports", "(untagged)" all render with cut-off letters.

## Changes

Legend rows used `leading-none`, so the line box is exactly the font size and glyph descenders extend below it. The legend slot in `ChartLegendLayout` is a scroll container (`overflow-y-auto`), which turns that overhang into a hard clip at the container edge.

Switched the row line height to `leading-4` (1rem, the standard pairing for `text-xs`) so the line box contains the full glyphs. Applies to all legend positions and both orientations.

```diff
-const rowClass = `inline-flex items-center gap-1.5 text-xs leading-none${dimmed}`
+const rowClass = `inline-flex items-center gap-1.5 text-xs leading-4${dimmed}`
```

Each legend row gets 4px taller. No API or behavior changes.

## How did you test this code?

Ran the quill charts legend unit suites with jest (`Legend`, `ChartLegend`, `ChartLegendLayout`, `useChartLegend`, `legendItemsFromSeries`) - 33 tests, all passing. I did not manually verify the rendering in a browser, but the screenshot in the report shows classic descender clipping from a line box shorter than the glyphs, which this resolves by construction.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task) from a screenshot report of the clipped legend. Claude traced the clipping to the `leading-none` row class in `Legend.tsx` interacting with the `overflow-y-auto` legend slot in `ChartLegendLayout.tsx`, and chose to fix the line height rather than pad the scroll container, since a line box that can't contain its glyphs breaks under any clipping ancestor. Claude ran the legend jest suites to verify.
