### PR TITLE
fix(signals): only comment on and close implementation PR when it's still open

### DIFF
--- a/products/signals/backend/implementation_pr.py
+++ b/products/signals/backend/implementation_pr.py
@@ -69,7 +69,9 @@ def close_implementation_pr_for_report(
 ) -> bool:
     """Best-effort: comment on and close the GitHub PR opened for this report's implementation task.
 
-    Called when a report is suppressed or snoozed — the open PR shouldn't linger. Leaves an
+    Called when a report is suppressed or snoozed — the open PR shouldn't linger. Only acts on a PR
+    that is still open: an already-closed or merged PR is left untouched (no comment, no close), so
+    we never leave a confusing "closing this PR" note on a PR that shipped months ago. Leaves an
     explanatory comment, then closes the PR. Returns True when the PR was closed, False when there
     was nothing to close or the close couldn't be completed. Never raises: the state transition
     must succeed regardless.
@@ -89,6 +91,30 @@ def close_implementation_pr_for_report(
         github = GitHubIntegration.first_for_team_repository(team_id, repository)
         if github is None:
             logger.info("close_implementation_pr_no_integration", report_id=str(report_id), repository=repository)
+            return False
+
+        # Only comment on and close a PR that's still open. A merged PR reports state "closed" with
+        # merged=True, and an already-closed PR reports state "closed" — in either case there's
+        # nothing to close, and leaving a comment would just be noise. If the state can't be
+        # confirmed, skip rather than risk commenting on a PR that already shipped.
+        pr_status = github.get_pull_request(repository, pr_number)
+        if not pr_status.get("success"):
+            logger.warning(
+                "close_implementation_pr_status_fetch_failed",
+                report_id=str(report_id),
+                pr_url=pr_url,
+                error=pr_status.get("error"),
+                status_code=pr_status.get("status_code"),
+            )
+            return False
+        if pr_status.get("state") != "open" or pr_status.get("merged"):
+            logger.info(
+                "close_implementation_pr_not_open",
+                report_id=str(report_id),
+                pr_url=pr_url,
+                state=pr_status.get("state"),
+                merged=pr_status.get("merged"),
+            )
             return False
 
         # Explain first, close second — a failed comment shouldn't stop the close.

--- a/products/signals/backend/test/test_dismissal_pr_close.py
+++ b/products/signals/backend/test/test_dismissal_pr_close.py
@@ -116,6 +116,7 @@ class TestCloseImplementationPrForReport(BaseTest):
     )
     def test_comments_on_and_closes_linked_pr(self, _name: str, reason: PrCloseReason):
         github = MagicMock()
+        github.get_pull_request.return_value = {"success": True, "state": "open", "merged": False}
         github.comment_on_pull_request.return_value = {"success": True}
         github.close_pull_request.return_value = {"success": True, "number": 123, "state": "closed"}
         with (
@@ -159,3 +160,43 @@ class TestCloseImplementationPrForReport(BaseTest):
             ),
         ):
             assert close_implementation_pr_for_report(self.team.id, "report-1") is False
+
+    @parameterized.expand(
+        [
+            ("already_closed", {"success": True, "state": "closed", "merged": False}),
+            ("already_merged", {"success": True, "state": "closed", "merged": True}),
+        ]
+    )
+    def test_skips_comment_and_close_when_pr_not_open(self, _name: str, pr_status: dict):
+        github = MagicMock()
+        github.get_pull_request.return_value = pr_status
+        with (
+            patch(
+                "products.signals.backend.implementation_pr.fetch_implementation_pr_urls_for_reports",
+                return_value={"report-1": _PR_URL},
+            ),
+            patch(
+                "products.signals.backend.implementation_pr.GitHubIntegration.first_for_team_repository",
+                return_value=github,
+            ),
+        ):
+            assert close_implementation_pr_for_report(self.team.id, "report-1") is False
+        github.comment_on_pull_request.assert_not_called()
+        github.close_pull_request.assert_not_called()
+
+    def test_skips_comment_and_close_when_status_unavailable(self):
+        github = MagicMock()
+        github.get_pull_request.return_value = {"success": False, "error": "boom", "status_code": 404}
+        with (
+            patch(
+                "products.signals.backend.implementation_pr.fetch_implementation_pr_urls_for_reports",
+                return_value={"report-1": _PR_URL},
+            ),
+            patch(
+                "products.signals.backend.implementation_pr.GitHubIntegration.first_for_team_repository",
+                return_value=github,
+            ),
+        ):
+            assert close_implementation_pr_for_report(self.team.id, "report-1") is False
+        github.comment_on_pull_request.assert_not_called()
+        github.close_pull_request.assert_not_called()


### PR DESCRIPTION
## Problem

When a signal report is suppressed or snoozed, we comment on and close the linked implementation PR. But that happened unconditionally — even when the PR had already been closed or merged. The result was the bot leaving a "🔕 Closing this PR because the linked PostHog report was suppressed" note on PRs that had shipped months earlier, which is confusing noise.

## Changes

`close_implementation_pr_for_report` now fetches the PR state first (via the existing `get_pull_request`) and only proceeds when the PR is still open. A merged PR (`state: "closed"`, `merged: true`) or an already-closed PR is left completely untouched — no comment, no close. If the state can't be confirmed (fetch failure), it also skips, so we never risk commenting on a PR that already shipped.

> [!NOTE]
> `close_pull_request` was already idempotent, so the bug was purely the stray comment plus a redundant close call. This moves the guard up front so neither happens.

## How did you test this code?

Added automated tests in `test_dismissal_pr_close.py`:
- new parameterized case covering already-closed and already-merged PRs, asserting neither `comment_on_pull_request` nor `close_pull_request` is called and the helper returns `False`
- new case for an unavailable status fetch, asserting the same skip behavior
- updated the existing open-PR test to stub `get_pull_request` returning an open state

I (the agent) could not run the Python suite in this environment (no Django install here), but both changed files byte-compile cleanly. The maintainer should run `pytest products/signals/backend/test/test_dismissal_pr_close.py` before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised in a Slack thread: the PostHog bot left a "closing this PR because the linked report was suppressed" comment on a PR that had already merged three months earlier. The fix gates the comment-and-close behind a fresh PR-state check so it only fires on genuinely open PRs. Authored by the PostHog Slack app (Claude).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783540097779789?thread_ts=1783540097.779789&cid=C09SK2PAGKF)*
