### PR TITLE
chore(metrics): add internal design docs for events model and fingerprint fix

### DIFF
--- a/docs/internal/metrics/dev-bridge-fixes.md
+++ b/docs/internal/metrics/dev-bridge-fixes.md
@@ -1,0 +1,118 @@
+# Metrics dev bridge — charts fixes (INFRA-A follow-up)
+
+Companion to [`deployment-layout.md`](./deployment-layout.md) and [`dashboard-mvp.md`](./dashboard-mvp.md).
+
+INFRA-A (charts #11808) wired the dev metrics bridge (vmagent remote-write → otel-collector → capture-logs → metrics1)
+but it (a) crash-looped the shared otel-collector daemonset and (b) never delivered a single metric.
+Two root causes → two charts changes. This is the record, plus the ArgoCD experiment used to validate before the PR.
+
+**Status:** the remote-write bridge (#11808) was **reverted** (#12233) and its follow-ups closed (#12235, INFRA-C #12021, prod-bridge #12020). The replacement is a dedicated **scrape** collector: **[charts#12239](https://github.com/PostHog/charts/pull/12239)** (dev, open) and **[charts#12248](https://github.com/PostHog/charts/pull/12248)** (prod-us/eu, draft, stacked on the dev PR). The remote-write diagnosis below is kept as the record of why.
+
+## Symptoms
+
+- `otel-collector-dev` daemonset: Degraded pods climbing (this is the **shared** logs/traces/metrics collector).
+- WarpStream `vcn_metrics_dev`: 0 throughput.
+- `posthog.metrics` (metrics1): 0 rows.
+
+## Root cause 1 — collector image predates the receiver
+
+The bridge adds a `prometheusremotewrite` receiver. That receiver was only promoted to alpha (and compiled into the
+released contrib image) in **v0.131.0**. The daemonset runs `opentelemetry-collector-contrib:0.127.0`, so the config
+fails to decode at startup:
+
+```text
+error decoding 'receivers': unknown type: "prometheusremotewrite" ... (valid values: [... prometheus prometheus_simple ...])
+```
+
+→ exit 1 → CrashLoopBackOff. The config lives in the shared configmap, so as pods cycle into it they crash fleet-wide.
+
+**Fix:** pin the collector image to `>= 0.131.0`.
+
+## Root cause 2 — exporter posts into the Cognito auth proxy
+
+`otlphttp/posthog-metrics.endpoint: https://app.dev.posthog.dev/i/` is the Cognito-ALB'd **app** host. POSTs get
+302-redirected to the login page (which returns 200), so the Go HTTP client follows the redirect and the collector
+reports the export as **successful** while capture-logs never receives the data — a silent black-hole. This is why the
+`debug` exporter logs metrics happily and there are no export errors, yet nothing reaches Kafka.
+
+The working local collector config (`otel-collector-config.dev.yaml`) proves the intended pattern: exporters talk to
+capture-logs **directly by service name** (`http://capture-logs:4318`), never a public domain.
+
+**Fix:** point the exporter at the in-cluster capture-logs Service. The collector is in namespace `otel`; capture-logs
+is in `posthog` (cf. `bin/send-dev-metrics.sh` port-forward `-n posthog svc/capture-logs … :4318`), so use the
+cross-namespace FQDN. otlphttp appends `/v1/metrics`.
+
+> Note: the existing **traces/logs** `otlphttp` exporter uses the same `app.dev.posthog.dev/i/` host and has the same
+> black-hole — it's just been masked because traces also export to `otlp/quickwit`. Worth fixing in the same pass.
+
+## Charts changes — `argocd/otel-collector/values/values.dev.yaml`
+
+```yaml
+# 1. Pin the image so the prometheusremotewrite receiver exists (file has no image: block today).
+image:
+  tag: '0.131.0'
+
+# 2. Send to the in-cluster capture-logs Service, not the Cognito-protected app host.
+config:
+  exporters:
+    otlphttp/posthog-metrics:
+      endpoint: http://capture-logs.posthog.svc.cluster.local:4318 # was: https://app.dev.posthog.dev/i/
+      tls:
+        insecure: true # plain HTTP in-cluster
+      headers:
+        authorization: Bearer <dev-capture-token> # value stays in charts values, not duplicated in this public repo
+      compression: gzip
+      timeout: 10s
+```
+
+Both are required for end-to-end delivery: change 1 makes the fleet healthy and the bridge _receive_; change 2 makes the
+metrics actually _arrive_.
+
+## ArgoCD experiment (validate before the PR)
+
+All doable in the ArgoCD UI (no kubectl needed). Turn **Auto-Sync OFF** on `otel-collector-dev` for the duration so it
+doesn't revert live edits.
+
+1. Edit the configmap `otel-collector-opentelemetry-collector-agent` (`relay.yaml`): set the `otlphttp/posthog-metrics`
+   endpoint to `http://capture-logs.posthog.svc.cluster.local:4318` (+ `tls.insecure: true`).
+2. Edit the **DaemonSet** `otel-collector-opentelemetry-collector-agent` → `spec.template.spec.containers[0].image` →
+   `…/opentelemetry-collector-contrib:0.131.0`. This triggers the rollout; new pods come up on 0.131 reading the fixed
+   configmap. (Rollout is `maxUnavailable: 10%`, so it rolls gradually.)
+3. Verify:
+   - Collector pod logs: `debug` exporter shows metrics; **no** otlphttp export errors.
+   - WarpStream `vcn_metrics_dev`: throughput > 0.
+   - `/metrics` SQL: `SELECT service_name, count(), max(timestamp) FROM posthog.metrics WHERE timestamp > now() - INTERVAL 1 HOUR GROUP BY 1`.
+
+Re-enable Auto-Sync **after** the charts PR merges.
+
+## Blocker (confirmed): vmagent RW v1 vs receiver RW v2
+
+The vmagent → bridge link **cannot work as designed** — a hard protocol incompatibility, confirmed in vmagent's remote-write logs (the collector is reachable now; it just rejects every block):
+
+```text
+unexpected status code received after sending a block ... during retry #16: 415; response body="Unsupported proto version"; re-sending the block in ...
+```
+
+- The OTel `prometheusremotewrite` receiver supports **Prometheus Remote Write 2.0 only** (`io.prometheus.write.v2.Request`).
+- vmagent (v1.97.1) sends **Remote Write 1.0** and has **no v2 support** (VictoriaMetrics open FR [#10413](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10413); they favor their zstd RW v1 over v2). There's also an open receiver bug rejecting remote-write-originated metrics ([contrib #41840](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41840)).
+- So every block is `415`'d and retried forever — vmagent's queue for that URL grows (280–445 KB blocks, retry #16+). The `/api/v1/write` path was never the problem.
+
+No values tweak fixes this. The collector-side fixes (image + endpoint) were still correct — they un-wedged the daemonset and fixed the black-hole endpoint — but the bridge can't receive vmagent's stream.
+
+### Redesign options (the real long-term fix)
+
+1. **Dedicated single-replica scrape collector** — a standalone otel-collector Deployment (not the daemonset) with a `prometheus` receiver that scrapes the dashboard targets via K8s SD, filters, and exports OTLP to capture-logs. Single replica → none of the daemonset N-duplication that made RW attractive originally. Pure OTel, no protocol issue. Tradeoff: re-scrapes targets (notably per-node cadvisor/node-exporter = extra kubelet load), needs SD RBAC.
+2. **RW v1 → OTLP shim** — keep vmagent's single scrape; point its second remote-write at a component that accepts RW v1 and re-emits OTLP (e.g. Grafana Alloy `prometheus.receive_http`). Avoids re-scraping; adds a component to run.
+3. **Wait for vmagent RW v2** (#10413) — no ETA; not viable now.
+
+**Chosen: option 1**, built as the `metrics-bridge` ArgoCD app — [charts#12239](https://github.com/PostHog/charts/pull/12239) (dev) + [charts#12248](https://github.com/PostHog/charts/pull/12248) (prod draft). A single-replica deployment-mode collector that scrapes annotation-discovered targets (ingestion services, kminion, envoy, kube-state, argo-rollouts) → `filter/dashboard` → OTLP → capture-logs; per-node cadvisor/node-exporter (`container_*`/`node_*`/`kubelet_*`) deferred. Token handling: **dev** sets the capture token inline in `values.dev.yaml` (matching the otel-collector daemonset's otlphttp exporter); **prod** uses **external-secrets** (ExternalSecret via the chart's `extraManifests`, mirroring the otel-ingest gateway) — the per-region internal-infra token is seeded in AWS Secrets Manager as `metrics-bridge-token-secrets` / `CAPTURE_TOKEN` via the **`PostHog/secrets`** tool, then synced automatically (hourly). Prod is gated on the prod ingest plane + `metrics1` DDL + a dedicated internal-infra project per region. Full rollout runbook is in the #12248 description.
+
+Meanwhile, stop the bleed: **remove the dead `:19291/api/v1/write` target from `argocd/vmagent/values/values.dev.yaml`** so vmagent stops retrying undeliverable blocks. (vmagent-dev has auto-sync on, so this only changes via a charts PR.)
+
+## Open item — token → team
+
+The bridge token maps to exactly one team. Local dev uses `phc_local` → team 1. If the bridge token isn't the token for
+the project you're querying (the `/metrics` tab you're watching), the rows land on a different team and you won't see
+them there even after both fixes. `deployment-layout.md`'s open decision is to send infra metrics to a dedicated
+`posthog-internal-infra` project rather than the dogfood team (so they don't flip `team_has_metrics`). Decide which
+before/with the PR.

--- a/docs/internal/metrics/events-model-architecture.md
+++ b/docs/internal/metrics/events-model-architecture.md
@@ -1,0 +1,160 @@
+# Metrics: the events model (`metric_events`) — architecture & decisions
+
+Companion to [`deployment-layout.md`](./deployment-layout.md), [`dashboard-mvp.md`](./dashboard-mvp.md), and [`dev-bridge-fixes.md`](./dev-bridge-fixes.md).
+
+**Status:** the foundation stack is open as drafts — [#66163](https://github.com/PostHog/posthog/pull/66163) (table), [#66169](https://github.com/PostHog/posthog/pull/66169) (HogQL), [#66183](https://github.com/PostHog/posthog/pull/66183) (ingest).
+The read/product layer (query runner, Samples view, trace pivot, frontend) comes next, **extending the existing metrics product** rather than standing up a separate surface.
+
+## The differentiating line (read this first)
+
+PostHog now has **two** metrics storage models, both on the LOGS ClickHouse cluster, both fed from the **same** Kafka stream:
+
+|                              | `metrics1` (pre-aggregated TSDB)                                                                                         | `metric_events` (events model)                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| **Row granularity**          | rolled up per `(team, time_bucket, service, metric, resource_fingerprint)` with a counts/min/max projection              | **one row per emission**                                                       |
+| **When aggregation happens** | at write / projection time                                                                                               | **at query time**                                                              |
+| **Carries**                  | `count`, `histogram_bounds`/`histogram_counts`, `aggregation_temporality`, `is_monotonic`, `projection_aggregate_counts` | `value`, `kind`, **`trace_id` (bloom-indexed)**, high-cardinality `attributes` |
+| **`ORDER BY`**               | `(team_id, time_bucket, service_name, metric_name, resource_fingerprint, timestamp)`                                     | `(team_id, metric_name, timestamp)`                                            |
+| **Cardinality posture**      | bounded (rolls up)                                                                                                       | unbounded (every point) → needs TTL + quota                                    |
+| **Retention**                | none today                                                                                                               | **30 days**                                                                    |
+| **Query shapes**             | `rate` / `increase` / `histogram_quantile` time-series                                                                   | **samples list, query-time agg, trace pivot**                                  |
+| **Best for**                 | dashboards, alerts — "is it up, how fast, what's the trend"                                                              | debugging a spike — "show me the actual events, and the trace behind this one" |
+| **Sentry analog**            | the model they moved _away_ from for the detail view                                                                     | "Samples" / Trace — the model they moved _to_                                  |
+
+**One sentence:** `metrics1` answers _"what is the shape of this metric over time"_; `metric_events` answers _"what were the individual emissions, and what trace caused this one."_
+
+They are **complementary, not a migration.** Neither replaces the other. A dashboard tile stays on `metrics1`; clicking into a spike to see the underlying events and jump to a trace is `metric_events`.
+
+## Why two models (the Sentry pivot)
+
+Sentry shipped pre-aggregated metrics, then publicly pivoted away from them (they wrote up the mistake on the Sentry engineering blog): pre-aggregation throws away exactly the information you need when something breaks.
+You can see _that_ p99 latency spiked, but not _which_ requests, with _which_ tags, tied to _which_ traces.
+Their fix was to store metric emissions as **events** with full attributes and trace linkage, and aggregate at read time — trading storage and query cost for the ability to drill from a chart all the way to a single trace.
+
+PostHog already has the platform that makes this cheap to adopt: an events/observability pipeline (capture-logs → Kafka → ClickHouse on the LOGS cluster) that already carries logs and traces with `trace_id`.
+Putting metric emissions next to them on the same cluster makes the metric→trace pivot a same-cluster lookup, not a cross-system join.
+`metrics1` stays as the efficient TSDB for dashboards and alerts; `metric_events` adds the differentiated drill-down.
+
+## Architecture
+
+### The pipeline (shared all the way to ClickHouse)
+
+```text
+SDK / OTLP / Prometheus remote-write
+        │
+        ▼
+   capture-logs (Rust gateway)         maps everything to one Avro MetricRecord
+        │  produces → topic: ingestion-metrics  (warpstream-metrics)
+        ▼
+   metrics-ingestion (Node consumer)   transform / enrich
+        │  produces → topic: clickhouse_metrics
+        ▼
+   ClickHouse LOGS cluster
+        │
+        ▼
+   kafka_metrics_avro   (Kafka engine, Avro, group clickhouse-metrics-avro[-new])
+        │
+        ├── kafka_metrics_avro_mv ─────────────▶ metrics1        (pre-aggregated TSDB)   ← existing
+        │
+        └── kafka_metrics_avro_to_metric_events ▶ metric_events  (events model)          ← NEW (#66183)
+```
+
+The key move: **one Kafka consumer, two destinations.**
+ClickHouse delivers every message from a Kafka-engine table to _all_ attached materialized views, so adding a second MV fans each data point into both tables.
+No new topic, consumer group, named collection, or Rust change — the existing `MetricRecord` Avro is already a superset of what the events model needs (it carries `value`, `trace_id`/`span_id`/`trace_flags`, `metric_type`, and the attribute maps).
+
+### Where things live
+
+- **Storage:** `metric_events1` (base, `ReplicatedMergeTree` in prod / `MergeTree` locally) + `metric_events` (Distributed wrapper) on the LOGS cluster, database `CLICKHOUSE_LOGS_CLUSTER_DATABASE`.
+- **Table definition:** `posthog/clickhouse/metrics/metric_events.py`, registered in `posthog/clickhouse/schema.py`, created in prod by migration `0277_metric_events.py` (`node_roles=[NodeRole.LOGS]`).
+- **Ingest (Kafka table + MVs):** `bin/clickhouse-metrics.sql`. Deliberately **not** in migrations — see D2 below.
+- **Query exposure:** `MetricEventsTable` in `posthog/hogql/database/schema/metrics.py`, registered in `posthog/hogql/database/database.py` under the `posthog` namespace → queryable as `posthog.metric_events`.
+
+### Query exposure (HogQL)
+
+`metric_events` is reachable as `posthog.metric_events`, with `team_id` isolation enforced by the HogQL layer (every compiled query gets a `team_id` filter injected — verified, not assumed).
+The events-model aggregations map by `kind`:
+
+- `counter` → `count()` / `sum(value)`
+- `gauge` → `argMax(value, timestamp)`
+- `distribution` → `quantile(value)` (raw values, no pre-bucketed histogram)
+
+The trace pivot is a `trace_id` equality lookup, served by the `idx_trace_id_bf` bloom filter.
+
+## Decisions & alternatives
+
+### D1 — Dual-write via a second MV, not a new topic/consumer
+
+**Context:** `metric_events` needs to be populated from the metric stream.
+**Decision:** attach a second MV (`kafka_metrics_avro_to_metric_events`) to the existing `kafka_metrics_avro` Kafka table.
+**Alternatives rejected:**
+
+- _New capture-logs topic + producer_ — Rust changes, a new WarpStream cluster/topic, new consumer group; weeks of infra for no extra capability.
+- _New Kafka-engine table on the same topic with its own consumer group_ — doubles Kafka fetch load and lets the two tables drift out of sync on rebalance.
+
+**Consequence:** zero new infrastructure, and `metrics1` and `metric_events` are guaranteed to see the exact same data because they read from one consumer. Cost: the new MV shares the source table's fate — a malformed-row bug in its `SELECT` could stall consumption for both, so the mapping mirrors the proven `metrics1` MV (`ifNull` guards, `kafka_skip_broken_messages = 100`).
+
+### D2 — Ingest DDL stays hand-managed, not in migrations
+
+**Context:** Django/ClickHouse migrations are the norm for storage tables.
+**Decision:** the Kafka-engine table and the Kafka→storage MVs live in `bin/clickhouse-metrics.sql` + manual prod DDL (recorded in the PR), matching how `metrics1`/`kafka_metrics_avro` are already deployed. The **storage** table (`metric_events1`) does get a real migration.
+**Why:** the Avro Kafka tables reference environment-specific brokers/named-collections and are intentionally kept out of `schema.py` (the logs Kafka tables aren't there either). Forcing the MV into a migration would make it depend on `kafka_metrics_avro`, which no migration creates — it would fail on a fresh cluster.
+**Consequence:** consistent with the existing metrics pipeline, but the prod MV is a manual step on merge (see Operational notes). This is a known rough edge of the metrics product, not new debt introduced here.
+
+### D3 — 30-day TTL on `metric_events`
+
+**Context:** `metrics1` has no retention today; events are far higher volume.
+**Decision:** `TTL toDateTime(timestamp) + INTERVAL 30 DAY`, `ttl_only_drop_parts = 1`.
+**Why:** one-row-per-emission is unbounded; without a TTL the table grows without limit. 30 days covers the debugging window (you drill into a spike while it's recent) while bounding cost. `ttl_only_drop_parts` makes expiry a cheap partition drop, not a mutation.
+
+### D4 — `trace_id` is a first-class, bloom-indexed column
+
+**Context:** the whole point of the events model is the metric→trace pivot.
+**Decision:** keep `trace_id`/`span_id`/`trace_flags` as real columns and add `idx_trace_id_bf` (bloom filter) plus bloom indexes on attribute keys and values.
+**Why:** the pivot ("show me the trace behind this emission") and high-cardinality attribute filters are the queries that justify the events model existing; they must be cheap.
+
+### D5 — Reuse the metrics Avro stream; no SDK or Rust changes for v1
+
+**Context:** we could define a new PostHog-native metric-event wire format.
+**Decision:** populate `metric_events` from the existing `clickhouse_metrics` Avro stream.
+**Consequence:** instant dogfooding on everything already emitting metrics, with no client work. The one limitation this imposes is D-known below.
+
+## What's built (the stack)
+
+| PR                                                      | Branch                              | Scope                                                                        |
+| ------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------- |
+| [#66163](https://github.com/PostHog/posthog/pull/66163) | `posthog-code/metric-events-table`  | `metric_events1` + distributed table, migration `0277`, `schema.py`, 30d TTL |
+| [#66169](https://github.com/PostHog/posthog/pull/66169) | `posthog-code/metric-events-hogql`  | `MetricEventsTable` → `posthog.metric_events` in HogQL                       |
+| [#66183](https://github.com/PostHog/posthog/pull/66183) | `posthog-code/metric-events-ingest` | second MV on `kafka_metrics_avro` → dual-write `metric_events`               |
+
+Each was validated against local ClickHouse before commit (the four events-model query shapes; HogQL compile with `team_id` injection; the MV type-checking against the real Avro source). Two bugs were caught by those gates pre-commit (CH multi-statement rejection; a pydantic `description` annotation).
+
+## What's next (read/product layer)
+
+Built **into the existing metrics product** (new capability alongside the `metrics1` time-series UI), each step locally validatable with inserted rows:
+
+1. **Query-time aggregation runner** for the events model (`counter`/`gauge`/`distribution`) — distinct from the `metrics1` `MetricQueryRunner`, which is built for the pre-aggregated/histogram-bucket shape.
+2. **Samples endpoint** — list raw emissions with their attributes (the Sentry "Samples" tab).
+3. **Trace pivot** — the metric→trace jump, the feature that justifies the model.
+4. **SDK emit** for raw distribution samples (closes the D-known limitation).
+5. **Frontend** — Samples tab + trace links in the existing metrics scene.
+6. **Cardinality / volume quota** — guard the unbounded write path per team.
+
+## Operational notes
+
+### Prod DDL to apply on merge
+
+`metric_events1` ships via migration `0277`. The **ingest MV is a manual step** on both LOGS regions (it depends on the prod `kafka_metrics_avro`). The exact `ReplicatedMergeTree`-flavored statement is in the [#66183](https://github.com/PostHog/posthog/pull/66183) body; mirror it into the metrics handoff/runbook when applying.
+
+### Cardinality & cost
+
+The events model writes one row per emission with high-cardinality attributes — the cost trade for query-time flexibility.
+The 30-day TTL bounds it; a per-team volume quota (item 6 above) is the planned backstop before opening it to customer ingest.
+Watch the same consumer-lag signal as `metrics1` (`metrics_kafka_metrics`) — the new MV rides the same Kafka table, so its write amplification shows up there.
+
+### Known limitation — pre-bucketed distributions
+
+Because v1 reuses the OTLP/Prometheus stream (D5), histogram/distribution metrics arrive **already bucketed**.
+A distribution therefore lands as a single `metric_events` row carrying its `value`, not as raw samples.
+Counters and gauges are true one-row-per-emission today; raw distribution samples need the SDK emit path (next-layer item 4).
+Quantiles over distributions are exact only once that lands; until then they reflect the bucketed input.

--- a/docs/internal/metrics/foundation-ingest-identity.md
+++ b/docs/internal/metrics/foundation-ingest-identity.md
@@ -1,0 +1,112 @@
+# Metrics foundation: ingest-side series identity (align to Snuffle's default layout)
+
+## Decision
+
+Adopt Snuffle's **default layout** for the raw-metrics (events-model) store:
+the series identity is **assigned once at ingest** and ClickHouse only stores it.
+We do **not** use Snuffle's experimental "PostHog layout", which computes identity inside ClickHouse via `cityHash64`.
+
+This keeps Rory's disk win (the series/samples split) intact, fixes the join, and deletes the workaround machinery we accumulated.
+
+## Why (root-cause recap)
+
+The merged events-model adopted the variant of Snuffle that **recomputes the series fingerprint in ClickHouse materialized views**
+(`cityHash64(metric_name, service_name, mapSort(resource_attributes), mapSort(attributes))`, duplicated in the `metric_series` and `metric_samples` MVs).
+
+In production this produced two distinct, locally-unreproducible ClickHouse hashing pathologies:
+
+1. **Disjoint fingerprints** — the two MVs hashed the same row to different values, so `metric_samples` and `metric_series` never joined (0% join, fully broken).
+2. **Cardinality collapse** — when the fingerprint is computed in an MV that _also_ materializes the hashed map as a stored column, the hash becomes lossy: in prod, 43,927 true distinct series collapsed to ~2,000.
+
+Neither reproduces in local ClickHouse 26.3 with synthetic data (8 attempts), i.e. it is environmental (Kafka source / real data shape / cluster settings).
+Seven candidate ClickHouse-side fixes (explicit casts, `toString`, column-type changes, a decoder→`Null`→chain) either failed or only achieved consistency _at the collapsed cardinality_.
+
+The lesson is the one every production TSDB already encodes:
+**identity is an ingest-time concern; the storage engine stores a pre-computed id and never recomputes it.**
+Prometheus (`labels.Hash()`), VictoriaMetrics (TSID), Mimir/Cortex, Sentry (Snuba indexer), and **Snuffle's own default layout** all do this.
+Snuffle's "PostHog layout" is the only one that hashes in ClickHouse — and it is the one that broke.
+
+## Architecture
+
+### 1. Identity at ingest — `rust/capture-logs`
+
+Compute the series id once when building each metric row (`metric_record.rs::build_number_row` and the histogram path), and ship it in the Avro payload.
+
+- `series_fingerprint: u64` is computed from a **canonical** serialization of everything stored per-series:
+  `(metric_name, metric_type, service_name, sorted(resource_attributes), sorted(attributes))`.
+  Sort the key/value pairs (e.g. collect into a `BTreeMap` or sort a `Vec`) so map iteration order can never change the id.
+  `metric_type` and `service_name` are in the hash (not just the labels) because `metric_series` stores them per fingerprint — omitting either would let a gauge and a sum (or two services) with identical labels collapse onto one deduped row, last writer winning the metadata.
+- Hash function: any stable, fast, well-distributed 64-bit hash (e.g. `xxh3` via `xxhash-rust`).
+  **It does not need to match ClickHouse's `cityHash64`** — nothing in ClickHouse recomputes it, so there is no cross-language byte-compatibility requirement. This is the whole point.
+- `team_id` is **not** part of the hash. It stays a separate dimension; every table is keyed `(team_id, metric_name, series_fingerprint)`, so two tenants with the same metric+labels get distinct rows with no collision. (Matches Snuffle's `ORDER BY (team_id, metric_name, id)`.)
+- A golden test asserts the Rust id is stable across runs and label-order permutations.
+
+> Naming: we keep the existing column name `series_fingerprint` (it is still a hash of the labels — just computed at ingest, not in ClickHouse), to avoid churning the merged HogQL tables / query runner / contracts. Semantically it is now "supplied by the writer."
+
+### 2. Storage schema — three tables (Snuffle default)
+
+| This product                                      | Snuffle default       | Purpose                                           |
+| ------------------------------------------------- | --------------------- | ------------------------------------------------- |
+| `metric_series` (`ReplacingMergeTree(last_seen)`) | `metrics_series`      | One row per unique series; **labels stored once** |
+| `metric_samples` (`MergeTree`, 30d TTL)           | `metrics_samples`     | The hot table; **tiny rows**                      |
+| `metric_label_index` (`ReplacingMergeTree`)       | `metrics_label_index` | Inverted index for label pruning at scale         |
+| (`trace_id`/`span_id` inline on `metric_samples`) | `metrics_exemplars`   | Metric→trace pivot                                |
+
+**`metric_series`** — `team_id, metric_name, series_fingerprint, labels, metric_type, unit, service_name, last_seen`.
+`ORDER BY (team_id, metric_name, series_fingerprint)`.
+Labels are stored **once per series**. Keep them as the existing decoded `Map`s (`resource_attributes`, `attributes`) — this is now safe because **nothing hashes them anymore**, and it matches how logs/traces store attributes. (Snuffle uses an opaque `labels_json String` to avoid `JSONExtract` in the query path; we can switch to that later if Map filtering on the series table becomes hot, but it is not required to fix the bug.)
+
+**`metric_samples`** — `team_id, metric_name, series_fingerprint, timestamp, value, trace_id, span_id, trace_flags`.
+`ORDER BY (team_id, metric_name, series_fingerprint, timestamp)`, 30-day TTL.
+This is where the ~89% disk win lives: no label maps, no uuid — just the id + the number.
+
+**`metric_label_index`** — `team_id, metric_name, label_key, label_value, series_fingerprint`.
+`ORDER BY (team_id, metric_name, label_key, label_value, series_fingerprint)`.
+Lets "find series where `topic_name='ingestion-logs'`" be a range scan instead of a `JSONExtract`/map scan over the series table.
+**Phaseable:** v1 can filter the (small, deduped) `metric_series` table directly and add this index as a fast-follow when series cardinality demands it. Included here because it is part of Snuffle's default layout and the eventual scale story.
+
+### 3. Ingest pipeline — ClickHouse is dumb storage
+
+```text
+kafka_metrics_avro
+  ├─ kafka_metrics_avro_mv         → metrics1            (unchanged; the existing wide table)
+  ├─ kafka_metrics_avro_to_series  → metric_series       (SELECT + INSERT, reads series_fingerprint from Avro)
+  └─ kafka_metrics_avro_to_samples → metric_samples      (SELECT + INSERT, reads series_fingerprint from Avro)
+        └─ metric_series_to_label_index → metric_label_index   (arrayJoin labels; phase 2)
+```
+
+The two MVs become **passthroughs**: they read `series_fingerprint` straight off the Avro column.
+No `cityHash64`, no `mapApply`/`JSONExtractString` for identity, no decoder MV, no `metric_events_decoded` `Null` table, no chained MVs.
+Because neither MV recomputes anything, the two tables physically cannot diverge or collapse.
+
+### 4. Read path
+
+- **Drill-down (samples for a metric):** filter `metric_samples` by `(team_id, metric_name, time window)`, join to `metric_series` on `series_fingerprint` for labels. `MetricEventSamplesQueryRunner` is unchanged in shape — it just joins on an ingest-supplied id.
+- **Filter by label:** filter `metric_series` (small) directly in v1; via `metric_label_index` intersection at scale.
+- **Metric→trace pivot:** `trace_id` on `metric_samples`. **Known gap:** exemplars are not populated upstream yet (`_exemplars` is unused in `metric_record.rs`), so `trace_id` is empty today — separate ingestion work, independent of this foundation.
+
+## What gets deleted
+
+- The `cityHash64(... mapApply(JSONExtractString ...) ...)` identity expression in both ingest MVs.
+- The decoder MV, the `metric_events_decoded` `Null` table, and the two chained MVs (the workaround).
+- Any bloom-filter indexes that only existed to support map-based identity lookups (re-add deliberately for query pruning, not identity).
+
+Net: fewer moving parts than today, and the parts that remain are all on Snuffle's proven path.
+
+## Migration / rollout
+
+1. **PR1 (rust):** `capture-logs` computes `series_fingerprint` and adds it to `KafkaMetricRow` + the Avro schema. Golden test (stable, order-independent). Ship and confirm the field is populated on the topic.
+2. **PR2 (clickhouse):** simplify the two MVs to passthroughs reading `series_fingerprint`; delete the decoder/`Null`/chain; (optional) add `metric_label_index` + its MV. A ClickHouse test asserts `metric_series` and `metric_samples` agree on a multi-label row (the test the original single-row check was missing).
+3. **Prod re-apply (per logs node, both regions):** drop the current MVs (and the decoder/`Null`/chain), `TRUNCATE metric_series` / `metric_samples`, create the passthrough MVs. Tables refill consistently from the next message.
+4. **Validation — now BOTH must hold** (the CH-hashing version could only ever get one):
+   - `orphans = 0` (every sample's `series_fingerprint` is in `metric_series`), **and**
+   - `uniqExact(series_fingerprint)` ≈ `uniqExact((metric_name, metric_type, service_name, resource_attributes, attributes))` from `metrics1` (no cardinality collapse).
+   - HogQL `pct_joined ≈ 100` across all metrics.
+
+## Current prod state
+
+EU is in the **collapsed-but-consistent** state from the last workaround (do not build/demo on it). It is not worse than before and not live, so no urgent rollback — but it is not fixed until this rollout lands. **US has not been touched** and should not be until EU validates with both checks above.
+
+## Appendix: alternative considered
+
+A pure **wide-table** foundation (one row per sample with labels, `metrics1`-style, à la ClickStack/SigNoz/Uptrace) is also proven and even simpler — but it is exactly the fat shape Rory's review rejected on disk grounds (~100× per-sample overhead at our cardinality). The split + ingest-side identity keeps that disk win while being equally correct, so it is the better foundation for a multi-tenant product.

--- a/docs/internal/metrics/investigate-and-display-ux.md
+++ b/docs/internal/metrics/investigate-and-display-ux.md
@@ -1,0 +1,111 @@
+# Metrics: Investigate & Display UX
+
+Design for the two jobs surfaced by the Logs-Capture latency incident
+(2026-06-28): going from a fired alert to an evidenced root cause
+(**investigate**), and turning that into a shareable artifact (**display**).
+In that incident the investigation succeeded but with friction (capability
+discovery, an off-by-a-day timestamp, corroboration via proxy metrics), and the
+display was impossible — there is no OTel-metrics insight node, so the agent
+baked static constants into HogQL line charts (accurate but dead).
+
+## Decisions (2026-06-29, DRI: Daniel Visca)
+
+1. **Investigate → shared primitives.** characterize / drill / pivot / correlate
+   are one backend capability consumed by BOTH the conversational agent (MCP)
+   and the in-app Metrics explorer. Not agent-only, not explorer-only.
+2. **Display → incident-report artifact first.** A narrative + charts pinned to
+   the incident window + cross-signal links, generated from an investigation.
+   Live monitoring dashboard tiles come later — the report's chart generalizes
+   into the dashboard insight node.
+
+## The seam: `InvestigationResult`
+
+The idea that makes both decisions cohere: **the shared primitive's output is
+the report's input.** One structured DTO is produced once and consumed three
+ways.
+
+`InvestigationResult`:
+
+- **symptom** — metric, magnitude, `onset_time`, `direction`, `change_ratio`
+- **top_movers** — label values whose behaviour changed (localized vs shared cause)
+- **verdicts** — normalized-vs-traffic, queue-wait-vs-slow-processing, etc.
+- **evidence** — correlated log filters + exemplar `trace_id`/`span_id`
+- **chart_specs** — the `query-metrics` clauses + pinned windows used
+- **confidence** + **narrative**
+
+- The **agent** renders it as narrative (Slack / Max).
+- The **explorer** renders it as an interactive panel (anomaly highlight, mover
+  chips, one-click pivot to logs/traces).
+- The **report** serializes it into the shareable artifact.
+
+One produce path, three consume paths. This is why "both surfaces" and "report
+born from the investigation" are the same build, not three.
+
+## Investigate — shared primitives
+
+Facade-level capabilities (`products/metrics/backend/facade`), exposed to MCP
+tools and the in-app API alike:
+
+| primitive                                                                  | status                                                             |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `discover(symptom)` → metric names                                         | exists (`list_metric_names`)                                       |
+| `characterize(metric, window, baseline?)` → anomaly summary                | exists (`characterize_metric_anomaly`)                             |
+| `query(clauses, formula, filters, group_by, interval)` → series            | exists (`run_metric_query`)                                        |
+| `pivot_to_traces(metric, filters, window)` → exemplar `trace_id`/`span_id` | **NEW** — from `metric_samples` trace columns (events-model stack) |
+| `correlate(service, onset_window)` → log filters + APM spans               | compose `query-logs` + APM span tools                              |
+| `investigate(alert_context \| metric+window)` → `InvestigationResult`      | **NEW** — the orchestrator that runs the loop                      |
+
+The loop itself is already authored — the `investigating-metric-anomalies`
+skill, whose worked example is literally this incident. "Shared primitives"
+means making its steps callable capabilities that return **structured data**, so
+the explorer can render exactly what the agent narrates.
+
+**Differentiator:** the metric → trace pivot (`trace_id` on samples) answers
+_why_, not just _what/when_. Grafana shows the chart; PostHog pivots to the slow
+trace and the log line at onset. That is the reason to investigate here rather
+than in Grafana, and it falls straight out of the events-model samples table.
+
+## Display — incident-report artifact
+
+Generated from an `InvestigationResult`:
+
+- **narrative** — summary banner, root cause, blast radius, confidence
+- **chart_specs** — query + pinned window, **re-runnable, not baked**: reopening
+  the report re-runs the exact query over the exact window, so it shows the spike
+  forever but is real data (the opposite of the transcript's baked HogQL constants)
+- **cross-signal links** — exemplar `trace_id`s, the log filters used
+
+**Host:** a dedicated artifact object, rendered with the explorer's existing
+metrics chart component (reuse, don't rebuild). A Notebook is the obvious
+narrative+embed host, but it's blocked by the same missing metrics-insight-node
+gap and can't pin a window cleanly; a dedicated artifact lets us control
+window-pinning and the structured links now, with notebook/dashboard embedding
+as a later integration once the chart generalizes into a NodeKind.
+
+## Build sequence (stacked PRs, on top of the events-model stack)
+
+0. **[in progress]** events-model stack (#66163–#66196) — series/samples split;
+   provides `trace_id`/`span_id` on samples (the pivot's data source).
+1. **trace-pivot primitive** — read `metric_samples` for exemplar `trace_id`s in
+   a window; facade + MCP. Builds on the PR4 samples endpoint.
+2. **`InvestigationResult` DTO + `investigate()` orchestrator** — compose the
+   loop into one structured result; MCP `investigate-metric`.
+3. **incident-report artifact** — model + create-from-result; facade + API + MCP
+   `incident-report-create`.
+4. **report rendering (frontend)** — reuse the metrics chart component for
+   pinned-window charts + narrative + cross-signal links; shareable link.
+5. **[later]** generalize the report chart into a dashboard metrics insight
+   NodeKind — the live-monitoring tiles.
+
+## Parallel keystone (does not block the artifact)
+
+**Prometheus remote-write ingest** — so investigations run on the alert's _own_
+series (e.g. Envoy `rq_time`), not proxies. Until this lands, every infra
+investigation is corroboration-by-proxy, exactly like the transcript.
+
+## Cheap early win
+
+Alerts carry **structured context** (metric, fire-time UTC, threshold, service)
+plus an "Investigate" action that calls `investigate()` with that context.
+Deletes the off-by-a-day timestamp math and the "do you even have access?"
+opening in one move.


### PR DESCRIPTION
## Problem

The metrics work of the past few weeks produced several load-bearing design decisions that only existed as local, untracked files. `docs/internal/metrics/` already holds the dashboard MVP and deployment layout docs, but the events-model architecture, the series-identity (fingerprint) decision, the dev metrics bridge post-mortem, and the investigate/display UX direction were not in the repo. Anyone picking up metrics work had no durable record of why things are shaped the way they are.

## Changes

Adds four design/record docs to `docs/internal/metrics/`, alongside the existing ones:

- `events-model-architecture.md` – the `metric_events` events model: why two models (aggregates vs raw events), the shared pipeline, and decisions D1-D5 (dual-write MV, hand-managed ingest DDL, 30-day TTL, bloom-indexed `trace_id`, reusing the Avro stream)
- `foundation-ingest-identity.md` – the series-identity decision: assign `series_fingerprint` once at ingest in `rust/capture-logs` (Snuffle's default layout) instead of recomputing it in ClickHouse MVs, with the root-cause recap of the join divergence and cardinality collapse that motivated it
- `dev-bridge-fixes.md` – record of the dev metrics bridge charts fixes: collector image predating the `prometheusremotewrite` receiver, the Cognito-proxied endpoint black hole, and the vmagent RW v1 vs receiver RW v2 protocol incompatibility that led to the scrape-collector redesign
- `investigate-and-display-ux.md` – the investigate/display UX direction: shared investigate primitives, the `InvestigationResult` seam, and the incident-report artifact, with the planned build sequence

No production code changes.

## How did you test this code?

Docs-only change. `markdownlint-cli2` passes on all four files (the pre-commit hook runs it).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal docs only, no user-facing docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel asked PostHog Code (Claude) to open a PR for the local metrics work. The branch's code changes already had an open PR, so the remaining un-PR'd work was these untracked design docs. Claude committed four of the five local files and fixed three fenced code blocks flagged by markdownlint. A fifth local file (a session-handoff context dump with live rollout state) was deliberately left out as it's ephemeral working memory, not a durable design record.