### PR TITLE
fix(aio): don't send temperature to models that reject it

### DIFF
--- a/products/ai_observability/backend/llm/providers/anthropic.py
+++ b/products/ai_observability/backend/llm/providers/anthropic.py
@@ -91,22 +91,6 @@ class AnthropicConfig:
         "claude-sonnet-4-0",
     ]
 
-    # Anthropic deprecated the sampling parameters (`temperature`/`top_p`/`top_k`) starting
-    # with Opus 4.7: setting them to a non-default value returns a 400. Their guidance is to
-    # omit them and steer via prompting. We never send a temperature unless a caller explicitly
-    # sets one; this list guards that explicit case so it degrades gracefully instead of 400ing.
-    # https://platform.claude.com/docs/en/about-claude/model-deprecations
-    MODELS_WITHOUT_TEMPERATURE: list[str] = [
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-sonnet-5",
-        "claude-fable-5",
-    ]
-
-    @classmethod
-    def supports_temperature(cls, model: str) -> bool:
-        return model not in cls.MODELS_WITHOUT_TEMPERATURE
-
 
 class AnthropicAdapter:
     """Anthropic provider implementing the unified Client interface."""
@@ -154,8 +138,10 @@ class AnthropicAdapter:
             **(self._build_analytics_kwargs(analytics, client)),
         }
 
-        # Only forward temperature when a caller explicitly set one and the model still accepts it.
-        if request.temperature is not None and AnthropicConfig.supports_temperature(request.model):
+        # Anthropic deprecated the sampling params (temperature/top_p/top_k) on newer models and
+        # recommends omitting them (https://platform.claude.com/docs/en/about-claude/model-deprecations).
+        # Forward temperature only when a caller explicitly set one.
+        if request.temperature is not None:
             create_kwargs["temperature"] = request.temperature
 
         if use_structured:
@@ -264,8 +250,8 @@ class AnthropicAdapter:
                 "stream": True,
             }
 
-            # Only forward temperature when a caller explicitly set one and the model still accepts it.
-            if request.temperature is not None and AnthropicConfig.supports_temperature(model_id):
+            # See complete(): forward temperature only when a caller explicitly set one.
+            if request.temperature is not None:
                 common_kwargs["temperature"] = request.temperature
 
             if analytics.capture:

--- a/products/ai_observability/backend/llm/providers/anthropic.py
+++ b/products/ai_observability/backend/llm/providers/anthropic.py
@@ -39,7 +39,6 @@ def _is_quota_or_billing_error(error: Exception) -> bool:
 class AnthropicConfig:
     MAX_TOKENS: int = 8192
     MAX_THINKING_TOKENS: int = 4096
-    TEMPERATURE: float = 0
     # Timeout in seconds for API calls. Set high to accommodate slow reasoning models.
     # Note: Infrastructure-level timeouts (load balancers, proxies) may still limit actual request duration.
     TIMEOUT: float = 300.0
@@ -92,8 +91,11 @@ class AnthropicConfig:
         "claude-sonnet-4-0",
     ]
 
-    # Newer models reject the `temperature` parameter with a 400
-    # ("temperature is deprecated for this model"). Skip sending it for these.
+    # Anthropic deprecated the sampling parameters (`temperature`/`top_p`/`top_k`) starting
+    # with Opus 4.7: setting them to a non-default value returns a 400. Their guidance is to
+    # omit them and steer via prompting. We never send a temperature unless a caller explicitly
+    # sets one; this list guards that explicit case so it degrades gracefully instead of 400ing.
+    # https://platform.claude.com/docs/en/about-claude/model-deprecations
     MODELS_WITHOUT_TEMPERATURE: list[str] = [
         "claude-opus-4-8",
         "claude-opus-4-7",
@@ -152,10 +154,9 @@ class AnthropicAdapter:
             **(self._build_analytics_kwargs(analytics, client)),
         }
 
