### PR TITLE
feat(taxonomic-filter): lemon-skin the menu rebuild surfaces

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -87,6 +87,14 @@ export const FilterRow = React.memo(function FilterRow({
                                 className="ml-2"
                                 noPadding
                             />
+                        ) : editable ? (
+                            // Invisible twin of the remove button: the trailing
+                            // add-filter row has nothing to remove, but reserving
+                            // the same gutter keeps a full-width filter component
+                            // right-aligned with the rows above.
+                            <span className="ml-2 invisible" aria-hidden="true">
+                                <LemonButton icon={orFiltering ? <IconTrash /> : <IconX />} size={size} noPadding />
+                            </span>
                         ) : null}
                     </>
                 ) : (

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -88,10 +88,6 @@ export const FilterRow = React.memo(function FilterRow({
                                 noPadding
                             />
                         ) : editable ? (
-                            // Invisible twin of the remove button: the trailing
-                            // add-filter row has nothing to remove, but reserving
-                            // the same gutter keeps a full-width filter component
-                            // right-aligned with the rows above.
                             <span className="ml-2 invisible" aria-hidden="true">
                                 <LemonButton icon={orFiltering ? <IconTrash /> : <IconX />} size={size} noPadding />
                             </span>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -277,6 +277,9 @@ export function MenuFilterDwhConfig({
             }}
         >
             <DialogContent
+                // Lemon-skin the dialog (lemon-skin.scss) — must ride on the
+                // portaled element itself, wrappers can't reach it
+                data-lemon-skin
                 // `nested` because a popover with focus management is
                 // already open underneath; tells base-ui to stack focus
                 // traps + handle overlay clicks correctly.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -276,8 +276,6 @@ export function MenuFilterDwhConfig({
             }}
         >
             <DialogContent
-                // Lemon-skin the dialog (lemon-skin.scss) — must ride on the
-                // portaled element itself, wrappers can't reach it
                 data-lemon-skin
                 // `nested` because a popover with focus management is
                 // already open underneath; tells base-ui to stack focus
@@ -522,8 +520,6 @@ interface ColumnSelectEntry {
     description?: string
 }
 
-/** Column name with its type inline (`id  integer`) — single-line so combobox
- *  rows and the trigger keep the standard menu-row height. */
 function ColumnLabel({ item }: { item: ColumnSelectEntry }): JSX.Element {
     return (
         <span className="flex min-w-0 items-baseline gap-2">
@@ -577,9 +573,6 @@ function ColumnSelect({ options, value, onChange, allowHogQL }: ColumnSelectProp
                 )}
             </Button>
             <ComboboxContent
-                // Portals to <body>, outside the skinned dialog — the skin
-                // attribute must ride on the portaled element itself (same
-                // wiring as the dialog + popover surfaces in this file).
                 data-lemon-skin
                 anchor={triggerRef}
                 className="min-w-(--anchor-width)"

--- a/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/DwhFlow.tsx
@@ -49,7 +49,6 @@ import {
     FieldContent,
     FieldDescription,
     FieldLabel,
-    ItemContent,
     ItemDescription,
     ItemTitle,
     Tabs,
@@ -523,6 +522,17 @@ interface ColumnSelectEntry {
     description?: string
 }
 
+/** Column name with its type inline (`id  integer`) — single-line so combobox
+ *  rows and the trigger keep the standard menu-row height. */
+function ColumnLabel({ item }: { item: ColumnSelectEntry }): JSX.Element {
+    return (
+        <span className="flex min-w-0 items-baseline gap-2">
+            <ItemTitle className="truncate">{item.title}</ItemTitle>
+            {item.description && <ItemDescription className="shrink-0">{item.description}</ItemDescription>}
+        </span>
+    )
+}
+
 function ColumnSelect({ options, value, onChange, allowHogQL }: ColumnSelectProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const triggerRef = useRef<HTMLButtonElement>(null)
@@ -559,30 +569,29 @@ function ColumnSelect({ options, value, onChange, allowHogQL }: ColumnSelectProp
                 onChange(item ? (item.value === HOGQL_SENTINEL ? '' : item.value) : '')
             }
         >
-            <Button ref={triggerRef} variant="outline" className="h-min" onClick={() => setOpen((prev) => !prev)}>
+            <Button ref={triggerRef} variant="outline" left onClick={() => setOpen((prev) => !prev)}>
                 {selectedItem ? (
-                    <ItemContent variant="menuItem">
-                        <ItemTitle>{selectedItem.title}</ItemTitle>
-                        {selectedItem.description && (
-                            <ItemDescription className="leading-none">{selectedItem.description}</ItemDescription>
-                        )}
-                    </ItemContent>
+                    <ColumnLabel item={selectedItem} />
                 ) : (
                     <span className="text-muted-foreground">Select a value</span>
                 )}
             </Button>
-            <ComboboxContent anchor={triggerRef} className="min-w-(--anchor-width)" align="start" sideOffset={8}>
+            <ComboboxContent
+                // Portals to <body>, outside the skinned dialog — the skin
+                // attribute must ride on the portaled element itself (same
+                // wiring as the dialog + popover surfaces in this file).
+                data-lemon-skin
+                anchor={triggerRef}
+                className="min-w-(--anchor-width)"
+                align="start"
+                sideOffset={8}
+            >
                 <ComboboxInput placeholder="Search columns" showTrigger={false} />
                 <ComboboxEmpty>No columns found</ComboboxEmpty>
                 <ComboboxList>
                     {(item: ColumnSelectEntry) => (
                         <ComboboxItem key={item.value} value={item} className="py-0">
-                            <ItemContent variant="menuItem">
-                                <ItemTitle>{item.title}</ItemTitle>
-                                {item.description && (
-                                    <ItemDescription className="leading-none">{item.description}</ItemDescription>
-                                )}
-                            </ItemContent>
+                            <ColumnLabel item={item} />
                         </ComboboxItem>
                     )}
                 </ComboboxList>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/HogQLEditor.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/HogQLEditor.tsx
@@ -12,7 +12,7 @@
  */
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 
-import { Button, DialogFooter, Skeleton } from '@posthog/quill'
+import { Button, DialogFooter, Field, FieldContent, FieldDescription, FieldLabel, Skeleton } from '@posthog/quill'
 
 import { Link } from 'lib/lemon-ui/Link'
 
@@ -75,44 +75,53 @@ export function MenuFilterHogQLEditor({
 
     return (
         <div className="flex flex-col flex-1 min-h-0">
-            {/* No category chips on this page — suppress the Tab hint. */}
-            <MenuFilterHeader title="Write SQL expression" onBack={onBack} showTabHint={false} />
+            <MenuFilterHeader title="Write SQL expression" onBack={onBack} />
             <div className="flex flex-col flex-1 min-h-0">
-                <div className="flex flex-col gap-2 p-3 flex-1 min-h-0 overflow-y-auto">
-                    {/* 78px matches the legacy HogQLEditor's inline editor. */}
-                    <Suspense fallback={<Skeleton className="h-[78px] w-full rounded-md" />}>
-                        <CodeEditorInline
-                            value={expression}
-                            onChange={(v) => setExpression(v ?? '')}
-                            language="hogQLExpr"
-                            minHeight="78px"
-                            autoFocus
-                            onPressCmdEnter={(value) => commit(value)}
-                            onMount={(editor, monaco) => {
-                                // Esc → onBack, but only when Monaco
-                                // isn't in a state where Esc has its
-                                // own meaning (suggestions, find,
-                                // snippet) — otherwise we'd swallow
-                                // intellisense dismissal.
-                                editor.addCommand(
-                                    monaco.KeyCode.Escape,
-                                    () => onBack(),
-                                    '!suggestWidgetVisible && !findWidgetVisible && !inSnippetMode'
-                                )
-                            }}
-                        />
-                    </Suspense>
-                    {/* Arbitrary-value size: `text-xs` is rebound to 14px under
-                        the lemon skin, which balloons the hint block. */}
-                    <pre className="text-[0.75rem] text-secondary whitespace-pre-wrap font-mono leading-snug m-0">
-                        {EXAMPLE_HINTS}
-                    </pre>
-                    <div className="flex items-baseline justify-between gap-2 text-[0.75rem]">
-                        <Link to="https://posthog.com/docs/sql" target="_blank">
-                            Learn more about SQL
-                        </Link>
-                        <span className="text-tertiary">Esc goes back · ⌘+Enter saves</span>
-                    </div>
+                <div className="flex flex-col gap-4 p-4 flex-1 min-h-0 overflow-y-auto">
+                    <Field>
+                        <FieldLabel>Expression</FieldLabel>
+                        <FieldContent className="gap-4">
+                            <Suspense fallback={<Skeleton className="h-[120px] w-full rounded-md" />}>
+                                <CodeEditorInline
+                                    value={expression}
+                                    onChange={(v) => setExpression(v ?? '')}
+                                    language="hogQLExpr"
+                                    minHeight="120px"
+                                    autoFocus
+                                    onPressCmdEnter={(value) => commit(value)}
+                                    onMount={(editor, monaco) => {
+                                        // Esc → onBack, but only when Monaco
+                                        // isn't in a state where Esc has its
+                                        // own meaning (suggestions, find,
+                                        // snippet) — otherwise we'd swallow
+                                        // intellisense dismissal.
+                                        editor.addCommand(
+                                            monaco.KeyCode.Escape,
+                                            () => onBack(),
+                                            '!suggestWidgetVisible && !findWidgetVisible && !inSnippetMode'
+                                        )
+                                    }}
+                                />
+                            </Suspense>
+                            <FieldDescription>
+                                <pre className="text-xs text-secondary whitespace-pre-wrap font-mono leading-snug m-0">
+                                    {EXAMPLE_HINTS}
+                                </pre>
+                                <div className="mt-2 text-xs">
+                                    <Link
+                                        to="https://posthog.com/docs/sql"
+                                        target="_blank"
+                                        className="underline text-primary"
+                                    >
+                                        Learn more about SQL
+                                    </Link>
+                                </div>
+                                <div className="mt-2 text-xs text-tertiary">
+                                    Esc goes back without saving. ⌘+Enter saves.
+                                </div>
+                            </FieldDescription>
+                        </FieldContent>
+                    </Field>
                 </div>
                 <DialogFooter>
                     <Button variant="outline" onClick={onBack}>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/HogQLEditor.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/HogQLEditor.tsx
@@ -12,7 +12,7 @@
  */
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 
-import { Button, DialogFooter, Field, FieldContent, FieldDescription, FieldLabel, Skeleton } from '@posthog/quill'
+import { Button, DialogFooter, Skeleton } from '@posthog/quill'
 
 import { Link } from 'lib/lemon-ui/Link'
 
@@ -75,53 +75,44 @@ export function MenuFilterHogQLEditor({
 
     return (
         <div className="flex flex-col flex-1 min-h-0">
-            <MenuFilterHeader title="Write SQL expression" onBack={onBack} />
+            {/* No category chips on this page — suppress the Tab hint. */}
+            <MenuFilterHeader title="Write SQL expression" onBack={onBack} showTabHint={false} />
             <div className="flex flex-col flex-1 min-h-0">
-                <div className="flex flex-col gap-4 p-4 flex-1 min-h-0 overflow-y-auto">
-                    <Field>
-                        <FieldLabel>Expression</FieldLabel>
-                        <FieldContent className="gap-4">
-                            <Suspense fallback={<Skeleton className="h-[120px] w-full rounded-md" />}>
-                                <CodeEditorInline
-                                    value={expression}
-                                    onChange={(v) => setExpression(v ?? '')}
-                                    language="hogQLExpr"
-                                    minHeight="120px"
-                                    autoFocus
-                                    onPressCmdEnter={(value) => commit(value)}
-                                    onMount={(editor, monaco) => {
-                                        // Esc → onBack, but only when Monaco
-                                        // isn't in a state where Esc has its
-                                        // own meaning (suggestions, find,
-                                        // snippet) — otherwise we'd swallow
-                                        // intellisense dismissal.
-                                        editor.addCommand(
-                                            monaco.KeyCode.Escape,
-                                            () => onBack(),
-                                            '!suggestWidgetVisible && !findWidgetVisible && !inSnippetMode'
-                                        )
-                                    }}
-                                />
-                            </Suspense>
-                            <FieldDescription>
-                                <pre className="text-xs text-secondary whitespace-pre-wrap font-mono leading-snug m-0">
-                                    {EXAMPLE_HINTS}
-                                </pre>
-                                <div className="mt-2 text-xs">
-                                    <Link
-                                        to="https://posthog.com/docs/sql"
-                                        target="_blank"
-                                        className="underline text-primary"
-                                    >
-                                        Learn more about SQL
-                                    </Link>
-                                </div>
-                                <div className="mt-2 text-xs text-tertiary">
-                                    Esc goes back without saving. ⌘+Enter saves.
-                                </div>
-                            </FieldDescription>
-                        </FieldContent>
-                    </Field>
+                <div className="flex flex-col gap-2 p-3 flex-1 min-h-0 overflow-y-auto">
+                    {/* 78px matches the legacy HogQLEditor's inline editor. */}
+                    <Suspense fallback={<Skeleton className="h-[78px] w-full rounded-md" />}>
+                        <CodeEditorInline
+                            value={expression}
+                            onChange={(v) => setExpression(v ?? '')}
+                            language="hogQLExpr"
+                            minHeight="78px"
+                            autoFocus
+                            onPressCmdEnter={(value) => commit(value)}
+                            onMount={(editor, monaco) => {
+                                // Esc → onBack, but only when Monaco
+                                // isn't in a state where Esc has its
+                                // own meaning (suggestions, find,
+                                // snippet) — otherwise we'd swallow
+                                // intellisense dismissal.
+                                editor.addCommand(
+                                    monaco.KeyCode.Escape,
+                                    () => onBack(),
+                                    '!suggestWidgetVisible && !findWidgetVisible && !inSnippetMode'
+                                )
+                            }}
+                        />
+                    </Suspense>
+                    {/* Arbitrary-value size: `text-xs` is rebound to 14px under
+                        the lemon skin, which balloons the hint block. */}
+                    <pre className="text-[0.75rem] text-secondary whitespace-pre-wrap font-mono leading-snug m-0">
+                        {EXAMPLE_HINTS}
+                    </pre>
+                    <div className="flex items-baseline justify-between gap-2 text-[0.75rem]">
+                        <Link to="https://posthog.com/docs/sql" target="_blank">
+                            Learn more about SQL
+                        </Link>
+                        <span className="text-tertiary">Esc goes back · ⌘+Enter saves</span>
+                    </div>
                 </div>
                 <DialogFooter>
                     <Button variant="outline" onClick={onBack}>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -135,12 +135,11 @@ function PreviewHeader({ details, viewUrl, entry }: PreviewHeaderProps): JSX.Ele
                 {viewUrl && (
                     <Button
                         variant="link"
-                        className="text-primary"
                         size="sm"
                         // The render prop swaps the native <button> for a Link (<a>),
                         // so tell Base UI not to expect native button semantics.
                         nativeButton={false}
-                        render={<Link to={viewUrl} target="_blank" className="text-xs underline" />}
+                        render={<Link to={viewUrl} target="_blank" />}
                     >
                         View
                     </Button>

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -627,7 +627,7 @@ export function TaxonomicFilterMenu({
                     eventDetails.cancel()
                 }}
             >
-                <span ref={triggerWrapRef} className={taxonomicTriggerWrapperClassName(fullWidthTrigger)}>
+                <span ref={triggerWrapRef} data-lemon-skin className={taxonomicTriggerWrapperClassName(fullWidthTrigger)}>
                     {useInputTrigger ? (
                         <MenuInputTrigger
                             iconButton={inputTriggerIcon}
@@ -657,6 +657,9 @@ export function TaxonomicFilterMenu({
                     {triggerAccessory}
                 </span>
                 <PopoverContent
+                    // Lemon-skin the panel (lemon-skin.scss) — the attribute must
+                    // ride on the portaled element itself, wrappers can't reach it
+                    data-lemon-skin
                     align="start"
                     side="bottom"
                     // Input trigger: shift the panel up by (trigger height +
@@ -770,7 +773,7 @@ export function TaxonomicFilterMenu({
                     onBack={state.origin === 'menu' ? openMenu : openDwhPick}
                 />
             )}
-            <DropdownMenuContent align="start" className="min-w-[240px]">
+            <DropdownMenuContent data-lemon-skin align="start" className="min-w-[240px]">
                 {/* The input-trigger box already does "type to make a new filter",
                     so the explicit "New filter…" row would be redundant there. */}
                 {!useInputTrigger && (

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -147,7 +147,7 @@ const QUICK_REOPEN_MS = 3000
 // that produce it — kept as named parts so a change to `MenuFilterHeader`'s
 // spacing or the input row's padding is visibly the thing to keep in sync here.
 const MENU_HEADER_PADDING_Y_PX = 16 // MenuFilterHeader `py-2` (top + bottom)
-const MENU_HEADER_BUTTON_HEIGHT_PX = 24 // "Go back" Button `size="sm"` (h-6)
+const MENU_HEADER_BUTTON_HEIGHT_PX = 26 // "Go back" Button `size="sm"` under lemon-skin (Lemon xsmall; 24 once the skin is off)
 const MENU_HEADER_BORDER_PX = 1 // MenuFilterHeader `border-b`
 const SEARCH_ROW_PADDING_PX = 8 // search-field row `p-2` (one side)
 const PANEL_BORDER_PX = 1 // PopoverContent border
@@ -627,7 +627,11 @@ export function TaxonomicFilterMenu({
                     eventDetails.cancel()
                 }}
             >
-                <span ref={triggerWrapRef} data-lemon-skin className={taxonomicTriggerWrapperClassName(fullWidthTrigger)}>
+                <span
+                    ref={triggerWrapRef}
+                    data-lemon-skin
+                    className={taxonomicTriggerWrapperClassName(fullWidthTrigger)}
+                >
                     {useInputTrigger ? (
                         <MenuInputTrigger
                             iconButton={inputTriggerIcon}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -147,7 +147,7 @@ const QUICK_REOPEN_MS = 3000
 // that produce it — kept as named parts so a change to `MenuFilterHeader`'s
 // spacing or the input row's padding is visibly the thing to keep in sync here.
 const MENU_HEADER_PADDING_Y_PX = 16 // MenuFilterHeader `py-2` (top + bottom)
-const MENU_HEADER_BUTTON_HEIGHT_PX = 26 // "Go back" Button `size="sm"` under lemon-skin (Lemon xsmall; 24 once the skin is off)
+const MENU_HEADER_BUTTON_HEIGHT_PX = 26 // "Go back" Button `size="sm"` under the lemon skin
 const MENU_HEADER_BORDER_PX = 1 // MenuFilterHeader `border-b`
 const SEARCH_ROW_PADDING_PX = 8 // search-field row `p-2` (one side)
 const PANEL_BORDER_PX = 1 // PopoverContent border
@@ -665,8 +665,6 @@ export function TaxonomicFilterMenu({
                     {triggerAccessory}
                 </span>
                 <PopoverContent
-                    // Lemon-skin the panel (lemon-skin.scss) — the attribute must
-                    // ride on the portaled element itself, wrappers can't reach it
                     data-lemon-skin
                     align="start"
                     side="bottom"
@@ -701,11 +699,6 @@ export function TaxonomicFilterMenu({
                     initialFocus={comboboxOverlaysTrigger ? comboboxInputRef : undefined}
                     className={cn(
                         'p-0 gap-0 overflow-hidden flex flex-col w-[calc(100%_-_2rem)]',
-                        // The combobox has an internal scroll area, so it wants a
-                        // fixed height to scroll within (and the full width for its
-                        // list + preview columns). The HogQL editor is a short form
-                        // — size it to its content (capped) at a narrower width so
-                        // the panel doesn't dwarf a three-line expression.
                         state.kind === 'hogql-edit'
                             ? '@[720px]/main-content-container:w-[560px] h-auto max-h-[min(600px,80vh)]'
                             : '@[720px]/main-content-container:w-[720px] h-[400px]'

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -152,10 +152,14 @@ const MENU_HEADER_BORDER_PX = 1 // MenuFilterHeader `border-b`
 const SEARCH_ROW_PADDING_PX = 8 // search-field row `p-2` (one side)
 const PANEL_BORDER_PX = 1 // PopoverContent border
 
-/** Panel-top to search-field-top: the header (padding + button + border) plus the
- *  search row's top padding. */
+/** Panel-top to search-field-top: the panel's own top border, the header
+ *  (padding + button + border), and the search row's top padding. */
 const INPUT_TRIGGER_PANEL_HEADER_OFFSET =
-    MENU_HEADER_PADDING_Y_PX + MENU_HEADER_BUTTON_HEIGHT_PX + MENU_HEADER_BORDER_PX + SEARCH_ROW_PADDING_PX
+    PANEL_BORDER_PX +
+    MENU_HEADER_PADDING_Y_PX +
+    MENU_HEADER_BUTTON_HEIGHT_PX +
+    MENU_HEADER_BORDER_PX +
+    SEARCH_ROW_PADDING_PX
 
 /** Panel-left to search-field-left: the panel border plus the search row's left
  *  padding. */
@@ -696,7 +700,15 @@ export function TaxonomicFilterMenu({
                     // popover's default focusable flow until rendered).
                     initialFocus={comboboxOverlaysTrigger ? comboboxInputRef : undefined}
                     className={cn(
-                        'p-0 gap-0 overflow-hidden flex flex-col w-[calc(100%_-_2rem)] @[720px]/main-content-container:w-[720px] h-[400px]'
+                        'p-0 gap-0 overflow-hidden flex flex-col w-[calc(100%_-_2rem)]',
+                        // The combobox has an internal scroll area, so it wants a
+                        // fixed height to scroll within (and the full width for its
+                        // list + preview columns). The HogQL editor is a short form
+                        // — size it to its content (capped) at a narrower width so
+                        // the panel doesn't dwarf a three-line expression.
+                        state.kind === 'hogql-edit'
+                            ? '@[720px]/main-content-container:w-[560px] h-auto max-h-[min(600px,80vh)]'
+                            : '@[720px]/main-content-container:w-[720px] h-[400px]'
                     )}
                 >
                     {state.kind === 'combobox' && (

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -164,9 +164,6 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     }
 
     return (
-        // data-lemon-skin: the armed trigger's wrapper carries it, so the
-        // resting placeholder must too — the skin's geometry corrections
-        // (lemon-skin.scss) apply identically to both states.
         <span data-lemon-skin className={taxonomicTriggerWrapperClassName(triggerButtonProps?.fullWidth)}>
             {useInputTrigger ? (
                 <MenuInputTrigger

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -164,7 +164,10 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     }
 
     return (
-        <span className={taxonomicTriggerWrapperClassName(triggerButtonProps?.fullWidth)}>
+        // data-lemon-skin: the armed trigger's wrapper carries it, so the
+        // resting placeholder must too — the skin's geometry corrections
+        // (lemon-skin.scss) apply identically to both states.
+        <span data-lemon-skin className={taxonomicTriggerWrapperClassName(triggerButtonProps?.fullWidth)}>
             {useInputTrigger ? (
                 <MenuInputTrigger
                     iconButton={

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -309,7 +309,7 @@ function LemonKitchenSink(): JSX.Element {
             </Section>
             <Section title="Select (closed)">
                 <LemonSelect<string>
-                    value={null}
+                    value={undefined}
                     onChange={() => {}}
                     placeholder="Choose a fruit..."
                     options={[

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -91,6 +91,9 @@ function LemonExamples(): JSX.Element {
                 Loading
             </LemonButton>
             <div className="flex gap-2 items-center">
+                <LemonButton type="secondary" size="xxsmall">
+                    xxsmall
+                </LemonButton>
                 <LemonButton type="secondary" size="xsmall">
                     xsmall
                 </LemonButton>
@@ -127,16 +130,17 @@ function QuillExamples(): JSX.Element {
             <QuillButton variant="primary" loading>
                 Loading
             </QuillButton>
+            {/* Labels name the Lemon size each quill size maps to under the skin */}
             <div className="flex gap-2 items-center">
                 <QuillButton variant="outline" size="xs">
-                    xsmall
+                    xxsmall
                 </QuillButton>
                 <QuillButton variant="outline" size="sm">
-                    small
+                    xsmall
                 </QuillButton>
-                <QuillButton variant="outline">medium</QuillButton>
+                <QuillButton variant="outline">small</QuillButton>
                 <QuillButton variant="outline" size="lg">
-                    large
+                    medium
                 </QuillButton>
             </div>
         </div>

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.scss
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.scss
@@ -41,6 +41,11 @@
         align-self: stretch; // Improves selectability
         width: 100%;
         padding: 0;
+
+        // Ellipsize overflowing placeholders (and unfocused values) instead of
+        // clipping mid-letter. Chrome ignores text-overflow on ::placeholder;
+        // it must live on the input itself.
+        text-overflow: ellipsis;
         cursor: inherit;
         background: none;
         border: none;

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.scss
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.scss
@@ -41,10 +41,6 @@
         align-self: stretch; // Improves selectability
         width: 100%;
         padding: 0;
-
-        // Ellipsize overflowing placeholders (and unfocused values) instead of
-        // clipping mid-letter. Chrome ignores text-overflow on ::placeholder;
-        // it must live on the input itself.
         text-overflow: ellipsis;
         cursor: inherit;
         background: none;

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -19,7 +19,7 @@
  * Covered: Button, Input, InputGroup, Textarea, Checkbox, Switch, RadioGroup,
  * Select, Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton,
  * Label, Kbd, Item, MenuLabel, Empty, Tooltip,
- * Popover/DropdownMenu/ContextMenu surfaces, Tabs (line variant),
+ * Popover/DropdownMenu/ContextMenu surfaces, Tabs (line + pill variants),
  * Dialog (→ LemonModal), Progress — plus a core-token rebind that turns
  * bespoke Tailwind in quill-based features lemony wholesale. First real
  * consumer: the taxonomic filter rebuild
@@ -125,13 +125,18 @@
 
 /* primary → Lemon primary (white face, brown border, amber 3D frame below) */
 
+/*
+ * Frame shadows: LemonButton's chrome paints a single `0 3px 0 -1px` fill
+ * (measured on ::after) — a -1px spread so the lip tucks inside the face's
+ * silhouette. A wider/second shadow reads as a detached outline behind the
+ * button, especially on small controls.
+ */
+
 [data-lemon-skin] .quill-button--variant-primary {
     color: var(--text-3000-light);
     background-color: var(--primary-3000-button-bg);
     border: 1px solid var(--primary-3000-button-border);
-    box-shadow:
-        0 0.1875rem 0 0 var(--primary-3000-frame-bg),
-        0 0.1875rem 0 1px var(--primary-3000-button-border);
+    box-shadow: 0 0.1875rem 0 -1px var(--primary-3000-frame-bg);
     translate: none;
 }
 
@@ -150,9 +155,7 @@
 [data-lemon-skin] .quill-button--variant-outline {
     background-color: var(--secondary-3000-button-bg);
     border: 1px solid var(--secondary-3000-button-border);
-    box-shadow:
-        0 0.1875rem 0 0 var(--secondary-3000-frame-bg),
-        0 0.1875rem 0 1px var(--secondary-3000-button-border);
+    box-shadow: 0 0.1875rem 0 -1px var(--secondary-3000-frame-bg);
 }
 
 [data-lemon-skin] .quill-button--variant-outline:not(:disabled, [aria-disabled='true']):hover {
@@ -189,9 +192,7 @@
     color: var(--danger-3000-button-border-hover);
     background-color: var(--secondary-3000-button-bg);
     border: 1px solid var(--danger-3000-button-border);
-    box-shadow:
-        0 0.1875rem 0 0 var(--danger-3000-frame-bg),
-        0 0.1875rem 0 1px var(--danger-3000-button-border);
+    box-shadow: 0 0.1875rem 0 -1px var(--danger-3000-frame-bg);
 }
 
 [data-lemon-skin] .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover {
@@ -446,13 +447,18 @@
 
 /* ═══ Badge → LemonTag ═════════════════════════════════════════════════ */
 
+/*
+ * LemonTag's `small` variant, not the default: badges here live inside
+ * dense list rows (taxonomic filter results) where the default 22px tag
+ * dwarfs the 14px row text.
+ */
 [data-lemon-skin] .quill-badge {
     height: auto;
-    padding: 0.125rem 0.25rem;
+    padding: 0 0.1875rem;
     font-family: var(--font-sans);
-    font-size: 0.6875rem;
+    font-size: 0.625rem;
     font-weight: 500;
-    line-height: 1rem;
+    line-height: 0.875rem;
     border-radius: var(--lemon-skin-radius);
 }
 
@@ -589,6 +595,38 @@
     border: none;
 }
 
+/* ═══ Lemon components inside skinned surfaces ═════════════════════════ */
+
+/*
+ * The rebuild's input trigger row is deliberately Lemon (LemonInput +
+ * LemonButton, "match the surrounding scene"), but its sizes are off in
+ * Lemon terms. Corrected from here rather than component code so all the
+ * look-tuning stays in this one file. Both LemonInput and LemonButton are
+ * sized by CSS variables, so a rebind is a faithful size swap.
+ */
+
+/* small → medium metrics: matches the sibling controls in the property
+   filter row (operator select, value input) — a smaller field next to them
+   reads as a different component. The combobox's overlay field gets the
+   same treatment, so it still lands exactly on the trigger. */
+[data-lemon-skin] .LemonInput.LemonInput--small {
+    --lemon-input-height: calc(2.125rem + 3px);
+
+    padding: 0.25rem 0.5rem;
+}
+
+/* An embedded LemonButton (the trigger's filter icon) gets xsmall metrics —
+   the only Lemon size that nests inside the field without poking past its
+   border. */
+[data-lemon-skin] .LemonInput .LemonButton {
+    --lemon-button-height: 1.625rem;
+    --lemon-button-font-size: 0.75rem;
+    --lemon-button-icon-size: 0.875rem;
+    --lemon-button-padding-horizontal: 0.375rem;
+    --lemon-button-padding-adjacent-icon: 0.25rem;
+    --lemon-button-gap: 0.25rem;
+}
+
 /*
  * Portal-mounted surfaces below (tooltip, popover, menus, select popup,
  * dialog): the skin attribute is passed to the *Content component and lands
@@ -614,8 +652,21 @@
 
 /* ═══ Popover / menu / select surfaces → Lemon Popover box ═════════════ */
 
-[data-lemon-skin] :is(.quill-popover__content, .quill-menu__content, .quill-menu__sub-content, .quill-select__content),
-:is(.quill-popover__content, .quill-menu__content, .quill-menu__sub-content, .quill-select__content)[data-lemon-skin] {
+[data-lemon-skin]
+    :is(
+        .quill-popover__content,
+        .quill-menu__content,
+        .quill-menu__sub-content,
+        .quill-select__content,
+        .quill-combobox__content
+    ),
+:is(
+    .quill-popover__content,
+    .quill-menu__content,
+    .quill-menu__sub-content,
+    .quill-select__content,
+    .quill-combobox__content
+)[data-lemon-skin] {
     font-family: var(--font-sans);
     font-size: 0.875rem;
     background-color: var(--color-bg-surface-popover);
@@ -641,17 +692,68 @@
     font-size: 0.75rem;
 }
 
-/* Select/menu rows sized like the small LemonButtons LemonMenu renders */
+/*
+ * Inside an input (quill InputGroup, or the LemonInput the input-trigger
+ * mode renders), embedded controls go flat: transparent face, no 3D lip,
+ * face border centered exactly in the field. Any vertical asymmetry from
+ * the frame shadow reads as misalignment at this size, however the pair
+ * is balanced.
+ */
+[data-lemon-skin] :is(.quill-input-group, .LemonInput) .quill-select__trigger {
+    background-color: transparent;
+    box-shadow: none;
+    translate: none;
+}
 
-[data-lemon-skin] .quill-select__item {
+[data-lemon-skin]
+    :is(.quill-input-group, .LemonInput)
+    .quill-select__trigger:not(:disabled, [aria-disabled='true']):hover {
+    background-color: transparent;
+}
+
+/* Flat buttons don't press-sink — there's no frame to sink onto. */
+[data-lemon-skin]
+    :is(.quill-input-group, .LemonInput)
+    .quill-select__trigger:not(:disabled, [aria-disabled='true']):active {
+    translate: none;
+}
+
+/* Select/combobox rows sized like the small LemonButtons LemonMenu renders.
+   Rows compose Button, whose size remap above fixes `height` — override to
+   auto so multi-line rows (title + description) grow their highlight box
+   instead of overflowing it. */
+
+[data-lemon-skin] :is(.quill-select__item, .quill-combobox__item) {
+    height: auto;
     min-height: 2.0625rem;
     font-size: 0.875rem;
     font-weight: 500;
     border-radius: var(--lemon-skin-radius);
 }
 
-[data-lemon-skin] .quill-select__item:focus {
+[data-lemon-skin] .quill-select__item:focus,
+[data-lemon-skin] .quill-combobox__item[data-highlighted] {
     background-color: var(--color-bg-fill-button-tertiary-hover);
+}
+
+/* Combobox rows compose Button, so the button-size remap above clobbers
+   quill's checkmark gutter and pins a fixed single-line height — restore
+   the gutter and let multi-line rows (title + description) grow. Self +
+   descendant variants, like the portal-surface rules below; the extra
+   class out-specifies the button-size rules instead of relying on order. */
+[data-lemon-skin] .quill-combobox__content .quill-combobox__item,
+.quill-combobox__content[data-lemon-skin] .quill-combobox__item {
+    height: auto;
+    min-height: 2.0625rem;
+    padding-inline-start: 1.875rem;
+}
+
+/* Rows zero their own padding via a `py-0` utility (compiled !important),
+   so the breathing room lives on the inner content — reached through
+   Button's internal <span> wrapper, hence descendant not child. */
+[data-lemon-skin] .quill-combobox__content .quill-combobox__item [data-slot='item-content'],
+.quill-combobox__content[data-lemon-skin] .quill-combobox__item [data-slot='item-content'] {
+    padding-block: 0.375rem;
 }
 
 [data-lemon-skin] .quill-select__item:not(:hover)[aria-selected='true'] {
@@ -696,6 +798,46 @@
 
 [data-lemon-skin] .quill-tabs__indicator--variant-line {
     background-color: var(--lemon-skin-accent);
+}
+
+/* ═══ Tabs (pill variant) → Lemon segmented look ═══════════════════════ */
+
+/*
+ * `bg-muted` in this app's Tailwind resolves to `--muted-3000` — PostHog's
+ * muted TEXT color — so a quill-style `bg-muted` surface (the DWH config
+ * field tabs) paints near-black. That's the exact trap quill-bridge.scss
+ * documents. The utility is compiled !important, but it reads a var, so
+ * rebinding the var on the element it lands on is the clean override.
+ */
+[data-lemon-skin] .quill-tabs__list--variant-default {
+    --muted-3000: var(--lemon-skin-bg-page);
+
+    background-color: var(--lemon-skin-bg-page);
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger {
+    font-size: 0.8125rem;
+    color: var(--lemon-skin-text-secondary);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger:hover {
+    color: var(--text-3000);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger[data-active] {
+    /* Quill paints the active pill `var(--background) !important` — rebind
+       the var it resolves (same trick as the line variant above). */
+    --background: var(--lemon-skin-surface);
+
+    color: var(--text-3000);
+}
+
+/* The sliding active-pill face behind the trigger */
+[data-lemon-skin] .quill-tabs__indicator--variant-default {
+    background-color: var(--lemon-skin-surface);
+    border-color: var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
 }
 
 /* ═══ Progress → LemonProgress ═════════════════════════════════════════ */

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -32,10 +32,10 @@
  * it lands on the portaled element itself — the taxonomic filter menu does
  * the latter, and the portal-surface rules below match both placements.
  *
- * Known gaps, acceptable for a prototype: link/link-muted button variants,
+ * Known gaps, acceptable for a prototype:
  * icon-* button sizes, Accordion/Collapsible, Card, Avatar, Table, Toast,
- * Drawer, Slider, Toggle, NumberField, and quill's `sm` control sizes keep
- * quill styling; no hover-raise/press-sink travel on buttons.
+ * Drawer, Slider, Toggle, NumberField keep quill styling; no
+ * hover-raise/press-sink travel on buttons.
  */
 
 /*
@@ -204,55 +204,92 @@
     translate: 0 0.1875rem;
 }
 
-/* Sizes → Lemon's xsmall / small / medium / large scale */
+/*
+ * link / link-muted → Lemon Link (accent text that shifts on hover, no
+ * underline — quill underlines on hover, Lemon never does). Inline like
+ * Lemon's Link, so zero out the button box. Wins over per-instance
+ * `underline` / `text-primary` utilities (layered) without extra weight.
+ */
+
+[data-lemon-skin] .quill-button--variant-link,
+[data-lemon-skin] .quill-button--variant-link-muted {
+    height: auto;
+    padding: 0;
+    color: var(--lemon-skin-accent);
+    text-decoration-line: none;
+    background: none;
+    border: none;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-button--variant-link-muted {
+    color: var(--text-3000);
+}
+
+[data-lemon-skin]
+    :is(.quill-button--variant-link, .quill-button--variant-link-muted):not(:disabled, [aria-disabled='true']):hover {
+    color: var(--lemon-skin-accent-hover);
+    text-decoration-line: none;
+    background: none;
+}
+
+/*
+ * Sizes → Lemon's scale, mapped by closest geometry, not ordinally. Quill
+ * runs compact (xs 20px / sm 24px / default 28px / lg 32px), so the ordinal
+ * mapping inflated every button by one Lemon step and dense surfaces (the
+ * taxonomic filter popover) came out oversized vs their legacy Lemon
+ * counterparts. Closest-geometry (xxsmall 20 / xsmall 26 / small 33 /
+ * medium 37) keeps Lemon density AND minimizes reflow at the eventual
+ * skin-off flip. Lemon `large` (49px) has no quill counterpart.
+ */
 
 [data-lemon-skin] .quill-button--size-default {
-    gap: 0.5rem;
-    height: 2.3125rem;
-    padding-inline: 0.75rem;
-    font-size: 0.875rem;
-}
-
-[data-lemon-skin] .quill-button--size-default svg:not([class*='size-']) {
-    width: 1.5rem;
-    height: 1.5rem;
-}
-
-[data-lemon-skin] .quill-button--size-xs {
-    gap: 0.25rem;
-    height: 1.625rem;
-    padding-inline: 0.375rem;
-    font-size: 0.75rem;
-    border-radius: var(--lemon-skin-radius);
-}
-
-[data-lemon-skin] .quill-button--size-xs svg:not([class*='size-']) {
-    width: 0.875rem;
-    height: 0.875rem;
-}
-
-[data-lemon-skin] .quill-button--size-sm {
     gap: 0.5rem;
     height: 2.0625rem;
     padding-inline: 0.5rem;
     font-size: 0.875rem;
 }
 
-[data-lemon-skin] .quill-button--size-sm svg:not([class*='size-']) {
+[data-lemon-skin] .quill-button--size-default svg:not([class*='size-']) {
     width: 1.25rem;
     height: 1.25rem;
 }
 
+[data-lemon-skin] .quill-button--size-xs {
+    gap: 0.1875rem;
+    height: 1.25rem;
+    padding-inline: 0.25rem;
+    font-size: 0.6875rem;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-button--size-xs svg:not([class*='size-']) {
+    width: 0.8125rem;
+    height: 0.8125rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm {
+    gap: 0.25rem;
+    height: 1.625rem;
+    padding-inline: 0.375rem;
+    font-size: 0.75rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm svg:not([class*='size-']) {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
 [data-lemon-skin] .quill-button--size-lg {
-    gap: 0.75rem;
-    height: 3.0625rem;
+    gap: 0.5rem;
+    height: 2.3125rem;
     padding-inline: 0.75rem;
-    font-size: 1rem;
+    font-size: 0.875rem;
 }
 
 [data-lemon-skin] .quill-button--size-lg svg:not([class*='size-']) {
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 1.5rem;
+    height: 1.5rem;
 }
 
 /* ═══ Input → LemonInput ═══════════════════════════════════════════════ */
@@ -336,8 +373,8 @@
 
 [data-lemon-skin] .quill-checkbox:focus-visible {
     border-color: var(--lemon-skin-accent-hover);
-    box-shadow: none;
     outline: -webkit-focus-ring-color auto 1px;
+    box-shadow: none;
 }
 
 [data-lemon-skin] .quill-checkbox[data-checked],
@@ -590,6 +627,18 @@
 [data-lemon-skin] .quill-menu__separator,
 [data-lemon-skin] .quill-select__separator {
     background-color: var(--lemon-skin-border);
+}
+
+/*
+ * SelectTrigger composes Button without forwarding its size (it sizes itself
+ * via `data-size` in select.css, which the button-size rules above out-cascade),
+ * so re-apply the geometry here: sm → Lemon xsmall, matching the button map.
+ */
+[data-lemon-skin] .quill-select__trigger[data-size='sm'] {
+    gap: 0.25rem;
+    height: 1.625rem;
+    padding-inline: 0.375rem;
+    font-size: 0.75rem;
 }
 
 /* Select/menu rows sized like the small LemonButtons LemonMenu renders */

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -16,16 +16,21 @@
  * Quill's own rules live in `@layer components`, so these unlayered overrides
  * win the cascade without specificity hacks.
  *
- * Covered: Button, Input, Textarea, Checkbox, Switch, RadioGroup, Select,
- * Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton, Label, Kbd,
- * Tooltip, Popover/DropdownMenu/ContextMenu surfaces, Tabs (line variant),
- * Dialog (→ LemonModal), Progress.
+ * Covered: Button, Input, InputGroup, Textarea, Checkbox, Switch, RadioGroup,
+ * Select, Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton,
+ * Label, Kbd, Item, MenuLabel, Empty, Tooltip,
+ * Popover/DropdownMenu/ContextMenu surfaces, Tabs (line variant),
+ * Dialog (→ LemonModal), Progress — plus a core-token rebind that turns
+ * bespoke Tailwind in quill-based features lemony wholesale. First real
+ * consumer: the taxonomic filter rebuild
+ * (lib/components/TaxonomicFilter/menu/).
  *
  * PORTAL CAVEAT: overlay content (tooltip, menus, select popup, dialog)
- * renders in portals at <body>, outside any scoped wrapper. Those rules only
- * take effect when the attributes sit on <body>/<html> — which is exactly the
- * eventual app-wide flip deployment. In scoped demos, overlays keep quill's
- * native look.
+ * renders in portals at <body>, outside any scoped wrapper. Two ways to
+ * cover it: put the attributes on <body>/<html> (the eventual app-wide flip
+ * deployment), or pass `data-lemon-skin` to the quill *Content component so
+ * it lands on the portaled element itself — the taxonomic filter menu does
+ * the latter, and the portal-surface rules below match both placements.
  *
  * Known gaps, acceptable for a prototype: link/link-muted button variants,
  * icon-* button sizes, Accordion/Collapsible, Card, Avatar, Table, Toast,
@@ -57,6 +62,7 @@
     --lemon-skin-border-hover: var(--color-posthog-3000-400);
     --lemon-skin-surface: var(--color-white);
     --lemon-skin-bg-page: var(--color-posthog-3000-50);
+    --lemon-skin-text-secondary: var(--color-neutral-750);
     --lemon-skin-radius: 0.375rem;
     --lemon-skin-radius-lg: 0.625rem;
 }
@@ -66,6 +72,44 @@
     --lemon-skin-border-hover: var(--color-neutral-cool-600);
     --lemon-skin-surface: var(--color-neutral-cool-850);
     --lemon-skin-bg-page: var(--color-neutral-cool-950);
+    --lemon-skin-text-secondary: var(--color-neutral-350);
+}
+
+/*
+ * Core quill semantic tokens → Lemon values. This is the broad brush: it
+ * recolors quill primitive CSS AND bespoke Tailwind in quill-based features
+ * (`bg-(--fill-hover)`, `text-muted-foreground`, `border-border`, `text-xs`)
+ * in one place, so feature code like the taxonomic filter rebuild turns
+ * lemony without per-feature rules. The per-component sections below refine
+ * geometry and typography on top.
+ *
+ * Quill primitives set `data-quill` on their own root elements, and
+ * tokens.scoped.css sets token values directly on every `[data-quill]`
+ * element — an inherited rebind from a wrapper would lose to those. The
+ * extra selectors out-specificity the scoped token sheet.
+ */
+[data-lemon-skin],
+[data-lemon-skin][data-quill],
+[data-lemon-skin] [data-quill] {
+    --foreground: var(--text-3000);
+    --muted-foreground: var(--lemon-skin-text-secondary);
+    --border: var(--lemon-skin-border);
+    --input: var(--lemon-skin-border);
+    --card: var(--color-bg-surface-popover);
+    --background: var(--lemon-skin-surface);
+    --primary: var(--lemon-skin-accent);
+    --primary-foreground: var(--lemon-skin-surface);
+    --fill-hover: var(--color-bg-fill-button-tertiary-hover);
+    --fill-selected: var(--color-bg-fill-button-tertiary-active);
+    --fill-expanded: var(--color-bg-fill-button-tertiary-active);
+    --radius-xs: 0.25rem;
+    --radius-sm: 0.375rem;
+    --radius-md: 0.375rem;
+    --radius-lg: 0.625rem;
+
+    /* Quill's base 12px text → Lemon's 14px, wherever quill CSS reads the var */
+    --text-xs: 0.875rem;
+    --shadow-md: var(--shadow-elevation-3000);
 }
 
 /* ═══ Button → LemonButton ═════════════════════════════════════════════ */
@@ -214,19 +258,41 @@
 /* ═══ Input → LemonInput ═══════════════════════════════════════════════ */
 
 [data-lemon-skin] .quill-input {
-    height: calc(2.125rem + 3px);
-    padding: 0.25rem 0.5rem;
     font-family: var(--font-sans);
     font-size: 0.875rem;
     color: var(--text-3000);
+}
+
+/*
+ * Geometry and chrome only for standalone inputs — inside an InputGroup the
+ * group owns the border and the fixed 2rem height (search overlays like the
+ * taxonomic filter's input-trigger measure against it).
+ */
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']) {
+    height: calc(2.125rem + 3px);
+    padding: 0.25rem 0.5rem;
     background-color: var(--color-bg-fill-input);
     border: 1px solid var(--lemon-skin-border);
     border-radius: var(--lemon-skin-radius);
 }
 
-[data-lemon-skin] .quill-input:hover:not(:disabled),
-[data-lemon-skin] .quill-input:focus-visible {
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']):hover:not(:disabled),
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']):focus-visible {
     /* Lemon inputs signal focus with a border-color change, not a ring */
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ InputGroup (input with addons) — recolor only, keep 2rem metrics ═ */
+
+[data-lemon-skin] .quill-input-group {
+    font-family: var(--font-sans);
+    background-color: var(--color-bg-fill-input);
+    border-color: var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-input-group:has([data-slot='input-group-control']:focus-visible) {
     border-color: var(--lemon-skin-border-hover);
     box-shadow: none;
 }
@@ -454,9 +520,49 @@
     border-radius: 0.25rem;
 }
 
-/* ═══ Tooltip → Lemon Tooltip (see PORTAL CAVEAT above) ════════════════ */
+/* ═══ Item rows (ItemGroup, ItemMenuItem, combobox rows) ═══════════════ */
 
-[data-lemon-skin] .quill-tooltip__content {
+[data-lemon-skin] .quill-item {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-item__title {
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-item__description {
+    font-size: 0.75rem;
+}
+
+/* ═══ MenuLabel → Lemon section title (no uppercase tracking) ══════════ */
+
+[data-lemon-skin] .quill-menu-label {
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--lemon-skin-text-secondary);
+    text-transform: none;
+    letter-spacing: normal;
+}
+
+/* ═══ Empty state — Lemon centers muted text without the dashed frame ══ */
+
+[data-lemon-skin] .quill-empty {
+    border: none;
+}
+
+/*
+ * Portal-mounted surfaces below (tooltip, popover, menus, select popup,
+ * dialog): the skin attribute is passed to the *Content component and lands
+ * ON the portaled element itself, so each surface rule needs a self variant
+ * alongside the descendant one.
+ */
+
+/* ═══ Tooltip → Lemon Tooltip ══════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-tooltip__content,
+.quill-tooltip__content[data-lemon-skin] {
     font-family: var(--font-sans);
     color: var(--color-text-primary-inverse);
     background-color: var(--color-bg-surface-tooltip);
@@ -471,10 +577,8 @@
 
 /* ═══ Popover / menu / select surfaces → Lemon Popover box ═════════════ */
 
-[data-lemon-skin] .quill-popover__content,
-[data-lemon-skin] .quill-menu__content,
-[data-lemon-skin] .quill-menu__sub-content,
-[data-lemon-skin] .quill-select__content {
+[data-lemon-skin] :is(.quill-popover__content, .quill-menu__content, .quill-menu__sub-content, .quill-select__content),
+:is(.quill-popover__content, .quill-menu__content, .quill-menu__sub-content, .quill-select__content)[data-lemon-skin] {
     font-family: var(--font-sans);
     font-size: 0.875rem;
     background-color: var(--color-bg-surface-popover);
@@ -561,9 +665,10 @@
     background-color: var(--brand-blue);
 }
 
-/* ═══ Dialog → LemonModal (see PORTAL CAVEAT above) ════════════════════ */
+/* ═══ Dialog → LemonModal ══════════════════════════════════════════════ */
 
-[data-lemon-skin] .quill-dialog__content {
+[data-lemon-skin] .quill-dialog__content,
+.quill-dialog__content[data-lemon-skin] {
     font-family: var(--font-sans);
     font-size: 0.875rem;
     background-color: var(--lemon-skin-surface);

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -123,14 +123,8 @@
     border-radius: var(--lemon-skin-radius);
 }
 
-/* primary → Lemon primary (white face, brown border, amber 3D frame below) */
-
-/*
- * Frame shadows: LemonButton's chrome paints a single `0 3px 0 -1px` fill
- * (measured on ::after) — a -1px spread so the lip tucks inside the face's
- * silhouette. A wider/second shadow reads as a detached outline behind the
- * button, especially on small controls.
- */
+/* primary → Lemon primary (white face, brown border, single 3D frame fill below,
+   matching LemonButton's chrome ::after `0 3px 0 -1px`) */
 
 [data-lemon-skin] .quill-button--variant-primary {
     color: var(--text-3000-light);
@@ -205,12 +199,7 @@
     translate: 0 0.1875rem;
 }
 
-/*
- * link / link-muted → Lemon Link (accent text that shifts on hover, no
- * underline — quill underlines on hover, Lemon never does). Inline like
- * Lemon's Link, so zero out the button box. Wins over per-instance
- * `underline` / `text-primary` utilities (layered) without extra weight.
- */
+/* link / link-muted → Lemon Link (accent text, no underline) */
 
 [data-lemon-skin] .quill-button--variant-link,
 [data-lemon-skin] .quill-button--variant-link-muted {
@@ -234,15 +223,8 @@
     background: none;
 }
 
-/*
- * Sizes → Lemon's scale, mapped by closest geometry, not ordinally. Quill
- * runs compact (xs 20px / sm 24px / default 28px / lg 32px), so the ordinal
- * mapping inflated every button by one Lemon step and dense surfaces (the
- * taxonomic filter popover) came out oversized vs their legacy Lemon
- * counterparts. Closest-geometry (xxsmall 20 / xsmall 26 / small 33 /
- * medium 37) keeps Lemon density AND minimizes reflow at the eventual
- * skin-off flip. Lemon `large` (49px) has no quill counterpart.
- */
+/* Sizes → Lemon's scale by closest geometry: xs→xxsmall, sm→xsmall,
+   default→small, lg→medium */
 
 [data-lemon-skin] .quill-button--size-default {
     gap: 0.5rem;
@@ -445,13 +427,8 @@
     border-color: var(--lemon-skin-accent);
 }
 
-/* ═══ Badge → LemonTag ═════════════════════════════════════════════════ */
+/* ═══ Badge → LemonTag (small variant — badges live in dense list rows) ═ */
 
-/*
- * LemonTag's `small` variant, not the default: badges here live inside
- * dense list rows (taxonomic filter results) where the default 22px tag
- * dwarfs the 14px row text.
- */
 [data-lemon-skin] .quill-badge {
     height: auto;
     padding: 0 0.1875rem;
@@ -597,27 +574,14 @@
 
 /* ═══ Lemon components inside skinned surfaces ═════════════════════════ */
 
-/*
- * The rebuild's input trigger row is deliberately Lemon (LemonInput +
- * LemonButton, "match the surrounding scene"), but its sizes are off in
- * Lemon terms. Corrected from here rather than component code so all the
- * look-tuning stays in this one file. Both LemonInput and LemonButton are
- * sized by CSS variables, so a rebind is a faithful size swap.
- */
-
-/* small → medium metrics: matches the sibling controls in the property
-   filter row (operator select, value input) — a smaller field next to them
-   reads as a different component. The combobox's overlay field gets the
-   same treatment, so it still lands exactly on the trigger. */
+/* trigger field: small → medium metrics */
 [data-lemon-skin] .LemonInput.LemonInput--small {
     --lemon-input-height: calc(2.125rem + 3px);
 
     padding: 0.25rem 0.5rem;
 }
 
-/* An embedded LemonButton (the trigger's filter icon) gets xsmall metrics —
-   the only Lemon size that nests inside the field without poking past its
-   border. */
+/* embedded button (the trigger's filter icon): → xsmall metrics */
 [data-lemon-skin] .LemonInput .LemonButton {
     --lemon-button-height: 1.625rem;
     --lemon-button-font-size: 0.75rem;
@@ -680,11 +644,7 @@
     background-color: var(--lemon-skin-border);
 }
 
-/*
- * SelectTrigger composes Button without forwarding its size (it sizes itself
- * via `data-size` in select.css, which the button-size rules above out-cascade),
- * so re-apply the geometry here: sm → Lemon xsmall, matching the button map.
- */
+/* SelectTrigger sizes itself via data-size, not Button's size prop: sm → xsmall */
 [data-lemon-skin] .quill-select__trigger[data-size='sm'] {
     gap: 0.25rem;
     height: 1.625rem;
@@ -692,13 +652,7 @@
     font-size: 0.75rem;
 }
 
-/*
- * Inside an input (quill InputGroup, or the LemonInput the input-trigger
- * mode renders), embedded controls go flat: transparent face, no 3D lip,
- * face border centered exactly in the field. Any vertical asymmetry from
- * the frame shadow reads as misalignment at this size, however the pair
- * is balanced.
- */
+/* Select triggers embedded in an input go flat, border centered in the field */
 [data-lemon-skin] :is(.quill-input-group, .LemonInput) .quill-select__trigger {
     background-color: transparent;
     box-shadow: none;
@@ -711,17 +665,13 @@
     background-color: transparent;
 }
 
-/* Flat buttons don't press-sink — there's no frame to sink onto. */
 [data-lemon-skin]
     :is(.quill-input-group, .LemonInput)
     .quill-select__trigger:not(:disabled, [aria-disabled='true']):active {
     translate: none;
 }
 
-/* Select/combobox rows sized like the small LemonButtons LemonMenu renders.
-   Rows compose Button, whose size remap above fixes `height` — override to
-   auto so multi-line rows (title + description) grow their highlight box
-   instead of overflowing it. */
+/* Select/combobox rows sized like the small LemonButtons LemonMenu renders */
 
 [data-lemon-skin] :is(.quill-select__item, .quill-combobox__item) {
     height: auto;
@@ -736,21 +686,15 @@
     background-color: var(--color-bg-fill-button-tertiary-hover);
 }
 
-/* Combobox rows compose Button, so the button-size remap above clobbers
-   quill's checkmark gutter and pins a fixed single-line height — restore
-   the gutter and let multi-line rows (title + description) grow. Self +
-   descendant variants, like the portal-surface rules below; the extra
-   class out-specifies the button-size rules instead of relying on order. */
 [data-lemon-skin] .quill-combobox__content .quill-combobox__item,
 .quill-combobox__content[data-lemon-skin] .quill-combobox__item {
     height: auto;
     min-height: 2.0625rem;
+
+    /* quill's checkmark gutter, clobbered by the button-size remap above */
     padding-inline-start: 1.875rem;
 }
 
-/* Rows zero their own padding via a `py-0` utility (compiled !important),
-   so the breathing room lives on the inner content — reached through
-   Button's internal <span> wrapper, hence descendant not child. */
 [data-lemon-skin] .quill-combobox__content .quill-combobox__item [data-slot='item-content'],
 .quill-combobox__content[data-lemon-skin] .quill-combobox__item [data-slot='item-content'] {
     padding-block: 0.375rem;
@@ -802,14 +746,9 @@
 
 /* ═══ Tabs (pill variant) → Lemon segmented look ═══════════════════════ */
 
-/*
- * `bg-muted` in this app's Tailwind resolves to `--muted-3000` — PostHog's
- * muted TEXT color — so a quill-style `bg-muted` surface (the DWH config
- * field tabs) paints near-black. That's the exact trap quill-bridge.scss
- * documents. The utility is compiled !important, but it reads a var, so
- * rebinding the var on the element it lands on is the clean override.
- */
 [data-lemon-skin] .quill-tabs__list--variant-default {
+    /* here `bg-muted` resolves to --muted-3000, Lemon's muted TEXT color
+       (the quill/Lemon token collision quill-bridge.scss documents) */
     --muted-3000: var(--lemon-skin-bg-page);
 
     background-color: var(--lemon-skin-bg-page);
@@ -826,14 +765,11 @@
 }
 
 [data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger[data-active] {
-    /* Quill paints the active pill `var(--background) !important` — rebind
-       the var it resolves (same trick as the line variant above). */
     --background: var(--lemon-skin-surface);
 
     color: var(--text-3000);
 }
 
-/* The sliding active-pill face behind the trigger */
 [data-lemon-skin] .quill-tabs__indicator--variant-default {
     background-color: var(--lemon-skin-surface);
     border-color: var(--lemon-skin-border);


### PR DESCRIPTION
## Problem

Stacked on [#69824](https://github.com/PostHog/posthog/pull/69824) (the skin prototype — read that first for the strategy).

The taxonomic filter menu rebuild (`rebuild-menu` variant, opt-in experiment) is quill-based, so it looks foreign inside Lemon scenes. This PR opts it into the quill-as-lemon skin and then iterates until its surfaces are visually at home next to the legacy picker: same control sizes, same chrome, same density.

## Changes

**Opt-in wiring** (`lib/components/TaxonomicFilter/menu/`): `data-lemon-skin` on the trigger wrapper (armed + resting placeholder), dropdown menu content, combobox popovers, and the DWH dialog. Overlays portal to `<body>`, so the attribute is passed to the `*Content` components and rides on the portaled element itself.

**Skin extensions and corrections** (`lemon-skin.scss`), driven by pixel-comparison against the legacy picker in a running app:

- Button sizes remap to Lemon's scale by closest geometry (xs→xxsmall … lg→medium), not ordinally — the ordinal mapping inflated every control one Lemon step.
- Frame shadows match LemonButton's real chrome (single `0 3px 0 -1px` fill); the previous double shadow drew a detached outline behind every framed button.
- Controls embedded in an input (the category select in the search field) render flat and centered, like the legacy pill's in-input category button.
- Badges map to LemonTag small (16px): they live in dense list rows.
- Lemon components inside skinned wrappers get geometry corrections from the skin (trigger field small→medium metrics, embedded icon button→xsmall) so component code keeps its semantic size props.
- Pill-variant tabs → Lemon segmented look, including rebinding `--muted-3000` where quill-style `bg-muted` resolves to Lemon's muted *text* color (the token collision `quill-bridge.scss` documents).
- Combobox popups join the skinned portal surfaces: popover chrome, menu-row sizing/hover, checkmark gutter, auto-height rows.

**Component fixes** (structural, hold with or without the skin):

- DWH column picker rows and trigger render name + type inline (single line, standard row height); trigger left-aligns at standard height.
- The HogQL editor panel sizes to its content (capped, 560px wide) instead of the combobox's fixed 720x400 — no more scrolling inside the popover for a three-line form.
- Input-trigger overlay offset accounts for the panel border (pre-existing 1px drift) and the skinned header button height.
- `FilterRow`: the trailing add-filter row reserves the remove-button gutter, so full-width pickers right-align with the rows above.
- `LemonInput`: overflowing placeholders ellipsize instead of clipping mid-letter.

> [!NOTE]
> Presentation-only on the `rebuild-menu` variant: no telemetry, ordering, promotion, or group changes; the two legacy variants are untouched (the `FilterRow`/`LemonInput` fixes benefit all variants). It does change the rebuild experiment's appearance, which its owner should sign off on.

## How did you test this code?

- `hogli test frontend/src/lib/components/TaxonomicFilter/menu/` — 66/66, and the PropertyFilters suites (221 total) after the `FilterRow` change.
- Iterated against a running local app: opened each surface (combobox, DWH dialog + column picker, HogQL editor, input-trigger rows) and compared computed styles (heights, paddings, shadows) against the legacy picker's equivalent controls.
- Existing `Filters/Taxonomic Filter (Menu rebuild)` stories snapshot the skinned surfaces in light and dark.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: presentation-only changes to an opt-in experimental variant.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code), directed by Sam screenshot-by-screenshot: each iteration was a visual defect he spotted (oversized buttons, a misaligned in-input select, overweight badges, a scrolling modal), which Claude diagnosed by measuring computed styles in the running app against the legacy picker and fixed — in the skin wherever possible, in component code only for structural issues or Lemon-on-Lemon sizing that the skin can't express. Notable rejected path: component-level size prop changes (small→xsmall etc.) were made, then deliberately reverted and re-expressed as skin rules to keep the migration's look-tuning in one file. The `/modifying-taxonomic-filter` repo skill was loaded before touching the filter; per its guidance this PR stays presentation-only (no mirroring into legacy variants needed).

One deliberate skin coupling to flag for the eventual skin-off flip: `MENU_HEADER_BUTTON_HEIGHT_PX` (input-trigger overlay math) is synced to the skinned Go back button height (26px) and must return to 24px when the skin is removed — commented in place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

