### PR TITLE
fix(data-warehouse): add organization_id as a project group property on the duckgres sink flag

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/enablement.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/enablement.py
@@ -59,7 +59,7 @@ def duckgres_sink_team_ids() -> list[int] | None:
                 groups={"organization": str(org_id), "project": str(team_id)},
                 group_properties={
                     "organization": {"id": str(org_id)},
-                    "project": {"id": str(team_id)},
+                    "project": {"id": str(team_id), "organization_id": str(org_id)},
                 },
                 only_evaluate_locally=True,
                 send_feature_flag_events=False,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_enablement.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_enablement.py
@@ -31,7 +31,7 @@ def test_duckgres_sink_flag_evaluated_locally_with_group_properties(
         groups={"organization": str(org.id), "project": str(team.id)},
         group_properties={
             "organization": {"id": str(org.id)},
-            "project": {"id": str(team.id)},
+            "project": {"id": str(team.id), "organization_id": str(org.id)},
         },
         only_evaluate_locally=True,
         send_feature_flag_events=False,


### PR DESCRIPTION
## Problem

`duckgres_sink_team_ids()` evaluates the `duckgres-batch-sink` flag with the team's uuid as distinct_id and two groups (`organization`, `project`). The `project` group's properties only carried `id`, so there was no way to write a flag condition scoped to `project.organization_id` — you'd have to fall back to the `organization` group directly, which doesn't compose with per-team overrides on the same flag.

## Changes

Added `organization_id` to the `project` group's properties in the flag-evaluation call, alongside the existing `id`. Mirrors the property Team rows already carry.

## How did you test this code?

Updated the existing test that asserts the exact `feature_enabled` call payload (`test_duckgres_sink_flag_evaluated_locally_with_group_properties`) to include the new key — that test already exists specifically to lock in the group_properties shape sent to this boundary call, so extending it is the correct action rather than adding a new test. No new test needed: there's no new branch of logic, just an additional static property value on an already-covered call path.

`pytest .../duckgres/test_enablement.py` — 2 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested directly during a review of duckgres batch sink feature-flag gating.
