### PR TITLE
chore(tests): replace sqlparse comment-strip in capture_queries with a head scanner

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1556,12 +1556,48 @@ class ClickhouseTestMixin(QueryMatchingTest):
     def capture_queries_startswith(self, query_prefixes: Union[str, tuple[str, ...]]):
         return self.capture_queries(lambda x: x.startswith(query_prefixes))
 
+    @staticmethod
+    def _strip_leading_sql_comments(sql: str) -> str:
+        """Drop leading whitespace and comments (keeping any parens) so head-anchored query
+        filters see the first real token. Equivalent to sqlparse.format(strip_comments=True)
+        for every filter used with capture_queries — all of them match on the statement head —
+        but without paying sqlparse's full-statement lexing (~100ms on large generated SQL)."""
+        i, n, parens = 0, len(sql), []
+        while i < n:
+            char = sql[i]
+            if char.isspace():
+                i += 1
+            elif char == "(":
+                parens.append("(")
+                i += 1
+            elif sql.startswith("/*", i):
+                end = sql.find("*/", i + 2)
+                if end == -1:
+                    break
+                i = end + 2
+            elif sql.startswith("--", i):
+                newline = sql.find("\n", i)
+                if newline == -1:
+                    i = n
+                    break
+                i = newline + 1
+            else:
+                break
+        return "".join(parens) + sql[i:]
+
     @contextmanager
     def capture_queries(self, query_filter: Callable[[str], bool]):
+        """Capture ClickHouse queries that pass query_filter.
+
+        The filter receives the query after stripping leading whitespace and comments (head-only
+        — see _strip_leading_sql_comments). All built-in filters (capture_select_queries,
+        capture_queries_startswith) are head-anchored, so this contract holds for them. Do not
+        pass a filter that matches on mid-statement text; it will not see comments embedded there.
+        """
         queries = []
 
         def execute_wrapper(original_client_execute, query, *args, **kwargs):
-            if query_filter(sqlparse.format(query, strip_comments=True).strip()):
+            if query_filter(self._strip_leading_sql_comments(query)):
                 queries.append(query)
             return original_client_execute(query, *args, **kwargs)
 


### PR DESCRIPTION
## Problem

Split out of #69163 (one PR per optimization).

`capture_queries` lexed every captured ClickHouse statement with `sqlparse.format(strip_comments=True)` just to strip leading comments before applying the filter — sqlparse's full-statement lexing costs ~100ms on large generated SQL, paid per captured query in snapshot-heavy suites.

## Changes

- New `_strip_leading_sql_comments`: a linear scanner that drops leading whitespace and comments (block and line, keeping any opening parens) so head-anchored filters see the first real token.
- `capture_queries` uses it instead of sqlparse. Every filter in the repo (`capture_select_queries`, `capture_queries_startswith`, and the ad-hoc lambdas) matches on the statement head, so this is equivalent for all of them.
- The `capture_queries` docstring pins the head-only contract so future filters don't rely on mid-statement comment stripping.

Measured effect in #69163: ~1.3s on the benchmark suite, more on snapshot-heavy suites.

## How did you test this code?

Automated only, run by the agent on the combined #69163 branch: the scanner was equivalence-tested against `sqlparse.format(strip_comments=True)` across representative statement shapes (leading block/line comments, parens, INSERT/ALTER/SELECT heads), and snapshot suites (which exercise `capture_queries` heavily) pass unchanged. This slice is unchanged apart from rebasing onto current master; ruff check/format pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes — test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code cloud task) directed by Paul in #69163's optimize-measure loop, found via cProfile showing sqlparse lexing as a test hot spot. Split out as its own PR when #69163 was broken up per-change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*