### PR TITLE
chore(personhog): stash leader reads

### DIFF
--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -220,7 +220,7 @@ impl LeaderBackend {
         // steady-state forward path copies nothing.
         match self
             .stash
-            .enqueue_or_forward(partition, &frame, &headers, key)
+            .enqueue_or_forward(partition, method, &frame, &headers, key)
             .await
         {
             StashDecision::Stashed(rx) => {

--- a/rust/personhog-router/src/backend/stash.rs
+++ b/rust/personhog-router/src/backend/stash.rs
@@ -1,17 +1,21 @@
-//! Per-partition stash queue for the write-path.
+//! Per-partition stash queue for the leader path.
 //!
 //! During a partition handoff, the coordinator advances the handoff state
 //! through `Freezing → Draining → Warming → Complete`. From the moment
 //! the handoff is created (in `Freezing`) and until the routing table
-//! flips at `Complete`, routers buffer (stash) incoming write requests
-//! for that partition here. When `Complete` arrives the stashed
-//! requests are drained in arrival order to the new owner.
+//! flips at `Complete`, routers buffer (stash) incoming leader-path
+//! requests — writes and strong reads alike — for that partition here.
+//! When `Complete` arrives the stashed requests are drained in arrival
+//! order to the new owner.
 //!
-//! This gives the protocol a clean "no split-brain writes" guarantee
-//! without returning errors to callers — every write that hits the
-//! router during the handoff window is either delivered to the new
-//! owner in arrival order or fails fast with `UNAVAILABLE` once its
-//! per-request deadline expires (see `RouterStashHandler`).
+//! Stashing both request kinds gives the protocol two guarantees at once:
+//! no split-brain writes, and strong reads that stay read-your-write
+//! through the handoff — a read queued behind the write it must observe
+//! (per-key FIFO) drains after it, instead of racing ahead to the old
+//! owner's frozen cache. Every request that hits the router during the
+//! handoff window is either delivered in arrival order or fails fast with
+//! `UNAVAILABLE` once its per-request deadline expires (see
+//! `RouterStashHandler`).
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -55,9 +59,12 @@ fn approximate_size(frame: &Bytes) -> usize {
     PER_REQUEST_OVERHEAD + frame.len()
 }
 
-/// A raw write held in the stash along with everything needed to replay it
-/// to the new owner and return the response to the original caller.
+/// A raw leader-path request held in the stash along with everything
+/// needed to replay it and return the response to the original caller.
 pub struct StashedRequest {
+    /// gRPC method the frame targets, so drain replays each request to
+    /// the path it arrived on (writes and strong reads share the stash).
+    pub method: &'static str,
     /// The raw gRPC request frame, forwarded verbatim on replay.
     pub frame: Bytes,
     /// The client's request headers, forwarded verbatim (the router stamps
@@ -185,6 +192,7 @@ impl StashTable {
     pub async fn enqueue_or_forward(
         &self,
         partition: u32,
+        method: &'static str,
         frame: &Bytes,
         headers: &HeaderMap,
         key: (i64, i64),
@@ -223,6 +231,7 @@ impl StashTable {
 
         let (tx, rx) = oneshot::channel();
         queue.requests.push_back(StashedRequest {
+            method,
             frame: frame.clone(),
             headers: headers.clone(),
             key,
@@ -345,6 +354,7 @@ mod tests {
         table
             .enqueue_or_forward(
                 partition,
+                "UpdatePersonProperties",
                 &Bytes::from_static(b"x"),
                 &HeaderMap::new(),
                 (1, person_id),
@@ -363,6 +373,7 @@ mod tests {
         table
             .enqueue_or_forward(
                 partition,
+                "UpdatePersonProperties",
                 &Bytes::from(vec![0u8; payload]),
                 &HeaderMap::new(),
                 (1, person_id),

--- a/rust/personhog-router/src/proxy.rs
+++ b/rust/personhog-router/src/proxy.rs
@@ -157,7 +157,7 @@ impl RawProxyInner {
         let (mut response, backend, channel_call_ms) = match method_name {
             "UpdatePersonProperties" => {
                 let (resp, call_ms) = self
-                    .raw_proxy_to_leader(req, "UpdatePersonProperties", true)
+                    .raw_proxy_to_leader(req, "UpdatePersonProperties")
                     .await;
                 (resp, "leader", call_ms)
             }
@@ -169,7 +169,7 @@ impl RawProxyInner {
                     == Some("strong");
 
                 if is_strong {
-                    let (resp, call_ms) = self.raw_proxy_to_leader(req, "GetPerson", false).await;
+                    let (resp, call_ms) = self.raw_proxy_to_leader(req, "GetPerson").await;
                     (resp, "leader", call_ms)
                 } else {
                     let (resp, call_ms) = self.raw_proxy_to_replica(req, method.clone()).await;
@@ -387,14 +387,22 @@ impl RawProxyInner {
     /// client, is hashed to a partition, and the request bytes are forwarded
     /// verbatim with the partition in the `x-partition` header. The body is
     /// never inspected, so client-compressed request frames transit
-    /// untouched. Writes (`use_stash`) go through the per-partition stash so
-    /// they buffer correctly during a handoff; reads forward directly and
-    /// surface the channel round-trip time for the network-overhead metric.
+    /// untouched.
+    ///
+    /// Both writes and strong reads go through the per-partition stash
+    /// during a handoff. Writes must buffer for the no-split-brain
+    /// guarantee; strong reads must buffer with them so read-your-write
+    /// holds across the handoff — a strong read racing ahead to the old
+    /// owner would miss any write parked in the stash before it, and a
+    /// read arriving after cutover on a router that hasn't seen Complete
+    /// would read the old owner's frozen cache after the new owner has
+    /// already accepted writes. Outside a handoff the stash is empty and
+    /// requests forward directly, surfacing the channel round-trip time
+    /// for the network-overhead metric.
     async fn raw_proxy_to_leader(
         &self,
         req: http::Request<BoxBody>,
         method: &'static str,
-        use_stash: bool,
     ) -> (http::Response<BoxBody>, Option<f64>) {
         let leader = match &self.leader {
             Some(l) => l.clone(),
@@ -432,25 +440,15 @@ impl RawProxyInner {
         let partition = leader.partition_for_person(team_id, person_id);
 
         let _in_flight = ClientInFlightGuard::new("leader");
-        if use_stash {
-            leader
-                .forward_or_stash(
-                    method,
-                    partition,
-                    (team_id, person_id),
-                    parts.headers,
-                    body_bytes,
-                )
-                .await
-        } else {
-            match leader
-                .forward_raw(method, partition, &parts.headers, &body_bytes)
-                .await
-            {
-                Ok((response, call_ms)) => (response, Some(call_ms)),
-                Err(status) => (grpc_error_response(status.code(), status.message()), None),
-            }
-        }
+        leader
+            .forward_or_stash(
+                method,
+                partition,
+                (team_id, person_id),
+                parts.headers,
+                body_bytes,
+            )
+            .await
     }
 }
 

--- a/rust/personhog-router/src/stash_handler.rs
+++ b/rust/personhog-router/src/stash_handler.rs
@@ -18,8 +18,9 @@ use crate::grpc_http::{grpc_error_response, grpc_status_code, is_grpc_error_resp
 ///   reads — for the partition in the shared `StashTable`. The routing-table layer calls `begin_stash` on
 ///   every non-terminal phase the router observes, so the call must
 ///   be idempotent — `StashTable::begin_stash` no-ops if the entry is
-///   already live. New writes park in a per-partition queue while the
-///   handoff progresses through `Freezing → Draining → Warming`.
+///   already live. New leader-path requests park in a per-partition
+///   queue while the handoff progresses through
+///   `Freezing → Draining → Warming`.
 /// * `Complete` → `drain_stash`: forward the buffered requests to the
 ///   new owner, each to the method it arrived on. The drain runs as a loop over the queue; any request
 ///   that arrives during drain (the dashmap entry is still live until

--- a/rust/personhog-router/src/stash_handler.rs
+++ b/rust/personhog-router/src/stash_handler.rs
@@ -11,21 +11,17 @@ use tonic::Code;
 use crate::backend::{LeaderBackend, StashedRequest};
 use crate::grpc_http::{grpc_error_response, grpc_status_code, is_grpc_error_response};
 
-/// gRPC method name for stashed writes — the stash buffers only the write
-/// path, so every replayed frame targets `UpdatePersonProperties`.
-const UPDATE_METHOD: &str = "UpdatePersonProperties";
-
 /// Stash handler for the router. Reacts to handoff phase transitions:
 ///
 /// * `Freezing` / `Draining` / `Warming` → `begin_stash`: start (or
-///   re-confirm) buffering writes for the partition in the shared
-///   `StashTable`. The routing-table layer calls `begin_stash` on
+///   re-confirm) buffering leader-path requests — writes and strong
+///   reads — for the partition in the shared `StashTable`. The routing-table layer calls `begin_stash` on
 ///   every non-terminal phase the router observes, so the call must
 ///   be idempotent — `StashTable::begin_stash` no-ops if the entry is
 ///   already live. New writes park in a per-partition queue while the
 ///   handoff progresses through `Freezing → Draining → Warming`.
-/// * `Complete` → `drain_stash`: forward the buffered writes to the
-///   new owner. The drain runs as a loop over the queue; any request
+/// * `Complete` → `drain_stash`: forward the buffered requests to the
+///   new owner, each to the method it arrived on. The drain runs as a loop over the queue; any request
 ///   that arrives during drain (the dashmap entry is still live until
 ///   drain observes the queue empty under the lock) is picked up by
 ///   the next iteration, preserving FIFO ordering across the cutover.
@@ -127,7 +123,7 @@ async fn forward_one(
     // headers, so no body poll is needed to classify them).
     let (response, outcome) = match leader_backend
         .forward_raw(
-            UPDATE_METHOD,
+            stashed_req.method,
             partition,
             &stashed_req.headers,
             &stashed_req.frame,

--- a/rust/personhog-router/tests/stash_integration.rs
+++ b/rust/personhog-router/tests/stash_integration.rs
@@ -124,9 +124,7 @@ async fn forward(
 /// its gRPC status code on error. The status lives in the response headers
 /// (router-generated errors, trailers-only leader errors) or the trailers
 /// (a normal leader response).
-async fn decode_response(
-    resp: http::Response<BoxBody>,
-) -> Result<UpdatePersonPropertiesResponse, Code> {
+async fn decode_response<T: Message + Default>(resp: http::Response<BoxBody>) -> Result<T, Code> {
     let (parts, body) = resp.into_parts();
     let collected = body.collect().await.expect("collect leader response body");
     let trailers = collected.trailers().cloned();
@@ -146,7 +144,7 @@ async fn decode_response(
     let msg = data
         .get(5..)
         .expect("successful response carries a gRPC frame");
-    Ok(UpdatePersonPropertiesResponse::decode(msg).expect("decode UpdatePersonPropertiesResponse"))
+    Ok(T::decode(msg).expect("decode leader response message"))
 }
 
 /// Drive a strong read through the backend's raw, stash-aware forward
@@ -179,31 +177,6 @@ async fn forward_read(
         )
         .await;
     response
-}
-
-/// Decode a router response into the typed read response, or its gRPC
-/// status code on error.
-async fn decode_read_response(resp: http::Response<BoxBody>) -> Result<GetPersonResponse, Code> {
-    let (parts, body) = resp.into_parts();
-    let collected = body.collect().await.expect("collect leader response body");
-    let trailers = collected.trailers().cloned();
-    let data = collected.to_bytes();
-
-    let status = parts
-        .headers
-        .get("grpc-status")
-        .or_else(|| trailers.as_ref().and_then(|t| t.get("grpc-status")))
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<i32>().ok())
-        .unwrap_or(0);
-    if status != 0 {
-        return Err(Code::from(status));
-    }
-
-    let msg = data
-        .get(5..)
-        .expect("successful response carries a gRPC frame");
-    Ok(GetPersonResponse::decode(msg).expect("decode GetPersonResponse"))
 }
 
 /// A request that arrives while the stash is open must park on a oneshot,
@@ -250,7 +223,9 @@ async fn request_during_stash_completes_after_drain() {
         .await
         .expect("drain should release the parked request promptly")
         .expect("task should not panic");
-    let response = decode_response(raw).await.expect("update should succeed");
+    let response = decode_response::<UpdatePersonPropertiesResponse>(raw)
+        .await
+        .expect("update should succeed");
     let returned = response.person.expect("leader returned a person");
     assert_eq!(returned.id, person.id);
     assert!(response.updated, "leader marked the update as applied");
@@ -296,7 +271,9 @@ async fn multiple_stashed_requests_drain_in_fifo() {
             .await
             .expect("each parked request should release after drain")
             .expect("task should not panic");
-        let resp = decode_response(raw).await.expect("update should succeed");
+        let resp = decode_response::<UpdatePersonPropertiesResponse>(raw)
+            .await
+            .expect("update should succeed");
         versions.push(resp.person.unwrap().version);
     }
 
@@ -333,7 +310,9 @@ async fn requests_for_unstashed_partition_forward_immediately() {
     let raw = tokio::time::timeout(Duration::from_secs(2), forward(&backend, req))
         .await
         .expect("forward should not block");
-    let response = decode_response(raw).await.expect("update should succeed");
+    let response = decode_response::<UpdatePersonPropertiesResponse>(raw)
+        .await
+        .expect("update should succeed");
     assert!(response.updated);
 }
 
@@ -362,7 +341,7 @@ async fn stash_full_returns_unavailable_via_backend() {
     // The second request hits the cap and is rejected.
     let req2 = mk_request(person.team_id, person.id, "second@example.com");
     let raw = forward(&backend, req2).await;
-    let code = decode_response(raw)
+    let code = decode_response::<UpdatePersonPropertiesResponse>(raw)
         .await
         .expect_err("second request must be rejected");
     assert_eq!(
@@ -395,7 +374,7 @@ async fn back_to_back_handoffs_use_fresh_queue() {
     tokio::time::sleep(Duration::from_millis(20)).await;
     handler.drain_stash(partition, "leader-a").await.unwrap();
     let raw_a = pending_a.await.unwrap();
-    decode_response(raw_a)
+    decode_response::<UpdatePersonPropertiesResponse>(raw_a)
         .await
         .expect("first handoff's stashed request should drain successfully");
 
@@ -413,7 +392,7 @@ async fn back_to_back_handoffs_use_fresh_queue() {
     );
     handler.drain_stash(partition, "leader-b").await.unwrap();
     let raw_b = pending_b.await.unwrap();
-    decode_response(raw_b)
+    decode_response::<UpdatePersonPropertiesResponse>(raw_b)
         .await
         .expect("second handoff's stashed request should drain successfully");
 }
@@ -472,10 +451,10 @@ async fn ordering_preserved_when_request_arrives_during_drain() {
 
     drain_task.await.unwrap();
 
-    let resp_a = decode_response(pending_a.await.unwrap())
+    let resp_a = decode_response::<UpdatePersonPropertiesResponse>(pending_a.await.unwrap())
         .await
         .expect("A should succeed");
-    let resp_b = decode_response(pending_b.await.unwrap())
+    let resp_b = decode_response::<UpdatePersonPropertiesResponse>(pending_b.await.unwrap())
         .await
         .expect("B should succeed");
 
@@ -524,7 +503,7 @@ async fn stash_wait_exceeded_returns_unavailable() {
     handler.drain_stash(partition, "leader-new").await.unwrap();
 
     let raw = pending.await.unwrap();
-    let code = decode_response(raw)
+    let code = decode_response::<UpdatePersonPropertiesResponse>(raw)
         .await
         .expect_err("drain must fail-fast past-deadline requests");
     assert_eq!(
@@ -568,7 +547,7 @@ async fn fenced_leader_during_drain_returns_unavailable() {
     handler.drain_stash(partition, "leader-new").await.unwrap();
 
     let response = pending.await.unwrap();
-    let code = decode_response(response)
+    let code = decode_response::<UpdatePersonPropertiesResponse>(response)
         .await
         .expect_err("fenced leader must reject the drained write");
     assert_eq!(
@@ -611,12 +590,12 @@ async fn stashed_strong_read_observes_stashed_write() {
 
     handler.drain_stash(partition, "leader-new").await.unwrap();
 
-    let write_resp = decode_response(write.await.unwrap())
+    let write_resp = decode_response::<UpdatePersonPropertiesResponse>(write.await.unwrap())
         .await
         .expect("stashed write must succeed on drain");
     assert!(write_resp.updated);
 
-    let read_resp = decode_read_response(read.await.unwrap())
+    let read_resp = decode_response::<GetPersonResponse>(read.await.unwrap())
         .await
         .expect("stashed read must succeed on drain");
     let props: serde_json::Value =
@@ -649,7 +628,7 @@ async fn stashed_read_past_deadline_returns_unavailable() {
 
     handler.drain_stash(partition, "leader-new").await.unwrap();
 
-    let code = decode_read_response(read.await.unwrap())
+    let code = decode_response::<GetPersonResponse>(read.await.unwrap())
         .await
         .expect_err("past-deadline read must fail fast");
     assert_eq!(

--- a/rust/personhog-router/tests/stash_integration.rs
+++ b/rust/personhog-router/tests/stash_integration.rs
@@ -16,7 +16,8 @@ use http::HeaderMap;
 use http_body_util::BodyExt;
 use personhog_coordination::routing_table::StashHandler;
 use personhog_proto::personhog::types::v1::{
-    UpdatePersonPropertiesRequest, UpdatePersonPropertiesResponse,
+    GetPersonRequest, GetPersonResponse, UpdatePersonPropertiesRequest,
+    UpdatePersonPropertiesResponse,
 };
 use personhog_router::backend::{LeaderBackend, LeaderBackendConfig, StashTable};
 use personhog_router::config::RetryConfig;
@@ -146,6 +147,63 @@ async fn decode_response(
         .get(5..)
         .expect("successful response carries a gRPC frame");
     Ok(UpdatePersonPropertiesResponse::decode(msg).expect("decode UpdatePersonPropertiesResponse"))
+}
+
+/// Drive a strong read through the backend's raw, stash-aware forward
+/// path — the same route `raw_proxy_to_leader` takes for a strong
+/// `GetPerson` — returning the router's gRPC response.
+async fn forward_read(
+    backend: &LeaderBackend,
+    team_id: i64,
+    person_id: i64,
+) -> http::Response<BoxBody> {
+    let req = GetPersonRequest {
+        team_id,
+        person_id,
+        read_options: None,
+    };
+    let encoded = req.encode_to_vec();
+    let mut buf = Vec::with_capacity(5 + encoded.len());
+    buf.push(0);
+    buf.extend_from_slice(&(encoded.len() as u32).to_be_bytes());
+    buf.extend(encoded);
+
+    let partition = backend.partition_for_person(team_id, person_id);
+    let (response, _call_ms) = backend
+        .forward_or_stash(
+            "GetPerson",
+            partition,
+            (team_id, person_id),
+            HeaderMap::new(),
+            Bytes::from(buf),
+        )
+        .await;
+    response
+}
+
+/// Decode a router response into the typed read response, or its gRPC
+/// status code on error.
+async fn decode_read_response(resp: http::Response<BoxBody>) -> Result<GetPersonResponse, Code> {
+    let (parts, body) = resp.into_parts();
+    let collected = body.collect().await.expect("collect leader response body");
+    let trailers = collected.trailers().cloned();
+    let data = collected.to_bytes();
+
+    let status = parts
+        .headers
+        .get("grpc-status")
+        .or_else(|| trailers.as_ref().and_then(|t| t.get("grpc-status")))
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(0);
+    if status != 0 {
+        return Err(Code::from(status));
+    }
+
+    let msg = data
+        .get(5..)
+        .expect("successful response carries a gRPC frame");
+    Ok(GetPersonResponse::decode(msg).expect("decode GetPersonResponse"))
 }
 
 /// A request that arrives while the stash is open must park on a oneshot,
@@ -517,6 +575,87 @@ async fn fenced_leader_during_drain_returns_unavailable() {
         code,
         Code::Unavailable,
         "fence rejections during drain must surface as retryable UNAVAILABLE"
+    );
+}
+
+/// The reason strong reads stash at all: a write parked in the stash is
+/// invisible everywhere until drain, so a strong read that raced ahead to
+/// the (frozen) old owner would violate read-your-write for the whole
+/// handoff window. Stashed behind the write in the same per-key FIFO, the
+/// read drains after it and observes it.
+#[tokio::test]
+async fn stashed_strong_read_observes_stashed_write() {
+    let person = create_test_person();
+    let leader_addr = start_test_leader(TestLeaderService::new().with_person(person.clone())).await;
+
+    let stash = StashTable::with_bounds(usize::MAX, usize::MAX);
+    let backend = make_backend(leader_addr, stash.clone()).await;
+    let handler = new_test_handler(Arc::clone(&backend));
+
+    let partition = backend.partition_for_person(person.team_id, person.id);
+    handler.begin_stash(partition, "leader-new").await.unwrap();
+
+    // Write first, then a strong read for the same person — both park.
+    let backend_w = Arc::clone(&backend);
+    let req = mk_request(person.team_id, person.id, "stashed-write@example.com");
+    let write = tokio::spawn(async move { forward(&backend_w, req).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let backend_r = Arc::clone(&backend);
+    let (team_id, person_id) = (person.team_id, person.id);
+    let read = tokio::spawn(async move { forward_read(&backend_r, team_id, person_id).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !write.is_finished() && !read.is_finished(),
+        "both must park"
+    );
+
+    handler.drain_stash(partition, "leader-new").await.unwrap();
+
+    let write_resp = decode_response(write.await.unwrap())
+        .await
+        .expect("stashed write must succeed on drain");
+    assert!(write_resp.updated);
+
+    let read_resp = decode_read_response(read.await.unwrap())
+        .await
+        .expect("stashed read must succeed on drain");
+    let props: serde_json::Value =
+        serde_json::from_slice(&read_resp.person.expect("person").properties).unwrap();
+    assert_eq!(
+        props["email"], "stashed-write@example.com",
+        "the drained read must observe the write stashed before it"
+    );
+}
+
+/// A stashed strong read is bounded by the same per-request deadline as a
+/// write: past `max_stash_wait` it fails fast with retryable UNAVAILABLE
+/// instead of parking until the client's gRPC deadline.
+#[tokio::test]
+async fn stashed_read_past_deadline_returns_unavailable() {
+    let person = create_test_person();
+    let leader_addr = start_test_leader(TestLeaderService::new().with_person(person.clone())).await;
+
+    let stash = StashTable::with_bounds(usize::MAX, usize::MAX);
+    let backend = make_backend(leader_addr, stash.clone()).await;
+    let handler = RouterStashHandler::new(Arc::clone(&backend), Duration::from_millis(50), 4);
+
+    let partition = backend.partition_for_person(person.team_id, person.id);
+    handler.begin_stash(partition, "leader-new").await.unwrap();
+
+    let backend_r = Arc::clone(&backend);
+    let (team_id, person_id) = (person.team_id, person.id);
+    let read = tokio::spawn(async move { forward_read(&backend_r, team_id, person_id).await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    handler.drain_stash(partition, "leader-new").await.unwrap();
+
+    let code = decode_read_response(read.await.unwrap())
+        .await
+        .expect_err("past-deadline read must fail fast");
+    assert_eq!(
+        code,
+        Code::Unavailable,
+        "past-deadline stashed reads must surface as retryable UNAVAILABLE"
     );
 }
 


### PR DESCRIPTION
## Problem

Strong reads on the leader path exist to give ingestion read-your-writes. During a partition handoff, that contract silently broke in two ways:

1. For the whole handoff window: from Freezing onward, writes park in the router's per-partition stash while strong reads keep flowing to the old owner's frozen cache. A client that writes and then strong-reads gets an answer missing its own write for the entire drain-plus-warm duration, exactly when the write is parked and invisible.
2. At cutover: the routing-table flip and the old owner's release ride independent watchers, so a slow router can route a strong read to the not-yet-released old owner after a fast router has already delivered new writes to the new owner. A milliseconds-wide window where a strong read returns stale state.

Both are wrong-answer bugs, not availability bugs, and both live in the one traffic class that explicitly asked for correctness.

## Changes

Strong GetPerson now routes through the same per-partition stash as writes. That closes both windows structurally:

- The freeze quorum already guarantees every registered router is stashing before any write can move (the handoff cannot leave Freezing until every router acked), so there is no router left that would route a read around the stash.
- The stash's per-key FIFO means a strong read queued behind the write it must observe drains after it, to the new owner, preserving read-your-write through the cutover.

Implementation is three small pieces:

- StashedRequest carries its gRPC method. The drain previously hardcoded UpdatePersonProperties as the replay target, so each stashed frame now drains to the method it arrived on.
- raw_proxy_to_leader loses its use_stash parameter: both leader methods go through forward_or_stash, whose no-stash-open path is identical to the old direct forward (including the round-trip timing the network-overhead metric relies on). Outside a handoff, behavior is unchanged to the byte.
- Stashed reads inherit the existing per-request deadline and drain policies: a read parked past max_stash_wait fails fast with retryable UNAVAILABLE rather than staleness, and the fence-race remap on drain applies to reads the same as writes.

The deliberate trade: strong reads for a partition mid-handoff now wait for cutover (bounded by the stash deadline) instead of being answered instantly from the frozen old cache.
Delayed-but-correct beats instant-but-stale for this traffic class, and eventual reads are untouched since they live entirely on the replica path.

What this deliberately does not cover: the double-zombie window (a router past its lease routing to a pod past its lease, both unaware of a completed handoff). Stashing cannot help there because a zombie router does not know to stash; that residual is documented and waits on read fencing alongside the epoch-fencing roadmap item.

## How did you test this code?

Agent-authored changes; automated tests only. Full personhog-router sweep green: lib (73), raw_proxy_integration (22), stash_integration (11). clippy and fmt clean.

New coverage and the regression each test catches:

- stashed_strong_read_observes_stashed_write: a write parks in the stash, a strong read for the same person parks behind it, drain runs, and the read must contain the write. Under the old routing this fails by construction, since the read would go to the frozen old owner and return the pre-write value. This is the read-your-write contract, pinned end to end through the drain.
- stashed_read_past_deadline_returns_unavailable: stashed reads get the same bounded, definitively-retryable failure contract as writes rather than parking until the client's gRPC deadline.
- Existing suites pin that nothing changed outside handoffs: strong reads with no stash open forward directly (raw-proxy integration), and all prior stash semantics (FIFO, deadline, fence remap, convergence under concurrent arrivals) hold with the method now threaded through.

## 🤖 Agent context

Autonomy: Human-driven (agent-assisted)

  Built in a Claude Code session directed by the assignee, as the follow-up chosen during a full-protocol review of the coordination hardening work: enumerating stale-read windows produced a three-way taxonomy (in-handoff read-your-write gap, cutover propagation race, double-zombie), and stashing strong reads closes the first two with machinery whose invariants the hardening PR already pinned. Alternatives weighed: reordering cutover so the old owner releases before routers flip (converts staleness to errors but adds a protocol phase, and keeps the in-handoff gap), and read fencing (covers zombies but requires clock-bound leases; deferred with epoch fencing). Key implementation decision: carry the method on StashedRequest rather than a parallel read-stash, so reads and writes share one FIFO per key, which is precisely what makes read-your-write ordering fall out for free; deleting use_stash instead of defaulting it keeps the single-path invariant compiler-enforced.
