### PR TITLE
fix(aio): route default client ai events at all stage

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -9,6 +9,7 @@ from asgiref.sync import async_to_sync
 from posthoganalytics.client import Client
 
 from posthog.git import get_git_branch, get_git_commit_short
+from posthog.ph_client import enable_dedicated_ai_endpoint_for_default_client
 from posthog.utils import (
     _build_flag_provider,
     get_available_timezones_with_offsets,
@@ -125,6 +126,10 @@ class PostHogConfig(AppConfig):
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:
             posthoganalytics.load_feature_flags()
+
+        # The feature_flag_definitions() call above constructs the default client, so
+        # the dedicated-AI-endpoint flag can only be applied from this point on.
+        enable_dedicated_ai_endpoint_for_default_client()
 
         from posthog.async_migrations.setup import setup_async_migrations
 

--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -31,6 +31,27 @@ def _use_dedicated_ai_endpoint(caller_stage: DedicatedAIEndpointRollout) -> bool
     return _DEDICATED_AI_ENDPOINT_STAGES.index(rollout) >= _DEDICATED_AI_ENDPOINT_STAGES.index(caller_stage)
 
 
+def enable_dedicated_ai_endpoint_for_default_client() -> None:
+    """Route the module-level default client's `$ai_*` events to the dedicated AI
+    endpoint at the `all` rollout stage.
+
+    Deliberate workaround: the SDK's lazy `setup()` doesn't accept
+    `_dedicated_ai_endpoint`, and we want to finish testing the endpoint on our own
+    traffic before rethinking the flag as a public option threaded through the
+    SDK's normal construction paths. Mutating the constructed client is safe: it
+    and its consumers read the flag per batch, and the SDK's post-fork consumer
+    rebuild copies it from the old consumers.
+    """
+    if not _use_dedicated_ai_endpoint(DedicatedAIEndpointRollout.ALL):
+        return
+    client = posthoganalytics.default_client
+    if client is None:
+        return
+    client._dedicated_ai_endpoint = True
+    for consumer in client.consumers or []:
+        consumer.dedicated_ai_endpoint = True
+
+
 def feature_enabled_or_false(
     key: str,
     distinct_id: Number | str | UUID | int,

--- a/posthog/test/test_ph_client.py
+++ b/posthog/test/test_ph_client.py
@@ -1,8 +1,10 @@
 from django.test import SimpleTestCase, override_settings
 
+import posthoganalytics
 from parameterized import parameterized
+from posthoganalytics import Posthog
 
-from posthog.ph_client import get_client
+from posthog.ph_client import enable_dedicated_ai_endpoint_for_default_client, get_client
 from posthog.settings.ingestion import (
     DedicatedAIEndpointRollout as Rollout,
     _parse_dedicated_ai_rollout,
@@ -44,3 +46,24 @@ class TestDedicatedAIEndpointRollout(SimpleTestCase):
     )
     def test_parse_rollout_falls_back_to_off_on_invalid(self, value, expected):
         self.assertEqual(_parse_dedicated_ai_rollout(value), expected)
+
+    @parameterized.expand(
+        [
+            (Rollout.OFF, False),
+            (Rollout.RUNNER, False),
+            (Rollout.ALL, True),
+        ]
+    )
+    def test_default_client_routes_ai_events_only_at_full_rollout(self, rollout, expected):
+        client = Posthog("test-key", send=False, enable_local_evaluation=False)
+        original = posthoganalytics.default_client
+        posthoganalytics.default_client = client  # ty: ignore[invalid-assignment]
+        try:
+            with override_settings(POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT=rollout):
+                enable_dedicated_ai_endpoint_for_default_client()
+        finally:
+            posthoganalytics.default_client = original
+        self.assertEqual(client._dedicated_ai_endpoint, expected)
+        self.assertTrue(client.consumers)
+        for consumer in client.consumers:
+            self.assertEqual(consumer.dedicated_ai_endpoint, expected)


### PR DESCRIPTION
## Problem

The `all` stage of `POSTHOG_DEDICATED_AI_ENDPOINT_ROLLOUT` (#68917) doesn't do what it promises. The original PR deferred `default_client` because the SDK's lazy `setup()` doesn't accept the `_dedicated_ai_endpoint` kwarg, on the mistaken assumption the remaining emitters would go through `get_client`.

This is a fix to changes that we own and that had already been approved, just makes it work as expected.

## Changes

- Add `enable_dedicated_ai_endpoint_for_default_client()` to `posthog/ph_client.py`: at the `all` stage, flips `_dedicated_ai_endpoint` on the already-constructed default client and its consumers. The SDK reads the flag per batch (and its post-fork consumer rebuild copies it from the old consumers), so post-construction mutation is safe and reaches every process.
- Call it in `PostHogConfig.ready()` right after the `feature_flag_definitions()` check, which is what constructs the default client, so the flag lands in web, celery, and temporal processes alike.

## How did you test this code?

I (Claude, via PostHog Code) added 3 parameterized cases to the existing `posthog/test/test_ph_client.py` (no DB, `SimpleTestCase`): they pin that the default client and its consumers are flipped only at the `all` stage — guarding the exact regression we just shipped, where `all` silently routed nothing. No existing test covered the `default_client` path. Ran the file locally (15 passed, 0.7s) plus `ruff` and `hogli ci:preflight --strict` on push. I did not run the full CI suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. Internal analytics routing only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus) via PostHog Code, directed by Carlos. Invoked `/writing-tests` before adding the test cases.

Context: after advancing the charts rollout to `all`, Grafana showed no step-up on capture-ai. Investigation traced it to this gap: `setup()` doesn't thread the kwarg, so #68917 scoped the gate to `get_client` and stated "product wrappers that use `default_client` are out of scope" — contradicting the same PR's goal of switching "all of them", since all non-runner AI emitters use `default_client`.

Key decisions:
- Mutate the constructed client instead of eagerly building one with the kwarg: replicating `setup()`'s ~20 constructor kwargs in our code would silently drift from the SDK. Verified against the pinned SDK (7.20.4) that the client checks `_dedicated_ai_endpoint` per enqueue (sync path), consumers check `dedicated_ai_endpoint` per batch, and `_reinit_after_fork` preserves the flag, so the mutation holds everywhere.
- Placed the call after the flag-definitions check in `ready()` because that call is what lazily constructs the default client; earlier would be a no-op on `None`. Where the client stays unconstructed (disabled/test/local dev), the helper no-ops and the rollout setting defaults to `off` anyway.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
