### PR TITLE
chore(cymbal): improve native profiling stacks

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -37,9 +37,10 @@
 - image: cymbal
   dockerfile: ./rust/Dockerfile
   project: 8dq0xkk0ck
-  # Frame pointers so the eBPF profiler can walk cymbal's native stacks on
-  # aarch64 (see EXTRA_RUSTFLAGS in rust/Dockerfile).
-  extra_rustflags: -C force-frame-pointers=yes
+  # Frame pointers and unwind tables so the profiler can walk Cymbal stacks on
+  # aarch64, including native dependency frames (see rust/Dockerfile).
+  extra_rustflags: -C force-frame-pointers=yes -C force-unwind-tables=yes
+  extra_cflags: -fno-omit-frame-pointer -fasynchronous-unwind-tables
 
 - image: embedding-worker
   dockerfile: ./rust/Dockerfile

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -172,6 +172,7 @@ jobs:
                       BIN=${{ matrix.bin || matrix.image }}
                       BUILD_FEATURES=${{ matrix.features || '' }}
                       EXTRA_RUSTFLAGS=${{ matrix.extra_rustflags || '' }}
+                      EXTRA_CFLAGS=${{ matrix.extra_cflags || '' }}
                       SCCACHE_WEBDAV_KEY_PREFIX=${{ steps.sccache.outputs.cache-key-prefix }}
                   secrets: |
                       SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -18,14 +18,15 @@ WORKDIR /app
 ARG BIN
 ARG BUILD_FEATURES=""
 ARG SCCACHE_WEBDAV_KEY_PREFIX
-# Extra rustc flags for specific images, set per-image in
-# .github/rust-images.yml (e.g. cymbal passes -C force-frame-pointers=yes so
-# the eBPF profiler can walk its native stacks on aarch64). Guarded exports
-# below because the RUSTFLAGS env var replaces [build].rustflags from
-# .cargo/config.toml entirely (no merging): when extra flags are set the
-# export re-adds --cfg tokio_unstable, and when unset RUSTFLAGS stays unset so
-# .cargo/config.toml keeps applying.
+# Extra compiler flags for specific images, set per-image in
+# .github/rust-images.yml. Cymbal opts into frame pointers and unwind tables so
+# the profiler can walk Rust and native dependency stacks on aarch64.
+# Guarded RUSTFLAGS exports below because the RUSTFLAGS env var replaces
+# [build].rustflags from .cargo/config.toml entirely (no merging): when extra
+# flags are set the export re-adds --cfg tokio_unstable, and when unset
+# RUSTFLAGS stays unset so .cargo/config.toml keeps applying.
 ARG EXTRA_RUSTFLAGS=""
+ARG EXTRA_CFLAGS=""
 ENV PROTO_ROOT=../proto SCCACHE_WEBDAV_KEY_PREFIX=${SCCACHE_WEBDAV_KEY_PREFIX}
 
 # Ensure working C compile setup (not installed by default in arm64 images)
@@ -39,6 +40,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
     if [ -n "$EXTRA_RUSTFLAGS" ]; then export RUSTFLAGS="--cfg tokio_unstable $EXTRA_RUSTFLAGS"; fi && \
+    if [ -n "$EXTRA_CFLAGS" ]; then export CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CFLAGS" AWS_LC_SYS_CFLAGS="$EXTRA_CFLAGS"; fi && \
     cargo chef cook --release --recipe-path recipe.json --bin $BIN ${BUILD_FEATURES:+--features $BUILD_FEATURES} && \
     sccache --show-stats
 
@@ -54,6 +56,7 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
     fi && \
     SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
     if [ -n "$EXTRA_RUSTFLAGS" ]; then export RUSTFLAGS="--cfg tokio_unstable $EXTRA_RUSTFLAGS"; fi && \
+    if [ -n "$EXTRA_CFLAGS" ]; then export CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CFLAGS" AWS_LC_SYS_CFLAGS="$EXTRA_CFLAGS"; fi && \
     cargo build --release --bin $BIN ${BUILD_FEATURES:+--features $BUILD_FEATURES} && \
     sccache --show-stats
 


### PR DESCRIPTION
## Problem

Cymbal release builds already emit Rust line tables and frame pointers, but native dependency frames can still be hard for continuous profilers to unwind. That makes CPU profiles less useful when samples land inside C or assembly-heavy dependencies.

The immediate motivation is `cymbal-resolution`: recent production profiles for the resolution mode showed most CPU samples collapsing into `[unknown]`, with the visible named samples concentrated in native crypto/TLS routines. `cymbal-resolution` runs from the same `cymbal` image, so improving Cymbal's native unwindability should make those profiles more actionable.

The goal is not just prettier flamegraphs. We need to separate "crypto is hot" from "what is causing crypto to be hot". Better stacks should tell us whether the CPU is coming from Postgres, S3, symbol parsing, cache misses, or connection setup.

## Changes

- Add an optional `EXTRA_CFLAGS` build arg to the shared Rust Dockerfile.
- Pass that arg from the Rust image matrix.
- Configure the Cymbal image to build native C/C++ dependencies with frame pointers and asynchronous unwind tables.
- Add Rust unwind tables to Cymbal's existing release `RUSTFLAGS`.

This is intentionally scoped to the Cymbal image. It should not affect other Rust service images. Runtime image size should only increase by the extra unwind/frame metadata in the copied release binary, not by source files or build artifacts. The existing line-table DWARF setting is already present and is the larger profiling-size contributor.

Expected follow-up insights after this deploy:

- If stacks point at `sqlx` / Postgres below TLS frames, focus on symbol-set DB lookup volume, batching, or connection behavior.
- If stacks point at AWS SDK / S3 below TLS frames, focus on S3 fetch rate, object-cache behavior, and HTTP keepalive.
- If stacks point at parsing/decompression after cache misses, focus on symbol-store cache size, admission, and routing locality.
- If stacks show repeated connect/handshake paths, focus on client pooling and keepalive rather than cache policy.
- If stacks remain mostly native crypto with no actionable caller attribution, investigate profiler mode or `aws-lc` assembly unwind metadata next.

## How did you test this code?

- Parsed `.github/rust-images.yml` and `.github/workflows/_rust-build-images.yml` with Ruby's YAML parser.
- I could not run `actionlint` in this environment because it is not installed.
- I did not run a full Docker image build locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. Internal build/profiling behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent tools to inspect the existing Rust image build path and make a targeted Dockerfile and image-matrix change. Skills consulted: `gating-production-deploys`, `depot-container-builds`, and `pr`.

The existing Rust build already had line-table DWARF and Cymbal Rust frame pointers. This PR keeps that setup and extends it to native dependency builds through C/C++ flags, without changing other Rust images. It complements the native symbol upload work in #69117, which targets Error tracking symbolication rather than profiler unwinding.
