### PR TITLE
fix(data-warehouse): use org's reconciled region in duckling backfill

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -217,7 +217,9 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
          BEFORE the stored DuckgresServer row on purpose: a row provisioned before the
          naming fix carries a stale, locally-derived bucket that names an object store
          that doesn't exist, and that stale value must not win. cp_bucket_for() also
-         reconciles the row so it converges for next time.
+         reconciles the row (bucket AND bucket_region) so it converges for next time —
+         the region is re-read from that reconciled row rather than assumed from this
+         deployment's default, since a bucket can live outside it.
       2. The stored DuckgresServer.bucket, only as a fallback when the control plane is
          unreachable/unconfigured — so a transient CP outage doesn't fail a run whose
          bucket is already known-good.
@@ -240,11 +242,17 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
             organization_id=org_id,
             bucket=cp_bucket,
         )
+        # cp_bucket_for() reconciles DuckgresServer.bucket_region from this same
+        # CP response before returning, so re-reading it here picks up the org's
+        # real region (which may differ from this deployment's default — e.g. an
+        # EU-provisioned bucket) instead of assuming the deployment default.
+        server = get_duckgres_server_for_organization(org_id)
+        bucket_region = (server.bucket_region if server else None) or DUCKGRES_BUCKET_REGION
         return DucklingTarget(
             team_id=team_id,
             organization_id=org_id,
             bucket=cp_bucket,
-            bucket_region=DUCKGRES_BUCKET_REGION,
+            bucket_region=bucket_region,
             events_table=events_table,
             persons_table=persons_table,
         )

--- a/posthog/dags/tests/test_events_backfill_to_duckling.py
+++ b/posthog/dags/tests/test_events_backfill_to_duckling.py
@@ -15,6 +15,7 @@ from dagster import build_asset_context
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
+    DUCKGRES_BUCKET_REGION,
     DucklingTarget,
     _fixup_partition_values_for_added_files,
     _resolve_duckling_target,
@@ -50,17 +51,23 @@ class TestResolveDucklingTarget:
         [
             # The control plane wins over a stored DuckgresServer bucket — a stale,
             # locally-derived stored value must never beat the authoritative name.
-            ("server_present_but_stale", _FakeRow("stale-stored-bucket", "eu-west-1")),
-            ("no_server", None),
-            ("server_blank", _FakeRow("", "eu-west-1")),
+            # bucket_region still comes from the stored row: cp_bucket_for() just
+            # reconciled it from this same CP response, so it's the org's real
+            # region — even when the row's bucket name is stale or blank.
+            ("server_present_but_stale", _FakeRow("stale-stored-bucket", "eu-west-1"), "eu-west-1"),
+            ("no_server", None, DUCKGRES_BUCKET_REGION),
+            ("server_blank", _FakeRow("", "eu-west-1"), "eu-west-1"),
         ]
     )
-    def test_control_plane_wins_over_stored_server(self, _name: str, server: "_FakeRow | None") -> None:
+    def test_control_plane_wins_over_stored_server(
+        self, _name: str, server: "_FakeRow | None", expected_region: str
+    ) -> None:
         target, mock_cp = self._resolve(server=server, cp_bucket="cp-bucket")
 
         mock_cp.assert_called_once_with("org-1")
         assert target.bucket == "cp-bucket"
         assert target.organization_id == "org-1"
+        assert target.bucket_region == expected_region
 
     def test_falls_back_to_stored_server_when_control_plane_unavailable(self) -> None:
         # CP returns nothing (unreachable/unconfigured) — use the known-good stored row.


### PR DESCRIPTION
## Problem

`_resolve_duckling_target()` (the events/persons duckling backfill's per-partition target resolver) consults the managed-warehouse control plane first via `managed_warehouse.cp_bucket_for(org_id)`. As a side effect, that call reconciles the org's real S3 bucket and region onto its `DuckgresServer` row (`_reconcile_bucket_from_status`). But when the control plane answered successfully, `_resolve_duckling_target` ignored that just-reconciled region and always used the deployment-wide default constant (`DUCKGRES_BUCKET_REGION`) instead - so an org whose managed warehouse lives outside this deployment's default region would have its backfill partitions exported with the wrong region in the generated S3 URL.

This was the last of three region-handling gaps found in an audit of this subsystem's EU/multi-region support. The other two (a hardcoded bucket-region fallback and a hardcoded `.us.postwh.com`-only sslmode check) were already fixed by an unrelated commit that landed on master before this work started.

## Changes

The control-plane-success branch now re-reads `get_duckgres_server_for_organization(org_id)` immediately after `cp_bucket_for()` succeeds and prefers its `bucket_region`, falling back to the deployment default only when no server row exists yet - mirroring the exact pattern the CP-unavailable fallback branch three lines below already uses. Docstring updated to describe the region source. No change to `DucklingTarget`'s shape or the function's signature.

## How did you test this code?

Extended the one existing parameterized test whose fixtures already carried non-default regions (`_FakeRow` with `"eu-west-1"`) but never asserted on `bucket_region` - that's the exact gap this closes. Three cases: a stale-but-present server row, no server row (falls back to the deployment default), and a server row with a blank bucket name but a real region (region still trusted). No new test file or class.

`pytest posthog/dags/tests/test_events_backfill_to_duckling.py posthog/dags/test_events_backfill_to_duckling.py` - 222 passed (both `TestResolveDucklingTarget` classes across both test files, plus every other test in each file). One unrelated pre-existing failure in `TestFixupPartitionValuesForAddedFiles` (a sqlx/Postgres migration-runner environment issue in an ephemeral test worktree, untouched by this change) - confirmed it reproduces identically on the commit this branch is based on, before this fix existed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via subagent-driven development from a written plan (`docs/superpowers/plans/2026-07-08-duckling-backfill-region-fix.md`): a Haiku implementer wrote the fix and tests per the plan's exact before/after code, a Sonnet task reviewer caught that the plan's own mandated commit-message text exceeded this repo's 72-character limit (fixed by amending the message only, re-reviewed clean), and a final Opus whole-branch review confirmed the fix is correct and flagged one non-blocking follow-up idea: `cp_bucket_for()` could return the region directly from the control-plane response instead of round-tripping through a second DB read of its own best-effort-reconciled write. Not implemented here - it touches `managed_warehouse.py`, out of scope for this fix, and the current behavior self-heals on the next run if the reconcile write silently fails.
