### PR TITLE
feat(conversations): stamp SLA state on message sent events

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -1,5 +1,7 @@
 import uuid
+from datetime import datetime
 
+from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 from unittest.mock import patch
 
@@ -130,6 +132,45 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["customer_name"] == "Test Customer"
         assert call_kwargs["properties"]["customer_email"] == "test@example.com"
         assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
+
+    @parameterized.expand(
+        [
+            (
+                "no_sla",
+                None,
+                {"sla_due_at": None, "sla_active": False, "sla_breached": False, "sla_delta_seconds": None},
+            ),
+            (
+                "on_track",
+                "2026-01-01T13:00:00+00:00",
+                {
+                    "sla_due_at": "2026-01-01T13:00:00+00:00",
+                    "sla_active": True,
+                    "sla_breached": False,
+                    "sla_delta_seconds": -3600,
+                },
+            ),
+            (
+                "breached",
+                "2026-01-01T11:00:00+00:00",
+                {
+                    "sla_due_at": "2026-01-01T11:00:00+00:00",
+                    "sla_active": True,
+                    "sla_breached": True,
+                    "sla_delta_seconds": 3600,
+                },
+            ),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_capture_message_sent_stamps_sla_state(self, _name, sla_due_at, expected, mock_capture):
+        self.ticket.sla_due_at = datetime.fromisoformat(sla_due_at) if sla_due_at else None
+
+        with freeze_time("2026-01-01T12:00:00Z"):
+            capture_message_sent(self.ticket, "msg-123", "Hello customer", author=self.user)
+
+        properties = mock_capture.call_args.kwargs["properties"]
+        assert {key: properties[key] for key in expected} == expected
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -252,12 +252,12 @@ def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
     """
     if ticket.sla_due_at is None:
         return {"sla_due_at": None, "sla_active": False, "sla_breached": False, "sla_delta_seconds": None}
-    delta_seconds = int((now - ticket.sla_due_at).total_seconds())
+    delta_seconds_float = (now - ticket.sla_due_at).total_seconds()
     return {
         "sla_due_at": ticket.sla_due_at.isoformat(),
         "sla_active": True,
-        "sla_breached": delta_seconds > 0,
-        "sla_delta_seconds": delta_seconds,
+        "sla_breached": delta_seconds_float > 0,
+        "sla_delta_seconds": int(delta_seconds_float),
     }
 
 

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -6,7 +6,10 @@ Staff/system actions use the actor's distinct_id; customer actions use the ticke
 Events are sent to the customer's PostHog project via their team's API token.
 """
 
+from datetime import datetime
 from typing import Literal
+
+from django.utils import timezone
 
 import structlog
 
@@ -240,6 +243,24 @@ def _get_customer_properties(ticket: Ticket, *, include_distinct_id: bool = Fals
     return properties
 
 
+def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
+    """SLA state at the moment of the event.
+
+    Stamped on events (rather than derived later) so attainment metrics reflect the
+    deadline that was in force at the time, even if the SLA is reset afterwards.
+    `sla_delta_seconds` is positive when past due, negative when time remains.
+    """
+    if ticket.sla_due_at is None:
+        return {"sla_due_at": None, "sla_active": False, "sla_breached": False, "sla_delta_seconds": None}
+    delta_seconds = int((now - ticket.sla_due_at).total_seconds())
+    return {
+        "sla_due_at": ticket.sla_due_at.isoformat(),
+        "sla_active": True,
+        "sla_breached": delta_seconds > 0,
+        "sla_delta_seconds": delta_seconds,
+    }
+
+
 def capture_ticket_created(ticket: Ticket) -> None:
     properties = _get_ticket_base_properties(ticket)
     properties.update(_get_customer_properties(ticket))
@@ -351,6 +372,7 @@ def capture_message_sent(
     properties["author_type"] = "team"
     properties.update(_get_actor_properties(author, "user"))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
+    properties.update(_get_sla_properties(ticket, timezone.now()))
 
     capture_internal(
         token=ticket.team.api_token,


### PR DESCRIPTION
## Problem

Support tickets have an SLA deadline (`sla_due_at`, set by workflows), but SLA state never leaves Postgres. There is no way to measure SLA attainment: how many replies went out within the deadline vs after it, and by how much.

Capturing breach state at reply time (rather than deriving it later from the ticket) also makes the metric honest. A workflow that extends or resets the SLA after the fact doesn't rewrite history, because each reply event carries the deadline that was in force when it was sent.

Part 2 of a series adding SLA notification and reporting support to the conversations product (part 1: #69339).

## Changes

`$conversation_message_sent` gains four properties evaluated at send time:

| Property | Meaning |
|---|---|
| `sla_due_at` | ISO deadline in force when the reply was sent, or null |
| `sla_active` | whether an SLA was set |
| `sla_breached` | whether the reply went out past the deadline |
| `sla_delta_seconds` | signed distance from the deadline, positive when past due |

With these, "% of replies within SLA" is a trends insight with a `sla_breached` breakdown, and breach magnitude distributions come from `sla_delta_seconds`.

## How did you test this code?

Added one parameterized test (`test_capture_message_sent_stamps_sla_state`, frozen clock) with no-SLA / on-track / breached cases. It catches sign flips or threshold regressions in `sla_delta_seconds`/`sla_breached`, which would silently corrupt attainment metrics. Full `products/conversations/backend/api/tests/test_events.py` suite passes (61 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-tests. We chose a single signed `sla_delta_seconds` over separate breach/remaining fields to avoid two overlapping conventions. Properties are stamped only on `$conversation_message_sent` (team/AI replies), not `$conversation_message_received`, since attainment is about the support team's response.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
