### PR TITLE
feat(data-warehouse): add --created-after window bound to unstick command

### DIFF
--- a/products/warehouse_sources/backend/management/commands/unstick_external_data_jobs.py
+++ b/products/warehouse_sources/backend/management/commands/unstick_external_data_jobs.py
@@ -80,6 +80,14 @@ class Command(BaseCommand):
             required=True,
             help="Only consider Running jobs created before this ISO-8601 timestamp (e.g. 2026-07-02T00:00:00Z)",
         )
+        parser.add_argument(
+            "--created-after",
+            type=str,
+            help=(
+                "Only consider Running jobs created at or after this ISO-8601 timestamp. "
+                "Bounds the sweep to an incident window instead of the full historical backlog."
+            ),
+        )
         parser.add_argument("--team-id", type=int, help="Scope by team")
         parser.add_argument("--source-type", type=str, help="Scope by source type, e.g. Stripe")
         parser.add_argument(
@@ -106,7 +114,7 @@ class Command(BaseCommand):
         parser.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
 
     def handle(self, *args: Any, **options: Any) -> None:
-        cutoff = self._parse_cutoff(options["created_before"])
+        cutoff = self._parse_cutoff(options["created_before"], flag="--created-before")
         live_run: bool = options["live_run"]
         reason: str = options["reason"]
         terminate_healthy: bool = options["terminate_healthy"]
@@ -115,6 +123,8 @@ class Command(BaseCommand):
         jobs = ExternalDataJob.objects.filter(status=ExternalDataJob.Status.RUNNING, created_at__lt=cutoff).order_by(
             "created_at"
         )
+        if options.get("created_after"):
+            jobs = jobs.filter(created_at__gte=self._parse_cutoff(options["created_after"], flag="--created-after"))
         if options.get("team_id") is not None:
             jobs = jobs.filter(team_id=options["team_id"])
         if options.get("source_type"):
@@ -327,11 +337,11 @@ class Command(BaseCommand):
         )
 
     @staticmethod
-    def _parse_cutoff(raw: str) -> datetime:
+    def _parse_cutoff(raw: str, *, flag: str) -> datetime:
         try:
             cutoff = datetime.fromisoformat(raw.replace("Z", "+00:00"))
         except ValueError:
-            raise CommandError(f"--created-before is not a valid ISO-8601 timestamp: {raw!r}")
+            raise CommandError(f"{flag} is not a valid ISO-8601 timestamp: {raw!r}")
         if cutoff.tzinfo is None:
             cutoff = cutoff.replace(tzinfo=UTC)
         return cutoff

--- a/products/warehouse_sources/backend/tests/management/test_unstick_external_data_jobs.py
+++ b/products/warehouse_sources/backend/tests/management/test_unstick_external_data_jobs.py
@@ -251,6 +251,19 @@ class TestSafetyRails:
         job.refresh_from_db()
         assert job.status == ExternalDataJob.Status.RUNNING
 
+    def test_created_after_excludes_older_backlog(self, team, fake_temporal, queue_conn):
+        _, old_zombie = _create_stuck_job(team, created_at=datetime(2024, 9, 1, tzinfo=UTC))
+        schema, incident_job = _create_stuck_job(team, created_at=BEFORE_CUTOFF)
+        assert incident_job.workflow_run_id is not None
+        fake_temporal.describe_results[incident_job.workflow_run_id] = _wedged()
+
+        _call("--created-after", "2026-06-28T00:00:00Z", "--live-run", "--yes")
+
+        old_zombie.refresh_from_db()
+        incident_job.refresh_from_db()
+        assert old_zombie.status == ExternalDataJob.Status.RUNNING
+        assert incident_job.status == ExternalDataJob.Status.FAILED
+
     def test_max_jobs_cap_aborts_before_any_write(self, team, fake_temporal, queue_conn):
         _, job_a = _create_stuck_job(team)
         _, job_b = _create_stuck_job(team)


### PR DESCRIPTION
## Problem

`unstick_external_data_jobs` (#69038) matches every `Running` job created before `--created-before`.
In production that includes the full historical backlog of zombie rows left behind by ungracefully-dead workflows over the years (hundreds of thousands of rows), not just the recent incident window the sweep is meant to fix.
There is no way to bound the sweep from below, and sweeping the backlog would cost one Temporal describe RPC per job — hours of runtime for rows that block nothing (their workflows left Temporal retention long ago).

## Changes

Adds an optional `--created-after` argument that bounds the sweep to a window:

```bash
python manage.py unstick_external_data_jobs \
    --created-after 2026-06-20T00:00:00Z --created-before 2026-07-02T00:00:00Z --live-run --trigger-sync
```

Same ISO-8601 parsing as `--created-before` (shared `_parse_cutoff`, now taking the flag name for error messages). Omitting it preserves the existing behavior.

## How did you test this code?

- Added `test_created_after_excludes_older_backlog`: a 2024 zombie row and an in-window wedged job coexist; the windowed live-run fixes only the in-window job. Catches the regression where the lower bound is ignored and a sweep silently targets the full backlog.
- Full command test suite green locally (18 passed), ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal ops command, documented via `--help`; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Claude Fable 5), follow-up to #69038 after the first production dry run matched ~585k historical Running rows instead of the recent incident set. Validated the backlog-vs-incident split by querying the internal warehouse mirror of the app database (monthly breakdown shows the bulk of Running rows dating to mid-2024, with only ~100 in the incident window on the smaller region).
- Considered filtering by "latest job per schema" instead of a time window; rejected as a much heavier query and unnecessary — the window plus the command's existing latest-job guard achieves the same effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
