### PR TITLE
fix(mcp): raise search pattern limit to 400 chars

### DIFF
--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -20,7 +20,7 @@ import {
 
 /** Upper bound on a `search` regex pattern — keeps a pathological pattern from
  *  forcing catastrophic backtracking against tool metadata. */
-const MAX_SEARCH_PATTERN_LENGTH = 200
+const MAX_SEARCH_PATTERN_LENGTH = 400
 
 /** Ranked (plain-word) search can match loosely on a common token like
  *  "create"; cap the returned names so a vague query can't dump the catalog. */

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -734,7 +734,7 @@ describe('exec tool', () => {
 
         it('rejects an overly long search pattern before compiling the regex', async () => {
             const exec = createExec([makeMockTool()])
-            const longPattern = 'a'.repeat(201)
+            const longPattern = 'a'.repeat(401)
             await expect(exec.handler(mockContext, { command: `search ${longPattern}` })).rejects.toThrow(
                 /pattern too long/i
             )


### PR DESCRIPTION
## Problem

The MCP `search` tool discovery command capped user-supplied patterns at 200 characters. That's too tight for a common, legitimate case: discovering several exact tools in one call with an anchored alternation like `^(tool-a|tool-b|tool-c|...)$`. Scout-style runs that routinely need a handful of exact tools hit `Search pattern too long (238 chars, max 200)` and had to split discovery across multiple calls, which adds latency and task-log noise.

## Changes

Bump `MAX_SEARCH_PATTERN_LENGTH` from 200 to 400 in `services/mcp/src/tools/exec.ts`. The bound still exists to limit the blast radius of a pathological backtracking regex; 400 comfortably fits the exact-name alternations that were being rejected while staying well short of anything unbounded. Updated the length-guard unit test to use a 401-char pattern.

## How did you test this code?

Updated the existing unit test in `services/mcp/tests/unit/exec.test.ts` that asserts overly long patterns are rejected before the regex compiles (now uses 401 chars). I (the agent) could not run the MCP test suite locally in this environment because its dev dependencies aren't installed in the sparse checkout; CI will run it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread relaying MCP agent feedback: the exact-name discovery regex was being rejected at 200 chars. The fix is a one-line constant bump plus the matching test tweak. Authored by the PostHog Slack app (Claude). No repo skills were needed for a change this small.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BE8C0JFNF/p1783521230504199?thread_ts=1783521230.504199&cid=C0BE8C0JFNF)*
