### PR TITLE
feat(dashboards): create inline-inserted insights at the chosen slot

### DIFF
--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -29,6 +29,34 @@ export const DEFAULT_INSERTED_TILE_SIZE = { w: 6, h: 5 } as const
 
 export const DEFAULT_TEXT_TILE_SIZE = { w: 2, h: 2 } as const
 
+/**
+ * Default grid size the dashboard gives an insight tile with no stored layout, by insight type.
+ * Shared with the inline insert so an insight can be created at its natural size instead of a
+ * generic fallback. `columnCount` is the breakpoint's column count (paths span the full width).
+ */
+export function getInsightTileDefaultSize(
+    query: ReturnType<typeof getQueryBasedInsightModel> | null,
+    columnCount: number
+): { w: number; h: number } {
+    if (isFunnelsQuery(query)) {
+        return { w: 4, h: 4 }
+    }
+    if (isRetentionQuery(query)) {
+        return { w: 6, h: 7 }
+    }
+    if (isPathsQuery(query)) {
+        // Paths take up so much space that they need to be full width to be readable.
+        return { w: columnCount, h: 7 }
+    }
+    if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.BoldNumber) {
+        return { w: 2, h: 2 }
+    }
+    if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.Metric) {
+        return { w: 3, h: 3 }
+    }
+    return { w: 6, h: 5 }
+}
+
 type WidgetCatalogLayout = DashboardWidgetCatalogEntry['defaultLayout']
 
 /**
@@ -239,29 +267,10 @@ export const calculateLayouts = (
 
         const layouts = (sortedDashboardTiles || []).map((tile) => {
             const query = tile.insight ? getQueryBasedInsightModel(tile.insight) : null
-            // Base constraints
-            let defaultW = 6
-            let defaultH = 5
             // Content-adjusted constraints (note that widths should be factors of 12)
-            if (tile.text) {
-                defaultW = DEFAULT_TEXT_TILE_SIZE.w
-                defaultH = DEFAULT_TEXT_TILE_SIZE.h
-            } else if (isFunnelsQuery(query)) {
-                defaultW = 4
-                defaultH = 4
-            } else if (isRetentionQuery(query)) {
-                defaultW = 6
-                defaultH = 7
-            } else if (isPathsQuery(query)) {
-                defaultW = columnCount // Paths take up so much space that they need to be full width to be readable
-                defaultH = 7
-            } else if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.BoldNumber) {
-                defaultW = 2
-                defaultH = 2
-            } else if (isTrendsQuery(query) && query.trendsFilter?.display === ChartDisplayType.Metric) {
-                defaultW = 3
-                defaultH = 3
-            }
+            const contentSize = tile.text ? DEFAULT_TEXT_TILE_SIZE : getInsightTileDefaultSize(query, columnCount)
+            let defaultW = contentSize.w
+            let defaultH = contentSize.h
             // Single-column layout width override
             if (breakpoint === 'xs') {
                 defaultW = 1

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
@@ -4,6 +4,8 @@ import { expectLogic, partial } from 'kea-test-utils'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { insightsApi } from 'scenes/insights/utils/api'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -261,6 +263,47 @@ describe('addSavedInsightsModalLogic', () => {
                 })
 
             expect(apiCallCount).toBe(1)
+        })
+    })
+
+    describe('inline insertion layout', () => {
+        // When added via the inline "+" bar, the insight's tile must be created at the recorded slot so it
+        // lands there rather than at the top; the header add (no slot) must not send a layout.
+        it.each([
+            {
+                scenario: 'with a pending slot',
+                slot: { x: 6, y: 4, w: null },
+                expectedLayout: { sm: { x: 6, y: 4, w: 6, h: 5 } },
+            },
+            { scenario: 'without a pending slot', slot: null, expectedLayout: undefined },
+        ])('addInsightToDashboard $scenario', async ({ slot, expectedLayout }) => {
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/insights/': () => [200, { count: 0, results: [] }],
+                    '/api/environments/:team_id/dashboards/55/': () => [200, { id: 55, tiles: [] }],
+                },
+            })
+            initKeaTests()
+
+            const dashLogic = dashboardLogic({ id: 55 })
+            dashLogic.mount()
+            if (slot) {
+                dashLogic.actions.setPendingInsertion(slot)
+            }
+
+            const updateSpy = jest.spyOn(insightsApi, 'update').mockResolvedValue(createInsight(1))
+
+            logic = addSavedInsightsModalLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.addInsightToDashboard(createInsight(1), 55)
+            }).toFinishAllListeners()
+
+            const payload = updateSpy.mock.calls[0][1] as { new_dashboard_tile_layouts?: { layouts: unknown }[] }
+            expect(payload.new_dashboard_tile_layouts?.[0]?.layouts).toEqual(expectedLayout)
+
+            updateSpy.mockRestore()
         })
     })
 })

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -11,6 +11,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { objectsEqual } from 'lib/utils/objects'
 import { toParams } from 'lib/utils/url'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { BREAKPOINT_COLUMN_COUNTS } from 'scenes/dashboard/dashboardUtils'
+import { getInsightTileDefaultSize } from 'scenes/dashboard/tileLayouts'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -222,17 +224,38 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
         },
 
         addInsightToDashboard: async ({ insight, dashboardId }) => {
+            const logic = dashboardLogic({ id: dashboardId })
+            logic.mount()
             try {
                 actions.setDashboardUpdateLoading(insight.id, true)
+
+                // Inline "+" insertion records a target slot; create the tile there so it lands at the
+                // slot instead of flashing at the top before the follow-up reflow.
+                const slot = logic.values.pendingInsertion
+                const newTileLayouts = slot
+                    ? [
+                          {
+                              dashboard_id: dashboardId,
+                              layouts: {
+                                  sm: (() => {
+                                      const size = getInsightTileDefaultSize(
+                                          getQueryBasedInsightModel(insight),
+                                          BREAKPOINT_COLUMN_COUNTS.sm
+                                      )
+                                      return { x: slot.x, y: slot.y, w: slot.w ?? size.w, h: size.h }
+                                  })(),
+                              },
+                          },
+                      ]
+                    : undefined
+
                 const response = await insightsApi.update(insight.id, {
                     dashboards: [...(insight.dashboards || []), dashboardId],
-                })
+                    ...(newTileLayouts ? { new_dashboard_tile_layouts: newTileLayouts } : {}),
+                } as Partial<QueryBasedInsightModel>)
                 if (response) {
                     actions.updateInsight(response)
-                    const logic = dashboardLogic({ id: dashboardId })
-                    logic.mount()
                     logic.actions.loadDashboard({ action: DashboardLoadAction.Update })
-                    logic.unmount()
                     lemonToast.success('Insight added to dashboard')
                 }
             } catch (e) {
@@ -240,6 +263,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
                 lemonToast.error('Failed to add insight to dashboard')
                 throw e
             } finally {
+                logic.unmount()
                 eventUsageLogic.actions.reportSavedInsightToDashboard(insight, dashboardId)
                 actions.setDashboardUpdateLoading(insight.id, false)
             }

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7991,6 +7991,31 @@ export interface DashboardTileBasicApi {
     deleted?: boolean | null
 }
 
+export interface InsightTileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface InsightTileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: InsightTileLayoutBoxApi
+    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+    xs?: InsightTileLayoutBoxApi
+}
+
+export interface NewDashboardTileLayoutApi {
+    /** Dashboard the insight is being added to (must appear in the `dashboards` field). */
+    dashboard_id: number
+    /** Grid layout for the tile created on that dashboard. */
+    layouts: InsightTileLayoutsApi
+}
+
 /**
  * @nullable
  */
