### PR TITLE
feat(cdp): add close crm destination template

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
@@ -1,0 +1,169 @@
+import { parseJSON } from '~/common/utils/json-parse'
+
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './close.template'
+
+const SEARCH_URL = 'https://api.close.com/api/v1/data/search/'
+const LEAD_URL = 'https://api.close.com/api/v1/lead/'
+
+const EXPECTED_HEADERS = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    Authorization: `Basic ${Buffer.from('API_KEY:').toString('base64')}`,
+}
+
+const EXPECTED_SEARCH_BODY = {
+    query: {
+        type: 'and',
+        queries: [
+            { type: 'object_type', object_type: 'contact' },
+            {
+                type: 'has_related',
+                this_object_type: 'contact',
+                related_object_type: 'contact_email',
+                related_query: {
+                    type: 'field_condition',
+                    field: { type: 'regular_field', object_type: 'contact_email', field_name: 'email' },
+                    condition: { type: 'text', mode: 'phrase', value: 'max@posthog.com' },
+                },
+            },
+        ],
+    },
+    _fields: { contact: ['id', 'lead_id'] },
+    _limit: 1,
+}
+
+describe('close template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    const defaultInputs = {
+        apiKey: 'API_KEY',
+        email: 'max@posthog.com',
+        leadName: 'PostHog',
+        properties: {
+            name: 'Max AI',
+            title: 'Hedgehog in Residence',
+        },
+        leadProperties: {},
+    }
+
+    const parseBody = (invocation: any): Record<string, any> => {
+        return parseJSON(invocation.queueParameters.body)
+    }
+
+    it('creates a lead when no contact matches', async () => {
+        const searchRequest = await tester.invoke(
+            { ...defaultInputs, leadProperties: { url: 'https://posthog.com' } },
+            {}
+        )
+
+        expect(searchRequest.error).toBeUndefined()
+        expect(searchRequest.finished).toBe(false)
+        const searchParams = searchRequest.invocation.queueParameters as any
+        expect(searchParams.url).toBe(SEARCH_URL)
+        expect(searchParams.method).toBe('POST')
+        expect(searchParams.headers).toEqual(EXPECTED_HEADERS)
+        expect(parseBody(searchRequest.invocation)).toEqual(EXPECTED_SEARCH_BODY)
+
+        const createRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [], cursor: null },
+        })
+
+        expect(createRequest.finished).toBe(false)
+        const createParams = createRequest.invocation.queueParameters as any
+        expect(createParams.url).toBe(LEAD_URL)
+        expect(createParams.method).toBe('POST')
+        expect(createParams.headers).toEqual(EXPECTED_HEADERS)
+        expect(parseBody(createRequest.invocation)).toEqual({
+            name: 'PostHog',
+            contacts: [
+                {
+                    emails: [{ email: 'max@posthog.com', type: 'office' }],
+                    name: 'Max AI',
+                    title: 'Hedgehog in Residence',
+                },
+            ],
+            url: 'https://posthog.com',
+        })
+
+        const done = await tester.invokeFetchResponse(createRequest.invocation, {
+            status: 200,
+            body: { id: 'lead_123' },
+        })
+        expect(done.error).toBeUndefined()
+        expect(done.finished).toBe(true)
+    })
+
+    it('updates the matched contact without touching its emails', async () => {
+        const searchRequest = await tester.invoke(defaultInputs, {
+            person: { properties: { $geoip_country_name: 'United States', plan: 'pay-as-you-go' } },
+        })
+
+        const updateRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [{ __object_type: 'contact', id: 'cont_123', lead_id: 'lead_456' }] },
+        })
+
+        expect(updateRequest.finished).toBe(false)
+        const updateParams = updateRequest.invocation.queueParameters as any
+        expect(updateParams.url).toBe('https://api.close.com/api/v1/contact/cont_123/')
+        expect(updateParams.method).toBe('PUT')
+        expect(updateParams.headers).toEqual(EXPECTED_HEADERS)
+        // only the explicitly mapped fields, and no "emails" key - a PUT would
+        // replace the contact's existing emails
+        expect(parseBody(updateRequest.invocation)).toEqual({
+            name: 'Max AI',
+            title: 'Hedgehog in Residence',
+        })
+
+        const done = await tester.invokeFetchResponse(updateRequest.invocation, {
+            status: 200,
+            body: { id: 'cont_123' },
+        })
+        expect(done.error).toBeUndefined()
+        expect(done.finished).toBe(true)
+    })
+
+    it('skips when email is empty', async () => {
+        const response = await tester.invoke({ ...defaultInputs, email: '' }, {})
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeFalsy()
+        expect(response.logs.some((log) => log.message.includes('No email set. Skipping...'))).toBe(true)
+    })
+
+    it('throws when the search request fails', async () => {
+        const searchRequest = await tester.invoke(defaultInputs, {})
+
+        const errorResponse = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 400,
+            body: { error: 'error' },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error from api.close.com (status 400)')
+    })
+
+    it('throws when the lead create request fails', async () => {
+        const searchRequest = await tester.invoke(defaultInputs, {})
+
+        const createRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [] },
+        })
+
+        const errorResponse = await tester.invokeFetchResponse(createRequest.invocation, {
+            status: 400,
+            body: { error: 'error' },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error from api.close.com (status 400)')
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
@@ -222,4 +222,21 @@ describe('close template', () => {
         expect(errorResponse.finished).toBe(true)
         expect(errorResponse.error).toMatch('Error from api.close.com (status 400)')
     })
+
+    it('throws when the contact update request fails', async () => {
+        const searchRequest = await tester.invoke(defaultInputs, {})
+
+        const updateRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [{ __object_type: 'contact', id: 'cont_123', lead_id: 'lead_456' }] },
+        })
+
+        const errorResponse = await tester.invokeFetchResponse(updateRequest.invocation, {
+            status: 400,
+            body: { error: 'error' },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error from api.close.com (status 400)')
+    })
 })

