### PR TITLE
chore(mcp): drop querying-posthog-data skill directive from execute-sql prompt

### DIFF
--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -14,10 +14,6 @@ Reach for `execute-sql` only when no `query-*` tool can express the question:
 
 If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch, not the starting point.
 
-### Always consult the `querying-posthog-data` skill
-
-Before writing any SQL, read the PostHog `querying-posthog-data` skill. It is the source of truth for up-to-date HogQL patterns, system table schemas (`system.insights`, `system.dashboards`, `system.cohorts`, etc.), and function references. Do not rely on training data — table and column names drift.
-
 {schema_discovery}
 
 ### Format SQL for readability


### PR DESCRIPTION
## Problem

MCP agent feedback flagged that `execute-sql` tells agents they must read the `querying-posthog-data` skill before writing any SQL, but `skill-get` can't retrieve that skill in every context (a headless Signals scout run hit a 404 for it). The directive sends agents to a dead end and forces a workaround.

## Changes

Removed the dedicated "Always consult the `querying-posthog-data` skill" section from the `execute-sql` tool prompt. The `{schema_discovery}` block already instructs agents to confirm system-table columns via `execute-sql` against `system.information_schema.*`, so schema discovery is still covered without pointing at a skill that may not resolve.

## How did you test this code?

No automated tests run — this is a copy-only change to a prompt template. The `{guidelines}` and `{schema_discovery}` interpolation points are untouched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread via the PostHog Slack app (Claude-based). The ask was to remove the recommendation to read the skill from the `execute-sql` guidance. I located the directive in `services/mcp/src/templates/execute-sql-prompt.md` and removed just that section, leaving the schema-discovery guidance intact since it independently covers the system-table workflow the skill section was gesturing at.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BE8C0JFNF/p1783519629011369?thread_ts=1783519629.011369&cid=C0BE8C0JFNF)*
