### PR TITLE
fix(mcp): stop execute-sql prompt claiming system.dashboards has last_modified_at

### DIFF
--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -123,13 +123,13 @@ ORDER BY timestamp
 <example>
 User: Do we have any insights tracking revenue or payments?
 Assistant: I'll search existing insights and dashboards via SQL.
-1. Discover columns: run the schema-discovery step from the workflow above to confirm `system.insights` and `system.dashboards` expose `name`, `description`, `deleted`, `last_modified_at`, and the ID columns I plan to project. Without this step I'd be guessing — column sets differ per system table.
+1. Discover columns: run the schema-discovery step from the workflow above to confirm which columns each table exposes before projecting or ordering by them. Column sets differ per system table — e.g. `system.insights` has `short_id` and `last_modified_at`, but `system.dashboards` has neither (its only timestamp is `created_at`). Without this step I'd be guessing.
 2. Search insights by name (using only confirmed columns): `execute-sql` with `SELECT id, name, short_id, description FROM system.insights WHERE NOT deleted AND (name ILIKE '%revenue%' OR name ILIKE '%payment%') ORDER BY last_modified_at DESC LIMIT 20`.
-3. If results are sparse, broaden to dashboards (re-using the same schema lookup — `system.dashboards` has its own column set, e.g. no `short_id`): `execute-sql` with `SELECT id, name, description FROM system.dashboards WHERE NOT deleted AND (name ILIKE '%revenue%' OR name ILIKE '%payment%') ORDER BY last_modified_at DESC LIMIT 20`.
+3. If results are sparse, broaden to dashboards (re-using the same schema lookup — `system.dashboards` has its own column set, e.g. no `short_id` and no `last_modified_at`): `execute-sql` with `SELECT id, name, description FROM system.dashboards WHERE NOT deleted AND (name ILIKE '%revenue%' OR name ILIKE '%payment%') ORDER BY created_at DESC LIMIT 20`.
 4. Validate promising insights with `insight-retrieve`.
 5. Summarize with links.
 <reasoning>
-1. Schema discovery is mandatory step 1 of the discovery workflow above; `system.*` tables' column sets differ per entity (e.g. not every system table has `last_modified_at` or `short_id`).
+1. Schema discovery is mandatory step 1 of the discovery workflow above; `system.*` tables' column sets differ per entity (e.g. `system.dashboards` has no `last_modified_at` or `short_id` — ordering it by `last_modified_at` fails field resolution).
 2. SQL against `system.*` tables is the fastest way to discover existing entities — no `query-*` tool covers entity search.
 3. ILIKE with multiple terms catches naming variants ("Monthly Revenue", "MRR", "Payment Events").
 4. `insight-retrieve` confirms the insight's query configuration still matches intent.


### PR DESCRIPTION
## Problem

The MCP `execute-sql` prompt template's "searching for existing insights" example told the model that `system.dashboards` exposes `last_modified_at` and ordered a dashboards query by it. That column only exists on `system.insights` — the `system.dashboards` virtual table (`posthog/hogql/database/schema/system.py`) only has `id, team_id, name, description, created_at, deleted, filters, variables`. Its only timestamp is `created_at`.

Because the example wrote `ORDER BY last_modified_at DESC` directly against `system.dashboards`, the model copied it verbatim (skipping the "confirm columns first" caveat) and the query failed field resolution with `Unable to resolve field: last_modified_at`.

## Changes

- Fix the dashboards example to `ORDER BY created_at DESC` (a real column).
- Make the schema-discovery guidance concrete: call out that `system.insights` has `short_id`/`last_modified_at` while `system.dashboards` has neither.
- Sharpen the reasoning note to name the exact failure that ordering dashboards by `last_modified_at` produces.

## How did you test this code?

No automated tests — this is a change to a prompt/markdown template only. Verified against the actual HogQL schema definitions in `posthog/hogql/database/schema/system.py` that `system.insights` defines `last_modified_at` and `system.dashboards` does not.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a report that the MCP `execute-sql` tool generated a query ordering `system.dashboards` by `last_modified_at`, which failed field resolution. Traced the source to the `execute-sql-prompt.md` template, which listed `last_modified_at` as a dashboards column and used it in an example `ORDER BY`. Cross-checked the real virtual-table definitions to confirm dashboards has no such column (only `created_at`), then corrected the example and its accompanying guidance.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1783517349194149)*