--- a/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/close/close.template.test.ts
@@ -44,8 +44,9 @@ describe('close template', () => {
         apiKey: 'API_KEY',
         email: 'max@posthog.com',
         leadName: 'PostHog',
+        firstName: 'Max',
+        lastName: 'AI',
         properties: {
-            name: 'Max AI',
             title: 'Hedgehog in Residence',
         },
         leadProperties: {},
@@ -127,6 +128,61 @@ describe('close template', () => {
         })
         expect(done.error).toBeUndefined()
         expect(done.finished).toBe(true)
+    })
+
+    it('omits name when both firstName and lastName are empty', async () => {
+        const searchRequest = await tester.invoke({ ...defaultInputs, firstName: '', lastName: '' }, {})
+
+        const createRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [] },
+        })
+
+        expect(parseBody(createRequest.invocation)).toEqual({
+            name: 'PostHog',
+            contacts: [
+                {
+                    emails: [{ email: 'max@posthog.com', type: 'office' }],
+                    title: 'Hedgehog in Residence',
+                },
+            ],
+        })
+    })
+
+    it('skips the PUT when a contact matches but there is nothing to update', async () => {
+        const searchRequest = await tester.invoke({ ...defaultInputs, firstName: '', lastName: '', properties: {} }, {})
+
+        const response = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [{ __object_type: 'contact', id: 'cont_123', lead_id: 'lead_456' }] },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeFalsy()
+        expect(response.logs.some((log) => log.message.includes('No contact fields to update. Skipping...'))).toBe(true)
+    })
+
+    it('JSON-stringifies object-valued property mappings', async () => {
+        const searchRequest = await tester.invoke(
+            {
+                ...defaultInputs,
+                properties: {
+                    title: 'Hedgehog in Residence',
+                    'custom.cf_addresses': [{ city: 'Berlin' }, { city: 'London' }],
+                },
+            },
+            {}
+        )
+
+        const createRequest = await tester.invokeFetchResponse(searchRequest.invocation, {
+            status: 200,
+            body: { data: [] },
+        })
+
+        const body = parseBody(createRequest.invocation)
+        expect(body.contacts[0]['custom.cf_addresses']).toBe('[{"city":"Berlin"},{"city":"London"}]')
+        expect(body.contacts[0].title).toBe('Hedgehog in Residence')
     })
 
     it('skips when email is empty', async () => {

--- a/nodejs/src/cdp/templates/_destinations/close/close.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/close/close.template.ts
@@ -1,0 +1,159 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    status: 'alpha',
+    free: false,
+    type: 'destination',
+    id: 'template-close',
+    name: 'Close',
+    description: 'Create and update leads in Close',
+    icon_url: '/static/services/close.png',
+    category: ['CRM', 'Customer Success'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.email)) {
+    print('No email set. Skipping...')
+    return
+}
+
+let headers := {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'Authorization': f'Basic {base64Encode(f'{inputs.apiKey}:')}',
+}
+
+let searchRes := fetch('https://api.close.com/api/v1/data/search/', {
+    'method': 'POST',
+    'headers': headers,
+    'body': {
+        'query': {
+            'type': 'and',
+            'queries': [
+                {'type': 'object_type', 'object_type': 'contact'},
+                {
+                    'type': 'has_related',
+                    'this_object_type': 'contact',
+                    'related_object_type': 'contact_email',
+                    'related_query': {
+                        'type': 'field_condition',
+                        'field': {'type': 'regular_field', 'object_type': 'contact_email', 'field_name': 'email'},
+                        'condition': {'type': 'text', 'mode': 'phrase', 'value': inputs.email}
+                    }
+                }
+            ]
+        },
+        '_fields': {'contact': ['id', 'lead_id']},
+        '_limit': 1
+    }
+})
+
+if (searchRes.status >= 400) {
+    throw Error(f'Error from api.close.com (status {searchRes.status}): {searchRes.body}')
+}
+
+let contactAttributes := {}
+
+for (let key, value in inputs.properties) {
+    if (not empty(value)) {
+        contactAttributes[key] := value
+    }
+}
+
+let res
+
+if (not empty(searchRes.body.data)) {
+    // Never send emails on update - PUT replaces the contact's whole emails array
+    res := fetch(f'https://api.close.com/api/v1/contact/{searchRes.body.data.1.id}/', {
+        'method': 'PUT',
+        'headers': headers,
+        'body': contactAttributes
+    })
+} else {
+    let contact := {
+        'emails': [{'email': inputs.email, 'type': 'office'}]
+    }
+    for (let key, value in contactAttributes) {
+        contact[key] := value
+    }
+    let lead := {
+        'name': inputs.leadName,
+        'contacts': [contact]
+    }
+    for (let key, value in inputs.leadProperties) {
+        if (not empty(value)) {
+            lead[key] := value
+        }
+    }
+    res := fetch('https://api.close.com/api/v1/lead/', {
+        'method': 'POST',
+        'headers': headers,
+        'body': lead
+    })
+}
+
+if (res.status >= 400) {
+    throw Error(f'Error from api.close.com (status {res.status}): {res.body}')
+}
+`,
+    inputs_schema: [
+        {
+            key: 'apiKey',
+            type: 'string',
+            label: 'Close API key',
+            description:
+                'You can create an API key in Settings > Developer > API keys: https://app.close.com/settings/developer/api-keys/',
+            secret: true,
+            required: true,
+        },
+        {
+            key: 'email',
+            type: 'string',
+            label: 'Email of the user',
+            description:
+                'Where to find the email of the contact. You can use the filters section to filter out unwanted emails or internal users.',
+            default: '{person.properties.email}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'leadName',
+            type: 'string',
+            label: 'Lead name',
+            description: 'Name of the lead (company) to create if no contact with this email exists yet.',
+            default: '{person.properties.company ?? person.properties.email}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'properties',
+            type: 'dictionary',
+            label: 'Contact field mapping',
+            description:
+                'Map of Close contact fields and their values. Note that Close only accepts valid contact fields (e.g. name, title, or custom.cf_FIELD_ID keys) - unknown fields may be rejected. Custom fields use the custom.cf_FIELD_ID format: https://developer.close.com/resources/custom-fields/',
+            default: {
+                name: "{f'{person.properties.first_name} {person.properties.last_name}' == ' ' ? null : f'{person.properties.first_name} {person.properties.last_name}'}",
+                title: '{person.properties.job_title}',
+            },
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'leadProperties',
+            type: 'dictionary',
+            label: 'Lead field mapping',
+            description:
+                'Map of Close lead fields and their values, only applied when a new lead is created (e.g. url or custom.cf_FIELD_ID keys).',
+            default: {},
+            secret: false,
+            required: false,
+        },
+    ],
+    filters: {
+        events: [
+            { id: '$identify', name: '$identify', type: 'events', order: 0 },
+            { id: '$set', name: '$set', type: 'events', order: 1 },
+        ],
+        actions: [],
+        filter_test_accounts: true,
+    },
+}

--- a/nodejs/src/cdp/templates/_destinations/close/close.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/close/close.template.ts
@@ -6,7 +6,8 @@ export const template: HogFunctionTemplate = {
     type: 'destination',
     id: 'template-close',
     name: 'Close',
-    description: 'Create and update leads in Close',
+    description:
+        'Sync PostHog persons to Close as contacts. Creates a new lead when no contact with the same email exists yet.',
     icon_url: '/static/services/close.png',
     category: ['CRM', 'Customer Success'],
     code_language: 'hog',
@@ -55,13 +56,26 @@ let contactAttributes := {}
 
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
-        contactAttributes[key] := value
+        if (typeof(value) in ('object', 'array', 'tuple')) {
+            contactAttributes[key] := jsonStringify(value)
+        } else {
+            contactAttributes[key] := value
+        }
     }
+}
+
+let fullName := trim(f'{inputs.firstName} {inputs.lastName}')
+if (not empty(fullName)) {
+    contactAttributes.name := fullName
 }
 
 let res
 
 if (not empty(searchRes.body.data)) {
+    if (empty(contactAttributes)) {
+        print('No contact fields to update. Skipping...')
+        return
+    }
     // Never send emails on update - PUT replaces the contact's whole emails array
     res := fetch(f'https://api.close.com/api/v1/contact/{searchRes.body.data.1.id}/', {
         'method': 'PUT',
@@ -125,13 +139,32 @@ if (res.status >= 400) {
             required: true,
         },
         {
+            key: 'firstName',
+            type: 'string',
+            label: 'First name',
+            description:
+                "First name of the contact. Combined with the last name and sent as Close's single `name` field; if both are empty the name is omitted.",
+            default: '{person.properties.first_name}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'lastName',
+            type: 'string',
+            label: 'Last name',
+            description:
+                "Last name of the contact. Combined with the first name and sent as Close's single `name` field; if both are empty the name is omitted.",
+            default: '{person.properties.last_name}',
+            secret: false,
+            required: false,
+        },
+        {
             key: 'properties',
             type: 'dictionary',
             label: 'Contact field mapping',
             description:
-                'Map of Close contact fields and their values. Note that Close only accepts valid contact fields (e.g. name, title, or custom.cf_FIELD_ID keys) - unknown fields may be rejected. Custom fields use the custom.cf_FIELD_ID format: https://developer.close.com/resources/custom-fields/',
+                'Map of Close contact fields and their values. Note that Close only accepts valid contact fields (e.g. title, or custom.cf_FIELD_ID keys) - unknown fields may be rejected. Custom fields use the custom.cf_FIELD_ID format: https://developer.close.com/resources/custom-fields/',
             default: {
-                name: "{f'{person.properties.first_name} {person.properties.last_name}' == ' ' ? null : f'{person.properties.first_name} {person.properties.last_name}'}",
                 title: '{person.properties.job_title}',
             },
             secret: false,

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -4,6 +4,7 @@ import { HogFunctionTemplate, NativeTemplate } from '../types'
 import { template as accoilTemplate } from './_destinations/accoil/accoil.template'
 import { template as appcuesTemplate } from './_destinations/appcues/appcues.template'
 import { template as clickupTemplate } from './_destinations/clickup/clickup.template'
+import { template as closeTemplate } from './_destinations/close/close.template'
 import { allComingSoonTemplates } from './_destinations/coming-soon/coming-soon-destinations.template'
 import { template as emailTemplate } from './_destinations/email/email.template'
 import { template as firebasePushTemplate } from './_destinations/firebase_push/firebase_push.template'
@@ -84,6 +85,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     appcuesTemplate,
     klimeTemplate,
     unifyTemplate,
+    closeTemplate,
 ]
 
 export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [


### PR DESCRIPTION
## Problem

The CDP has destination templates for HubSpot, Salesforce, Attio, and Intercom, but nothing for [Close](https://close.com) CRM. Teams using Close can't sync PostHog person data into their CRM without hand-rolling a webhook destination.

## Changes

<img width="1233" height="849" alt="Screenshot 2026-07-09 at 10 02 20" src="https://github.com/user-attachments/assets/0922dee6-c297-4aec-ae34-6246db93e833" />


Adds a `template-close` destination ("Create and update leads in Close") in the Node.js CDP templates tree (`nodejs/src/cdp/templates/_destinations/close/`), where new destination templates live:

- Searches Close for an existing contact by email via `POST /api/v1/data/search/` (the documented advanced filtering endpoint, since the legacy `GET /lead/?query=` param is no longer documented).
- If a contact matches, updates it via `PUT /api/v1/contact/{id}/`. The update body deliberately never includes `emails`, since a PUT replaces the contact's whole emails array.
- If nothing matches, creates a new lead with an embedded contact via `POST /api/v1/lead/`, with a configurable lead name and lead field mapping.
- Auth is HTTP Basic with the API key as username and empty password, per Close's docs (same Hog pattern as the accoil and Twilio templates).
- Inputs follow existing CRM template conventions: secret `apiKey`, `email`, plus contact and lead field mapping dictionaries. There is deliberately no "include all person properties" toggle - that pattern has caused problems in other destinations, so every field sent to Close must be mapped explicitly. Default filters are `$identify` and `$set` with test accounts filtered.
- Status is `alpha` while it's unproven against real Close accounts.

One deliberate deviation from the Intercom flow this is modeled on: on multiple matches we update the first match (`_limit: 1`) instead of throwing, because in Close the same email legitimately appears on multiple leads (a lead is a company), and throwing would produce chronic unactionable failures.

The `close.png` icon already existed in `frontend/public/services/` from the "coming soon" warehouse source listing, so no new asset. Registration is the standard two-line addition to `nodejs/src/cdp/templates/index.ts`.

## How did you test this code?

Automated tests only, all run locally and passing
tested locally

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Explored existing CRM templates, verified Close API docs via web fetch, then modeled the flow on the Intercom template (search then upsert) with API key auth like accoil.
- Skills invoked: `/writing-tests` before authoring the test file.
- Decisions: a first version was written as a Python template under `posthog/cdp/templates/`, then reworked into the Node.js templates tree at Meikel's direction since that's where new destinations go. An "include all person properties" toggle from the Intercom pattern was removed at Meikel's direction (it has been a recurring source of problems); the status was set to alpha likewise. Chose the advanced filtering endpoint over the undocumented legacy lead query param, searched contacts rather than leads so one call returns both contact id and lead id, and update-first-match instead of Intercom's throw-on-multiple (rationale above). A second event-logging template (Close custom activities) was considered and left out since custom activities need per-org activity type IDs, which adds setup friction.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