@@ -8032,6 +8057,8 @@ export interface InsightApi {
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
      *      */
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
+    /** Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position. */
+    new_dashboard_tile_layouts?: NewDashboardTileLayoutApi[]
     /**
      *
      *     The datetime this insight's results were generated.

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -466,6 +466,34 @@ def _last_refresh_for_shared_gate(insight: Insight, dashboard_tile: DashboardTil
     return cs.last_refresh or cs.created_at
 
 
+# Mirrors dashboards' TileLayoutBoxSerializer/TileLayoutsSerializer. Duplicated rather than imported
+# because products.dashboards.backend.api.dashboard imports InsightSerializer, so importing back would
+# create a circular import.
+class InsightTileLayoutBoxSerializer(serializers.Serializer):
+    x = serializers.IntegerField(required=False, help_text="Column position in the dashboard grid (0-indexed).")
+    y = serializers.IntegerField(required=False, help_text="Row position in the dashboard grid (0-indexed).")
+    w = serializers.IntegerField(
+        required=False, help_text="Width in grid columns. The desktop grid is 12 columns wide."
+    )
+    h = serializers.IntegerField(required=False, help_text="Height in grid rows.")
+
+
+class InsightTileLayoutsSerializer(serializers.Serializer):
+    sm = InsightTileLayoutBoxSerializer(
+        required=False, help_text="Layout for the standard (desktop) breakpoint. The grid is 12 columns wide."
+    )
+    xs = InsightTileLayoutBoxSerializer(
+        required=False, help_text="Layout for the small (mobile) breakpoint. The grid is 1 column wide."
+    )
+
+
+class NewDashboardTileLayoutSerializer(serializers.Serializer):
+    dashboard_id = serializers.IntegerField(
+        help_text="Dashboard the insight is being added to (must appear in the `dashboards` field)."
+    )
+    layouts = InsightTileLayoutsSerializer(help_text="Grid layout for the tile created on that dashboard.")
+
+
 class InsightSerializer(InsightBasicSerializer):
     result = serializers.SerializerMethodField()
     hasMore = serializers.SerializerMethodField()
@@ -513,6 +541,16 @@ class InsightSerializer(InsightBasicSerializer):
     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
     """,
     )
+    new_dashboard_tile_layouts = NewDashboardTileLayoutSerializer(
+        many=True,
+        required=False,
+        write_only=True,
+        help_text=(
+            "Optional grid layout for tiles newly created when this insight is added to dashboards via the "
+            "`dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their "
+            "layout. Used to place an inline-inserted tile at a chosen slot instead of the default position."
+        ),
+    )
     query = QueryFieldSerializer(required=False, allow_null=True)
     query_status = serializers.SerializerMethodField()
     hogql = serializers.SerializerMethodField()
@@ -534,6 +572,7 @@ class InsightSerializer(InsightBasicSerializer):
             "deleted",
             "dashboards",
             "dashboard_tiles",
+            "new_dashboard_tile_layouts",
             "last_refresh",
             "cache_target_age",
             "next_allowed_client_refresh",
@@ -617,6 +656,9 @@ class InsightSerializer(InsightBasicSerializer):
 
         created_by = validated_data.pop("created_by", request.user)
         dashboards = validated_data.pop("dashboards", None)
+        # Write-only, not a model field — pop before Insight.objects.create(**validated_data) below.
+        new_tile_layouts = validated_data.pop("new_dashboard_tile_layouts", None)
+        layouts_by_dashboard_id = {entry["dashboard_id"]: entry["layouts"] for entry in (new_tile_layouts or [])}
 
         # Validate dashboard access before creating anything: create() runs in autocommit,
         # so raising mid-way would otherwise leave an orphaned insight (and emit user actions
@@ -650,7 +692,11 @@ class InsightSerializer(InsightBasicSerializer):
 
         for dashboard in target_dashboards:
             DashboardTile.objects.create(
-                insight=insight, dashboard=dashboard, team_id=dashboard.team_id, last_refresh=now()
+                insight=insight,
+                dashboard=dashboard,
+                team_id=dashboard.team_id,
+                last_refresh=now(),
+                layouts=layouts_by_dashboard_id.get(dashboard.id, {}),
             )
             report_user_action(
                 self.context["request"].user,
@@ -711,6 +757,9 @@ class InsightSerializer(InsightBasicSerializer):
         # update corrects this for older records.
         validated_data.setdefault("saved", True)
 
+        # Write-only, not a model field — pop before super().update() regardless of branch.
+        new_tile_layouts = validated_data.pop("new_dashboard_tile_layouts", None)
+
         if validated_data.keys() & Insight.MATERIAL_INSIGHT_FIELDS:
             instance.last_modified_at = now()
             instance.last_modified_by = self.context["request"].user
@@ -722,7 +771,7 @@ class InsightSerializer(InsightBasicSerializer):
         else:
             dashboards = validated_data.pop("dashboards", None)
             if dashboards is not None:
-                self._update_insight_dashboards(dashboards, instance)
+                self._update_insight_dashboards(dashboards, instance, new_tile_layouts=new_tile_layouts)
 
         updated_insight = super().update(instance, validated_data)
         # Delete linked alerts only when the insight can no longer carry any alert. A switch between
@@ -795,7 +844,11 @@ class InsightSerializer(InsightBasicSerializer):
 
         return []
 
-    def _update_insight_dashboards(self, dashboards: list[Dashboard], instance: Insight) -> None:
+    def _update_insight_dashboards(
+        self, dashboards: list[Dashboard], instance: Insight, new_tile_layouts: list[dict] | None = None
+    ) -> None:
+        # Optional per-dashboard layout for tiles created below, so an inline-inserted tile lands at its slot.
+        layouts_by_dashboard_id = {entry["dashboard_id"]: entry["layouts"] for entry in (new_tile_layouts or [])}
         old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
         new_dashboard_ids = [d.id for d in dashboards if not d.deleted]
 
@@ -819,10 +872,18 @@ class InsightSerializer(InsightBasicSerializer):
             if dashboard.team != instance.team:
                 raise serializers.ValidationError("Dashboard not found")
 
-            tile, _ = DashboardTile.objects_including_soft_deleted.get_or_create(insight=instance, dashboard=dashboard)
+            requested_layout = layouts_by_dashboard_id.get(dashboard.id)
+            tile, _ = DashboardTile.objects_including_soft_deleted.get_or_create(
+                insight=instance,
+                dashboard=dashboard,
+                defaults={"layouts": requested_layout} if requested_layout else {},
+            )
 
             if tile.deleted:
                 tile.deleted = False
+                # Re-adding a previously removed tile: honor the requested slot if one was given.
+                if requested_layout:
+                    tile.layouts = requested_layout
                 tile.save()
 
             report_user_action(

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -1199,6 +1199,34 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         tile: DashboardTile = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id)
         self.assertIsNotNone(tile)
 
+    @parameterized.expand(["create", "update"])
+    def test_adding_insight_to_dashboard_applies_requested_tile_layout(self, path: str) -> None:
+        # Guards inline insertion: a layout passed with the add must land on the new tile so the
+        # inserted insight appears at the chosen slot instead of the default position.
+        dashboard_id, _ = self.dashboard_api.create_dashboard({})
+        layout = {"sm": {"x": 6, "y": 4, "w": 6, "h": 5}}
+
+        if path == "create":
+            insight_id, _ = self.dashboard_api.create_insight(
+                {
+                    "filters": {"events": [{"id": "$pageview"}]},
+                    "dashboards": [dashboard_id],
+                    "new_dashboard_tile_layouts": [{"dashboard_id": dashboard_id, "layouts": layout}],
+                }
+            )
+        else:
+            insight_id, _ = self.dashboard_api.create_insight({"filters": {"events": [{"id": "$pageview"}]}})
+            self.dashboard_api.update_insight(
+                insight_id,
+                {
+                    "dashboards": [dashboard_id],
+                    "new_dashboard_tile_layouts": [{"dashboard_id": dashboard_id, "layouts": layout}],
+                },
+            )
+
+        tile = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id)
+        self.assertEqual(tile.layouts, layout)
+
     def test_insight_items_on_a_dashboard_ignore_deleted_dashboards(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({})
         deleted_dashboard_id, _ = self.dashboard_api.create_dashboard({})

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -1227,6 +1227,30 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         tile = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id)
         self.assertEqual(tile.layouts, layout)
 
+    def test_adding_insight_to_multiple_dashboards_applies_each_dashboards_own_layout(self) -> None:
+        # Guards layouts_by_dashboard_id keying: a mixup (e.g. applying the first entry to every
+        # dashboard) would silently place one of the two tiles at the wrong slot.
+        dashboard_a_id, _ = self.dashboard_api.create_dashboard({})
+        dashboard_b_id, _ = self.dashboard_api.create_dashboard({})
+        layout_a = {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        layout_b = {"sm": {"x": 6, "y": 3, "w": 3, "h": 4}}
+
+        insight_id, _ = self.dashboard_api.create_insight(
+            {
+                "filters": {"events": [{"id": "$pageview"}]},
+                "dashboards": [dashboard_a_id, dashboard_b_id],
+                "new_dashboard_tile_layouts": [
+                    {"dashboard_id": dashboard_a_id, "layouts": layout_a},
+                    {"dashboard_id": dashboard_b_id, "layouts": layout_b},
+                ],
+            }
+        )
+
+        tile_a = DashboardTile.objects.get(dashboard__id=dashboard_a_id, insight__id=insight_id)
+        tile_b = DashboardTile.objects.get(dashboard__id=dashboard_b_id, insight__id=insight_id)
+        self.assertEqual(tile_a.layouts, layout_a)
+        self.assertEqual(tile_b.layouts, layout_b)
+
     def test_insight_items_on_a_dashboard_ignore_deleted_dashboards(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({})
         deleted_dashboard_id, _ = self.dashboard_api.create_dashboard({})

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7345,6 +7345,31 @@ export interface DashboardTileBasicApi {
     deleted?: boolean | null
 }
 
+export interface InsightTileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface InsightTileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: InsightTileLayoutBoxApi
+    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+    xs?: InsightTileLayoutBoxApi
+}
+
+export interface NewDashboardTileLayoutApi {
+    /** Dashboard the insight is being added to (must appear in the `dashboards` field). */
+    dashboard_id: number
+    /** Grid layout for the tile created on that dashboard. */
+    layouts: InsightTileLayoutsApi
+}
+
 /**
  * * `engineering` - Engineering
  * * `data` - Data
@@ -7456,6 +7481,8 @@ export interface InsightApi {
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
      *      */
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
+    /** Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position. */
+    new_dashboard_tile_layouts?: NewDashboardTileLayoutApi[]
     /**
      *
      *     The datetime this insight's results were generated.
@@ -7576,6 +7603,8 @@ export interface PatchedInsightApi {
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
      *      */
     readonly dashboard_tiles?: readonly DashboardTileBasicApi[]
