### PR TITLE
chore(tests): memoize sqlparse formatting for query snapshots

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1253,6 +1253,24 @@ def also_test_with_materialized_columns(
     return decorator
 
 
+# sqlparse.format(reindent=True) is quadratic-ish on large statements (~70ms on a big HogQL
+# listing query) and snapshot-heavy suites format hundreds per run. It's a pure function of the
+# input, and clean_varying_query_parts normalizes team ids/UUIDs/timestamps so the same query
+# shapes recur across tests - cache the formatting. Keys are the full SQL strings, so the cap
+# bounds memory rather than correctness.
+_sqlparse_format_cache: dict[str, str] = {}
+_SQLPARSE_FORMAT_CACHE_MAX_ENTRIES = 2048
+
+
+def _format_sql_for_snapshot(query: str) -> str:
+    formatted = _sqlparse_format_cache.get(query)
+    if formatted is None:
+        formatted = sqlparse.format(query, reindent=True)
+        if len(_sqlparse_format_cache) < _SQLPARSE_FORMAT_CACHE_MAX_ENTRIES:
+            _sqlparse_format_cache[query] = formatted
+    return formatted
+
+
 @pytest.mark.usefixtures("unittest_snapshot")
 class QueryMatchingTest:
     snapshot: Any
@@ -1265,7 +1283,7 @@ class QueryMatchingTest:
         query = clean_varying_query_parts(query, replace_all_numbers)
 
         try:
-            assert sqlparse.format(query, reindent=True) == self.snapshot
+            assert _format_sql_for_snapshot(query) == self.snapshot
         except AssertionError:
             diff_lines = "\n".join(self.snapshot.get_assert_diff())
             error_message = f"Query does not match snapshot. Update snapshots with --snapshot-update.\n\n{diff_lines}"
@@ -1935,7 +1953,7 @@ class HogQLSnapshotExtension(AmberSnapshotExtension):
     def serialize(cls, data, **kwargs):
         """Serialize the HogQL query."""
         # Format the query for readability
-        formatted = sqlparse.format(data, reindent=True)
+        formatted = _format_sql_for_snapshot(data)
         return f"'''\n{formatted}\n'''\n"
 
 


### PR DESCRIPTION
## Problem

**Saving: replay listing suite 131.7 → 123.9s (−6%); funnel unordered suite ~68 → 59.3s (−13%); any snapshot-heavy suite benefits.** `sqlparse.format(reindent=True)` is quadratic-ish on large statements (~70ms on a big replay listing query) and snapshot assertions format hundreds per run.

## Changes

Cache formatted output in `posthog/test/base.py` (`_format_sql_for_snapshot`, capped dict), shared by `assertQueryMatchesSnapshot` and the HogQL snapshot serializer. Formatting is a pure function of the input, and `clean_varying_query_parts` normalizes team ids/UUIDs/timestamps first so the same query shapes recur across tests. Output is byte-identical — no snapshot files change.

## How did you test this code?

Full replay-listing suite passes 209/209; savings measured with adjacent-run medians on the cumulative speed-up branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #69256 at Paul's request. Authored by Claude Code (PostHog Code cloud task).
