### PR TITLE
feat(slack): persona onboarding conversation with fleet reveal and channel setup

### DIFF
--- a/docs/internal/slack-local-setup-guide.md
+++ b/docs/internal/slack-local-setup-guide.md
@@ -98,7 +98,7 @@ features:
     always_online: true
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
+    messages_tab_enabled: true
     messages_tab_read_only_enabled: false
 oauth_config:
   redirect_urls:
@@ -111,9 +111,13 @@ oauth_config:
       - groups:read
       - channels:history
       - groups:history
+      - channels:join
+      - channels:manage
       - chat:write
       - canvases:write
       - files:write
+      - im:history
+      - assistant:write
       - reactions:write
       - users:read
       - users:read.email
@@ -126,6 +130,9 @@ settings:
     bot_events:
       - app_mention
       - app_home_opened
+      - message.im
+      - assistant_thread_started
+      - assistant_thread_context_changed
   interactivity:
     is_enabled: true
     request_url: https://<you>-posthog.ngrok.dev/slack/interactivity-callback
@@ -145,6 +152,15 @@ Django must be up at that moment.
 > sign-in-with-Slack flow needs `user` scopes `identity.basic` + `identity.email` and the second
 > redirect URL (`/complete/slack-link/`). Drop those if you don't want either feature locally —
 > they're behind the `slack-app-home` and `slack-app-oauth` flags.
+
+> The DM assistant + persona onboarding surface needs `im:history` + `assistant:write`, the
+> `message.im` / `assistant_thread_*` events, and the messages tab enabled — plus the **Agents &
+> AI Apps** toggle switched on in the app's settings UI (the manifest alone doesn't flip it).
+> `channels:join` lets onboarding add the bot to a picked public channel by itself — without it
+> every channel pick falls back to the `/invite` + Verify flow. `channels:manage` powers the
+> "Create #posthog-inbox" button; the button is hidden when the scope is missing. Optionally add
+> `search:read.public` for persona/tool detection from workspace messages — detection silently
+> degrades to profile-title matching without it.
 
 ## Step 3 — backend credentials and `SITE_URL`
 
@@ -197,6 +213,12 @@ If you already sync flags the usual way locally, it's likely on already — noth
 Slack mention webhook itself is not flag-gated — once the `slack` integration is
 connected, `@PostHog` events reach the agent unconditionally.
 
+The Slack-app surfaces are gated by remote-evaluated flags (create them in your local
+PostHog and target your team — `products/slack_app/backend/feature_flags.py`):
+`slack-app-home` (App Home tab), `slack-app-assistant` (DM assistant kill-switch), and
+`slack-app-persona-onboarding` (the CSM onboarding conversation + home card). Persona
+onboarding needs all three: home for the card, assistant for the DM surface, and its own flag.
+
 ## Step 5 — connect the integrations
 
 **Slack.** PostHog Code piggybacks on the regular Slack notifications install — there's no
