### PR TITLE
chore(clickhouse): fix invalid ALTER TABLE IF EXISTS in migration docs

### DIFF
--- a/posthog/clickhouse/migrations/AGENTS.md
+++ b/posthog/clickhouse/migrations/AGENTS.md
@@ -165,13 +165,16 @@ engine=Distributed(
 > Do not initiate step 2 without confirmation that step 1 has been completed.
 
 > [!INFO]
-> Always use `IF EXISTS` or `IF NOT EXISTS` clauses:
+> Always use `IF EXISTS` / `IF NOT EXISTS` guards. For `ALTER TABLE` the guard goes on the
+> operation, **not** on the table — `ALTER TABLE IF EXISTS ...` is a ClickHouse syntax error.
 >
-> `CREATE TABLE IF NOT EXISTS`
+> `CREATE TABLE IF NOT EXISTS my_table ...`
 >
-> `ALTER TABLE IF EXISTS`
+> `ALTER TABLE my_table ADD COLUMN IF NOT EXISTS my_col ...`
 >
-> `ALTER TABLE IF EXISTS ADD COLUMN`
+> `ALTER TABLE my_table MODIFY COLUMN IF EXISTS my_col ...`
+>
+> `ALTER TABLE my_table DROP COLUMN IF EXISTS my_col`
 
 > [!CAUTION]
 > Never drop or recreate `kafka_events_json_ws` or `events_json_ws_mv`. These tables are a
@@ -337,7 +340,7 @@ SYNC is not necessary for non-replicated objects: Kafka table engine, Distribute
 
 ```python
 run_sql_with_exceptions(
-    "ALTER TABLE IF EXISTS my_table ADD COLUMN ...",
+    "ALTER TABLE my_table ADD COLUMN IF NOT EXISTS ...",
     node_roles=[NodeRole.DATA],
     is_alter_on_replicated_table=True
 )
@@ -349,7 +352,7 @@ The `is_alter_on_replicated_table=True` flag ensures the ALTER runs on one host 
 
 ```python
 run_sql_with_exceptions(
-    "ALTER TABLE IF EXISTS sharded_my_table ADD COLUMN ...",
+    "ALTER TABLE sharded_my_table ADD COLUMN IF NOT EXISTS ...",
     node_roles=[NodeRole.DATA],
     sharded=True
 )
@@ -361,7 +364,7 @@ The `sharded=True` flag ensures the ALTER runs once per shard.
 
 ```python
 run_sql_with_exceptions(
-    "ALTER TABLE IF EXISTS distributed_my_table ADD COLUMN ...",
+    "ALTER TABLE distributed_my_table ADD COLUMN IF NOT EXISTS ...",
     node_roles=[NodeRole.DATA]
 )
 ```


### PR DESCRIPTION
## Problem

The migration guide (`posthog/clickhouse/migrations/AGENTS.md`) told contributors to write `ALTER TABLE IF EXISTS <table> ADD COLUMN ...`, but ClickHouse rejects `IF EXISTS` immediately after `ALTER TABLE` with a syntax error. The guard belongs on the operation instead (`ADD`/`MODIFY`/`DROP COLUMN IF [NOT] EXISTS`). Every real migration in the repo already does it that way, so only the docs were wrong — anyone copying the example got a statement that fails to parse.

## Changes

Fix the four `ALTER TABLE IF EXISTS` occurrences in `AGENTS.md` (`CLAUDE.md` is a symlink to it) to put the guard on the column op, and add a one-line note that `ALTER TABLE IF EXISTS ...` is invalid.

```diff
- "ALTER TABLE IF EXISTS my_table ADD COLUMN ..."
+ "ALTER TABLE my_table ADD COLUMN IF NOT EXISTS ..."
```

## How did you test this code?

Verified against a live ClickHouse 26.3 node that `ALTER TABLE IF EXISTS <t> MODIFY COLUMN ...` fails with `SYNTAX_ERROR`, while `ALTER TABLE <t> MODIFY COLUMN IF EXISTS <col> ...` succeeds. Cross-checked that all existing migrations already use the column-level guard.

Docs-only change.
