### PR TITLE
fix(aio): guard null query response in sentiment generations fetch

### DIFF
--- a/products/ai_observability/frontend/sentimentQueries.ts
+++ b/products/ai_observability/frontend/sentimentQueries.ts
@@ -172,7 +172,7 @@ async function queryStoredGenerationSentiments(
     )
 
     const sentimentByTargetId = new Map<string, GenerationSentiment>()
-    for (const row of response.results || []) {
+    for (const row of response?.results || []) {
         const [, generationId, label, score, scores, messages, messageCount] = row
         const normalized = normalizeSentimentResult({
             label,
@@ -279,7 +279,7 @@ async function queryGenerationInputs(
     )
 
     const inputs = new Map<string, unknown>()
-    for (const [uuid, , aiInput] of response.results || []) {
+    for (const [uuid, , aiInput] of response?.results || []) {
         if (uuid && hasUsableInput(aiInput)) {
             inputs.set(String(uuid), aiInput)
         }
@@ -338,7 +338,7 @@ export async function fetchSentimentGenerationsPage(
     }
 
     const response = await api.query(generationsQuery)
-    const generationRows = (response.results || [])
+    const generationRows = (response?.results || [])
         .map((row) => mapGenerationRow(row))
         .filter((row): row is SentimentGeneration => row !== null)
 
@@ -361,6 +361,6 @@ export async function fetchSentimentGenerationsPage(
                 sentiment: sentimentByGenerationKey[generation.uuid] ?? null,
             }))
             .filter((generation) => generation.sentiment !== null),
-        rawCount: response.results?.length ?? 0,
+        rawCount: response?.results?.length ?? 0,
     }
 }


### PR DESCRIPTION
## Problem

The AI observability Sentiment tab throws a handled `TypeError: Cannot read properties of null (reading 'results')`. `api.query(...)` can resolve to `null` when a query is aborted mid-flight (for example when the user navigates away from the Sentiment tab or changes filters before the request finishes). The code read `response.results` directly, guarding only against `results` being null but not `response` itself, so an aborted query threw.

Surfaced via an error tracking alert routing AI-observability web errors. Impact is small and the error is caught by the kea loader, so users saw the generations list silently fail to populate for that aborted load rather than a crash — but it fired the alert as noise.

## Changes

Guard every `response.results` read in `fetchSentimentGenerationsPage` and its sentiment/input lookup helpers with optional chaining (`response?.results`), so an aborted/null query resolves to an empty page instead of throwing.

## How did you test this code?

No automated tests added — this is a one-line-per-site null-safety guard on an existing code path. Verified by inspection that all four `response.results` reads in the file are now null-safe. I (the agent) did not run the app manually.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread starting from an error tracking alert. Used the PostHog error tracking MCP tools to locate the issue, pull a sample exception with resolved stack frames (pointing at `sentimentQueries.ts`), and confirm the cause. Invoked the `/investigating-error-issue` skill. The `.results`-of-null pattern is systemic across many loaders in the app; this PR is scoped to the file the alert watches.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1783504297642409?thread_ts=1783504297.642409&cid=C0A006STKHR)*