-        if AnthropicConfig.supports_temperature(request.model):
-            create_kwargs["temperature"] = (
-                request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE
-            )
+        # Only forward temperature when a caller explicitly set one and the model still accepts it.
+        if request.temperature is not None and AnthropicConfig.supports_temperature(request.model):
+            create_kwargs["temperature"] = request.temperature
 
         if use_structured:
             assert request.response_format is not None
@@ -238,7 +239,6 @@ class AnthropicAdapter:
 
         reasoning_on = model_id in AnthropicConfig.SUPPORTED_MODELS_WITH_THINKING and request.thinking
 
-        effective_temperature = request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE
         effective_max_tokens = request.max_tokens if request.max_tokens is not None else AnthropicConfig.MAX_TOKENS
 
         tools = self._convert_tools(request.tools) if request.tools else None
@@ -264,8 +264,9 @@ class AnthropicAdapter:
                 "stream": True,
             }
 
-            if AnthropicConfig.supports_temperature(model_id):
-                common_kwargs["temperature"] = effective_temperature
+            # Only forward temperature when a caller explicitly set one and the model still accepts it.
+            if request.temperature is not None and AnthropicConfig.supports_temperature(model_id):
+                common_kwargs["temperature"] = request.temperature
 
             if analytics.capture:
                 common_kwargs["posthog_distinct_id"] = analytics.distinct_id

--- a/products/ai_observability/backend/llm/providers/anthropic.py
+++ b/products/ai_observability/backend/llm/providers/anthropic.py
@@ -92,6 +92,19 @@ class AnthropicConfig:
         "claude-sonnet-4-0",
     ]
 
+    # Newer models reject the `temperature` parameter with a 400
+    # ("temperature is deprecated for this model"). Skip sending it for these.
+    MODELS_WITHOUT_TEMPERATURE: list[str] = [
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    ]
+
+    @classmethod
+    def supports_temperature(cls, model: str) -> bool:
+        return model not in cls.MODELS_WITHOUT_TEMPERATURE
+
 
 class AnthropicAdapter:
     """Anthropic provider implementing the unified Client interface."""
@@ -136,9 +149,13 @@ class AnthropicAdapter:
             "system": system_prompt,
             "messages": messages,
             "max_tokens": request.max_tokens or AnthropicConfig.MAX_TOKENS,
-            "temperature": request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE,
             **(self._build_analytics_kwargs(analytics, client)),
         }
+
+        if AnthropicConfig.supports_temperature(request.model):
+            create_kwargs["temperature"] = (
+                request.temperature if request.temperature is not None else AnthropicConfig.TEMPERATURE
+            )
 
         if use_structured:
             assert request.response_format is not None
@@ -245,8 +262,10 @@ class AnthropicAdapter:
                 "model": model_id,
                 "system": system_prompt,
                 "stream": True,
-                "temperature": effective_temperature,
             }
+
+            if AnthropicConfig.supports_temperature(model_id):
+                common_kwargs["temperature"] = effective_temperature
 
             if analytics.capture:
                 common_kwargs["posthog_distinct_id"] = analytics.distinct_id

--- a/products/ai_observability/backend/llm/providers/test/test_anthropic.py
+++ b/products/ai_observability/backend/llm/providers/test/test_anthropic.py
@@ -98,12 +98,36 @@ class TestAnthropicTemperature:
             )
             return mock_client.messages.create.call_args.kwargs
 
+    def _stream_with_model(self, model: str, temperature: float | None = None):
+        with patch("products.ai_observability.backend.llm.providers.anthropic.anthropic.Anthropic") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = iter([])
+
+            # stream() is a generator; drain it so the request is actually built and sent
+            list(
+                AnthropicAdapter().stream(
+                    CompletionRequest(
+                        model=model,
+                        messages=[{"role": "user", "content": "hi"}],
+                        provider="anthropic",
+                        system="s",
+                        temperature=temperature,
+                    ),
+                    api_key="sk-ant-test",
+                    analytics=AnalyticsContext(capture=False),
+                )
+            )
+            return mock_client.messages.create.call_args.kwargs
+
     @parameterized.expand(["claude-haiku-4-5", "claude-opus-4-8", "claude-fable-5"])
     def test_temperature_omitted_when_not_set(self, model: str):
         # Evals never set a temperature; we must not inject one (Anthropic's guidance is to omit,
         # and injecting temperature=0 is what 400'd on models where it's deprecated)
         assert "temperature" not in self._complete_with_model(model, temperature=None)
