### PR TITLE
feat(slack): first-patrol digest after fleet provisioning

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -13,6 +13,7 @@ from posthog.temporal.ai.slack_app.posthog_code_slack_interactivity import (
 )
 from posthog.temporal.ai.slack_app.posthog_code_slack_mention import PostHogCodeSlackMentionWorkflow
 from posthog.temporal.ai.slack_app.posthog_code_slack_mention_command import PostHogCodeSlackMentionCommandWorkflow
+from posthog.temporal.ai.slack_app.posthog_slack_first_patrol import PostHogSlackFirstPatrolWorkflow
 from posthog.temporal.ai.slack_app.posthog_slack_inbox_onboarding import PostHogSlackInboxOnboardingWorkflow
 
 from .llm_traces_summaries.summarize_traces import (
@@ -37,6 +38,7 @@ POSTHOG_CODE_SLACK_WORKFLOWS = [
     PostHogCodeSlackMentionCommandWorkflow,
     PostHogCodeSlackTerminateTaskWorkflow,
     PostHogSlackInboxOnboardingWorkflow,
+    PostHogSlackFirstPatrolWorkflow,
 ]
 
 POSTHOG_CODE_SLACK_ACTIVITIES = [

--- a/posthog/temporal/ai/slack_app/__init__.py
+++ b/posthog/temporal/ai/slack_app/__init__.py
@@ -14,6 +14,7 @@ from posthog.temporal.ai.slack_app.activities import (
     classify_message_is_agent_directed,
     classify_posthog_code_task_needs_repo_activity,
     classify_untagged_followup_activity,
+    collect_first_patrol_digest_activity,
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
     create_posthog_code_task_for_repo_activity,
@@ -23,6 +24,7 @@ from posthog.temporal.ai.slack_app.activities import (
     forward_posthog_code_followup_activity,
     handle_posthog_code_rules_command_activity,
     handle_posthog_code_slack_mention_command_activity,
+    post_first_patrol_digest_activity,
     post_posthog_code_internal_error_activity,
     post_posthog_code_no_repos_activity,
     post_posthog_code_picker_timeout_activity,
@@ -61,6 +63,8 @@ SLACK_APP_ACTIVITIES = [
     create_posthog_code_routing_rule_activity,
     handle_posthog_code_slack_mention_command_activity,
     run_posthog_slack_inbox_onboarding_activity,
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
 ]
 
 __all__ = [

--- a/posthog/temporal/ai/slack_app/activities/__init__.py
+++ b/posthog/temporal/ai/slack_app/activities/__init__.py
@@ -6,6 +6,10 @@ from posthog.temporal.ai.slack_app.activities.classifiers import (
     classify_task_needs_repo,
     classify_untagged_followup_activity,
 )
+from posthog.temporal.ai.slack_app.activities.first_patrol import (
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
+)
 from posthog.temporal.ai.slack_app.activities.messaging import (
     POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE,
     POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
@@ -64,6 +68,8 @@ __all__ = [
     "post_posthog_code_repo_picker_activity",
     "resolve_posthog_code_slack_command_user_activity",
     "resolve_posthog_code_slack_user_activity",
+    "collect_first_patrol_digest_activity",
+    "post_first_patrol_digest_activity",
     "run_posthog_slack_inbox_onboarding",
     "run_posthog_slack_inbox_onboarding_activity",
 ]

--- a/posthog/temporal/ai/slack_app/activities/first_patrol.py
+++ b/posthog/temporal/ai/slack_app/activities/first_patrol.py
@@ -1,0 +1,35 @@
+import structlog
+from temporalio import activity
+
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+
+logger = structlog.get_logger(__name__)
+
+
+@activity.defn
+def collect_first_patrol_digest_activity(inputs: PostHogSlackFirstPatrolInputs) -> dict | None:
+    from products.slack_app.backend.first_patrol import (
+        collect_first_patrol_digest,  # noqa: PLC0415 — Django app import deferred to activity runtime
+    )
+
+    return collect_first_patrol_digest(
+        team_id=inputs.team_id,
+        channel_name=inputs.channel_name,
+        scout_config_ids=inputs.scout_config_ids,
+        provisioned_at_iso=inputs.provisioned_at_iso,
+    )
+
+
+@activity.defn
+def post_first_patrol_digest_activity(inputs: PostHogSlackFirstPatrolInputs, digest: dict) -> None:
+    from products.slack_app.backend.first_patrol import (
+        post_first_patrol_digest,  # noqa: PLC0415 — Django app import deferred to activity runtime
+    )
+
+    post_first_patrol_digest(
+        integration_id=inputs.integration_id,
+        slack_user_id=inputs.slack_user_id,
+        dm_channel_id=inputs.dm_channel_id,
+        thread_ts=inputs.thread_ts,
+        digest=digest,
+    )

--- a/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
+++ b/posthog/temporal/ai/slack_app/posthog_slack_first_patrol.py
@@ -1,0 +1,59 @@
+import json
+from datetime import timedelta
+
+import structlog
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.ai.slack_app.activities.first_patrol import (
+    collect_first_patrol_digest_activity,
+    post_first_patrol_digest_activity,
+)
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+from posthog.temporal.common.base import PostHogWorkflow
+
+# Give the immediate first runs (dispatched at provisioning, ~15 min ceiling each) time to
+# finish before the first check; retry once for coordinator/queue lag, then give up silently.
+FIRST_PATROL_INITIAL_DELAY_SECONDS = 45 * 60
+FIRST_PATROL_RETRY_DELAY_SECONDS = 30 * 60
+FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS = 2 * 60
+
+logger = structlog.get_logger(__name__)
+
+
+@workflow.defn(name="posthog-slack-first-patrol")
+class PostHogSlackFirstPatrolWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> PostHogSlackFirstPatrolInputs:
+        loaded = json.loads(inputs[0])
+        return PostHogSlackFirstPatrolInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: PostHogSlackFirstPatrolInputs) -> None:
+        await workflow.sleep(timedelta(seconds=FIRST_PATROL_INITIAL_DELAY_SECONDS))
+        digest = await workflow.execute_activity(
+            collect_first_patrol_digest_activity,
+            args=(inputs,),
+            start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        if digest is None:
+            # Nothing to DM yet — no completed runs (queue lag, quota skip) or a clean patrol
+            # so far. One more chance for a late finding, then silence.
+            await workflow.sleep(timedelta(seconds=FIRST_PATROL_RETRY_DELAY_SECONDS))
+            digest = await workflow.execute_activity(
+                collect_first_patrol_digest_activity,
+                args=(inputs,),
+                start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+        if digest is None:
+            return
+        await workflow.execute_activity(
+            post_first_patrol_digest_activity,
+            args=(inputs, digest),
+            start_to_close_timeout=timedelta(seconds=FIRST_PATROL_ACTIVITY_TIMEOUT_SECONDS),
+            # Single attempt: the DM isn't idempotent — a retry after a post-then-crash
+            # would double-message the user. Best-effort over duplicates.
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )

--- a/posthog/temporal/ai/slack_app/types.py
+++ b/posthog/temporal/ai/slack_app/types.py
@@ -110,3 +110,15 @@ class PostHogCodeSlackMentionCommandResult:
     status: str  # "done" | "needs_picker"
     pending_rule_text: str | None = None
     target_integration_id: int | None = None
+
+
+@dataclass
+class PostHogSlackFirstPatrolInputs:
+    team_id: int
+    integration_id: int
+    slack_user_id: str
+    dm_channel_id: str
+    thread_ts: str | None
+    channel_name: str
+    scout_config_ids: list[str]
+    provisioned_at_iso: str

--- a/posthog/temporal/tests/ai/test_first_patrol_workflow.py
+++ b/posthog/temporal/tests/ai/test_first_patrol_workflow.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from posthog.temporal.ai.slack_app import posthog_slack_first_patrol as wf_module
+from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs
+
+DIGEST = {"text": "t", "variant": "finding", "runs_completed": 1}
+
+
+def _inputs() -> PostHogSlackFirstPatrolInputs:
+    return PostHogSlackFirstPatrolInputs(
+        team_id=1,
+        integration_id=2,
+        slack_user_id="U1",
+        dm_channel_id="D1",
+        thread_ts=None,
+        channel_name="posthog-inbox",
+        scout_config_ids=["c1"],
+        provisioned_at_iso="2026-07-02T00:00:00",
+    )
+
+
+async def _run_with(collect_results: list) -> tuple[list[str], AsyncMock]:
+    calls: list[str] = []
+    remaining = list(collect_results)
+
+    async def fake_execute(activity_fn, *, args, **kwargs):
+        calls.append(activity_fn.__name__)
+        if activity_fn.__name__ == "collect_first_patrol_digest_activity":
+            return remaining.pop(0)
+        return None
+
+    sleep_mock = AsyncMock()
+    with (
+        patch.object(wf_module.workflow, "sleep", new=sleep_mock),
+        patch.object(wf_module.workflow, "execute_activity", new=fake_execute),
+    ):
+        await wf_module.PostHogSlackFirstPatrolWorkflow().run(_inputs())
+    return calls, sleep_mock
+
+
+@pytest.mark.asyncio
+async def test_digest_on_first_check_posts_after_initial_delay():
+    calls, sleep_mock = await _run_with([DIGEST])
+    assert calls == ["collect_first_patrol_digest_activity", "post_first_patrol_digest_activity"]
+    assert sleep_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_first_check_retries_once_then_posts():
+    calls, sleep_mock = await _run_with([None, DIGEST])
+    assert calls == [
+        "collect_first_patrol_digest_activity",
+        "collect_first_patrol_digest_activity",
+        "post_first_patrol_digest_activity",
+    ]
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_report_after_retry_exits_silently():
+    calls, sleep_mock = await _run_with([None, None])
+    assert calls == ["collect_first_patrol_digest_activity", "collect_first_patrol_digest_activity"]
+    assert sleep_mock.await_count == 2

--- a/products/slack_app/backend/first_patrol.py
+++ b/products/slack_app/backend/first_patrol.py
@@ -1,0 +1,134 @@
+"""First-patrol digest: after CSM onboarding provisions the scout fleet and fires immediate
+first runs, a delayed Temporal workflow checks the outcomes and DMs the user a digest — but
+only when a scout actually found something. A clean patrol stays silent: run-state DMs are
+noise, and findings already land in the delivery channel.
+
+The Temporal workflow/activities live in ``posthog/temporal/ai/slack_app/``; this module
+holds the plain functions they delegate to (dispatch, collection, copy, delivery) so the
+behavior is unit-testable without a Temporal environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+
+from posthog.models.integration import Integration, SlackIntegration
+
+from products.slack_app.backend.analytics import capture_slack_event, slack_user_distinct_id
+from products.slack_app.backend.persona_onboarding import PERSONA_CSM, PERSONA_SCOUT_CATALOG, inbox_url
+
+logger = structlog.get_logger(__name__)
+
+EVENT_DIGEST_SENT = "slack_persona_onboarding_first_patrol_digest_sent"
+
+_TITLE_BY_SKILL = {spec.skill_name: spec.title for spec in PERSONA_SCOUT_CATALOG[PERSONA_CSM]}
+
+
+def start_first_patrol_digest_workflow(
+    *,
+    team_id: int,
+    integration_id: int,
+    slack_user_id: str,
+    dm_channel_id: str,
+    thread_ts: str | None,
+    channel_name: str,
+    scout_config_ids: list[str],
+    provisioned_at_iso: str,
+) -> None:
+    """Enqueue the delayed digest workflow. Raises on dispatch failure — the caller
+    (persona onboarding) treats it as best-effort."""
+    from django.conf import settings  # noqa: PLC0415 — keeps the temporal graph off the slack import path
+
+    from temporalio.common import WorkflowIDReusePolicy  # noqa: PLC0415 — same
+
+    from posthog.temporal.ai.slack_app.posthog_slack_first_patrol import (  # noqa: PLC0415 — same
+        PostHogSlackFirstPatrolWorkflow,
+    )
+    from posthog.temporal.ai.slack_app.types import PostHogSlackFirstPatrolInputs  # noqa: PLC0415 — same
+    from posthog.temporal.common.client import sync_connect  # noqa: PLC0415 — same
+
+    client = sync_connect()
+    asyncio.run(
+        client.start_workflow(
+            PostHogSlackFirstPatrolWorkflow.run,
+            PostHogSlackFirstPatrolInputs(
+                team_id=team_id,
+                integration_id=integration_id,
+                slack_user_id=slack_user_id,
+                dm_channel_id=dm_channel_id,
+                thread_ts=thread_ts,
+                channel_name=channel_name,
+                scout_config_ids=scout_config_ids,
+                provisioned_at_iso=provisioned_at_iso,
+            ),
+            id=f"posthog-slack-first-patrol-{integration_id}-{slack_user_id}",
+            task_queue=settings.TASKS_TASK_QUEUE,
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+        )
+    )
+
+
+def _first_sentence(summary: str, limit: int = 140) -> str:
+    text = " ".join((summary or "").split())
+    if not text:
+        return ""
+    sentence = text.split(". ")[0].rstrip(".")
+    if len(sentence) > limit:
+        # Truncated → the ellipsis is the terminal punctuation; don't also append a period.
+        return sentence[: limit - 1].rstrip() + "…"
+    return sentence + "."
+
+
+def collect_first_patrol_digest(
+    *, team_id: int, channel_name: str, scout_config_ids: list[str], provisioned_at_iso: str
+) -> dict | None:
+    """Compose the digest from the first runs' outcomes. ``None`` when there is nothing worth
+    a DM — no run has completed yet, or every completed run came back clean. The workflow
+    retries once (a still-running scout may yet report a finding), then gives up silently."""
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off the slack import path
+        collect_scout_run_digests,
+    )
+
+    digests = collect_scout_run_digests(
+        team_id=team_id, scout_config_ids=scout_config_ids, since_iso=provisioned_at_iso
+    )
+    if digests is None:
+        return None
+    found = [digest for digest in digests if digest.notifications_sent or digest.reports_filed]
+    if not found:
+        return None
+    first = found[0]
+    title = _TITLE_BY_SKILL.get(first.skill_name, first.skill_name)
+    headline = _first_sentence(first.summary) or "it flagged an account that needs attention."
+    text = (
+        f"Your scouts just finished their first patrol — *{title}* found something: {headline} "
+        f"Full details in #{channel_name} and your <{inbox_url(team_id)}|PostHog inbox>."
+    )
+    if len(found) > 1:
+        extra = len(found) - 1
+        text += f" ({extra} more scout{'s' if extra > 1 else ''} reported findings too.)"
+    return {"text": text, "variant": "finding", "runs_completed": len(digests)}
+
+
+def post_first_patrol_digest(
+    *, integration_id: int, slack_user_id: str, dm_channel_id: str, thread_ts: str | None, digest: dict
+) -> None:
+    integration = Integration.objects.filter(id=integration_id, kind="slack").first()
+    if integration is None:
+        logger.info("first_patrol_integration_gone", integration_id=integration_id)
+        return
+    SlackIntegration(integration).client.chat_postMessage(
+        channel=dm_channel_id, thread_ts=thread_ts, text=digest["text"]
+    )
+    capture_slack_event(
+        integration,
+        EVENT_DIGEST_SENT,
+        slack_user_id=slack_user_id,
+        # Same per-user person as the onboarding funnel, so the digest chains as its final step.
+        distinct_id=slack_user_distinct_id(integration.integration_id, slack_user_id),
+        variant=digest.get("variant"),
+        runs_completed=digest.get("runs_completed"),
+        persona=PERSONA_CSM,
+    )

--- a/products/slack_app/backend/persona_onboarding.py
+++ b/products/slack_app/backend/persona_onboarding.py
@@ -1576,3 +1576,28 @@ def _provision_and_complete(ctx: _FlowContext, channel_id: str, channel_name: st
         **{key: value for key, value in readiness.items() if key != "ready_details"},
     )
     _republish_home(ctx.integration, ctx.slack_user_id)
+    _start_first_patrol_digest(ctx, results, channel_name)
+
+
+def _start_first_patrol_digest(ctx: _FlowContext, results: list, channel_name: str) -> None:
+    """Kick the delayed first-patrol digest workflow — best-effort, never user-visible on failure."""
+    config_ids = [result.config_id for result in results if result.config_id and not result.channel_conflict]
+    if not config_ids:
+        return
+    try:
+        from products.slack_app.backend.first_patrol import (  # noqa: PLC0415 — keeps the temporal graph off the slack import path
+            start_first_patrol_digest_workflow,
+        )
+
+        start_first_patrol_digest_workflow(
+            team_id=ctx.integration.team_id,
+            integration_id=ctx.integration.id,
+            slack_user_id=ctx.slack_user_id,
+            dm_channel_id=str(ctx.state.get("dm_channel_id") or ""),
+            thread_ts=ctx.state.get("thread_ts"),
+            channel_name=channel_name,
+            scout_config_ids=config_ids,
+            provisioned_at_iso=timezone.now().isoformat(),
+        )
+    except Exception:
+        logger.warning("persona_onboarding_digest_dispatch_failed", exc_info=True)

--- a/products/slack_app/backend/tests/test_first_patrol.py
+++ b/products/slack_app/backend/tests/test_first_patrol.py
@@ -1,0 +1,165 @@
+import pytest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.signals.backend.facade.api import ScoutRunDigest
+from products.slack_app.backend import first_patrol
+
+COLLECT_PATH = "products.signals.backend.facade.api.collect_scout_run_digests"
+CAPTURE_PATH = "products.slack_app.backend.first_patrol.capture_slack_event"
+WEBCLIENT = "posthog.models.integration.WebClient"
+WORKSPACE = "T1"
+SLACK_USER = "U1"
+DM_CHANNEL = "D1"
+
+
+def _collect(digests):
+    with patch(COLLECT_PATH, return_value=digests):
+        return first_patrol.collect_first_patrol_digest(
+            team_id=1, channel_name="posthog-inbox", scout_config_ids=["c1"], provisioned_at_iso="2026-07-02T00:00:00"
+        )
+
+
+class TestFirstPatrolDigestComposition:
+    @parameterized.expand(
+        [
+            ("no_completed_runs", None),
+            (
+                "clean_patrol",
+                [
+                    ScoutRunDigest(
+                        skill_name="signals-scout-slack-csm-account-pulse",
+                        summary="Checked 214 accounts, all within baseline.",
+                        notifications_sent=0,
+                        reports_filed=0,
+                    ),
+                    ScoutRunDigest(
+                        skill_name="signals-scout-slack-csm-revenue-watch",
+                        summary="",
+                        notifications_sent=0,
+                        reports_filed=0,
+                    ),
+                ],
+            ),
+        ]
+    )
+    def test_returns_none_so_no_dm_is_sent(self, _name, digests):
+        assert _collect(digests) is None
+
+    def test_finding_variant_leads_with_the_finding_and_links_channel(self):
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-slack-csm-account-pulse",
+                    summary="Initech's weekly active users dropped 60% vs baseline. Fleet otherwise steady.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+                ScoutRunDigest(
+                    skill_name="signals-scout-slack-csm-support-watch",
+                    summary="Queue quiet.",
+                    notifications_sent=0,
+                    reports_filed=0,
+                ),
+            ]
+        )
+        assert digest["variant"] == "finding"
+        assert "Account pulse" in digest["text"]
+        assert "Initech's weekly active users dropped 60% vs baseline." in digest["text"]
+        assert "#posthog-inbox" in digest["text"]
+        assert digest["runs_completed"] == 2
+
+    def test_long_finding_headline_has_no_doubled_punctuation(self):
+        long_summary = "The account " + "very " * 60 + "quietly slid this week."
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-slack-csm-account-pulse",
+                    summary=long_summary,
+                    notifications_sent=1,
+                    reports_filed=1,
+                )
+            ]
+        )
+        assert "…." not in digest["text"]
+        assert "…" in digest["text"]
+
+    def test_multiple_finders_counted_beyond_the_headline(self):
+        digest = _collect(
+            [
+                ScoutRunDigest(
+                    skill_name="signals-scout-slack-csm-account-pulse",
+                    summary="A slid.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+                ScoutRunDigest(
+                    skill_name="signals-scout-slack-csm-support-watch",
+                    summary="B spiked.",
+                    notifications_sent=1,
+                    reports_filed=1,
+                ),
+            ]
+        )
+        assert digest["variant"] == "finding"
+        assert "1 more scout reported findings too" in digest["text"]
+
+
+class TestPostFirstPatrolDigest:
+    # The digest DM is the onboarding funnel's final step. Nothing else asserts the emitted
+    # identity — the composition tests stop at collect, and the workflow test mocks this post —
+    # so an arg-swap or a fallback to capture_slack_event's team-uuid default would silently
+    # detach the digest from per-user funnel chaining.
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.organization = Organization.objects.create(name="Org")
+        self.team = Team.objects.create(organization=self.organization, name="Team")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=WORKSPACE,
+            config={"scope": "chat:write"},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    @patch(CAPTURE_PATH)
+    @patch(WEBCLIENT)
+    def test_dm_posts_and_pins_event_to_the_per_user_person(self, mock_webclient, mock_capture):
+        digest = {"text": "Your scouts found something.", "variant": "finding", "runs_completed": 2}
+
+        first_patrol.post_first_patrol_digest(
+            integration_id=self.integration.id,
+            slack_user_id=SLACK_USER,
+            dm_channel_id=DM_CHANNEL,
+            thread_ts="111.222",
+            digest=digest,
+        )
+
+        mock_webclient.return_value.chat_postMessage.assert_called_once_with(
+            channel=DM_CHANNEL, thread_ts="111.222", text=digest["text"]
+        )
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[1] == first_patrol.EVENT_DIGEST_SENT
+        assert mock_capture.call_args.kwargs["distinct_id"] == first_patrol.slack_user_distinct_id(
+            self.integration.integration_id, SLACK_USER
+        )
+        assert mock_capture.call_args.kwargs["persona"] == first_patrol.PERSONA_CSM
+
+    @patch(CAPTURE_PATH)
+    @patch(WEBCLIENT)
+    def test_missing_integration_is_a_silent_no_op(self, mock_webclient, mock_capture):
+        first_patrol.post_first_patrol_digest(
+            integration_id=self.integration.id + 999,
+            slack_user_id=SLACK_USER,
+            dm_channel_id=DM_CHANNEL,
+            thread_ts=None,
+            digest={"text": "unused", "variant": "finding", "runs_completed": 1},
+        )
+
+        mock_webclient.assert_not_called()
+        mock_capture.assert_not_called()

--- a/products/slack_app/backend/tests/test_persona_onboarding_flow.py
+++ b/products/slack_app/backend/tests/test_persona_onboarding_flow.py
@@ -32,6 +32,7 @@ PROVISION = "products.signals.backend.facade.api.provision_persona_scouts"
 WEBCLIENT = "posthog.models.integration.WebClient"
 
 CSM_SKILL_NAMES = [spec.skill_name for spec in persona_onboarding.PERSONA_SCOUT_CATALOG[persona_onboarding.PERSONA_CSM]]
+DIGEST_START = "products.slack_app.backend.first_patrol.start_first_patrol_digest_workflow"
 
 
 def _template(name: str, *, redirect: bool = True) -> TemplateInfo:
@@ -53,6 +54,14 @@ ALL_TEMPLATES = [
     _template("Jira"),
     _template("Stripe"),
 ]
+
+
+@pytest.fixture(autouse=True)
+def _no_temporal_digest_dispatch():
+    # The completion path enqueues the first-patrol digest workflow; without this patch the
+    # tests wait out a real Temporal connection attempt (~80s of timeout across the module).
+    with patch(DIGEST_START) as mock_start:
+        yield mock_start
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

Part 5 of the 6-PR CSM onboarding stack (parent: #69293). After onboarding provisions the fleet and fires first runs, the user hears nothing until a scout finds something. A delayed digest closes that loop so the first scout touch lands within the first hour, and stays silent when the patrol is clean.

## Changes

- `first_patrol.py` collects the fleet's first-run outcomes into a DM digest: findings get summarized with a link into the channel; a clean patrol produces no message at all (returning `None` skips the send).
- Temporal workflow `posthog-slack-first-patrol` with a delayed start, one retry when no runs have completed yet (queue lag, quota skips), then silent exit.
- The onboarding completion path enqueues the workflow best-effort; a dispatch failure is never user-visible.
- The digest event carries the same per-user distinct_id and persona as the rest of the funnel.

## How did you test this code?

`pytest products/slack_app/backend/tests/test_first_patrol.py posthog/temporal/tests/ai/test_first_patrol_workflow.py products/slack_app/backend/tests/test_persona_onboarding_flow.py` (68 passed). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, behavior is internal to the onboarding flow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code (`/writing-tests` invoked for the suites). Previously the first-patrol part of #69081 plus the quiet-when-clean fix and digest identity from #69086; the digest is born without the all-clear variant instead of shipping it in one PR and deleting it in another.
