### PR TITLE
fix(onboarding): stop query params fusing into the step id on navigation

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -537,6 +537,35 @@ describe('onboardingLogic — flow composition', () => {
             expect(logic.values.stepId).toBe('authorized_domains:web_analytics')
         })
 
+        it('keeps passthrough params separate from ?step= when navigating (GitHub-callback params)', async () => {
+            // The GitHub App install callback returns to onboarding with extra query params
+            // (integration_id, installation_id). Advancing a step must keep them as separate
+            // params — a naive path+search concat fused them into the step value
+            // (step=configure:x?integration_id=14), which no flow step resolves, leaving the
+            // host on a spinner forever.
+            router.actions.push('/onboarding/product_analytics?step=install:product_analytics&integration_id=14')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            await expectLogic(logic, () => {
+                logic.actions.goToNextStep()
+            }).toDispatchActions(['setStepId'])
+            expect(router.values.searchParams).toMatchObject({
+                step: 'configure:product_analytics',
+                integration_id: 14,
+            })
+            expect(logic.values.currentFlowStep?.id).toBe('configure:product_analytics')
+        })
+
+        it('self-corrects a step id with fused query params instead of treating it as namespaced', async () => {
+            router.actions.push(
+                `/onboarding/product_analytics?step=${encodeURIComponent('configure:product_analytics?integration_id=14')}`
+            )
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            // The mangled id contains ':' but must not count as a known step key — it resolves
+            // to '' (flow[0]) rather than leaving currentFlowStep null and the host spinning.
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('install:product_analytics')
+        })
+
         it('sets subscribedDuringOnboarding when ?success=true is present', async () => {
             await expectLogic(logic, () => {
                 router.actions.push('/onboarding/web_analytics?success=true')

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -666,8 +666,12 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // `appendSharedTrailingSteps`; self-correcting too eagerly here would clobber
             // the URL before the flow settles, leaving the user on `flow[0]` even after
             // billing arrives.
+            // A `?` or `&` means query params fused into the step value (a mangled URL) — never
+            // treat that as a valid namespaced id, or self-correction skips it and the host
+            // spins forever waiting for a step that can't resolve.
             const isKnownStepKey = (id: string): boolean =>
-                Object.values(OnboardingStepKey).includes(id as OnboardingStepKey) || id.includes(':')
+                !/[?&]/.test(id) &&
+                (Object.values(OnboardingStepKey).includes(id as OnboardingStepKey) || id.includes(':'))
             if (stepId && values.flow.length > 0 && !isKnownStepKey(stepId)) {
                 const exact = values.flow.find((step) => step.id === stepId)
                 const loose = exact ? null : values.flow.find((step) => step.stepKey === stepId)
@@ -771,21 +775,27 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // loads, so they may not be in `flow` when the URL push lands. Stripping them
             // from the URL would re-fire `setStepId('')` and permanently lose the request.
             const isKnownStepKey =
-                Object.values(OnboardingStepKey).includes(stepId as OnboardingStepKey) || stepId.includes(':')
+                !/[?&]/.test(stepId) &&
+                (Object.values(OnboardingStepKey).includes(stepId as OnboardingStepKey) || stepId.includes(':'))
             const stepResolves =
                 !stepId ||
                 values.flow.length === 0 ||
                 isKnownStepKey ||
                 !!values.flow.find((s) => s.id === stepId || s.stepKey === stepId)
-            const url = urls.onboarding({
-                productKey: values.productKey ?? undefined,
-                step: stepResolves ? stepId || undefined : undefined,
-                withProducts: values.secondaryProductKeys.length ? values.secondaryProductKeys : undefined,
-            })
+            // The first tuple element must be a bare pathname: kea-router joins the tuple by
+            // string concatenation (`path + '?' + search`), so a query embedded here would get a
+            // second `?` appended for `passthrough` — parsed back, the extra params fuse into the
+            // step value (`step=configure:x?integration_id=14`) and the step never resolves.
+            const url = urls.onboarding({ productKey: values.productKey ?? undefined })
+            const searchParams: Record<string, any> = {
+                ...passthrough,
+                ...(stepResolves && stepId ? { step: stepId } : {}),
+                ...(values.secondaryProductKeys.length ? { with: values.secondaryProductKeys.join(',') } : {}),
+            }
             // Use `replace` so the user doesn't accumulate one history entry per onboarding
             // step — otherwise pressing browser Back after onboarding requires N presses to
             // escape, where N is the number of steps the user advanced.
-            return [url, passthrough, undefined, { replace: true }]
+            return [url, searchParams, undefined, { replace: true }]
         },
         updateCurrentTeamSuccess(val) {
             if (values.productKey && val.payload?.has_completed_onboarding_for?.[values.productKey]) {


### PR DESCRIPTION
## Problem

After connecting the GitHub App during onboarding and advancing a step, users get stuck on a full-page spinner.

The GitHub callback returns to onboarding with extra query params (`integration_id`, `installation_id`). `onboardingLogic`'s `setStepId` actionToUrl returned a first tuple element that already embedded `?step=...`, with the leftover params as the searchParams element. kea-router joins the tuple by plain string concatenation (`path + '?' + search`), producing a second `?`:

```text
/onboarding/product_analytics?step=configure%3Aproduct_analytics?integration_id=14
```

Parsed back, the step value becomes `configure:product_analytics?integration_id=14`. No flow step matches it, so `currentFlowStep` resolves null and `OnboardingFlowHost` spins forever. The self-correction guards also let it through, since `isKnownStepKey` treats any value containing `:` as a valid namespaced id.

Plain onboarding runs never hit this because there are no passthrough params, so the second `?` is never appended. That is also why local wizard runs are unaffected.

## Changes

- `setStepId` actionToUrl now returns a bare pathname and passes `step`/`with` through the searchParams object alongside the passthrough params, which kea-router encodes correctly.
- `isKnownStepKey` (both the listener and the actionToUrl mirror) no longer accepts values containing `?` or `&`, so an already-mangled URL from an old link self-corrects to the first step instead of hanging.

## How did you test this code?

Two new kea logic tests in `onboardingLogic.test.ts`:

- navigating with `integration_id` present keeps it as a separate param and the next step resolves — fails on the old concat with the fused step value
- a URL with a fused step value self-corrects to `flow[0]` instead of leaving `currentFlowStep` null — fails without the `isKnownStepKey` hardening

Full suite passes (71/71). I did not manually reproduce the GitHub connect flow locally; the diagnosis is from production event traces showing the exact mangled URLs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal navigation bug.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored with Claude Code from a user bug report. Traced production $pageview events to find the mangled URLs, verified kea-router's `combineUrl` merges correctly but its `actionToUrl` concatenates naively, and reproduced the mechanism in a logic test before fixing. Invoked /writing-tests before adding tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)