### PR TITLE
chore(tests): batch journeys_for person creation into bulk inserts

### DIFF
--- a/posthog/test/persons.py
+++ b/posthog/test/persons.py
@@ -275,6 +275,74 @@ def _build_person(create_kwargs: dict[str, Any]) -> Person:
 # ── Public helpers: Person ───────────────────────────────────────────
 
 
+def create_people_bulk(specs: list[dict[str, Any]]) -> list[Person]:
+    """Create many persons at once: one ClickHouse insert per table instead of two per person.
+
+    Each spec is a create_person() kwargs dict (team/team_id, distinct_ids, uuid, ...). Row values
+    mirror what create_person writes via posthog.models.person.util.create_person /
+    create_person_distinct_id — only batched. Note: distinct-id rows use Python-side
+    (freezegun-frozen) time for _timestamp rather than ClickHouse server now(); harmless because
+    pdi2 dedup uses version, not _timestamp. The persons-DB-layer path (fake off) falls back to
+    per-person create_person.
+    """
+    import json  # noqa: PLC0415
+
+    from posthog.clickhouse.client import sync_execute  # noqa: PLC0415
+    from posthog.models.person.sql import BULK_INSERT_PERSON_DISTINCT_ID2, INSERT_PERSON_BULK_SQL  # noqa: PLC0415
+
+    if _get_active_fake() is None:
+        return [create_person(**spec) for spec in specs]
+
+    persons: list[Person] = []
+    person_rows: list[dict[str, Any]] = []
+    distinct_id_rows: list[dict[str, Any]] = []
+    for spec in specs:
+        create_kwargs = {key: value for key, value in spec.items() if key != "distinct_ids"}
+        if "team" in create_kwargs and create_kwargs["team"] is None:
+            create_kwargs.pop("team")
+        dids = [str(d) for d in (spec.get("distinct_ids") or [])]
+        person = _build_person(create_kwargs)
+        person._distinct_ids = list(dids)
+        if not signals.is_muted:
+            timestamp = now().astimezone(dt.UTC).replace(tzinfo=None)
+            created_at = person.created_at.astimezone(dt.UTC).replace(tzinfo=None) if person.created_at else timestamp
+            person_rows.append(
+                {
+                    "id": str(person.uuid),
+                    "created_at": created_at,
+                    "team_id": person.team_id,
+                    "properties": json.dumps(person.properties or {}),
+                    "is_identified": int(person.is_identified),
+                    "_timestamp": timestamp,
+                    "_offset": 0,
+                    "is_deleted": 0,
+                    "version": person.version or 0,
+                    "last_seen_at": timestamp.replace(minute=0, second=0, microsecond=0),
+                }
+            )
+            for distinct_id in dids:
+                distinct_id_rows.append(
+                    {
+                        "distinct_id": distinct_id,
+                        "person_id": str(person.uuid),
+                        "team_id": person.team_id,
+                        "is_deleted": 0,
+                        "version": 0,
+                        "_timestamp": timestamp,
+                        "_offset": 0,
+                        "_partition": 0,
+                    }
+                )
+        _seed_person_into_fake(person, dids)
+        persons.append(person)
+
+    if person_rows:
+        sync_execute(INSERT_PERSON_BULK_SQL, person_rows, flush=False)
+    if distinct_id_rows:
+        sync_execute(BULK_INSERT_PERSON_DISTINCT_ID2, distinct_id_rows, flush=False)
+    return persons
+
+
 def create_person(*, team: Team | None = None, distinct_ids: list[str] | None = None, **kwargs: Any) -> Person:
     """Create a person for tests.
 

--- a/posthog/test/test_journeys.py
+++ b/posthog/test/test_journeys.py
@@ -43,23 +43,35 @@ def journeys_for(
     Writing tests in this way reduces duplication in test setup
     And clarifies the preconditions of the test
     """
+    from posthog.test.persons import create_people_bulk  # noqa: PLC0415
+
     flush_persons_and_events()
     people = {}
-    events_to_create = []
-    for distinct_id, events in events_by_person.items():
+    to_create_bulk: list[dict[str, Any]] = []
+    for distinct_id in events_by_person:
         if create_people:
             # Create the person UUID from the distinct ID and test path, so that SQL snapshots are deterministic
             derived_uuid = UUID(
                 bytes=md5((os.getenv("PYTEST_CURRENT_TEST", "some_test") + distinct_id).encode("utf-8")).digest()
             )
-            people[distinct_id] = update_or_create_person(
-                distinct_ids=[distinct_id], team_id=team.pk, uuid=derived_uuid
-            )
+            existing_person = get_person_by_distinct_id(team.pk, distinct_id)
+            if existing_person is not None:
+                people[distinct_id] = update_or_create_person(
+                    distinct_ids=[distinct_id], team_id=team.pk, uuid=derived_uuid
+                )
+            else:
+                to_create_bulk.append({"team_id": team.pk, "distinct_ids": [distinct_id], "uuid": derived_uuid})
         else:
             existing_person = get_person_by_distinct_id(team.pk, distinct_id)
             assert existing_person is not None
             people[distinct_id] = existing_person
 
+    # One bulk ClickHouse insert per table instead of two inserts per person.
+    for spec, person in zip(to_create_bulk, create_people_bulk(to_create_bulk)):
+        people[spec["distinct_ids"][0]] = person
+
+    events_to_create = []
+    for distinct_id, events in events_by_person.items():
         for event in events:
             # Populate group properties as well
             group_mapping = {}


### PR DESCRIPTION
## Problem

Split out of #69163 (one PR per optimization).

`journeys_for` — the shared test fixture behind most funnel/trends/paths suites — created each person with two synchronous ClickHouse inserts (person + distinct id). A benchmark run issued ~800 single-row inserts for person setup alone.

## Changes

- New `create_people_bulk(specs)` in `posthog/test/persons.py`: batches all new persons into one ClickHouse insert per table (persons, distinct ids). Rows are built identically to the per-person path (same columns and value semantics as `create_person`/`create_person_distinct_id`), the personhog fake is seeded per person, `signals.is_muted` is honored, and when the fake is off it falls back to per-person creation.
- `journeys_for` routes not-yet-existing persons through the bulk helper and keeps `update_or_create_person` for persons that already exist (preserving update semantics).
- Known benign difference (documented in the docstring): distinct-id rows use Python-side, freezegun-frozen time for `_timestamp` rather than ClickHouse server `now()`; pdi2 dedup uses `version`, not `_timestamp`.

Measured effect in #69163: ~800 single-row inserts per benchmark run → 2 bulk inserts, ~1s.

## How did you test this code?

Automated only, run by the agent on the combined #69163 branch (real Postgres 16 + ClickHouse): person-data integrity verified via `test_insight_actors_query_runner.py`, `test_funnel_breakdowns_by_current_url.py`, and trends actors/breakdown subsets, plus the funnel benchmark suite. This slice is unchanged apart from rebasing onto current master; ruff check/format pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes — test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code cloud task) directed by Paul in #69163's optimize-measure loop. The `signals.is_muted` handling and fake-off fallback came out of qa-swarm review findings on the original PR. Split out as its own PR when #69163 was broken up per-change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*