### PR TITLE
fix(insights): throttle shared force refresh with a redis slot

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -221,16 +221,17 @@ def execution_mode_from_refresh(refresh_requested: bool | str | None) -> Executi
     return ExecutionMode.CACHE_ONLY_NEVER_CALCULATE
 
 
-# Minimum age before a shared insight may honor `?refresh=force_blocking`.
-# Sourced from the same generated schema as the frontend's auto-refresh interval so the
-# two cannot drift. Best-effort throttle, not a hard rate limit.
+# Throttle window for `?refresh=force_blocking` on shared insights: at most one forced
+# recompute per insight/tile per window. Sourced from the same generated schema as the
+# frontend's auto-refresh interval so the two cannot drift. Best-effort throttle, not a
+# hard rate limit.
 SHARED_FORCE_BLOCKING_MIN_AGE = timedelta(seconds=DashboardAutoRefreshInterval().root)
 
 
 _SHARED_MODE_WHITELIST = {
     ExecutionMode.CACHE_ONLY_NEVER_CALCULATE: ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
     # force_blocking is gated by `shared_insights_execution_mode`; downgrades to IF_STALE
-    # when the throttle clock is younger than `SHARED_FORCE_BLOCKING_MIN_AGE`.
+    # unless the caller acquired the per-insight throttle slot.
     ExecutionMode.CALCULATE_BLOCKING_ALWAYS: ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
     ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE: ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
     # Used by the shared-notebook inline query payload builder. Without this entry the
@@ -238,12 +239,6 @@ _SHARED_MODE_WHITELIST = {
     # the frontend to incorrectly render a "unsupported node" placeholder until the async calc finishes and a later reload picks up the warm cache.
     ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE: ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
 }
-
-
-def _is_force_blocking_eligible_for_shared(last_refresh: datetime | None) -> bool:
-    if last_refresh is None:
-        return False
-    return datetime.now(UTC) - last_refresh >= SHARED_FORCE_BLOCKING_MIN_AGE
 
 
 def _classify_error_for_slo(exc: Exception) -> tuple[QueryErrorCategory, SloOutcome]:
@@ -275,14 +270,11 @@ def _classify_error_for_slo(exc: Exception) -> tuple[QueryErrorCategory, SloOutc
 def shared_insights_execution_mode(
     execution_mode: ExecutionMode,
     *,
-    last_refresh: datetime | None = None,
+    force_blocking_allowed: bool = False,
 ) -> ExecutionMode:
-    if execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS and not _is_force_blocking_eligible_for_shared(
-        last_refresh
-    ):
+    if execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS and not force_blocking_allowed:
         logger.info(
             "shared_force_blocking_throttled",
-            last_refresh=last_refresh.isoformat() if last_refresh else None,
             min_age_seconds=int(SHARED_FORCE_BLOCKING_MIN_AGE.total_seconds()),
         )
         return ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -908,8 +908,6 @@ class TestApplySeriesCustomNames(BaseTest):
         cached_results: list[dict],
         expected_results: list[dict],
     ):
-        from datetime import UTC
-
         from posthog.schema import CachedTrendsQueryResponse
 
         runner = TrendsQueryRunner(query=query, team=self.team)
@@ -986,8 +984,6 @@ class TestApplySeriesCustomNames(BaseTest):
         expected_results: list,
         expect_modified: bool,
     ):
-        from datetime import UTC
-
         from posthog.schema import CachedFunnelsQueryResponse, FunnelsQuery
 
         from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
@@ -1038,8 +1034,6 @@ class TestApplySeriesCustomNames(BaseTest):
         expected_results: list,
         expect_modified: bool,
     ):
-        from datetime import UTC
-
         from posthog.schema import CachedStickinessQueryResponse, StickinessQuery
 
         from products.product_analytics.backend.hogql_queries.stickiness.stickiness_query_runner import (
@@ -1105,8 +1099,6 @@ class TestApplySeriesCustomNames(BaseTest):
         expected_results: list,
         expect_modified: bool,
     ):
-        from datetime import UTC
-
         from posthog.schema import CachedLifecycleQueryResponse, LifecycleQuery
 
         from posthog.hogql_queries.insights.lifecycle.lifecycle_query_runner import LifecycleQueryRunner
