### PR TITLE
fix(phai): attribute Max web insight queries to posthog_ai source

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -50,7 +50,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
-from posthog.event_usage import get_request_analytics_properties, report_user_or_team_action
+from posthog.event_usage import EventSource, get_request_analytics_properties, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters, apply_dashboard_variables
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -199,6 +199,10 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
 
             if data.limit_context == SchemaLimitContext.POSTHOG_AI:
                 limit_context: LimitContext | None = LimitContext.POSTHOG_AI
+                # Max's insight tiles run in the browser, so the request looks like a session
+                # web request and get_event_source classifies it as "web". Attribute it to
+                # posthog_ai instead, matching the server-side executor's tagging.
+                analytics_props["source"] = EventSource.POSTHOG_AI
             elif (
                 is_async_query(query_dict)
                 or is_insight_actors_query(query_dict)

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -38,6 +38,7 @@ from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import Product, QueryTags
+from posthog.event_usage import EventSource
 from posthog.models.utils import UUIDT
 
 from products.event_definitions.backend.models.property_definition import PropertyDefinition, PropertyType
@@ -736,6 +737,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         )
         mock_process_query_model.assert_called_once()
         self.assertEqual(mock_process_query_model.call_args[1]["limit_context"], LimitContext.POSTHOG_AI)
+        # The posthog_ai limit context also retags the analytics source, so Max's insight tiles
+        # (browser session requests that would otherwise read as "web") are attributed to posthog_ai.
+        self.assertEqual(mock_process_query_model.call_args[1]["analytics_props"]["source"], EventSource.POSTHOG_AI)
 
     @patch("posthog.api.query.process_query_model")
     def test_query_limit_context_default(self, mock_process_query_model):


### PR DESCRIPTION
## Problem

Max's insight tiles render in the browser on the `/ai` page and re-run their query through `POST /api/query`. That request carries a session cookie, so `get_event_source` classifies it as `web` — masking Max-driven query load in the `query executed` / `query api response` `source` breakdown, where it should read as `posthog_ai`.

The frontend already tags these requests: `frontend/src/scenes/max/messages/VisualizationWidget.tsx` sets `limitContext: 'posthog_ai'`, which arrives as `limit_context: 'posthog_ai'` in the request body. The backend read that field for the row-limit context but not for analytics attribution.

This is the browser-path complement to #69288 (which tags Max's server-side executor). Together they make both of Max's query paths report `source: posthog_ai`.

## Changes

- `posthog/api/query.py`: when a query runs in the `POSTHOG_AI` limit context, override the analytics `source` to `posthog_ai` (mutated in place, so both the `query executed` and `query api response` captures are retagged).

Note: `limit_context: 'posthog_ai'` is a client-settable field, so any caller that explicitly declares the AI limit context is now attributed to `posthog_ai`. In practice Max is the only production setter, and attributing an explicitly-declared AI context to `posthog_ai` is the intended behavior.

## How did you test this code?

- Extended `test_query_limit_context_posthog_ai` to assert `analytics_props["source"] == EventSource.POSTHOG_AI` is forwarded to `process_query_model` (the existing case only checked `limit_context`). Guards against silently reverting Max's browser tiles back to `source: web`. Passing locally.

## Publish to changelog?

no