### PR TITLE
chore(metrics): sync internal design docs with shipped state

### DIFF
--- a/docs/internal/metrics/dashboard-mvp.md
+++ b/docs/internal/metrics/dashboard-mvp.md
@@ -1,7 +1,9 @@
 # Metrics Dashboard MVP — Replacing the Grafana logs.json inside PostHog
 
-**Status:** design — owners @daniel-v, #team-apm (@jonmcwest, @frankh).
-**Sibling docs:** [`docs/internal/prom-compat/design.md`](../prom-compat/design.md) (read plane for Prometheus ecosystem — out of scope here).
+**Status:** designed 2026-06-11; synced with shipped state 2026-07-08. Owners @daniel-v, #team-apm (@jonmcwest, @frankh).
+Phases 0-2 and the viewer (P8) have shipped. The infra bridge shipped in a different shape than planned (see Phase 1 outcome below).
+The dashboard-integration phase (P10+) is superseded: the dashboards platform now disallows chart-primary widget types, so metrics tiles will ship as insight tiles instead (see Phase 3).
+**Sibling docs:** the Prometheus-ecosystem read plane (Track A) is a separate stack outside this repo, out of scope here.
 
 ## Why
 
@@ -9,7 +11,7 @@ The cluster's `logs.json` Grafana dashboard (≈60 panels, source: `PostHog/graf
 We already store metrics natively in `metrics1` on the logs ClickHouse cluster.
 This doc scopes the work to render that exact dashboard inside PostHog (`/dashboard/...`) against `posthog.metrics`, so on-call can leave Grafana behind.
 
-Native PostHog Metrics stays the user-facing product. The Prometheus-ecosystem read plane (`services/prom-compat/`, Track A) is a separate stack reading the same storage.
+Native PostHog Metrics stays the user-facing product. The Prometheus-ecosystem read plane (prom-compat, Track A) is a separate stack outside this repo, reading the same storage.
 
 ## Non-goals (deliberately deferred)
 
@@ -24,39 +26,41 @@ Native PostHog Metrics stays the user-facing product. The Prometheus-ecosystem r
 **Ingest data plane** — shipped or in-flight:
 
 - `rust/capture-logs/`: OTLP/HTTP receiver at `/v1/metrics` (and `/i/v1/metrics`), JSON or protobuf, writes to Kafka. `rust/capture-logs/src/main.rs:154-160`, `src/service.rs:703-820`.
-- `nodejs/src/metrics-ingestion/metrics-ingestion-consumer.ts`: drains Kafka into ClickHouse with quota + ratelimit (`MetricsRateLimiterService`).
+- `nodejs/src/ingestion/pipelines/metrics/metrics-ingestion-consumer.ts`: drains Kafka into ClickHouse with quota + ratelimit (`MetricsRateLimiterService`).
 - ClickHouse `metrics1` table (OTel-shaped, gauge / sum / histogram / exp-histogram / summary), MVs into `metric_attributes`. `posthog/clickhouse/metrics/metrics1.py`. Registered in `posthog/clickhouse/schema.py:332-333`.
