### PR TITLE
feat(integrations): capture integration created event

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -429,7 +429,13 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                 self.context["request"].user, self.context["get_team"]()
             ):
                 raise PermissionDenied("Editing an existing integration requires project admin access.")
-            return instance
+        report_user_action(
+            self.context["request"].user,
+            "integration created",
+            {"integration_kind": kind, "is_overwrite": is_overwrite},
+            team=self.context["get_team"](),
+        )
+        return instance
 
     def _build_integration(self, validated_data: Any) -> Any:
         request = self.context["request"]


### PR DESCRIPTION
## Problem

The onboarding wizard cloud run experiment needs to measure drop-off at the GitHub connect step, but nothing is captured when a user successfully connects an integration. The only integration analytics event today is `integration access requested`. Users who bounce between clicking "Connect GitHub" and coming back with a working integration are invisible in the funnel.

## Changes

Captures a server-side `integration created` event (via `report_user_action`) in `IntegrationSerializer.create`, after the upsert transaction commits. Properties:

- `integration_kind` - e.g. `github`, `slack`
- `is_overwrite` - whether the POST replaced an existing integration or added a new one

Server-side because the GitHub App install is a full-page redirect. A frontend capture on return can be lost to navigation, while this fires on the exact POST that lands the connect. It also covers every integration kind and surface for free.

## How did you test this code?

Existing integration API tests cover the create path. No behavior change beyond the analytics capture, verified with ruff and Pyright locally. I did not add a test for the capture itself since it would only assert the mock was called.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal analytics only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Invoked /improving-drf-endpoints before touching the serializer (no schema changes needed, the change is capture-only). Chose a backend event over a frontend capture on redirect-return because it cannot be lost to navigation and covers all integration kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)