### PR TITLE
feat(replay-vision): render group-summary citations as slack links

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -82,9 +82,9 @@ _SYSTEM_PROMPT = (
 
 _MARKDOWN_HEADING_RE = re.compile(r"^#{1,6}\s*(.+?)\s*#*$", re.MULTILINE)
 _MARKDOWN_BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
-# `[obs N]` citation markers the model emits (see `_fetch_observations`); the in-app view resolves them to
-# observation links, Slack drops them.
-_OBS_CITATION_RE = re.compile(r"\s*\[obs \d+\]")
+# `[obs N]` citation markers the model emits (see `_fetch_observations`); the in-app view and the Slack pass
+# both resolve them to observation links. The captured group is the 1-based observation number.
+_OBS_CITATION_RE = re.compile(r"\[obs (\d+)\]")
 # Cap adjacent citations on the stored report so an over-cited theme renders a representative handful, not a
 # wall of links. Cross-section variety stays the prompt's job.
 _MAX_CITATIONS_PER_RUN = 6
@@ -158,7 +158,7 @@ def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryR
     markdown = strip_external_links_markdown(
         _summary_header(action, batch.window_start, len(batch.lines), batch.window_total) + markdown
     )
-    slack_text = _markdown_to_slack(markdown)
+    slack_text = _markdown_to_slack(markdown, team_id=team.id, observation_ids=batch.observation_ids)
 
     run.synthesized_markdown = markdown
     run.output = {"slack": slack_text}
@@ -445,10 +445,28 @@ def _run_synthesis(team: Team, action: VisionAction, lines: list[str]) -> str:
     return (response.choices[0].message.content or "").strip()
 
 
-def _markdown_to_slack(markdown: str) -> str:
-    """Light Markdown→Slack-mrkdwn pass: headings and **bold** become *bold*. Truncates long reports."""
-    # Drop `[obs N]` markers — Slack can't resolve them to links yet; `synthesized_markdown` keeps them for in-app.
-    text = _OBS_CITATION_RE.sub("", markdown)
+def _observation_url(team_id: int, observation_id: str) -> str:
+    return f"{settings.SITE_URL}/project/{team_id}/replay-vision/observations/{observation_id}"
+
+
+def _citations_to_slack_links(markdown: str, team_id: int, observation_ids: list[str]) -> str:
+    """Resolve each `[obs N]` citation into a Slack `<url|[N]>` link to that observation; drop any that don't
+    resolve (an out-of-range or hallucinated reference) so no bare label lingers. These links are added after
+    `strip_external_links_markdown` has already run, so the observation URLs aren't defanged."""
+
+    def _link(match: "re.Match[str]") -> str:
+        n = int(match.group(1))
+        if 1 <= n <= len(observation_ids):
+            return f"<{_observation_url(team_id, observation_ids[n - 1])}|[{n}]>"
+        return ""
+
+    return _OBS_CITATION_RE.sub(_link, markdown)
+
+
+def _markdown_to_slack(markdown: str, *, team_id: int, observation_ids: list[str]) -> str:
+    """Light Markdown→Slack-mrkdwn pass: headings and **bold** become *bold*, and `[obs N]` citations become
+    `[N]` links to each observation. Truncates long reports."""
+    text = _citations_to_slack_links(markdown, team_id, observation_ids)
     text = _MARKDOWN_HEADING_RE.sub(lambda m: f"*{m.group(1)}*", text)
     text = _MARKDOWN_BOLD_RE.sub(lambda m: f"*{m.group(1)}*", text)
     if len(text) > SLACK_TEXT_MAX:

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.conf import settings
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -130,11 +131,10 @@ class TestVisionActionSynthesis(BaseTest):
         self.assertIn("[obs 2] (", prompts[0])
         self.assertNotIn("[obs 3]", prompts[0])
 
-    def test_slack_drops_citations_that_markdown_keeps(self) -> None:
-        # The canonical report keeps the `[obs N]` citation markers for the in-app renderer to resolve into
-        # links; the Slack payload drops them (Slack has no observation deep-link to resolve them to yet), so
-        # the prose stays clean rather than carrying bare labels.
-        self._observation("Users churned at checkout", title="Checkout")
+    def test_slack_renders_citations_as_observation_links(self) -> None:
+        # The canonical report keeps the raw `[obs N]` markers for the in-app renderer; the Slack payload
+        # resolves them to `<url|[N]>` links so a Slack reader can open the recording behind a cited theme.
+        obs = self._observation("Users churned at checkout", title="Checkout")
         action = self._action()
         run = self._run_for(action)
 
@@ -142,8 +142,22 @@ class TestVisionActionSynthesis(BaseTest):
 
         run.refresh_from_db()
         self.assertIn("[obs 1]", run.synthesized_markdown)
+        expected_link = f"<{settings.SITE_URL}/project/{self.team.id}/replay-vision/observations/{obs.id}|[1]>"
+        self.assertIn(expected_link, run.output["slack"])
         self.assertNotIn("[obs 1]", run.output["slack"])
-        self.assertIn("Users hit friction at checkout.", run.output["slack"])
+
+    def test_slack_drops_unresolvable_citation(self) -> None:
+        # A citation the model invents past the observation count can't resolve to a link, so it's dropped
+        # rather than emitted as a dead label or a link to the wrong recording.
+        self._observation("Users churned at checkout", title="Checkout")
+        action = self._action()
+        run = self._run_for(action)
+
+        self._synthesize(action, run, llm_content="Friction everywhere [obs 9].")
+
+        run.refresh_from_db()
+        self.assertNotIn("[9]", run.output["slack"])
+        self.assertNotIn("[obs 9]", run.output["slack"])
 
     def test_caps_runaway_citation_lists(self) -> None:
         # A theme the model backs with many recordings must not render a wall of citations: an adjacent run
@@ -596,13 +610,13 @@ class TestMarkdownToSlack(BaseTest):
         ]
     )
     def test_markdown_converted_to_slack_mrkdwn(self, _label: str, markdown: str, expected: str) -> None:
