### PR TITLE
fix(data-viz): preserve negative values in quill stacked bar charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2652,6 +2652,18 @@ snapshots:
         hash: v1.k794b7964.69538e1bccbe3b3af6c49373f9a2abd97496e99821332a2add8b4e4355ef8391.7apb3z0jtmMkQKPLPIzojr8sJA0pirbAD7S0if_coeU
     insights-retentionlinechart--realistic-curve--light:
         hash: v1.k794b7964.a676a22c376a69efc58f71bc328ddccb3d16e34f8d5b833d2a74ddf3db70d482.34ys4jWcmKwIvZ07aOeBLI8RTRbepooFqJUzMytMHb0
+    insights-sqlbargraph--grouped-bar-with-negative-values--dark:
+        hash: v1.k794b7964.96661956bfb88def6ac0978969ec4bb3187c27d740ac267aa7c003d5dc88d98f.kSlPtFZQ4s2I7ssZRA0qLUthG4IpVsO1yPjXlnE5vhM
+    insights-sqlbargraph--grouped-bar-with-negative-values--light:
+        hash: v1.k794b7964.b235c2b03f5cebfcc9e0344ad4c3d09057e47a8913a0cd958570e39417bff572.nT_3Icz6F0NMqQg0Y3RD5uqZj8q5e-gYR-IJmsLoDzE
+    insights-sqlbargraph--stacked-bar--dark:
+        hash: v1.k794b7964.455dd9370e551548a689c548c9f80f4cb8f909a9a37a744e90c8b1803bc318b8.ObBczeEAiHxme10OUevCul7_Uefq2pbjOJFcYglOdA0
+    insights-sqlbargraph--stacked-bar--light:
+        hash: v1.k794b7964.6b8dbb66da73ce0719af51d0b035072af88aaab3f8575028b70f0c925bc6b82b.wTqMYDh4pIYJdWHmhKcd5eRZazowSX9o58X-Znp1VuY
+    insights-sqlbargraph--stacked-bar-with-negative-values--dark:
+        hash: v1.k794b7964.f1d4f08820b41780902ccf0a56d5b05315b6ae420da662caa4d621d6eb5a9e2f.9nCqJx4hFHmL-fWYrrC0FBI65AU9Q4-C41iymlMKZHk
+    insights-sqlbargraph--stacked-bar-with-negative-values--light:
+        hash: v1.k794b7964.013320c042e09c007de0763de69835764030d60201eb747b42fa4a737398e7c9.vNmEaCqqYeN4wXeu19Sg26CTTSMs2q4yH3fHfBqPSNg
     insights-sqlpiegraph--breakdown-colors--dark:
         hash: v1.k794b7964.459b2f2dad813b806560c40f292c41503482dcc864756aa5c27e936ef6ad5890.35VUrVQBDx9LxDWhN1L1896BV62m-OhK3d4ujQHrU5o
     insights-sqlpiegraph--breakdown-colors--light:

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.stories.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.stories.tsx
@@ -1,0 +1,92 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { ReactNode } from 'react'
+
+import { ChartSettings } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import { AxisSeries } from '../../dataVisualizationLogic'
+import { LineGraphProps } from './LineGraph'
+import { SqlBarGraph } from './SqlBarGraph'
+
+const meta: Meta<typeof SqlBarGraph> = {
+    title: 'Insights/SqlBarGraph',
+    component: SqlBarGraph,
+    parameters: {
+        layout: 'centered',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof SqlBarGraph>
+
+const xData: AxisSeries<string> = {
+    column: { name: 'month', type: { name: 'STRING', isNumerical: false }, label: 'month', dataIndex: 0 },
+    data: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+}
+
+const numericSeries = (name: string, dataIndex: number, data: (number | null)[]): AxisSeries<number | null> => ({
+    column: { name, type: { name: 'INTEGER', isNumerical: true }, label: name, dataIndex },
+    data,
+    settings: {},
+})
+
+const positiveSeries: AxisSeries<number | null>[] = [
+    numericSeries('signups', 1, [420, 380, 510, 460, 550]),
+    numericSeries('upgrades', 2, [120, 140, 90, 160, 130]),
+]
+
+// Mixed-sign series, including a month (Mar) where the negatives outweigh the positives so the
+// stack's net total dips below the baseline.
+const mixedSignSeries: AxisSeries<number | null>[] = [
+    numericSeries('new_mrr', 1, [400, 250, 300, 220, 280]),
+    numericSeries('churned_mrr', 2, [-120, -180, -350, -80, -300]),
+]
+
+// SqlBarGraph fills its flex parent, so the story needs a column container with a definite height —
+// otherwise the chart resolves to height 0 and quill paints a 0-size canvas (mirrors SqlPieGraph).
+function Stage({ children }: { children: ReactNode }): JSX.Element {
+    // eslint-disable-next-line react/forbid-dom-props
+    return <div style={{ height: 420, width: 760, display: 'flex', flexDirection: 'column' }}>{children}</div>
+}
+
+const render = (props: LineGraphProps): JSX.Element => (
+    <Stage>
+        <SqlBarGraph {...props} />
+    </Stage>
+)
+
+const baseSettings: ChartSettings = { showLegend: true }
+
+export const StackedBar: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: positiveSeries,
+            visualizationType: ChartDisplayType.ActionsStackedBar,
+            chartSettings: baseSettings,
+        }),
+}
+
+/** Stacked bars with negative values render below the zero baseline (diverging stack) instead of
+ *  being clamped to 0 — guards the regression fixed by wiring `divergingStack` through
+ *  `buildBarChartConfig`. */
+export const StackedBarWithNegativeValues: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: mixedSignSeries,
+            visualizationType: ChartDisplayType.ActionsStackedBar,
+            chartSettings: baseSettings,
+        }),
+}
+
+export const GroupedBarWithNegativeValues: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: mixedSignSeries,
+            visualizationType: ChartDisplayType.ActionsBar,
+            chartSettings: baseSettings,
+        }),
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -746,8 +746,18 @@ describe('sqlLineGraphAdapter', () => {
         })
 
         it.each<[string, ChartDisplayType, ChartSettings, boolean]>([
-            ['enables divergingStack for stacked bars so negatives render below zero', ChartDisplayType.ActionsStackedBar, {}, true],
-            ['disables divergingStack for percent-stacked bars', ChartDisplayType.ActionsStackedBar, { stackBars100: true }, false],
+            [
+                'enables divergingStack for stacked bars so negatives render below zero',
+                ChartDisplayType.ActionsStackedBar,
+                {},
+                true,
+            ],
+            [
+                'disables divergingStack for percent-stacked bars',
+                ChartDisplayType.ActionsStackedBar,
+                { stackBars100: true },
+                false,
+            ],
             ['disables divergingStack for grouped bars', ChartDisplayType.ActionsBar, {}, false],
         ])('%s', (_name, visualizationType, chartSettings, expected) => {
             const config = buildBarChartConfig({

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -745,6 +745,21 @@ describe('sqlLineGraphAdapter', () => {
             expect((config.yAxis as YAxisConfig)?.scale).toBe('linear')
         })
 
+        it.each<[string, ChartDisplayType, ChartSettings, boolean]>([
+            ['enables divergingStack for stacked bars so negatives render below zero', ChartDisplayType.ActionsStackedBar, {}, true],
+            ['disables divergingStack for percent-stacked bars', ChartDisplayType.ActionsStackedBar, { stackBars100: true }, false],
+            ['disables divergingStack for grouped bars', ChartDisplayType.ActionsBar, {}, false],
+        ])('%s', (_name, visualizationType, chartSettings, expected) => {
+            const config = buildBarChartConfig({
+                xData: dateXData,
+                chartSettings,
+                timezone: 'UTC',
+                visualizationType,
+                ySeriesData: [ySeries('a', [1, -2])],
+            })
+            expect(config.divergingStack).toBe(expected)
+        })
+
         it('formats y-axis ticks with the first series column settings for plain bars', () => {
             const config = buildBarChartConfig({
                 xData: dateXData,

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -471,6 +471,9 @@ export function buildBarChartConfig({
         goalLines: schemaGoalLinesToConfigs(goalLines),
         showAxisLines: buildAxisLinesConfig(chartSettings),
         barLayout,
+        // Stacked bars must preserve negative values (SQL results can be negative) so they render
+        // below the zero baseline instead of being clamped to 0. Only the stacked layout stacks.
+        divergingStack: barLayout === 'stacked',
         // Percent bars scale against a [0, 1] domain; trend lines plot raw series values, so they'd
         // render off-scale and invisible.
         trendLines: barLayout === 'percent' ? [] : buildTrendLineConfigs(ySeriesData),


### PR DESCRIPTION
## Problem

Part of the quill SQL charts rollout (`product-analytics-quill-sql-charts`). With the flag on, a SQL insight displayed as a stacked bar chart silently clamps every negative value to zero, so bars that should extend below the baseline just disappear. The legacy Chart.js renderer stacked negatives below zero natively, so this is a regression against what users had.

Root cause: quill's `BarChart` builds stacked bands with `computeStackData`, which clamps each value with `Math.max(0, raw)` unless the chart opts into `divergingStack` (d3's `stackOffsetDiverging`). The SQL adapter's `buildBarChartConfig` never set that flag. Product analytics hit the same thing and already opts in via `TrendsBarChart`.

## Changes

- `buildBarChartConfig` now sets `divergingStack: barLayout === 'stacked'`, matching the `TrendsBarChart` behavior. Positives stack up from zero, negatives stack down.
- Percent-stacked and grouped layouts are unchanged (`divergingStack` only applies to the stacked layout, and quill ignores it otherwise).

> [!NOTE]
> The combo chart path (`SqlComboGraph`, mixed bar + line series) still clamps negatives in stacked mode – quill's `ComboChart` has no diverging option at all today. That needs a quill-side change and is not covered here.

## How did you test this code?

Added `it.each` cases to `sqlLineGraphAdapter.test.ts` asserting `divergingStack` is true for stacked bars and false for percent-stacked and grouped, which fails without the fix. Ran the full `sqlLineGraphAdapter.test.ts` (134 passed) and `SqlBarGraph.test.tsx` (11 passed) locally. I did not manually verify in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam reported that stacked bar charts stopped showing negative values during the quill SQL chart rollout and asked why. I (Claude, via PostHog Code) traced it from the flag gating in `LineGraph.tsx` through `SqlBarGraph` into quill's `buildStackData`, found the `Math.max(0, raw)` clamp behind the missing `divergingStack` flag, and applied the same fix trends already uses. Considered gating on whether the data actually contains negatives, but rejected it – trends enables diverging unconditionally for stacked layouts and the offset is a no-op for all-positive data.