@@ -241,6 +263,33 @@ when the repo-discovery agent has to choose among repos (a no-repo prompt skips 
 
 Follow-ups — reply in-thread with another `@mention` — are forwarded to the running sandbox and
 should react 👀 → 🦔 (or ❌ if the sandbox is gone). Expected from the code; not verified in our run.
+
+## Step 8 — CSM persona onboarding smoke test
+
+With the three flags from Step 4 on and the app reinstalled with the Step 2 scopes:
+
+1. Open the bot's **Home tab** — until you onboard it shows only the welcome + **Start
+   onboarding** card (settings appear after onboarding). Click it; the card flips to
+   _Onboarding in progress_ with an **Open our conversation** button that deep-links into the DM.
+2. Walk the DM flow: confirm **Customer success (CSM)** → fleet reveal → pick a channel and tap
+   **Add PostHog**. With `channels:join` granted the bot joins public channels itself; without
+   it (or for channels it can't join) you get the `/invite @posthog-slack-dev` + Verify fallback.
+3. Completion fires each scout's first run through Temporal immediately — the `temporal-worker`
+   mprocs process must be up. A real run additionally needs the agent-sandbox stack
+   (`SANDBOX_PROVIDER=docker` + `SANDBOX_LLM_GATEWAY_URL` in `.env.local`; see the
+   `debugging-local-task-agent-runs` skill) and CSM-shaped data — with no accounts/tickets/billing
+   data the scouts close out empty by design, so no finding appears. Note the scout coordinator's
+   30-minute schedule is not registered under `DEBUG`; only these provisioning-fired first runs
+   and manual runs happen locally.
+4. To see a finding land in the delivery channel without a real scout run:
+
+   ```bash
+   python manage.py simulate_scout_finding --team-id 1
+   ```
+
+   posts a clearly-labeled simulated finding through the exact production delivery path
+   (config lookup, owner tagging, Block Kit compose, `chat.postMessage`) to the channel that
+   onboarding configured.
 
 ## Debugging
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, cast
 from urllib.parse import urlencode, urlparse
 
@@ -62,6 +63,7 @@ from products.slack_app.backend.api import (
 )
 from products.slack_app.backend.views import (
     slack_app_command_handler,
+    slack_mcp_connected,
     slack_user_link_authorize,
     slack_user_link_callback,
 )
@@ -196,6 +198,26 @@ def integration_connect_redirect(request: HttpRequest, kind: str) -> HttpRespons
     )
     authorize_url = "/api/environments/{}/integrations/authorize/?{}".format(
         project_id, urlencode({"kind": kind, "next": next_path})
+    )
+    return HttpResponseRedirect(authorize_url)
+
+
+def mcp_connect_redirect(request: HttpRequest, template_id: uuid.UUID) -> HttpResponse:
+    """Login-gated entry point for connecting an MCP store server from a Slack message.
+    Bounces into the mcp_store authorize endpoint with a same-origin return URL so the user
+    lands back in Slack after the provider OAuth (see ``slack_mcp_connected``). The callback
+    URL is constructed internally (never taken from the query) so this can't be used as an
+    open redirect; ``state`` is an opaque signed token the return endpoint verifies."""
+    project_id = request.GET.get("project_id") or getattr(request.user, "current_team_id", None)
+    if not project_id or not str(project_id).isdigit():
+        return HttpResponse("Missing or invalid project_id", status=400)
+    state = request.GET.get("state", "")
+    if not state:
+        return HttpResponse("Missing state", status=400)
+    callback_url = "{}/integrations/slack/mcp-connected/?{}".format(settings.SITE_URL, urlencode({"state": state}))
+    authorize_url = "/api/environments/{}/mcp_server_installations/authorize/?{}".format(
+        project_id,
+        urlencode({"template_id": template_id, "install_source": "slack", "posthog_code_callback_url": callback_url}),
     )
     return HttpResponseRedirect(authorize_url)
 
@@ -422,6 +444,8 @@ urlpatterns = [
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", login_required(authorize_and_redirect)),
     path("integrations/connect/<str:kind>/", login_required(integration_connect_redirect)),
+    path("integrations/connect-mcp/<uuid:template_id>/", login_required(mcp_connect_redirect)),
+    path("integrations/slack/mcp-connected/", slack_mcp_connected, name="slack_mcp_connected"),
     path(
         "shared_dashboard/<str:access_token>",
         sharing.SharingViewerPageViewSet.as_view({"get": "retrieve"}),

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -149,6 +149,11 @@ def _resolve_account(team_id: int, account_id: str | None = None, external_id: s
         return None
 
 
+def count_accounts(team_id: int) -> int:
+    """Number of accounts the team has — a cheap data-readiness probe for other products."""
+    return Account.objects.for_team(team_id).count()
+
+
 def search_accounts(
     team_id: int, query: str, user_access_control: "UserAccessControl", limit: int
 ) -> tuple[list[contracts.AccountRef], int]:

--- a/products/slack_app/backend/analytics.py
+++ b/products/slack_app/backend/analytics.py
@@ -29,16 +29,32 @@ def slack_event_props(integration: Integration, *, slack_user_id: str | None = N
     return props
 
 
+def slack_user_distinct_id(workspace_id: str, slack_user_id: str) -> str:
+    """Stable per-Slack-user distinct_id for events that must chain into per-user funnels.
+    Deliberately synthetic (not the linked PostHog user's distinct_id): it is computable at
+    every capture site — interactivity handlers, home opens before user resolution, Temporal
+    activities — so every step of a flow lands on the same person."""
+    return f"slack:{workspace_id}:{slack_user_id}"
+
+
 def capture_slack_event(
-    integration: Integration, event: str, *, slack_user_id: str | None = None, **props: object
+    integration: Integration,
+    event: str,
+    *,
+    slack_user_id: str | None = None,
+    distinct_id: str | None = None,
+    **props: object,
 ) -> None:
-    """Capture a Slack app event, keyed on the team (``distinct_id`` = team uuid) with org/team groups.
-    Best-effort: analytics never breaks the flow."""
+    """Capture a Slack app event with org/team groups. Best-effort: analytics never breaks the flow.
+
+    ``distinct_id`` defaults to the team uuid, which collapses every user in a workspace into one
+    person — fine for volume counts, useless for funnels. Flows that need per-user conversion
+    tracking must pass ``slack_user_distinct_id(...)``."""
     try:
         team = integration.team
         with ph_scoped_capture() as capture:
             capture(
-                distinct_id=str(team.uuid),
+                distinct_id=distinct_id or str(team.uuid),
                 event=event,
                 properties=slack_event_props(integration, slack_user_id=slack_user_id, **props),
                 groups=groups(team.organization, team),

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -51,7 +51,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
 from posthog.utils import get_instance_region
 
-from products.slack_app.backend import inbox_channel, onboarding
+from products.slack_app.backend import inbox_channel, onboarding, persona_onboarding
 from products.slack_app.backend.feature_flags import (
     is_slack_app_assistant_enabled,
     is_slack_app_oauth_enabled,
@@ -1635,6 +1635,24 @@ def _route_assistant_event(
     posthog_user = resolution.user
 
     if event_type == "assistant_thread_started":
+        # Land onboarding on the same project the first-DM path resolves to, so the CSM fleet
+        # doesn't depend on which entry point fired first. Fall back to the workspace probe when
+        # the user's target is ambiguous (multi-project, no default) — the picker resolves that on
+        # the first DM.
+        onboarding_target = (
+            resolution.integration or (resolution.candidates[0] if len(resolution.candidates) == 1 else None) or probe
+        )
+        if persona_onboarding.maybe_intercept_assistant_surface(
+            onboarding_target,
+            posthog_user_id=posthog_user.id,
+            workspace_id=slack_team_id,
+            slack_user_id=slack_user_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            accessible_integration_ids=[integration.id for integration in resolution.candidates],
+            entry_point="thread_started",
+        ):
+            return ROUTE_HANDLED_LOCALLY
         return _handle_assistant_thread_started(SlackIntegration(probe), channel_id, thread_ts)
     if event_type == "assistant_thread_context_changed":
         _store_assistant_channel_context(probe.id, channel_id, thread_ts, ctx_channel)
@@ -1645,6 +1663,17 @@ def _route_assistant_event(
     mention_target = resolution.integration or (accessible[0] if len(accessible) == 1 else None)
     if mention_target is None:
         _post_pick_a_project_hint(SlackIntegration(accessible[0]), accessible, event)
+        return ROUTE_HANDLED_LOCALLY
+    if persona_onboarding.maybe_intercept_assistant_surface(
+        mention_target,
+        posthog_user_id=posthog_user.id,
+        workspace_id=slack_team_id,
+        slack_user_id=slack_user_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        accessible_integration_ids=[integration.id for integration in accessible],
+        entry_point="first_dm",
+    ):
         return ROUTE_HANDLED_LOCALLY
     return _handle_assistant_dm_message(
         event, mention_target, slack_team_id, event_id, channel_id, thread_ts, posthog_user=posthog_user
@@ -2576,6 +2605,18 @@ _AI_PREFERENCES_ACTION_IDS = frozenset(
     }
 )
 _AI_PREFERENCES_CALLBACK_IDS = frozenset({EDIT_MODAL_PERSONAL_CALLBACK_ID, EDIT_MODAL_WORKSPACE_CALLBACK_ID})
+
+
+def _is_persona_onboarding_interactivity(payload: dict, payload_type: str) -> bool:
+    """True when the payload is a persona-onboarding interaction (home card or DM steps).
+    Like the AI-settings actions, these are workspace-scoped and carry no per-row hint, so
+    the cross-region router claims locality on the workspace integration alone."""
+    if payload_type != "block_actions":
+        return False
+    for action in payload.get("actions", []) or ():
+        if str(action.get("action_id") or "").startswith(persona_onboarding.ACTION_PREFIX):
+            return True
+    return False
 
 
 def _is_ai_preferences_interactivity(payload: dict, payload_type: str) -> bool:
@@ -3624,6 +3665,13 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
             kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
+    elif slack_team_id and _is_persona_onboarding_interactivity(payload, payload_type):
+        # Persona-onboarding buttons (home card + DM steps) are workspace-scoped like the
+        # AI-settings actions above — claim locality on the workspace integration alone.
+        local = Integration.objects.filter(
+            kind=SLACK_INTEGRATION_KIND,
+            integration_id=slack_team_id,
+        ).exists()
 
     proxied = was_proxied(request)
     incoming_host = request.get_host()
@@ -3727,6 +3775,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
                 return inbox_interactivity.handle_inbox_sources(payload)
             if action_id == onboarding.INBOX_AI_APPROVAL_ACTION_ID:
                 return inbox_interactivity.handle_inbox_ai_approval(payload)
+            if action_id and action_id.startswith(persona_onboarding.ACTION_PREFIX):
+                return persona_onboarding.handle_block_action(payload, action)
             if action_id in _AI_PREFERENCES_ACTION_IDS:
                 return _handle_ai_preferences_block_action(payload, action)
 

--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -153,3 +153,26 @@ def is_slack_app_assistant_enabled(team: Team) -> bool:
     except Exception:
         logger.exception("assistant_feature_flag_eval_failed")
         return False
+
+
+SLACK_APP_PERSONA_ONBOARDING_FLAG = "slack-app-persona-onboarding"
+
+
+def is_persona_onboarding_enabled(team: Team) -> bool:
+    """Gate for the persona onboarding flow: the DM conversation, the DM/thread
+    intercepts, and the App Home "Start onboarding" card. Evaluated on the
+    workspace's team so the whole surface stays dark when off."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                SLACK_APP_PERSONA_ONBOARDING_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("persona_onboarding_feature_flag_eval_failed")
+        return False

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -10,15 +10,102 @@ only thin wiring.
 
 from __future__ import annotations
 
+import threading
 import dataclasses
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+from urllib.parse import urlencode
+
+from django.core import signing
+from django.core.cache import cache
+from django.db import close_old_connections
+from django.http import HttpResponse
+from django.utils import timezone
 
 import structlog
+from slack_sdk.errors import SlackApiError
 
-from posthog.models.integration import SlackIntegration
+from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.user import User
 
+from products.mcp_store.backend.facade.api import get_active_installations, list_active_templates
+from products.mcp_store.backend.facade.contracts import TemplateInfo
+
+if TYPE_CHECKING:
+    from slack_sdk.web import SlackResponse
+
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
+from products.slack_app.backend.feature_flags import is_persona_onboarding_enabled
+from products.slack_app.backend.inbox_channel import (
+    INBOX_CHANNEL_REQUIRED_SCOPES,
+    ensure_inbox_channel,
+    invite_user_to_inbox,
+)
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
+from products.slack_app.backend.onboarding import _public_url
 from products.slack_app.backend.services import slack_search
+from products.slack_app.backend.services.integration_resolver import load_integrations, resolve_user_for_workspace
 
 logger = structlog.get_logger(__name__)
+
+# Block Kit action ids. Everything in this flow shares the prefix so the interactivity
+# dispatcher and region-locality arms can route on it without per-step registration.
+ACTION_PREFIX = "persona_onboarding_"
+START_ACTION_ID = "persona_onboarding_start"
+# URL button on the App Home card that deep-links into the onboarding DM; ack-only.
+OPEN_DM_ACTION_ID = "persona_onboarding_open_dm"
+PERSONA_SELECT_ACTION_ID = "persona_onboarding_select"  # values: "csm" | "engineer" | "other"
+SKIP_ACTION_ID = "persona_onboarding_skip"
+CHANNEL_SELECT_ACTION_ID = "persona_onboarding_channel_select"
+CHANNEL_CONFIRM_ACTION_ID = "persona_onboarding_channel_confirm"
+CHANNEL_CREATE_ACTION_ID = "persona_onboarding_channel_create"
+CHANNEL_VERIFY_ACTION_ID = "persona_onboarding_channel_verify"
+# The confirm button reads the dropdown's current selection out of payload["state"]["values"],
+# which Slack keys by block_id — so the selector's block needs a stable one.
+CHANNEL_SELECT_BLOCK_ID = "persona_onboarding_channel_block"
+# URL buttons — clicks open the browser but still emit a block_action that must be acked.
+CONNECT_SOURCE_ACTION_ID = "persona_onboarding_connect_source"
+
+SCOUTS_DOC_URL = "https://posthog.com/docs/self-driving/scouts"
+
+# Single-flight window for the kickoff post (see `start_onboarding_dm`).
+_START_CLAIM_TTL_SECONDS = 60
+# Single-flight window for block-action handling (see `_run_action`). Slack delivers each click as
+# its own request, so a double-click lands two handler threads racing the same state write.
+_ACTION_CLAIM_TTL_SECONDS = 30
+
+# Funnel: home_card_shown → started → persona_selected → fleet_shown → channel_configured →
+# completed (skipped/grandfathered are exits; invite_needed, nudged, and error mark friction
+# between steps). Every event shares a per-user distinct_id and carries persona context so
+# conversion can be broken down by persona at any step.
+EVENT_HOME_CARD_SHOWN = "slack_persona_onboarding_home_card_shown"
+EVENT_STARTED = "slack_persona_onboarding_started"
+EVENT_PERSONA_SELECTED = "slack_persona_onboarding_persona_selected"
+EVENT_FLEET_SHOWN = "slack_persona_onboarding_fleet_shown"
+EVENT_CONNECT_CLICKED = "slack_persona_onboarding_connect_clicked"
+EVENT_MCP_CONNECTED = "slack_persona_onboarding_mcp_connected"
+EVENT_CHANNEL_INVITE_NEEDED = "slack_persona_onboarding_channel_invite_needed"
+EVENT_CHANNEL_CONFIGURED = "slack_persona_onboarding_channel_configured"
+EVENT_COMPLETED = "slack_persona_onboarding_completed"
+EVENT_SKIPPED = "slack_persona_onboarding_skipped"
+EVENT_GRANDFATHERED = "slack_persona_onboarding_grandfathered"
+EVENT_NUDGED = "slack_persona_onboarding_nudged"
+EVENT_ERROR = "slack_persona_onboarding_error"
+
+# Signed state carried by Connect buttons through the MCP OAuth round-trip; long-lived because
+# the fleet-reveal message can sit unread in a DM for a while before anyone clicks it.
+_CONNECT_STATE_SALT = "slack_app.persona_onboarding.mcp_connect"
+CONNECT_STATE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+
+
+def sign_connect_state(workspace_id: str, slack_user_id: str, readiness_key: str, template_name: str) -> str:
+    payload = {"w": workspace_id, "u": slack_user_id, "k": readiness_key, "t": template_name}
+    return signing.dumps(payload, salt=_CONNECT_STATE_SALT)
+
+
+def unsign_connect_state(state: str) -> dict:
+    """Raises ``django.core.signing.BadSignature`` on tampered or expired state."""
+    return signing.loads(state, salt=_CONNECT_STATE_SALT, max_age=CONNECT_STATE_MAX_AGE_SECONDS)
 
 
 # ============================================================================
@@ -150,3 +237,1342 @@ def detect_workspace_tools(slack: SlackIntegration, workspace_id: str, slack_use
         if len(hits) >= _TOOL_HIT_MIN:
             detected.append(tool.server_name)
     return detected
+
+
+# ============================================================================
+# Deep links into the PostHog app
+# ============================================================================
+
+
+def mcp_connect_url(team_id: int, template_id: str, state: str) -> str:
+    """Login-gated browser entry that starts the MCP OAuth connect and returns through Slack."""
+    return _public_url(f"/integrations/connect-mcp/{template_id}/?{urlencode({'project_id': team_id, 'state': state})}")
+
+
+def mcp_store_url(team_id: int, template_id: str | None = None) -> str:
+    base = f"/project/{team_id}/settings/mcp-servers"
+    return _public_url(f"{base}?{urlencode({'mcp': template_id})}" if template_id else base)
+
+
+def inbox_url(team_id: int) -> str:
+    return _public_url(f"/project/{team_id}/inbox")
+
+
+def slack_dm_deep_link(workspace_id: str, dm_channel_id: str) -> str:
+    """https deep link that opens the Slack client on the DM — works in Block Kit URL buttons
+    on every client, unlike the slack:// protocol form."""
+    return f"https://slack.com/app_redirect?{urlencode({'team': workspace_id, 'channel': dm_channel_id})}"
+
+
+def onboarding_dm_deep_link(workspace_id: str, slack_user_id: str) -> str | None:
+    """Deep link to the in-flight onboarding conversation, for the App Home card."""
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    state = row.onboarding_state if row is not None and isinstance(row.onboarding_state, dict) else None
+    dm_channel_id = str(state.get("dm_channel_id") or "") if state else ""
+    return slack_dm_deep_link(workspace_id, dm_channel_id) if dm_channel_id else None
+
+
+# ============================================================================
+# Persona scout catalog + data readiness
+# ============================================================================
+
+PERSONA_CSM = "csm"
+PERSONA_ENGINEER = "engineer"
+PERSONA_OTHER = "other"
+
+STEP_AWAITING_PERSONA = "awaiting_persona"
+STEP_AWAITING_CHANNEL = "awaiting_channel"
+
+
+@dataclasses.dataclass(frozen=True)
+class ScoutSpec:
+    skill_name: str
+    title: str
+    description: str
+    readiness_key: str
+    recommended_servers: tuple[str, ...]  # MCP store template names whose data would feed it
+    gap_line: str  # "works best with …" copy when readiness is False
+
+
+PERSONA_SCOUT_CATALOG: dict[str, tuple[ScoutSpec, ...]] = {
+    PERSONA_CSM: (
+        ScoutSpec(
+            skill_name="signals-scout-slack-csm-account-pulse",
+            title="Account pulse",
+            description=(
+                "Watches each account's product usage and flags the ones sliding toward churn or "
+                "heating up toward expansion, tagging the account owner."
+            ),
+            readiness_key="account_pulse",
+            recommended_servers=("Salesforce", "HubSpot"),
+            gap_line="works best with account data like PostHog customer analytics accounts or a connected CRM.",
+        ),
+        ScoutSpec(
+            skill_name="signals-scout-slack-csm-support-watch",
+            title="Support watch",
+            description=(
+                "Watches support tickets for spikes, escalations, and accounts going loud (or silent) "
+                "right before renewal."
+            ),
+            readiness_key="support_watch",
+            recommended_servers=("Zendesk", "Intercom", "Linear", "Jira", "Freshdesk"),
+            gap_line="works best with a ticketing tool.",
+        ),
+        ScoutSpec(
+            skill_name="signals-scout-slack-csm-revenue-watch",
+            title="Renewal & billing watch",
+            description=(
+                "Watches billing data for failed payments, cancellations, and contraction on the accounts you own."
+            ),
+            readiness_key="revenue_watch",
+            recommended_servers=("Stripe",),
+            gap_line="works best with billing data like Stripe or PostHog revenue analytics.",
+        ),
+    ),
+}
+
+_SUPPORT_SOURCE_KINDS = ("Zendesk", "Intercom", "Linear", "Jira", "Freshdesk")
+_CRM_SOURCE_KINDS = ("Salesforce", "Hubspot")
+
+
+@dataclasses.dataclass(frozen=True)
+class CsmDataReadiness:
+    account_pulse: bool
+    support_watch: bool
+    revenue_watch: bool
+    accounts_count: int
+    # readiness_key -> human phrase for the data source that made the scout ready (e.g. "your
+    # PostHog customer analytics accounts"), so the reveal can say what's used by default.
+    ready_details: dict[str, str] = dataclasses.field(default_factory=dict)
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    def analytics_props(self) -> dict:
+        # ready_details is presentation-only with variable keys — keep it out of the flat event schema.
+        return {key: value for key, value in self.as_dict().items() if key != "ready_details"}
+
+
+def _active_source_kinds(team_id: int) -> set[str]:
+    from products.warehouse_sources.backend.models.external_data_source import (  # noqa: PLC0415 — keeps the warehouse stack off the slack import path
+        ExternalDataSource,
+    )
+
+    return set(
+        ExternalDataSource.objects.filter(team_id=team_id).exclude(deleted=True).values_list("source_type", flat=True)
+    )
+
+
+def _connected_mcp_server_names(team_id: int, posthog_user_id: int | None) -> set[str]:
+    """Lowercased names of the user's ready MCP store installations (template + display names)."""
+    if not posthog_user_id:
+        return set()
+    names: set[str] = set()
+    for installation in get_active_installations(team_id, posthog_user_id):
+        for name in (installation.template_name, installation.name):
+            if name:
+                names.add(name.lower())
+    return names
+
+
+def _first_connected_recommended(spec: ScoutSpec, connected_names: set[str]) -> str | None:
+    return next((name for name in spec.recommended_servers if name.lower() in connected_names), None)
+
+
+def check_csm_data_readiness(team_id: int, posthog_user_id: int | None = None) -> CsmDataReadiness:
+    """Per-scout data probes for the fleet reveal + completion copy. Presentation only —
+    a probe failure renders as "no data yet", never blocks onboarding."""
+    accounts_count = 0
+    try:
+        from products.customer_analytics.backend.facade.api import (  # noqa: PLC0415 — keeps the customer-analytics stack off the slack import path
+            count_accounts,
+        )
+
+        accounts_count = count_accounts(team_id)
+    except Exception:
+        logger.warning("persona_onboarding_accounts_probe_failed", exc_info=True)
+
+    tickets_exist = False
+    try:
+        from products.conversations.backend.models.ticket import (  # noqa: PLC0415 — keeps the conversations stack off the slack import path
+            Ticket,
+        )
+
+        tickets_exist = Ticket.objects.filter(team_id=team_id).exists()
+    except Exception:
+        logger.warning("persona_onboarding_tickets_probe_failed", exc_info=True)
+
+    source_kinds: set[str] = set()
+    try:
+        source_kinds = _active_source_kinds(team_id)
+    except Exception:
+        logger.warning("persona_onboarding_sources_probe_failed", exc_info=True)
+
+    mcp_connected: set[str] = set()
+    try:
+        mcp_connected = _connected_mcp_server_names(team_id, posthog_user_id)
+    except Exception:
+        logger.warning("persona_onboarding_mcp_probe_failed", exc_info=True)
+
+    specs_by_key = {spec.readiness_key: spec for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]}
+
+    def resolve(readiness_key: str, posthog_detail: str | None, source_matches: tuple[str, ...]) -> str | None:
+        """First data source that makes the scout ready, as a human phrase — PostHog-native data
+        wins so users see they don't need to connect anything."""
+        if posthog_detail:
+            return posthog_detail
+        source_kind = next((kind for kind in source_matches if kind in source_kinds), None)
+        if source_kind:
+            return f"your {source_kind} data synced into PostHog"
+        server_name = _first_connected_recommended(specs_by_key[readiness_key], mcp_connected)
+        if server_name:
+            return f"your connected {server_name} MCP server"
+        return None
+
+    details = {
+        "account_pulse": resolve(
+            "account_pulse",
+            "your PostHog customer analytics accounts" if accounts_count > 0 else None,
+            _CRM_SOURCE_KINDS,
+        ),
+        "support_watch": resolve(
+            "support_watch",
+            "your PostHog conversations tickets" if tickets_exist else None,
+            _SUPPORT_SOURCE_KINDS,
+        ),
+        "revenue_watch": resolve("revenue_watch", None, ("Stripe",)),
+    }
+    return CsmDataReadiness(
+        account_pulse=details["account_pulse"] is not None,
+        support_watch=details["support_watch"] is not None,
+        revenue_watch=details["revenue_watch"] is not None,
+        accounts_count=accounts_count,
+        ready_details={key: detail for key, detail in details.items() if detail},
+    )
+
+
+# ============================================================================
+# Settings-row state helpers
+# ============================================================================
+
+
+def get_or_create_settings_row(workspace_id: str, slack_user_id: str) -> SlackSettings:
+    row, _ = SlackSettings.objects.get_or_create(slack_workspace_id=workspace_id, slack_user_id=slack_user_id)
+    return row
+
+
+def is_onboarded(row: SlackSettings | None) -> bool:
+    return row is not None and row.onboarded_at is not None
+
+
+def has_prior_slack_activity(integration_ids: list[int], slack_user_id: str) -> bool:
+    if not integration_ids:
+        return False
+    return SlackThreadTaskMapping.objects.filter(
+        integration_id__in=integration_ids, latest_actor_slack_user_id=slack_user_id
+    ).exists()
+
+
+def _grandfather(integration: Integration, row: SlackSettings, slack_user_id: str, posthog_user_id: int) -> None:
+    row.onboarded_at = timezone.now()
+    row.onboarding_state = None
+    row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
+    capture_slack_event(
+        integration,
+        EVENT_GRANDFATHERED,
+        slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
+        posthog_user_id=posthog_user_id,
+    )
+
+
+def compute_home_onboarding_status(integration: Integration, workspace_id: str, slack_user_id: str) -> str:
+    """ "hidden" | "start" | "in_progress" — drives the App Home onboarding card."""
+    if not is_persona_onboarding_enabled(integration.team):
+        return "hidden"
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    if is_onboarded(row):
+        return "hidden"
+    if row is not None and isinstance(row.onboarding_state, dict):
+        return "in_progress"
+    return "start"
+
+
+# ============================================================================
+# Block builders
+# ============================================================================
+
+
+def _section(text: str) -> dict:
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def _context(text: str) -> dict:
+    return {"type": "context", "elements": [{"type": "mrkdwn", "text": text}]}
+
+
+def _button(label: str, action_id: str, value: str = "", *, style: str | None = None, url: str | None = None) -> dict:
+    # Slack rejects a message whose interactive elements share an action_id, so a button's value
+    # doubles as an id suffix; `handle_block_action` dispatches on the base id before the ":".
+    button: dict = {
+        "type": "button",
+        "text": {"type": "plain_text", "text": label},
+        "action_id": f"{action_id}:{value}" if value else action_id,
+    }
+    if value:
+        button["value"] = value
+    if style:
+        button["style"] = style
+    if url:
+        button["url"] = url
+    return button
+
+
+def build_kickoff_blocks(display_name: str, candidate: str | None) -> list[dict]:
+    hey = f"🦔 Hey {display_name}! I'm PostHog's Slack agent. I can dig into data, ship code, and help get things done."
+    skip = _button("Skip setup", SKIP_ACTION_ID)
+    if candidate == PERSONA_CSM:
+        intro = f"{hey} Before we get going, let me set things up right for you.\n\nIt looks like you're a CSM — is that right?"
+        buttons = [
+            _button("Yes — set me up as a CSM", PERSONA_SELECT_ACTION_ID, PERSONA_CSM, style="primary"),
+            _button("I'm an engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    elif candidate == PERSONA_ENGINEER:
+        intro = (
+            f"{hey} Before we get going, let me set things up right for you.\n\nLooks like you're an engineer — right?"
+        )
+        buttons = [
+            _button("Yep, engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER, style="primary"),
+            _button("I'm in customer success", PERSONA_SELECT_ACTION_ID, PERSONA_CSM),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    else:
+        intro = f"{hey}\n\nQuick question so I can set things up right for you — which best describes what you do?"
+        buttons = [
+            _button("Engineer", PERSONA_SELECT_ACTION_ID, PERSONA_ENGINEER),
+            _button("Customer success (CSM)", PERSONA_SELECT_ACTION_ID, PERSONA_CSM),
+            _button("Something else", PERSONA_SELECT_ACTION_ID, PERSONA_OTHER),
+            skip,
+        ]
+    return [_section(intro), {"type": "actions", "elements": buttons}]
+
+
+_MAX_CONNECT_BUTTONS_PER_SCOUT = 3
+
+
+def _connect_button(
+    team_id: int, spec: ScoutSpec, template: TemplateInfo, workspace_id: str, slack_user_id: str
+) -> dict:
+    # OAuth templates connect straight from the browser and return through Slack; API-key
+    # templates need the store UI, so their button deep-links to the detail panel instead.
+    if template.connect_via_redirect:
+        state = sign_connect_state(workspace_id, slack_user_id, spec.readiness_key, template.name)
+        url = mcp_connect_url(team_id, template.id, state)
+    else:
+        url = mcp_store_url(team_id, template.id)
+    # Button values are "<readiness_key>:<server|store>": sibling connect buttons must not
+    # collide on value (it doubles as the action_id suffix), and telemetry gets the scout.
+    return _button(
+        f"Connect {template.name}", CONNECT_SOURCE_ACTION_ID, f"{spec.readiness_key}:{template.name}", url=url
+    )
+
+
+def build_fleet_reveal_blocks(
+    team_id: int,
+    readiness: dict,
+    detected_tools: list[str],
+    templates: list[TemplateInfo],
+    workspace_id: str,
+    slack_user_id: str,
+) -> list[dict]:
+    templates_by_name = {template.name.lower(): template for template in templates}
+    ready_details = readiness.get("ready_details") or {}
+    blocks: list[dict] = [
+        _section(
+            "Great, I'm going to create a few scouts for you. Scouts are little agents that patrol "
+            "your data on a schedule and ping you whenever there's something to worry about "
+            f"(<{SCOUTS_DOC_URL}|here's how they work>)."
+        )
+    ]
+    if any(not readiness.get(spec.readiness_key) for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]):
+        blocks.append(
+            _context(
+                "Scouts use your PostHog data by default. Connecting a tool below is optional; "
+                "it just gives them more signal."
+            )
+        )
+    for index, spec in enumerate(PERSONA_SCOUT_CATALOG[PERSONA_CSM], start=1):
+        blocks.append(_section(f"*{index}. {spec.title}*\n{spec.description}"))
+        if readiness.get(spec.readiness_key):
+            detail = ready_details.get(spec.readiness_key)
+            blocks.append(
+                _context(f"✅ Ready — I'll use {detail}." if detail else "✅ Ready — I can see the data this needs.")
+            )
+            continue
+        candidates = [
+            templates_by_name[name.lower()] for name in spec.recommended_servers if name.lower() in templates_by_name
+        ]
+        detected = next(
+            (template for name in detected_tools for template in candidates if template.name.lower() == name.lower()),
+            None,
+        )
+        if detected is not None:
+            candidates = [detected, *[template for template in candidates if template is not detected]]
+            blocks.append(
+                _section(f"⚠️ {spec.title} {spec.gap_line} I see you're using {detected.name} — want to connect it now?")
+            )
+        else:
+            blocks.append(_context(f"⚠️ {spec.gap_line} Connect one any time — this scout picks it up automatically."))
+        if candidates:
+            blocks.append(
+                {
+                    "type": "actions",
+                    "elements": [
+                        _connect_button(team_id, spec, template, workspace_id, slack_user_id)
+                        for template in candidates[:_MAX_CONNECT_BUTTONS_PER_SCOUT]
+                    ],
+                }
+            )
+        else:
+            blocks.append(
+                {
+                    "type": "actions",
+                    "elements": [
+                        _button(
+                            "Browse the MCP store",
+                            CONNECT_SOURCE_ACTION_ID,
+                            f"{spec.readiness_key}:store",
+                            url=mcp_store_url(team_id),
+                        )
+                    ],
+                }
+            )
+    return blocks
+
+
+def build_channel_prompt_blocks(can_create_channel: bool) -> list[dict]:
+    # Picking from the dropdown is easy to fat-finger, so it does nothing on its own —
+    # the explicit Add PostHog button next to it is what commits the choice.
+    select_row: list[dict] = [
+        {
+            "type": "conversations_select",
+            "action_id": CHANNEL_SELECT_ACTION_ID,
+            "placeholder": {"type": "plain_text", "text": "Pick a channel"},
+            # Never offer external-shared channels — these alerts carry account intel.
+            "filter": {"include": ["public"], "exclude_external_shared_channels": True, "exclude_bot_users": True},
+        },
+        _button("Add PostHog", CHANNEL_CONFIRM_ACTION_ID, style="primary"),
+    ]
+    secondary_row: list[dict] = []
+    if can_create_channel:
+        secondary_row.append(_button("Create #posthog-inbox", CHANNEL_CREATE_ACTION_ID))
+    # Skip is a bail-out at every step: without it a CSM who can't (or won't) pick a channel
+    # is wedged, since the DM intercept hijacks every message while onboarding_state is set.
+    secondary_row.append(_button("Skip for now", SKIP_ACTION_ID))
+    return [
+        _section(
+            "One more thing: this works best if you add me to a channel where I can post findings. "
+            "Pick one and tap Add PostHog, or I can create #posthog-inbox for you."
+            if can_create_channel
+            else "One more thing: this works best if you add me to a channel where I can post findings. "
+            "Pick one below and tap Add PostHog."
+        ),
+        {"type": "actions", "block_id": CHANNEL_SELECT_BLOCK_ID, "elements": select_row},
+        {"type": "actions", "elements": secondary_row},
+    ]
+
+
+def build_invite_needed_blocks(channel_id: str, channel_name: str) -> list[dict]:
+    return [
+        _section(
+            f"I can't post in #{channel_name} yet — I'm not a member. Type `/invite @PostHog` there "
+            "(or mention @PostHog in the channel and Slack will offer to add me), then tap Verify. "
+            "Or pick a different channel above."
+        ),
+        {
+            "type": "actions",
+            "elements": [
+                _button("Verify", CHANNEL_VERIFY_ACTION_ID, channel_id, style="primary"),
+                _button("Skip for now", SKIP_ACTION_ID),
+            ],
+        },
+    ]
+
+
+def build_locked_in_blocks(
+    team_name: str, channel_name: str, readiness: dict, channel_conflict: str | None, team_id: int
+) -> list[dict]:
+    # Name the project: a Slack workspace can map to several PostHog projects and the fleet lands
+    # in the one that resolved for this user, so say which so a multi-project CSM isn't guessing.
+    if channel_conflict:
+        first = (
+            f"Your scouts are already running for *{team_name}* and posting to #{channel_conflict} — "
+            "I've left that as-is. You're onboarded! 🎉"
+        )
+    else:
+        first = (
+            f"🎉 You're locked in for *{team_name}*. I've already sent your scouts on their first "
+            f"patrol — I'll message you when a scout finds something, and findings land in "
+            f"#{channel_name} with the account owner tagged when I can find them."
+        )
+    blocks = [_section(first)]
+    gap_titles = [spec.title for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM] if not readiness.get(spec.readiness_key)]
+    if gap_titles:
+        names = ", ".join(gap_titles)
+        verb = "is" if len(gap_titles) == 1 else "are"
+        blocks.append(
+            _context(
+                f"Heads-up: {names} {verb} waiting on data — connect a source from the list above and "
+                "they wake up on their own."
+            )
+        )
+    blocks.append(
+        _section(
+            f"Manage your scouts (pause, cadence, run history) any time from your <{inbox_url(team_id)}|PostHog inbox>, or ask me to do it for you."
+            "\n\nIn the meantime, do you want to work on anything? You can ask me things like:\n\n"
+            "• _Which of my accounts had the biggest usage drop this month?_\n"
+            "• _Summarize what Acme did last week._"
+        )
+    )
+    return blocks
+
+
+FLEET_REVEAL_TEXT = "I'm going to create a few scouts for you."
+ENGINEER_COMPLETION_TEXT = "Got it, engineer it is."
+OTHER_COMPLETION_TEXT = (
+    "Thanks! Message me here any time — ask about your product data, dashboards, or anything PostHog."
+)
+SKIP_TEXT = "No problem — skipping setup. Message me whenever; settings live in my Home tab."
+PICK_CHANNEL_FIRST_TEXT = "Pick a channel from the dropdown first, then tap Add PostHog."
+NUDGE_PERSONA_TEXT = "One quick thing first — tap one of the buttons above (or Skip) and then I'm all yours."
+NUDGE_CHANNEL_TEXT = (
+    "Almost there — pick a channel for account alerts above (or Skip), then send me that message again."
+)
+ERROR_TEXT = "Something went wrong on my end — tap the button again, or skip setup and message me anytime."
+
+
+# ============================================================================
+# Flow entry points (called from api.py) + interactivity handlers
+# ============================================================================
+
+
+@dataclasses.dataclass
+class _FlowContext:
+    integration: Integration
+    slack: SlackIntegration
+    row: SlackSettings
+    workspace_id: str
+    slack_user_id: str
+    state: dict
+
+
+def _load_context(payload: dict) -> _FlowContext | None:
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if not workspace_id or not slack_user_id:
+        return None
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    if row is None or not isinstance(row.onboarding_state, dict):
+        return None
+    state = row.onboarding_state
+    integration = Integration.objects.filter(id=state.get("integration_id"), kind="slack").first()
+    # Defensive: the stored integration must still belong to the clicking workspace.
+    if integration is None or integration.integration_id != workspace_id:
+        return None
+    ctx = _FlowContext(integration, SlackIntegration(integration), row, workspace_id, slack_user_id, state)
+    _retarget_to_click(ctx, payload)
+    return ctx
+
+
+def _capture_flow_event(ctx: _FlowContext, event: str, **props: object) -> None:
+    """Capture a funnel event for an in-flight onboarding: per-user distinct_id (steps must
+    chain on one person) plus persona context on every step for breakdowns. Explicit props win
+    over the defaults."""
+    props.setdefault("persona", ctx.row.persona)
+    props.setdefault("persona_candidate", ctx.state.get("persona_candidate"))
+    props.setdefault("posthog_user_id", ctx.state.get("posthog_user_id"))
+    capture_slack_event(
+        ctx.integration,
+        event,
+        slack_user_id=ctx.slack_user_id,
+        distinct_id=slack_user_distinct_id(ctx.workspace_id, ctx.slack_user_id),
+        **props,
+    )
+
+
+def _retarget_to_click(ctx: _FlowContext, payload: dict) -> None:
+    """Point follow-up posts at the thread hosting the clicked button. In the assistant surface
+    every top-level DM message roots its own conversation, so replying anywhere else opens a
+    brand-new History entry instead of continuing inline."""
+    channel_id = (payload.get("channel") or {}).get("id")
+    message = payload.get("message") or {}
+    anchor = message.get("thread_ts") or message.get("ts")
+    if not channel_id or not anchor:
+        return
+    if channel_id != ctx.state.get("dm_channel_id") or anchor != ctx.state.get("thread_ts"):
+        ctx.state["dm_channel_id"] = channel_id
+        ctx.state["thread_ts"] = anchor
+        _save_state(ctx.row, ctx.state)
+
+
+def _display_name(slack: SlackIntegration, slack_user_id: str) -> str:
+    try:
+        info = slack.client.users_info(user=slack_user_id)
+        profile = (info.get("user") or {}).get("profile") or {}
+        name = profile.get("display_name") or profile.get("real_name") or ""
+        return name.split()[0] if name else "there"
+    except Exception:
+        return "there"
+
+
+def _post(ctx: _FlowContext, blocks: list[dict], text: str) -> SlackResponse:
+    return ctx.slack.client.chat_postMessage(
+        channel=ctx.state.get("dm_channel_id"),
+        thread_ts=ctx.state.get("thread_ts"),
+        text=text,
+        blocks=blocks,
+    )
+
+
+def _save_state(row: SlackSettings, state: dict | None) -> None:
+    row.onboarding_state = state
+    row.save(update_fields=["onboarding_state", "updated_at"])
+
+
+def _remember_message_ts(ctx: _FlowContext, key: str, posted: SlackResponse) -> None:
+    """Track a posted message so a later step can rewrite it in place (e.g. flip the channel
+    prompt to a done note once the channel is configured)."""
+    ts = posted.get("ts")
+    if ts:
+        ctx.state[key] = ts
+        _save_state(ctx.row, ctx.state)
+
+
+def _freeze_buttons(ctx: _FlowContext, payload: dict, note: str) -> None:
+    """Replace the clicked message's action blocks with a note, so stale buttons can't
+    double-fire. Best-effort — a failure here never blocks the step itself."""
+    channel_id = (payload.get("channel") or {}).get("id")
+    message = payload.get("message") or {}
+    ts = message.get("ts")
+    if not channel_id or not ts:
+        return
+    blocks = [block for block in (message.get("blocks") or []) if block.get("type") != "actions"]
+    blocks.append(_context(note))
+    try:
+        ctx.slack.client.chat_update(channel=channel_id, ts=ts, text=note, blocks=blocks)
+    except Exception:
+        logger.warning("persona_onboarding_freeze_buttons_failed", exc_info=True)
+
+
+def _republish_home(integration: Integration, slack_user_id: str) -> None:
+    # Deferred: slack_app_home imports this module for the onboarding card, so a module-level
+    # import here would be a true circular import.
+    from products.slack_app.backend.services.slack_app_home import republish_home_for_user  # noqa: PLC0415
+
+    try:
+        republish_home_for_user(integration, slack_user_id)
+    except Exception:
+        logger.warning("persona_onboarding_home_republish_failed", exc_info=True)
+
+
+def _publish_starting_home(integration: Integration, slack_user_id: str) -> None:
+    # Deferred: slack_app_home imports this module for the onboarding card, so a module-level
+    # import here would be a true circular import.
+    from products.slack_app.backend.services.slack_app_home import publish_onboarding_starting_home  # noqa: PLC0415
+
+    # Swallow like _republish_home: feedback is best-effort, the kickoff must still run.
+    try:
+        publish_onboarding_starting_home(integration, slack_user_id)
+    except Exception:
+        logger.warning("persona_onboarding_home_republish_failed", exc_info=True)
+
+
+def start_onboarding_dm(
+    integration: Integration,
+    slack_user_id: str,
+    *,
+    posthog_user_id: int,
+    entry_point: str,
+    channel_id: str | None = None,
+    thread_ts: str | None = None,
+) -> None:
+    """Open (or reuse) the DM and post the kickoff question; idempotent — an in-flight
+    onboarding reposts its current step instead of resetting."""
+    slack = SlackIntegration(integration)
+    workspace_id = integration.integration_id
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if isinstance(row.onboarding_state, dict):
+        ctx = _FlowContext(integration, slack, row, workspace_id, slack_user_id, row.onboarding_state)
+        _repost_current_step(ctx)
+        return
+    # Kickoff runs off the request thread, so a double-click on Start (or a redelivered DM
+    # event) can race here before state is saved — the claim makes the kickoff single-flight.
+    claim_key = f"slack_persona_onboarding_start:{workspace_id}:{slack_user_id}"
+    if not cache.add(claim_key, "1", timeout=_START_CLAIM_TTL_SECONDS):
+        return
+    try:
+        row.refresh_from_db(fields=["onboarding_state"])
+        if isinstance(row.onboarding_state, dict):
+            return
+        _post_kickoff(integration, slack, row, slack_user_id, entry_point, channel_id, thread_ts, posthog_user_id)
+    finally:
+        # By now state is saved (or the kickoff failed and may be retried) — the claim has done its job.
+        cache.delete(claim_key)
+
+
+def _post_kickoff(
+    integration: Integration,
+    slack: SlackIntegration,
+    row: SlackSettings,
+    slack_user_id: str,
+    entry_point: str,
+    channel_id: str | None,
+    thread_ts: str | None,
+    posthog_user_id: int,
+) -> None:
+    workspace_id = integration.integration_id
+    candidate, source = detect_persona(slack, workspace_id, slack_user_id)
+    display_name = _display_name(slack, slack_user_id)
+    if channel_id is None:
+        opened = slack.client.conversations_open(users=slack_user_id)
+        channel_id = (opened.get("channel") or {}).get("id")
+        if not channel_id:
+            logger.warning("persona_onboarding_dm_open_failed", slack_user_id=slack_user_id)
+            return
+    blocks = build_kickoff_blocks(display_name, candidate)
+    # Post before saving state: the state row keys off this message's ts + resolved channel, so it
+    # can only be written after the post lands. The reverse (save first) is worse — a failed post
+    # would strand the user with onboarding_state set and no DM to act on. The single-flight claim in
+    # `start_onboarding_dm` bounds the duplicate-post window; a save failure after a successful post
+    # (then a redelivery) is the narrow residual and re-posts an idempotent, user-retryable kickoff.
+    posted = slack.client.chat_postMessage(
+        channel=channel_id, thread_ts=thread_ts, text="Quick setup — which best describes what you do?", blocks=blocks
+    )
+    row.onboarding_state = {
+        "step": STEP_AWAITING_PERSONA,
+        "persona_candidate": candidate,
+        "detection_source": source,
+        "team_id": integration.team_id,
+        "integration_id": integration.id,
+        "posthog_user_id": posthog_user_id,
+        "dm_channel_id": channel_id,
+        # A top-level kickoff roots its own conversation in the assistant surface — anchor
+        # follow-ups under it so the whole flow stays in that one thread.
+        "thread_ts": thread_ts or posted.get("ts"),
+        "kickoff_ts": posted.get("ts"),
+        "started_at": timezone.now().isoformat(),
+    }
+    row.save(update_fields=["onboarding_state", "updated_at"])
+    capture_slack_event(
+        integration,
+        EVENT_STARTED,
+        slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
+        entry_point=entry_point,
+        persona_candidate=candidate,
+        detection_source=source or "none",
+        search_available=slack_search.search_available(
+            slack, slack_search.get_cached_action_token(workspace_id, slack_user_id)
+        ),
+        posthog_user_id=posthog_user_id,
+    )
+
+
+def maybe_intercept_assistant_surface(
+    integration: Integration,
+    *,
+    posthog_user_id: int,
+    workspace_id: str,
+    slack_user_id: str,
+    channel_id: str,
+    thread_ts: str | None,
+    accessible_integration_ids: list[int],
+    entry_point: str,
+) -> bool:
+    """The DM / assistant-container gate. Returns True when the event was consumed by
+    onboarding (caller must not start an agent task or post the default welcome)."""
+    if not is_persona_onboarding_enabled(integration.team):
+        return False
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if is_onboarded(row):
+        return False
+    if has_prior_slack_activity(accessible_integration_ids, slack_user_id):
+        # An established user predating this flow — never ambush them with onboarding.
+        _grandfather(integration, row, slack_user_id, posthog_user_id)
+        return False
+    # The consume/pass-through decision must be made inline, but everything past it talks to
+    # Slack (detection searches, posts) — run it off the event-request thread so the events API
+    # gets its ack inside Slack's 3s window (late acks trigger redelivery, i.e. duplicate posts).
+    if isinstance(row.onboarding_state, dict):
+        ctx = _FlowContext(
+            integration, SlackIntegration(integration), row, workspace_id, slack_user_id, row.onboarding_state
+        )
+        if entry_point == "first_dm":
+            _run_in_background(lambda: _post_nudge(ctx), task="nudge")
+        else:
+            # A re-opened assistant container is a fresh thread — retarget the stored pointer so the
+            # repost lands where the user is looking, not in the (now hidden) original thread.
+            if channel_id and (channel_id != ctx.state.get("dm_channel_id") or thread_ts != ctx.state.get("thread_ts")):
+                ctx.state["dm_channel_id"] = channel_id
+                ctx.state["thread_ts"] = thread_ts
+                _save_state(ctx.row, ctx.state)
+            _run_in_background(lambda: _repost_current_step(ctx), task="repost_step")
+        return True
+    _run_in_background(
+        lambda: start_onboarding_dm(
+            integration,
+            slack_user_id,
+            posthog_user_id=posthog_user_id,
+            entry_point=entry_point,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+        ),
+        task="start_onboarding",
+    )
+    return True
+
+
+def _run_in_background(fn: Callable[[], None], *, task: str) -> None:
+    """Run best-effort work off the interactivity request thread. Slack voids a block action
+    after 3s and shows a warning on the clicked button; the kickoff path makes far too many
+    Slack API calls to fit, and every step of it is idempotent + user-retryable."""
+
+    def runner() -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("persona_onboarding_background_task_failed", task=task)
+        finally:
+            close_old_connections()
+
+    threading.Thread(target=runner, name=f"persona-onboarding-{task}", daemon=True).start()
+
+
+def handle_home_start(payload: dict) -> HttpResponse:
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if workspace_id and slack_user_id:
+        _run_in_background(lambda: _run_home_start(workspace_id, slack_user_id), task="home_start")
+    return HttpResponse(status=200)
+
+
+def _run_home_start(workspace_id: str, slack_user_id: str) -> None:
+    result = load_integrations(slack_team_id=workspace_id, kinds=["slack"], slack_user_id=slack_user_id)
+    if not result.candidates:
+        return
+    probe = result.integration if result.integration in result.candidates else result.candidates[0]
+    if not is_persona_onboarding_enabled(probe.team):
+        return
+    resolution = resolve_user_for_workspace(
+        workspace_result=result, slack_team_id=workspace_id, slack_user_id=slack_user_id
+    )
+    if resolution.user is None:
+        return
+    target = resolution.integration or (resolution.candidates[0] if resolution.candidates else probe)
+    row = get_or_create_settings_row(workspace_id, slack_user_id)
+    if is_onboarded(row):
+        _republish_home(target, slack_user_id)
+        return
+    # Flip the Home card before the kickoff's Slack round-trips so the click gets instant
+    # feedback, then converge to the truthful state however the kickoff ends — without the
+    # finally, an exception mid-kickoff leaves the stale Start card up until the next open.
+    _publish_starting_home(target, slack_user_id)
+    try:
+        start_onboarding_dm(target, slack_user_id, posthog_user_id=resolution.user.id, entry_point="home_button")
+    finally:
+        _republish_home(target, slack_user_id)
+
+
+def handle_block_action(payload: dict, action: dict) -> HttpResponse:
+    # Valued buttons carry their value as an ":<value>" action_id suffix (see `_button`);
+    # routing happens on the base id. Every handler that talks to Slack or the DB runs off
+    # the request thread: Slack voids a block action after 3s and paints a warning on the
+    # clicked button, so the ack must never wait on our work.
+    action_id = str(action.get("action_id") or "").split(":", 1)[0]
+    if action_id == START_ACTION_ID:
+        return handle_home_start(payload)
+    if action_id in (OPEN_DM_ACTION_ID, CHANNEL_SELECT_ACTION_ID):
+        # Open-DM is a URL button (the client navigates on its own); picking from the
+        # dropdown is inert — Add PostHog commits the choice. Ack only.
+        return HttpResponse(status=200)
+    handlers: dict[str, Callable[[], None]] = {
+        CONNECT_SOURCE_ACTION_ID: lambda: _handle_connect_click(payload, action),
+        PERSONA_SELECT_ACTION_ID: lambda: _handle_persona_select(payload, action),
+        SKIP_ACTION_ID: lambda: _handle_skip(payload),
+        CHANNEL_CONFIRM_ACTION_ID: lambda: _handle_channel_confirm(payload),
+        CHANNEL_CREATE_ACTION_ID: lambda: _handle_channel_create(payload),
+        CHANNEL_VERIFY_ACTION_ID: lambda: _handle_channel_verify(payload, action),
+    }
+    handler = handlers.get(action_id)
+    if handler is not None:
+        _run_in_background(lambda: _run_action(handler, payload, action_id), task=action_id)
+    return HttpResponse(status=200)
+
+
+def _run_action(handler: Callable[[], None], payload: dict, action_id: str) -> None:
+    # A double-click lands two handler threads that both clear the `step ==` guard before either
+    # writes state (double-posting a completion). A per-user
+    # claim makes handling single-flight: only the first thread runs the handler; the duplicate
+    # skips. The first thread's `_freeze_buttons` (a chat_update on the shared message) is what the
+    # user sees, so a skipped duplicate never strands frozen buttons.
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    claim_key = (
+        f"slack_onboarding_action_claim:{workspace_id}:{slack_user_id}" if workspace_id and slack_user_id else None
+    )
+    if claim_key is not None and not cache.add(claim_key, 1, timeout=_ACTION_CLAIM_TTL_SECONDS):
+        return
+    try:
+        handler()
+    except Exception:
+        logger.exception("persona_onboarding_action_failed", action_id=action_id)
+        ctx = _load_context(payload)
+        if ctx is not None:
+            _capture_flow_event(ctx, EVENT_ERROR, stage=action_id)
+            try:
+                _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+            except Exception:
+                logger.warning("persona_onboarding_error_post_failed", exc_info=True)
+    finally:
+        if claim_key is not None:
+            cache.delete(claim_key)
+
+
+def _post_nudge(ctx: _FlowContext) -> None:
+    step = ctx.state.get("step")
+    text = NUDGE_CHANNEL_TEXT if step == STEP_AWAITING_CHANNEL else NUDGE_PERSONA_TEXT
+    _post(ctx, [_section(text)], text)
+    _repost_current_step(ctx)
+    # Friction signal: the user tried to talk to the bot instead of finishing the step.
+    _capture_flow_event(ctx, EVENT_NUDGED, step=step)
+
+
+def _repost_current_step(ctx: _FlowContext) -> None:
+    step = ctx.state.get("step")
+    if step == STEP_AWAITING_CHANNEL:
+        pending_channel = ctx.state.get("pending_channel_id")
+        if pending_channel:
+            _post_invite_needed(ctx, pending_channel, ctx.state.get("pending_channel_name") or pending_channel)
+        else:
+            _post_channel_prompt(ctx)
+        return
+    display_name = _display_name(ctx.slack, ctx.slack_user_id)
+    blocks = build_kickoff_blocks(display_name, ctx.state.get("persona_candidate"))
+    _post(ctx, blocks, "Quick setup — which best describes what you do?")
+
+
+def _post_channel_prompt(ctx: _FlowContext, can_create: bool | None = None) -> None:
+    if can_create is None:
+        can_create = _can_create_channel(ctx.slack)
+    posted = _post(ctx, build_channel_prompt_blocks(can_create), "Pick a channel for scout findings.")
+    _remember_message_ts(ctx, "channel_prompt_ts", posted)
+
+
+def _post_invite_needed(ctx: _FlowContext, channel_id: str, channel_name: str) -> None:
+    posted = _post(ctx, build_invite_needed_blocks(channel_id, channel_name), "Invite me to the channel, then verify.")
+    _remember_message_ts(ctx, "invite_message_ts", posted)
+
+
+def _can_create_channel(slack: SlackIntegration) -> bool:
+    try:
+        return not slack.missing_scopes(INBOX_CHANNEL_REQUIRED_SCOPES)
+    except Exception:
+        return False
+
+
+def _handle_connect_click(payload: dict, action: dict) -> None:
+    # URL button — the browser already navigated; just ack + record the click.
+    # Values are "<readiness_key>:<server>" (readiness_key is colon-free, so split on the
+    # first colon to keep server names that themselves contain colons intact) — or a bare
+    # server name like "github" for buttons not tied to a readiness gap.
+    raw_value = str(action.get("value") or "")
+    if ":" in raw_value:
+        scout_key, _, server_name = raw_value.partition(":")
+    else:
+        scout_key, server_name = "", raw_value
+    ctx = _load_context(payload)
+    if ctx is not None:
+        _capture_flow_event(ctx, EVENT_CONNECT_CLICKED, server_name=server_name, scout_readiness_key=scout_key or None)
+        return
+    # Connect buttons outlive the flow (the engineer completion's GitHub button, a finished
+    # CSM's fleet-reveal buttons), so clicks after state is cleared still need recording.
+    workspace_id = str((payload.get("team") or {}).get("id") or "")
+    slack_user_id = str((payload.get("user") or {}).get("id") or "")
+    if not workspace_id or not slack_user_id:
+        return
+    result = load_integrations(slack_team_id=workspace_id, kinds=["slack"], slack_user_id=slack_user_id)
+    integration = result.integration or (result.candidates[0] if result.candidates else None)
+    if integration is None:
+        return
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    capture_slack_event(
+        integration,
+        EVENT_CONNECT_CLICKED,
+        slack_user_id=slack_user_id,
+        distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
+        server_name=server_name,
+        scout_readiness_key=scout_key or None,
+        persona=row.persona if row is not None else None,
+    )
+
+
+def handle_mcp_connect_return(
+    *,
+    workspace_id: str,
+    slack_user_id: str,
+    readiness_key: str,
+    template_name: str,
+    success: bool,
+    error: str = "",
+    capture_event: bool = True,
+) -> str:
+    """Post-OAuth landing for a Connect button: refresh the fleet-reveal message with fresh
+    readiness and return the Slack deep link that sends the user back to the conversation.
+
+    ``capture_event`` gates only the connect-conversion analytics: the signed state is reusable,
+    so the caller dedupes it per token. The fleet refresh below is DB-recomputed and idempotent,
+    so it always runs regardless."""
+    row = SlackSettings.objects.filter(slack_workspace_id=workspace_id, slack_user_id=slack_user_id).first()
+    state = row.onboarding_state if row is not None and isinstance(row.onboarding_state, dict) else None
+    integration = None
+    if state is not None:
+        integration = Integration.objects.filter(id=state.get("integration_id"), kind="slack").first()
+        if integration is not None and integration.integration_id != workspace_id:
+            integration = None
+    if integration is not None:
+        if capture_event:
+            capture_slack_event(
+                integration,
+                EVENT_MCP_CONNECTED,
+                slack_user_id=slack_user_id,
+                distinct_id=slack_user_distinct_id(workspace_id, slack_user_id),
+                server_name=template_name,
+                scout_readiness_key=readiness_key,
+                success=success,
+                error=error or None,
+                persona=row.persona if row is not None else None,
+                posthog_user_id=state.get("posthog_user_id") if state else None,
+            )
+        if row is not None and state is not None and success:
+            _refresh_fleet_reveal(integration, row, state, workspace_id, slack_user_id)
+    dm_channel_id = str(state.get("dm_channel_id") or "") if state else ""
+    if dm_channel_id:
+        return f"slack://channel?team={workspace_id}&id={dm_channel_id}"
+    return f"slack://open?team={workspace_id}"
+
+
+def _refresh_fleet_reveal(
+    integration: Integration, row: SlackSettings, state: dict, workspace_id: str, slack_user_id: str
+) -> None:
+    readiness = check_csm_data_readiness(integration.team_id, state.get("posthog_user_id"))
+    state["readiness"] = readiness.as_dict()
+    _save_state(row, state)
+    fleet_ts = state.get("fleet_message_ts")
+    channel_id = state.get("dm_channel_id")
+    if not fleet_ts or not channel_id:
+        return
+    blocks = build_fleet_reveal_blocks(
+        integration.team_id,
+        readiness.as_dict(),
+        state.get("detected_tools") or [],
+        list_active_templates(),
+        workspace_id,
+        slack_user_id,
+    )
+    try:
+        SlackIntegration(integration).client.chat_update(
+            channel=channel_id, ts=fleet_ts, text=FLEET_REVEAL_TEXT, blocks=blocks
+        )
+    except Exception:
+        logger.warning("persona_onboarding_fleet_refresh_failed", exc_info=True)
+
+
+def _handle_persona_select(payload: dict, action: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_PERSONA:
+        _repost_current_step(ctx)
+        return
+    persona = str(action.get("value") or "")
+    if persona not in (PERSONA_CSM, PERSONA_ENGINEER, PERSONA_OTHER):
+        return
+    labels = {PERSONA_CSM: "Customer success (CSM)", PERSONA_ENGINEER: "Engineer", PERSONA_OTHER: "Something else"}
+    # The CSM branch probes data readiness + workspace tools before its next post lands —
+    # the freeze note doubles as a "working on it" so those seconds don't read as a hang.
+    note = f"You picked: {labels[persona]}"
+    if persona == PERSONA_CSM:
+        note += " — one sec while I look at what data you have…"
+    _freeze_buttons(ctx, payload, note)
+    _capture_flow_event(
+        ctx,
+        EVENT_PERSONA_SELECTED,
+        persona=persona,
+        matched_detection=persona == ctx.state.get("persona_candidate"),
+    )
+
+    if persona in (PERSONA_ENGINEER, PERSONA_OTHER):
+        ctx.row.persona = persona
+        ctx.row.onboarded_at = timezone.now()
+        ctx.row.onboarding_state = None
+        ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+        completion_props: dict[str, object] = {}
+        if persona == PERSONA_ENGINEER:
+            text = ENGINEER_COMPLETION_TEXT
+        else:
+            text = OTHER_COMPLETION_TEXT
+        _post(ctx, [_section(text)], text)
+        _capture_flow_event(ctx, EVENT_COMPLETED, persona=persona, scouts_provisioned=0, **completion_props)
+        _republish_home(ctx.integration, ctx.slack_user_id)
+        return
+
+    # CSM: reveal the fleet (with per-scout readiness + connect offers), then ask for a channel.
+    ctx.row.persona = PERSONA_CSM
+    readiness = check_csm_data_readiness(ctx.integration.team_id, ctx.state.get("posthog_user_id"))
+    detected_tools = detect_workspace_tools(ctx.slack, ctx.workspace_id, ctx.slack_user_id)
+    ctx.state.update(
+        {"step": STEP_AWAITING_CHANNEL, "readiness": readiness.as_dict(), "detected_tools": detected_tools}
+    )
+    ctx.row.onboarding_state = ctx.state
+    ctx.row.save(update_fields=["persona", "onboarding_state", "updated_at"])
+    posted = _post(
+        ctx,
+        build_fleet_reveal_blocks(
+            ctx.integration.team_id,
+            readiness.as_dict(),
+            detected_tools,
+            list_active_templates(),
+            ctx.workspace_id,
+            ctx.slack_user_id,
+        ),
+        FLEET_REVEAL_TEXT,
+    )
+    # Remember the reveal message so the post-OAuth return leg can flip its ⚠️ lines to ✅.
+    if posted and posted.get("ts"):
+        ctx.state["fleet_message_ts"] = posted.get("ts")
+        _save_state(ctx.row, ctx.state)
+    _post_channel_prompt(ctx)
+    _capture_flow_event(ctx, EVENT_FLEET_SHOWN, detected_tools=detected_tools, **readiness.analytics_props())
+
+
+def _handle_skip(payload: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    step = ctx.state.get("step")
+    _freeze_buttons(ctx, payload, "Setup skipped.")
+    ctx.row.onboarded_at = timezone.now()
+    ctx.row.onboarding_state = None
+    ctx.row.save(update_fields=["onboarded_at", "onboarding_state", "updated_at"])
+    _post(ctx, [_section(SKIP_TEXT)], SKIP_TEXT)
+    _capture_flow_event(ctx, EVENT_SKIPPED, step=step)
+    _republish_home(ctx.integration, ctx.slack_user_id)
+
+
+def _channel_name_best_effort(slack: SlackIntegration, channel_id: str) -> str:
+    try:
+        info = slack.client.conversations_info(channel=channel_id)
+        return (info.get("channel") or {}).get("name") or channel_id
+    except Exception:
+        return channel_id
+
+
+def _handle_channel_confirm(payload: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    values = (payload.get("state") or {}).get("values") or {}
+    select_state = (values.get(CHANNEL_SELECT_BLOCK_ID) or {}).get(CHANNEL_SELECT_ACTION_ID) or {}
+    channel_id = str(select_state.get("selected_conversation") or "")
+    if not channel_id:
+        _post(ctx, [_section(PICK_CHANNEL_FIRST_TEXT)], PICK_CHANNEL_FIRST_TEXT)
+        return
+    channel_name = _channel_name_best_effort(ctx.slack, channel_id)
+    # Instant feedback + double-click protection: the whole setup runs off the ack thread and
+    # takes seconds (hello post, provisioning, first runs), so the clicked controls must react now.
+    _freeze_buttons(ctx, payload, f"⏳ Setting up #{channel_name} — sending your scouts on their first patrol…")
+    _attempt_channel_setup(ctx, channel_id, channel_name, method="selected", repost_picker_on_invite=True)
+
+
+def _handle_channel_create(payload: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    if not _can_create_channel(ctx.slack):
+        _post_channel_prompt(ctx, can_create=False)
+        return
+    _freeze_buttons(ctx, payload, "⏳ Creating #posthog-inbox and sending your scouts on their first patrol…")
+    ensured = ensure_inbox_channel(ctx.integration)
+    if ensured is None:
+        _post_channel_prompt(ctx)
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        return
+    channel_id, channel_target_name = ensured
+    invite_user_to_inbox(ctx.integration, channel_id, ctx.slack_user_id)
+    _attempt_channel_setup(
+        ctx, channel_id, channel_target_name.lstrip("#"), method="created", repost_picker_on_invite=True
+    )
+
+
+def _handle_channel_verify(payload: dict, action: dict) -> None:
+    ctx = _load_context(payload)
+    if ctx is None:
+        return
+    if ctx.state.get("step") != STEP_AWAITING_CHANNEL:
+        _repost_current_step(ctx)
+        return
+    channel_id = str(action.get("value") or ctx.state.get("pending_channel_id") or "")
+    if not channel_id:
+        return
+    channel_name = ctx.state.get("pending_channel_name") or _channel_name_best_effort(ctx.slack, channel_id)
+    _freeze_buttons(ctx, payload, f"⏳ Checking #{channel_name}…")
+    _attempt_channel_setup(ctx, channel_id, channel_name, method="verified", invite_required=True)
+
+
+# Membership-shaped hello failures that the /invite-then-Verify flow can recover from.
+_INVITE_FALLBACK_ERRORS = ("not_in_channel", "channel_not_found", "is_archived", "restricted_action")
+
+
+def _post_channel_hello(ctx: _FlowContext, channel_id: str) -> str | None:
+    """Post the channel hello; it doubles as the membership probe. Returns the Slack error
+    string for membership-shaped failures, None on success; anything else raises."""
+    try:
+        ctx.slack.client.chat_postMessage(
+            channel=channel_id,
+            text=(
+                f"👋 I'll post scout findings here — set up by <@{ctx.slack_user_id}>. "
+                "First patrol is already underway."
+            ),
+        )
+        return None
+    except SlackApiError as exc:
+        error = str((getattr(exc, "response", None) or {}).get("error", ""))
+        if error in _INVITE_FALLBACK_ERRORS:
+            return error
+        raise
+
+
+def _try_join_channel(slack: SlackIntegration, channel_id: str) -> bool:
+    try:
+        slack.client.conversations_join(channel=channel_id)
+        return True
+    except SlackApiError as exc:
+        logger.warning(
+            "persona_onboarding_channel_join_failed",
+            channel_id=channel_id,
+            error=(getattr(exc, "response", None) or {}).get("error"),
+        )
+        return False
+
+
+def _attempt_channel_setup(
+    ctx: _FlowContext,
+    channel_id: str,
+    channel_name: str,
+    *,
+    method: str,
+    invite_required: bool = False,
+    repost_picker_on_invite: bool = False,
+) -> None:
+    error = _post_channel_hello(ctx, channel_id)
+    if error == "not_in_channel" and _try_join_channel(ctx.slack, channel_id):
+        # Public channel and we hold channels:join — add ourselves instead of asking for /invite.
+        error = _post_channel_hello(ctx, channel_id)
+    if error is not None:
+        ctx.state.update({"pending_channel_id": channel_id, "pending_channel_name": channel_name})
+        _save_state(ctx.row, ctx.state)
+        if repost_picker_on_invite:
+            # The clicked picker was frozen for feedback — put a fresh one back so choosing a
+            # different channel stays possible alongside the /invite path.
+            _post_channel_prompt(ctx)
+        _post_invite_needed(ctx, channel_id, channel_name)
+        # Drop-off marker: users parked at /invite-then-Verify with no channel_configured after
+        # this are the ones who wedged here.
+        _capture_flow_event(ctx, EVENT_CHANNEL_INVITE_NEEDED, method=method, error=error, retry=invite_required)
+        return
+    _capture_flow_event(ctx, EVENT_CHANNEL_CONFIGURED, method=method, invite_required=invite_required)
+    _provision_and_complete(ctx, channel_id, channel_name)
+
+
+def _resolve_channel_prompts(ctx: _FlowContext, channel_name: str) -> None:
+    """Rewrite the now-stale channel-setup messages (prompt with the picker, invite-then-verify
+    ask) to a done note so their controls don't linger after the channel is configured.
+    Best-effort — a failure here never blocks completion."""
+    note = f"✅ Channel set — I'll post scout findings to #{channel_name}."
+    dm_channel_id = ctx.state.get("dm_channel_id")
+    if not dm_channel_id:
+        return
+    # Deduped: both keys can point at the same message (e.g. after a repost), and one
+    # rewrite per message is enough.
+    for ts in dict.fromkeys(ctx.state.get(key) for key in ("channel_prompt_ts", "invite_message_ts")):
+        if not ts:
+            continue
+        try:
+            ctx.slack.client.chat_update(channel=dm_channel_id, ts=ts, text=note, blocks=[_section(note)])
+        except Exception:
+            logger.warning("persona_onboarding_channel_prompt_update_failed", exc_info=True)
+
+
+def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: str) -> None:
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off the slack import path
+        provision_persona_scouts,
+    )
+
+    user = User.objects.filter(id=ctx.state.get("posthog_user_id")).first()
+    if user is None:
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        _capture_flow_event(ctx, EVENT_ERROR, stage="provisioning_user_missing")
+        return
+    try:
+        results = provision_persona_scouts(
+            team=ctx.integration.team,
+            created_by=user,
+            slack_integration_id=ctx.integration.id,
+            channel_id=channel_id,
+            channel_name=channel_name,
+            skill_names=[spec.skill_name for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]],
+        )
+    except Exception:
+        logger.exception("persona_onboarding_provisioning_failed", team_id=ctx.integration.team_id)
+        _post(ctx, [_section(ERROR_TEXT)], ERROR_TEXT)
+        # Funnel leak between channel_configured and completed — the user stays un-onboarded.
+        _capture_flow_event(ctx, EVENT_ERROR, stage="provisioning")
+        return
+
+    readiness = ctx.state.get("readiness") or {}
+    channel_conflict = next((result.channel_conflict for result in results if result.channel_conflict), None)
+    # Mark onboarded BEFORE the celebratory post: provisioning + first runs already happened, so a
+    # transient post failure must not leave the user un-onboarded with live scouts (which would
+    # re-fire all three first runs and re-post the channel hello on the next retry).
+    ctx.row.persona = PERSONA_CSM
+    ctx.row.onboarded_at = timezone.now()
+    ctx.row.onboarding_state = None
+    ctx.row.save(update_fields=["persona", "onboarded_at", "onboarding_state", "updated_at"])
+    _resolve_channel_prompts(ctx, channel_name)
+    _post(
+        ctx,
+        build_locked_in_blocks(
+            ctx.integration.team.name, channel_name, readiness, channel_conflict, ctx.integration.team_id
+        ),
+        "You're locked in — your scouts are on their first patrol.",
+    )
+    _capture_flow_event(
+        ctx,
+        EVENT_COMPLETED,
+        persona=PERSONA_CSM,
+        scouts_provisioned=len([result for result in results if result.config_id]),
+        first_runs_fired=len([result for result in results if result.first_run_started]),
+        channel_conflict=bool(channel_conflict),
+        # readiness still carries ready_details for the Block Kit render above; keep it out of analytics.
+        **{key: value for key, value in readiness.items() if key != "ready_details"},
+    )
+    _republish_home(ctx.integration, ctx.slack_user_id)

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -30,8 +30,11 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
+from products.slack_app.backend import persona_onboarding
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
+from products.slack_app.backend.services.slack_auth import check_integrations_auth_and_filter
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
     build_ai_preferences_payload,
@@ -409,6 +412,56 @@ def _header_blocks() -> list[dict]:
             "Tune how @PostHog mentions get routed and answered from this Slack workspace.",
         ),
     ]
+
+
+def render_onboarding_home_view(status: str, dm_link: str | None) -> dict:
+    """Pre-onboarding home: just a welcome and the onboarding card. The settings sections stay
+    hidden until the user finishes (or skips) onboarding, so setup is the only thing to do here."""
+    blocks: list[dict] = [
+        _section_title(
+            "Welcome to PostHog! 👋",
+            "I'm PostHog's Slack agent. I can dig into data, ship code, and help get things done.\n",
+        ),
+        {"type": "divider"},
+        *_onboarding_card_blocks(status, dm_link),
+    ]
+    return {"type": "home", "callback_id": HOME_CALLBACK_ID, "blocks": blocks}
+
+
+def _onboarding_card_blocks(status: str, dm_link: str | None) -> list[dict]:
+    if status == "starting":
+        # Optimistic card published the moment the Start click is handled — the kickoff makes
+        # several Slack API round-trips, so the truthful "in progress" republish lags by seconds.
+        text = "✨ *Setting things up…* I'll DM you in a moment."
+        return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
+    if status == "in_progress":
+        if dm_link:
+            # Deep link straight into the conversation — a DM from a bot is easy to miss in the
+            # sidebar, and the whole flow should keep the user inside Slack.
+            button: dict = {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Open our conversation"},
+                "action_id": persona_onboarding.OPEN_DM_ACTION_ID,
+                "url": dm_link,
+                "style": "primary",
+            }
+            text = "✨ *Onboarding in progress* — I've sent you a DM to continue."
+        else:
+            button = {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Resume in DMs"},
+                "action_id": persona_onboarding.START_ACTION_ID,
+            }
+            text = "✨ *Onboarding in progress* — check your DMs from me."
+    else:
+        button = {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Start onboarding"},
+            "action_id": persona_onboarding.START_ACTION_ID,
+            "style": "primary",
+        }
+        text = "✨ *New here?* Let me set things up for you — takes under a minute."
+    return [{"type": "section", "text": {"type": "mrkdwn", "text": text}, "accessory": button}]
 
 
 def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> list[dict]:
@@ -1037,6 +1090,63 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     if not is_slack_app_home_enabled(integration):
         return
 
+    republish_home_for_user(integration, slack_user_id, track_impression=True)
+
+
+def _publish_onboarding_home_if_needed(
+    integration: Integration, slack_user_id: str, *, track_impression: bool = False
+) -> bool:
+    """Publish the onboarding-only home when the user hasn't onboarded yet (flag-gated inside
+    the status computation). Returns True when it published — the caller must then skip the
+    settings view, which also skips its several Slack/DB round-trips of state resolution.
+
+    ``track_impression`` is set only for user-initiated home opens: the card is the top of the
+    onboarding funnel, and programmatic republishes (after each flow step) aren't impressions."""
+    onboarding_status = persona_onboarding.compute_home_onboarding_status(
+        integration, integration.integration_id, slack_user_id
+    )
+    if onboarding_status == "hidden":
+        return False
+    dm_link = (
+        persona_onboarding.onboarding_dm_deep_link(integration.integration_id, slack_user_id)
+        if onboarding_status == "in_progress"
+        else None
+    )
+    _publish_home_view(integration, slack_user_id, render_onboarding_home_view(onboarding_status, dm_link))
+    if track_impression:
+        capture_slack_event(
+            integration,
+            persona_onboarding.EVENT_HOME_CARD_SHOWN,
+            slack_user_id=slack_user_id,
+            distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
+            status=onboarding_status,
+        )
+    return True
+
+
+def publish_onboarding_starting_home(integration: Integration, slack_user_id: str) -> None:
+    """Optimistic Home update for the Start onboarding click: the kickoff makes several Slack
+    API round-trips before the truthful republish, and the click itself gives no feedback."""
+    _publish_home_view(integration, slack_user_id, render_onboarding_home_view("starting", None))
+
+
+def _publish_home_view(integration: Integration, slack_user_id: str, view: dict) -> None:
+    try:
+        SlackIntegration(integration).client.views_publish(user_id=slack_user_id, view=view)
+    except Exception:
+        logger.exception(
+            "slack_app_home_publish_failed",
+            slack_user_id=slack_user_id,
+            slack_team_id=integration.integration_id,
+        )
+
+
+def republish_home_for_user(integration: Integration, slack_user_id: str, *, track_impression: bool = False) -> None:
+    """Recompute and publish the Home tab for one user — the shared publish path for
+    `app_home_opened` (which tracks the onboarding-card impression) and for flows
+    (persona onboarding) that change what home shows."""
+    if _publish_onboarding_home_if_needed(integration, slack_user_id, track_impression=track_impression):
+        return
     effective = resolve_ai_preferences(integration, slack_user_id)
     user_row, workspace_row = _load_rows(integration, slack_user_id)
 
@@ -1055,14 +1165,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
         project_state=project_state,
         tasks_state=tasks_state,
     )
-    try:
-        slack.client.views_publish(user_id=slack_user_id, view=view)
-    except Exception:
-        logger.exception(
-            "slack_app_home_publish_failed",
-            slack_user_id=slack_user_id,
-            slack_team_id=slack_team_id,
-        )
+    _publish_home_view(integration, slack_user_id, view)
 
 
 def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpResponse:
@@ -1217,14 +1320,20 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 
 
 def _get_slack_integration(slack_team_id: str) -> Integration | None:
-
+    # A workspace can carry several installs and stale ones keep dead tokens (re-installs,
+    # revoked projects), so prefer a candidate whose bot token passes the cached auth check —
+    # blindly taking `.first()` routed every home publish through a dead token.
     if not slack_team_id:
         return None
-    return (
+    candidates = list(
         Integration.objects.select_related("team", "team__organization")
         .filter(kind="slack", integration_id=slack_team_id)
-        .first()
+        .order_by("id")
     )
+    if not candidates:
+        return None
+    healthy = check_integrations_auth_and_filter(candidates)
+    return healthy[0] if healthy else candidates[0]
 
 
 def _load_rows(integration: Integration, slack_user_id: str) -> tuple[SlackSettings | None, SlackSettings | None]:
@@ -1402,6 +1511,8 @@ def _republish_home(
     selected_status: str | None = None,
     page: int = 0,
 ) -> None:
+    if _publish_onboarding_home_if_needed(integration, slack_user_id):
+        return
     user_row, workspace_row = _load_rows(integration, slack_user_id)
     effective = resolve_ai_preferences(integration, slack_user_id)
     slack = SlackIntegration(integration)

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -39,6 +39,7 @@ from products.slack_app.backend.services.slack_app_home import (
     PreferenceSource,
     TaskItem,
     TasksState,
+    _get_slack_integration,
     handle_ai_preferences_block_action,
     handle_app_home_opened,
     handle_app_home_view_submission,
@@ -102,6 +103,18 @@ def non_admin_user():
     with patch(
         "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
         return_value=False,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _all_candidates_healthy():
+    # `_get_slack_integration` auth-checks candidates through slack_auth, which builds its own
+    # WebClient (a real network call in tests). Default every candidate to healthy; the picker
+    # tests override this with their own patch.
+    with patch(
+        "products.slack_app.backend.services.slack_app_home.check_integrations_auth_and_filter",
+        side_effect=lambda candidates, **kwargs: candidates,
     ):
         yield
 
@@ -887,3 +900,36 @@ class TestWorkspaceSubmitAdminGate:
         body = json.loads(response.content)
         assert body["response_action"] == "errors"
         assert not SlackSettings.objects.filter(slack_user_id__isnull=True).exists()
+
+
+class TestGetSlackIntegration:
+    # A workspace with a stale install kept a dead token at the lowest id; `.first()` routed
+    # every home publish through it (`invalid_auth`), so the picker must prefer a candidate
+    # that passes the auth check and only fall back to id order when none do.
+    AUTH_FILTER = "products.slack_app.backend.services.slack_app_home.check_integrations_auth_and_filter"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        organization = Organization.objects.create(name="Org")
+        self.dead = Integration.objects.create(
+            team=Team.objects.create(organization=organization, name="Stale"),
+            kind="slack",
+            integration_id=SLACK_WORKSPACE_ID,
+            sensitive_config={"access_token": "xoxb-dead"},
+        )
+        self.live = Integration.objects.create(
+            team=Team.objects.create(organization=organization, name="Live"),
+            kind="slack",
+            integration_id=SLACK_WORKSPACE_ID,
+            sensitive_config={"access_token": "xoxb-live"},
+        )
+
+    def test_prefers_auth_healthy_integration(self):
+        with patch(self.AUTH_FILTER, side_effect=lambda candidates, **kwargs: [self.live]):
+            picked = _get_slack_integration(SLACK_WORKSPACE_ID)
+        assert picked is not None and picked.id == self.live.id
+
+    def test_falls_back_to_first_when_none_healthy(self):
+        with patch(self.AUTH_FILTER, return_value=[]):
+            picked = _get_slack_integration(SLACK_WORKSPACE_ID)
+        assert picked is not None and picked.id == self.dead.id

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -1,0 +1,1084 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import Client
+from django.utils import timezone
+
+from parameterized import parameterized
+from slack_sdk.errors import SlackApiError
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, TemplateInfo
+from products.signals.backend.facade.api import ScoutProvisionResult
+from products.slack_app.backend import api, persona_onboarding
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
+from products.slack_app.backend.services import slack_app_home
+from products.tasks.backend.models import Task, TaskRun
+
+WORKSPACE = "T1"
+SLACK_USER = "U1"
+DM_CHANNEL = "D1"
+PICKED_CHANNEL = "C9"
+
+FLAG = "products.slack_app.backend.persona_onboarding.is_persona_onboarding_enabled"
+PROVISION = "products.signals.backend.facade.api.provision_persona_scouts"
+WEBCLIENT = "posthog.models.integration.WebClient"
+
+CSM_SKILL_NAMES = [spec.skill_name for spec in persona_onboarding.PERSONA_SCOUT_CATALOG[persona_onboarding.PERSONA_CSM]]
+
+
+def _template(name: str, *, redirect: bool = True) -> TemplateInfo:
+    return TemplateInfo(
+        id=f"tmpl-{name.lower()}",
+        name=name,
+        auth_type="oauth" if redirect else "api_key",
+        icon_key="",
+        connect_via_redirect=redirect,
+    )
+
+
+ALL_TEMPLATES = [
+    _template("Salesforce"),
+    _template("HubSpot"),
+    _template("Zendesk"),
+    _template("Intercom", redirect=False),
+    _template("Linear"),
+    _template("Jira"),
+    _template("Stripe"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _mute_analytics():
+    # Every handler fires capture_slack_event, whose ph_scoped_capture flushes on a blocking
+    # network shutdown — mock it to keep the suite fast; the mock also lets tests inspect kwargs.
+    with patch("products.slack_app.backend.persona_onboarding.capture_slack_event") as mock_capture:
+        yield mock_capture
+
+
+@pytest.fixture(autouse=True)
+def _inline_background_work():
+    # Handlers ack Slack fast and do their real work off-thread; run that work inline so tests
+    # observe effects synchronously and DB access stays on the test connection.
+    with patch.object(persona_onboarding, "_run_in_background", side_effect=lambda fn, task: fn()):
+        yield
+
+
+class _FlowTestBase:
+    @pytest.fixture(autouse=True)
+    def setup(self, db, django_capture_on_commit_callbacks):
+        self.capture_on_commit = django_capture_on_commit_callbacks
+        cache.clear()
+        self.organization = Organization.objects.create(name="Org")
+        self.team = Team.objects.create(organization=self.organization, name="Team")
+        self.user = User.objects.create(email="csm@example.com", first_name="Pat")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=WORKSPACE,
+            config={"scope": "chat:write,channels:manage"},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    def _client(self, mock_webclient_class: MagicMock) -> MagicMock:
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ok": True, "ts": "111.222"}
+        client.chat_update.return_value = {"ok": True}
+        client.conversations_open.return_value = {"channel": {"id": DM_CHANNEL}}
+        client.conversations_info.return_value = {"channel": {"id": PICKED_CHANNEL, "name": "cs-alerts"}}
+        client.users_info.return_value = {"user": {"profile": {"title": "", "display_name": "Pat"}}}
+        client.views_publish.return_value = {"ok": True}
+        mock_webclient_class.return_value = client
+        return client
+
+    def _row(self) -> SlackSettings:
+        return SlackSettings.objects.get(slack_workspace_id=WORKSPACE, slack_user_id=SLACK_USER)
+
+    def _seed_state(self, step: str, **extra: object) -> SlackSettings:
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        state: dict = {
+            "step": step,
+            "persona_candidate": None,
+            "detection_source": None,
+            "team_id": self.team.id,
+            "integration_id": self.integration.id,
+            "posthog_user_id": self.user.id,
+            "dm_channel_id": DM_CHANNEL,
+            "thread_ts": None,
+            "kickoff_ts": "111.222",
+            "started_at": "2026-07-02T00:00:00+00:00",
+        }
+        state.update(extra)
+        row.onboarding_state = state
+        row.save(update_fields=["onboarding_state", "updated_at"])
+        return row
+
+    def _payload(self, action: dict) -> dict:
+        return {
+            "team": {"id": WORKSPACE},
+            "user": {"id": SLACK_USER},
+            "channel": {"id": DM_CHANNEL},
+            "message": {"ts": "1.2", "blocks": []},
+            "actions": [action],
+        }
+
+    def _posted_text(self, client: MagicMock) -> str:
+        parts: list[str] = []
+        for call in client.chat_postMessage.call_args_list:
+            parts.append(str(call.kwargs.get("text") or ""))
+            for block in call.kwargs.get("blocks") or []:
+                text = (block.get("text") or {}).get("text", "")
+                if isinstance(text, str):
+                    parts.append(text)
+                for element in block.get("elements", []):
+                    element_text = element.get("text")
+                    parts.append(
+                        element_text if isinstance(element_text, str) else (element_text or {}).get("text", "")
+                    )
+        return " ".join(parts)
+
+
+class TestInterceptAssistantSurface(_FlowTestBase):
+    def _intercept(self, entry_point: str = "first_dm") -> bool:
+        return persona_onboarding.maybe_intercept_assistant_surface(
+            self.integration,
+            posthog_user_id=self.user.id,
+            workspace_id=WORKSPACE,
+            slack_user_id=SLACK_USER,
+            channel_id=DM_CHANNEL,
+            thread_ts=None,
+            accessible_integration_ids=[self.integration.id],
+            entry_point=entry_point,
+        )
+
+    @patch(FLAG, return_value=False)
+    @patch(WEBCLIENT)
+    def test_flag_off_is_inert(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+
+        assert self._intercept() is False
+
+        client.chat_postMessage.assert_not_called()
+        assert not SlackSettings.objects.filter(slack_workspace_id=WORKSPACE, slack_user_id=SLACK_USER).exists()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_new_user_gets_kickoff_dm_and_state(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+
+        assert self._intercept() is True
+
+        client.chat_postMessage.assert_called_once()
+        row = self._row()
+        assert row.onboarded_at is None
+        state = row.onboarding_state
+        assert state["step"] == persona_onboarding.STEP_AWAITING_PERSONA
+        assert state["team_id"] == self.team.id
+        assert state["integration_id"] == self.integration.id
+        assert state["posthog_user_id"] == self.user.id
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_prior_activity_grandfathers_without_onboarding(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        task = Task.objects.create(team=self.team, title="t")
+        task_run = TaskRun.objects.create(team=self.team, task=task)
+        SlackThreadTaskMapping.objects.create(
+            team=self.team,
+            integration=self.integration,
+            slack_workspace_id=WORKSPACE,
+            channel="C0",
+            thread_ts="1.0",
+            task=task,
+            task_run=task_run,
+            mentioning_slack_user_id=SLACK_USER,
+            latest_actor_slack_user_id=SLACK_USER,
+        )
+
+        assert self._intercept() is False
+
+        row = self._row()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        client.chat_postMessage.assert_not_called()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_onboarded_row_is_never_intercepted(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        row.onboarded_at = timezone.now()
+        row.save(update_fields=["onboarded_at", "updated_at"])
+
+        assert self._intercept() is False
+
+        client.chat_postMessage.assert_not_called()
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_dm_during_in_flight_onboarding_nudges_without_reset(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        assert self._intercept() is True
+        original_kickoff_ts = self._row().onboarding_state["kickoff_ts"]
+        client.chat_postMessage.reset_mock()
+        client.chat_postMessage.return_value = {"ok": True, "ts": "999.999"}
+
+        assert self._intercept(entry_point="first_dm") is True
+
+        assert persona_onboarding.NUDGE_PERSONA_TEXT in self._posted_text(client)
+        assert self._row().onboarding_state["kickoff_ts"] == original_kickoff_ts
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_reopened_pane_retargets_the_thread_pointer(self, mock_webclient, _flag):
+        # Kickoff in the original thread, then re-open the assistant container (fresh thread):
+        # the repost must land in the new thread, not the stale one.
+        client = self._client(mock_webclient)
+        assert self._intercept(entry_point="thread_started") is True
+        persona_onboarding.maybe_intercept_assistant_surface(
+            self.integration,
+            posthog_user_id=self.user.id,
+            workspace_id=WORKSPACE,
+            slack_user_id=SLACK_USER,
+            channel_id="D_NEW",
+            thread_ts="new-thread-ts",
+            accessible_integration_ids=[self.integration.id],
+            entry_point="thread_started",
+        )
+        state = self._row().onboarding_state
+        assert state["dm_channel_id"] == "D_NEW"
+        assert state["thread_ts"] == "new-thread-ts"
+        assert client.chat_postMessage.call_args.kwargs["channel"] == "D_NEW"
+
+
+class TestPersonaSelection(_FlowTestBase):
+    def _select(self, value: str) -> None:
+        action = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": value}
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+    @patch(WEBCLIENT)
+    def test_csm_select_reveals_fleet_then_asks_for_channel(self, mock_webclient, _mute_analytics):
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+
+        self._select("csm")
+
+        row.refresh_from_db()
+        assert row.persona == "csm"
+        assert row.onboarded_at is None
+        state = row.onboarding_state
+        assert state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert set(state["readiness"]) == {
+            "account_pulse",
+            "support_watch",
+            "revenue_watch",
+            "accounts_count",
+            "ready_details",
+        }
+        # ready_details is presentation-only — it must stay out of the flat analytics event schema.
+        fleet_shown = next(
+            call for call in _mute_analytics.call_args_list if call.args[1] == persona_onboarding.EVENT_FLEET_SHOWN
+        )
+        assert "ready_details" not in fleet_shown.kwargs
+        assert "account_pulse" in fleet_shown.kwargs
+        assert state["detected_tools"] == []
+        # The post-OAuth return leg needs this pointer to flip the reveal's ⚠️ lines to ✅.
+        assert state["fleet_message_ts"] == "111.222"
+        # Completion needs this pointer to rewrite the channel prompt to its done note.
+        assert state["channel_prompt_ts"] == "111.222"
+        assert client.chat_postMessage.call_count == 2
+        reveal_blocks, prompt_blocks = (call.kwargs["blocks"] for call in client.chat_postMessage.call_args_list)
+        assert persona_onboarding.SCOUTS_DOC_URL in str(reveal_blocks)
+        assert any(
+            element.get("action_id") == persona_onboarding.CHANNEL_SELECT_ACTION_ID
+            for block in prompt_blocks
+            for element in block.get("elements", [])
+        )
+
+    @patch(WEBCLIENT)
+    def test_replayed_csm_click_reposts_channel_step_without_double_transition(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(
+            persona_onboarding.STEP_AWAITING_CHANNEL,
+            readiness={"account_pulse": False, "support_watch": False, "revenue_watch": False, "accounts_count": 0},
+            detected_tools=[],
+        )
+        row.persona = persona_onboarding.PERSONA_CSM
+        row.save(update_fields=["persona"])
+
+        self._select("csm")
+
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert client.chat_postMessage.call_count == 1
+        assert persona_onboarding.SCOUTS_DOC_URL not in self._posted_text(client)
+        assert any(
+            element.get("action_id") == persona_onboarding.CHANNEL_SELECT_ACTION_ID
+            for block in client.chat_postMessage.call_args.kwargs["blocks"]
+            for element in block.get("elements", [])
+        )
+
+    @parameterized.expand(
+        [
+            ("top_level_click", {"ts": "555.1", "blocks": []}, "555.1"),
+            ("threaded_click", {"ts": "555.2", "thread_ts": "555.1", "blocks": []}, "555.1"),
+        ]
+    )
+    @patch(WEBCLIENT)
+    def test_reply_threads_under_clicked_message(self, _name, message, expected_anchor, mock_webclient):
+        # A reply outside the clicked message's thread opens a brand-new conversation in the
+        # assistant surface — the click location must win over the stored (here: None) pointer.
+        client = self._client(mock_webclient)
+        self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": "engineer"}
+        payload = self._payload(action)
+        payload["message"] = message
+
+        persona_onboarding.handle_block_action(payload, action)
+
+        assert client.chat_postMessage.call_count >= 1
+        assert all(call.kwargs["thread_ts"] == expected_anchor for call in client.chat_postMessage.call_args_list)
+
+    @patch(WEBCLIENT)
+    def test_skip_marks_onboarded_without_persona(self, mock_webclient):
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": persona_onboarding.SKIP_ACTION_ID}
+
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.persona is None
+        assert row.onboarding_state is None
+        assert persona_onboarding.SKIP_TEXT in self._posted_text(client)
+
+
+class TestChannelStep(_FlowTestBase):
+    def _seed_channel_state(self) -> SlackSettings:
+        row = self._seed_state(
+            persona_onboarding.STEP_AWAITING_CHANNEL,
+            readiness={"account_pulse": False, "support_watch": False, "revenue_watch": False, "accounts_count": 0},
+            detected_tools=[],
+        )
+        row.persona = persona_onboarding.PERSONA_CSM
+        row.save(update_fields=["persona"])
+        return row
+
+    def _results(self, channel_conflict: str | None = None) -> list[ScoutProvisionResult]:
+        return [
+            ScoutProvisionResult(
+                skill_name=skill_name,
+                config_id=f"cfg-{index}",
+                created=True,
+                channel_conflict=channel_conflict if index == 0 else None,
+                first_run_started=True,
+            )
+            for index, skill_name in enumerate(CSM_SKILL_NAMES)
+        ]
+
+    def _select_channel(self) -> None:
+        # Selection is committed by the Add PostHog button; the picked channel rides along in
+        # the message's input state, like Slack sends it.
+        action = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+        payload = self._payload(action)
+        payload["state"] = {
+            "values": {
+                persona_onboarding.CHANNEL_SELECT_BLOCK_ID: {
+                    persona_onboarding.CHANNEL_SELECT_ACTION_ID: {"selected_conversation": PICKED_CHANNEL}
+                }
+            }
+        }
+        persona_onboarding.handle_block_action(payload, action)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_select_provisions_fleet_and_finalizes_row(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        mock_provision.assert_called_once()
+        kwargs = mock_provision.call_args.kwargs
+        assert kwargs["team"] == self.team
+        assert kwargs["created_by"] == self.user
+        assert kwargs["slack_integration_id"] == self.integration.id
+        assert kwargs["channel_id"] == PICKED_CHANNEL
+        assert kwargs["channel_name"] == "cs-alerts"
+        assert kwargs["skill_names"] == CSM_SKILL_NAMES
+        row.refresh_from_db()
+        assert row.persona == persona_onboarding.PERSONA_CSM
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        assert "locked in" in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_skip_at_channel_step_onboards_without_provisioning(self, mock_webclient, mock_provision):
+        # A CSM who can't/won't pick a channel must be able to bail — otherwise the DM intercept
+        # wedges them out of the assistant entirely.
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+        action = {"action_id": persona_onboarding.SKIP_ACTION_ID}
+        persona_onboarding.handle_block_action(self._payload(action), action)
+        mock_provision.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        assert "skipping setup" in self._posted_text(client).lower()
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_selecting_a_channel_alone_does_nothing(self, mock_webclient, mock_provision):
+        # The dropdown fires a block action on every selection — acting on it directly is how
+        # a mis-click used to add the bot to the wrong channel.
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+        action = {"action_id": persona_onboarding.CHANNEL_SELECT_ACTION_ID, "selected_conversation": PICKED_CHANNEL}
+
+        response = persona_onboarding.handle_block_action(self._payload(action), action)
+
+        assert response.status_code == 200
+        mock_provision.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_confirm_without_selection_asks_for_a_channel(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        self._seed_channel_state()
+        action = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        mock_provision.assert_not_called()
+        assert persona_onboarding.PICK_CHANNEL_FIRST_TEXT in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_confirm_joins_public_channel_before_asking_for_invite(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+        joined = False
+
+        def reject_until_joined(channel=None, **kwargs):
+            if channel == PICKED_CHANNEL and not joined:
+                raise SlackApiError("not_in_channel", {"error": "not_in_channel"})
+            return {"ok": True, "ts": "1.3"}
+
+        def join(channel=None, **kwargs):
+            nonlocal joined
+            joined = True
+            return {"ok": True}
+
+        client.chat_postMessage.side_effect = reject_until_joined
+        client.conversations_join.side_effect = join
+
+        self._select_channel()
+
+        client.conversations_join.assert_called_once_with(channel=PICKED_CHANNEL)
+        mock_provision.assert_called_once()
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+
+    def test_channel_prompt_keeps_confirm_next_to_selector(self):
+        blocks = persona_onboarding.build_channel_prompt_blocks(True)
+        select_row = next(
+            block for block in blocks if block.get("block_id") == persona_onboarding.CHANNEL_SELECT_BLOCK_ID
+        )
+        assert [element.get("action_id") for element in select_row["elements"]] == [
+            persona_onboarding.CHANNEL_SELECT_ACTION_ID,
+            persona_onboarding.CHANNEL_CONFIRM_ACTION_ID,
+        ]
+        other_rows = [block for block in blocks if block.get("type") == "actions" and block is not select_row]
+        assert [element.get("action_id") for row in other_rows for element in row["elements"]] == [
+            persona_onboarding.CHANNEL_CREATE_ACTION_ID,
+            persona_onboarding.SKIP_ACTION_ID,
+        ]
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_completion_rewrites_channel_prompt_to_done_note(self, mock_webclient, mock_provision):
+        # Without the rewrite, the picker stays live after onboarding completes and a stray
+        # click re-runs channel setup against a finished flow.
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+        row.onboarding_state["channel_prompt_ts"] = "55.66"
+        row.save(update_fields=["onboarding_state"])
+
+        self._select_channel()
+
+        prompt_updates = [call for call in client.chat_update.call_args_list if call.kwargs.get("ts") == "55.66"]
+        assert len(prompt_updates) == 1
+        assert prompt_updates[0].kwargs["channel"] == DM_CHANNEL
+        assert "Channel set" in prompt_updates[0].kwargs["text"]
+        assert "#cs-alerts" in prompt_updates[0].kwargs["text"]
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_prompt_and_invite_offer_a_skip(self, mock_webclient, mock_provision):
+        assert any(
+            element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
+            for block in persona_onboarding.build_channel_prompt_blocks(True)
+            for element in block.get("elements", [])
+        )
+        assert any(
+            element.get("action_id") == persona_onboarding.SKIP_ACTION_ID
+            for block in persona_onboarding.build_invite_needed_blocks("C1", "alerts")
+            for element in block.get("elements", [])
+        )
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_provisioning_failure_leaves_user_unonboarded_and_retryable(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.side_effect = RuntimeError("temporal down")
+        row = self._seed_channel_state()
+        self._select_channel()
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert "something went wrong" in self._posted_text(client).lower()
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_not_in_channel_defers_provisioning_until_verify(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results()
+        row = self._seed_channel_state()
+
+        def reject_picked_channel(channel=None, **kwargs):
+            if channel == PICKED_CHANNEL:
+                raise SlackApiError("not_in_channel", {"error": "not_in_channel"})
+            return {"ok": True, "ts": "1.3"}
+
+        client.chat_postMessage.side_effect = reject_picked_channel
+        # Joining isn't possible either (e.g. missing channels:join) — only /invite can recover.
+        client.conversations_join.side_effect = SlackApiError("missing_scope", {"error": "missing_scope"})
+        self._select_channel()
+
+        mock_provision.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["pending_channel_id"] == PICKED_CHANNEL
+        assert row.onboarding_state["invite_message_ts"] == "1.3"
+        assert "/invite" in self._posted_text(client)
+        # The clicked picker was frozen for feedback — a fresh one must come back, or a user
+        # who picked an uninvitable channel is wedged on /invite-or-skip.
+        assert any(
+            block.get("block_id") == persona_onboarding.CHANNEL_SELECT_BLOCK_ID
+            for call in client.chat_postMessage.call_args_list
+            for block in call.kwargs.get("blocks") or []
+        )
+
+        client.chat_postMessage.side_effect = None
+        verify_action = {"action_id": persona_onboarding.CHANNEL_VERIFY_ACTION_ID, "value": PICKED_CHANNEL}
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.handle_block_action(self._payload(verify_action), verify_action)
+
+        mock_provision.assert_called_once()
+        assert mock_provision.call_args.kwargs["channel_id"] == PICKED_CHANNEL
+        # The /invite-then-verify path must carry its own funnel label so it stays distinct from
+        # the dropdown path in the channel-configured conversion.
+        configured = [c for c in capture.call_args_list if c.args[1] == persona_onboarding.EVENT_CHANNEL_CONFIGURED]
+        assert [c.kwargs["method"] for c in configured] == ["verified"]
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+        # The stale invite-then-verify ask flips to the done note so Verify can't double-fire.
+        invite_updates = [call for call in client.chat_update.call_args_list if call.kwargs.get("ts") == "1.3"]
+        assert len(invite_updates) == 1
+        assert "Channel set" in invite_updates[0].kwargs["text"]
+
+    @patch(PROVISION, side_effect=RuntimeError("enabled cap reached"))
+    @patch(WEBCLIENT)
+    def test_provisioning_failure_keeps_flow_retryable(self, mock_webclient, _mock_provision):
+        client = self._client(mock_webclient)
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_CHANNEL
+        assert persona_onboarding.ERROR_TEXT in self._posted_text(client)
+
+    @patch(PROVISION)
+    @patch(WEBCLIENT)
+    def test_channel_conflict_uses_already_running_copy(self, mock_webclient, mock_provision):
+        client = self._client(mock_webclient)
+        mock_provision.return_value = self._results(channel_conflict="scout-hq")
+        row = self._seed_channel_state()
+
+        self._select_channel()
+
+        text = self._posted_text(client)
+        assert "already running" in text
+        assert "#scout-hq" in text
+        row.refresh_from_db()
+        assert row.onboarded_at is not None
+
+
+class TestFastAck(_FlowTestBase):
+    @patch(WEBCLIENT)
+    def test_slow_handlers_never_run_on_the_ack_thread(self, mock_webclient):
+        # Slack voids a block action after 3s — if a handler's Slack/DB work creeps back onto
+        # the request thread, users see "operation timed out" on the button again.
+        client = self._client(mock_webclient)
+        self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": f"{persona_onboarding.PERSONA_SELECT_ACTION_ID}:csm", "value": "csm"}
+        deferred: list = []
+        with patch.object(persona_onboarding, "_run_in_background", side_effect=lambda fn, task: deferred.append(fn)):
+            response = persona_onboarding.handle_block_action(self._payload(action), action)
+        assert response.status_code == 200
+        assert len(deferred) == 1
+        client.chat_postMessage.assert_not_called()
+        client.chat_update.assert_not_called()
+
+
+class TestKickoffSingleFlight(_FlowTestBase):
+    @patch(WEBCLIENT)
+    def test_held_claim_blocks_duplicate_kickoff(self, mock_webclient):
+        # The kickoff runs off-thread, so a double-clicked Start (or a redelivered DM event)
+        # races state creation — the cache claim must make the second entry a no-op.
+        client = self._client(mock_webclient)
+        cache.add(f"slack_persona_onboarding_start:{WORKSPACE}:{SLACK_USER}", "1", timeout=60)
+
+        persona_onboarding.start_onboarding_dm(
+            self.integration, SLACK_USER, posthog_user_id=self.user.id, entry_point="home_button"
+        )
+
+        client.chat_postMessage.assert_not_called()
+        assert self._row().onboarding_state is None
+
+
+class TestActionSingleFlight(_FlowTestBase):
+    @patch(WEBCLIENT)
+    def test_held_claim_blocks_duplicate_action(self, mock_webclient):
+        # Slack sends each click as its own request, so a concurrent duplicate must not double-run
+        # the state-mutating handler (double completion post, followup re-write). A held per-user
+        # claim skips the handler; clearing it lets the next run complete.
+        client = self._client(mock_webclient)
+        row = self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        action = {"action_id": f"{persona_onboarding.PERSONA_SELECT_ACTION_ID}:engineer", "value": "engineer"}
+        claim_key = f"slack_onboarding_action_claim:{WORKSPACE}:{SLACK_USER}"
+
+        cache.add(claim_key, 1, timeout=60)
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        client.chat_postMessage.assert_not_called()
+        row.refresh_from_db()
+        assert row.onboarded_at is None
+        assert row.onboarding_state is not None
+
+        cache.delete(claim_key)
+        persona_onboarding.handle_block_action(self._payload(action), action)
+
+        row.refresh_from_db()
+        assert row.persona == "engineer"
+        assert row.onboarded_at is not None
+        assert row.onboarding_state is None
+
+
+class TestOnboardingHomeView(_FlowTestBase):
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_home_is_onboarding_only_with_dm_deep_link_until_onboarded(self, mock_webclient, _flag):
+        client = self._client(mock_webclient)
+        self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+
+        slack_app_home.republish_home_for_user(self.integration, SLACK_USER)
+
+        view = client.views_publish.call_args.kwargs["view"]
+        flat = str(view["blocks"])
+        assert "AI model" not in flat  # settings sections stay hidden pre-onboarding
+        card = view["blocks"][-1]
+        assert card["accessory"]["action_id"] == persona_onboarding.OPEN_DM_ACTION_ID
+        query = parse_qs(urlparse(card["accessory"]["url"]).query)
+        assert query == {"team": [WORKSPACE], "channel": [DM_CHANNEL]}
+
+
+class TestHomeOnboardingStatus(_FlowTestBase):
+    @parameterized.expand(
+        [
+            ("flag_off", False, "in_flight", "hidden"),
+            ("no_row", True, None, "start"),
+            ("in_flight", True, "in_flight", "in_progress"),
+            ("onboarded", True, "onboarded", "hidden"),
+        ]
+    )
+    @patch(FLAG)
+    def test_home_card_status_matrix(self, _name, flag_on, row_state, expected, mock_flag):
+        mock_flag.return_value = flag_on
+        if row_state == "in_flight":
+            self._seed_state(persona_onboarding.STEP_AWAITING_PERSONA)
+        elif row_state == "onboarded":
+            row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+            row.onboarded_at = timezone.now()
+            row.save(update_fields=["onboarded_at", "updated_at"])
+
+        assert persona_onboarding.compute_home_onboarding_status(self.integration, WORKSPACE, SLACK_USER) == expected
+
+
+class TestPersonaOnboardingInteractivityRouting:
+    @parameterized.expand(
+        [
+            ("persona_step_action", "block_actions", persona_onboarding.PERSONA_SELECT_ACTION_ID, True),
+            ("home_start_action", "block_actions", persona_onboarding.START_ACTION_ID, True),
+            ("unrelated_action", "block_actions", "posthog_code_repo_select", False),
+            ("view_submission", "view_submission", persona_onboarding.PERSONA_SELECT_ACTION_ID, False),
+        ]
+    )
+    def test_is_persona_onboarding_interactivity(self, _name, payload_type, action_id, expected):
+        payload = {"actions": [{"action_id": action_id}]}
+        assert api._is_persona_onboarding_interactivity(payload, payload_type) is expected
+
+    def test_payload_without_actions_is_not_claimed(self):
+        assert api._is_persona_onboarding_interactivity({}, "block_actions") is False
+
+
+class TestBlockKitActionIdUniqueness:
+    # Slack rejects any message whose interactive elements share an action_id (`invalid_blocks`),
+    # so every builder that can emit sibling buttons is exercised in its busiest configuration.
+    @parameterized.expand(
+        [
+            ("kickoff_ask", lambda: persona_onboarding.build_kickoff_blocks("Pat", None)),
+            (
+                "kickoff_csm_candidate",
+                lambda: persona_onboarding.build_kickoff_blocks("Pat", persona_onboarding.PERSONA_CSM),
+            ),
+            (
+                "kickoff_engineer_candidate",
+                lambda: persona_onboarding.build_kickoff_blocks("Pat", persona_onboarding.PERSONA_ENGINEER),
+            ),
+            (
+                "fleet_reveal_all_gaps_no_templates",
+                lambda: persona_onboarding.build_fleet_reveal_blocks(1, {}, [], [], "T1", "U1"),
+            ),
+            (
+                "fleet_reveal_all_gaps_templates_and_tools",
+                lambda: persona_onboarding.build_fleet_reveal_blocks(
+                    1, {}, ["Linear", "Zendesk"], ALL_TEMPLATES, "T1", "U1"
+                ),
+            ),
+            ("channel_prompt_with_create", lambda: persona_onboarding.build_channel_prompt_blocks(True)),
+            ("invite_needed", lambda: persona_onboarding.build_invite_needed_blocks("C1", "posthog-inbox")),
+        ]
+    )
+    def test_action_ids_unique_within_message(self, _name, build):
+        blocks = build()
+        action_ids = [
+            element["action_id"]
+            for block in blocks
+            for element in block.get("elements", [])
+            if isinstance(element, dict) and "action_id" in element
+        ]
+        assert action_ids, "builder emitted no interactive elements — extractor or builder is broken"
+        assert len(action_ids) == len(set(action_ids)), f"duplicate action_ids in one message: {action_ids}"
+
+
+class TestFleetRevealConnectButtons:
+    def _buttons_by_label(self, blocks: list[dict]) -> dict[str, dict]:
+        return {
+            element["text"]["text"]: element
+            for block in blocks
+            for element in block.get("elements", [])
+            if isinstance(element, dict) and element.get("type") == "button"
+        }
+
+    def test_connect_buttons_link_into_mcp_connect_flow(self):
+        blocks = persona_onboarding.build_fleet_reveal_blocks(1, {}, ["Zendesk"], ALL_TEMPLATES, WORKSPACE, SLACK_USER)
+        buttons = self._buttons_by_label(blocks)
+
+        zendesk = buttons["Connect Zendesk"]
+        assert "/integrations/connect-mcp/tmpl-zendesk/" in zendesk["url"]
+        query = parse_qs(urlparse(zendesk["url"]).query)
+        assert query["project_id"] == ["1"]
+        payload = persona_onboarding.unsign_connect_state(query["state"][0])
+        assert payload == {"w": WORKSPACE, "u": SLACK_USER, "k": "support_watch", "t": "Zendesk"}
+
+        # API-key templates can't finish from a bare redirect — their button deep-links to the store.
+        intercom = buttons["Connect Intercom"]
+        assert "/settings/mcp-servers?mcp=tmpl-intercom" in intercom["url"]
+
+    def test_ready_scouts_name_their_default_data_source(self):
+        # Users shouldn't feel obligated to connect a tool when PostHog already has the data —
+        # ready scouts say what they'll use, and gapped ones say connecting is optional.
+        readiness = {
+            "revenue_watch": True,
+            "ready_details": {"revenue_watch": "your Stripe data synced into PostHog"},
+        }
+        blocks = persona_onboarding.build_fleet_reveal_blocks(1, readiness, [], [], WORKSPACE, SLACK_USER)
+        text = str(blocks)
+        assert "I'll use your Stripe data synced into PostHog." in text
+        assert "Connecting a tool below is optional" in text
+
+    def test_without_matching_templates_offers_store_browse(self):
+        blocks = persona_onboarding.build_fleet_reveal_blocks(1, {}, [], [], WORKSPACE, SLACK_USER)
+        buttons = [
+            element
+            for block in blocks
+            for element in block.get("elements", [])
+            if isinstance(element, dict) and element.get("type") == "button"
+        ]
+        assert len(buttons) == len(persona_onboarding.PERSONA_SCOUT_CATALOG[persona_onboarding.PERSONA_CSM])
+        assert all(button["text"]["text"] == "Browse the MCP store" for button in buttons)
+        assert all("/settings/mcp-servers" in button["url"] for button in buttons)
+
+
+class TestCsmReadinessWithMcpInstallations(_FlowTestBase):
+    @parameterized.expand(
+        [
+            ("crm_feeds_account_pulse", "HubSpot", "account_pulse"),
+            ("ticketing_feeds_support_watch", "Jira", "support_watch"),
+            ("billing_feeds_revenue_watch", "Stripe", "revenue_watch"),
+        ]
+    )
+    def test_connected_server_marks_only_its_scout_ready(self, _name, server_name, readiness_key):
+        installation = ActiveInstallationInfo(id="i1", name="My server", proxy_path="/x", template_name=server_name)
+        with patch.object(persona_onboarding, "get_active_installations", return_value=[installation]):
+            readiness = persona_onboarding.check_csm_data_readiness(self.team.id, self.user.id)
+        assert getattr(readiness, readiness_key) is True
+        # The reveal names the data source so users know what powers the scout by default.
+        assert server_name in readiness.ready_details[readiness_key]
+        others = {"account_pulse", "support_watch", "revenue_watch"} - {readiness_key}
+        assert not any(getattr(readiness, key) for key in others)
+
+
+class TestMcpConnectReturn(_FlowTestBase):
+    URL = "/integrations/slack/mcp-connected/"
+
+    def _signed_state(self) -> str:
+        return persona_onboarding.sign_connect_state(WORKSPACE, SLACK_USER, "revenue_watch", "Stripe")
+
+    def _seed_channel_step(self, **extra: object) -> SlackSettings:
+        return self._seed_state(
+            persona_onboarding.STEP_AWAITING_CHANNEL,
+            readiness={"account_pulse": False, "support_watch": False, "revenue_watch": False, "accounts_count": 0},
+            detected_tools=[],
+            fleet_message_ts="42.42",
+            **extra,
+        )
+
+    @patch(WEBCLIENT)
+    def test_success_updates_fleet_message_and_links_back_to_slack(self, mock_webclient):
+        client = self._client(mock_webclient)
+        self._seed_channel_step()
+        stripe = ActiveInstallationInfo(id="i1", name="Stripe", proxy_path="/x", template_name="Stripe")
+        with (
+            patch.object(persona_onboarding, "get_active_installations", return_value=[stripe]),
+            patch.object(persona_onboarding, "list_active_templates", return_value=ALL_TEMPLATES),
+        ):
+            response = Client().get(self.URL, {"state": self._signed_state(), "status": "success"})
+
+        assert response.status_code == 200
+        assert f"slack://channel?team={WORKSPACE}&amp;id={DM_CHANNEL}" in response.content.decode()
+        client.chat_update.assert_called_once()
+        assert client.chat_update.call_args.kwargs["ts"] == "42.42"
+        assert self._row().onboarding_state["readiness"]["revenue_watch"] is True
+
+    @patch(WEBCLIENT)
+    def test_replayed_return_captures_connect_event_once(self, mock_webclient):
+        # The signed state is reusable for 30 days; a back-button/reload must not re-fire the
+        # connect-conversion event, while the fleet refresh (DB-recomputed) still runs each time.
+        client = self._client(mock_webclient)
+        self._seed_channel_step()
+        stripe = ActiveInstallationInfo(id="i1", name="Stripe", proxy_path="/x", template_name="Stripe")
+        state = self._signed_state()
+        with (
+            patch.object(persona_onboarding, "get_active_installations", return_value=[stripe]),
+            patch.object(persona_onboarding, "list_active_templates", return_value=ALL_TEMPLATES),
+            patch.object(persona_onboarding, "capture_slack_event") as capture,
+        ):
+            first = Client().get(self.URL, {"state": state, "status": "success"})
+            second = Client().get(self.URL, {"state": state, "status": "success"})
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        capture.assert_called_once()
+        assert capture.call_args.args[1] == persona_onboarding.EVENT_MCP_CONNECTED
+        assert client.chat_update.call_count == 2
+
+    @patch(WEBCLIENT)
+    def test_error_status_skips_message_update(self, mock_webclient):
+        client = self._client(mock_webclient)
+        self._seed_channel_step()
+
+        response = Client().get(self.URL, {"state": self._signed_state(), "status": "error", "error": "cancelled"})
+
+        assert response.status_code == 200
+        client.chat_update.assert_not_called()
+
+    def test_invalid_state_rejected(self):
+        assert Client().get(self.URL, {"state": "garbage"}).status_code == 400
+
+
+class TestHomeStartFlow(_FlowTestBase):
+    # The Start button must ack inside Slack's 3s budget, so the kickoff work runs in a
+    # background task; this pins the wiring end to end — click → interim card published,
+    # kickoff DM posted, state row created, home republished — with the background seam
+    # collapsed to inline.
+    @patch(WEBCLIENT)
+    def test_click_posts_kickoff_and_republishes_home(self, mock_webclient_class):
+        client = self._client(mock_webclient_class)
+        workspace_result = MagicMock(candidates=[self.integration], integration=self.integration)
+        user_resolution = MagicMock(user=self.user, integration=self.integration, candidates=[self.integration])
+        action = {"action_id": persona_onboarding.START_ACTION_ID}
+        with (
+            patch(FLAG, return_value=True),
+            patch.object(persona_onboarding, "_run_in_background", side_effect=lambda fn, task: fn()),
+            patch.object(persona_onboarding, "load_integrations", return_value=workspace_result),
+            patch.object(persona_onboarding, "resolve_user_for_workspace", return_value=user_resolution),
+            patch.object(persona_onboarding, "_republish_home") as republish,
+        ):
+            response = persona_onboarding.handle_block_action(
+                {"team": {"id": WORKSPACE}, "user": {"id": SLACK_USER}, "actions": [action]}, action
+            )
+        assert response.status_code == 200
+        client.chat_postMessage.assert_called_once()
+        row = self._row()
+        assert row.onboarding_state["step"] == persona_onboarding.STEP_AWAITING_PERSONA
+        # Follow-ups must thread under the kickoff — an unthreaded reply roots a brand-new
+        # conversation in the assistant surface instead of continuing this one.
+        assert row.onboarding_state["thread_ts"] == "111.222"
+        republish.assert_called_once()
+        # The interim card is the click's only immediate feedback — it must land before the
+        # kickoff's Slack round-trips, not after (the truthful republish is mocked out above,
+        # so this is the sole views_publish).
+        assert "Setting things up" in str(client.views_publish.call_args.kwargs["view"]["blocks"])
+        call_order = [name for name, _args, _kwargs in client.method_calls]
+        assert call_order.index("views_publish") < call_order.index("chat_postMessage")
+
+    @patch(WEBCLIENT)
+    def test_home_republished_even_when_kickoff_raises(self, mock_webclient_class):
+        # A kickoff that dies mid-flight (Slack hiccup, dev-server reload) must still converge
+        # the Home tab to the truthful state — otherwise the stale Start card sits there until
+        # the user happens to re-open the tab.
+        client = self._client(mock_webclient_class)
+        client.chat_postMessage.side_effect = RuntimeError("slack down")
+        workspace_result = MagicMock(candidates=[self.integration], integration=self.integration)
+        user_resolution = MagicMock(user=self.user, integration=self.integration, candidates=[self.integration])
+        with (
+            patch(FLAG, return_value=True),
+            patch.object(persona_onboarding, "load_integrations", return_value=workspace_result),
+            patch.object(persona_onboarding, "resolve_user_for_workspace", return_value=user_resolution),
+            patch.object(persona_onboarding, "_republish_home") as republish,
+            pytest.raises(RuntimeError),
+        ):
+            persona_onboarding._run_home_start(WORKSPACE, SLACK_USER)
+        republish.assert_called_once()
+
+
+class TestFunnelAnalytics(_FlowTestBase):
+    # The funnel contract: every step of one user's onboarding must land on the same per-user
+    # distinct_id (else conversion collapses to team level and steps stop chaining) and carry
+    # persona for breakdowns. The other flow tests mute analytics, so nothing else guards the
+    # emitted stream.
+    DISTINCT_ID = f"slack:{WORKSPACE}:{SLACK_USER}"
+
+    @patch(PROVISION)
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_csm_flow_events_share_person_and_persona(self, mock_webclient, _flag, mock_provision):
+        self._client(mock_webclient)
+        mock_provision.return_value = [
+            ScoutProvisionResult(
+                skill_name=skill_name,
+                config_id=f"cfg-{index}",
+                created=True,
+                channel_conflict=None,
+                first_run_started=True,
+            )
+            for index, skill_name in enumerate(CSM_SKILL_NAMES)
+        ]
+        select = {"action_id": persona_onboarding.PERSONA_SELECT_ACTION_ID, "value": "csm"}
+        confirm = {"action_id": persona_onboarding.CHANNEL_CONFIRM_ACTION_ID}
+        confirm_payload = self._payload(confirm)
+        confirm_payload["state"] = {
+            "values": {
+                persona_onboarding.CHANNEL_SELECT_BLOCK_ID: {
+                    persona_onboarding.CHANNEL_SELECT_ACTION_ID: {"selected_conversation": PICKED_CHANNEL}
+                }
+            }
+        }
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.maybe_intercept_assistant_surface(
+                self.integration,
+                posthog_user_id=self.user.id,
+                workspace_id=WORKSPACE,
+                slack_user_id=SLACK_USER,
+                channel_id=DM_CHANNEL,
+                thread_ts=None,
+                accessible_integration_ids=[self.integration.id],
+                entry_point="first_dm",
+            )
+            persona_onboarding.handle_block_action(self._payload(select), select)
+            persona_onboarding.handle_block_action(confirm_payload, confirm)
+
+        assert [call.args[1] for call in capture.call_args_list] == [
+            persona_onboarding.EVENT_STARTED,
+            persona_onboarding.EVENT_PERSONA_SELECTED,
+            persona_onboarding.EVENT_FLEET_SHOWN,
+            persona_onboarding.EVENT_CHANNEL_CONFIGURED,
+            persona_onboarding.EVENT_COMPLETED,
+        ]
+        assert {call.kwargs["distinct_id"] for call in capture.call_args_list} == {self.DISTINCT_ID}
+        by_event = {call.args[1]: call.kwargs for call in capture.call_args_list}
+        assert by_event[persona_onboarding.EVENT_STARTED]["posthog_user_id"] == self.user.id
+        for event in (
+            persona_onboarding.EVENT_PERSONA_SELECTED,
+            persona_onboarding.EVENT_FLEET_SHOWN,
+            persona_onboarding.EVENT_CHANNEL_CONFIGURED,
+            persona_onboarding.EVENT_COMPLETED,
+        ):
+            assert by_event[event]["persona"] == persona_onboarding.PERSONA_CSM
+        assert by_event[persona_onboarding.EVENT_COMPLETED]["scouts_provisioned"] == len(CSM_SKILL_NAMES)
+
+    @patch(WEBCLIENT)
+    def test_connect_click_after_completion_still_tracked(self, mock_webclient):
+        # Connect buttons outlive the flow (the engineer completion's GitHub button); a click
+        # after onboarding_state is cleared must still record, with the persona off the row.
+        self._client(mock_webclient)
+        row = persona_onboarding.get_or_create_settings_row(WORKSPACE, SLACK_USER)
+        row.persona = persona_onboarding.PERSONA_ENGINEER
+        row.onboarded_at = timezone.now()
+        row.save(update_fields=["persona", "onboarded_at", "updated_at"])
+        action = {"action_id": f"{persona_onboarding.CONNECT_SOURCE_ACTION_ID}:github", "value": "github"}
+
+        with patch.object(persona_onboarding, "capture_slack_event") as capture:
+            persona_onboarding.handle_block_action(self._payload(action), action)
+
+        capture.assert_called_once()
+        assert capture.call_args.args[1] == persona_onboarding.EVENT_CONNECT_CLICKED
+        assert capture.call_args.kwargs["distinct_id"] == self.DISTINCT_ID
+        assert capture.call_args.kwargs["persona"] == persona_onboarding.PERSONA_ENGINEER
+        assert capture.call_args.kwargs["server_name"] == "github"
+
+    @patch(FLAG, return_value=True)
+    @patch(WEBCLIENT)
+    def test_home_impression_fires_only_on_user_initiated_open(self, mock_webclient, _flag):
+        # Programmatic republishes (after every flow step) must not count as impressions, or
+        # the funnel's top inflates by a few events per onboarding.
+        self._client(mock_webclient)
+        with patch.object(slack_app_home, "capture_slack_event") as capture:
+            slack_app_home.republish_home_for_user(self.integration, SLACK_USER, track_impression=True)
+            assert capture.call_args.args[1] == persona_onboarding.EVENT_HOME_CARD_SHOWN
+            assert capture.call_args.kwargs["distinct_id"] == self.DISTINCT_ID
+            assert capture.call_args.kwargs["status"] == "start"
+            capture.reset_mock()
+            slack_app_home.republish_home_for_user(self.integration, SLACK_USER)
+            capture.assert_not_called()

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -1143,6 +1143,55 @@ class TestAssistantEvents(TestCase):
             )
             slack_cls.return_value.client.assistant_threads_setSuggestedPrompts.assert_not_called()
 
+    def test_thread_started_onboarding_targets_resolved_project_not_probe(self):
+        # In a multi-project workspace the workspace probe and the user's resolved default can
+        # differ; the thread-started entry point must land onboarding on the resolved project (as
+        # the first-DM path does) so the fleet doesn't depend on which entry point fired first.
+        from products.slack_app.backend.services.integration_resolver import (
+            ResolutionResult,
+            UserAndIntegrationsResolution,
+        )
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        resolved = Integration.objects.create(
+            team=other_team,
+            kind="slack",
+            integration_id="T12345",
+            config={"scope": "chat:write"},
+            sensitive_config={"access_token": "xoxb-other"},
+        )
+        load = patch(
+            "products.slack_app.backend.api.load_integrations",
+            return_value=ResolutionResult(
+                integration=self.integration, source="workspace_default", candidates=[self.integration, resolved]
+            ),
+        )
+        resolve = patch(
+            "products.slack_app.backend.api.resolve_user_for_workspace",
+            return_value=UserAndIntegrationsResolution(
+                user=self.user,
+                integration=resolved,
+                candidates=[self.integration, resolved],
+                source="user_default",
+            ),
+        )
+        enabled_p = patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+        usp = patch("products.slack_app.backend.api._us_should_handle_instead", return_value=False)
+        slack = patch("products.slack_app.backend.api.SlackIntegration")
+        intercept = patch(
+            "products.slack_app.backend.persona_onboarding.maybe_intercept_assistant_surface", return_value=True
+        )
+        with load, resolve, enabled_p, usp, slack, intercept as mock_intercept:
+            self._route(
+                {
+                    "type": "assistant_thread_started",
+                    "assistant_thread": {"user_id": "U123", "channel_id": "D001", "thread_ts": "111.222"},
+                }
+            )
+
+        mock_intercept.assert_called_once()
+        assert mock_intercept.call_args.args[0] == resolved
+
     def test_context_changed_caches_viewed_channel(self):
         from products.slack_app.backend.api import _get_assistant_channel_context
 

--- a/products/slack_app/backend/views/__init__.py
+++ b/products/slack_app/backend/views/__init__.py
@@ -6,6 +6,12 @@ per-flow submodule. New view modules should be re-exported here too.
 """
 
 from products.slack_app.backend.views.slack_command import slack_app_command_handler
+from products.slack_app.backend.views.slack_mcp_connect_return import slack_mcp_connected
 from products.slack_app.backend.views.slack_user_link import slack_user_link_authorize, slack_user_link_callback
 
-__all__ = ["slack_app_command_handler", "slack_user_link_authorize", "slack_user_link_callback"]
+__all__ = [
+    "slack_app_command_handler",
+    "slack_mcp_connected",
+    "slack_user_link_authorize",
+    "slack_user_link_callback",
+]

--- a/products/slack_app/backend/views/slack_mcp_connect_return.py
+++ b/products/slack_app/backend/views/slack_mcp_connect_return.py
@@ -1,0 +1,76 @@
+"""Browser return leg for MCP servers connected from Slack onboarding messages.
+
+A Connect button in the fleet-reveal DM carries a signed state naming the Slack workspace,
+user, scout, and server. After the provider OAuth completes, mcp_store redirects here; we
+refresh the fleet-reveal message (⚠️ → ✅) and bounce the user straight back into Slack.
+"""
+
+import hashlib
+
+from django.core import signing
+from django.core.cache import cache
+from django.http import HttpRequest, HttpResponse
+from django.utils.html import escape
+
+import structlog
+
+from products.slack_app.backend import persona_onboarding
+
+logger = structlog.get_logger(__name__)
+
+_PAGE = """<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{title}</title>
+    {refresh}
+    <style>
+      body {{
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0;
+      }}
+      main {{ text-align: center; max-width: 26rem; padding: 0 1rem; }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>{heading}</h1>
+      <p>{body}</p>
+    </main>
+  </body>
+</html>"""
+
+
+def slack_mcp_connected(request: HttpRequest) -> HttpResponse:
+    state_token = str(request.GET.get("state") or "")
+    try:
+        payload = persona_onboarding.unsign_connect_state(state_token)
+    except signing.BadSignature:
+        return HttpResponse("This link is invalid or has expired.", status=400)
+    success = request.GET.get("status", "success") != "error"
+    # The signed state is reusable for its whole 30-day life, so a back-button or reload re-hits
+    # this GET. Fire the connect-conversion event once per state token (hashed — raw tokens make
+    # poor cache keys) so replays don't inflate the metric; the fleet refresh stays idempotent.
+    token_hash = hashlib.sha256(state_token.encode()).hexdigest()
+    first_visit = cache.add(
+        f"slack_mcp_connect_event:{token_hash}", 1, timeout=persona_onboarding.CONNECT_STATE_MAX_AGE_SECONDS
+    )
+    deep_link = persona_onboarding.handle_mcp_connect_return(
+        workspace_id=str(payload.get("w") or ""),
+        slack_user_id=str(payload.get("u") or ""),
+        readiness_key=str(payload.get("k") or ""),
+        template_name=str(payload.get("t") or ""),
+        success=success,
+        error=str(request.GET.get("error") or ""),
+        capture_event=first_visit,
+    )
+    server = escape(str(payload.get("t") or "MCP server"))
+    if success:
+        heading = f"{server} connected 🎉"
+        body = f'Taking you back to Slack…<br /><a href="{escape(deep_link)}">Open Slack</a>'
+        refresh = f'<meta http-equiv="refresh" content="0; url={escape(deep_link)}" />'
+    else:
+        heading = f"{server} connection failed"
+        body = f'Head back to Slack and try again.<br /><a href="{escape(deep_link)}">Open Slack</a>'
+        refresh = ""
+    return HttpResponse(_PAGE.format(title=heading, refresh=refresh, heading=heading, body=body))

--- a/tach.toml
+++ b/tach.toml
@@ -614,10 +614,14 @@ layer = "modules"
 path = "products.slack_app"
 depends_on = [
     "posthog",
+    "products.conversations",
+    "products.customer_analytics",
     "products.dashboards",
+    "products.mcp_store",
     "products.product_analytics",
     "products.signals",
     "products.tasks",
+    "products.warehouse_sources",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

Part 4 of the 6-PR CSM onboarding stack (parent: #69292), and the core of it: the Block Kit conversation that greets a new assistant user, confirms their persona, and for CSMs provisions the scout fleet with a delivery channel.

## Changes

- Deterministic DM state machine in `persona_onboarding.py`: kickoff with detection-prefilled persona buttons, CSM fleet reveal with per-scout data readiness (PostHog data counts as ready by default, MCP connections and warehouse sources upgrade it), channel select/create/confirm/verify with invite fallback, and completion that provisions via the part 2 facade.
- Fleet reveal Connect buttons run through MCP store OAuth (part 3) with signed state carried across the round trip. `posthog/urls.py` gains the login-gated redirect entry and the connect-return view refreshes the reveal's readiness lines and deep-links back into the DM.
- Fast acks throughout: block actions ack immediately and do real work off-thread, with per-user single-flight cache claims so double-clicks can't double-post or double-provision.
- App Home shows an onboarding-only card (with a DM deep link) until the user is onboarded; existing users with prior Slack activity are grandfathered silently.
- Per-user funnel analytics baked into every step: events share a `slack:{workspace}:{user}` distinct_id and carry persona context, and the post-OAuth connect event is deduped against 30-day state replays.
- Feature-flag gated (`slack-persona-onboarding`); the flag off means the flow is fully dark.
- Local setup guide under `docs/internal/` covering the Slack app manifest, flags, and a smoke test using part 2's simulate command.

## How did you test this code?

`pytest products/slack_app/backend/tests/test_persona_onboarding_flow.py tests/services/test_slack_app_home.py tests/test_posthog_code_event_handler.py` (163 passed). No manual testing in this session; the flow was previously smoke-tested against a dev Slack workspace per the included setup guide.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`docs/internal/slack-local-setup-guide.md` is included here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code (`/writing-tests` invoked for the suites). This PR consolidates what were previously #69081 (conversation), #69083 (channel confirm polish), the Slack half of #69082 (connect offers), the UX rework half of #69085 (fast acks, kickoff split, home card), and the analytics from #69086, so reviewers see each handler once in its final form instead of watching it get rewritten across five PRs. A multi-agent review pass on the old stack contributed the single-flight action claims, the connect-event replay dedupe, and the flat analytics schema, which are folded in as original code here.
