### PR TITLE
feat(conversations): expose ticket messages in the SQL editor

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1548,10 +1548,61 @@ support_tickets: PostgresTable = PostgresTable(
             name="session_context", description="JSON context captured from the user's session."
         ),
         "sla_due_at": DateTimeDatabaseField(
-            name="sla_due_at", nullable=True, description="When the ticket's SLA response is due."
+            name="sla_due_at",
+            nullable=True,
+            description="When the ticket's SLA response is due; a past value on an unresolved ticket means the SLA is currently breached.",
+        ),
+        "snoozed_until": DateTimeDatabaseField(
+            name="snoozed_until", nullable=True, description="When a snoozed ticket automatically reopens, if snoozed."
+        ),
+        "organization_id": StringDatabaseField(
+            name="organization_id",
+            nullable=True,
+            description="External organization/account identifier the requester belongs to, if known.",
         ),
         "created_at": DateTimeDatabaseField(name="created_at", description="When the ticket was opened."),
         "updated_at": DateTimeDatabaseField(name="updated_at", description="When the ticket was last updated."),
+    },
+)
+
+support_ticket_messages: PostgresTable = PostgresTable(
+    name="support_ticket_messages",
+    postgres_table_name="posthog_comment",
+    access_scope="ticket",
+    # Ticket messages are stored as comments; only expose that scope, and mirror the API's deleted filter.
+    predicates=[parse_expr("scope = 'conversations_ticket'"), parse_expr("ifNull(deleted, false) != true")],
+    description="Messages on support tickets (customer messages, team and AI replies, private notes); one row per message.",
+    fields={
+        "id": StringDatabaseField(name="id", description="Message UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        # Backing columns for the table predicates; hidden because the filters make them constant.
+        "scope": StringDatabaseField(name="scope", hidden=True),
+        "deleted": BooleanDatabaseField(name="deleted", nullable=True, hidden=True),
+        "ticket_id": StringDatabaseField(
+            name="item_id", description="Ticket this message belongs to; joins to support_tickets.id."
+        ),
+        "content": StringDatabaseField(name="content", nullable=True, description="Message text."),
+        "author_type": ExpressionField(
+            name="author_type",
+            expr=parse_expr("JSONExtractString(ifNull(item_context, '{}'), 'author_type')"),
+            description="Who wrote the message: 'customer', 'support' (team member), or 'AI'.",
+        ),
+        "is_private": ExpressionField(
+            name="is_private",
+            expr=parse_expr("toInt(JSONExtractBool(ifNull(item_context, '{}'), 'is_private'))"),
+            description="1 for private internal notes not visible to the customer, 0 for customer-visible messages.",
+        ),
+        "created_by_id": IntegerDatabaseField(
+            name="created_by_id",
+            nullable=True,
+            description="Team member who wrote the message; NULL for customer or AI messages.",
+        ),
+        "item_context": StringJSONDatabaseField(
+            name="item_context",
+            nullable=True,
+            description="JSON message metadata (author type, privacy, delivery status).",
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the message was sent."),
     },
 )
 
@@ -2089,6 +2140,7 @@ class SystemTables(TableNode):
         "session_recordings": TableNode(name="session_recordings", table=session_recordings),
         "source_schemas": TableNode(name="source_schemas", table=source_schemas),
         "source_sync_jobs": TableNode(name="source_sync_jobs", table=source_sync_jobs),
+        "support_ticket_messages": TableNode(name="support_ticket_messages", table=support_ticket_messages),
         "support_tickets": TableNode(name="support_tickets", table=support_tickets),
         "surveys": TableNode(name="surveys", table=surveys),
         "task_runs": TableNode(name="task_runs", table=task_runs),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -18,6 +18,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.models import Group, GroupTypeMapping, GroupUsageMetric, Organization, Tag, Team
 from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.comment import Comment
 from posthog.models.project import Project
 from posthog.models.scoping import team_scope
 from posthog.persons_db import persons_db_connection
@@ -555,6 +556,17 @@ def _create_support_ticket(team: Team, label: str) -> Ticket:
     )
 
 
+def _create_support_ticket_message(team: Team, label: str) -> Comment:
+    ticket = _create_support_ticket(team, label)
+    return Comment.objects.create(
+        team=team,
+        scope="conversations_ticket",
+        item_id=str(ticket.id),
+        content=f"message_{label}",
+        item_context={"author_type": "customer", "is_private": False},
+    )
+
+
 def _create_survey(team: Team, label: str) -> Survey:
     return Survey.objects.create(team=team, name=f"survey_{label}", type="popover")
 
@@ -713,6 +725,7 @@ SYSTEM_TABLE_FACTORIES = [
     ("session_recording_playlists", _create_session_recording_playlist),
     ("session_recordings", _create_session_recording),
     ("source_schemas", _create_source_schema),
+    ("support_ticket_messages", _create_support_ticket_message),
     ("support_tickets", _create_support_ticket),
     ("surveys", _create_survey),
     ("tags", _create_tag),
@@ -849,6 +862,44 @@ class TestSystemTablesTaskInternalExclusionIsolation(NonAtomicBaseTest):
 
         assert str(regular_task.pk) in ids
         assert str(internal_task.pk) not in ids
+
+
+class TestSystemTablesSupportTicketMessagesScope(NonAtomicBaseTest):
+    """End-to-end check that support_ticket_messages only exposes ticket-scoped, non-deleted
+    comments; other comment scopes (insight/dashboard discussions) must never leak through."""
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_only_ticket_scoped_non_deleted_comments_returned(self):
+        ticket = _create_support_ticket(self.team, "scope_test")
+        message = Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(ticket.id),
+            content="visible message",
+            item_context={"author_type": "support", "is_private": True},
+        )
+        other_scope = Comment.objects.create(
+            team=self.team, scope="Insight", item_id="some-insight", content="insight discussion"
+        )
+        deleted = Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(ticket.id),
+            content="deleted message",
+            deleted=True,
+        )
+
+        response = execute_hogql_query(
+            "SELECT id, ticket_id, author_type, is_private FROM system.support_ticket_messages",
+            team=self.team,
+            user=self.user,
+        )
+
+        returned = [(str(row[0]), row[1], row[2], row[3]) for row in response.results]
+        assert returned == [(str(message.pk), str(ticket.id), "support", 1)]
+        assert str(other_scope.pk) not in {r[0] for r in returned}
+        assert str(deleted.pk) not in {r[0] for r in returned}
 
 
 class TestSystemTablesNotebookMarkdown(NonAtomicBaseTest):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -8493,6 +8493,94 @@
           "row_count": null,
           "type": "system"
       },
