### PR TITLE
fix(tasks): boot the agent after the wizard step for cloud wizard runs

### DIFF
--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -592,6 +592,12 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         # the agent (see run_wizard activity / TaskProcessingContext.wizard_config).
         if wizard_config is not None:
             extra_state["wizard_config"] = wizard_config
+            # The agent-server self-delivers pending_user_message the moment it boots. With
+            # overlap-clone-boot the server launches during provisioning, so that first turn
+            # ("commit the wizard's changes, open a PR") runs before run_wizard has touched the
+            # repo, finds nothing to commit, and consumes the prompt — the run then idles forever.
+            # Wizard runs must boot the agent only after the wizard step.
+            extra_state["overlap_clone_boot_enabled"] = False
 
         # The first message handed to the agent once its server is ready (forward_pending_user_message
         # reads it from run state). Without it a background run boots the agent idle — it never gets a

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -450,3 +450,7 @@ class TestFacadeReadsAndMappers(TestCase):
         # The agent server boots idle; forward_pending_user_message only kicks it off if the run state
         # carries the prompt. Without this the cloud wizard stalls right after "Started agent".
         self.assertEqual(run.state.get("pending_user_message"), WIZARD_PR_AGENT_PROMPT)
+        # The agent-server self-delivers pending_user_message the moment it boots, so an
+        # overlap-clone-boot launch (before run_wizard) burns the prompt on an untouched repo
+        # and the run never opens a PR. Wizard runs must pin the overlap boot off.
+        self.assertIs(run.state.get("overlap_clone_boot_enabled"), False)


### PR DESCRIPTION
## Problem

Cloud setup-wizard runs (onboarding "set up PostHog for me" flow) reach the wizard step, complete it, and then never commit the changes or open a PR. The run goes silent and idles until the inactivity timeout.

Root cause is a boot-ordering race between two mechanisms that both deliver the run's first prompt:

1. The sandbox agent-server **self-delivers** `pending_user_message` from run state the moment it boots (`autoInitializeSession` → `sendInitialTaskMessage`).
2. With `tasks-overlap-clone-boot` enabled (prod), the workflow launches the agent-server **during sandbox provisioning — before the `run_wizard` activity executes**.

So the kickoff turn ("commit the wizard's changes and open a PR") runs against a repo the wizard hasn't touched yet, finds nothing to commit, ends in ~1 minute, and consumes `pending_user_message` from state. When the wizard finishes several minutes later, `forward_pending_user_message` finds no message and no-ops (sub-millisecond "success" in worker logs), so the agent is never told to commit the wizard's output.

Local dev is unaffected because the `tasks-*` flags evaluate false there, so the agent-server only starts after the wizard step — which is why this never reproduced locally.

Prod evidence (both wizard runs inspected show the identical signature): agent event burst starts within seconds of agent-server launch, **while `run_wizard` is still executing**, ends after ~1 minute, and zero agent events follow the wizard's completion; `forward_pending_user_message` completes in <1ms with no `forward_pending_message_attempted` log.

## Changes

Cloud wizard runs now pin `overlap_clone_boot_enabled: False` in run state, which `_is_overlap_clone_boot_enabled` honors ahead of the feature flag. The workflow then starts the agent-server only after `run_wizard`, so the boot-time self-prompt fires with the wizard's changes on disk — the same ordering local dev already has.

## How did you test this code?

- Extended `test_create_wizard_cloud_run_seeds_pending_user_message` to assert wizard runs pin `overlap_clone_boot_enabled` to `False` — catches a regression where the override is dropped (e.g. during a flag cleanup), which would silently reintroduce the race in prod while all other tests stay green. No existing test covered the wizard-run/overlap-boot interaction.
- Ran `products/tasks/backend/tests/test_facade.py` locally (pass).
- Not tested by the agent: an end-to-end cloud wizard run against prod infrastructure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal workflow ordering fix, no user-facing API or documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code (Fable 5). Root cause found by tracing prod worker/agent-proxy logs for stalled onboarding runs, then reading the agent-server boot path in the companion repo; a multi-agent investigation (parallel code readers + an adversarial refuter) eliminated three earlier hypotheses (ingress stream timeout, kickoff delivery timeout, duplicate-prompt turn cancellation) before converging on the boot-ordering race.
- Skills invoked: /writing-tests.
- Chose the run-state override (already honored by `_is_overlap_clone_boot_enabled`) over changing the workflow or the agent-server because it is the smallest change that restores the ordering local dev already exercises; alternatives (moving `pending_user_message` seeding to post-wizard, or gating the agent-server self-prompt) touch the first-message contract shared with other run origins.
- Related: the tracking issue for this incident also covers the inactivity-timeout zombie fix in #69398.
