### PR TITLE
feat(tracing): add column facets and own-filter exclusion to attribute breakdown

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -44538,7 +44538,7 @@
             "type": "string"
         },
         "TraceSpanBreakdownType": {
-            "enum": ["span_attribute", "span_resource_attribute"],
+            "enum": ["span", "span_attribute", "span_resource_attribute"],
             "type": "string"
         },
         "TraceSpansAggregationQuery": {
@@ -44644,12 +44644,12 @@
             "additionalProperties": false,
             "properties": {
                 "breakdownKey": {
-                    "description": "Attribute key to group by (e.g. `http.response.status_code`, `server.address`).",
+                    "description": "Attribute key to group by (e.g. `http.response.status_code`, `server.address`). For the `span` breakdown type, must be an allowlisted top-level column (`service_name`, `status_code`).",
                     "type": "string"
                 },
                 "breakdownType": {
                     "$ref": "#/definitions/TraceSpanBreakdownType",
-                    "description": "Where the key lives: span-level attributes or resource-level attributes."
+                    "description": "Where the key lives: an allowlisted top-level span column, span-level attributes, or resource-level attributes."
                 },
                 "compareFilter": {
                     "$ref": "#/definitions/CompareFilter",
@@ -44657,6 +44657,10 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
+                },
+                "excludeBreakdownFilter": {
+                    "description": "Drop filters targeting the breakdown key itself (including `serviceNames` for a `service_name` breakdown) so a facet's value list stays complete while one of its values is selected.",
+                    "type": "boolean"
                 },
                 "filterGroup": {
                     "$ref": "#/definitions/PropertyGroupFilter"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3657,15 +3657,18 @@ export interface AttributeBreakdownRow {
     p95_duration_nano: number
 }
 
-export type TraceSpanBreakdownType = 'span_attribute' | 'span_resource_attribute'
+export type TraceSpanBreakdownType = 'span' | 'span_attribute' | 'span_resource_attribute'
 export type TraceSpanBreakdownOrderBy = 'count' | 'error_count'
 
 export interface TraceSpansAttributeBreakdownQuery extends DataNode<TraceSpansAttributeBreakdownQueryResponse> {
     kind: NodeKind.TraceSpansAttributeBreakdownQuery
     dateRange: DateRange
-    /** Attribute key to group by (e.g. `http.response.status_code`, `server.address`). */
+    /**
+     * Attribute key to group by (e.g. `http.response.status_code`, `server.address`).
+     * For the `span` breakdown type, must be an allowlisted top-level column (`service_name`, `status_code`).
+     */
     breakdownKey: string
-    /** Where the key lives: span-level attributes or resource-level attributes. */
+    /** Where the key lives: an allowlisted top-level span column, span-level attributes, or resource-level attributes. */
     breakdownType: TraceSpanBreakdownType
     /** Order rows by span count or error count, descending. Defaults to count. */
     orderBy?: TraceSpanBreakdownOrderBy
@@ -3673,6 +3676,11 @@ export interface TraceSpansAttributeBreakdownQuery extends DataNode<TraceSpansAt
     compareFilter?: CompareFilter
     filterGroup?: PropertyGroupFilter
     serviceNames?: string[]
+    /**
+     * Drop filters targeting the breakdown key itself (including `serviceNames` for a `service_name`
+     * breakdown) so a facet's value list stays complete while one of its values is selected.
+     */
+    excludeBreakdownFilter?: boolean
 }
 
 export interface TraceSpansAttributeBreakdownQueryResponse extends AnalyticsQueryResponseBase {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -23932,11 +23932,18 @@ class TraceSpansAttributeBreakdownQuery(BaseModel):
     )
     breakdownKey: str = Field(
         ...,
-        description=("Attribute key to group by (e.g. `http.response.status_code`, `server.address`)."),
+        description=(
+            "Attribute key to group by (e.g. `http.response.status_code`,"
+            " `server.address`). For the `span` breakdown type, must be an allowlisted"
+            " top-level column (`service_name`, `status_code`)."
+        ),
     )
     breakdownType: TraceSpanBreakdownType = Field(
         ...,
-        description=("Where the key lives: span-level attributes or resource-level attributes."),
+        description=(
+            "Where the key lives: an allowlisted top-level span column, span-level"
+            " attributes, or resource-level attributes."
+        ),
     )
     compareFilter: CompareFilter | None = Field(
         default=None,
@@ -23945,6 +23952,14 @@ class TraceSpansAttributeBreakdownQuery(BaseModel):
         ),
     )
     dateRange: DateRange
+    excludeBreakdownFilter: bool | None = Field(
+        default=None,
+        description=(
+            "Drop filters targeting the breakdown key itself (including `serviceNames`"
+            " for a `service_name` breakdown) so a facet's value list stays complete"
+            " while one of its values is selected."
+        ),
+    )
     filterGroup: PropertyGroupFilter | None = None
     kind: Literal["TraceSpansAttributeBreakdownQuery"] = "TraceSpansAttributeBreakdownQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3282,6 +3282,7 @@ class TraceSpanBreakdownOrderBy(StrEnum):
 
 
 class TraceSpanBreakdownType(StrEnum):
+    SPAN = "span"
     SPAN_ATTRIBUTE = "span_attribute"
     SPAN_RESOURCE_ATTRIBUTE = "span_resource_attribute"
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -551,6 +551,9 @@ SPECTACULAR_SETTINGS = {
         # AgentRevision.state (model ChoiceField) and RevisionNotDraftError.state (the
         # bundle-edit 409 body) share one choice set — pin them to a single named enum.
         "AgentRevisionStateEnum": ["draft", "ready", "live", "archived"],
+        # Tracing's span-filter `type` and attribute-breakdown `breakdownType` share one
+        # choice set (top-level column vs span attribute vs resource attribute).
+        "SpanPropertyTypeEnum": ["span", "span_attribute", "span_resource_attribute"],
         "CustomPropertyDisplayTypeEnum": [
             "text",
             "number",

--- a/products/tracing/backend/attribute_breakdown_query_runner.py
+++ b/products/tracing/backend/attribute_breakdown_query_runner.py
@@ -31,6 +31,10 @@ _ORDER_COLUMNS: dict[TraceSpanBreakdownOrderBy, str] = {
     TraceSpanBreakdownOrderBy.ERROR_COUNT: "error_count",
 }
 
+# Top-level columns the `span` breakdown type may group by. The allowlist (enforced at both the
+# API and runner level) keeps arbitrary column names out of the generated SQL.
+FACET_COLUMNS: frozenset[str] = frozenset({"service_name", "status_code"})
+
 
 class TraceSpansAttributeBreakdownQueryRunner(
     _SpanAggregationMixin, AnalyticsQueryRunner[TraceSpansAttributeBreakdownQueryResponse]
@@ -46,24 +50,50 @@ class TraceSpansAttributeBreakdownQueryRunner(
 
     def __init__(self, query: TraceSpansAttributeBreakdownQuery, *args, **kwargs) -> None:
         super().__init__(query, *args, **kwargs)
+        if self.query.breakdownType == TraceSpanBreakdownType.SPAN and self.query.breakdownKey not in FACET_COLUMNS:
+            raise ValueError(f"Unsupported span column for breakdown: {self.query.breakdownKey!r}")
         self.modifiers.convertToProjectTimezone = False
         self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
         self._extract_filters()
+
+    def _extract_filters(self) -> None:
+        super()._extract_filters()
+        if not self.query.excludeBreakdownFilter:
+            return
+        # Facet semantics: a facet's value list must ignore its own selection (otherwise selecting
+        # a value collapses the facet to one row), while all other filters still apply.
+        key = self.query.breakdownKey
+        if self.query.breakdownType == TraceSpanBreakdownType.SPAN:
+            self.span_filters = [f for f in self.span_filters if f.key != key]
+            if key == "service_name":
+                # The dedicated service filter targets the same column as the breakdown.
+                self.query.serviceNames = None
+        elif self.query.breakdownType == TraceSpanBreakdownType.SPAN_ATTRIBUTE:
+            # Extraction suffixed the keys with their physical-map type (`__str` / `__float`).
+            suffixed = {f"{key}__str", f"{key}__float"}
+            self.span_attribute_filters = [f for f in self.span_attribute_filters if f.key not in suffixed]
+        else:
+            self.resource_attribute_filters = [f for f in self.resource_attribute_filters if f.key != key]
 
     def _calculate(self) -> TraceSpansAttributeBreakdownQueryResponse:
         current_rows, previous_rows = self._run_with_compare()
         return TraceSpansAttributeBreakdownQueryResponse(results=current_rows, compare=previous_rows)
 
     def _build_query(self, query_date_range: QueryDateRange) -> ast.SelectQuery:
-        if self.query.breakdownType == TraceSpanBreakdownType.SPAN_RESOURCE_ATTRIBUTE:
+        breakdown_field: ast.Expr
+        if self.query.breakdownType == TraceSpanBreakdownType.SPAN:
+            # Allowlisted top-level column (validated in __init__). toString keeps the response
+            # shape uniform — status_code is an Int16 (0/1/2) but rows always carry string values.
+            breakdown_field = ast.Call(name="toString", args=[ast.Field(chain=[self.query.breakdownKey])])
+        elif self.query.breakdownType == TraceSpanBreakdownType.SPAN_RESOURCE_ATTRIBUTE:
             # resource_attributes' property group matches any key as-is.
-            breakdown_chain: list[str | int] = ["resource_attributes", self.query.breakdownKey]
+            breakdown_field = ast.Field(chain=["resource_attributes", self.query.breakdownKey])
         else:
             # Span attribute keys carry a type suffix in the physical map (attributes_map_str);
             # the property-group resolver only rewrites suffixed keys to map access — a bare key
             # falls through to a JSON read, which is illegal on the Map column. Every value is
             # present in the __str map (the float/datetime maps are derived from it).
-            breakdown_chain = ["attributes", f"{self.query.breakdownKey}__str"]
+            breakdown_field = ast.Field(chain=["attributes", f"{self.query.breakdownKey}__str"])
         order_column = _ORDER_COLUMNS[self.query.orderBy or TraceSpanBreakdownOrderBy.COUNT]
 
         query = parse_select(
@@ -88,7 +118,7 @@ class TraceSpansAttributeBreakdownQueryRunner(
             LIMIT {limit}
             """,
             placeholders={
-                "breakdown_field": ast.Field(chain=breakdown_chain),
+                "breakdown_field": breakdown_field,
                 "where": self._where_without_date_range(),
                 "limit": ast.Constant(value=_ROW_LIMIT),
                 **query_date_range.to_placeholders(),
@@ -117,6 +147,7 @@ def run_attribute_breakdown_query(
     compare_filter: CompareFilter | None = None,
     filter_group: PropertyGroupFilter | None = None,
     service_names: list[str] | None = None,
+    exclude_breakdown_filter: bool = False,
 ) -> TraceSpansAttributeBreakdownQueryResponse | CachedTraceSpansAttributeBreakdownQueryResponse:
     """Facade-friendly entry point for running an attribute breakdown query."""
     query = TraceSpansAttributeBreakdownQuery(
@@ -127,6 +158,7 @@ def run_attribute_breakdown_query(
         compareFilter=compare_filter,
         filterGroup=filter_group,
         serviceNames=service_names,
+        excludeBreakdownFilter=exclude_breakdown_filter,
     )
     runner = TraceSpansAttributeBreakdownQueryRunner(query, team)
     response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)

--- a/products/tracing/backend/facade/api.py
+++ b/products/tracing/backend/facade/api.py
@@ -34,6 +34,7 @@ from posthog.schema import (
 )
 
 from products.tracing.backend.attribute_breakdown_query_runner import (
+    FACET_COLUMNS as _FACET_COLUMNS,
     run_attribute_breakdown_query as _run_attribute_breakdown_query,
 )
 from products.tracing.backend.count_query_runner import run_count_query as _run_count_query
@@ -45,6 +46,11 @@ from products.tracing.backend.symbol_stats_query_runner import run_symbol_stats_
 
 if TYPE_CHECKING:
     from posthog.models import Team
+
+
+# Allowlisted top-level span columns for the "span" breakdown type. Re-exported so the
+# presentation layer can validate `breakdownKey` without reaching into the query runner.
+FACET_COLUMNS = _FACET_COLUMNS
 
 
 # --- Converters (model -> frozen dataclass) ---

--- a/products/tracing/backend/facade/api.py
+++ b/products/tracing/backend/facade/api.py
@@ -82,6 +82,7 @@ def run_attribute_breakdown_query(
     compare_filter: CompareFilter | None = None,
     filter_group: PropertyGroupFilter | None = None,
     service_names: list[str] | None = None,
+    exclude_breakdown_filter: bool = False,
 ) -> TraceSpansAttributeBreakdownQueryResponse | CachedTraceSpansAttributeBreakdownQueryResponse:
     """Run a span breakdown grouped by one attribute's value within a filtered span set."""
     return _run_attribute_breakdown_query(
@@ -93,6 +94,7 @@ def run_attribute_breakdown_query(
         compare_filter=compare_filter,
         filter_group=filter_group,
         service_names=service_names,
+        exclude_breakdown_filter=exclude_breakdown_filter,
     )
 
 

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -41,6 +41,7 @@ from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.event_usage import report_user_action
 from posthog.hogql_queries.query_runner import ExecutionMode
 
+from ..attribute_breakdown_query_runner import FACET_COLUMNS
 from ..facade.api import (
     annotate_self_time,
     run_attribute_breakdown_query,
@@ -365,11 +366,16 @@ class _TracingAggregationRequestSerializer(serializers.Serializer):
 class _TracingAttributeBreakdownQueryBodySerializer(serializers.Serializer):
     breakdownKey = serializers.CharField(
         required=True,
-        help_text='Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list.',
+        help_text='Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. For the "span" breakdown type, must be one of the allowlisted top-level columns: "service_name", "status_code".',
     )
     breakdownType = serializers.ChoiceField(
-        choices=["span_attribute", "span_resource_attribute"],
-        help_text='Where the key lives: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.',
+        choices=["span", "span_attribute", "span_resource_attribute"],
+        help_text='Where the key lives: "span" for allowlisted top-level span columns, "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.',
+    )
+    excludeBreakdownFilter = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected.",
     )
     orderBy = serializers.ChoiceField(
         choices=["count", "error_count"],
@@ -1034,7 +1040,13 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             breakdown_type = TraceSpanBreakdownType(query_data.get("breakdownType") or "")
         except ValueError:
             return Response(
-                {"detail": '`breakdownType` must be "span_attribute" or "span_resource_attribute".'},
+                {"detail": '`breakdownType` must be "span", "span_attribute" or "span_resource_attribute".'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if breakdown_type == TraceSpanBreakdownType.SPAN and breakdown_key not in FACET_COLUMNS:
+            return Response(
+                {"detail": f"`breakdownKey` for a span column breakdown must be one of: {sorted(FACET_COLUMNS)}."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -1076,6 +1088,7 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             compare_filter=compare_filter,
             filter_group=filter_group,
             service_names=query_data.get("serviceNames", None),
+            exclude_breakdown_filter=bool(query_data.get("excludeBreakdownFilter")),
         )
 
         return Response(

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -41,8 +41,8 @@ from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.event_usage import report_user_action
 from posthog.hogql_queries.query_runner import ExecutionMode
 
-from ..attribute_breakdown_query_runner import FACET_COLUMNS
 from ..facade.api import (
+    FACET_COLUMNS,
     annotate_self_time,
     run_attribute_breakdown_query,
     run_count_query,

--- a/products/tracing/backend/tests/test_attribute_breakdown.py
+++ b/products/tracing/backend/tests/test_attribute_breakdown.py
@@ -118,3 +118,102 @@ class TestTraceSpansAttributeBreakdown(_TraceSpansTestBase):
             {(row["value"], row["count"]) for row in rows},
             {("api2.amplitude.com", 4)},
         )
+
+    @parameterized.expand(
+        [
+            ("service_name", {("cdp", 9, 4), ("other", 1, 0)}),
+            # Int16 column: values come back stringified so the response shape stays uniform.
+            ("status_code", {("2", 4, 4), ("0", 6, 0)}),
+        ]
+    )
+    def test_span_column_breakdown(self, breakdown_key, expected):
+        rows = self._breakdown(breakdownKey=breakdown_key, breakdownType="span")
+        self.assertEqual(
+            {(row["value"], row["count"], row["error_count"]) for row in rows},
+            expected,
+        )
+
+    def test_span_column_breakdown_rejects_non_allowlisted_key(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/tracing/spans/attribute-breakdown/",
+            {
+                "query": {
+                    "dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO},
+                    "breakdownKey": "timestamp",
+                    "breakdownType": "span",
+                }
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    @parameterized.expand(
+        [
+            # Each case selects one value of the facet's own dimension; with exclusion the facet
+            # must still list every value (not collapse to the selected one).
+            (
+                "service_names_filter",
+                {"breakdownKey": "service_name", "breakdownType": "span", "serviceNames": ["other"]},
+                {"cdp", "other"},
+            ),
+            (
+                "span_column_filter",
+                {
+                    "breakdownKey": "status_code",
+                    "breakdownType": "span",
+                    "filterGroup": [{"key": "status_code", "operator": "exact", "type": "span", "value": "Error"}],
+                },
+                {"0", "2"},
+            ),
+            (
+                "span_attribute_filter",
+                {
+                    "breakdownKey": "server.address",
+                    "breakdownType": "span_attribute",
+                    "filterGroup": [
+                        {
+                            "key": "server.address",
+                            "operator": "exact",
+                            "type": "span_attribute",
+                            "value": "api.mixpanel.com",
+                        }
+                    ],
+                },
+                {"api2.amplitude.com", "api.mixpanel.com", ""},
+            ),
+            (
+                "resource_attribute_filter",
+                {
+                    "breakdownKey": "k8s.pod.name",
+                    "breakdownType": "span_resource_attribute",
+                    "filterGroup": [
+                        {
+                            "key": "k8s.pod.name",
+                            "operator": "exact",
+                            "type": "span_resource_attribute",
+                            "value": "pod-a",
+                        }
+                    ],
+                },
+                {"pod-a", "pod-b", "pod-c"},
+            ),
+        ]
+    )
+    def test_exclude_breakdown_filter_keeps_facet_complete(self, _name, query_fields, expected_values):
+        rows = self._breakdown(excludeBreakdownFilter=True, **query_fields)
+        self.assertEqual({row["value"] for row in rows}, expected_values)
+
+    def test_exclude_breakdown_filter_keeps_other_filters(self):
+        # Exclusion only drops the facet's own filter — the serviceNames scope must still apply,
+        # so the amplitude span in the "other" service stays excluded (5, not 6).
+        rows = self._breakdown(
+            breakdownKey="server.address",
+            breakdownType="span_attribute",
+            serviceNames=["cdp"],
+            excludeBreakdownFilter=True,
+            filterGroup=[
+                {"key": "server.address", "operator": "exact", "type": "span_attribute", "value": "api.mixpanel.com"}
+            ],
+        )
+        by_value = {row["value"]: row["count"] for row in rows}
+        self.assertEqual(by_value["api2.amplitude.com"], 5)

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -35,10 +35,9 @@ export interface _CompareFilterApi {
  * * `span_attribute` - span_attribute
  * * `span_resource_attribute` - span_resource_attribute
  */
-export type _SpanPropertyFilterTypeEnumApi =
-    (typeof _SpanPropertyFilterTypeEnumApi)[keyof typeof _SpanPropertyFilterTypeEnumApi]
+export type SpanPropertyTypeEnumApi = (typeof SpanPropertyTypeEnumApi)[keyof typeof SpanPropertyTypeEnumApi]
 
-export const _SpanPropertyFilterTypeEnumApi = {
+export const SpanPropertyTypeEnumApi = {
     Span: 'span',
     SpanAttribute: 'span_attribute',
     SpanResourceAttribute: 'span_resource_attribute',
@@ -80,7 +79,7 @@ export interface _SpanPropertyFilterApi {
      * * `span` - span
      * * `span_attribute` - span_attribute
      * * `span_resource_attribute` - span_resource_attribute */
-    type: _SpanPropertyFilterTypeEnumApi
+    type: SpanPropertyTypeEnumApi
     /** Comparison operator.
      *
      * * `exact` - exact
@@ -115,17 +114,6 @@ export interface _TracingAggregationRequestApi {
 }
 
 /**
- * * `span_attribute` - span_attribute
- * * `span_resource_attribute` - span_resource_attribute
- */
-export type BreakdownTypeEnumApi = (typeof BreakdownTypeEnumApi)[keyof typeof BreakdownTypeEnumApi]
-
-export const BreakdownTypeEnumApi = {
-    SpanAttribute: 'span_attribute',
-    SpanResourceAttribute: 'span_resource_attribute',
-} as const
-
-/**
  * * `count` - count
  * * `error_count` - error_count
  */
@@ -138,13 +126,16 @@ export const _TracingAttributeBreakdownQueryBodyOrderByEnumApi = {
 } as const
 
 export interface _TracingAttributeBreakdownQueryBodyApi {
-    /** Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. */
+    /** Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. For the "span" breakdown type, must be one of the allowlisted top-level columns: "service_name", "status_code". */
     breakdownKey: string
-    /** Where the key lives: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
+    /** Where the key lives: "span" for allowlisted top-level span columns, "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
      *
+     * * `span` - span
      * * `span_attribute` - span_attribute
      * * `span_resource_attribute` - span_resource_attribute */
-    breakdownType: BreakdownTypeEnumApi
+    breakdownType: SpanPropertyTypeEnumApi
+    /** Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected. */
+    excludeBreakdownFilter?: boolean
     /** Order rows by span count or error count, descending. Defaults to count.
      *
      * * `count` - count

--- a/products/tracing/frontend/generated/api.zod.ts
+++ b/products/tracing/frontend/generated/api.zod.ts
@@ -99,6 +99,7 @@ export const TracingSpansAggregateCreateBody = /* @__PURE__ */ zod.object({
         .describe('The span aggregation query to execute.'),
 })
 
+export const tracingSpansAttributeBreakdownCreateBodyQueryOneExcludeBreakdownFilterDefault = false
 export const tracingSpansAttributeBreakdownCreateBodyQueryOneCompareFilterOneCompareDefault = false
 export const tracingSpansAttributeBreakdownCreateBodyQueryOneFilterGroupDefault = []
 
@@ -108,15 +109,21 @@ export const TracingSpansAttributeBreakdownCreateBody = /* @__PURE__ */ zod.obje
             breakdownKey: zod
                 .string()
                 .describe(
-                    'Attribute key to group by (e.g. \"server.address\", \"http.response.status_code\"). Discover keys with apm-attributes-list.'
+                    'Attribute key to group by (e.g. \"server.address\", \"http.response.status_code\"). Discover keys with apm-attributes-list. For the \"span\" breakdown type, must be one of the allowlisted top-level columns: \"service_name\", \"status_code\".'
                 ),
             breakdownType: zod
-                .enum(['span_attribute', 'span_resource_attribute'])
+                .enum(['span', 'span_attribute', 'span_resource_attribute'])
                 .describe(
-                    '\* `span_attribute` - span_attribute\n\* `span_resource_attribute` - span_resource_attribute'
+                    '\* `span` - span\n\* `span_attribute` - span_attribute\n\* `span_resource_attribute` - span_resource_attribute'
                 )
                 .describe(
-                    'Where the key lives: \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n\* `span_attribute` - span_attribute\n\* `span_resource_attribute` - span_resource_attribute'
+                    'Where the key lives: \"span\" for allowlisted top-level span columns, \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n\* `span` - span\n\* `span_attribute` - span_attribute\n\* `span_resource_attribute` - span_resource_attribute'
+                ),
+            excludeBreakdownFilter: zod
+                .boolean()
+                .default(tracingSpansAttributeBreakdownCreateBodyQueryOneExcludeBreakdownFilterDefault)
+                .describe(
+                    "Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected."
                 ),
             orderBy: zod
                 .enum(['count', 'error_count'])

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11790,18 +11790,6 @@ export namespace Schemas {
       value: string | number;
     }
 
-    /**
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
-     */
-    export type BreakdownTypeEnum = typeof BreakdownTypeEnum[keyof typeof BreakdownTypeEnum];
-
-
-    export const BreakdownTypeEnum = {
-      SpanAttribute: 'span_attribute',
-      SpanResourceAttribute: 'span_resource_attribute',
-    } as const;
-
     export interface BreakdownValue {
       count: number;
       value: string;
@@ -27214,6 +27202,7 @@ export namespace Schemas {
 
 
     export const TraceSpanBreakdownType = {
+      Span: 'span',
       SpanAttribute: 'span_attribute',
       SpanResourceAttribute: 'span_resource_attribute',
     } as const;
@@ -27249,13 +27238,15 @@ export namespace Schemas {
     }
 
     export interface TraceSpansAttributeBreakdownQuery {
-      /** Attribute key to group by (e.g. `http.response.status_code`, `server.address`). */
+      /** Attribute key to group by (e.g. `http.response.status_code`, `server.address`). For the `span` breakdown type, must be an allowlisted top-level column (`service_name`, `status_code`). */
       breakdownKey: string;
-      /** Where the key lives: span-level attributes or resource-level attributes. */
+      /** Where the key lives: an allowlisted top-level span column, span-level attributes, or resource-level attributes. */
       breakdownType: TraceSpanBreakdownType;
       /** Optional comparison window — when `compare` is true, the runner returns an extra `compare` result set. */
       compareFilter?: CompareFilter | null;
       dateRange: DateRange;
+      /** Drop filters targeting the breakdown key itself (including `serviceNames` for a `service_name` breakdown) so a facet's value list stays complete while one of its values is selected. */
+      excludeBreakdownFilter?: boolean | null;
       filterGroup?: PropertyGroupFilter | null;
       kind?: 'TraceSpansAttributeBreakdownQuery';
       /** Modifiers used when performing the query */
@@ -52944,6 +52935,20 @@ export namespace Schemas {
     }
 
     /**
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     */
+    export type SpanPropertyTypeEnum = typeof SpanPropertyTypeEnum[keyof typeof SpanPropertyTypeEnum];
+
+
+    export const SpanPropertyTypeEnum = {
+      Span: 'span',
+      SpanAttribute: 'span_attribute',
+      SpanResourceAttribute: 'span_resource_attribute',
+    } as const;
+
+    /**
      * * `severity` - severity
      * * `service` - service
      */
@@ -57113,20 +57118,6 @@ export namespace Schemas {
     }
 
     /**
-     * * `span` - span
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
-     */
-    export type _SpanPropertyFilterTypeEnum = typeof _SpanPropertyFilterTypeEnum[keyof typeof _SpanPropertyFilterTypeEnum];
-
-
-    export const _SpanPropertyFilterTypeEnum = {
-      Span: 'span',
-      SpanAttribute: 'span_attribute',
-      SpanResourceAttribute: 'span_resource_attribute',
-    } as const;
-
-    /**
      * * `exact` - exact
      * * `is_not` - is_not
      * * `icontains` - icontains
@@ -57162,7 +57153,7 @@ export namespace Schemas {
        * * `span` - span
        * * `span_attribute` - span_attribute
        * * `span_resource_attribute` - span_resource_attribute */
-      type: _SpanPropertyFilterTypeEnum;
+      type: SpanPropertyTypeEnum;
       /** Comparison operator.
        *
        * * `exact` - exact
@@ -57339,13 +57330,16 @@ export namespace Schemas {
     } as const;
 
     export interface _TracingAttributeBreakdownQueryBody {
-      /** Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. */
+      /** Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. For the "span" breakdown type, must be one of the allowlisted top-level columns: "service_name", "status_code". */
       breakdownKey: string;
-      /** Where the key lives: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
+      /** Where the key lives: "span" for allowlisted top-level span columns, "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
        *
+       * * `span` - span
        * * `span_attribute` - span_attribute
        * * `span_resource_attribute` - span_resource_attribute */
-      breakdownType: BreakdownTypeEnum;
+      breakdownType: SpanPropertyTypeEnum;
+      /** Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected. */
+      excludeBreakdownFilter?: boolean;
       /** Order rows by span count or error count, descending. Defaults to count.
        *
        * * `count` - count

--- a/services/mcp/src/generated/tracing/api.ts
+++ b/services/mcp/src/generated/tracing/api.ts
@@ -114,6 +114,7 @@ export const TracingSpansAttributeBreakdownCreateParams = /* @__PURE__ */ zod.ob
         ),
 })
 
+export const tracingSpansAttributeBreakdownCreateBodyQueryOneExcludeBreakdownFilterDefault = false
 export const tracingSpansAttributeBreakdownCreateBodyQueryOneCompareFilterOneCompareDefault = false
 export const tracingSpansAttributeBreakdownCreateBodyQueryOneFilterGroupDefault = []
 
@@ -123,13 +124,21 @@ export const TracingSpansAttributeBreakdownCreateBody = /* @__PURE__ */ zod.obje
             breakdownKey: zod
                 .string()
                 .describe(
-                    'Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list.'
+                    'Attribute key to group by (e.g. "server.address", "http.response.status_code"). Discover keys with apm-attributes-list. For the "span" breakdown type, must be one of the allowlisted top-level columns: "service_name", "status_code".'
                 ),
             breakdownType: zod
-                .enum(['span_attribute', 'span_resource_attribute'])
-                .describe('* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute')
+                .enum(['span', 'span_attribute', 'span_resource_attribute'])
                 .describe(
-                    'Where the key lives: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.\n\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute'
+                    '* `span` - span\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute'
+                )
+                .describe(
+                    'Where the key lives: "span" for allowlisted top-level span columns, "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.\n\n* `span` - span\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute'
+                ),
+            excludeBreakdownFilter: zod
+                .boolean()
+                .default(tracingSpansAttributeBreakdownCreateBodyQueryOneExcludeBreakdownFilterDefault)
+                .describe(
+                    "Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected."
                 ),
             orderBy: zod
                 .enum(['count', 'error_count'])

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/apm-attribute-breakdown.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/apm-attribute-breakdown.json
@@ -5,12 +5,12 @@
             "description": "The attribute breakdown query to execute.",
             "properties": {
                 "breakdownKey": {
-                    "description": "Attribute key to group by (e.g. \"server.address\", \"http.response.status_code\"). Discover keys with apm-attributes-list.",
+                    "description": "Attribute key to group by (e.g. \"server.address\", \"http.response.status_code\"). Discover keys with apm-attributes-list. For the \"span\" breakdown type, must be one of the allowlisted top-level columns: \"service_name\", \"status_code\".",
                     "type": "string"
                 },
                 "breakdownType": {
-                    "description": "Where the key lives: \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute",
-                    "enum": ["span_attribute", "span_resource_attribute"],
+                    "description": "Where the key lives: \"span\" for allowlisted top-level span columns, \"span_attribute\" for span-level attributes, \"span_resource_attribute\" for resource-level attributes.\n\n* `span` - span\n* `span_attribute` - span_attribute\n* `span_resource_attribute` - span_resource_attribute",
+                    "enum": ["span", "span_attribute", "span_resource_attribute"],
                     "type": "string"
                 },
                 "compareFilter": {
@@ -62,6 +62,11 @@
                         }
                     },
                     "type": "object"
+                },
+                "excludeBreakdownFilter": {
+                    "default": false,
+                    "description": "Drop filters targeting the breakdown key itself (including serviceNames for a service_name breakdown), so a facet's value list stays complete while one of its values is selected.",
+                    "type": "boolean"
                 },
                 "filterGroup": {
                     "default": [],


### PR DESCRIPTION
## Problem

The tracing facet rail (being built behind `tracing-facet-rail`, shell landed in #68597) needs the `attribute-breakdown` endpoint to behave like a facet source, and it can't yet in two ways.

First, breakdowns only work on span and resource attribute map keys, not on top-level columns. The two most useful facets, `service_name` and `status_code`, are plain columns on `trace_spans`.

Second, breakdowns apply every active filter, including a filter on the breakdown key itself. For a facet that's wrong: select `service_name = api` and the service facet collapses to one row, making multi-select impossible. A facet's value list must ignore its own selection while every other filter still applies. This mirrors how the logs facet rail computes its cross-filtered counts.

## Changes

- New `span` breakdown type for top-level columns, guarded by a `FACET_COLUMNS` allowlist (`service_name`, `status_code`) at both the API and runner level so arbitrary column names never reach the SQL. Values are `toString()`-ed so `status_code` (Int16) rows keep the uniform string shape.
- New `excludeBreakdownFilter` flag on the query. When set, the runner drops filters targeting the breakdown key from the extracted filter lists, including the dedicated `serviceNames` scope when the breakdown is `service_name`, and span-attribute keys are matched against their physical-map suffixed forms (`__str`/`__float`).
- Schema updated at the source (`schema-general.ts`) and regenerated (`schema.py`, `schema_enums.py`, `schema.json`). Serializer and facade signatures extended; OpenAPI types regenerated.
- The new `breakdownType` choice set now matches the span filter `type` choice set, which tripped drf-spectacular's enum-collision check, so both are pinned to one `SpanPropertyTypeEnum` via `ENUM_NAME_OVERRIDES`.

## How did you test this code?

Full tracing backend suite passes (213 tests). Six new cases in `test_attribute_breakdown.py`, each guarding a regression no existing test catches:

- `test_span_column_breakdown` (parameterized): a column breakdown that stops resolving (illegal map read) or loses the `toString` cast would fail on the stringified `status_code` values.
- `test_span_column_breakdown_rejects_non_allowlisted_key`: locks in the 400 for non-allowlisted columns, the injection guard.
- `test_exclude_breakdown_filter_keeps_facet_complete` (parameterized over all four filter homes: `serviceNames`, span column, span attribute, resource attribute): fails if exclusion prunes the wrong list or misses the suffixed span-attribute keys.
- `test_exclude_breakdown_filter_keeps_other_filters`: fails if exclusion over-prunes and drops filters on other dimensions.

Also ran `ruff` and `hogli build:openapi` (clean after the enum override).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, additive API fields on an alpha product's internal endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed the work, Claude (PostHog Code) implemented it. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, plus the schema-first workflow (TS schema → `hogli build:schema` → `hogli build:openapi`).

Decisions: the new breakdown type is named `span` to match the existing `SpanPropertyFilterType` naming for top-level columns rather than inventing a `column` term. Own-filter exclusion prunes the runner's extracted filter lists after extraction (rather than rewriting the incoming `filterGroup`) so suffix handling stays in one place. The enum collision was resolved by pinning both same-valued choice sets to `SpanPropertyTypeEnum`, following the `find_enum_collisions` suggestion.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
