### PR TITLE
perf(hogql): cache the static system-table access-scope list

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -150,6 +150,7 @@ from posthog.models.team.team import Team, WeekStartDay
 from posthog.ph_client import feature_enabled_or_false
 from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl
 from posthog.schema_enums import DatabaseSerializedFieldType, PersonsOnEventsMode, SessionTableVersion
+from posthog.scopes import APIScopeObject
 from posthog.synthetic_user import SyntheticUser
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
@@ -442,6 +443,23 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
     return TableNode(children=children)
 
 
+@cache
+def _system_table_access_scopes() -> tuple[tuple[str, APIScopeObject], ...]:
+    """(table name, access scope) for the access-controlled Postgres system tables.
+
+    Cached for the process lifetime — this result directly gates table visibility in access-control
+    decisions, so every entry here MUST remain process-static. Do NOT make a system table's
+    access_scope dynamic (per-team, per-flag, or env-driven at call time): this cache would silently
+    serve stale scopes and bypass the restriction. Today SystemTables().children is a static
+    class-level dict of module-level PostgresTable constants, which satisfies that invariant.
+    """
+    return tuple(
+        (name, table_node.table.access_scope)
+        for name, table_node in SystemTables().children.items()
+        if isinstance(table_node.table, PostgresTable) and table_node.table.access_scope is not None
+    )
+
+
 def _compute_system_table_access_decision(
     team: "Team",
     user: Optional["User | SyntheticUser"],
@@ -452,18 +470,12 @@ def _compute_system_table_access_decision(
     reads are query-free) and the system-node table names to remove.
 
     Pass user_access_control when it's already preloaded to reuse the instance and avoid an extra query."""
-    system_children = SystemTables().children
+    scoped_tables = _system_table_access_scopes()
 
     # Anonymous or synthetic principal: keep only access-controlled tables its scopes cover (none for anonymous / team token).
     if user is None or isinstance(user, SyntheticUser):
         readable_scopes = user.readable_system_table_access_scopes() if user is not None else set()
-        return None, {
-            name
-            for name, table_node in system_children.items()
-            if isinstance(table_node.table, PostgresTable)
-            and table_node.table.access_scope is not None
-            and table_node.table.access_scope not in readable_scopes
-        }
+        return None, {name for name, access_scope in scoped_tables if access_scope not in readable_scopes}
 
     user_access_control = user_access_control or UserAccessControl(user=user, team=team)
 
@@ -472,11 +484,8 @@ def _compute_system_table_access_decision(
         return user_access_control, set()
 
     denied: set[str] = set()
-    for name, table_node in system_children.items():
-        table = table_node.table
-        if not isinstance(table, PostgresTable) or table.access_scope is None:
-            continue  # Not access-controlled, keep it
-        access_level = user_access_control.access_level_for_resource(table.access_scope)
+    for name, access_scope in scoped_tables:
+        access_level = user_access_control.access_level_for_resource(access_scope)
         if access_level and access_level != NO_ACCESS_LEVEL:
             continue  # User has access, keep it
         denied.add(name)


### PR DESCRIPTION
## Problem

Split out of #69163 (one PR per optimization).

Every HogQL query compilation calls `_compute_system_table_access_decision`, which instantiated `SystemTables()` and walked its children to collect the access-controlled `(table name, access scope)` pairs — rebuilding the same static metadata thousands of times per test run and on every production query.

## Changes

- New `_system_table_access_scopes()` behind `functools.cache`: computes the `(name, access_scope)` tuple once per process.
- `_compute_system_table_access_decision` consumes the cached tuple instead of instantiating `SystemTables()` per call.
- The docstring pins the safety invariant: this result gates table visibility in access-control decisions, so every system-table `access_scope` must remain process-static (no per-team/per-flag/env-driven scopes), otherwise the cache would serve stale scopes. Today `SystemTables().children` is a static class-level dict of module-level `PostgresTable` constants, which satisfies that.

Measured effect in #69163: ~3s off the 54-test benchmark suite; every query compilation benefits.

## How did you test this code?

Automated only, run by the agent on the combined #69163 branch (real Postgres 16 + ClickHouse):

- `posthog/hogql/database/test/test_database.py` (109 tests, includes the access-decision spies)
- System-table scoping classes in `test_system_tables.py` (72 tests)
- `products/access_control/backend/tests/test_property_access_control.py` (33 tests)

This slice is unchanged apart from rebasing onto current master; ruff check/format pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes — behavior-preserving internal caching.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code cloud task) directed by Paul, found via cProfile of the benchmark suite in #69163's optimize-measure loop, then split out as its own PR when #69163 was broken up per-change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*