+        assert "temperature" not in self._stream_with_model(model, temperature=None)
 
     @parameterized.expand(["claude-haiku-4-5", "claude-opus-4-6"])
     def test_explicit_temperature_forwarded(self, model: str):
         assert self._complete_with_model(model, temperature=0.5)["temperature"] == 0.5
+        assert self._stream_with_model(model, temperature=0.5)["temperature"] == 0.5

--- a/products/ai_observability/backend/llm/providers/test/test_anthropic.py
+++ b/products/ai_observability/backend/llm/providers/test/test_anthropic.py
@@ -100,14 +100,10 @@ class TestAnthropicTemperature:
 
     @parameterized.expand(["claude-haiku-4-5", "claude-opus-4-8", "claude-fable-5"])
     def test_temperature_omitted_when_not_set(self, model: str):
-        # Evals never set a temperature; we must not inject one (Anthropic's guidance is to omit)
+        # Evals never set a temperature; we must not inject one (Anthropic's guidance is to omit,
+        # and injecting temperature=0 is what 400'd on models where it's deprecated)
         assert "temperature" not in self._complete_with_model(model, temperature=None)
 
-    @parameterized.expand(["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"])
-    def test_explicit_temperature_sent_for_models_that_accept_it(self, model: str):
+    @parameterized.expand(["claude-haiku-4-5", "claude-opus-4-6"])
+    def test_explicit_temperature_forwarded(self, model: str):
         assert self._complete_with_model(model, temperature=0.5)["temperature"] == 0.5
-
-    @parameterized.expand(["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"])
-    def test_explicit_temperature_dropped_for_models_that_reject_it(self, model: str):
-        # These 400 with "temperature is deprecated for this model" if we send it
-        assert "temperature" not in self._complete_with_model(model, temperature=0.5)

--- a/products/ai_observability/backend/llm/providers/test/test_anthropic.py
+++ b/products/ai_observability/backend/llm/providers/test/test_anthropic.py
@@ -79,7 +79,7 @@ class TestAnthropicTemperature:
         mock_response.usage.output_tokens = 1
         return mock_response
 
-    def _complete_with_model(self, model: str):
+    def _complete_with_model(self, model: str, temperature: float | None = None):
         with patch("products.ai_observability.backend.llm.providers.anthropic.anthropic.Anthropic") as mock_cls:
             mock_client = MagicMock()
             mock_cls.return_value = mock_client
@@ -91,17 +91,23 @@ class TestAnthropicTemperature:
                     messages=[{"role": "user", "content": "hi"}],
                     provider="anthropic",
                     system="s",
+                    temperature=temperature,
                 ),
                 api_key="sk-ant-test",
                 analytics=AnalyticsContext(capture=False),
             )
             return mock_client.messages.create.call_args.kwargs
 
-    @parameterized.expand(["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"])
-    def test_temperature_omitted_for_models_that_reject_it(self, model: str):
-        # Newer models 400 with "temperature is deprecated for this model" if we send it
-        assert "temperature" not in self._complete_with_model(model)
+    @parameterized.expand(["claude-haiku-4-5", "claude-opus-4-8", "claude-fable-5"])
+    def test_temperature_omitted_when_not_set(self, model: str):
+        # Evals never set a temperature; we must not inject one (Anthropic's guidance is to omit)
+        assert "temperature" not in self._complete_with_model(model, temperature=None)
 
     @parameterized.expand(["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"])
