### PR TITLE
chore(tests): strip ON CLUSTER from TRUNCATEs in the test statement runner

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1580,6 +1580,16 @@ class ClickhouseTestMixin(QueryMatchingTest):
 
 
 def run_clickhouse_statement_in_parallel(statements: list[str]):
+    # Test infrastructure runs a single-node ClickHouse, so ON CLUSTER only adds
+    # distributed-DDL keeper round-trips (~0.3-0.5s per statement) without changing
+    # the outcome — strip it from TRUNCATEs.
+    # If a CI variant ever runs multi-replica this strip must be removed or gated; without it,
+    # TRUNCATE without ON CLUSTER only touches the connected node and leaves others dirty.
+    statements = [
+        re.sub(r"\s+ON CLUSTER\s+'?[\w-]+'?", "", stmt) if stmt.lstrip().upper().startswith("TRUNCATE") else stmt
+        for stmt in statements
+    ]
+
     def _execute_with_retry(stmt: str) -> None:
         max_attempts = 5
         for attempt in range(max_attempts):


### PR DESCRIPTION
## Problem

Split out of #69163 (one PR per optimization).

`run_clickhouse_statement_in_parallel` — a test-only helper — executes TRUNCATE statements that carry `ON CLUSTER`. Test infrastructure runs a single-node ClickHouse, so the clause only adds distributed-DDL keeper round-trips (~300–525ms per statement) without changing the outcome. Suites using `ClickhouseDestroyTablesMixin` pay this on every test.

## Changes

- Strip `ON CLUSTER <name>` from statements starting with `TRUNCATE` before executing, dropping per-truncate time to ~47ms.
- The comment pins the safety constraint: pytest always runs single-node (the multinode CI workflow runs a migration smoke script, never pytest); if a CI variant ever runs pytest multi-replica, this strip must be removed or gated, since TRUNCATE without `ON CLUSTER` only touches the connected node.

## How did you test this code?

Automated only, run by the agent on the combined #69163 branch (real Postgres 16 + ClickHouse): benchmark and `ClickhouseDestroyTablesMixin`-based suites pass with per-truncate timings measured before/after. This slice is unchanged apart from rebasing onto current master; ruff check/format pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes — test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code cloud task) directed by Paul in #69163's optimize-measure loop, found via ClickHouse `system.query_log` timing of the truncate statements. Split out as its own PR when #69163 was broken up per-change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*