### PR TITLE
chore(clickhouse): record hclexp -version in live schema dump

### DIFF
--- a/posthog/clickhouse/hcl/README.md
+++ b/posthog/clickhouse/hcl/README.md
@@ -50,7 +50,9 @@ The convergence gate closes it, in **two steps** that run inside the multinode m
 
 1. **`dump-live.sh [outdir]`** — `hclexp introspect` each managed role's live node into
    `<outdir>/<env>-<role>.hcl`, dropping unmanaged / transient objects via `exclude.hcl`. Needs the
-   cluster (a `--network host` container, or `HCLEXP_BIN` locally).
+   cluster (a `--network host` container, or `HCLEXP_BIN` locally). Also writes
+   `<outdir>/hclexp-version.txt` (`hclexp -version`) recording the tool build that produced the dump —
+   informational provenance, not gated by `check-live.sh`.
 2. **`check-live.sh <dumpdir>`** — for each role, `hclexp diff -format json` the committed
    `golden/<env>-<role>.hcl` against the dump, drop the ignored operations (named_collections +
    `exclude.hcl` globs), and require nothing left. Offline — only needs `hclexp`.

--- a/posthog/clickhouse/hcl/dump-live.sh
+++ b/posthog/clickhouse/hcl/dump-live.sh
@@ -59,6 +59,13 @@ run_hclexp() {
   docker run --rm --network host -v "$PWD:/work" -v "$tmp:$tmp" -w /work "$HCLEXP_IMAGE" "$@"
 }
 
+# Record the hclexp build that produced this dump (informational provenance; not
+# gated by check-live). Best-effort: an image predating `-version` must not fail
+# the dump, so keep it off the rc path.
+run_hclexp -version > "$OUTDIR/hclexp-version.txt" 2>&1 \
+  || echo "WARN: hclexp -version unavailable (older image?) — see $OUTDIR/hclexp-version.txt" >&2
+chmod 0644 "$OUTDIR/hclexp-version.txt" 2>/dev/null || true
+
 rc=0
 for spec in "${ROLES[@]}"; do
   read -r role dhost dport ddb <<<"$spec"


### PR DESCRIPTION
## Problem

`dump-live.sh` captures the live ClickHouse schema per node for the convergence gate, but leaves no record of which `hclexp` / `chschema` build produced a given dump. The only version signal today is the pinned image SHA, scattered across `bin/hclexp`, `dump-live.sh`, and the CI workflows. When a gate result is inspected later, or when the pinned image is being bumped, nothing in the dump itself says which tool build ran.

## Changes

`dump-live.sh` now writes `<outdir>/hclexp-version.txt` (the full `hclexp -version` output) next to the per-role `.hcl` dumps. It uses the same `run_hclexp` resolver as the introspection, so the recorded version matches whatever binary or image actually produced the dumps.

It is best-effort and stays off the `rc` path: an image predating the `-version` flag degrades to a warning and never fails the dump or the gate. Informational provenance only, so `check-live.sh` is unchanged and simply ignores the extra file (it reads only the explicit per-role paths). README updated to describe the new file.

> [!NOTE]
> No enforcement is added. The file records the tool build for traceability, it is not diffed against a golden.

## How did you test this code?

Ran against the local multinode ClickHouse stack:

- `dump-live.sh` writes the 4-line `-version` block to `hclexp-version.txt`, all per-role dumps are still produced, and the dump-dir stdout line is intact.
- `check-live.sh` runs unchanged and ignores the `.txt`.
- Failure path: a stub `hclexp` that exits non-zero on `-version` emits the warning, the loop continues under `set -e`, and the exit code comes only from introspect (not the version step).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