-    def test_temperature_sent_for_models_that_accept_it(self, model: str):
-        assert self._complete_with_model(model)["temperature"] == AnthropicConfig.TEMPERATURE
+    def test_explicit_temperature_sent_for_models_that_accept_it(self, model: str):
+        assert self._complete_with_model(model, temperature=0.5)["temperature"] == 0.5
+
+    @parameterized.expand(["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"])
+    def test_explicit_temperature_dropped_for_models_that_reject_it(self, model: str):
+        # These 400 with "temperature is deprecated for this model" if we send it
+        assert "temperature" not in self._complete_with_model(model, temperature=0.5)

--- a/products/ai_observability/backend/llm/providers/test/test_anthropic.py
+++ b/products/ai_observability/backend/llm/providers/test/test_anthropic.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
+
 from products.ai_observability.backend.llm.providers.anthropic import AnthropicAdapter, AnthropicConfig
+from products.ai_observability.backend.llm.types import AnalyticsContext, CompletionRequest
 
 
 class TestAnthropicListModels:
@@ -64,3 +67,41 @@ class TestAnthropicListModels:
 class TestAnthropicRecommendedModels:
     def test_recommended_models_equals_supported_models(self):
         assert AnthropicAdapter.recommended_models() == set(AnthropicConfig.SUPPORTED_MODELS)
+
+
+class TestAnthropicTemperature:
+    def _make_mock_response(self):
+        mock_block = MagicMock()
+        mock_block.text = "yes"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+        mock_response.usage.input_tokens = 1
+        mock_response.usage.output_tokens = 1
+        return mock_response
+
+    def _complete_with_model(self, model: str):
+        with patch("products.ai_observability.backend.llm.providers.anthropic.anthropic.Anthropic") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = self._make_mock_response()
+
+            AnthropicAdapter().complete(
+                CompletionRequest(
+                    model=model,
+                    messages=[{"role": "user", "content": "hi"}],
+                    provider="anthropic",
+                    system="s",
+                ),
+                api_key="sk-ant-test",
+                analytics=AnalyticsContext(capture=False),
+            )
+            return mock_client.messages.create.call_args.kwargs
+
+    @parameterized.expand(["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"])
+    def test_temperature_omitted_for_models_that_reject_it(self, model: str):
+        # Newer models 400 with "temperature is deprecated for this model" if we send it
+        assert "temperature" not in self._complete_with_model(model)
+
+    @parameterized.expand(["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"])
+    def test_temperature_sent_for_models_that_accept_it(self, model: str):
+        assert self._complete_with_model(model)["temperature"] == AnthropicConfig.TEMPERATURE


### PR DESCRIPTION
## Problem

The Anthropic adapter injected a default `temperature=0` on every request. Anthropic [deprecated the sampling params](https://platform.claude.com/docs/en/about-claude/model-deprecations) (`temperature`/`top_p`/`top_k`) on Opus 4.7+, so a non-default value now 400s (`temperature is deprecated for this model`). Eval judges never set a temperature, so that injected default was the only reason their requests carried one — and why they failed on newer judge models. The 400 retried to the Temporal max and failed the whole eval workflow, tripping the eval error-rate alert.

Raised from a Slack thread triaging an LLM-as-a-judge error spike.

## Changes

- Stop injecting `temperature=0`; forward `temperature` only when a caller explicitly sets one (both `complete` and `stream` paths). Matches Anthropic's "omit and use prompting" guidance and fixes evals on every model.
- Removed the now-unused `AnthropicConfig.TEMPERATURE` constant.

Behavior change: eval judges on models that still accept `temperature` move from `0` to the model default — fine for online evals (each generation is scored once; `temperature=0` was never a determinism guarantee) and what Anthropic recommends.

## How did you test this code?

Parameterized `TestAnthropicTemperature` at the SDK boundary (mocked client, no DB): temperature omitted when unset (the regression guard) and forwarded verbatim when set. Ran `ruff check`/`ruff format`; couldn't run the Python suite here (no venv) — to be confirmed in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread. Diagnosed from the Temporal stack trace, verified against the live Anthropic deprecations/migration docs, and confirmed the adapter's only consumers are evals (never set temperature) and the playground proxy (sets it only when the user does). Iterated with the reviewer from a per-model gate to simply dropping the injected default. Invoked `/claude-api` and `/writing-tests`.
