### PR TITLE
feat(conversations): emit SLA approaching and breached events

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -75,6 +75,7 @@ from posthog.utils import get_crontab, get_instance_region
 
 from products.approvals.backend.tasks import expire_old_change_requests, validate_pending_change_requests
 from products.conversations.backend.tasks import (
+    emit_ticket_sla_events,
     flush_pending_email_replies,
     poll_teams_shared_channels,
     wake_snoozed_tickets,
@@ -720,6 +721,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="*"),
         wake_snoozed_tickets.s(),
         name="wake snoozed conversation tickets",
+    )
+
+    # Emit SLA approaching/breached events for conversation tickets (workflow alert triggers)
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*"),
+        emit_ticket_sla_events.s(),
+        name="emit conversation ticket sla events",
     )
 
     # Re-drive queued outbound support email replies (survives a multi-day email provider outage)

--- a/products/conversations/backend/api/external.py
+++ b/products/conversations/backend/api/external.py
@@ -6,6 +6,7 @@ to third-party developers in the future.
 Authenticated via team secret API token passed as a Bearer token in the Authorization header.
 """
 
+import json
 import uuid
 import hashlib
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -29,7 +30,12 @@ from posthog.models.tag import tagify
 from products.conversations.backend.api.tickets import assign_ticket
 from products.conversations.backend.cache import invalidate_unread_count_cache
 from products.conversations.backend.models import Ticket
-from products.conversations.backend.models.constants import Priority, Status
+from products.conversations.backend.models.constants import (
+    SLA_MAX_WARNING_MINUTES,
+    SLA_MAX_WARNING_OFFSETS,
+    Priority,
+    Status,
+)
 from products.conversations.backend.services.sla import WEEKDAYS, compute_sla_deadline
 
 logger = structlog.get_logger(__name__)
@@ -88,6 +94,16 @@ class ExternalTicketUpdateSerializer(serializers.Serializer):
     sla_amount = serializers.FloatField(required=False, min_value=0.000001)
     sla_unit = serializers.ChoiceField(choices=["minute", "hour", "day"], required=False, default="hour")
     sla_business_hours = serializers.JSONField(required=False, allow_null=True)
+    sla_warning_minutes = serializers.ListField(
+        child=serializers.IntegerField(min_value=1, max_value=SLA_MAX_WARNING_MINUTES),
+        required=False,
+        max_length=SLA_MAX_WARNING_OFFSETS,
+        help_text=(
+            "Minutes before sla_due_at at which to emit a $conversation_sla_approaching event, "
+            "e.g. [180, 60] for warnings 3 hours and 1 hour before breach. "
+            "Empty falls back to the team-level default."
+        ),
+    )
     snoozed_until = serializers.DateTimeField(required=False, allow_null=True)
     assignee = serializers.JSONField(required=False, allow_null=True)
     tags = serializers.ListField(child=serializers.CharField(max_length=200), required=False, max_length=100)
@@ -290,7 +306,9 @@ class ExternalTicketView(APIView):
 
         serializer = ExternalTicketUpdateSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response({"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+            # ListField item errors are keyed by int index, which the strict JSON renderer
+            # rejects; round-trip through json to stringify keys.
+            return Response({"error": json.loads(json.dumps(serializer.errors))}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             ticket = Ticket.objects.get(id=ticket_id, team_id=team.id)
@@ -375,6 +393,22 @@ class ExternalTicketView(APIView):
                         field="sla_due_at",
                         before=old_sla_due_at.isoformat() if old_sla_due_at else None,
                         after=ticket.sla_due_at.isoformat() if ticket.sla_due_at else None,
+                        action="changed",
+                    )
+                )
+
+        if "sla_warning_minutes" in serializer.validated_data:
+            old_warning_minutes = ticket.sla_warning_minutes
+            new_warning_minutes = sorted(set(serializer.validated_data["sla_warning_minutes"]), reverse=True)
+            if old_warning_minutes != new_warning_minutes:
+                ticket.sla_warning_minutes = new_warning_minutes
+                update_fields.append("sla_warning_minutes")
+                changes.append(
+                    Change(
+                        type="Ticket",
+                        field="sla_warning_minutes",
+                        before=old_warning_minutes,
+                        after=new_warning_minutes,
                         action="changed",
                     )
                 )

--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -1,5 +1,7 @@
 import uuid
+from datetime import datetime
 
+from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 from unittest.mock import patch
 
@@ -130,6 +132,45 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["customer_name"] == "Test Customer"
         assert call_kwargs["properties"]["customer_email"] == "test@example.com"
         assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
+
+    @parameterized.expand(
+        [
+            (
+                "no_sla",
+                None,
+                {"sla_due_at": None, "sla_active": False, "sla_breached": False, "sla_delta_seconds": None},
+            ),
+            (
+                "on_track",
+                "2026-01-01T13:00:00+00:00",
+                {
+                    "sla_due_at": "2026-01-01T13:00:00+00:00",
+                    "sla_active": True,
+                    "sla_breached": False,
+                    "sla_delta_seconds": -3600,
+                },
+            ),
+            (
+                "breached",
+                "2026-01-01T11:00:00+00:00",
+                {
+                    "sla_due_at": "2026-01-01T11:00:00+00:00",
+                    "sla_active": True,
+                    "sla_breached": True,
+                    "sla_delta_seconds": 3600,
+                },
+            ),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_capture_message_sent_stamps_sla_state(self, _name, sla_due_at, expected, mock_capture):
+        self.ticket.sla_due_at = datetime.fromisoformat(sla_due_at) if sla_due_at else None
+
+        with freeze_time("2026-01-01T12:00:00Z"):
+            capture_message_sent(self.ticket, "msg-123", "Hello customer", author=self.user)
+
+        properties = mock_capture.call_args.kwargs["properties"]
+        assert {key: properties[key] for key in expected} == expected
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/api/tests/test_external.py
+++ b/products/conversations/backend/api/tests/test_external.py
@@ -230,6 +230,35 @@ class TestExternalTicketAPI(BaseTest):
         self.ticket.refresh_from_db()
         self.assertIsNone(self.ticket.sla_due_at)
 
+    def test_patch_sla_warning_minutes_persists_sorted_and_deduped(self):
+        response = self.client.patch(
+            self.url,
+            {"sla_amount": 4, "sla_unit": "hour", "sla_warning_minutes": [60, 180, 60]},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.ticket.refresh_from_db()
+        self.assertEqual(self.ticket.sla_warning_minutes, [180, 60])
+
+    @parameterized.expand(
+        [
+            ("negative", [-5]),
+            ("zero", [0]),
+            ("over_seven_days", [10081]),
+            ("not_a_list", "60"),
+            ("too_many", list(range(1, 23))),
+        ]
+    )
+    def test_patch_sla_warning_minutes_rejects_invalid(self, _name, value):
+        response = self.client.patch(
+            self.url,
+            {"sla_warning_minutes": value},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_patch_sla_due_at_invalid_format(self):
         response = self.client.patch(
             self.url,

--- a/products/conversations/backend/api/tests/test_sla_events.py
+++ b/products/conversations/backend/api/tests/test_sla_events.py
@@ -1,0 +1,124 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from products.conversations.backend.models import Ticket
+from products.conversations.backend.models.constants import Status
+from products.conversations.backend.tasks import emit_ticket_sla_events
+
+DUE_AT = datetime(2026, 1, 10, 12, 0, 0, tzinfo=UTC)
+
+
+@patch("products.conversations.backend.events.capture_internal")
+class TestEmitTicketSlaEvents(BaseTest):
+    def _create_ticket(self, **kwargs) -> Ticket:
+        defaults = {
+            "team": self.team,
+            "widget_session_id": str(uuid.uuid4()),
+            "distinct_id": "customer-123",
+            "channel_source": "widget",
+            "status": Status.OPEN,
+            "sla_due_at": DUE_AT,
+        }
+        defaults.update(kwargs)
+        return Ticket.objects.create_with_number(**defaults)
+
+    def _sweep_at(self, at: datetime) -> None:
+        with freeze_time(at):
+            emit_ticket_sla_events()
+
+    def _emitted(self, mock_capture) -> list[tuple[str, dict]]:
+        return [
+            (call.kwargs["event_name"], call.kwargs["properties"])
+            for call in mock_capture.call_args_list
+            if call.kwargs["event_name"].startswith("$conversation_sla")
+        ]
+
+    def test_warning_then_breach_lifecycle_with_dedup(self, mock_capture):
+        ticket = self._create_ticket(sla_warning_minutes=[60, 30])
+
+        # 50 minutes before due: only the 60-minute threshold has been crossed
+        self._sweep_at(DUE_AT - timedelta(minutes=50))
+        events = self._emitted(mock_capture)
+        assert [name for name, _ in events] == ["$conversation_sla_approaching"]
+        assert events[0][1]["threshold_minutes"] == 60
+        assert events[0][1]["minutes_remaining"] == 50
+        assert events[0][1]["ticket_id"] == str(ticket.id)
+        assert events[0][1]["sla_breached"] is False
+
+        # Re-running at the same moment must not re-emit
+        self._sweep_at(DUE_AT - timedelta(minutes=50))
+        assert len(self._emitted(mock_capture)) == 1
+
+        # 20 minutes before due: the 30-minute threshold fires
+        self._sweep_at(DUE_AT - timedelta(minutes=20))
+        events = self._emitted(mock_capture)
+        assert [name for name, _ in events] == ["$conversation_sla_approaching"] * 2
+        assert events[1][1]["threshold_minutes"] == 30
+
+        # Past due: breach fires once
+        self._sweep_at(DUE_AT + timedelta(minutes=5))
+        self._sweep_at(DUE_AT + timedelta(minutes=6))
+        events = self._emitted(mock_capture)
+        assert [name for name, _ in events][-1] == "$conversation_sla_breached"
+        assert len(events) == 3
+        assert events[2][1]["minutes_overdue"] == 5
+        assert events[2][1]["sla_breached"] is True
+
+    def test_sla_reset_rearms_warning_and_breach(self, mock_capture):
+        ticket = self._create_ticket(sla_warning_minutes=[30])
+        self._sweep_at(DUE_AT + timedelta(minutes=1))
+        assert [name for name, _ in self._emitted(mock_capture)] == ["$conversation_sla_breached"]
+
+        # A workflow extends the deadline: markers are keyed to the old due_at, so both re-arm
+        new_due_at = DUE_AT + timedelta(hours=4)
+        Ticket.objects.filter(id=ticket.id).update(sla_due_at=new_due_at)
+
+        self._sweep_at(new_due_at - timedelta(minutes=10))
+        self._sweep_at(new_due_at + timedelta(minutes=1))
+        assert [name for name, _ in self._emitted(mock_capture)] == [
+            "$conversation_sla_breached",
+            "$conversation_sla_approaching",
+            "$conversation_sla_breached",
+        ]
+
+    def test_catchup_after_downtime_emits_only_nearest_threshold(self, mock_capture):
+        self._create_ticket(sla_warning_minutes=[120, 60, 30])
+
+        # First sweep runs late: all three thresholds already crossed
+        self._sweep_at(DUE_AT - timedelta(minutes=10))
+        events = self._emitted(mock_capture)
+        assert [name for name, _ in events] == ["$conversation_sla_approaching"]
+        assert events[0][1]["threshold_minutes"] == 30
+
+        # The skipped thresholds are marked, not queued for later
+        self._sweep_at(DUE_AT - timedelta(minutes=5))
+        assert len(self._emitted(mock_capture)) == 1
+
+    def test_team_default_offsets_used_when_ticket_has_none(self, mock_capture):
+        self.team.conversations_settings = {"sla_warning_minutes": [15]}
+        self.team.save(update_fields=["conversations_settings"])
+        self._create_ticket()
+
+        self._sweep_at(DUE_AT - timedelta(minutes=10))
+        events = self._emitted(mock_capture)
+        assert [name for name, _ in events] == ["$conversation_sla_approaching"]
+        assert events[0][1]["threshold_minutes"] == 15
+
+    def test_no_offsets_means_no_warning_but_breach_still_fires(self, mock_capture):
+        self._create_ticket()
+        self._sweep_at(DUE_AT - timedelta(minutes=10))
+        assert self._emitted(mock_capture) == []
+
+        self._sweep_at(DUE_AT + timedelta(minutes=1))
+        assert [name for name, _ in self._emitted(mock_capture)] == ["$conversation_sla_breached"]
+
+    def test_resolved_and_no_sla_tickets_are_skipped(self, mock_capture):
+        self._create_ticket(status=Status.RESOLVED, sla_warning_minutes=[30])
+        self._create_ticket(sla_due_at=None, sla_warning_minutes=[30])
+
+        self._sweep_at(DUE_AT + timedelta(minutes=5))
+        assert self._emitted(mock_capture) == []

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -54,7 +54,14 @@ from products.conversations.backend.events import (
     capture_ticket_status_changed,
 )
 from products.conversations.backend.models import EmailChannel, Ticket, TicketAssignment
-from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
+from products.conversations.backend.models.constants import (
+    SLA_MAX_WARNING_MINUTES,
+    SLA_MAX_WARNING_OFFSETS,
+    Channel,
+    ChannelDetail,
+    Priority,
+    Status,
+)
 from products.conversations.backend.person_lookup import _get_persons_by_email
 
 from ee.models.rbac.role import Role
@@ -235,6 +242,15 @@ class TicketSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
     assignee = TicketAssignmentSerializer(source="assignment", read_only=True)
     person = TicketPersonSerializer(read_only=True, allow_null=True)
     email_to = serializers.SerializerMethodField()
+    sla_warning_minutes = serializers.ListField(
+        child=serializers.IntegerField(min_value=1, max_value=SLA_MAX_WARNING_MINUTES),
+        required=False,
+        max_length=SLA_MAX_WARNING_OFFSETS,
+        help_text=(
+            "Minutes before sla_due_at at which a $conversation_sla_approaching event fires, "
+            "e.g. [180, 60]. Empty falls back to the team-level default."
+        ),
+    )
 
     class Meta:
         model = Ticket
@@ -262,6 +278,7 @@ class TicketSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
             "session_id",
             "session_context",
             "sla_due_at",
+            "sla_warning_minutes",
             "snoozed_until",
             "slack_channel_id",
             "slack_thread_ts",

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -6,7 +6,10 @@ Staff/system actions use the actor's distinct_id; customer actions use the ticke
 Events are sent to the customer's PostHog project via their team's API token.
 """
 