@@ -1180,8 +1172,6 @@ class TestApplySeriesCustomNames(BaseTest):
         cached_results: list[dict],
         expect_modified: bool,
     ):
-        from datetime import UTC
-
         from posthog.schema import CachedTrendsQueryResponse
 
         runner = TrendsQueryRunner(query=query, team=self.team)
@@ -1203,47 +1193,29 @@ class TestApplySeriesCustomNames(BaseTest):
 class TestSharedInsightsExecutionMode(BaseTest):
     @parameterized.expand(
         [
-            # name, execution_mode, last_refresh_offset (None = no signal, timedelta = age), expected_mode
+            # name, execution_mode, force_blocking_allowed, expected_mode
             (
-                "force_blocking_no_last_refresh_downgrades",
+                "force_blocking_throttled_downgrades",
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-                None,
+                False,
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
             ),
             (
-                "force_blocking_just_refreshed_downgrades",
+                "force_blocking_slot_acquired_passes_through",
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-                timedelta(seconds=10),
-                ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-            ),
-            (
-                "force_blocking_just_under_threshold_downgrades",
-                ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-                timedelta(minutes=29, seconds=59),
-                ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-            ),
-            (
-                "force_blocking_at_threshold_passes_through",
-                ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-                timedelta(minutes=30),
-                ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-            ),
-            (
-                "force_blocking_long_stale_passes_through",
-                ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-                timedelta(hours=24),
+                True,
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
             ),
             (
                 "cache_only_remaps_to_extended_async",
                 ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
-                timedelta(seconds=10),
+                False,
                 ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
             ),
             (
                 "recent_cache_async_passes_through",
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
-                None,
+                False,
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
             ),
             (
@@ -1253,7 +1225,7 @@ class TestSharedInsightsExecutionMode(BaseTest):
                 # ship a CacheMissResponse to the frontend, which renders the "unsupported node"
                 # placeholder until a later reload picks up the warmed cache.
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
-                None,
+                False,
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
             ),
         ]
@@ -1262,11 +1234,10 @@ class TestSharedInsightsExecutionMode(BaseTest):
         self,
         _name: str,
         execution_mode: ExecutionMode,
-        last_refresh_offset: timedelta | None,
+        force_blocking_allowed: bool,
         expected_mode: ExecutionMode,
     ) -> None:
-        last_refresh = None if last_refresh_offset is None else datetime.now(UTC) - last_refresh_offset
-        result = shared_insights_execution_mode(execution_mode, last_refresh=last_refresh)
+        result = shared_insights_execution_mode(execution_mode, force_blocking_allowed=force_blocking_allowed)
         self.assertEqual(result, expected_mode)
 
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from functools import lru_cache
 from typing import Any, Union, cast
 
