### PR TITLE
feat(lemon-ui): add shitpost mode for button copy

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -172,6 +172,9 @@ export const FEATURE_FLAGS = {
     CHRISTMAS_OVERRIDE: 'christmas-override', // owner: #team-growth, overrides the checks for Christmas to return true when this is enabled
     HALLOWEEN_OVERRIDE: 'halloween-override', // owner: #team-growth, overrides the checks for Halloween to return true when this is enabled
 
+    // Just for fun
+    SHITPOST_MODE: 'shitpost-mode', // owner: @sarah-sanders, hackathon — rewrites UI button copy to shitpost-y equivalents. See `lib/shitpost/shitpostCopy.ts`
+
     // UX flags, used to control the UX of the app
     CREATE_BUTTON_NAV_EXPERIMENT: 'create-button-nav-experiment', // owner: #team-platform-ux multivariate=control,test — adds a Create dropdown to the top of the Browse tab in the left nav
     MORE_MENU_ICON_EXPERIMENT: 'more-menu-icon-experiment', // owner: #team-platform-ux multivariate=control,test — A/B test of the "More" nav button icon: control = 3-line hamburger menu icon, test = filled burger glyph

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -5,6 +5,9 @@ import React, { useContext } from 'react'
 
 import { IconChevronDown, IconChevronRight, IconExternal } from '@posthog/icons'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { shitpostify } from 'lib/shitpost/shitpostCopy'
+
 import { LemonDropdown, LemonDropdownProps } from '../LemonDropdown'
 import { INTERACTIVE_CLOSE_DELAY_MS } from '../LemonInput/LemonInput'
 import { Link } from '../Link'
@@ -180,6 +183,11 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
             const [, parentPopoverLevel] = useContext(PopoverOverlayContext)
             const within3000PageHeader = useContext(WithinPageHeaderContext)
 
+            // Shitpost mode: rewrite plain-string labels to shitpost-y copy. Only the rendered
+            // text is swapped; the original `children` still drives layout logic below.
+            const shitpostMode = useFeatureFlag('SHITPOST_MODE')
+            const content = shitpostMode && typeof children === 'string' ? shitpostify(children) : children
+
             if (!active && popoverVisibility) {
                 active = true
             }
@@ -278,7 +286,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                 >
                     <span className="LemonButton__chrome">
                         {icon ? <span className="LemonButton__icon">{icon}</span> : null}
-                        {children ? <span className="LemonButton__content">{children}</span> : null}
+                        {children ? <span className="LemonButton__content">{content}</span> : null}
                         {sideIcon ? (
                             <span className="LemonButton__icon">{sideIcon}</span>
                         ) : targetBlank && !hideExternalLinkIcon && !icon ? (

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -5,8 +5,7 @@ import React, { useContext } from 'react'
 
 import { IconChevronDown, IconChevronRight, IconExternal } from '@posthog/icons'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { shitpostify } from 'lib/shitpost/shitpostCopy'
+import { isShitpostModeEnabled, shitpostify } from 'lib/shitpost/shitpostCopy'
 
 import { LemonDropdown, LemonDropdownProps } from '../LemonDropdown'
 import { INTERACTIVE_CLOSE_DELAY_MS } from '../LemonInput/LemonInput'
@@ -185,8 +184,8 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
 
             // Shitpost mode: rewrite plain-string labels to shitpost-y copy. Only the rendered
             // text is swapped; the original `children` still drives layout logic below.
-            const shitpostMode = useFeatureFlag('SHITPOST_MODE')
-            const content = shitpostMode && typeof children === 'string' ? shitpostify(children) : children
+            const content =
+                typeof children === 'string' && isShitpostModeEnabled() ? shitpostify(children) : children
 
             if (!active && popoverVisibility) {
                 active = true

--- a/frontend/src/lib/shitpost/shitpostCopy.ts
+++ b/frontend/src/lib/shitpost/shitpostCopy.ts
@@ -1,3 +1,6 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 // Shitpost mode (hackathon): when the `shitpost-mode` feature flag is on, UI copy that
 // passes through a shared component (starting with `LemonButton`) is rewritten to a
 // slightly shitpost-y equivalent. This is deliberately a thin, opt-in interception layer
@@ -35,6 +38,19 @@ const SHITPOST_DICTIONARY: Record<string, string> = {
     copy: 'Steal this',
     refresh: 'Bonk it',
     'try again': 'Have another go',
+}
+
+/**
+ * Whether shitpost mode is currently active.
+ *
+ * Reads the flag via `findMounted()` rather than a kea subscription so it stays safe to call
+ * from low-level shared components (e.g. `LemonButton`) in any render context, including
+ * Storybook where `featureFlagLogic` may not be mounted. Returns `false` when the logic isn't
+ * mounted, which keeps the feature off by default.
+ */
+export function isShitpostModeEnabled(): boolean {
+    const featureFlags = featureFlagLogic.findMounted()?.values.featureFlags
+    return !!featureFlags?.[FEATURE_FLAGS.SHITPOST_MODE]
 }
 
 /**

--- a/frontend/src/lib/shitpost/shitpostCopy.ts
+++ b/frontend/src/lib/shitpost/shitpostCopy.ts
@@ -1,0 +1,46 @@
+// Shitpost mode (hackathon): when the `shitpost-mode` feature flag is on, UI copy that
+// passes through a shared component (starting with `LemonButton`) is rewritten to a
+// slightly shitpost-y equivalent. This is deliberately a thin, opt-in interception layer
+// rather than a real i18n framework — PostHog has no string catalogue, so this doubles as a
+// proof of concept for "what a central copy layer could hook into".
+
+// Keys are the original copy lower-cased and trimmed; values are the replacement in the
+// casing we want rendered (Sentence case, to match the app's convention).
+const SHITPOST_DICTIONARY: Record<string, string> = {
+    dismiss: 'This is trash',
+    cancel: 'Nope',
+    save: 'Yeet it',
+    'save changes': 'Yeet the changes',
+    'save & close': 'Yeet and dip',
+    delete: 'Obliterate',
+    submit: 'Send it',
+    confirm: 'Absolutely',
+    continue: 'Onward',
+    create: 'Manifest',
+    done: 'Ship it',
+    retry: 'Do it again',
+    close: 'Begone',
+    upgrade: 'Take my money',
+    'learn more': 'Teach me',
+    'get started': "Let's gooo",
+    'load more': 'Gimme more',
+    apply: 'Make it so',
+    reset: 'Nuke it',
+    export: 'Yoink the data',
+    yes: 'Hell yes',
+    no: 'Hard pass',
+    back: 'Retreat',
+    next: 'Onwards',
+    edit: 'Tinker',
+    copy: 'Steal this',
+    refresh: 'Bonk it',
+    'try again': 'Have another go',
+}
+
+/**
+ * Rewrite a single piece of button copy to its shitpost-y equivalent.
+ * Returns the input unchanged when there is no mapping, so it is always safe to call.
+ */
+export function shitpostify(text: string): string {
+    return SHITPOST_DICTIONARY[text.trim().toLowerCase()] ?? text
+}


### PR DESCRIPTION
## Problem

Shitpost mode. Someone wanted the app's buttons to speak a little more freely: "Dismiss" becomes "This is trash", that sort of thing. Floated as a hackathon idea in Slack, so I (actually the PostHog Slack app / Claude) prototyped it.

While scoping it we confirmed PostHog has no i18n or central string catalogue, so there was no existing copy layer to hook into. This PR adds the smallest possible one.

## Changes

- New `shitpost-mode` feature flag (`FEATURE_FLAGS.SHITPOST_MODE`).
- New `lib/shitpost/shitpostCopy.ts`: a tiny copy dictionary plus a `shitpostify()` helper that maps a label to its shitpost-y equivalent, returning the input unchanged when there's no match.
- `LemonButton` reads the flag and, when on, swaps plain-string labels through `shitpostify()`. Only the rendered text changes; the original `children` still drives layout logic (icon placement, `no-content`).

Because nearly every button in the app routes through `LemonButton`, one interception point covers a large surface with no per-call changes. Off by default, so zero impact unless the flag is enabled.

> [!NOTE]
> This is a hackathon prototype. It doubles as a proof of concept for what a real central copy / i18n layer could hook into later.

## How did you test this code?

I (Claude) could not run the frontend typecheck or lint in this environment (shallow clone, no `node_modules`), and I did not exercise it in a running app. The change is small and self-contained. A reviewer should flip the `shitpost-mode` flag locally and confirm button labels swap (e.g. a "Cancel" button reads "Nope") and that layout is unaffected. No automated tests added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prototyped by the PostHog Slack app (Claude) from a Slack thread. No repo skills were required for a change this small. Approach: rather than grep-and-replace hardcoded strings across the codebase, I added a single opt-in interception layer at the shared `LemonButton` component and kept the swap limited to plain-string children so button layout logic stays on the untouched `children`. The copy dictionary is intentionally small and easy to extend.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C04JN5NNMPF/p1783525872475999?thread_ts=1783525872.475999&cid=C04JN5NNMPF)*
