### PR TITLE
fix(aio): use raw error value in trace links

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityErrors.test.ts
+++ b/products/ai_observability/frontend/AIObservabilityErrors.test.ts
@@ -1,0 +1,45 @@
+import { router } from 'kea-router'
+
+import { urls } from 'scenes/urls'
+
+import { initKeaTests } from '~/test/init'
+import { type AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { buildErrorTracesUrl } from './AIObservabilityErrors'
+
+describe('AIObservabilityErrors', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('links to traces with the raw normalized error value', () => {
+        const existingFilter: AnyPropertyFilter = {
+            type: PropertyFilterType.Event,
+            key: '$ai_model',
+            operator: PropertyOperator.Exact,
+            value: 'gpt-4o',
+        }
+        const errorString = 'TypeError: Cannot read "message" at C:\\app\\index.ts'
+
+        const url = buildErrorTracesUrl(errorString, { date_from: '-24h' }, [existingFilter])
+        router.actions.push(url)
+
+        expect(router.values.location.pathname.endsWith(urls.aiObservabilityTraces())).toBe(true)
+        expect(router.values.searchParams).toMatchObject({ date_from: '-24h' })
+        expect(router.values.searchParams.filters).toEqual([
+            existingFilter,
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_is_error',
+                operator: PropertyOperator.Exact,
+                value: 'true',
+            },
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_error_normalized',
+                operator: PropertyOperator.Exact,
+                value: errorString,
+            },
+        ])
+    })
+})

--- a/products/ai_observability/frontend/AIObservabilityErrors.tsx
+++ b/products/ai_observability/frontend/AIObservabilityErrors.tsx
@@ -12,11 +12,36 @@ import { urls } from 'scenes/urls'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { type InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
-import { PropertyFilterType, PropertyOperator } from '~/types'
+import { type AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { buildApplyUrlStatePayload, aiObservabilitySharedLogic } from './aiObservabilitySharedLogic'
 import { useSortableColumns } from './hooks/useSortableColumns'
 import { aiObservabilityErrorsLogic } from './tabs/aiObservabilityErrorsLogic'
+
+export function buildErrorTracesUrl(
+    errorString: string,
+    searchParams: Record<string, unknown>,
+    currentPropertyFilters: AnyPropertyFilter[]
+): string {
+    return combineUrl(urls.aiObservabilityTraces(), {
+        ...searchParams,
+        filters: [
+            ...currentPropertyFilters,
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_is_error',
+                operator: PropertyOperator.Exact,
+                value: 'true',
+            },
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_error_normalized',
+                operator: PropertyOperator.Exact,
+                value: errorString,
+            },
+        ],
+    }).url
+}
 
 export function AIObservabilityErrors(): JSX.Element {
     const sharedLogic = useMountedLogic(aiObservabilitySharedLogic)
@@ -90,28 +115,7 @@ export function AIObservabilityErrors(): JSX.Element {
                                 <div className="flex items-center gap-1">
                                     <Tooltip title={errorString}>
                                         <Link
-                                            to={
-                                                combineUrl(urls.aiObservabilityTraces(), {
-                                                    ...searchParams,
-                                                    filters: [
-                                                        {
-                                                            type: PropertyFilterType.Event,
-                                                            key: '$ai_is_error',
-                                                            operator: PropertyOperator.Exact,
-                                                            value: 'true',
-                                                        },
-                                                        {
-                                                            type: PropertyFilterType.Event,
-                                                            key: '$ai_error_normalized',
-                                                            operator: PropertyOperator.Exact,
-                                                            // Escape backslashes and quotes to match HogQL's JSONExtractRaw extraction
-                                                            value: errorString
-                                                                .replace(/\\/g, '\\\\')
-                                                                .replace(/"/g, '\\"'),
-                                                        },
-                                                    ],
-                                                }).url
-                                            }
+                                            to={buildErrorTracesUrl(errorString, searchParams, currentPropertyFilters)}
                                             className="font-mono text-sm"
                                             data-attr="llm-errors-row-click"
                                         >


### PR DESCRIPTION
## Problem

Clicking an AI observability error built a traces filter with an escaped normalized error value, which could differ from the stored `$ai_error_normalized` value.

## Changes

- Build error-to-traces links with the raw normalized error value.
- Preserve current property filters when adding the error filters.
- Add a regression test for quote and backslash round-tripping.

## How did you test this code?

Automated tests cover the clicked error link filter value. Full frontend typecheck was attempted but is currently blocked by unrelated existing generated-type and navigation/tracing errors outside this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. This fixes an internal UI filtering bug.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the change at the user's direction. Skills invoked: `/writing-tests`, `/hogli`, `create-pr`, and the AI observability product guide. I verified this path uses typed property filters, so HogQL handles quoting when compiling the filter; the previous manual escaping was not needed here.