@@ -80,6 +80,7 @@ from posthog.hogql_queries.legacy_compatibility.feature_flag import get_query_me
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.hogql_queries.query_runner import (
     BLOCKING_EXECUTION_MODES,
+    SHARED_FORCE_BLOCKING_MIN_AGE,
     ExecutionMode,
     execution_mode_from_refresh,
     shared_insights_execution_mode,
@@ -115,6 +116,7 @@ from posthog.rbac.user_access_control import (
     UserAccessControlSerializerMixin,
     access_level_satisfied_for_resource,
 )
+from posthog.redis import get_client
 from posthog.resource_limits import LimitKey, check_count_limit
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -137,7 +139,6 @@ from products.product_analytics.backend.api.insight_metadata import generate_ins
 from products.product_analytics.backend.api.insight_suggestions import get_insight_analysis, get_insight_suggestions
 from products.product_analytics.backend.api.insight_variable import map_stale_to_latest
 from products.product_analytics.backend.models.insight import Insight, InsightViewed
-from products.product_analytics.backend.models.insight_caching_state import InsightCachingState
 from products.product_analytics.backend.models.insight_variable import InsightVariable
 
 from common.hogvm.python.utils import HogVMException
@@ -448,23 +449,16 @@ class QueryFieldSerializer(serializers.Serializer):
         return data
 
 
-def _last_refresh_for_shared_gate(insight: Insight, dashboard_tile: DashboardTile | None) -> datetime | None:
-    """Throttle clock for `?refresh=force_blocking` on shared insights. On DB error, returns
-    ``now()`` so the gate fails closed."""
+def _acquire_shared_force_refresh_slot(team_id: int, insight_id: int, dashboard_tile_id: int | None) -> bool:
+    """Throttle slot for `?refresh=force_blocking` on shared insights: at most one forced
+    recompute per insight/tile per `SHARED_FORCE_BLOCKING_MIN_AGE` window. The slot is burned
+    on acquisition even if the calculation later fails (best-effort throttle). On Redis error,
+    returns False so the gate fails closed."""
+    key = f"shared_force_refresh:{team_id}:{insight_id}:{dashboard_tile_id or 0}"
     try:
-        if dashboard_tile is not None:
-            cs = next(iter(dashboard_tile.caching_states.all()), None)
-        else:
-            cs = (
-                InsightCachingState.objects.filter(insight=insight, dashboard_tile=None)
-                .only("last_refresh", "created_at")
-                .first()
-            )
+        return bool(get_client().set(key, "1", nx=True, ex=int(SHARED_FORCE_BLOCKING_MIN_AGE.total_seconds())))
     except Exception:
-        return datetime.now(UTC)
-    if cs is None:
-        return insight.created_at
-    return cs.last_refresh or cs.created_at
+        return False
 
 
 class InsightSerializer(InsightBasicSerializer):
@@ -1111,9 +1105,14 @@ class InsightSerializer(InsightBasicSerializer):
 
                 is_shared = self.context.get("is_shared", False)
                 if is_shared:
+                    force_blocking_allowed = (
+                        execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS
+                        and _acquire_shared_force_refresh_slot(
+                            insight.team_id, insight.pk, dashboard_tile.pk if dashboard_tile else None
+                        )
+                    )
                     execution_mode = shared_insights_execution_mode(
-                        execution_mode,
-                        last_refresh=_last_refresh_for_shared_gate(insight, dashboard_tile),
+                        execution_mode, force_blocking_allowed=force_blocking_allowed
                     )
 
                 # Shared rendering bypasses the FE scene-tag flow, so set product/feature

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -60,7 +60,6 @@ from products.alerts.backend.models.alert import AlertConfiguration
 from products.cohorts.backend.models.cohort import Cohort
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
-from products.product_analytics.backend.api.insight import _last_refresh_for_shared_gate
 from products.product_analytics.backend.models.insight import Insight, InsightViewed
 from products.product_analytics.backend.models.insight_caching_state import InsightCachingState
 from products.product_analytics.backend.models.insight_variable import InsightVariable
@@ -539,10 +538,9 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             calculate_for_query_based_insight.assert_called_once_with(
                 mock.ANY,
                 dashboard=mock.ANY,
-                # The shared force_blocking gate downgrades to IF_STALE because the insight was
-                # just created — the InsightCachingState row's `created_at` is younger than
-                # `SHARED_FORCE_BLOCKING_MIN_AGE` and the throttle clock falls back to it.
-                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                # The first forced refresh in the window acquires the Redis throttle slot,
+                # so force_blocking passes through.
+                execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                 team=self.team,
                 user=mock.ANY,
                 user_access_control=mock.ANY,
@@ -552,25 +550,24 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 analytics_props=ANY,
             )
 
-    @parameterized.expand(
-        [
-            # When no caching state row exists, the gate falls back to insight.created_at so
-            # legitimate stale-refresh isn't silently blocked on insights without rows.
-            ("missing_row_falls_back_to_insight_created_at", True),
-            ("existing_row_used_when_present", False),
-        ]
-    )
-    def test_last_refresh_for_shared_gate_fallback(self, _name: str, delete_caching_state: bool) -> None:
-        insight = Insight.objects.create(team=self.team, filters={"events": [{"id": "$pageview"}]})
-        if delete_caching_state:
-            InsightCachingState.objects.filter(insight=insight).delete()
-            self.assertIsNone(InsightCachingState.objects.filter(insight=insight).first())
-            expected = insight.created_at
-        else:
-            cs = InsightCachingState.objects.filter(insight=insight, dashboard_tile=None).first()
-            assert cs is not None  # narrows type for mypy
-            expected = cs.created_at  # last_refresh is null on a freshly created row
-        self.assertEqual(_last_refresh_for_shared_gate(insight, None), expected)
+        with patch(
+            "posthog.caching.calculate_results.calculate_for_query_based_insight"
+        ) as calculate_for_query_based_insight:
+            self.client.get(valid_url, data={"refresh": True})
+            calculate_for_query_based_insight.assert_called_once_with(
+                mock.ANY,
+                dashboard=mock.ANY,
+                # A second forced refresh within `SHARED_FORCE_BLOCKING_MIN_AGE` finds the
+                # slot taken and downgrades to IF_STALE.
+                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                team=self.team,
+                user=mock.ANY,
+                user_access_control=mock.ANY,
+                filters_override={},
+                variables_override={},
+                tile_filters_override={},
+                analytics_props=ANY,
+            )
 
     def test_get_insight_by_short_id(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}


### PR DESCRIPTION
## Problem

The `?refresh=force_blocking` throttle on shared/embedded insights reads its clock from `InsightCachingState.last_refresh` — the last remaining production read of that model, whose original purpose (proactive cache refresh) no longer runs. This couples an anti-abuse throttle to a mostly-vestigial table.

This is option 1 of 2 candidate approaches — compare with the cache-age variant in [#69416](https://github.com/PostHog/posthog/pull/69416).

## ELI5

Anyone with a shared insight link (no login) can add `?refresh=force_blocking` to make PostHog re-run the query from scratch on ClickHouse. That's expensive, so we only allow it once every 30 minutes. The question is how we remember when the last one happened; today that memory lives in a database table we want to delete.

This PR is a "take a ticket" system. Think of a ticket dispenser next to the insight: the first person who asks for a forced refresh grabs the ticket and gets a real recompute. The ticket only regenerates after 30 minutes; until then, everyone else who asks is served the existing result instead. The ticket is just a small Redis key that auto-expires. Simple, and a hard-ish cap on how often anyone can force work. Tradeoffs: it's a new piece of state, the ticket is spent even if the refresh crashes, and it doesn't know or care how fresh the data actually is. In one line: this option limits *how often you can ask*; the sibling PR limits *how often the answer actually gets recomputed, based on how fresh it already is*.

## Changes

- Replace the DB-based throttle clock with a per-insight/tile Redis slot: `SET NX EX` with TTL `SHARED_FORCE_BLOCKING_MIN_AGE` (30 min), so a shared viewer gets at most one forced synchronous recompute per insight/tile per window.
- `shared_insights_execution_mode` now takes `force_blocking_allowed: bool` instead of `last_refresh`; on Redis errors the gate fails closed (downgrade to `RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE`), matching the old DB-error behavior.
- Removed `_last_refresh_for_shared_gate` and the `InsightCachingState` read from the insight API.

Behavior change vs before: the window starts at the first forced request rather than at the last successful refresh, and a brand-new shared insight's first forced refresh now goes through (previously it was blocked for 30 min after creation via the `created_at` fallback).

## How did you test this code?

- Updated `TestSharedInsightsExecutionMode` for the new signature (throttled vs slot-acquired force_blocking, plus the existing whitelist passthroughs).
- Extended `test_get_insight_in_shared_context` to assert the throttle end-to-end: first `refresh=true` on a shared URL passes through as `CALCULATE_BLOCKING_ALWAYS`, a second within the window downgrades — catches a regression where the Redis gate stops limiting repeat forced refreshes (or blocks the first legitimate one), which no existing test covered.
- No local DB in the sandbox, so the suites run in CI; `ruff check`/`format` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — internal throttle mechanics, no user-facing API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code); skills invoked: /improving-drf-endpoints, /writing-tests.
- **Why:** first step toward retiring `InsightCachingState` — this severs its last production read. Two mechanisms were considered; this PR implements the Redis rate-limit slot, a sibling PR implements the cache-age-override variant so the two can be compared.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
