### PR TITLE
fix(data-warehouse): show correct synced table name

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -173,6 +173,8 @@ function DetailsSection({
     onConfigureSyncMethod: () => void
     onViewSyncHistory: () => void
 }): JSX.Element {
+    const syncedTableName = schema.table?.hogql_name ?? schema.table?.name
+
     return (
         <div>
             <SectionHeader
@@ -265,20 +267,21 @@ function DetailsSection({
                 </div>
                 <div className="flex items-center justify-between">
                     <span className="text-muted">Synced table</span>
-                    {schema.table ? (
+                    {schema.table && syncedTableName ? (
                         <Link
                             to={urls.sqlEditor({
-                                query: defaultQuery(schema.table.name, schema.table.columns).source.query,
+                                query: defaultQuery(syncedTableName, schema.table.columns).source.query,
                             })}
                             onClick={(event) => {
                                 event.preventDefault()
-                                const table = schema.table!
                                 newInternalTab(
-                                    urls.sqlEditor({ query: defaultQuery(table.name, table.columns).source.query })
+                                    urls.sqlEditor({
+                                        query: defaultQuery(syncedTableName, schema.table!.columns).source.query,
+                                    })
                                 )
                             }}
                         >
-                            <code>{schema.table.name}</code>
+                            <code>{syncedTableName}</code>
                         </Link>
                     ) : (
                         <span className="text-muted">Not yet synced</span>


### PR DESCRIPTION
## Problem

The schema details page showed a malformed synced table’s name when a prefix was used

## Changes

Use the backend-provided HogQL name (`hogql_name`) for the “Synced table” field and for the SQL editor link.

| Before | After |
| --- | --- |
| <img width="578" height="392" alt="Screenshot 2026-07-06 at 23 27 43" src="https://github.com/user-attachments/assets/4177fc7f-49fc-46ae-98d8-e35c8bd150d3" /> | <img width="576" height="400" alt="Screenshot 2026-07-06 at 23 27 07" src="https://github.com/user-attachments/assets/2a2d1dd2-ba6e-46e2-8b03-4dc4d729d747" /> |

## How did you test this code?

I visually checked that “Synced table” field, see attached screenshots

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No