### PR TITLE
fix(cymbal): correct symbol store cache accounting

### DIFF
--- a/rust/cymbal/src/core/symbolication/symbol_store/caching.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/caching.rs
@@ -55,11 +55,8 @@ where
         drop(cache);
 
         // Do the fetch, not holding the lock across it to allow
-        // concurrent fetches to occur (de-duping fetches is
-        // up to the caller of `lookup`, since relying on the
-        // cache to do it means assuming the caching layer is
-        // the outer layer, which is not something the interface
-        // guarentees)
+        // concurrent fetches to occur. De-duping fetches is handled by the
+        // `AtMostOne` provider wrapper in the production catalog.
         let found = self.inner.fetch(team_id, r).await?;
         let parsed = self.inner.parse(found).await?;
         let bytes = parsed.byte_count();
@@ -97,6 +94,9 @@ impl SymbolSetCache {
     where
         T: Any + Send + Sync,
     {
+        if let Some(old) = self.cached.remove(&key) {
+            self.held_bytes = self.held_bytes.saturating_sub(old.bytes);
+        }
         self.held_bytes += bytes;
         self.cached.insert(
             key,
@@ -178,11 +178,10 @@ mod tests {
         sync::Arc,
     };
 
-    use async_trait::async_trait;
-    use reqwest::Url;
-
     use super::*;
     use crate::symbolication::symbol_store::chunk_id::OrChunkId;
+    use async_trait::async_trait;
+    use reqwest::Url;
 
     struct FakeProvider {
         fetches: Arc<AtomicUsize>,
@@ -240,5 +239,16 @@ mod tests {
         assert_eq!(both.as_ref(), b"both");
         assert_eq!(chunk_only.as_ref(), b"chunk-id");
         assert_eq!(fetches.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn replacing_cache_entry_keeps_held_bytes_accurate() {
+        let mut cache = SymbolSetCache::new(10);
+
+        cache.insert("key".to_string(), Arc::new(vec![0; 6]), 6);
+        cache.insert("key".to_string(), Arc::new(vec![0; 6]), 6);
+
+        assert_eq!(cache.held_bytes, 6);
+        assert_eq!(cache.cached.len(), 1);
     }
 }


### PR DESCRIPTION
## Problem

The symbol-store cache can over-count memory when an insert replaces an existing cache entry. That inflated `held_bytes` value can trigger unnecessary evictions and lower cache hit rates.

## Changes

- Subtract an existing entry's byte count before replacing it in `SymbolSetCache::insert`.
- Add a regression test that catches duplicate insert accounting drift.

## How did you test this code?

- `cargo fmt -p cymbal`
- `cargo test -p cymbal symbolication::symbol_store::caching`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. Internal cache behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the `pr` skill and the pi coding agent tools to inspect, edit, test, commit, push, and open this draft PR. The change was driven by follow-up production observations that symbol-store cache misses and evictions remained high after Cymbal routing improvements.

I initially considered adding cache-layer singleflight, but the production catalog already wraps cache providers with `AtMostOne`, which serializes same-key lookups before they reach the cache. This PR keeps the narrower accounting fix.
