### PR TITLE
fix(workflows): send transactional emails regardless of opt-out status

### DIFF
--- a/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -101,7 +101,8 @@ describe('RecipientPreferencesService', () => {
         describe('for email actions', () => {
             const createEmailAction = (
                 to: string = 'test@example.com',
-                categoryId: string
+                categoryId: string,
+                categoryType?: 'marketing' | 'transactional'
             ): Extract<HogFlowAction, { type: 'function_email' }> => ({
                 id: 'email',
                 name: 'Send email',
@@ -111,6 +112,7 @@ describe('RecipientPreferencesService', () => {
                 config: {
                     template_id: 'template-email',
                     message_category_id: categoryId,
+                    message_category_type: categoryType,
                     inputs: {
                         email: {
                             value: {
@@ -245,6 +247,29 @@ describe('RecipientPreferencesService', () => {
                 expect(result).toBe(true)
                 expect(mockRecipientsManagerGetAllMarketingMessagingPreference).toHaveBeenCalledWith(recipient)
             })
+
+            it.each([
+                ['the specific category', { '123e4567-e89b-12d3-a456-426614174000': 'OPTED_OUT' }],
+                ['all marketing messaging', { $all: 'OPTED_OUT' }],
+            ])(
+                'should return false for a transactional email even when recipient is opted out of %s',
+                async (_label, preferences) => {
+                    const action = createEmailAction(
+                        'test@example.com',
+                        '123e4567-e89b-12d3-a456-426614174000',
+                        'transactional'
+                    )
+                    const invocation = createFunctionStepInvocation(action)
+
+                    mockRecipientsManagerGet.mockResolvedValue(createRecipient('test@example.com', preferences))
+
+                    const result = await service.shouldSkipAction(invocation, action)
+
+                    expect(result).toBe(false)
+                    // Transactional messages bypass the opt-out lookup entirely
+                    expect(mockRecipientsManagerGet).not.toHaveBeenCalled()
+                }
+            )
 
             it('should return true if recipient is opted out of specific category even when opted in to all marketing', async () => {
                 const action = createEmailAction('test@example.com', '123e4567-e89b-12d3-a456-426614174000')

--- a/nodejs/src/cdp/services/messaging/recipient-preferences.service.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-preferences.service.ts
@@ -15,9 +15,17 @@ export class RecipientPreferencesService {
         invocation: CyclotronJobInvocationHogFunction,
         action: HogFlowAction
     ): Promise<boolean> {
-        return (
-            this.isSubjectToRecipientPreferences(action) && (await this.isRecipientOptedOutOfAction(invocation, action))
-        )
+        if (!this.isSubjectToRecipientPreferences(action)) {
+            return false
+        }
+
+        // Transactional messages are not eligible for opt-outs, so they send regardless of
+        // whether the recipient has opted out of this category or of all marketing messaging.
+        if (action.config.message_category_type === 'transactional') {
+            return false
+        }
+
+        return await this.isRecipientOptedOutOfAction(invocation, action)
     }
 
     private isSubjectToRecipientPreferences(action: HogFlowAction): action is MessageAction {


### PR DESCRIPTION
## Problem

Transactional messages are advertised as not eligible for opt-outs. On the message-preferences UI we tell customers "Transactional messages are not eligible for opt-outs", and transactional emails already skip unsubscribe headers on the way out.

But the workflow send path never honored that for the actual send decision. `RecipientPreferencesService.shouldSkipAction` decided whether to skip a message purely from opt-out state (the specific category preference, plus the `$all` marketing preference). It never looked at the message category type. So a recipient who opted out of a category, or opted out of all marketing via one-click unsubscribe (`$all: OPTED_OUT`), had their transactional emails silently skipped too.

This came in via a support ticket ([conversations #1962](https://us.posthog.com/project/2/support/tickets/1962), internal): a customer switched their workflow email to a transactional category and still saw sends skipped for opted-out recipients.

## Changes

Bypass the opt-out lookup entirely when the action's message category type is `transactional`. `shouldSkipAction` now returns `false` for transactional messages before it ever consults recipient preferences.

The category type is already carried on the action config (`message_category_type`) - the workflow editor sets it from the selected category when the category is chosen. So the runtime needs no extra category lookup, it just reads what's already on the action. This applies to both email and SMS actions, since they share the same skip path.

Known limitation: workflows saved before `message_category_type` existed on the action config carry `message_category_id` but no type, so they still fall through to the opt-out check until re-saved. Not backfilled here - re-selecting the category on the step repopulates it.

## How did you test this code?

Added two parameterized cases to `recipient-preferences.service.test.ts` asserting a transactional email is not skipped even when the recipient is opted out of the specific category or of all marketing (`$all`), and that it short-circuits without hitting the recipient lookup at all. This is the regression the ticket hit, and no existing case exercised `message_category_type`.

I (Claude) ran the full `recipient-preferences.service.test.ts` suite locally: 21/21 pass. No manual end-to-end send was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Harley directed this from a support ticket triage. I (Claude) traced the send path, confirmed the root cause in `RecipientPreferencesService`, and verified the category type is already plumbed onto the action config by the workflow editor - so the fix is a single guard rather than a new runtime category fetch, which is the heavier approach we deliberately avoided.

Skills invoked: `/writing-tests` (gated the two new test cases before writing them).