+      "system.support_ticket_messages": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "ticket_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "ticket_id",
+                  "id": null,
+                  "name": "ticket_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "content": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "content",
+                  "id": null,
+                  "name": "content",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "author_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "author_type",
+                  "id": null,
+                  "name": "author_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "is_private": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_private",
+                  "id": null,
+                  "name": "is_private",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "item_context": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "item_context",
+                  "id": null,
+                  "name": "item_context",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.support_ticket_messages",
+          "name": "system.support_ticket_messages",
+          "row_count": null,
+          "type": "system"
+      },
       "system.support_tickets": {
           "fields": {
               "id": {
@@ -8694,6 +8782,26 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "datetime"
+              },
+              "snoozed_until": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "snoozed_until",
+                  "id": null,
+                  "name": "snoozed_until",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "organization_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "organization_id",
+                  "id": null,
+                  "name": "organization_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               },
               "created_at": {
                   "chain": null,
@@ -17278,6 +17386,94 @@
           "row_count": null,
           "type": "system"
       },
+      "system.support_ticket_messages": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "ticket_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "ticket_id",
+                  "id": null,
+                  "name": "ticket_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "content": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "content",
+                  "id": null,
+                  "name": "content",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "author_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "author_type",
+                  "id": null,
+                  "name": "author_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "is_private": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_private",
+                  "id": null,
+                  "name": "is_private",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "item_context": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "item_context",
+                  "id": null,
+                  "name": "item_context",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.support_ticket_messages",
+          "name": "system.support_ticket_messages",
+          "row_count": null,
+          "type": "system"
+      },
       "system.support_tickets": {
           "fields": {
               "id": {
@@ -17479,6 +17675,26 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "datetime"
+              },
+              "snoozed_until": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "snoozed_until",
+                  "id": null,
+                  "name": "snoozed_until",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "organization_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "organization_id",
+                  "id": null,
+                  "name": "organization_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               },
               "created_at": {
                   "chain": null,


### PR DESCRIPTION
## Problem

Support tickets are queryable in the SQL editor via `system.support_tickets`, but the messages on those tickets are not. That makes standard support metrics that live at reply granularity (reply counts per ticket, reply cadence, customer vs team vs AI message breakdowns) impossible to compute in SQL.

Part 1 of a series adding SLA notification and reporting support to the conversations product. Later parts add ticket lifecycle timestamps, SLA state on message events, and SLA warning/breach events for workflow-driven Slack alerts.

## Changes

- New `system.support_ticket_messages` table backed by `posthog_comment`, exposed only for `scope = 'conversations_ticket'` and non-deleted rows (mirroring the REST API's filters), gated by the existing `ticket` access scope.
  - Derived `author_type` ('customer', 'support', 'AI') and `is_private` columns extracted from `item_context`, plus `ticket_id` (joins to `support_tickets.id`), `content`, `created_by_id`, `created_at`.
- `system.support_tickets` gains `snoozed_until` and `organization_id` columns.
- Column descriptions on both tables so `system.information_schema` documents them.

Example the table unlocks:

```sql
SELECT t.ticket_number, countIf(m.author_type = 'support') AS team_replies
FROM system.support_tickets t
LEFT JOIN system.support_ticket_messages m ON m.ticket_id = t.id
GROUP BY t.ticket_number
```

## How did you test this code?

- New team-isolation factory for `support_ticket_messages` in the parameterized `test_system_table_returns_only_own_team_data` suite (required by the `test_all_system_tables_have_isolation_tests` guardrail) - catches cross-team leakage through the new table.
- New `TestSystemTablesSupportTicketMessagesScope` end-to-end test - catches removal or breakage of the scope/deleted predicates, which would leak non-ticket comments (insight/dashboard discussions) into the table, and covers the `author_type`/`is_private` JSON extraction.
- Ran `test_database.py` (serialization snapshots updated) and `test_hogql_access_control.py` - all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-tests. We considered exposing tickets as a top-level HogQL table (like `events`) but rejected it: the root-tables policy in `database.py` forbids new root tables, the per-resource access gate only runs on the `system` namespace, and a bare name risks collisions with customer warehouse tables. The `deleted` predicate is NULL-safe (`ifNull(deleted, false)`) because `Comment.deleted` is nullable.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
