### PR TITLE
chore(tests): cheapen freezegun's per-freeze module cache validation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -196,7 +196,7 @@ def _cheapen_freezegun_module_hash() -> None:
         return f"{id(module)}-{keys_hash}"
 
     _fast_module_attributes_hash.__wrapped__ = api._get_module_attributes_hash  # type: ignore[attr-defined]
-    api._get_module_attributes_hash = _fast_module_attributes_hash
+    api._get_module_attributes_hash = _fast_module_attributes_hash  # ty: ignore[invalid-assignment]
 
 
 def pytest_configure(config) -> None:

--- a/conftest.py
+++ b/conftest.py
@@ -173,11 +173,38 @@ def _cache_url_resolution() -> None:
     resolvers.URLResolver.resolve = resolve  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
+def _cheapen_freezegun_module_hash() -> None:
+    # Every freeze_time().start() revalidates freezegun's per-module patch cache by
+    # hashing each loaded module's attribute list: hash(frozenset(dir(module))) across
+    # every module in sys.modules, per freeze. dir() sorts and materializes a list per
+    # module, so freeze-heavy suites pay seconds per run for it (2.25M hash calls in a
+    # profiled replay-listing run). tuple(module.__dict__) carries the same invalidation
+    # signal ~6x cheaper: every module attribute add/delete mutates __dict__ (dir() has
+    # no extra visibility for cache purposes — PEP 562 lazy attrs only materialize into
+    # __dict__ anyway), and both keys share the same blind spot (rebinding an existing
+    # name), so semantics are unchanged. Installed before any freeze so the cache never
+    # mixes hash schemes.
+    import types  # noqa: PLC0415 — deferred until pytest_configure
+
+    from freezegun import api  # noqa: PLC0415 — deferred until pytest_configure
+
+    def _fast_module_attributes_hash(module: types.ModuleType) -> str:
+        try:
+            keys_hash = hash(tuple(module.__dict__))
+        except (ImportError, TypeError, AttributeError):
+            keys_hash = 0
+        return f"{id(module)}-{keys_hash}"
+
+    _fast_module_attributes_hash.__wrapped__ = api._get_module_attributes_hash  # type: ignore[attr-defined]
+    api._get_module_attributes_hash = _fast_module_attributes_hash
+
+
 def pytest_configure(config) -> None:
     _cache_reverse_rel_identity()
     _cache_select_masks()
     _cache_drf_field_info()
     _cache_url_resolution()
+    _cheapen_freezegun_module_hash()
 
 
 def pytest_collection_finish() -> None:


### PR DESCRIPTION
## Problem

**Saving: replay listing suite 116.8 → 110.6s (−5.3%); every `freeze_time`-using suite benefits.** Each `freeze_time().start()` revalidates freezegun's per-module patch cache with `hash(frozenset(dir(module)))` across all of `sys.modules` — `dir()` sorts and materializes a list per module, per freeze (2.25M hash calls in a profiled replay-listing run).

## Changes

Patch it in the root `conftest.py` (beside the existing session-boot optimizations) to `hash(tuple(module.__dict__))`: ~6× cheaper per scan with the same invalidation semantics — every module attribute change mutates `__dict__`, and both keys share the same rebinding blind spot.

## How did you test this code?

Full replay-listing suite passes 209/209; freeze/unfreeze smoke-tested; savings measured with adjacent same-box run medians.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #69256 at Paul's request. Authored by Claude Code (PostHog Code cloud task).