+from datetime import datetime
 from typing import Literal
+
+from django.utils import timezone
 
 import structlog
 
@@ -240,6 +243,24 @@ def _get_customer_properties(ticket: Ticket, *, include_distinct_id: bool = Fals
     return properties
 
 
+def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
+    """SLA state at the moment of the event.
+
+    Stamped on events (rather than derived later) so attainment metrics reflect the
+    deadline that was in force at the time, even if the SLA is reset afterwards.
+    `sla_delta_seconds` is positive when past due, negative when time remains.
+    """
+    if ticket.sla_due_at is None:
+        return {"sla_due_at": None, "sla_active": False, "sla_breached": False, "sla_delta_seconds": None}
+    delta_seconds = int((now - ticket.sla_due_at).total_seconds())
+    return {
+        "sla_due_at": ticket.sla_due_at.isoformat(),
+        "sla_active": True,
+        "sla_breached": delta_seconds > 0,
+        "sla_delta_seconds": delta_seconds,
+    }
+
+
 def capture_ticket_created(ticket: Ticket) -> None:
     properties = _get_ticket_base_properties(ticket)
     properties.update(_get_customer_properties(ticket))
@@ -351,6 +372,7 @@ def capture_message_sent(
     properties["author_type"] = "team"
     properties.update(_get_actor_properties(author, "user"))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
+    properties.update(_get_sla_properties(ticket, timezone.now()))
 
     capture_internal(
         token=ticket.team.api_token,

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -261,6 +261,45 @@ def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
     }
 
 
+def capture_sla_approaching(ticket: Ticket, threshold_minutes: int, now: datetime) -> None:
+    """A configured SLA warning threshold was crossed; emitted once per threshold by the sweep task."""
+    assert ticket.sla_due_at is not None
+    properties = _get_ticket_base_properties(ticket)
+    properties.update(_get_actor_properties(None, "system"))
+    properties.update(_get_customer_properties(ticket, include_distinct_id=True))
+    properties.update(_get_sla_properties(ticket, now))
+    properties["threshold_minutes"] = threshold_minutes
+    properties["minutes_remaining"] = max(int((ticket.sla_due_at - now).total_seconds() // 60), 0)
+
+    capture_internal(
+        token=ticket.team.api_token,
+        event_name="$conversation_sla_approaching",
+        event_source=EVENT_SOURCE,
+        distinct_id=ticket.distinct_id or ticket.channel_source or "unknown",
+        timestamp=None,
+        properties=properties,
+    )
+
+
+def capture_sla_breached(ticket: Ticket, now: datetime) -> None:
+    """The SLA deadline passed; emitted once per deadline value by the sweep task."""
+    assert ticket.sla_due_at is not None
+    properties = _get_ticket_base_properties(ticket)
+    properties.update(_get_actor_properties(None, "system"))
+    properties.update(_get_customer_properties(ticket, include_distinct_id=True))
+    properties.update(_get_sla_properties(ticket, now))
+    properties["minutes_overdue"] = max(int((now - ticket.sla_due_at).total_seconds() // 60), 0)
+
+    capture_internal(
+        token=ticket.team.api_token,
+        event_name="$conversation_sla_breached",
+        event_source=EVENT_SOURCE,
+        distinct_id=ticket.distinct_id or ticket.channel_source or "unknown",
+        timestamp=None,
+        properties=properties,
+    )
+
+
 def capture_ticket_created(ticket: Ticket) -> None:
     properties = _get_ticket_base_properties(ticket)
     properties.update(_get_customer_properties(ticket))

--- a/products/conversations/backend/migrations/0047_ticket_sla_warning_fields.py
+++ b/products/conversations/backend/migrations/0047_ticket_sla_warning_fields.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("conversations", "0046_ticket_org_id_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ticket",
+            name="sla_events_sent",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="ticket",
+            name="sla_warning_minutes",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/products/conversations/backend/migrations/0048_ticket_sla_sweep_idx.py
+++ b/products/conversations/backend/migrations/0048_ticket_sla_sweep_idx.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("conversations", "0047_ticket_sla_warning_fields"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="ticket",
+            index=models.Index(
+                fields=["sla_due_at"],
+                name="posthog_con_sla_sweep_idx",
+                condition=models.Q(sla_due_at__isnull=False),
+            ),
+        ),
+    ]

--- a/products/conversations/backend/migrations/max_migration.txt
+++ b/products/conversations/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0046_ticket_org_id_indexes
+0048_ticket_sla_sweep_idx

--- a/products/conversations/backend/models/constants.py
+++ b/products/conversations/backend/models/constants.py
@@ -41,3 +41,8 @@ class Priority(models.TextChoices):
 class RuleType(models.TextChoices):
     TONE = "tone", "Tone"
     ESCALATION = "escalation", "Escalation"
+
+
+# Cap on SLA warning offsets (7 days, in minutes); also the SLA event sweep's scan horizon.
+SLA_MAX_WARNING_MINUTES = 10080
+SLA_MAX_WARNING_OFFSETS = 20

--- a/products/conversations/backend/models/ticket.py
+++ b/products/conversations/backend/models/ticket.py
@@ -102,6 +102,15 @@ class Ticket(UUIDTModel):
     # SLA deadline — set via workflows, null means no SLA
     sla_due_at = models.DateTimeField(null=True, blank=True)
 
+    # Minutes before sla_due_at at which to emit $conversation_sla_approaching (e.g. [180, 60]).
+    # Set alongside the SLA; empty falls back to team.conversations_settings["sla_warning_minutes"].
+    sla_warning_minutes = models.JSONField(default=list, blank=True)
+
+    # Sweep dedup markers: {"due_at": "<iso>", "warned_minutes": [...], "breached": bool}.
+    # Keyed to the deadline they were emitted for, so changing sla_due_at re-arms all
+    # SLA events without any explicit clearing in the write paths.
+    sla_events_sent = models.JSONField(default=dict, blank=True)
+
     # Snooze — when set, ticket is "on hold" until this time, then auto-reopened by wake task
     snoozed_until = models.DateTimeField(null=True, blank=True)
 
@@ -147,6 +156,12 @@ class Ticket(UUIDTModel):
                 fields=["snoozed_until"],
                 name="posthog_con_snooze_wake_idx",
                 condition=models.Q(snoozed_until__isnull=False),
+            ),
+            # SLA: event sweep task (cross-team, only non-null rows)
+            models.Index(
+                fields=["sla_due_at"],
+                name="posthog_con_sla_sweep_idx",
+                condition=models.Q(sla_due_at__isnull=False),
             ),
             models.Index(fields=["organization_id"], name="posthog_org_id_idx"),
             models.Index(

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -2,6 +2,7 @@
 
 import html as html_mod
 import json
+import uuid
 from datetime import datetime, timedelta
 from email.utils import formataddr
 from typing import Any, cast
@@ -31,7 +32,11 @@ from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage import object_storage
 
 from products.conversations.backend.cache import NUDGE_DISMISS_TTL, suppress_nudge
-from products.conversations.backend.events import capture_ticket_status_changed
+from products.conversations.backend.events import (
+    capture_sla_approaching,
+    capture_sla_breached,
+    capture_ticket_status_changed,
+)
 from products.conversations.backend.formatting import (
     extract_images_from_rich_content,
     rich_content_to_html,
@@ -53,7 +58,7 @@ from products.conversations.backend.models import (
     TeamConversationsTeamsChannelSync,
     TeamConversationsTeamsConfig,
 )
-from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
+from products.conversations.backend.models.constants import SLA_MAX_WARNING_MINUTES, Channel, ChannelDetail, Status
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.slack import (
@@ -1630,6 +1635,107 @@ def wake_snoozed_tickets() -> None:
 
     if total:
         logger.info("wake_snoozed_tickets_completed", count=total)
+
+
+SLA_SWEEP_BATCH_SIZE = 100
+
+
+def _sla_warning_offsets(ticket: Ticket) -> list[int]:
+    """Warning offsets for a ticket: its own, else the team default, sanitized."""
+    raw = ticket.sla_warning_minutes or (ticket.team.conversations_settings or {}).get("sla_warning_minutes") or []
+    if not isinstance(raw, list):
+        return []
+    return sorted(
+        {int(o) for o in raw if isinstance(o, int | float) and 1 <= o <= SLA_MAX_WARNING_MINUTES}, reverse=True
+    )
+
+
+def _emit_sla_events_for_ticket(ticket: Ticket, now: datetime) -> bool:
+    """Emit due SLA events for one ticket; returns whether dedup markers changed.
+
+    Markers are trusted only when stamped for the current deadline, so an SLA
+    reset (new sla_due_at) re-arms both warnings and the breach event.
+    """
+    assert ticket.sla_due_at is not None
+    due_key = ticket.sla_due_at.isoformat()
+    markers = ticket.sla_events_sent if isinstance(ticket.sla_events_sent, dict) else {}
+    if markers.get("due_at") != due_key:
+        markers = {"due_at": due_key, "warned_minutes": [], "breached": False}
+
+    if now >= ticket.sla_due_at:
+        if markers.get("breached"):
+            return False
+        # Warnings that weren't emitted in time (e.g. worker downtime) are moot once breached.
+        markers["breached"] = True
+        ticket.sla_events_sent = markers
+        ticket.save(update_fields=["sla_events_sent"])
+        try:
+            capture_sla_breached(ticket, now)
+        except Exception:
+            logger.exception("sla_breached_event_failed", ticket_id=str(ticket.id))
+        return True
+
+    warned = {int(m) for m in markers.get("warned_minutes") or []}
+    crossed = [
+        offset
+        for offset in _sla_warning_offsets(ticket)
+        if offset not in warned and now >= ticket.sla_due_at - timedelta(minutes=offset)
+    ]
+    if not crossed:
+        return False
+
+    # If several thresholds were crossed at once (catch-up after downtime), alert only for
+    # the nearest one but mark them all, so a recovering worker doesn't send an alert storm.
+    markers["warned_minutes"] = sorted(warned | set(crossed))
+    ticket.sla_events_sent = markers
+    ticket.save(update_fields=["sla_events_sent"])
+    try:
+        capture_sla_approaching(ticket, min(crossed), now)
+    except Exception:
+        logger.exception("sla_approaching_event_failed", ticket_id=str(ticket.id))
+    return True
+
+
+@shared_task(ignore_result=True)
+def emit_ticket_sla_events() -> None:
+    """Emit $conversation_sla_approaching / $conversation_sla_breached for tickets nearing
+    or past their SLA deadline, so workflows can trigger alerts on them."""
+
+    now = timezone.now()
+    horizon = now + timedelta(minutes=SLA_MAX_WARNING_MINUTES)
+    total = 0
+    last_key: tuple[datetime, uuid.UUID] | None = None
+
+    # Keyset pagination: processed rows still match the filter (unlike the snooze wake),
+    # so advance a (sla_due_at, id) cursor instead of re-reading from the start.
+    while True:
+        with transaction.atomic():
+            queryset = (
+                Ticket.objects.select_for_update(skip_locked=True, of=("self",))
+                .select_related("team")
+                .filter(sla_due_at__isnull=False, sla_due_at__lte=horizon)
+                .exclude(status=Status.RESOLVED)
+                .order_by("sla_due_at", "id")
+            )
+            if last_key is not None:
+                queryset = queryset.filter(
+                    models.Q(sla_due_at__gt=last_key[0]) | models.Q(sla_due_at=last_key[0], id__gt=last_key[1])
+                )
+            batch = list(queryset[:SLA_SWEEP_BATCH_SIZE])
+            if not batch:
+                break
+
+            for ticket in batch:
+                if _emit_sla_events_for_ticket(ticket, now):
+                    total += 1
+
+            last_key = (batch[-1].sla_due_at, batch[-1].id)
+
+        if len(batch) < SLA_SWEEP_BATCH_SIZE:
+            break
+
+    if total:
+        logger.info("emit_ticket_sla_events_completed", count=total)
 
 
 # ---------------------------------------------------------------------------

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -1729,7 +1729,9 @@ def emit_ticket_sla_events() -> None:
                 if _emit_sla_events_for_ticket(ticket, now):
                     total += 1
 
-            last_key = (batch[-1].sla_due_at, batch[-1].id)
+            last_ticket = batch[-1]
+            assert last_ticket.sla_due_at is not None  # guaranteed by the sla_due_at__isnull=False filter
+            last_key = (last_ticket.sla_due_at, last_ticket.id)
 
         if len(batch) < SLA_SWEEP_BATCH_SIZE:
             break

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -712,6 +712,13 @@ export interface TicketApi {
      * @nullable
      */
     sla_due_at?: string | null
+    /**
+     * Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.
+     * @maxItems 20
+     * @items.minimum 1
+     * @items.maximum 10080
+     */
+    sla_warning_minutes?: number[]
     /** @nullable */
     snoozed_until?: string | null
     /** @nullable */
@@ -804,6 +811,13 @@ export interface PatchedTicketApi {
      * @nullable
      */
     sla_due_at?: string | null
+    /**
+     * Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.
+     * @maxItems 20
+     * @items.minimum 1
+     * @items.maximum 10080
+     */
+    sla_warning_minutes?: number[]
     /** @nullable */
     snoozed_until?: string | null
     /** @nullable */

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -152,6 +152,10 @@ export const ConversationsQueuePartialUpdateBody = /* @__PURE__ */ zod.looseObje
 
 export const ConversationsQueueClearCreateBody = /* @__PURE__ */ zod.looseObject({})
 
+export const conversationsTicketsCreateBodySlaWarningMinutesItemMax = 10080
+
+export const conversationsTicketsCreateBodySlaWarningMinutesMax = 20
+
 export const ConversationsTicketsCreateBody = /* @__PURE__ */ zod
     .object({
         status: zod
@@ -180,6 +184,13 @@ export const ConversationsTicketsCreateBody = /* @__PURE__ */ zod
             .datetime({ offset: true })
             .nullish()
             .describe('SLA deadline set via workflows. Null means no SLA.'),
+        sla_warning_minutes: zod
+            .array(zod.number().min(1).max(conversationsTicketsCreateBodySlaWarningMinutesItemMax))
+            .max(conversationsTicketsCreateBodySlaWarningMinutesMax)
+            .optional()
+            .describe(
+                'Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.'
+            ),
         snoozed_until: zod.iso.datetime({ offset: true }).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
@@ -188,6 +199,10 @@ export const ConversationsTicketsCreateBody = /* @__PURE__ */ zod
 /**
  * Handle ticket updates including assignee changes.
  */
+export const conversationsTicketsUpdateBodySlaWarningMinutesItemMax = 10080
+
+export const conversationsTicketsUpdateBodySlaWarningMinutesMax = 20
+
 export const ConversationsTicketsUpdateBody = /* @__PURE__ */ zod
     .object({
         status: zod
@@ -216,10 +231,21 @@ export const ConversationsTicketsUpdateBody = /* @__PURE__ */ zod
             .datetime({ offset: true })
             .nullish()
             .describe('SLA deadline set via workflows. Null means no SLA.'),
+        sla_warning_minutes: zod
+            .array(zod.number().min(1).max(conversationsTicketsUpdateBodySlaWarningMinutesItemMax))
+            .max(conversationsTicketsUpdateBodySlaWarningMinutesMax)
+            .optional()
+            .describe(
+                'Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.'
+            ),
         snoozed_until: zod.iso.datetime({ offset: true }).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')
+
+export const conversationsTicketsPartialUpdateBodySlaWarningMinutesItemMax = 10080
+
+export const conversationsTicketsPartialUpdateBodySlaWarningMinutesMax = 20
 
 export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
@@ -249,6 +275,13 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
             .datetime({ offset: true })
             .nullish()
             .describe('SLA deadline set via workflows. Null means no SLA.'),
+        sla_warning_minutes: zod
+            .array(zod.number().min(1).max(conversationsTicketsPartialUpdateBodySlaWarningMinutesItemMax))
+            .max(conversationsTicketsPartialUpdateBodySlaWarningMinutesMax)
+            .optional()
+            .describe(
+                'Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.'
+            ),
         snoozed_until: zod.iso.datetime({ offset: true }).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36126,6 +36126,13 @@ export namespace Schemas {
          * @nullable
          */
       sla_due_at?: string | null;
+      /**
+         * Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.
+         * @maxItems 20
+         * @items.minimum 1
+         * @items.maximum 10080
+         */
+      sla_warning_minutes?: number[];
       /** @nullable */
       snoozed_until?: string | null;
       /** @nullable */
@@ -43573,6 +43580,13 @@ export namespace Schemas {
          * @nullable
          */
       sla_due_at?: string | null;
+      /**
+         * Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.
+         * @maxItems 20
+         * @items.minimum 1
+         * @items.maximum 10080
+         */
+      sla_warning_minutes?: number[];
       /** @nullable */
       snoozed_until?: string | null;
       /** @nullable */

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -128,6 +128,10 @@ export const ConversationsTicketsPartialUpdateParams = /* @__PURE__ */ zod.objec
         ),
 })
 
+export const conversationsTicketsPartialUpdateBodySlaWarningMinutesItemMax = 10080
+
+export const conversationsTicketsPartialUpdateBodySlaWarningMinutesMax = 20
+
 export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
         status: zod
@@ -153,6 +157,13 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
             .datetime({ offset: true })
             .nullish()
             .describe('SLA deadline set via workflows. Null means no SLA.'),
+        sla_warning_minutes: zod
+            .array(zod.number().min(1).max(conversationsTicketsPartialUpdateBodySlaWarningMinutesItemMax))
+            .max(conversationsTicketsPartialUpdateBodySlaWarningMinutesMax)
+            .optional()
+            .describe(
+                'Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.'
+            ),
         snoozed_until: zod.iso.datetime({ offset: true }).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -188,6 +188,9 @@ const conversationsTicketsUpdate = (): ToolBase<
         if (params.sla_due_at !== undefined) {
             body['sla_due_at'] = params.sla_due_at
         }
+        if (params.sla_warning_minutes !== undefined) {
+            body['sla_warning_minutes'] = params.sla_warning_minutes
+        }
         if (params.snoozed_until !== undefined) {
             body['snoozed_until'] = params.snoozed_until
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-update.json
@@ -35,6 +35,16 @@
             ],
             "description": "SLA deadline set via workflows. Null means no SLA."
         },
+        "sla_warning_minutes": {
+            "description": "Minutes before sla_due_at at which a $conversation_sla_approaching event fires, e.g. [180, 60]. Empty falls back to the team-level default.",
+            "items": {
+                "maximum": 10080,
+                "minimum": 1,
+                "type": "number"
+            },
+            "maxItems": 20,
+            "type": "array"
+        },
         "snoozed_until": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

There is no way to get alerted before a ticket breaches its SLA. Workflows can set a per-ticket `sla_due_at`, but no event fires as the deadline nears or passes, and workflow `delay` actions are fixed durations that can't track a per-ticket deadline. Different teams also want different warning schedules (one wants pings 3h and 1h before breach, another only 30min before).

Part 4 of the SLA series (#69339, #69345, #69354).

> [!NOTE]
> Stacked on #69345 (`posthog-code/sla-message-event-props`) - it reuses the `_get_sla_properties` helper introduced there. Merge that first, then rebase this to master.

## Changes

**Configuration.** `Ticket.sla_warning_minutes` (e.g. `[180, 60]`) is set by the same workflow step that sets the SLA, via the external ticket API or the standard PATCH endpoint. Since workflows already branch on priority to assign different SLAs, per-ticket offsets let P0 tickets warn on a different schedule than P2. Empty falls back to `team.conversations_settings["sla_warning_minutes"]`.

**Sweep.** A per-minute Celery task (`emit_ticket_sla_events`, modeled on the snooze wake task) scans unresolved tickets with a deadline inside the 7-day warning horizon, using a new cross-team partial index on `sla_due_at` (the existing SLA index is team-prefixed, useless for a global scan). It emits:

- `$conversation_sla_approaching` with `threshold_minutes` (the configured offset that fired - workflows filter on this), `minutes_remaining`, and the standard ticket/customer/SLA props
- `$conversation_sla_breached` with `minutes_overdue`, once per deadline value

**Dedup and reset semantics.** Markers in `Ticket.sla_events_sent` are keyed to the `sla_due_at` they were emitted for. A workflow that extends or resets the SLA changes that key, so all events re-arm with zero clearing code in the write paths. Catch-up after worker downtime emits only the nearest crossed threshold (marking the rest) to avoid alert storms. Events emit at-most-once relative to the marker save.

**Also fixes** a latent 500 in the external ticket API: `ListField` item validation errors are keyed by integer index, which the strict JSON renderer rejects (`Dict key must be str`) - this already affected the existing `tags` field.

## How did you test this code?

New `test_sla_events.py` suite (frozen clock, real Postgres, mocked capture boundary), each catching a distinct regression:

- warning→breach lifecycle with dedup across repeated sweeps (alert-spam regression)
- SLA reset re-arms warnings and breach (missed-alert regression)
- catch-up after downtime emits only the nearest threshold (alert-storm regression)
- team-default fallback, no-offsets (breach still fires), resolved/no-SLA exclusion

Serializer tests in `test_external.py`: persistence (sorted desc, deduped) and parameterized invalid inputs - the invalid cases also cover the renderer 500 fix, since they returned a 500 before it. Ran the full conversations API suites (`test_external`, `test_tickets`, `test_sla_events`) - 232 green. Migration split per the safe-migrations rules: additive fields, then `SafeAddIndexConcurrently` in a non-atomic migration. Regenerated OpenAPI types (`hogli build:openapi`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /django-migrations, /improving-drf-endpoints, /writing-tests. Design decisions: per-ticket warning offsets over a team-only setting (priority-differentiated schedules) and over threshold-free periodic state events (per-minute billed events plus workflow-side dedup isn't expressible in HogFlow filters). Keyset pagination in the sweep instead of the wake task's requeue loop, because processed rows still match the filter. Deliberately no `$conversation_sla_set` event: the external API emits no events by design (workflow loop avoidance) and the activity log already records SLA changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