-- `charts` (in-flight `daniel/metrics-prod-rollout`): WarpStream metrics cluster + `kafka.metricsBrokers` on capture-logs + `/i/v1/metrics` Contour ingress + `metrics-ingestion` deployment, prod-us + prod-eu.
+- `charts`: WarpStream metrics cluster + `kafka.metricsBrokers` on capture-logs + `/i/v1/metrics` Contour ingress + `metrics-ingestion`, live in prod-us + prod-eu (charts#11702, merged 2026-06-03).
 - `posthog-cloud-infra`#8321/8322/8415/8434/8489 (merged): Kafka topics + S3 bucket + IRSA + CH named collection + Postgres app user.
 - `argocd/otel-collector/` (daemonset, already deployed): an existing OTel Collector with `prometheus` + `otlp` receivers and a `metrics` pipeline whose exporter today is `debug`.
 
-**Product surface — alpha (gated by `FEATURE_FLAGS.METRICS`):**
+**Product surface — alpha (gated by `FEATURE_FLAGS.METRICS`), as shipped:**
 
-- `products/metrics/backend/facade/api.py`: `team_has_metrics(team)`, `query_metric(team, metric_name, aggregation, date_from, date_to)`, `list_metric_names(team, search, limit)`.
-- `products/metrics/backend/metric_query_runner.py`: single-metric runner, aggregations `sum | avg | count | p95`, auto-bucketed to ~60 points.
-- `products/metrics/frontend/MetricsScene.tsx`: Viewer tab (single-metric) + HogQL SQL editor over `posthog.metrics`.
+- `products/metrics/backend/facade/api.py`: `team_has_metrics`, `run_metric_query` (multi-clause + server-side formula), `list_metric_names`, `list_metric_event_samples`, `characterize_metric_anomaly`, `investigate`. Contracts in `facade/contracts.py`, wire shape `[{labels, points}]`.
+- `products/metrics/backend/metric_query_runner.py`: label filters with `resource | attribute | auto` scope, group-by on a shared interval grid, aggregations `sum | avg | count | p95 | rate | increase | histogram_quantile` (temporality-aware, counter-reset clamped), auto-bucketed to ~60 points.
+- `products/metrics/frontend/MetricsScene.tsx`: multi-series Viewer (chart + stat modes, filters, group-by) + HogQL SQL editor over `posthog.metrics`. No formula input in the Viewer yet (backend `formula.py` shipped, UI did not).
+- MCP tools in `products/metrics/mcp/tools.yaml`: `query-metrics`, `metric-names-list`, `characterize-metric-anomaly` (the original "MCP is a follow-on" note below is obsolete).
+- Events model for drill-down: `metric_samples` / `metric_series` split with ingest-assigned series fingerprints, live in prod both regions since 2026-07-02.
 
-## Gap to close
+## Gap to close (status as of 2026-07-08)
 
-|                       | Today                            | Target                                                                               |
-| --------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |
-| Filters               | none (metric name + agg only)    | label / attribute predicates with explicit scope (`resource` / `attribute` / `auto`) |
-| Group-by              | none                             | shared interval grid, multi-series response                                          |
-| Aggregations          | sum / avg / count / p95          | + `rate`, `increase`, `histogram_quantile`                                           |
-| Multi-metric          | one clause                       | N clauses + server-side HogQL formula                                                |
-| Storage seam          | direct `attributes_map_str[...]` | `attribute_field(name)` helper used everywhere                                       |
-| Wire shape            | `[{time, value}]`                | `[{labels, points}]` — stable from PR2                                               |
-| Dashboard widget      | none                             | `metric_timeseries` widget type                                                      |
-| Dashboard variables   | n/a                              | dashboard filters propagate into widget config                                       |
-| Annotations           | n/a                              | PostHog Annotations render as vertical lines on metric widgets                       |
-| Scraped infra metrics | not flowing                      | existing collector's metrics pipeline exports to capture-logs                        |
-| MCP                   | none                             | follow-on, not in this MVP                                                           |
+|                       | Status | Notes                                                                                      |
+| --------------------- | ------ | ------------------------------------------------------------------------------------------ |
+| Filters               | ✅     | label / attribute predicates with explicit scope (`resource` / `attribute` / `auto`)       |
+| Group-by              | ✅     | shared interval grid, multi-series response                                                |
+| Aggregations          | ✅     | `rate`, `increase`, `histogram_quantile` shipped alongside sum / avg / count / p95         |
+| Multi-metric          | ✅     | N clauses + server-side formula (`backend/formula.py`); no formula input in the Viewer yet |
+| Storage seam          | ✅     | `attribute_field(name)` helper used everywhere                                             |
+| Wire shape            | ✅     | `[{labels, points}]`                                                                       |
+| Dashboard tiles       | ❌     | superseded plan: insight tiles via a `MetricsQuery` node kind, not a widget (see Phase 3)  |
+| Dashboard variables   | ❌     | dashboard filters propagate into metric insight tiles                                      |
+| Annotations           | ❌     | PostHog Annotations render as vertical lines on metric charts                              |
+| Scraped infra metrics | ✅     | via the dedicated `metrics-bridge` scrape collector, dev + prod (see Phase 1 outcome)      |
+| MCP                   | ✅     | `query-metrics`, `metric-names-list`, `characterize-metric-anomaly`                        |
 
 ## Architecture (target)
 
 ```text
 [ envoy /stats/prometheus       ]                  [ posthog services /metrics ]
-[ kminion /metrics              ]   ──scrape──>    [ otel-collector daemonset  ]   ──OTLP/HTTP──>   capture-logs /i/v1/metrics
+[ kminion /metrics              ]   ──scrape──>    [ metrics-bridge collector  ]   ──OTLP/HTTP──>   capture-logs /i/v1/metrics
 [ kube-state-metrics, cadvisor  ]                  [ prometheus receiver       ]                            │
 [ node-exporter                 ]                  [ otlphttp/posthog exporter ]                            │
                                                                                                             ▼
@@ -99,6 +103,8 @@ Twenty-three PRs, each <400 LOC including tests. Each is a separate `gt create` 
 | **INFRA-D** | charts  | Replicate INFRA-A + INFRA-C to `values.prod-us.yaml` and `values.prod-eu.yaml`.                                                                                                                                                                                                                                                                                                                                                                         | Lands after `daniel/metrics-prod-rollout` merges and CH `metrics1` is applied in prod. |
 | **INFRA-E** | charts  | Broaden scrape config to the remaining targets the full dashboard needs (`capture-logs`, `logs-ingestion`, `metrics-ingestion` `/metrics` endpoints once SDK side is verified).                                                                                                                                                                                                                                                                         | Gates on P9 (UI can render) so we can sanity-check live.                               |
 
+**Phase 1 outcome (what actually shipped).** The plan above (extend the shared otel-collector daemonset with a remote-write bridge) failed twice in dev: the daemonset image predated the `prometheusremotewrite` receiver, and vmagent speaks Remote Write 1.0 while the receiver only accepts 2.0, a hard protocol incompatibility. charts#11808 was reverted (#12233) and its follow-ups closed. The replacement is a dedicated single-replica **`metrics-bridge`** scrape collector (prometheus receiver, annotation-discovered targets, OTLP export to capture-logs): charts#12239 (dev, merged 2026-06-17), charts#12440 (prod-us + prod-eu, merged 2026-06-25), charts#12493 (scrape memory bound). **INFRA-B (internal-infra quota exemption) was never implemented** and remains an open decision; `MetricsRateLimiterService` has no exemption path today.
+
 ### Phase 2 — Query layer (PostHog repo)
 
 | #      | Repo    | PR                                                                                                                                                                              | Notes                                                                        |
@@ -111,6 +117,9 @@ Twenty-three PRs, each <400 LOC including tests. Each is a separate `gt create` 
 
 ### Phase 3 — Viewer + widget (PostHog repo)
 
+> **Status:** P8 shipped (multi-series chart + label filters + group-by; also a stat mode with anomaly baseline). P9 is half-shipped: the group-by selector exists, the formula expression input does not.
+> **P10-P13 are superseded as written.** The dashboards platform now forbids chart-primary widget types (`products/dashboards/CONTRIBUTING.md`: charts/trends on a dashboard go on insight tiles, widgets are for product-native lists). See "Phase 3 (revised)" below; the original rows are kept for the record.
+
 | #       | Repo    | PR                                                                                                                                                                                                              | Notes                                                                                              |
 | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | **P8**  | posthog | `MetricsViewer` — multi-series chart rendering, label-filter UI (consumes the P2 contract).                                                                                                                     | First UI delivery — every later UI consumes the same code path.                                    |
@@ -119,6 +128,17 @@ Twenty-three PRs, each <400 LOC including tests. Each is a separate `gt create` 
 | **P11** | posthog | `metric_timeseries` widget frontend — WidgetCard + catalog entry + config form.                                                                                                                                 | Widget lives in dashboards UI.                                                                     |
 | **P12** | posthog | Dashboard variables / filters → metric widget filter injection (`$service`-equivalent).                                                                                                                         | Replicates the Grafana variable UX.                                                                |
 | **P13** | posthog | PostHog Annotations rendered as vertical lines on metric widgets.                                                                                                                                               | Replaces Grafana's "Deploys" annotation.                                                           |
+
+### Phase 3 (revised) — metrics on dashboards as insight tiles
+
+The widget path is closed, and the insight path is both sanctioned and cheaper: insights get dashboards, per-tile filter overrides, refresh/caching, sharing, subscriptions, and the alerts product for free. Precedent: logs registered `NodeKind.LogsQuery` + a runner in `posthog/hogql_queries/query_runner.py`, making it renderable through the generic `Query` component.
+
+| #        | PR                                                                                                                                                                    | Notes                                                                                               |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **P10r** | `MetricsQuery` node kind in the schema; runner delegates to the existing `run_metric_query` facade (no new facade method).                                            | Same "no new facade method" rule as the original P10.                                               |
+| **P11r** | `Query.tsx` dispatch branch rendering the existing `MetricsViewer` chart components; "Save as insight" from the Viewer; insight lands on dashboards as a normal tile. | Interim escape hatch already works today: SQL-tab HogQL saved as a `DataVisualizationNode` insight. |
+| **P12r** | Dashboard variables / filters propagate into `MetricsQuery` tiles (the `$service` equivalent).                                                                        | Today HogQL insight variables only bind to SQL tiles.                                               |
+| **P13r** | PostHog Annotations rendered as vertical lines on metric charts.                                                                                                      | The `AnnotationsOverlay` currently wires into Trends rendering only.                                |
 
 ### Out of stack (separate plans)
 
@@ -132,18 +152,18 @@ Twenty-three PRs, each <400 LOC including tests. Each is a separate `gt create` 
 1. **P0 + P1 land before any infra PR.** Real data should not hit `metrics1` at scale before the storage seam (`attribute_field`) and the contract dataclasses are merged — once data exists, you can't undo it cheaply.
 2. **INFRA-A..C land between P2 and P3.** P3+ tests run against dev `metrics1` with real OTLP-ingested rows, not synthetic ones, to catch resource-vs-attribute bugs that fixtures miss.
 3. **INFRA-A and INFRA-E are different PRs on purpose.** Narrow scrape in dev first; broad scrape only after the query layer can handle it. Resist the temptation to merge them "to save a PR" — that's how storage bloats 5-10× before the schema rewrite lands.
-4. **Widget PRs (P10+) must not introduce any new facade method.** If you reach for one, the gap is in the viewer's exercise of the contract — go fix it in P3-P9.
+4. **Dashboard-tile PRs (P10r+) must not introduce any new facade method.** If you reach for one, the gap is in the viewer's exercise of the contract — go fix it in P3-P9.
 
 ## Local verification path
 
-`hogli dev:setup` → select **`metrics`** intent (`devenv/intent-map.yaml:99-101`). This boots `capture-logs`, `ingestion-metrics`, and the dependencies. `metrics1` is created by the standard CH bootstrap.
+`hogli dev:setup` → select **`metrics`** intent (`devenv/intent-map.yaml`). This boots `capture-logs`, `ingestion-metrics`, and the dependencies. `metrics1` is created by the standard CH bootstrap. `bin/verify-metrics-pipe` checks end-to-end arrival.
 
 Per-PR sanity checks:
 
 - **P0–P2**: `hogli test products/metrics/backend/tests/` + `curl POST /api/projects/2/metrics/query` (new shape). HogQL SQL tab in `/metrics` works against `posthog.metrics` from day one.
 - **P3–P7**: curl + JSON. UI does not show new features until P8/P9.
 - **P8+**: browser at `/metrics` (alpha flag on).
-- **P11+**: browser at `/dashboard/...` — add a `metric_timeseries` tile.
+- **P11r+**: browser at `/dashboard/...` — save a Viewer query as an insight and add it as a tile.
 
 Seeder script for ad-hoc dev data (no PRs needed):
 
@@ -168,8 +188,8 @@ FROM numbers(3600)"
 - Scraping the whole namespace → INFRA-A scopes to the exact targets the dashboard needs.
 - Cumulative vs delta confusion → `aggregation_temporality` checked in P5 before applying `runningDifference`.
 
-## Open decisions (need owner input)
+## Open decisions — resolved
 
-1. **Internal-infra project** — which project receives scraped cluster metrics in each environment? Recommend a dedicated `posthog-internal-infra` project with its own `team_id` so `team_has_metrics` doesn't flip on the dogfood project. Cap budget separately from customer billing.
-2. **Naming convention** — keep Prometheus `snake_case_total` for scraped metrics (preserves dashboard expressions) and use OTel dotted (`http.server.duration`) for new SDK-emitted metrics. Document; do not mix.
-3. **Token sensitivity** — existing `argocd/otel-collector/values/values.dev.yaml` exposes `Bearer sTMFPsFhdP1Ssg` in plain YAML for the traces pipeline. Confirm: that's a project public capture token, not a personal API key. Apply the same model to the new `otlphttp/posthog-metrics` exporter.
+1. **Internal-infra project** — decided against a dedicated project: scraped cluster metrics land in PostHog's internal project in each environment (local dev uses the local demo project). The quota half of this decision is still open because INFRA-B never shipped (see Phase 1 outcome).
+2. **Naming convention** — decided: keep-as-emitted. Prometheus `snake_case_total` for scraped metrics, OTel dotted names for SDK-emitted metrics; do not rewrite either.
+3. **Token sensitivity** — resolved: bridge tokens are project capture tokens, not personal API keys. Dev keeps the token inline in charts values (matching the daemonset's existing exporters); prod syncs it via external-secrets.

--- a/docs/internal/metrics/deployment-layout.md
+++ b/docs/internal/metrics/deployment-layout.md
@@ -12,7 +12,7 @@ Why this is safe and correct for a days-to-alpha timeline:
 - The streams layout is the _eventual_ target (Snuffle benchmarks ~89.5% less disk, ~31→3 bytes/sample) but it changes the ingestion write path + adds a backfill — too much risk to land under an alpha deadline.
 - The `attribute_field()` helper (P0) is the migration seam: when storage moves to streams, only that one function changes, not every query call site.
 
-**Action when we do the storage track:** model `metrics_series` keyed by a full series fingerprint — Snuffle computes it as `cityHash64(metric_name, service_name, mapSort(resource_attributes), mapSort(attributes_map_str))`. We already materialize a partial `resource_fingerprint = cityHash64(resource_attributes)` on `metrics1`; the full series identity adds metric_name + service_name + sorted data-point attributes.
+**Update (2026-07):** the series identity question is settled differently than sketched here. The `metric_series` / `metric_samples` split shipped as the events-model drill-down track (posthog#66163/#66169/#66183, live in prod both regions since 2026-07-02), and the series fingerprint is **assigned at ingest in capture-logs (SipHash-1-3, includes `metric_type`)** rather than computed in ClickHouse with cityHash64 (posthog#67195/#67196). The passthrough MVs drop rows with a NULL fingerprint. `metrics1` remains the pre-aggregated TSDB read path; its streams-table rewrite is still the deferred post-alpha track, with `attribute_field()` as the seam.
 
 ## The full data path (all environments)
 
@@ -20,63 +20,56 @@ Why this is safe and correct for a days-to-alpha timeline:
 producers ─► capture-logs /i/v1/metrics ─► Kafka (WarpStream "metrics") ─► metrics-ingestion consumer ─► ClickHouse metrics1 (logs cluster)
    │                                                                                                              │
    ├─ app SDKs (OTLP, customer traffic)                                                                           ▼
-   └─ infra/service metrics via vmagent ─► otel-collector bridge (prometheusremotewrite→OTLP)         products/metrics (HogQL) + prom-compat (PromQL)
+   └─ infra/service metrics ─► metrics-bridge scrape collector (prometheus receiver → OTLP)           products/metrics (HogQL) + prom-compat (PromQL)
 ```
 
 Two producer classes:
 
 1. **Customer OTLP** — apps push OTLP straight to `/i/v1/metrics`. Already works in every env where the ingest path is live.
-2. **Our own infra/service metrics** — vmagent already scrapes them; the otel-collector bridge (INFRA-A) fans a copy into `/i/v1/metrics`. This is the "pipe our logs services through" path.
+2. **Our own infra/service metrics** — the dedicated `metrics-bridge` collector scrapes the dashboard targets and pushes OTLP into `/i/v1/metrics`. (The original vmagent remote-write design was scrapped: vmagent only speaks Remote Write 1.0, the OTel receiver only accepts 2.0.)
 
 ## Status matrix — what exists where
 
 Legend: ✅ live · ⏳ in-flight (PR) · ➕ this stack adds it · — n/a
 
-| Layer                                                    | local             | dev               | prod-us       | prod-eu       | Where it lives                                 |
-| -------------------------------------------------------- | ----------------- | ----------------- | ------------- | ------------- | ---------------------------------------------- |
-| Kafka topics (`ingestion_metrics`, `clickhouse_metrics`) | ✅ (compose)      | ✅                | ✅            | ✅            | cloud-infra #8321                              |
-| WarpStream metrics cluster + S3 + IRSA                   | —                 | ✅                | ⏳            | ⏳            | charts `warpstream-metrics`; cloud-infra #8322 |
-| CH named collection `warpstream_metrics`                 | —                 | ✅                | ✅            | ✅            | cloud-infra #8415/#8489                        |
-| metrics-ingestion Postgres app user                      | ✅                | ✅                | ✅            | ✅            | cloud-infra #8434                              |
-| capture-logs `kafka.metricsBrokers`/`metricsTopic`       | ✅ (compose)      | ✅                | ⏳            | ⏳            | charts `capture-logs` (global in rollout)      |
-| Contour ingress `/i/v1/metrics`                          | ✅ (caddy)        | ✅                | ⏳            | ⏳            | charts `contour-ingress`                       |
-| metrics-ingestion consumer deploy                        | ✅ (mprocs)       | ✅                | ⏳            | ⏳            | charts `logs/metrics-ingestion`                |
-| ClickHouse `metrics1` + MVs                              | ✅ (CH bootstrap) | ✅                | ⏳ direct SQL | ⏳ direct SQL | `posthog/clickhouse/metrics/`                  |
-| **otel-collector bridge** (infra→metrics1)               | ➕ local recipe   | ➕ INFRA-A #11808 | ➕ INFRA-D    | ➕ INFRA-D    | charts `otel-collector` + `vmagent`            |
-| Rate-limit/quota exemption for internal-infra token      | —                 | ➕ INFRA-B        | ➕ INFRA-D    | ➕ INFRA-D    | `nodejs/.../metrics-rate-limiter.service.ts`   |
-| Feature flag `METRICS` + `metrics:read` scope            | ✅ code           | ✅ code           | ✅ code       | ✅ code       | posthog repo (all envs share)                  |
-| Query layer (filters/group-by/rate/hist/formula)         | ➕ this stack     | ➕                | ➕            | ➕            | `products/metrics/backend`                     |
+| Layer                                                    | local             | dev             | prod-us         | prod-eu         | Where it lives                                                                    |
+| -------------------------------------------------------- | ----------------- | --------------- | --------------- | --------------- | --------------------------------------------------------------------------------- |
+| Kafka topics (`ingestion_metrics`, `clickhouse_metrics`) | ✅ (compose)      | ✅              | ✅              | ✅              | cloud-infra #8321                                                                 |
+| WarpStream metrics cluster + S3 + IRSA                   | —                 | ✅              | ✅              | ✅              | charts `warpstream-metrics`; cloud-infra #8322                                    |
+| CH named collection `warpstream_metrics`                 | —                 | ✅              | ✅              | ✅              | cloud-infra #8415/#8489                                                           |
+| metrics-ingestion Postgres app user                      | ✅                | ✅              | ✅              | ✅              | cloud-infra #8434                                                                 |
+| capture-logs `kafka.metricsBrokers`/`metricsTopic`       | ✅ (compose)      | ✅              | ✅              | ✅              | charts `capture-logs`; rollout charts#11702                                       |
+| Contour ingress `/i/v1/metrics`                          | ✅ (caddy)        | ✅              | ✅              | ✅              | charts `contour-ingress`                                                          |
+| metrics-ingestion consumer deploy                        | ✅ (mprocs)       | ✅              | ✅              | ✅              | charts `logs/metrics-ingestion`                                                   |
+| ClickHouse `metrics1` + MVs + samples/series             | ✅ (CH bootstrap) | ✅              | ✅ direct SQL   | ✅ direct SQL   | `posthog/clickhouse/metrics/`, `bin/clickhouse-metrics.sql`                       |
+| **metrics-bridge** scrape collector (infra→metrics1)     | ✅ dev collector  | ✅ charts#12239 | ✅ charts#12440 | ✅ charts#12440 | charts `metrics-bridge` ArgoCD app                                                |
+| Rate-limit/quota exemption for internal-infra token      | —                 | ❌ not built    | ❌ not built    | ❌ not built    | `nodejs/src/ingestion/pipelines/metrics/services/metrics-rate-limiter.service.ts` |
+| Feature flag `METRICS` + `metrics:read` scope            | ✅ code           | ✅ code         | ✅ code         | ✅ code         | posthog repo (all envs share)                                                     |
+| Query layer (filters/group-by/rate/hist/formula)         | ✅ shipped        | ✅              | ✅              | ✅              | `products/metrics/backend`                                                        |
 
-**Read:** the ingestion data plane is **done in dev**, and **pending in prod** behind `daniel/metrics-prod-rollout` (charts) + the post-merge `metrics1` SQL apply on the prod-us/prod-eu logs CH clusters. cloud-infra scaffolding (topics/S3/IRSA/CH collection/PG user) is **merged in all three envs**.
+**Read (2026-07-08):** the ingestion data plane is **live end-to-end in dev, prod-us, and prod-eu**, including the events-model tables with ingest-assigned fingerprints (rollout completed 2026-07-02). The two open items are the internal-infra quota exemption (INFRA-B, never built) and retention: `metrics1` and `metric_attributes` still have **no TTL**.
 
 ## What still has to be added, by repo
 
 ### posthog (this stack)
 
-- Query layer: `MetricQueryRequest`/`MetricSeries` contracts → endpoint → shared metric-math library (filters, group-by, rate, increase, histogram_quantile, formula). **This is the product gap; nothing else replaces it.**
-- INFRA-B: internal-infra token quota exemption in `MetricsRateLimiterService`.
-- (Post-alpha) Alerting on the shared math library; streams-table storage migration.
+- ~~Query layer~~ **shipped**: `MetricQueryRequest`/`MetricSeries` contracts, filters, group-by, rate, increase, histogram_quantile, formula, all live behind `POST .../metrics/query/`.
+- INFRA-B: internal-infra token quota exemption in `MetricsRateLimiterService`. **Still open, never implemented.**
+- Retention: `MODIFY TTL` migration for `metrics1` + `metric_attributes` (use `materialize_ttl_after_modify = 0`). **Still open.**
+- (Post-alpha) Alerting on the shared math library; `metrics1` streams-table storage migration; dashboard insight tiles (see `dashboard-mvp.md` Phase 3 revised).
 
-### charts
+### charts — done
 
-- INFRA-A (#11808, dev): otel-collector `prometheusremotewrite` bridge + vmagent second remote-write. **Draft up.**
-- INFRA-C (dev): drop the `debug` exporter once metrics1 arrival is confirmed.
-- INFRA-D (prod-us + prod-eu): replicate the bridge after `metrics-prod-rollout` merges and prod `metrics1` SQL is applied. Decide internal-infra project here.
-- INFRA-E: broaden the bridge filter beyond the initial dashboard metric set once the query layer can render more.
-- (Merge) `daniel/metrics-prod-rollout`: takes the ingestion data plane to prod-us + prod-eu.
+The remote-write bridge plan (INFRA-A/#11808) was reverted after a hard vmagent RW-1.0 vs receiver RW-2.0 protocol incompatibility. What shipped instead: a dedicated `metrics-bridge` scrape collector, dev (charts#12239) and prod-us + prod-eu (charts#12440), with a scrape memory bound (charts#12493). The ingestion data plane reached prod via charts#11702.
 
 ### posthog-cloud-infra
 
 - **Nothing new required** for alpha — topics/S3/IRSA/CH collection/PG user are all merged in every env.
-- Open decision (INFRA-D): provision a dedicated `posthog-internal-infra` project + token per env so scraped infra metrics don't flip `team_has_metrics` on the dogfood team and so internal-infra volume is billed/quota'd separately.
+- Decision made: scraped infra metrics land in PostHog's internal project per environment (no dedicated project). The separate-quota half of the intent is unmet until INFRA-B ships.
 
-### Per-env "go live" checklist for prod
+### Per-env "go live" checklist for prod — ✅ completed 2026-07
 
-1. Merge `daniel/metrics-prod-rollout` (charts).
-2. Apply `metrics1` + MV DDL to prod-us and prod-eu logs CH clusters (direct SQL, as in dev).
-3. Point a smoke OTLP producer at the prod `/i/v1/metrics`; confirm rows in `metrics1`.
-4. Land INFRA-D (bridge) per env; confirm vmagent → bridge → metrics1 for the dashboard metric set.
-5. Verify `team_has_metrics` + the query layer against real prod series.
+All five steps are done in both regions: charts rollout merged, `metrics1` + samples/series DDL applied (fingerprint cutover 2026-07-02), smoke OTLP verified, scrape collector live, query layer verified against real prod series.
 
 ## Local validation (the priority) — fully functional metrics on a laptop
 


### PR DESCRIPTION
## Problem

`docs/internal/metrics/dashboard-mvp.md` and `deployment-layout.md` froze at design time (June 11) while the implementation shipped. An engineer following them today would rebuild things that exist, follow an infra design that was reverted, and build a dashboard widget type the dashboards platform no longer allows.

## Changes

Docs only, no code. Syncs both docs with what actually shipped:

- Query layer, viewer, and MCP tools marked shipped (the "gap to close" table now carries per-row status).
- Phase 1 outcome recorded: the otel-collector remote-write bridge was reverted (vmagent Remote Write 1.0 vs receiver 2.0 incompatibility) and replaced by the dedicated `metrics-bridge` scrape collector, dev + prod. INFRA-B (internal-infra quota exemption) flagged as never implemented.
- P10-P13 (the `metric_timeseries` dashboard widget) rewritten as "Phase 3 revised": metrics tiles ship as insight tiles via a `MetricsQuery` node kind, per `products/dashboards/CONTRIBUTING.md` which disallows chart-primary widget types.
- deployment-layout status matrix updated to the live prod state, series-fingerprint paragraph corrected to the shipped ingest-assigned design, settled decisions recorded, stale code paths fixed (`nodejs/src/metrics-ingestion/` moved to `nodejs/src/ingestion/pipelines/metrics/`).

## How did you test this code?

Docs-only change. Every status claim was verified against the repo and PR states this session (merged PRs, table definitions in `posthog/clickhouse/metrics/`, HogQL schema, `bin/clickhouse-metrics.sql`, charts PR states via the GitHub API).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal docs are the change itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) audited the five internal metrics docs against the codebase and PR history, then Daniel directed it to open PRs for the corrections. Skills invoked: /manage-dashboard-widgets (established the no-chart-widgets platform rule that supersedes P10-P13), /pr-slicing, /get-stamp. The main judgment call: keep the original P10-P13 rows for the record and add a "Phase 3 revised" section, rather than rewriting history in place.
