### PR TITLE
fix: sync team name on project rename

### DIFF
--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -43,10 +43,8 @@ describe('teamLogic', () => {
                     '/api/projects/@current': () => [500, {}],
                 },
                 patch: {
-                    '/api/environments/:id': async ({ request }) => [
-                        200,
-                        { ...MOCK_DEFAULT_TEAM, ...((await request.json()) as Record<string, any>) },
-                    ],
+                    // Only /api/projects is mocked: a name-only update must not hit the
+                    // deprecated /api/environments endpoint
                     '/api/projects/:id': async ({ request }) => [
                         200,
                         { ...MOCK_DEFAULT_PROJECT, ...((await request.json()) as Record<string, any>) },
@@ -62,11 +60,11 @@ describe('teamLogic', () => {
             expect(projectLogic.values.currentProject).toBeNull()
 
             await expectLogic(logic, () => {
-                logic.actions.updateCurrentTeam({ name: 'Compliance Dashboard Prod' })
+                logic.actions.updateCurrentTeam({ name: 'Renamed project' })
             }).toDispatchActions([projectLogic.actionTypes.loadCurrentProjectSuccess, 'updateCurrentTeamSuccess'])
 
-            expect(logic.values.currentTeam?.name).toBe('Compliance Dashboard Prod')
-            expect(projectLogic.values.currentProject?.name).toBe('Compliance Dashboard Prod')
+            expect(logic.values.currentTeam?.name).toBe('Renamed project')
+            expect(projectLogic.values.currentProject?.name).toBe('Renamed project')
         })
     })
 

--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -1,10 +1,12 @@
-import { MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
+import { MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AppContext } from '~/types'
 
+import { projectLogic } from './projectLogic'
 import { teamLogic } from './teamLogic'
 
 describe('teamLogic', () => {
@@ -25,6 +27,46 @@ describe('teamLogic', () => {
         it('currentProjectId returns the project id', async () => {
             await expectLogic(logic).toDispatchActions(['loadCurrentTeamSuccess'])
             expect(logic.values.currentProjectId).toBe(MOCK_DEFAULT_TEAM.project_id)
+        })
+    })
+
+    describe('updateCurrentTeam with a name-only payload', () => {
+        beforeEach(() => {
+            initKeaTests(false)
+            // Simulate projectLogic not having loaded yet, as the rename must not depend on it
+            window.POSTHOG_APP_CONTEXT = {
+                ...window.POSTHOG_APP_CONTEXT,
+                current_project: undefined,
+            } as unknown as AppContext
+            useMocks({
+                get: {
+                    '/api/projects/@current': () => [500, {}],
+                },
+                patch: {
+                    '/api/environments/:id': async ({ request }) => [
+                        200,
+                        { ...MOCK_DEFAULT_TEAM, ...((await request.json()) as Record<string, any>) },
+                    ],
+                    '/api/projects/:id': async ({ request }) => [
+                        200,
+                        { ...MOCK_DEFAULT_PROJECT, ...((await request.json()) as Record<string, any>) },
+                    ],
+                },
+            })
+            logic = teamLogic()
+            logic.mount()
+        })
+
+        it('renames the parent project and syncs it into projectLogic', async () => {
+            await expectLogic(logic).toDispatchActions(['loadCurrentTeamSuccess'])
+            expect(projectLogic.values.currentProject).toBeNull()
+
+            await expectLogic(logic, () => {
+                logic.actions.updateCurrentTeam({ name: 'Compliance Dashboard Prod' })
+            }).toDispatchActions([projectLogic.actionTypes.loadCurrentProjectSuccess, 'updateCurrentTeamSuccess'])
+
+            expect(logic.values.currentTeam?.name).toBe('Compliance Dashboard Prod')
+            expect(projectLogic.values.currentProject?.name).toBe('Compliance Dashboard Prod')
         })
     })
 

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -67,6 +67,8 @@ export const teamLogic = kea<teamLogicType>([
             ['loadCurrentOrganization'],
             customProductsLogic,
             ['loadCustomProducts'],
+            projectLogic,
+            ['loadCurrentProjectSuccess'],
         ],
     })),
     actions({
@@ -117,12 +119,20 @@ export const teamLogic = kea<teamLogicType>([
                         api.update(`api/environments/${values.currentTeam.id}`, payload),
                         undefined,
                     ]
-                    if (Object.keys(payload).length === 1 && payload.name && values.currentProject) {
-                        // If we're only updating the name, update the project name as well for equivalence
-                        promises[1] = api.update(`api/projects/${values.currentProject.id}`, { name: payload.name })
+                    if (Object.keys(payload).length === 1 && payload.name && values.currentTeam.project_id) {
+                        // If we're only updating the name, update the project name as well for equivalence.
+                        // Use project_id from the team, as currentProject may not be loaded yet
+                        promises[1] = api.update(`api/projects/${values.currentTeam.project_id}`, {
+                            name: payload.name,
+                        })
                     }
-                    const [patchedTeam] = await Promise.all(promises)
+                    const [patchedTeam, patchedProject] = await Promise.all(promises)
                     breakpoint()
+
+                    if (patchedProject) {
+                        // Sync projectLogic too, as surfaces like the project switcher read currentProject.name
+                        actions.loadCurrentProjectSuccess(patchedProject)
+                    }
 
                     // We need to reload current org (which lists its teams) in organizationLogic
                     actions.loadCurrentOrganization()

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -115,23 +115,21 @@ export const teamLogic = kea<teamLogicType>([
                         }
                     }
 
-                    const promises: [Promise<TeamType>, Promise<ProjectType> | undefined] = [
-                        api.update(`api/environments/${values.currentTeam.id}`, payload),
-                        undefined,
-                    ]
+                    let patchedTeam: TeamType | TeamPublicType
                     if (Object.keys(payload).length === 1 && payload.name && values.currentTeam.project_id) {
-                        // If we're only updating the name, update the project name as well for equivalence.
-                        // Use project_id from the team, as currentProject may not be loaded yet
-                        promises[1] = api.update(`api/projects/${values.currentTeam.project_id}`, {
-                            name: payload.name,
-                        })
-                    }
-                    const [patchedTeam, patchedProject] = await Promise.all(promises)
-                    breakpoint()
-
-                    if (patchedProject) {
+                        // Renames go through /api/projects, which mirrors the name onto the passthrough
+                        // team server-side. /api/environments is deprecated, don't add calls to it
+                        const patchedProject = await api.update<ProjectType>(
+                            `api/projects/${values.currentTeam.project_id}`,
+                            { name: payload.name }
+                        )
+                        breakpoint()
                         // Sync projectLogic too, as surfaces like the project switcher read currentProject.name
                         actions.loadCurrentProjectSuccess(patchedProject)
+                        patchedTeam = { ...values.currentTeam, name: patchedProject.name }
+                    } else {
+                        patchedTeam = await api.update(`api/environments/${values.currentTeam.id}`, payload)
+                        breakpoint()
                     }
 
                     // We need to reload current org (which lists its teams) in organizationLogic

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1209,6 +1209,12 @@ class ProjectBackwardCompatSerializer(
                 should_team_be_saved_too = True
                 setattr(team, attr, value)
 
+        if "name" in validated_data:
+            # Keep Team.name mirroring Project.name: surfaces like the organization's teams
+            # list and the app context still read the name off the Team row
+            should_team_be_saved_too = True
+            team.name = validated_data["name"]
+
         instance.save()
         if should_team_be_saved_too:
             team.save()

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -702,6 +702,18 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(self.team.base_currency, "EUR")
         self.assertEqual(self.team.capture_dead_clicks, True)
 
+    def test_rename_project_syncs_passthrough_team_name(self):
+        response = self.client.patch(
+            f"/api/projects/{self.project.id}/",
+            {"name": "Renamed project"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        self.project.refresh_from_db()
+        self.team.refresh_from_db()
+        self.assertEqual(self.project.name, "Renamed project")
+        self.assertEqual(self.team.name, "Renamed project")
+
     def test_customer_analytics_config_writes_through_to_team(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()


### PR DESCRIPTION
## Problem

Renaming a project from the project settings page shows a "Name updated successfully!" toast, but the UI keeps showing the old name. Came out of a support report: https://posthoghelp.zendesk.com/agent/tickets/61962 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/63191)

Since the `/api/environments/*` → `/api/projects/*` rewrite rolled out to 100% (#68511), the settings page's `PATCH /api/environments/:id {name}` is served by the **projects viewset**, where `name` is not a `team_passthrough_field`. So the rename writes `Project.name` only and **`Team.name` is never updated**. Most surfaces still read `Team.name` off the Team row (the organization serializer's teams list that feeds the project switcher, and the server-rendered app context that bootstraps `teamLogic` on page load), so the stale name sticks forever.

This affects every project rename since the rewrite rollout. 
<img width="1352" height="1358" alt="2026-07-08 19 01 22" src="https://github.com/user-attachments/assets/a828e5fe-c4c3-47c5-9b4e-e5245c4df6d7" />


## Changes

- `ProjectSerializer.update` now mirrors `name` onto the passthrough `Team` and saves it, so `Team.name` readers (org teams list, app context) stay correct no matter which route the rename came in on
- Name-only updates now go through a single `PATCH /api/projects/:project_id` instead of the old double-PATCH "equivalence" hack 


## How did you test this code?

Tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No