### PR TITLE
fix(actions): skip unstable useId ids when creating actions from events

### DIFF
--- a/frontend/src/lib/utils/actions.test.ts
+++ b/frontend/src/lib/utils/actions.test.ts
@@ -21,6 +21,27 @@ describe('elementToSelector', () => {
         expect(actual).toEqual('.potato.soup')
     })
 
+    it('ignores unstable useId-derived attr_id and falls back to tag + class', () => {
+        const element = {
+            tag_name: 'button',
+            attr_id: 'radix-:rr:',
+            attr_class: ['btn'],
+        } as ElementType
+
+        const actual = elementToSelector(element, [])
+        expect(actual).toEqual('button.btn')
+    })
+
+    it('ignores an unstable useId-derived data attribute value and falls back', () => {
+        const element = {
+            tag_name: 'div',
+            attributes: { 'attr__data-id': 'base-ui-:rg:-viewport' },
+        } as unknown as ElementType
+
+        const actual = elementToSelector(element, ['data-id'])
+        expect(actual).toEqual('div')
+    })
+
     const dataAttributeValueCases = [
         {
             name: 'keeps dots unescaped so backend literal matching still works',

--- a/frontend/src/lib/utils/actions.ts
+++ b/frontend/src/lib/utils/actions.ts
@@ -41,6 +41,15 @@ export const TAGS_TO_IGNORE = ['html', 'body', 'meta', 'head', 'script', 'link',
 
 export const escapeRegex = (str: string): string => str.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1')
 
+// React's useId() emits per-render identifiers like ":r5:" (React <= 18) or "«r5»" (React 19),
+// which component libraries embed in DOM ids/attributes (e.g. id="radix-:rr:", data-id="base-ui-:rg:-viewport").
+// They change between renders and deploys, so a selector built on one never matches recorded events.
+const UNSTABLE_GENERATED_ID_REGEX = /:r[0-9a-z]*:|«r[0-9a-z]*»/i
+
+export function containsUnstableGeneratedId(value: string): boolean {
+    return UNSTABLE_GENERATED_ID_REGEX.test(value)
+}
+
 export function matchesDataAttribute(element: ElementType, dataAttributes: string[]): string | void {
     if (!element.attributes) {
         return
@@ -62,10 +71,13 @@ export function elementToSelector(element: ElementType, dataAttributes: string[]
     let selector = ''
     const attribute = matchesDataAttribute(element, dataAttributes)
     if (attribute) {
-        selector += `[${attribute}="${escapeQuotedSelectorValue(element.attributes[`attr__${attribute}`])}"]`
-        return selector
+        const attributeValue = element.attributes[`attr__${attribute}`]
+        if (!containsUnstableGeneratedId(attributeValue)) {
+            selector += `[${attribute}="${escapeQuotedSelectorValue(attributeValue)}"]`
+            return selector
+        }
     }
-    if (element.attr_id) {
+    if (element.attr_id && !containsUnstableGeneratedId(element.attr_id)) {
         selector += `[id="${CSS.escape(element.attr_id)}"]`
         return selector
     }

--- a/frontend/src/models/saveAsActionDialog.test.tsx
+++ b/frontend/src/models/saveAsActionDialog.test.tsx
@@ -113,6 +113,37 @@ describe('saveAsActionDialog', () => {
             })
         })
 
+        it('does not bake an unstable useId-derived id into the selector for an icon button', () => {
+            const step = eventToActionStep(
+                makeAutocaptureEvent({
+                    elements: [
+                        { tag_name: 'svg', attributes: {}, order: 0 },
+                        { tag_name: 'button', attr_id: 'radix-:rr:', attr_class: ['btn'], attributes: {}, order: 1 },
+                    ],
+                }) as any,
+                []
+            )
+            expect(step.selector).not.toBeUndefined()
+            expect(step.selector).not.toContain(':r')
+        })
+
+        it('anchors on a stable data attribute rather than an unstable id ancestor', () => {
+            const step = eventToActionStep(
+                makeAutocaptureEvent({
+                    elements: [
+                        { tag_name: 'span', attr_id: 'radix-:rr:', attributes: {}, order: 0 },
+                        {
+                            tag_name: 'div',
+                            attributes: { 'attr__data-attr': 'signup-button' },
+                            order: 1,
+                        },
+                    ],
+                }) as any,
+                ['data-attr']
+            )
+            expect(step.selector).toBe('[data-attr="signup-button"] > span')
+        })
+
         it('applies the $event_type=submit property when present', () => {
             const step = eventToActionStep(
                 makeAutocaptureEvent({

--- a/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
+++ b/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
@@ -1,10 +1,10 @@
-import { CLICK_TARGETS, elementToSelector, matchesDataAttribute } from 'lib/utils/actions'
+import { CLICK_TARGETS, containsUnstableGeneratedId, elementToSelector, matchesDataAttribute } from 'lib/utils/actions'
 
 import { ActionStepType, ElementType, PropertyFilterType, PropertyOperator } from '~/types'
 
 export function recurseSelector(elements: ElementType[], parts: string, index: number): string {
     const element = elements[index]
-    if (element.attr_id) {
+    if (element.attr_id && !containsUnstableGeneratedId(element.attr_id)) {
         return `[id="${element.attr_id}"] > ${parts}`
     }
     if (index > 0) {
@@ -38,7 +38,11 @@ export function applyDataAttributeSelector(
     }
     for (let i = 0; i < elements.length; i++) {
         const element = elements[i]
-        if (matchesDataAttribute(element, dataAttributes) || element.attr_id) {
+        const dataAttribute = matchesDataAttribute(element, dataAttributes)
+        const hasStableDataAttribute =
+            dataAttribute && !containsUnstableGeneratedId(element.attributes?.[`attr__${dataAttribute}`] ?? '')
+        const hasStableId = element.attr_id && !containsUnstableGeneratedId(element.attr_id)
+        if (hasStableDataAttribute || hasStableId) {
             let selector = elementToSelector(element, dataAttributes)
             if (i > 0 && !CLICK_TARGETS.includes(element.tag_name)) {
                 const clickedTagName = elements[0].tag_name

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -1,7 +1,13 @@
 import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 import { CSSProperties } from 'react'
 
-import { CLICK_TARGETS, CLICK_TARGET_SELECTOR, TAGS_TO_IGNORE, escapeRegex } from 'lib/utils/actions'
+import {
+    CLICK_TARGETS,
+    CLICK_TARGET_SELECTOR,
+    TAGS_TO_IGNORE,
+    containsUnstableGeneratedId,
+    escapeRegex,
+} from 'lib/utils/actions'
 
 import { patch } from '~/toolbar/patch'
 import { toolbarLogger } from '~/toolbar/toolbarLogger'
@@ -11,6 +17,8 @@ import { finder } from '~/toolbar/vendor/finder'
 import { ActionStepType } from '~/types'
 
 import { ActionStepPropertyKey } from './actions/ActionStep'
+
+export { containsUnstableGeneratedId } from 'lib/utils/actions'
 
 export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 
@@ -674,15 +682,6 @@ export function unescapeCssSelector(foundSelector: string): string {
         }
         return escaped
     })
-}
-
-// React's useId() emits per-render identifiers like ":r5:" (React <= 18) or "«r5»" (React 19),
-// which component libraries embed in DOM attributes (e.g. data-id="base-ui-:rg:-viewport").
-// They change between renders and deploys, so a selector built on one never matches recorded events.
-const UNSTABLE_GENERATED_ID_REGEX = /:r[0-9a-z]*:|«r[0-9a-z]*»/i
-
-export function containsUnstableGeneratedId(value: string): boolean {
-    return UNSTABLE_GENERATED_ID_REGEX.test(value)
 }
 
 export function makeNavigateWrapper(onNavigate: () => void, patchKey: string): () => () => void {


### PR DESCRIPTION
## Problem

"Create action from event" on an autocapture event (e.g. a clicked button) can create an action that matches no events, even after widening the date range.

Closes #42992

The selector is built from the clicked element's DOM ancestry, and it uses `attr_id`/data-attribute values even when they are React `useId()` output like `radix-:rr:`. Those change every render, so the selector never matches future events. The toolbar's live-DOM builder already guards against this; the event-based path did not.

## Changes

- Share `containsUnstableGeneratedId` from `lib/utils/actions` (re-exported from `toolbar/utils`).
- `elementToSelector`, `recurseSelector`, `applyDataAttributeSelector`: skip unstable generated ids and fall back to tag/class/nth or a stable ancestor.

## How did you test this code?

Automated only (no manual UI testing by me, Claude):

- `actions.test.ts`: `elementToSelector` ignores an unstable `attr_id` and an unstable data-attr value.
- `saveAsActionDialog.test.tsx`: `eventToActionStep` produces no `:r` id for an icon button and anchors on a stable `data-attr` ancestor instead.

Ran affected suites (`actions`, `saveAsActionDialog`, `toolbar/utils`): all pass. Typecheck clean on changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) via PostHog Code, directed by Matt. Traced the flow from `EventRowActions` to `eventToActionStep`, confirmed against real autocapture events in ClickHouse that clicked elements carry `:r..:` ids, and verified the backend matcher unescapes `\:` (so a stored id matches its own source event but no future render). Left the separate `url_matching: 'exact'` over-strictness alone to keep this surgical. Skill invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
