### PR TITLE
fix(dashboards): make template dashboard creation atomic

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1633,6 +1633,39 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 tag_names = list(dashboard.tagged_items.values_list("tag__name", flat=True))
                 self.assertNotIn("probe-tag", tag_names)
 
+    def test_template_tile_failure_rolls_back_whole_dashboard(self) -> None:
+        from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
+
+        DashboardTemplate.objects.create(
+            team=self.team,
+            template_name="atomic-probe",
+            scope="team",
+            dashboard_filters={},
+            tiles=[
+                {"type": "TEXT", "body": "first-tile", "layouts": {}, "color": None},
+                {"type": "INSIGHT", "name": "second-tile", "layouts": {}, "color": None},
+            ],
+        )
+
+        dashboards_before = Dashboard.objects.filter(team=self.team).count()
+        tiles_before = DashboardTile.objects.count()
+
+        # Simulate a tile failing partway through creation (after the first tile already succeeded).
+        with patch(
+            "posthog.helpers.dashboard_templates._create_tile_for_insight",
+            side_effect=Exception("tile creation blew up"),
+        ):
+            _, response = self.dashboard_api.create_dashboard(
+                {"name": "atomic-probe", "use_template": "atomic-probe"},
+                expected_status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        self.assertEqual(response["attr"], "use_template")
+        # No half-populated dashboard, orphan dashboard row, or leftover tiles/text may survive.
+        self.assertEqual(Dashboard.objects.filter(team=self.team).count(), dashboards_before)
+        self.assertEqual(DashboardTile.objects.count(), tiles_before)
+        self.assertFalse(Text.objects.filter(body="first-tile").exists())
+
     def test_dashboard_creation_validation(self):
         existing_dashboard = Dashboard.objects.create(team=self.team, name="existing dashboard", created_by=self.user)
 

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
+from django.db import transaction
 from django.db.models import Q
 
 import structlog
@@ -503,61 +504,64 @@ def create_from_template(
     dashboard.filters = template.dashboard_filters
     dashboard.description = template.dashboard_description or ""
 
-    for template_tag in template.tags or []:
-        tag, _ = Tag.objects.get_or_create(
-            name=template_tag,
-            team_id=dashboard.team_id,
-            defaults={"team_id": dashboard.team_id},
-        )
-        dashboard.tagged_items.create(tag_id=tag.id)
-    dashboard.save()
+    # Apply the template as a single unit: if any tile fails to create we must not leave a
+    # half-populated dashboard behind, so tags, the dashboard save, and every tile are atomic.
+    with transaction.atomic():
+        for template_tag in template.tags or []:
+            tag, _ = Tag.objects.get_or_create(
+                name=template_tag,
+                team_id=dashboard.team_id,
+                defaults={"team_id": dashboard.team_id},
+            )
+            dashboard.tagged_items.create(tag_id=tag.id)
+        dashboard.save()
 
-    for template_tile in template.tiles or []:
-        tile_type = template_tile.get("type")
-        if tile_type == "INSIGHT":
-            query = template_tile.get("query", None)
-            _create_tile_for_insight(
-                dashboard,
-                name=template_tile.get("name"),
-                query=query,
-                description=template_tile.get("description"),
-                color=template_tile.get("color"),
-                layouts=template_tile.get("layouts"),
-                user=user,
-            )
-        elif tile_type == "TEXT":
-            _create_tile_for_text(
-                dashboard,
-                color=template_tile.get("color"),
-                layouts=template_tile.get("layouts"),
-                body=template_tile.get("body"),
-                transparent_background=template_tile.get("transparent_background"),
-            )
-        elif tile_type == "BUTTON":
-            button = {**template_tile, **(template_tile.get("button_tile") or {})}
-            _create_tile_for_button(
-                dashboard,
-                color=template_tile.get("color"),
-                layouts=template_tile.get("layouts"),
-                url=button.get("url", ""),
-                text=button.get("text", ""),
-                placement=button.get("placement", "left"),
-                style=button.get("style", "primary"),
-                transparent_background=template_tile.get("transparent_background"),
-            )
-        elif tile_type == "WIDGET":
-            _create_tile_for_widget(
-                dashboard,
-                widget_type=template_tile.get("widget_type", ""),
-                config=template_tile.get("config", {}),
-                color=template_tile.get("color"),
-                layouts=template_tile.get("layouts"),
-                transparent_background=template_tile.get("transparent_background"),
-                user=user,
-                user_access_control=user_access_control,
-            )
-        else:
-            logger.error("dashboard_templates.creation.unknown_type", template=template)
+        for template_tile in template.tiles or []:
+            tile_type = template_tile.get("type")
+            if tile_type == "INSIGHT":
+                query = template_tile.get("query", None)
+                _create_tile_for_insight(
+                    dashboard,
+                    name=template_tile.get("name"),
+                    query=query,
+                    description=template_tile.get("description"),
+                    color=template_tile.get("color"),
+                    layouts=template_tile.get("layouts"),
+                    user=user,
+                )
+            elif tile_type == "TEXT":
+                _create_tile_for_text(
+                    dashboard,
+                    color=template_tile.get("color"),
+                    layouts=template_tile.get("layouts"),
+                    body=template_tile.get("body"),
+                    transparent_background=template_tile.get("transparent_background"),
+                )
+            elif tile_type == "BUTTON":
+                button = {**template_tile, **(template_tile.get("button_tile") or {})}
+                _create_tile_for_button(
+                    dashboard,
+                    color=template_tile.get("color"),
+                    layouts=template_tile.get("layouts"),
+                    url=button.get("url", ""),
+                    text=button.get("text", ""),
+                    placement=button.get("placement", "left"),
+                    style=button.get("style", "primary"),
+                    transparent_background=template_tile.get("transparent_background"),
+                )
+            elif tile_type == "WIDGET":
+                _create_tile_for_widget(
+                    dashboard,
+                    widget_type=template_tile.get("widget_type", ""),
+                    config=template_tile.get("config", {}),
+                    color=template_tile.get("color"),
+                    layouts=template_tile.get("layouts"),
+                    transparent_background=template_tile.get("transparent_background"),
+                    user=user,
+                    user_access_control=user_access_control,
+                )
+            else:
+                logger.error("dashboard_templates.creation.unknown_type", template=template)
 
 
 def _create_tile_for_text(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1310,16 +1310,18 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 existing_dashboard.quick_filter_ids, team_id
             )
 
-        dashboard = Dashboard.objects.create(team_id=team_id, filters=filters, **validated_data)
-
         if use_template:
+            # Create the dashboard and apply the template together so a tile failing partway through
+            # rolls back the whole dashboard rather than leaving a half-populated, corrupt one behind.
             try:
-                create_dashboard_from_template(
-                    use_template,
-                    dashboard,
-                    cast(User, request.user),
-                    user_access_control=user_access_control,
-                )
+                with transaction.atomic():
+                    dashboard = Dashboard.objects.create(team_id=team_id, filters=filters, **validated_data)
+                    create_dashboard_from_template(
+                        use_template,
+                        dashboard,
+                        cast(User, request.user),
+                        user_access_control=user_access_control,
+                    )
             except AttributeError as error:
                 logger.error(
                     "dashboard_create.create_from_template_failed",
@@ -1329,20 +1331,38 @@ class DashboardSerializer(DashboardMetadataSerializer):
                     exc_info=True,
                 )
                 raise serializers.ValidationError({"use_template": f"Invalid template provided: {use_template}"})
+            except exceptions.APIException:
+                # Already a clean 4xx (e.g. widget/tile validation); the dashboard has been rolled back,
+                # so let the specific error surface unchanged.
+                raise
+            except Exception as error:
+                # Any other failure while building tiles has now been rolled back; surface a clean
+                # error instead of a 500 with a corrupt dashboard left in the database.
+                logger.exception(
+                    "dashboard_create.create_from_template_failed",
+                    team_id=team_id,
+                    template=use_template,
+                    error=error,
+                )
+                raise serializers.ValidationError(
+                    {"use_template": f"Failed to create dashboard from template: {use_template}"}
+                )
+        else:
+            dashboard = Dashboard.objects.create(team_id=team_id, filters=filters, **validated_data)
 
-        elif existing_dashboard:
-            existing_tiles = (
-                DashboardTile.objects.filter(dashboard=existing_dashboard)
-                .exclude(deleted=True)
-                .select_related("insight", "text", "button_tile", "widget")
-            )
-            duplicate_tiles = self.initial_data.get("duplicate_tiles", False)
-            for existing_tile in existing_tiles:
-                # Widget tiles move with their widget row; other tiles re-link shared insight/text/button rows.
-                if duplicate_tiles or existing_tile.widget_id is not None:
-                    self._deep_duplicate_tiles(dashboard, existing_tile, user_access_control)
-                else:
-                    existing_tile.copy_to_dashboard(dashboard)
+            if existing_dashboard:
+                existing_tiles = (
+                    DashboardTile.objects.filter(dashboard=existing_dashboard)
+                    .exclude(deleted=True)
+                    .select_related("insight", "text", "button_tile", "widget")
+                )
+                duplicate_tiles = self.initial_data.get("duplicate_tiles", False)
+                for existing_tile in existing_tiles:
+                    # Widget tiles move with their widget row; other tiles re-link shared insight/text/button rows.
+                    if duplicate_tiles or existing_tile.widget_id is not None:
+                        self._deep_duplicate_tiles(dashboard, existing_tile, user_access_control)
+                    else:
+                        existing_tile.copy_to_dashboard(dashboard)
 
         # Manual tag creation since this create method doesn't call super()
         self._attempt_set_tags(tags, dashboard)


### PR DESCRIPTION
## Problem

Creating a dashboard from an organization (or team/global) template built the dashboard and its tiles without a transaction: the dashboard row was created first, then each tile was added one at a time. If any tile failed partway through, the user got a 500 and was left with a half-populated, corrupt dashboard (and, on an invalid template key, an orphaned empty dashboard row).

## Changes

- Wrap the dashboard-row creation and template application in a single `transaction.atomic()` in `DashboardSerializer.create`, so a mid-creation failure rolls the whole dashboard back — no partial dashboards persist.
- Convert unexpected template-application failures into a clean `400` instead of a `500`, while letting already-typed 4xx errors (e.g. tile/widget validation) surface unchanged.
- Make `create_from_template` atomic internally too, so its other callers get the same all-or-nothing guarantee around tag + tile creation.

## How did you test this code?

Added a regression test (`test_template_tile_failure_rolls_back_whole_dashboard`) that simulates a tile failing partway through template creation and asserts the response is a 400 and that no dashboard, tile, or text row is left behind — a rollback path no existing test covered. I was not able to run the suite in this environment (no local Python/Django/DB toolchain); the changed files pass `py_compile` and `ruff check`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread flagging the partial-dashboard bug. Invoked the `/improving-drf-endpoints` skill (serializer change is behavioral only, no field/schema changes) and `/writing-tests` (to gate the added regression test). Considered scoping the transaction to only the tile loop inside `create_from_template`, but that alone would still leave an orphaned dashboard row, so the atomic block was widened to include the dashboard-row creation at the call site.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1783508179782169?thread_ts=1783508179.782169&cid=C0B8ZE81ZT7)*