+    /** Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position. */
+    new_dashboard_tile_layouts?: NewDashboardTileLayoutApi[]
     /**
      *
      *     The datetime this insight's results were generated.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7529,6 +7529,31 @@ export namespace Schemas {
       deleted?: boolean | null;
     }
 
+    export interface InsightTileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface InsightTileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: InsightTileLayoutBox;
+      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+      xs?: InsightTileLayoutBox;
+    }
+
+    export interface NewDashboardTileLayout {
+      /** Dashboard the insight is being added to (must appear in the `dashboards` field). */
+      dashboard_id: number;
+      /** Grid layout for the tile created on that dashboard. */
+      layouts: InsightTileLayouts;
+    }
+
     export type EffectivePrivilegeLevelEnum = typeof EffectivePrivilegeLevelEnum[keyof typeof EffectivePrivilegeLevelEnum];
 
 
@@ -7586,6 +7611,8 @@ export namespace Schemas {
        *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
        *      */
       readonly dashboard_tiles: readonly DashboardTileBasic[];
+      /** Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position. */
+      new_dashboard_tile_layouts?: NewDashboardTileLayout[];
       /**
          *
        *     The datetime this insight's results were generated.
@@ -39395,6 +39422,8 @@ export namespace Schemas {
        *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
        *      */
       readonly dashboard_tiles?: readonly DashboardTileBasic[];
+      /** Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position. */
+      new_dashboard_tile_layouts?: NewDashboardTileLayout[];
       /**
          *
        *     The datetime this insight's results were generated.

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -205,6 +205,58 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
             .describe(
                 '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        '
             ),
+        new_dashboard_tile_layouts: zod
+            .array(
+                zod.object({
+                    dashboard_id: zod
+                        .number()
+                        .describe('Dashboard the insight is being added to (must appear in the `dashboards` field).'),
+                    layouts: zod
+                        .object({
+                            sm: zod
+                                .object({
+                                    x: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Column position in the dashboard grid (0-indexed).'),
+                                    y: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Row position in the dashboard grid (0-indexed).'),
+                                    w: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                                    h: zod.number().optional().describe('Height in grid rows.'),
+                                })
+                                .optional()
+                                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+                            xs: zod
+                                .object({
+                                    x: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Column position in the dashboard grid (0-indexed).'),
+                                    y: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Row position in the dashboard grid (0-indexed).'),
+                                    w: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                                    h: zod.number().optional().describe('Height in grid rows.'),
+                                })
+                                .optional()
+                                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+                        })
+                        .describe('Grid layout for the tile created on that dashboard.'),
+                })
+            )
+            .optional()
+            .describe(
+                "Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position."
+            ),
         description: zod.string().max(insightsCreateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),
         favorited: zod.boolean().optional(),
@@ -312,6 +364,58 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        '
+            ),
+        new_dashboard_tile_layouts: zod
+            .array(
+                zod.object({
+                    dashboard_id: zod
+                        .number()
+                        .describe('Dashboard the insight is being added to (must appear in the `dashboards` field).'),
+                    layouts: zod
+                        .object({
+                            sm: zod
+                                .object({
+                                    x: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Column position in the dashboard grid (0-indexed).'),
+                                    y: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Row position in the dashboard grid (0-indexed).'),
+                                    w: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                                    h: zod.number().optional().describe('Height in grid rows.'),
+                                })
+                                .optional()
+                                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+                            xs: zod
+                                .object({
+                                    x: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Column position in the dashboard grid (0-indexed).'),
+                                    y: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Row position in the dashboard grid (0-indexed).'),
+                                    w: zod
+                                        .number()
+                                        .optional()
+                                        .describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                                    h: zod.number().optional().describe('Height in grid rows.'),
+                                })
+                                .optional()
+                                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+                        })
+                        .describe('Grid layout for the tile created on that dashboard.'),
+                })
+            )
+            .optional()
+            .describe(
+                "Optional grid layout for tiles newly created when this insight is added to dashboards via the `dashboards` field. Only applied to tiles that don't already exist; existing tiles keep their layout. Used to place an inline-inserted tile at a chosen slot instead of the default position."
             ),
         description: zod.string().max(insightsPartialUpdateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -195,6 +195,7 @@ const InsightCreateSchema = InsightsCreateBody.omit({
     derived_name: true,
     order: true,
     deleted: true,
+    new_dashboard_tile_layouts: true,
     _create_in_folder: true,
 }).extend({
     query: InsightQuery,
@@ -306,8 +307,13 @@ const insightGet = (): ToolBase<typeof InsightGetSchema, WithPostHogUrl<Schemas.
 
 const InsightUpdateSchema = InsightsPartialUpdateParams.omit({ project_id: true })
     .extend(
-        InsightsPartialUpdateBody.omit({ derived_name: true, order: true, deleted: true, _create_in_folder: true })
-            .shape
+        InsightsPartialUpdateBody.omit({
+            derived_name: true,
+            order: true,
+            deleted: true,
+            new_dashboard_tile_layouts: true,
+            _create_in_folder: true,
+        }).shape
     )
     .extend({
         query: InsightQuery.optional(),


### PR DESCRIPTION
## Problem

Stacked on top of the inline text/widget insertion work (base PR). Adding an insight via the inline "+" bar still flashed the tile at the top before the follow-up reflow moved it, because an insight can only be added by mutating the insight's `dashboards` list, which creates the tile with no layout.

## Changes

- Adds an optional write-only `new_dashboard_tile_layouts` field to the insight serializer, applied when the tile is created (both create and update paths). Adding an insight can only go through the insight's `dashboards` list; the dashboard PATCH explicitly refuses insight tiles, so this is the one place a layout can be attached.
- The inline add flow (`addSavedInsightsModalLogic`) forwards the recorded slot, so the insight tile is born at the slot. The existing `applyPendingInsertion` `newTileAlreadyAtSlot` branch (from the base PR) then only shifts the displaced tiles.
- Insight default sizing is shared via `getInsightTileDefaultSize` so an inline-inserted insight keeps its natural per-type size instead of a generic fallback (behavior of `calculateLayouts` preserved).
- Regenerated OpenAPI + MCP types for the new field.

Displaced-tile shift still uses the follow-up PATCH, same as text/widget.

## How did you test this code?

Automated (Jest + pytest), run locally by me (Claude):

- `test_insight.py` - `new_dashboard_tile_layouts` is applied to the created tile on both the create and update paths (parameterized).
- `addSavedInsightsModalLogic.test.ts` - the add forwards the slot layout when a pending slot exists, omits it otherwise.
- `tileLayouts.test.ts` unchanged and green after extracting `getInsightTileDefaultSize` (behavior preserved).
- Adjacent insight backend dashboard tests: 12 passed.

Verified at the state/request level; I didn't drive the running app, so the on-screen reflow isn't visually confirmed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) split this off the base inline-insertion PR at Matt's request, since the insight parity needed a backend change and is larger. Confirmed from the code that insights can only be added through the insight's `dashboards` list (the dashboard PATCH refuses insight tiles), so a serializer field was required, and got sign-off before doing it. Followed `/improving-drf-endpoints` for the field and `/writing-tests` for the cases; ran `hogli build:openapi` to regenerate frontend + MCP types.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
