### PR TITLE
fix(phai): tag Max insight query executions as posthog_ai source

### DIFF
--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -49,6 +49,7 @@ from posthog.api.services.query import process_query_dict
 from posthog.clickhouse.client.execute_async import get_query_status
 from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tag_queries, tags_context
 from posthog.errors import ExposedCHQueryError
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.query_runner import BLOCKING_EXECUTION_MODES, ExecutionMode
 from posthog.models import Team
 from posthog.rbac.user_access_control import UserAccessControlError
@@ -342,6 +343,7 @@ class AssistantQueryExecutor:
                         execution_mode=execution_mode,
                         limit_context=LimitContext.POSTHOG_AI,
                         user=user,
+                        analytics_props={"source": EventSource.POSTHOG_AI},
                     )
 
             # If the query has a blocking execution, execute on a separate thread. Otherwise, use the main thread


### PR DESCRIPTION
## Problem

Max's server-side insight execution in `ee/hogai/context/insight/query_executor.py` called `process_query_dict` without `analytics_props`. As a result the `query executed` product-analytics event it emits carried **no `source`**, landing in the untagged bucket rather than being attributable to PostHog AI.

The `source` field is set only by `get_event_source(request)` in the HTTP query endpoint (`posthog/api/query.py`), and that function has no `posthog_ai` branch — `posthog_ai` is only ever applied when a caller passes it explicitly (as several other hogai tools already do). Since Max's executor never passed it, its query load was invisible in the `source` breakdown.

## Changes

- Pass `analytics_props={"source": EventSource.POSTHOG_AI}` into the `process_query_dict` call in the Max query executor, mirroring the pattern used by other hogai tools (`chat_agent/.../toolkit.py`, `utils/helpers.py`, etc.).

Note: this tags Max's server-side execution. The `/ai` page's frontend insight tiles re-run the same query through `POST /api/query` as a genuine browser session request, which remains classified as `web` — that is a separate capture and out of scope here.

## How did you test this code?

- Verified the analytics `source` derivation is entirely request-driven (`get_event_source`) and confirmed the executor path previously passed no `analytics_props`, so its events had no source.
- Ruff lint + format and `ty` type-check pass on the changed file (via lint-staged and `hogli ci:preflight`).

## Publish to changelog?

no