### PR TITLE
fix(data-warehouse): make empty Google Search Console property list actionable

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/GoogleSearchConsoleSiteSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/GoogleSearchConsoleSiteSelector.tsx
@@ -121,7 +121,7 @@ function GoogleSearchConsoleSiteFieldWithSuggestions({ integrationId }: { integr
                             suggestions={siteUrls}
                             suggestionsLoading={sitesLoading}
                             searchPlaceholder="Filter verified properties…"
-                            emptyMessage="No properties accessible by this account."
+                            emptyMessage="No properties found for this Google account. In Google Search Console, grant the connected account access to a verified property, then reconnect."
                             loadingMessage="Loading from Google…"
                         />
                         {savedValueMissing && (


### PR DESCRIPTION
## Problem

When someone connects a Google Search Console source, the OAuth handshake succeeds and shows an "Integration successful" toast. But if the connected Google account has no accessible Search Console properties (or the credential is later rejected), the property dropdown just reads "No properties accessible by this account." with no guidance on what to do next. Users hit this dead end and abandon the setup.

The same empty message also renders when the sites request fails silently, so a genuine "reconnect and grant access" situation looks identical to a truly empty list.

## Changes

Make the empty-state copy actionable. Instead of stating the account has no properties, it now tells the user how to fix it: grant the connected account access to a verified property in Google Search Console, then reconnect.

```diff
- emptyMessage="No properties accessible by this account."
+ emptyMessage="No properties found for this Google account. In Google Search Console, grant the connected account access to a verified property, then reconnect."
```

This is a copy-only change to the property selector's empty state.

## How did you test this code?

No automated tests changed. This is a static string in a presentational field. I could not run the frontend linter/typecheck locally (no `node_modules` in this environment); CI covers both. The change is a single string-literal edit with no logic impact.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude (Claude Code) authored this while synthesizing friction themes from data-warehouse onboarding session summaries. Several users reached the Google Search Console property step, saw an empty dropdown, and had no idea the fix was to grant the connected account access to a property in Search Console. The backend already returns actionable copy for the credential-rejection path, but the empty dropdown case had none, so I improved just that string. I deliberately kept this to copy only and left the larger change (surfacing the swallowed load error distinctly from a truly empty list) as a follow-up recommendation, since that touches the kea logic and is less obviously safe.
