### PR TITLE
chore(tasks): remove agent-server --autoPublish support probe

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -927,10 +927,6 @@ class DockerSandbox(SandboxBase):
         if relayed_mcp_servers:
             relay_mcp_servers_arg = f" --relayMcpServers {shlex.quote(json.dumps(relayed_mcp_servers))}"
 
-        if auto_publish and not self.agent_server_supports_auto_publish():
-            logger.warning(f"Installed agent-server in sandbox {self.id} predates --autoPublish; starting review-first")
-            auto_publish = False
-
         command = self._build_agent_server_command(
             repo_path,
             task_id,

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -1107,10 +1107,6 @@ class ModalSandbox(SandboxBase):
         if relayed_mcp_servers:
             relay_mcp_servers_arg = f" --relayMcpServers {shlex.quote(json.dumps(relayed_mcp_servers))}"
 
-        if auto_publish and not self.agent_server_supports_auto_publish():
-            logger.warning(f"Installed agent-server in sandbox {self.id} predates --autoPublish; starting review-first")
-            auto_publish = False
-
         command = self._build_agent_server_command(
             repo_path,
             task_id,

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -243,13 +243,6 @@ class SandboxBase(ABC):
             timeout_seconds=45,
         )
 
-    def agent_server_supports_auto_publish(self) -> bool:
-        """Sandboxes restored from old snapshots can carry an agent-server that rejects unknown
-        CLI options, so probe the installed binary before passing --autoPublish; unsupported
-        binaries degrade to review-first instead of crashing at launch."""
-        result = self.execute("grep -q autoPublish /scripts/node_modules/.bin/agent-server", timeout_seconds=10)
-        return result.exit_code == 0
-
     def clone_repository(
         self,
         repository: str,

--- a/products/tasks/backend/tests/test_agentsh.py
+++ b/products/tasks/backend/tests/test_agentsh.py
@@ -323,58 +323,6 @@ class TestModalSandboxAgentShWrapping(TestCase):
         else:
             self.assertNotIn("--autoPublish", cmd)
 
-    @parameterized.expand(
-        [
-            ("modal", True),
-            ("modal", False),
-            ("docker", True),
-            ("docker", False),
-        ]
-    )
-    def test_start_agent_server_drops_auto_publish_when_binary_lacks_support(self, provider, supported):
-        from products.tasks.backend.logic.services.docker_sandbox import DockerSandbox
-        from products.tasks.backend.logic.services.modal_sandbox import ModalSandbox
-        from products.tasks.backend.logic.services.sandbox import ExecutionResult
-
-        # Snapshots restored from old images carry an agent-server that rejects unknown
-        # options; the launch probe must drop --autoPublish instead of crashing the run.
-        launched: list[str] = []
-
-        def execute(command: str, timeout_seconds: int | None = None) -> ExecutionResult:
-            if "--taskId" in command:
-                launched.append(command)
-                return ExecutionResult(stdout="", stderr="", exit_code=0)
-            self.assertIn("grep", command)
-            return ExecutionResult(stdout="", stderr="", exit_code=0 if supported else 1)
-
-        sandbox: ModalSandbox | DockerSandbox
-        if provider == "modal":
-            sandbox = ModalSandbox.__new__(ModalSandbox)
-        else:
-            sandbox = DockerSandbox.__new__(DockerSandbox)
-            sandbox._host_port = 8080
-        sandbox.id = "sb-test"
-        cast_sandbox: Any = sandbox
-        cast_sandbox.is_running = Mock(return_value=True)
-        cast_sandbox._agent_server_is_healthy = Mock(return_value=False)
-        cast_sandbox._free_agent_server_port = Mock()
-        cast_sandbox.write_file = Mock()
-        cast_sandbox.execute = execute
-
-        sandbox.start_agent_server(
-            repository="org/repo",
-            task_id="test-task",
-            run_id="test-run",
-            auto_publish=True,
-            wait_for_health=False,
-        )
-
-        self.assertEqual(len(launched), 1)
-        if supported:
-            self.assertIn("--autoPublish true", launched[0])
-        else:
-            self.assertNotIn("--autoPublish", launched[0])
-
     def test_command_includes_allowed_domains(self):
         from products.tasks.backend.logic.services.modal_sandbox import ModalSandbox
 


### PR DESCRIPTION
## Problem

#68864 added a launch-time probe (a `grep` on the installed agent-server binary) that drops `--autoPublish` when a sandbox restored from an old snapshot carries a binary predating the option, so those runs degrade to review-first instead of failing with `unknown option '--autoPublish'`.

That protection is transitional. Once snapshots taken before `@posthog/agent` 2.3.1306 (published 2026-07-07) have aged out of task-resume and repo-cache reuse, every binary a sandbox can launch accepts the flag, and the probe is one wasted exec per opted-in launch.

> [!NOTE]
> Hold this until roughly a week after #68864 shipped (so ~2026-07-15). Merging early re-arms the launch crash for opted-in runs restored from pre-2026-07-07 snapshots.

## Changes

- Remove `agent_server_supports_auto_publish()` from `SandboxBase` and its call sites in `DockerSandbox.start_agent_server` and `ModalSandbox.start_agent_server`.
- Remove the probe's regression test. The remaining `test_command_includes_auto_publish_flag_only_when_opted_in` still guards the flag emission itself.

## How did you test this code?

Pure removal, the exact inverse of the probe commit from #68864 (67 deletions, no additions). Ruff clean; the existing auto-publish flag tests are unchanged and run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at the driver's request as a scheduled follow-up to #68864. No design decisions beyond inverting the probe commit; rebuilt on master after #68864 squash-merged.