### PR TITLE
fix(tasks): stop infra log lines resetting the run inactivity timeout

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1738,6 +1738,24 @@ def set_task_run_output(
     return _task_run_detail_to_dto(run)
 
 
+def _entries_show_agent_activity(entries: list[dict]) -> bool:
+    """Only ACP `session/*` notifications count as the agent doing work.
+
+    Infra lines (`_posthog/console`, credential-refresh notices, errors) must not
+    reset the workflow's inactivity timeout: the workflow's own 20-minute credential
+    refresh makes the sandbox log a line, so treating every entry as agent activity
+    lets a run whose agent went silent keep itself alive forever.
+    """
+    for entry in entries:
+        notification = entry.get("notification")
+        if not isinstance(notification, dict):
+            continue
+        method = notification.get("method")
+        if isinstance(method, str) and method.startswith("session/"):
+            return True
+    return False
+
+
 def append_task_run_log(
     run_id: str | UUID, task_id: str | UUID, team_id: int, *, entries: list[dict]
 ) -> contracts.TaskRunDetailDTO | None:
@@ -1746,7 +1764,7 @@ def append_task_run_log(
     if run is None:
         return None
     run.append_log(entries)
-    run.heartbeat_workflow(agent_active=True)
+    run.heartbeat_workflow(agent_active=_entries_show_agent_activity(entries))
     return _task_run_detail_to_dto(run)
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4263,7 +4263,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         response = self.client.post(
             f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/append_log/",
-            {"entries": [{"type": "info", "message": "hello"}]},
+            {"entries": [{"type": "info", "message": "hello", "notification": {"method": "session/update"}}]},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -2,7 +2,7 @@ import importlib
 from datetime import timedelta
 from typing import ClassVar
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone as django_timezone
@@ -450,3 +450,43 @@ class TestFacadeReadsAndMappers(TestCase):
         # The agent server boots idle; forward_pending_user_message only kicks it off if the run state
         # carries the prompt. Without this the cloud wizard stalls right after "Started agent".
         self.assertEqual(run.state.get("pending_user_message"), WIZARD_PR_AGENT_PROMPT)
+
+
+class TestAppendLogAgentActivity(TestCase):
+    # Guards the zombie-run regression: infra log lines (credential refresh -> _posthog/console)
+    # heartbeating with agent_active=True reset the workflow's inactivity timeout every 20
+    # minutes, so a run whose agent went silent could never time out.
+    @parameterized.expand(
+        [
+            ("session_update", [{"notification": {"method": "session/update", "params": {}}}], True),
+            ("session_request", [{"notification": {"method": "session/request_permission", "params": {}}}], True),
+            ("console_only", [{"notification": {"method": "_posthog/console", "params": {"message": "x"}}}], False),
+            ("error_only", [{"notification": {"method": "_posthog/error", "params": {}}}], False),
+            ("no_notification", [{"message": "plain infra line"}], False),
+            ("malformed_notification", [{"notification": "not-a-dict"}], False),
+            (
+                "mixed_infra_and_session",
+                [
+                    {"notification": {"method": "_posthog/console", "params": {}}},
+                    {"notification": {"method": "session/update", "params": {}}},
+                ],
+                True,
+            ),
+        ]
+    )
+    def test_entries_show_agent_activity(self, _name, entries, expected):
+        self.assertIs(facade._entries_show_agent_activity(entries), expected)
+
+    def test_append_task_run_log_heartbeats_with_classified_activity(self):
+        run = MagicMock()
+        with (
+            patch.object(facade, "_get_visible_run", return_value=run),
+            patch.object(facade, "_task_run_detail_to_dto", return_value=None),
+        ):
+            facade.append_task_run_log(
+                "r", "t", 1, entries=[{"notification": {"method": "_posthog/console", "params": {}}}]
+            )
+            run.heartbeat_workflow.assert_called_once_with(agent_active=False)
+            run.reset_mock()
+            facade.append_task_run_log("r", "t", 1, entries=[{"notification": {"method": "session/update"}}])
+            run.heartbeat_workflow.assert_called_once_with(agent_active=True)


### PR DESCRIPTION
## Problem

Task runs whose agent goes silent can keep themselves alive forever, never reaching a terminal state. Every wizard cloud run queued today (18/18) is in this state: hours old, no agent output, no timeout.

The loop: `append_task_run_log` heartbeats the workflow with `agent_active=True` for **any** log entry the sandbox posts. The workflow's own credential refresher runs every 20 minutes and makes the sandbox emit an infra log line, which arrives via `append_log` and resets the 1-hour inactivity timeout. Refresh -> log -> "agent active" -> timer reset -> refresh. Production web logs show the two aligned within seconds, every 20 minutes, for 3+ hours per run.

## Changes

`append_task_run_log` now classifies the entries before heartbeating: only ACP `session/*` notifications (agent messages, tool calls, permission requests, usage updates) count as agent activity. Infra lines (`_posthog/console`, plain log dicts, `_posthog/error`) still get appended to the S3 log but heartbeat with `agent_active=False`, which the workflow signal ignores — so the inactivity timeout can actually fire.

> [!NOTE]
> This restores the timeout safety net; it does not fix why the post-wizard agent produces no output in the first place (tracked separately). With this change those runs fail after the 1h inactivity window instead of hanging forever.

## How did you test this code?

New tests in `test_facade.py`: a parameterized suite over `_entries_show_agent_activity` (session vs console vs error vs malformed vs mixed entries) plus one wiring test asserting `append_task_run_log` passes the classification into `heartbeat_workflow`. The wiring test fails against the old unconditional `agent_active=True`. All 8 pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored with Claude Code during a production investigation into wizard cloud runs never completing: correlated per-run Temporal activity events, worker logs, and web-tier `append_log` requests to identify the self-sustaining heartbeat loop, then confirmed the unconditional `agent_active=True` in the facade. Invoked /writing-tests before adding tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)