### PR TITLE
chore(docs): add YOLO demo placeholder

### DIFF
--- a/docs/internal/yolo-demo.md
+++ b/docs/internal/yolo-demo.md
@@ -1,0 +1,13 @@
+# YOLO demo
+
+A minimal placeholder demo used to exercise the automated draft-PR flow end to end.
+It intentionally contains no product code and changes no behavior.
+
+## What this is
+
+- A single self-contained markdown file under `docs/internal/`.
+- Safe to delete at any time — nothing imports or references it.
+
+## Why it exists
+
+To validate that a change can be branched, committed as a signed commit, and opened as a draft PR without touching any application code.


### PR DESCRIPTION
## Problem

I needed a low-risk way to exercise the automated draft-PR flow end to end (branch, signed commit, draft PR) without touching any application code.

## Changes

Adds a single self-contained placeholder doc at `docs/internal/yolo-demo.md`. Nothing imports or references it, and no product behavior changes. Safe to delete at any time.

## How did you test this code?

No tests are relevant — this is a docs-only placeholder. I (the agent) did not run any test suite, since no code paths are affected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs-only; no product docs update required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) at Vojta's request to add a "YOLO demo" and open a draft PR. The request was intentionally minimal, so I chose the least invasive interpretation: a placeholder markdown doc rather than any scaffolded product code. No skills were required for a docs-only change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUXMK175K/p1783523357551089)*
