### PR TITLE
feat(metrics): mirror nodejs prometheus metrics into the metrics product

### DIFF
--- a/nodejs/src/common/api/router.ts
+++ b/nodejs/src/common/api/router.ts
@@ -4,6 +4,7 @@ import express, { Request, Response } from 'ultimate-express'
 import { corsMiddleware } from '~/common/api/middleware/cors'
 import { httpMetricsMiddleware } from '~/common/api/middleware/http-metrics'
 import { createInternalApiAuthMiddleware } from '~/common/api/middleware/internal-api-auth'
+import { startInternalMetricsExporterFromEnv } from '~/common/internal-metrics-exporter'
 import { logger } from '~/common/utils/logger'
 import { HealthCheckResultError, PluginServerService } from '~/types'
 
@@ -39,6 +40,10 @@ export function setupCommonRoutes(
     app.get('/_ready', buildGetHealth(services))
     app.get('/_metrics', getMetrics)
     app.get('/metrics', getMetrics)
+
+    // Dogfooding: mirror this process's prometheus metrics into the PostHog
+    // Metrics product. No-op unless POSTHOG_INTERNAL_METRICS_TOKEN is set.
+    startInternalMetricsExporterFromEnv()
 
     return app
 }

--- a/nodejs/src/common/internal-metrics-exporter.test.ts
+++ b/nodejs/src/common/internal-metrics-exporter.test.ts
@@ -1,0 +1,188 @@
+import { Counter, Gauge, Histogram, Registry } from 'prom-client'
+
+import { parseJSON } from '~/common/utils/json-parse'
+
+import {
+    InternalMetricsExporter,
+    buildOtlpMetricsPayload,
+    internalMetricsConfigFromEnv,
+} from './internal-metrics-exporter'
+
+describe('internal-metrics-exporter', () => {
+    let registry: Registry
+
+    beforeEach(() => {
+        registry = new Registry()
+    })
+
+    describe('buildOtlpMetricsPayload', () => {
+        const build = async (): Promise<ReturnType<typeof buildOtlpMetricsPayload>> =>
+            buildOtlpMetricsPayload(await registry.getMetricsAsJSON(), {
+                serviceName: 'test-service',
+                startTimeMs: 1700000000000,
+                nowMs: 1700000060000,
+            })
+
+        it('converts counters to cumulative monotonic sums with label attributes', async () => {
+            const counter = new Counter({
+                name: 'orders_total',
+                help: 'orders',
+                labelNames: ['plan'],
+                registers: [registry],
+            })
+            counter.inc({ plan: 'free' }, 3)
+            counter.inc({ plan: 'pro' }, 5)
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            expect(metric.name).toBe('orders_total')
+            expect(metric.sum.aggregationTemporality).toBe(2)
+            expect(metric.sum.isMonotonic).toBe(true)
+            const points = metric.sum.dataPoints
+            expect(points).toHaveLength(2)
+            const byPlan = Object.fromEntries(
+                points.map((p: any) => [p.attributes.find((a: any) => a.key === 'plan').value.stringValue, p.asDouble])
+            )
+            expect(byPlan).toEqual({ free: 3, pro: 5 })
+            expect(points[0].startTimeUnixNano).toBe('1700000000000000000')
+            expect(points[0].timeUnixNano).toBe('1700000060000000000')
+        })
+
+        it('converts gauges to gauge data points', async () => {
+            const gauge = new Gauge({ name: 'queue_depth', help: 'depth', registers: [registry] })
+            gauge.set(17)
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            expect(metric.gauge.dataPoints[0].asDouble).toBe(17)
+        })
+
+        it('converts histograms: cumulative le buckets become per-bucket counts, +Inf becomes the overflow bucket', async () => {
+            const hist = new Histogram({
+                name: 'latency_ms',
+                help: 'latency',
+                buckets: [10, 50, 100],
+                registers: [registry],
+            })
+            hist.observe(5) // le=10
+            hist.observe(40) // le=50
+            hist.observe(45) // le=50
+            hist.observe(2000) // +Inf overflow
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            const dp = metric.histogram.dataPoints[0]
+            expect(metric.histogram.aggregationTemporality).toBe(2)
+            expect(dp.explicitBounds).toEqual([10, 50, 100])
+            expect(dp.bucketCounts).toEqual([1, 2, 0, 1])
+            expect(dp.count).toBe(4)
+            expect(dp.sum).toBeCloseTo(5 + 40 + 45 + 2000)
+        })
+
+        it('splits histogram label sets into separate data points', async () => {
+            const hist = new Histogram({
+                name: 'latency_ms',
+                help: 'latency',
+                labelNames: ['route'],
+                buckets: [10],
+                registers: [registry],
+            })
+            hist.observe({ route: '/a' }, 5)
+            hist.observe({ route: '/b' }, 20)
+
+            const payload = await build()
+            const dps = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0].histogram.dataPoints
+            expect(dps).toHaveLength(2)
+            const byRoute = Object.fromEntries(
+                dps.map((p: any) => [
+                    p.attributes.find((a: any) => a.key === 'route').value.stringValue,
+                    p.bucketCounts,
+                ])
+            )
+            expect(byRoute).toEqual({ '/a': [1, 0], '/b': [0, 1] })
+        })
+
+        it('attaches service.name as a resource attribute and returns null when there are no metrics', async () => {
+            expect(await build()).toBeNull()
+
+            new Gauge({ name: 'g', help: 'g', registers: [registry] }).set(1)
+            const payload = await build()
+            expect(payload!.resourceMetrics[0].resource.attributes).toContainEqual({
+                key: 'service.name',
+                value: { stringValue: 'test-service' },
+            })
+        })
+    })
+
+    describe('InternalMetricsExporter', () => {
+        beforeEach(() => {
+            jest.useFakeTimers()
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('posts the registry as OTLP JSON on the configured interval', async () => {
+            const gauge = new Gauge({ name: 'depth', help: 'depth', registers: [registry] })
+            gauge.set(42)
+            const fetchMock = jest.fn().mockResolvedValue({ status: 200 })
+
+            const exporter = new InternalMetricsExporter(
+                { host: 'https://us.i.posthog.com', token: 'phc_test', intervalSeconds: 15, serviceName: 'svc' },
+                registry,
+                fetchMock as any
+            )
+            exporter.start()
+
+            await jest.advanceTimersByTimeAsync(15000)
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            const [url, init] = fetchMock.mock.calls[0]
+            expect(url).toBe('https://us.i.posthog.com/i/v1/metrics?token=phc_test')
+            expect(init.method).toBe('POST')
+            const body = parseJSON(init.body)
+            expect(body.resourceMetrics[0].scopeMetrics[0].metrics[0].name).toBe('depth')
+
+            await jest.advanceTimersByTimeAsync(15000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+
+            exporter.stop()
+            await jest.advanceTimersByTimeAsync(60000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('survives fetch failures and keeps exporting', async () => {
+            new Gauge({ name: 'depth', help: 'depth', registers: [registry] }).set(1)
+            const fetchMock = jest.fn().mockRejectedValue(new Error('offline'))
+
+            const exporter = new InternalMetricsExporter(
+                { host: 'https://us.i.posthog.com', token: 'phc_test', intervalSeconds: 15, serviceName: 'svc' },
+                registry,
+                fetchMock as any
+            )
+            exporter.start()
+            await jest.advanceTimersByTimeAsync(30000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+            exporter.stop()
+        })
+    })
+
+    describe('internalMetricsConfigFromEnv', () => {
+        it('is disabled without a token and enabled with one', () => {
+            expect(internalMetricsConfigFromEnv({})).toBeNull()
+
+            const config = internalMetricsConfigFromEnv({
+                POSTHOG_INTERNAL_METRICS_TOKEN: 'phc_x',
+                POSTHOG_INTERNAL_METRICS_HOST: 'https://us.i.posthog.com',
+                POSTHOG_INTERNAL_METRICS_SERVICE_NAME: 'plugin-server',
+                POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS: '30',
+            })
+            expect(config).toEqual({
+                token: 'phc_x',
+                host: 'https://us.i.posthog.com',
+                serviceName: 'plugin-server',
+                intervalSeconds: 30,
+            })
+        })
+    })
+})

--- a/nodejs/src/common/internal-metrics-exporter.ts
+++ b/nodejs/src/common/internal-metrics-exporter.ts
@@ -1,0 +1,295 @@
+import { Registry, register as globalRegistry } from 'prom-client'
+
+import { logger } from '~/common/utils/logger'
+import { FetchResponse, internalFetch } from '~/common/utils/request'
+
+/**
+ * Exports this process's prom-client metrics into the PostHog Metrics product
+ * (dogfooding): every interval, the registry is snapshotted, converted to an
+ * OTLP/JSON `ExportMetricsServiceRequest`, and POSTed to `/i/v1/metrics` with
+ * a project token. The same metrics keep flowing to the Prometheus scrape
+ * endpoint untouched — this is an additive second sink, off unless
+ * `POSTHOG_INTERNAL_METRICS_TOKEN` is set.
+ *
+ * Unlike the infra-level scrape collector (which labels everything with the
+ * scrape job's `service.name`, e.g. `kubernetes-pods`), this exporter sets a
+ * real per-service `service.name`, so the Metrics UI can filter and group by
+ * the actual service.
+ *
+ * Prometheus counters/histograms are cumulative, so data points are exported
+ * with cumulative temporality and a fixed process-start `startTimeUnixNano` —
+ * the metrics read path diffs cumulative series with counter-reset handling.
+ */
+
+export interface InternalMetricsConfig {
+    host: string
+    token: string
+    serviceName: string
+    intervalSeconds: number
+}
+
+interface OtlpKeyValue {
+    key: string
+    value: { stringValue: string }
+}
+
+interface OtlpNumberDataPoint {
+    attributes: OtlpKeyValue[]
+    startTimeUnixNano: string
+    timeUnixNano: string
+    asDouble: number
+}
+
+interface OtlpHistogramDataPoint {
+    attributes: OtlpKeyValue[]
+    startTimeUnixNano: string
+    timeUnixNano: string
+    count: number
+    sum: number
+    bucketCounts: number[]
+    explicitBounds: number[]
+}
+
+interface OtlpMetric {
+    name: string
+    sum?: { aggregationTemporality: number; isMonotonic: boolean; dataPoints: OtlpNumberDataPoint[] }
+    gauge?: { dataPoints: OtlpNumberDataPoint[] }
+    histogram?: { aggregationTemporality: number; dataPoints: OtlpHistogramDataPoint[] }
+}
+
+interface OtlpMetricsPayload {
+    resourceMetrics: Array<{
+        resource: { attributes: OtlpKeyValue[] }
+        scopeMetrics: Array<{ scope: { name: string }; metrics: OtlpMetric[] }>
+    }>
+}
+
+const OTLP_TEMPORALITY_CUMULATIVE = 2
+
+// Shape of `registry.getMetricsAsJSON()` entries (prom-client's
+// MetricObjectWithValues) — declared locally so the converter is typed
+// without depending on prom-client's non-exported internals.
+interface PromMetric {
+    name: string
+    type: string
+    values: Array<{ value: number; labels: Record<string, string | number>; metricName?: string }>
+}
+
+function msToUnixNano(ms: number): string {
+    return String(ms) + '000000'
+}
+
+function toAttributes(labels: Record<string, string | number>): OtlpKeyValue[] {
+    return Object.entries(labels).map(([key, value]) => ({ key, value: { stringValue: String(value) } }))
+}
+
+function labelsKey(labels: Record<string, string | number>): string {
+    return JSON.stringify(Object.entries(labels).sort(([a], [b]) => (a < b ? -1 : 1)))
+}
+
+function convertHistogram(metric: PromMetric, startNano: string, nowNano: string): OtlpHistogramDataPoint[] {
+    // prom-client emits one entry per (label set, le) bucket with CUMULATIVE
+    // counts, plus `<name>_sum` and `<name>_count` entries per label set.
+    // Group by the label set without `le`, then de-cumulate the buckets.
+    interface SeriesAccumulator {
+        labels: Record<string, string | number>
+        buckets: Array<{ le: number; cumulative: number }>
+        sum: number
+        count: number
+    }
+    const series = new Map<string, SeriesAccumulator>()
+
+    for (const entry of metric.values) {
+        const { le, ...rest } = entry.labels as Record<string, string | number> & { le?: string | number }
+        const key = labelsKey(rest)
+        let acc = series.get(key)
+        if (!acc) {
+            acc = { labels: rest, buckets: [], sum: 0, count: 0 }
+            series.set(key, acc)
+        }
+        if (entry.metricName?.endsWith('_sum')) {
+            acc.sum = entry.value
+        } else if (entry.metricName?.endsWith('_count')) {
+            acc.count = entry.value
+        } else if (le !== undefined) {
+            acc.buckets.push({ le: le === '+Inf' ? Infinity : Number(le), cumulative: entry.value })
+        }
+    }
+
+    const dataPoints: OtlpHistogramDataPoint[] = []
+    for (const acc of series.values()) {
+        acc.buckets.sort((a, b) => a.le - b.le)
+        const explicitBounds = acc.buckets.filter((b) => Number.isFinite(b.le)).map((b) => b.le)
+        const bucketCounts: number[] = []
+        let previous = 0
+        for (const bucket of acc.buckets) {
+            bucketCounts.push(bucket.cumulative - previous)
+            previous = bucket.cumulative
+        }
+        dataPoints.push({
+            attributes: toAttributes(acc.labels),
+            startTimeUnixNano: startNano,
+            timeUnixNano: nowNano,
+            count: acc.count,
+            sum: acc.sum,
+            bucketCounts,
+            explicitBounds,
+        })
+    }
+    return dataPoints
+}
+
+export function buildOtlpMetricsPayload(
+    promMetrics: PromMetric[],
+    options: { serviceName: string; startTimeMs: number; nowMs: number }
+): OtlpMetricsPayload | null {
+    const startNano = msToUnixNano(options.startTimeMs)
+    const nowNano = msToUnixNano(options.nowMs)
+    const metrics: OtlpMetric[] = []
+
+    for (const metric of promMetrics) {
+        if (metric.values.length === 0) {
+            continue
+        }
+        if (metric.type === 'counter') {
+            metrics.push({
+                name: metric.name,
+                sum: {
+                    aggregationTemporality: OTLP_TEMPORALITY_CUMULATIVE,
+                    isMonotonic: true,
+                    dataPoints: metric.values.map((v) => ({
+                        attributes: toAttributes(v.labels),
+                        startTimeUnixNano: startNano,
+                        timeUnixNano: nowNano,
+                        asDouble: v.value,
+                    })),
+                },
+            })
+        } else if (metric.type === 'gauge') {
+            metrics.push({
+                name: metric.name,
+                gauge: {
+                    dataPoints: metric.values.map((v) => ({
+                        attributes: toAttributes(v.labels),
+                        startTimeUnixNano: startNano,
+                        timeUnixNano: nowNano,
+                        asDouble: v.value,
+                    })),
+                },
+            })
+        } else if (metric.type === 'histogram') {
+            const dataPoints = convertHistogram(metric, startNano, nowNano)
+            if (dataPoints.length > 0) {
+                metrics.push({
+                    name: metric.name,
+                    histogram: { aggregationTemporality: OTLP_TEMPORALITY_CUMULATIVE, dataPoints },
+                })
+            }
+        }
+        // Summaries are skipped: prom-client summaries are rare here and the
+        // quantile representation doesn't round-trip losslessly.
+    }
+
+    if (metrics.length === 0) {
+        return null
+    }
+
+    return {
+        resourceMetrics: [
+            {
+                resource: {
+                    attributes: toAttributes({ 'service.name': options.serviceName }),
+                },
+                scopeMetrics: [{ scope: { name: 'posthog-nodejs-internal-metrics' }, metrics }],
+            },
+        ],
+    }
+}
+
+export function internalMetricsConfigFromEnv(env: Record<string, string | undefined>): InternalMetricsConfig | null {
+    const token = env.POSTHOG_INTERNAL_METRICS_TOKEN
+    if (!token) {
+        return null
+    }
+    return {
+        token,
+        host: env.POSTHOG_INTERNAL_METRICS_HOST || 'https://us.i.posthog.com',
+        serviceName: env.POSTHOG_INTERNAL_METRICS_SERVICE_NAME || 'posthog-nodejs',
+        intervalSeconds: Number(env.POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS) || 15,
+    }
+}
+
+export class InternalMetricsExporter {
+    private timer?: NodeJS.Timeout
+    private readonly startTimeMs = Date.now()
+
+    constructor(
+        private readonly config: InternalMetricsConfig,
+        private readonly registry: Registry = globalRegistry,
+        private readonly fetchImpl: (
+            url: string,
+            options: { method: string; headers: Record<string, string>; body: string }
+        ) => Promise<Pick<FetchResponse, 'status'>> = internalFetch
+    ) {}
+
+    start(): void {
+        if (this.timer) {
+            return
+        }
+        this.timer = setInterval(() => void this.exportOnce(), this.config.intervalSeconds * 1000)
+        this.timer.unref?.()
+        logger.info('📈', 'Internal metrics exporter started', {
+            host: this.config.host,
+            serviceName: this.config.serviceName,
+            intervalSeconds: this.config.intervalSeconds,
+        })
+    }
+
+    stop(): void {
+        if (this.timer) {
+            clearInterval(this.timer)
+            this.timer = undefined
+        }
+    }
+
+    private async exportOnce(): Promise<void> {
+        try {
+            const promMetrics = (await this.registry.getMetricsAsJSON()) as unknown as PromMetric[]
+            const payload = buildOtlpMetricsPayload(promMetrics, {
+                serviceName: this.config.serviceName,
+                startTimeMs: this.startTimeMs,
+                nowMs: Date.now(),
+            })
+            if (!payload) {
+                return
+            }
+            const url = `${this.config.host}/i/v1/metrics?token=${encodeURIComponent(this.config.token)}`
+            const response = await this.fetchImpl(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            })
+            if (response.status < 200 || response.status >= 300) {
+                logger.warn('📈', 'Internal metrics export failed', { status: response.status })
+            }
+        } catch (error) {
+            // Metrics export must never take a service down with it.
+            logger.warn('📈', 'Internal metrics export errored', { error })
+        }
+    }
+}
+
+let exporter: InternalMetricsExporter | undefined
+
+/** Starts the exporter once per process if `POSTHOG_INTERNAL_METRICS_TOKEN` is set. */
+export function startInternalMetricsExporterFromEnv(): void {
+    if (exporter) {
+        return
+    }
+    const config = internalMetricsConfigFromEnv(process.env)
+    if (!config) {
+        return
+    }
+    exporter = new InternalMetricsExporter(config)
+    exporter.start()
+}


### PR DESCRIPTION
## Problem

Our node services' prometheus metrics reach the Metrics product only via the infra-level scrape collector, which stamps everything with the scrape job's identity (`service_name: kubernetes-pods`) — you can't filter or group by the actual service. And most services aren't covered at all; their metrics go only to the external TSDB.

Dogfooding the Metrics product means our own services should report into it directly, with a real per-service `service.name`.

## Changes

Adds an opt-in internal metrics exporter to the shared nodejs service plumbing:

- `internal-metrics-exporter.ts`: every interval (default 15s), snapshots the process's prom-client registry (`getMetricsAsJSON`), converts it to an OTLP/JSON `ExportMetricsServiceRequest`, and POSTs it to `/i/v1/metrics` with a project token via the repo's `internalFetch` util.
  - counters → cumulative monotonic sums, gauges → gauges, histograms → cumulative-`le` buckets de-cumulated into OTLP bucket counts (`+Inf` becomes the overflow bucket); label sets become data-point attributes. The metrics read path already handles cumulative temporality with counter-reset logic, so no client-side state is needed beyond a fixed process-start time.
  - export failures are logged and swallowed — the exporter can never take a service down; the interval timer is `unref`ed so it never holds a process open.
- Wired via `setupCommonRoutes` (the same seam that serves `/metrics`), so every node service gets it. **No-op unless `POSTHOG_INTERNAL_METRICS_TOKEN` is set** — zero behavior change until the env vars are rolled out per service (`POSTHOG_INTERNAL_METRICS_HOST`, `POSTHOG_INTERNAL_METRICS_SERVICE_NAME`, `POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS`).

The prometheus scrape endpoint is untouched — this is an additive second sink, so the existing TSDB pipeline keeps working during any transition.

No new dependencies.

## How did you test this code?

TDD — 8 unit tests written first (conversion of counters/gauges/histograms including the cumulative-`le` de-cumulation and `+Inf` overflow bucket, label-set splitting, interval posting with fake timers, failure tolerance, env gating).

Also verified end to end against production ingest: ran the exporter with a real prom-client registry twice ~5s apart with traffic between exports; the metrics read back exactly — counter `increase` returned precisely the between-export delta (5), the untouched label set returned 0, and `histogram_quantile(0.5)` interpolated correctly from the de-cumulated buckets. Cumulative semantics round-trip through the product's counter-reset-aware read path as designed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal-only, env-gated; no user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel asked PostHog Code (Claude) to make PostHog's own services report their metrics into the Metrics product, replacing the external-TSDB-only flow. Skills invoked: /writing-tests. Chose a registry-bridge over per-call-site re-instrumentation: one exporter mirrors all ~370 existing prom metrics without touching any call sites, and keeps both sinks alive during transition. Conversion encodings (numeric u64 fields, string nano timestamps, cumulative temporality) match what the ingest's deserializer accepts, verified earlier against its parse tests and live prod sends.

---