### PR TITLE
feat(llm-gateway): usage-based posthog_code user cost limit

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -69,6 +69,13 @@ FREE_PLAN_COST_LIMIT = UserCostLimit(
     sustained_window_seconds=2592000,
 )
 
+USAGE_BASED_POSTHOG_CODE_COST_LIMIT = UserCostLimit(
+    burst_limit_usd=500.0,
+    burst_window_seconds=86400,
+    sustained_limit_usd=5000.0,
+    sustained_window_seconds=2592000,
+)
+
 
 _COST_LIMIT_KEY_ALIASES: dict[str, str] = {
     "array": "posthog_code",

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -10,6 +10,7 @@ from redis.asyncio import Redis
 from llm_gateway.config import (
     DEFAULT_USER_COST_LIMIT,
     FREE_PLAN_COST_LIMIT,
+    USAGE_BASED_POSTHOG_CODE_COST_LIMIT,
     get_settings,
 )
 
@@ -17,7 +18,12 @@ if TYPE_CHECKING:
     from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
 from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_rate_limit_multiplier
-from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT, get_billing_period_number, is_pro_plan
+from llm_gateway.services.plan_resolver import (
+    POSTHOG_CODE_PRODUCT,
+    get_billing_period_number,
+    is_pro_plan,
+    is_usage_based_plan,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -35,6 +41,7 @@ def _is_free_plan_throttled(context: ThrottleContext) -> bool:
     return (
         context.product == POSTHOG_CODE_PRODUCT
         and not is_pro_plan(context.plan_key)
+        and not is_usage_based_plan(context.plan_key)
         and context.seat_created_at is not None
     )
 
@@ -239,6 +246,9 @@ class _UserCostThrottleBase(CostThrottle):
         return f"{base}:m{mult}"
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
+        if context.product == POSTHOG_CODE_PRODUCT and is_usage_based_plan(context.plan_key):
+            return USAGE_BASED_POSTHOG_CODE_COST_LIMIT
+
         if _is_free_plan_throttled(context):
             return FREE_PLAN_COST_LIMIT
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1233,6 +1233,38 @@ class TestPlanAwareThrottling:
         assert result.allowed is True
 
     @pytest.mark.asyncio
+    async def test_usage_based_plan_not_free_throttled(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(
+            product="posthog_code",
+            plan_key="posthog-code-usage-20260701",
+            seat_created_at="2026-01-01T00:00:00+00:00",
+        )
+
+        await throttle.record_cost(context, 100.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_usage_based_plan_gets_5000_sustained_limit(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        context = make_context(
+            product="posthog_code",
+            plan_key="posthog-code-usage-20260701",
+            seat_created_at="2026-01-01T00:00:00+00:00",
+        )
+
+        await throttle.record_cost(context, 3000.0)
+        assert (await throttle.allow_request(context)).allowed is True
+
+        await throttle.record_cost(context, 2000.0)
+        assert (await throttle.allow_request(context)).allowed is False
+
+    @pytest.mark.asyncio
     async def test_renamed_pro_plan_allows_higher_usage(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 


### PR DESCRIPTION
## Problem

PostHog Code usage-based pricing needs a gateway-side user spend guard that fits the existing Code entitlement model. Code plan resolution is intentionally user-level (`best=true` across the user's orgs), so adding a team-scoped plan-gated cap would mix user-level entitlement with team-level rate limiting.

## Changes

- Reuses the existing `UserCostBurstThrottle` / `UserCostSustainedThrottle` path for usage-based Code plans.
- Adds `USAGE_BASED_POSTHOG_CODE_COST_LIMIT`: $500/day burst and $5k/billing-period sustained for `posthog_code` users on usage-based plan keys.
- Keeps existing behavior for seat-based subscribers and free seats: subscribers use the existing Code limits, free seats use the free-plan limits.
- Keeps `usage_based_plan_prefixes` settings-driven so the billing plan prefix can be adjusted without a code change.

This PR no longer adds a separate team-level cost throttle. Customer-level aggregate enforcement is handled by the `posthog_code_credits` quota path in the previous stack PR once Billing supplies the resource limit.

## How did you test this code?

- `cd services/llm-gateway && uv run pytest tests/test_cost_throttles.py tests/test_usage.py -q`
- `cd services/llm-gateway && uv run ruff check src/llm_gateway/config.py src/llm_gateway/rate_limiting/cost_throttles.py src/llm_gateway/services/plan_resolver.py tests/test_cost_throttles.py`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Originally explored a team-level cap, then switched to the existing user-level Code throttle model after reviewing why `best=true` plan resolution exists. The resulting change is intentionally smaller: usage-based plans get their own user sustained limit, while customer-level quota enforcement stays in the billing/quota path below this PR.