-        out = _markdown_to_slack(markdown)
+        out = _markdown_to_slack(markdown, team_id=self.team.id, observation_ids=[])
         self.assertIn(expected, out)
         self.assertNotIn("#", out)
         self.assertNotIn("**", out)
 
     def test_truncates_long_text(self) -> None:
-        out = _markdown_to_slack("x" * 50_000)
+        out = _markdown_to_slack("x" * 50_000, team_id=self.team.id, observation_ids=[])
         self.assertLessEqual(len(out), 39_000)
         self.assertIn("truncated", out)
 
@@ -613,7 +627,7 @@ class TestMarkdownToSlack(BaseTest):
 
         padding = "a" * (SLACK_TEXT_MAX - 5)
         evil = "https://evil.example.com/exfil"
-        out = _markdown_to_slack(padding + evil)
+        out = _markdown_to_slack(padding + evil, team_id=self.team.id, observation_ids=[])
         # The host must not appear as a live (unquoted) URL in the output.
         sanitized = out.replace("`https://evil.example.com/exfil`", "")
         self.assertNotIn("https://evil.example.com/exfil", sanitized)


### PR DESCRIPTION
## Problem

Stacked on [#69395](https://github.com/PostHog/posthog/pull/69395), which added observation citations to group summaries and rendered them in-app. That PR stripped the `[obs N]` markers from the Slack delivery, since Slack had no observation deep-link to resolve them to. This PR closes that gap so the Slack summary has the same citations as the in-app view.

## Changes

- The Slack pass now resolves each `[obs N]` marker into a Slack `<url|obs N>` link to that observation, instead of stripping it.
- Links are built after `strip_external_links_markdown` has run over the report, so the observation URLs are added last and never defanged. The Slack `<url|label>` form also survives the truncation re-sanitization (its lookbehinds skip a URL preceded by `<`).
- A citation that doesn't resolve to a real observation (out of range, or a model invention) is dropped rather than emitted as a dead label or a link to the wrong recording.

> [!NOTE]
> The canonical `synthesized_markdown` still carries the raw `[obs N]` markers. Only the derived Slack payload gets absolute links, so the in-app renderer (which resolves markers to SPA links itself) is unchanged.

## How did you test this code?

No database or frontend toolchain in this environment, so I (Claude) could not run the suite locally. CI runs it. Test changes in `test_vision_action_synthesis.py`:

- Converted the PR1 "Slack drops citations" test into "Slack renders citations as `<url|obs N>` links", asserting the exact observation URL.
- Added a case that an out-of-range `[obs 9]` is dropped from the Slack payload (no dead label, no misdirected link).
- Updated the three existing `_markdown_to_slack` unit tests for the new keyword args.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim (kim@posthog.com) directed this work; authored by Claude (PostHog Code). Left unassigned because I couldn't verify Kim's GitHub handle this session.

This is the Slack half of a two-PR stack the user asked for (in-app first, Slack stacked on top). Design note: I resolve markers per-surface rather than baking URLs into the stored report, because the report passes through `strip_external_links_markdown`, which flattens relative links and only keeps `*.posthog.com` absolute links. Building the Slack links last, after that pass, keeps them intact for self-hosted domains too.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
