### PR TITLE
chore(ci): add team-experiments as prompt management codeowner

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -222,10 +222,10 @@ services/mcp/src/tools/generated/ai_observability.ts @PostHog/team-ai-observabil
 services/mcp/src/tools/aiObservability/ @PostHog/team-ai-observability
 services/mcp/src/ui-apps/apps/generated/llm-costs.tsx @PostHog/team-ai-observability
 
-# Prompt management - owned by @PostHog/team-ai-observability plus @jurajmajerik as individual owner
-products/ai_observability/frontend/prompts/ @PostHog/team-ai-observability @jurajmajerik
-products/ai_observability/backend/models/llm_prompt.py @PostHog/team-ai-observability @jurajmajerik
-posthog/**/*llm_prompt*.py @PostHog/team-ai-observability @jurajmajerik
+# Prompt management - shared between @PostHog/team-ai-observability and @PostHog/team-experiments
+products/ai_observability/frontend/prompts/ @PostHog/team-ai-observability @PostHog/team-experiments
+products/ai_observability/backend/models/llm_prompt.py @PostHog/team-ai-observability @PostHog/team-experiments
+posthog/**/*llm_prompt*.py @PostHog/team-ai-observability @PostHog/team-experiments
 
 # LLM Gateway - owned by @PostHog/team-ai-gateway
 nodejs/src/ingestion/pipelines/ai/costs/ @PostHog/team-ai-observability @PostHog/team-ai-gateway


### PR DESCRIPTION
## Problem

Prompt management sits under `products/ai_observability/`, so ownership resolves to team-ai-observability only. Experiments is contributing heavily there (with AI observability's blessing), and the individual-owner carve-out in CODEOWNERS-soft doesn't count for team-membership checks in review tooling.

## Changes

Replaced the individual owner with `@PostHog/team-experiments` on the three prompt management rules in CODEOWNERS-soft, making ownership shared between the two teams.

## How did you test this code?

Config-only change; verified the paths in the rules still exist.