### PR TITLE
feat(product-analytics): add data-attr to SQL quill charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlComboGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlComboGraph.tsx
@@ -33,6 +33,7 @@ export const SqlComboGraph = (props: LineGraphProps): JSX.Element => {
                     labels={model.labels}
                     theme={model.theme}
                     config={model.config}
+                    dataAttr="sql-combo-graph"
                     onError={handleChartError}
                 />
             )}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.tsx
@@ -70,6 +70,7 @@ export const SqlLineGraph = (props: LineGraphProps): JSX.Element => {
                     labels={model.labels}
                     theme={model.theme}
                     config={model.config}
+                    dataAttr="sql-line-graph"
                     tooltip={onPointClickProp ? renderTooltip : undefined}
                     onPointClick={onPointClickProp ? onPointClick : undefined}
                     onError={handleChartError}


### PR DESCRIPTION
## Problem

The SQL / DataViz line and combo charts rendered via `@posthog/quill-charts` (`SqlLineGraph`, `SqlComboGraph`, gated behind `product-analytics-quill-sql-charts`) render their container `<div>` with only Tailwind classes and no `data-attr`. That means there's no stable DOM hook to tell "a SQL chart is on screen" apart from other insight views like tables.

I hit this while setting up an in-app feedback survey that should only pop when a user is actually looking at a chart, not a table. The product analytics trends charts were easy to target because they already stamp `data-attr="trend-line-graph"` (via `TrendsLineChart`), but the SQL quill charts had nothing to match, so the survey couldn't fire on them.

## Changes

Pass a `dataAttr` to the two SQL quill chart components, reusing the `dataAttr` prop that `TimeSeriesLineChart` / `TimeSeriesComboChart` already accept and forward to the `ChartShell` wrapper's `data-attr`:

- `SqlLineGraph` → `data-attr="sql-line-graph"`
- `SqlComboGraph` → `data-attr="sql-combo-graph"`

This mirrors the existing `dataAttr="trend-line-graph"` convention on the product analytics trends charts. No behavior change beyond adding the attribute. The table view keeps its own `data-attr="insights-table-graph"`, so chart-vs-table targeting via CSS selector now works for SQL charts too.

## How did you test this code?

I (Claude) did not run the app or manually verify the rendered DOM. What I did:

- Typechecked the two edited files with `tsgo --noEmit` — no errors in them (the `dataAttr?: string` prop is already part of both quill chart component signatures).
- Linted both files with oxlint — 0 warnings, 0 errors.

Worth a reviewer eyeballing the running charts to confirm the `data-attr` lands on the expected wrapper element. No automated tests added: this is a one-line prop pass-through of an already-typed, already-tested prop, so a new test would only assert React forwards a prop, which the quill package's own tests already cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (PostHog Code / Claude Code) made the change. It started as survey-targeting work: I wanted an insights feedback survey that only appears on chart views, and noticed it was also showing on table views. Claude used an Explore subagent to trace how the trends charts expose `data-attr="trend-line-graph"` through `ChartShell`, found the SQL quill charts had no equivalent, and confirmed `TimeSeriesLineChart` / `TimeSeriesComboChart` already accept a `dataAttr` prop — so the fix is a prop pass-through rather than a new wrapper attribute. No repo skills were invoked. The survey selector on the PostHog side has already been widened to match `sql-line-graph` / `sql-combo-graph`; those only start matching once this deploys.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
