### PR TITLE
feat(charts): flint-chart backend spike emitting quill-charts specs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -205,6 +205,7 @@
         "eventsource-parser": "^3.0.0",
         "fast-deep-equal": "catalog:",
         "fastpriorityqueue": "^0.7.5",
+        "flint-chart": "0.1.3",
         "frimousse": "^0.3.0",
         "fuse.js": "catalog:",
         "hast-util-to-html": "^9.0.5",

--- a/frontend/src/lib/charts/flint/FlintQuillChart.stories.tsx
+++ b/frontend/src/lib/charts/flint/FlintQuillChart.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ChartAssemblyInput } from 'flint-chart/core'
+
+import { FlintQuillChart } from './FlintQuillChart'
+
+type Story = StoryObj<typeof FlintQuillChart>
+const meta: Meta<typeof FlintQuillChart> = {
+    title: 'Components/Flint quill chart',
+    component: FlintQuillChart,
+    tags: ['autodocs'],
+    decorators: [
+        (StoryComponent) => (
+            <div style={{ width: 640, height: 360 }}>
+                <StoryComponent />
+            </div>
+        ),
+    ],
+}
+export default meta
+
+const SIGNUPS_BY_PLAN: ChartAssemblyInput['data'] = {
+    values: [
+        { month: '2026-01-01', plan: 'Free', signups: 840 },
+        { month: '2026-01-01', plan: 'Paid', signups: 120 },
+        { month: '2026-02-01', plan: 'Free', signups: 910 },
+        { month: '2026-02-01', plan: 'Paid', signups: 180 },
+        { month: '2026-03-01', plan: 'Free', signups: 1050 },
+        { month: '2026-03-01', plan: 'Paid', signups: 260 },
+        { month: '2026-04-01', plan: 'Free', signups: 980 },
+        { month: '2026-04-01', plan: 'Paid', signups: 340 },
+    ],
+}
+
+const SEMANTIC_TYPES = { month: 'Date', plan: 'Category', signups: 'Quantity' }
+
+export const GroupedBar: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Grouped Bar Chart',
+                encodings: { x: { field: 'plan' }, y: { field: 'signups', aggregate: 'sum' } },
+            },
+        },
+    },
+}
+
+export const StackedBarOverTime: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Stacked Bar Chart',
+                encodings: { x: { field: 'month' }, y: { field: 'signups' }, color: { field: 'plan' } },
+            },
+        },
+    },
+}
+
+export const MultiSeriesLine: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Line Chart',
+                encodings: { x: { field: 'month' }, y: { field: 'signups' }, color: { field: 'plan' } },
+            },
+        },
+    },
+}
+
+export const StackedArea: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Area Chart',
+                encodings: { x: { field: 'month' }, y: { field: 'signups' }, color: { field: 'plan' } },
+            },
+        },
+    },
+}
+
+export const Doughnut: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Doughnut Chart',
+                encodings: { color: { field: 'plan' }, size: { field: 'signups' } },
+            },
+        },
+    },
+}
+
+export const UnsupportedChartType: Story = {
+    args: {
+        input: {
+            data: SIGNUPS_BY_PLAN,
+            semantic_types: SEMANTIC_TYPES,
+            chart_spec: {
+                chartType: 'Sankey Diagram',
+                encodings: { x: { field: 'plan' }, y: { field: 'signups' } },
+            },
+        },
+    },
+}

--- a/frontend/src/lib/charts/flint/FlintQuillChart.tsx
+++ b/frontend/src/lib/charts/flint/FlintQuillChart.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 import { BarChart, LineChart, PieChart } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 
 import { assembleQuill } from './assembleQuill'
 import type { QuillChartSpec } from './types'
@@ -29,6 +29,9 @@ export function FlintQuillChart({ input, className, dataAttr }: FlintQuillChartP
             return { ok: false, error: e instanceof Error ? e.message : String(e) }
         }
     }, [input])
+    // Layer the app-level chart styling (refreshed style: axis lines, tick marks,
+    // crosshair, monotone curve) under the assembled config, like every other app chart
+    const config = useChartConfig(() => (result.ok ? result.spec.config : undefined), [result])
 
     if (!result.ok) {
         return <div className="text-danger text-sm p-2">Could not render chart: {result.error}</div>
@@ -41,7 +44,7 @@ export function FlintQuillChart({ input, className, dataAttr }: FlintQuillChartP
                 <BarChart
                     series={spec.series}
                     labels={spec.labels}
-                    config={spec.config}
+                    config={config}
                     theme={theme}
                     className={className}
                     dataAttr={dataAttr}
@@ -52,7 +55,7 @@ export function FlintQuillChart({ input, className, dataAttr }: FlintQuillChartP
                 <LineChart
                     series={spec.series}
                     labels={spec.labels}
-                    config={spec.config}
+                    config={config}
                     theme={theme}
                     className={className}
                     dataAttr={dataAttr}
@@ -62,7 +65,7 @@ export function FlintQuillChart({ input, className, dataAttr }: FlintQuillChartP
             return (
                 <PieChart
                     series={spec.series}
-                    config={spec.config}
+                    config={config}
                     theme={theme}
                     className={className}
                     dataAttr={dataAttr}

--- a/frontend/src/lib/charts/flint/FlintQuillChart.tsx
+++ b/frontend/src/lib/charts/flint/FlintQuillChart.tsx
@@ -1,0 +1,72 @@
+import type { ChartAssemblyInput } from 'flint-chart/core'
+import { useMemo } from 'react'
+
+import { BarChart, LineChart, PieChart } from '@posthog/quill-charts'
+
+import { useChartTheme } from 'lib/charts/hooks'
+
+import { assembleQuill } from './assembleQuill'
+import type { QuillChartSpec } from './types'
+
+export interface FlintQuillChartProps {
+    /** A Flint chart input: inline rows + semantic types + a compact chart spec. */
+    input: ChartAssemblyInput
+    className?: string
+    dataAttr?: string
+}
+
+type AssemblyResult = { ok: true; spec: QuillChartSpec } | { ok: false; error: string }
+
+/** Renders a Flint chart spec with quill-charts: compiles the input through
+ *  Flint's semantic/layout pipeline via `assembleQuill()` and renders the
+ *  resulting component with the app chart theme. */
+export function FlintQuillChart({ input, className, dataAttr }: FlintQuillChartProps): JSX.Element {
+    const theme = useChartTheme()
+    const result = useMemo((): AssemblyResult => {
+        try {
+            return { ok: true, spec: assembleQuill(input) }
+        } catch (e) {
+            return { ok: false, error: e instanceof Error ? e.message : String(e) }
+        }
+    }, [input])
+
+    if (!result.ok) {
+        return <div className="text-danger text-sm p-2">Could not render chart: {result.error}</div>
+    }
+
+    const spec = result.spec
+    switch (spec.component) {
+        case 'BarChart':
+            return (
+                <BarChart
+                    series={spec.series}
+                    labels={spec.labels}
+                    config={spec.config}
+                    theme={theme}
+                    className={className}
+                    dataAttr={dataAttr}
+                />
+            )
+        case 'LineChart':
+            return (
+                <LineChart
+                    series={spec.series}
+                    labels={spec.labels}
+                    config={spec.config}
+                    theme={theme}
+                    className={className}
+                    dataAttr={dataAttr}
+                />
+            )
+        case 'PieChart':
+            return (
+                <PieChart
+                    series={spec.series}
+                    config={spec.config}
+                    theme={theme}
+                    className={className}
+                    dataAttr={dataAttr}
+                />
+            )
+    }
+}

--- a/frontend/src/lib/charts/flint/aggregate.ts
+++ b/frontend/src/lib/charts/flint/aggregate.ts
@@ -1,0 +1,94 @@
+import type { ChartEncoding } from 'flint-chart/core'
+
+/**
+ * Opt-in aggregation transform, reimplementing the contract of flint-chart's
+ * internal `applyAggregation` (not exported from `flint-chart/core`):
+ *
+ * - Rows group by every channel that has a `field` and no `aggregate`.
+ * - Each aggregated channel yields a derived column `${field}_${op}`
+ *   (`count` yields `_count`) — the names `resolveChannelSemantics` rewrites
+ *   `ChannelSemantics.field` to, so templates pick them up automatically.
+ * - When every derived column already exists, the caller pre-aggregated and
+ *   the data passes through untouched.
+ */
+export function applyAggregation(
+    encodings: Record<string, ChartEncoding>,
+    data: Record<string, unknown>[]
+): Record<string, unknown>[] {
+    if (!data || data.length === 0) {
+        return data
+    }
+
+    const specs: { field?: string; op: string; target: string }[] = []
+    for (const enc of Object.values(encodings)) {
+        if (!enc?.aggregate) {
+            continue
+        }
+        if (enc.aggregate !== 'count' && !enc.field) {
+            continue
+        }
+        specs.push({
+            field: enc.field,
+            op: enc.aggregate,
+            target: enc.aggregate === 'count' ? '_count' : `${enc.field}_${enc.aggregate}`,
+        })
+    }
+    if (specs.length === 0) {
+        return data
+    }
+    if (specs.every((s) => Object.prototype.hasOwnProperty.call(data[0], s.target))) {
+        return data
+    }
+
+    const groupFields: string[] = []
+    const seen = new Set<string>()
+    for (const enc of Object.values(encodings)) {
+        if (!enc || enc.aggregate || !enc.field || seen.has(enc.field)) {
+            continue
+        }
+        seen.add(enc.field)
+        groupFields.push(enc.field)
+    }
+
+    const groups = new Map<string, Record<string, unknown>[]>()
+    for (const row of data) {
+        const key = JSON.stringify(groupFields.map((f) => row[f] ?? null))
+        let bucket = groups.get(key)
+        if (!bucket) {
+            bucket = []
+            groups.set(key, bucket)
+        }
+        bucket.push(row)
+    }
+
+    const reduceOp = (rows: Record<string, unknown>[], spec: { field?: string; op: string }): number => {
+        if (spec.op === 'count') {
+            return rows.length
+        }
+        const nums = rows.map((r) => Number(r[spec.field as string])).filter((v) => Number.isFinite(v))
+        if (nums.length === 0) {
+            return 0
+        }
+        const sum = nums.reduce((a, b) => a + b, 0)
+        return spec.op === 'sum' ? sum : sum / nums.length
+    }
+
+    const out: Record<string, unknown>[] = []
+    for (const rows of groups.values()) {
+        const aggregated: Record<string, unknown> = {}
+        for (const f of groupFields) {
+            aggregated[f] = rows[0][f]
+        }
+        for (const spec of specs) {
+            const val = reduceOp(rows, spec)
+            aggregated[spec.target] = val
+            // Keep the source column populated so semantic/format inference for
+            // the measure channel still sees representative numeric values
+            if (spec.op !== 'count' && spec.field) {
+                aggregated[spec.field] = val
+            }
+        }
+        out.push(aggregated)
+    }
+    return out
+}

--- a/frontend/src/lib/charts/flint/assembleQuill.test.ts
+++ b/frontend/src/lib/charts/flint/assembleQuill.test.ts
@@ -111,6 +111,30 @@ describe('assembleQuill', () => {
         ])
     })
 
+    it('folds multi-measure encodings into one series per measure without a synthetic axis title', () => {
+        const spec = assembleQuill({
+            data: {
+                values: [
+                    { week: '2026-04-19', pageviews: 1200, users: 300 },
+                    { week: '2026-04-26', pageviews: 1500, users: 340 },
+                ],
+            },
+            semantic_types: { week: 'Date', pageviews: 'Quantity', users: 'Quantity' },
+            chart_spec: {
+                chartType: 'Line Chart',
+                encodings: { x: { field: 'week' }, y: [{ field: 'pageviews' }, { field: 'users' }] },
+            },
+        }) as QuillLineChartSpec
+
+        expect(spec.series).toEqual([
+            expect.objectContaining({ label: 'pageviews', data: [1200, 1500] }),
+            expect.objectContaining({ label: 'users', data: [300, 340] }),
+        ])
+        // The fold's internal value column must not leak into the axis title
+        expect(spec.config.yAxisLabel).toBeUndefined()
+        expect(spec.config.legend?.show).toBe(true)
+    })
+
     it('derives _count from an aggregate encoding and charts row counts', () => {
         const spec = assembleQuill({
             data: {

--- a/frontend/src/lib/charts/flint/assembleQuill.test.ts
+++ b/frontend/src/lib/charts/flint/assembleQuill.test.ts
@@ -1,0 +1,142 @@
+import type { ChartAssemblyInput } from 'flint-chart/core'
+
+import { assembleQuill } from './assembleQuill'
+import type { QuillBarChartSpec, QuillLineChartSpec, QuillPieChartSpec } from './types'
+
+const SALES_ROWS = [
+    { region: 'North', product: 'Widget', revenue: 100 },
+    { region: 'South', product: 'Widget', revenue: 200 },
+    { region: 'North', product: 'Gadget', revenue: 300 },
+    { region: 'South', product: 'Gadget', revenue: 400 },
+]
+
+function barInput(chartType: string, overrides?: Partial<ChartAssemblyInput['chart_spec']>): ChartAssemblyInput {
+    return {
+        data: { values: SALES_ROWS },
+        semantic_types: { region: 'Category', product: 'Category', revenue: 'Price' },
+        chart_spec: {
+            chartType,
+            encodings: { x: { field: 'region' }, y: { field: 'revenue' }, color: { field: 'product' } },
+            ...overrides,
+        },
+    }
+}
+
+describe('assembleQuill', () => {
+    it('throws on chart types the quill backend has no template for', () => {
+        expect(() => assembleQuill(barInput('Scatter Plot'))).toThrow(/Unknown quill chart type: Scatter Plot/)
+    })
+
+    test.each([
+        ['Bar Chart', 'grouped'],
+        ['Grouped Bar Chart', 'grouped'],
+        ['Stacked Bar Chart', 'stacked'],
+    ])('%s pivots long-form rows into category-aligned quill series with barLayout %s', (chartType, barLayout) => {
+        const spec = assembleQuill(barInput(chartType)) as QuillBarChartSpec
+
+        expect(spec.component).toBe('BarChart')
+        expect(spec.labels).toEqual(['North', 'South'])
+        expect(spec.config.barLayout).toBe(barLayout)
+        expect(spec.config.axisOrientation).toBe('vertical')
+        // One series per color-channel value, data aligned to the label order
+        expect(spec.series).toEqual([
+            expect.objectContaining({ key: 'Widget', data: [100, 200] }),
+            expect.objectContaining({ key: 'Gadget', data: [300, 400] }),
+        ])
+        expect(spec.config.legend?.show).toBe(true)
+    })
+
+    it('renders horizontal bars when the category sits on the y channel', () => {
+        const input = barInput('Bar Chart')
+        input.chart_spec.encodings = { y: { field: 'region' }, x: { field: 'revenue' } }
+        const spec = assembleQuill(input) as QuillBarChartSpec
+
+        expect(spec.config.axisOrientation).toBe('horizontal')
+        expect(spec.labels).toEqual(['North', 'South'])
+        expect(spec.series).toHaveLength(1)
+        expect(spec.series[0].data).toEqual([400, 600])
+        expect(spec.config.legend?.show).toBe(false)
+    })
+
+    it('sorts temporal x values chronologically even when rows arrive out of order', () => {
+        const spec = assembleQuill({
+            data: {
+                values: [
+                    { day: '2026-03-01', signups: 30 },
+                    { day: '2026-01-01', signups: 10 },
+                    { day: '2026-02-01', signups: 20 },
+                ],
+            },
+            semantic_types: { day: 'Date', signups: 'Quantity' },
+            chart_spec: {
+                chartType: 'Line Chart',
+                encodings: { x: { field: 'day' }, y: { field: 'signups' } },
+            },
+        }) as QuillLineChartSpec
+
+        expect(spec.component).toBe('LineChart')
+        expect(spec.series[0].data).toEqual([10, 20, 30])
+        expect(spec.labels).toHaveLength(3)
+        expect(spec.series[0].fill).toBeUndefined()
+    })
+
+    it('Area Chart emits filled series so quill stacks them', () => {
+        const spec = assembleQuill(barInput('Area Chart')) as QuillLineChartSpec
+
+        expect(spec.component).toBe('LineChart')
+        expect(spec.series).toHaveLength(2)
+        for (const s of spec.series) {
+            expect(s.fill).toEqual({ opacity: 0.4 })
+        }
+    })
+
+    test.each([
+        ['Pie Chart', 0],
+        ['Doughnut Chart', 0.5],
+    ])('%s sums the size measure per color category (innerRadiusRatio %d)', (chartType, innerRadiusRatio) => {
+        const spec = assembleQuill({
+            data: { values: SALES_ROWS },
+            semantic_types: { product: 'Category', revenue: 'Price' },
+            chart_spec: {
+                chartType,
+                encodings: { color: { field: 'product' }, size: { field: 'revenue' } },
+            },
+        }) as QuillPieChartSpec
+
+        expect(spec.component).toBe('PieChart')
+        expect(spec.config.innerRadiusRatio).toBe(innerRadiusRatio)
+        expect(spec.series).toEqual([
+            expect.objectContaining({ label: 'Widget', data: [300] }),
+            expect.objectContaining({ label: 'Gadget', data: [700] }),
+        ])
+    })
+
+    it('derives _count from an aggregate encoding and charts row counts', () => {
+        const spec = assembleQuill({
+            data: {
+                values: [
+                    { plan: 'free', user: 'a' },
+                    { plan: 'free', user: 'b' },
+                    { plan: 'paid', user: 'c' },
+                ],
+            },
+            semantic_types: { plan: 'Category' },
+            chart_spec: {
+                chartType: 'Bar Chart',
+                encodings: { x: { field: 'plan' }, y: { aggregate: 'count' } },
+            },
+        }) as QuillBarChartSpec
+
+        expect(spec.labels).toEqual(['free', 'paid'])
+        expect(spec.series[0].data).toEqual([2, 1])
+    })
+
+    it('ignores facet channels with a warning instead of failing', () => {
+        const input = barInput('Bar Chart')
+        input.chart_spec.encodings = { ...input.chart_spec.encodings, column: { field: 'product' } }
+        const spec = assembleQuill(input)
+
+        expect(spec.component).toBe('BarChart')
+        expect(spec._warnings).toEqual([expect.objectContaining({ code: 'facet-unsupported', channel: 'column' })])
+    })
+})

--- a/frontend/src/lib/charts/flint/assembleQuill.ts
+++ b/frontend/src/lib/charts/flint/assembleQuill.ts
@@ -1,0 +1,180 @@
+import type {
+    AssembleOptions,
+    ChartAssemblyInput,
+    ChartEncoding,
+    ChartWarning,
+    InstantiateContext,
+    LayoutDeclaration,
+} from 'flint-chart/core'
+import {
+    applyEncodingOverrides,
+    computeChannelBudgets,
+    computeLayout,
+    computeZeroDecision,
+    convertTemporalData,
+    filterOverflow,
+    normalizeStaticSeries,
+    resolveChannelSemantics,
+} from 'flint-chart/core'
+
+import { applyAggregation } from './aggregate'
+import { quillGetTemplateDef, quillTemplateDefs } from './templates'
+import type { QuillChartSpec } from './types'
+
+// Defaults mirroring flint-chart's internal resolveBaseSize/deriveStretchCaps
+// (not exported from flint-chart/core)
+const DEFAULT_BASE_SIZE = { width: 400, height: 320 }
+const DEFAULT_MAX_STRETCH = 1.5
+
+const FACET_CHANNELS = ['column', 'row'] as const
+
+/**
+ * Assemble a quill-charts spec from a Flint chart input.
+ *
+ * The quill analog of flint-chart's `assembleVegaLite` / `assembleECharts` /
+ * `assembleChartjs`: Flint's compiler frontend (semantic resolution) and
+ * optimizer (overflow + layout) run unchanged from `flint-chart/core`; only
+ * the Stage 3 code generator differs, emitting quill component props instead
+ * of a rendering-library config. Colors and pixel-level layout are left to
+ * quill, which themes from CSS variables and computes its own layout — only
+ * Flint's semantic decisions (sort order, zero baseline, formatting, series
+ * routing, overflow truncation) carry through.
+ *
+ * Not supported (yet): faceting (`column`/`row` are ignored with a warning),
+ * named-view pivots, and chart types quill has no component for — see
+ * `quillTemplateDefs` for what is.
+ */
+export function assembleQuill(input: ChartAssemblyInput): QuillChartSpec {
+    const chartType = input.chart_spec.chartType
+    const chartTemplate = quillGetTemplateDef(chartType)
+    if (!chartTemplate) {
+        const available = quillTemplateDefs.map((t) => t.chart).join(', ')
+        throw new Error(`Unknown quill chart type: ${chartType}. Available types: ${available}`)
+    }
+    if (!input.data.values) {
+        throw new Error('The quill backend requires inline data (`data.values`); `data.url` is not supported')
+    }
+
+    const semanticTypes = input.semantic_types ?? {}
+    const chartProperties = input.chart_spec.chartProperties
+    const sizeCeiling = input.chart_spec.canvasSize
+    const specBase = input.chart_spec.baseSize ?? DEFAULT_BASE_SIZE
+    const baseSize = sizeCeiling
+        ? { width: Math.min(specBase.width, sizeCeiling.width), height: Math.min(specBase.height, sizeCeiling.height) }
+        : { ...specBase }
+
+    const warnings: ChartWarning[] = []
+
+    // ── PRE-PHASE: static series normalization + facet stripping ──
+    const normalized = normalizeStaticSeries(input.chart_spec.encodings, input.data.values, semanticTypes)
+    let data = normalized.data
+    const rawEncodings: Record<string, ChartEncoding> = { ...normalized.encodings }
+    for (const channel of FACET_CHANNELS) {
+        if (rawEncodings[channel]) {
+            warnings.push({
+                severity: 'warning',
+                code: 'facet-unsupported',
+                message: `The quill backend does not support faceting; the '${channel}' encoding was ignored`,
+                channel,
+            })
+            delete rawEncodings[channel]
+        }
+    }
+
+    const encodings = applyEncodingOverrides(chartTemplate, rawEncodings, chartProperties)
+    data = applyAggregation(encodings, data)
+
+    // ── PHASE 0: resolve semantics ──
+    const convertedData = convertTemporalData(data, semanticTypes)
+    const channelSemantics = resolveChannelSemantics(encodings, data, semanticTypes, convertedData)
+
+    const tplMark = chartTemplate.template?.mark
+    const effectiveMarkType = (typeof tplMark === 'string' ? tplMark : tplMark?.type) || 'point'
+    for (const [channel, cs] of Object.entries(channelSemantics)) {
+        if ((channel === 'x' || channel === 'y') && cs.type === 'quantitative') {
+            const numericValues = data
+                .map((r: Record<string, unknown>) => r[cs.field])
+                .filter((v): v is number => typeof v === 'number' && !isNaN(v))
+            cs.zero = computeZeroDecision(cs.semanticAnnotation.semanticType, channel, effectiveMarkType, numericValues)
+        }
+    }
+
+    // ── STEP 0a: template layout declaration ──
+    const declaration: LayoutDeclaration = chartTemplate.declareLayoutMode
+        ? chartTemplate.declareLayoutMode(channelSemantics, data, chartProperties)
+        : {}
+
+    const options = input.options ?? {}
+    const effectiveOptions: AssembleOptions = {
+        ...options,
+        ...declaration.paramOverrides,
+    }
+    const maxStretch = effectiveOptions.maxStretch ?? DEFAULT_MAX_STRETCH
+    effectiveOptions.maxStretchX = sizeCeiling ? Math.max(1, sizeCeiling.width / baseSize.width) : maxStretch
+    effectiveOptions.maxStretchY = sizeCeiling ? Math.max(1, sizeCeiling.height / baseSize.height) : maxStretch
+
+    // ── STEP 0b/0c: budgets + overflow filtering ──
+    const budgets = computeChannelBudgets(channelSemantics, declaration, convertedData, baseSize, effectiveOptions)
+    const overflowResult = filterOverflow(
+        channelSemantics,
+        declaration,
+        encodings,
+        convertedData,
+        budgets,
+        new Set([effectiveMarkType])
+    )
+    const values = overflowResult.filteredData
+    warnings.push(...overflowResult.warnings)
+
+    // ── PHASE 1: layout ──
+    const layoutResult = computeLayout(
+        channelSemantics,
+        declaration,
+        values,
+        baseSize,
+        effectiveOptions,
+        budgets.facetGrid
+    )
+    layoutResult.truncations = overflowResult.truncations
+
+    // ── PHASE 2: instantiate the quill spec ──
+    const resolvedEncodings: Record<string, { field: string; type: string; aggregate?: string }> = {}
+    for (const [channel, encoding] of Object.entries(encodings)) {
+        const cs = channelSemantics[channel]
+        if (cs) {
+            resolvedEncodings[channel] = { field: cs.field, type: cs.type, aggregate: encoding.aggregate }
+        }
+    }
+
+    const instantiateContext: InstantiateContext = {
+        channelSemantics,
+        layout: layoutResult,
+        table: values,
+        fullTable: convertedData,
+        resolvedEncodings,
+        encodings,
+        chartProperties,
+        staticSeries: normalized.staticSeries,
+        canvasSize: baseSize,
+        semanticTypes,
+        chartType,
+        assembleOptions: effectiveOptions,
+    }
+
+    const spec: Record<string, unknown> = structuredClone(chartTemplate.template)
+    chartTemplate.instantiate(spec, instantiateContext)
+    if (!spec.component) {
+        throw new Error(
+            `Could not assemble a '${chartType}': the encodings did not resolve to the channels the template needs`
+        )
+    }
+
+    const assembled = spec as unknown as QuillChartSpec
+    if (warnings.length > 0) {
+        assembled._warnings = warnings
+    }
+    assembled._width = layoutResult.subplotWidth
+    assembled._height = layoutResult.subplotHeight
+    assembled._dataLength = values.length
+    return assembled
+}

--- a/frontend/src/lib/charts/flint/index.ts
+++ b/frontend/src/lib/charts/flint/index.ts
@@ -1,0 +1,4 @@
+export { assembleQuill } from './assembleQuill'
+export { FlintQuillChart, type FlintQuillChartProps } from './FlintQuillChart'
+export type { QuillBarChartSpec, QuillChartSpec, QuillLineChartSpec, QuillPieChartSpec, QuillSpecMeta } from './types'
+export { quillGetTemplateDef, quillTemplateDefs } from './templates'

--- a/frontend/src/lib/charts/flint/template-utils.ts
+++ b/frontend/src/lib/charts/flint/template-utils.ts
@@ -1,0 +1,178 @@
+import type { ChannelSemantics, FormatSpec } from 'flint-chart/core'
+
+import { dayjs } from 'lib/dayjs'
+
+const isDiscrete = (type: string | undefined): boolean => type === 'nominal' || type === 'ordinal'
+
+/** Extract unique category values for a field, preserving data order, then
+ *  applying the canonical ordinal sort when the semantics provide one.
+ *  (Port of the equivalent helper in flint-chart's Chart.js backend.) */
+export function extractCategories(
+    data: Record<string, unknown>[],
+    field: string,
+    ordinalSortOrder?: string[]
+): string[] {
+    const seen = new Set<string>()
+    const result: string[] = []
+    for (const row of data) {
+        const val = row[field]
+        if (val != null) {
+            const key = String(val)
+            if (!seen.has(key)) {
+                seen.add(key)
+                result.push(key)
+            }
+        }
+    }
+    if (ordinalSortOrder && ordinalSortOrder.length > 0) {
+        const orderMap = new Map(ordinalSortOrder.map((v, i) => [v, i]))
+        result.sort((a, b) => {
+            const ia = orderMap.get(a)
+            const ib = orderMap.get(b)
+            if (ia !== undefined && ib !== undefined) {
+                return ia - ib
+            }
+            if (ia !== undefined) {
+                return -1
+            }
+            if (ib !== undefined) {
+                return 1
+            }
+            return 0
+        })
+    }
+    return result
+}
+
+export function groupBy(data: Record<string, unknown>[], field: string): Map<string, Record<string, unknown>[]> {
+    const groups = new Map<string, Record<string, unknown>[]>()
+    for (const row of data) {
+        const key = String(row[field] ?? '')
+        let bucket = groups.get(key)
+        if (!bucket) {
+            bucket = []
+            groups.set(key, bucket)
+        }
+        bucket.push(row)
+    }
+    return groups
+}
+
+/** Build a category-aligned value array for one series. Quill's `Series.data`
+ *  is a plain `number[]` parallel to `labels`, so categories a series has no
+ *  row for become 0. Duplicate rows for one category are summed. */
+export function buildCategoryAlignedData(
+    rows: Record<string, unknown>[],
+    catField: string,
+    valField: string,
+    categories: string[]
+): number[] {
+    const byCategory = new Map<string, number>()
+    for (const row of rows) {
+        const cat = String(row[catField] ?? '')
+        const val = Number(row[valField])
+        if (Number.isFinite(val)) {
+            byCategory.set(cat, (byCategory.get(cat) ?? 0) + val)
+        }
+    }
+    return categories.map((c) => byCategory.get(c) ?? 0)
+}
+
+/** Detect which positional axis carries the discrete categories and which the measure. */
+export function detectAxes(channelSemantics: Record<string, ChannelSemantics>): {
+    categoryAxis: 'x' | 'y'
+    valueAxis: 'x' | 'y'
+} {
+    if (channelSemantics.x && isDiscrete(channelSemantics.x.type)) {
+        return { categoryAxis: 'x', valueAxis: 'y' }
+    }
+    if (channelSemantics.y && isDiscrete(channelSemantics.y.type)) {
+        return { categoryAxis: 'y', valueAxis: 'x' }
+    }
+    return { categoryAxis: 'x', valueAxis: 'y' }
+}
+
+/** Turn Flint's semantic FormatSpec into a quill tick formatter. Intentionally
+ *  partial: prefix/suffix/abbreviation and percent patterns cover the semantic
+ *  types agents actually hit; full d3-format pattern support is a follow-up. */
+export function makeTickFormatter(format?: FormatSpec): ((value: number) => string) | undefined {
+    if (!format) {
+        return undefined
+    }
+    const { pattern, prefix = '', suffix = '', abbreviate } = format
+    const isPercentPattern = !!pattern && pattern.includes('%')
+    return (value: number): string => {
+        let v = value
+        let percentSuffix = ''
+        if (isPercentPattern) {
+            // d3 percent patterns (".1%") multiply by 100 and append the sign
+            v = value * 100
+            percentSuffix = '%'
+        }
+        let body: string
+        if (abbreviate && Math.abs(v) >= 1000) {
+            body = Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(v)
+        } else {
+            body = Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(v)
+        }
+        return `${prefix}${body}${percentSuffix}${suffix}`
+    }
+}
+
+/** d3 strftime tokens → dayjs format tokens, for the subset Flint's semantic
+ *  layer emits via `ChannelSemantics.temporalFormat`. */
+const STRFTIME_TO_DAYJS: Record<string, string> = {
+    '%Y': 'YYYY',
+    '%y': 'YY',
+    '%m': 'MM',
+    '%b': 'MMM',
+    '%B': 'MMMM',
+    '%d': 'D',
+    '%e': 'D',
+    '%a': 'ddd',
+    '%A': 'dddd',
+    '%H': 'HH',
+    '%I': 'hh',
+    '%M': 'mm',
+    '%S': 'ss',
+    '%p': 'A',
+    '%j': 'DDD',
+    '%q': 'Q',
+}
+
+export function strftimeToDayjsFormat(pattern: string): string {
+    return pattern.replace(/%[a-zA-Z]/g, (token) => STRFTIME_TO_DAYJS[token] ?? token)
+}
+
+/** Format one temporal value (Date, ISO string, or epoch ms/s) as an axis label. */
+export function formatTemporalLabel(raw: unknown, temporalFormat?: string): string {
+    if (raw == null) {
+        return ''
+    }
+    let d
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+        // Values below ~1e12 read as Unix seconds (same heuristic as the Chart.js backend)
+        d = dayjs(raw < 1e12 ? raw * 1000 : raw)
+    } else {
+        d = dayjs(raw as string | Date)
+    }
+    if (!d.isValid()) {
+        return String(raw)
+    }
+    return d.format(temporalFormat ? strftimeToDayjsFormat(temporalFormat) : 'MMM D, YYYY')
+}
+
+/** Millisecond timestamp for sorting temporal rows; NaN when unparseable. */
+export function temporalSortValue(raw: unknown): number {
+    if (raw == null) {
+        return NaN
+    }
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+        return raw < 1e12 ? raw * 1000 : raw
+    }
+    if (raw instanceof Date) {
+        return raw.getTime()
+    }
+    const t = new Date(String(raw)).getTime()
+    return Number.isFinite(t) ? t : NaN
+}

--- a/frontend/src/lib/charts/flint/templates/bar.ts
+++ b/frontend/src/lib/charts/flint/templates/bar.ts
@@ -1,4 +1,5 @@
 import type { ChartTemplateDef, InstantiateContext } from 'flint-chart/core'
+import { STATIC_SERIES_VALUE_COLUMN } from 'flint-chart/core'
 
 import type { Series } from '@posthog/quill-charts'
 import type { BarChartConfig } from '@posthog/quill-charts'
@@ -48,6 +49,7 @@ function instantiateBar(
 
     const horizontal = categoryAxis === 'y'
     const valueFormatter = makeTickFormatter(valCS.format)
+    const valueAxisLabel = valCS.field === STATIC_SERIES_VALUE_COLUMN ? undefined : valCS.field
     const config: BarChartConfig = {
         barLayout,
         axisOrientation: horizontal ? 'horizontal' : 'vertical',
@@ -56,8 +58,10 @@ function instantiateBar(
         // Quill's value axis is y for vertical bars and x for horizontal ones,
         // but yTickFormatter always formats the value axis
         yTickFormatter: valueFormatter,
-        xAxisLabel: horizontal ? valCS.field : catCS.field,
-        yAxisLabel: horizontal ? catCS.field : valCS.field,
+        // The static-series fold points the measure at a synthetic value column; the
+        // legend names the folded measures, so a synthetic axis title is just noise
+        xAxisLabel: horizontal ? valueAxisLabel : catCS.field,
+        yAxisLabel: horizontal ? catCS.field : valueAxisLabel,
         legend: { show: series.length > 1 },
     }
 

--- a/frontend/src/lib/charts/flint/templates/bar.ts
+++ b/frontend/src/lib/charts/flint/templates/bar.ts
@@ -54,7 +54,9 @@ function instantiateBar(
         barLayout,
         axisOrientation: horizontal ? 'horizontal' : 'vertical',
         showGrid: true,
-        barCornerRadius: typeof ctx.chartProperties?.cornerRadius === 'number' ? ctx.chartProperties.cornerRadius : 0,
+        // Left undefined unless the spec asks, so app-level styling defaults apply
+        barCornerRadius:
+            typeof ctx.chartProperties?.cornerRadius === 'number' ? ctx.chartProperties.cornerRadius : undefined,
         // Quill's value axis is y for vertical bars and x for horizontal ones,
         // but yTickFormatter always formats the value axis
         yTickFormatter: valueFormatter,

--- a/frontend/src/lib/charts/flint/templates/bar.ts
+++ b/frontend/src/lib/charts/flint/templates/bar.ts
@@ -1,0 +1,100 @@
+import type { ChartTemplateDef, InstantiateContext } from 'flint-chart/core'
+
+import type { Series } from '@posthog/quill-charts'
+import type { BarChartConfig } from '@posthog/quill-charts'
+
+import { buildCategoryAlignedData, detectAxes, extractCategories, groupBy, makeTickFormatter } from '../template-utils'
+import type { QuillBarChartSpec } from '../types'
+
+function declareBandedCategoryAxis(
+    channelSemantics: Parameters<NonNullable<ChartTemplateDef['declareLayoutMode']>>[0]
+): ReturnType<NonNullable<ChartTemplateDef['declareLayoutMode']>> {
+    const { categoryAxis } = detectAxes(channelSemantics)
+    return { axisFlags: { [categoryAxis]: { banded: true } } }
+}
+
+function instantiateBar(
+    barLayout: 'grouped' | 'stacked',
+    spec: Record<string, unknown>,
+    ctx: InstantiateContext
+): void {
+    const { channelSemantics, table } = ctx
+    const { categoryAxis, valueAxis } = detectAxes(channelSemantics)
+    const catCS = channelSemantics[categoryAxis]
+    const valCS = channelSemantics[valueAxis]
+    if (!catCS?.field || !valCS?.field) {
+        return
+    }
+
+    const categories = extractCategories(table, catCS.field, catCS.ordinalSortOrder)
+    const colorField = channelSemantics.color?.field
+
+    let series: Series[]
+    if (colorField && colorField !== catCS.field) {
+        series = [...groupBy(table, colorField).entries()].map(([name, rows]) => ({
+            key: name,
+            label: name,
+            data: buildCategoryAlignedData(rows, catCS.field, valCS.field, categories),
+        }))
+    } else {
+        series = [
+            {
+                key: valCS.field,
+                label: valCS.field,
+                data: buildCategoryAlignedData(table, catCS.field, valCS.field, categories),
+            },
+        ]
+    }
+
+    const horizontal = categoryAxis === 'y'
+    const valueFormatter = makeTickFormatter(valCS.format)
+    const config: BarChartConfig = {
+        barLayout,
+        axisOrientation: horizontal ? 'horizontal' : 'vertical',
+        showGrid: true,
+        barCornerRadius: typeof ctx.chartProperties?.cornerRadius === 'number' ? ctx.chartProperties.cornerRadius : 0,
+        // Quill's value axis is y for vertical bars and x for horizontal ones,
+        // but yTickFormatter always formats the value axis
+        yTickFormatter: valueFormatter,
+        xAxisLabel: horizontal ? valCS.field : catCS.field,
+        yAxisLabel: horizontal ? catCS.field : valCS.field,
+        legend: { show: series.length > 1 },
+    }
+
+    const assembled: Pick<QuillBarChartSpec, 'component' | 'series' | 'labels' | 'config'> = {
+        component: 'BarChart',
+        series,
+        labels: categories,
+        config,
+    }
+    Object.assign(spec, assembled)
+    delete spec.mark
+    delete spec.encoding
+}
+
+export const quillBarChartDef: ChartTemplateDef = {
+    chart: 'Bar Chart',
+    template: { mark: 'bar', encoding: {} },
+    channels: ['x', 'y', 'color'],
+    markCognitiveChannel: 'length',
+    declareLayoutMode: declareBandedCategoryAxis,
+    instantiate: (spec, ctx) => instantiateBar('grouped', spec, ctx),
+}
+
+export const quillGroupedBarChartDef: ChartTemplateDef = {
+    chart: 'Grouped Bar Chart',
+    template: { mark: 'bar', encoding: {} },
+    channels: ['x', 'y', 'color'],
+    markCognitiveChannel: 'length',
+    declareLayoutMode: declareBandedCategoryAxis,
+    instantiate: (spec, ctx) => instantiateBar('grouped', spec, ctx),
+}
+
+export const quillStackedBarChartDef: ChartTemplateDef = {
+    chart: 'Stacked Bar Chart',
+    template: { mark: 'bar', encoding: {} },
+    channels: ['x', 'y', 'color'],
+    markCognitiveChannel: 'length',
+    declareLayoutMode: declareBandedCategoryAxis,
+    instantiate: (spec, ctx) => instantiateBar('stacked', spec, ctx),
+}

--- a/frontend/src/lib/charts/flint/templates/bar.ts
+++ b/frontend/src/lib/charts/flint/templates/bar.ts
@@ -50,8 +50,10 @@ function instantiateBar(
     const horizontal = categoryAxis === 'y'
     const valueFormatter = makeTickFormatter(valCS.format)
     const valueAxisLabel = valCS.field === STATIC_SERIES_VALUE_COLUMN ? undefined : valCS.field
+    // Flint's canonical stack property: stackMode 'normalize' → share-of-total stacking
+    const normalized = barLayout === 'stacked' && ctx.chartProperties?.stackMode === 'normalize'
     const config: BarChartConfig = {
-        barLayout,
+        barLayout: normalized ? 'percent' : barLayout,
         axisOrientation: horizontal ? 'horizontal' : 'vertical',
         showGrid: true,
         // Left undefined unless the spec asks, so app-level styling defaults apply

--- a/frontend/src/lib/charts/flint/templates/index.ts
+++ b/frontend/src/lib/charts/flint/templates/index.ts
@@ -1,0 +1,21 @@
+import type { ChartTemplateDef } from 'flint-chart/core'
+
+import { quillBarChartDef, quillGroupedBarChartDef, quillStackedBarChartDef } from './bar'
+import { quillAreaChartDef, quillLineChartDef } from './line'
+import { quillDoughnutChartDef, quillPieChartDef } from './pie'
+
+/** Chart templates the quill backend implements. Names must match Flint's
+ *  cross-backend registry names (`chart_spec.chartType`) exactly. */
+export const quillTemplateDefs: ChartTemplateDef[] = [
+    quillBarChartDef,
+    quillGroupedBarChartDef,
+    quillStackedBarChartDef,
+    quillLineChartDef,
+    quillAreaChartDef,
+    quillPieChartDef,
+    quillDoughnutChartDef,
+]
+
+export function quillGetTemplateDef(chartType: string): ChartTemplateDef | undefined {
+    return quillTemplateDefs.find((t) => t.chart === chartType)
+}

--- a/frontend/src/lib/charts/flint/templates/line.ts
+++ b/frontend/src/lib/charts/flint/templates/line.ts
@@ -1,4 +1,5 @@
 import type { ChartTemplateDef, InstantiateContext } from 'flint-chart/core'
+import { STATIC_SERIES_VALUE_COLUMN } from 'flint-chart/core'
 
 import type { LineChartConfig, Series } from '@posthog/quill-charts'
 
@@ -94,7 +95,9 @@ function instantiateLine(area: boolean, spec: Record<string, unknown>, ctx: Inst
         floatBaseline: yCS.zero?.zero === false,
         yTickFormatter: makeTickFormatter(yCS.format),
         xAxisLabel: xCS.field,
-        yAxisLabel: yCS.field,
+        // The static-series fold points y at a synthetic value column; the legend
+        // names the folded measures, so a synthetic axis title is just noise
+        yAxisLabel: yCS.field === STATIC_SERIES_VALUE_COLUMN ? undefined : yCS.field,
         legend: { show: series.length > 1 },
     }
 

--- a/frontend/src/lib/charts/flint/templates/line.ts
+++ b/frontend/src/lib/charts/flint/templates/line.ts
@@ -1,0 +1,134 @@
+import type { ChartTemplateDef, InstantiateContext } from 'flint-chart/core'
+
+import type { LineChartConfig, Series } from '@posthog/quill-charts'
+
+import {
+    buildCategoryAlignedData,
+    extractCategories,
+    formatTemporalLabel,
+    groupBy,
+    makeTickFormatter,
+    temporalSortValue,
+} from '../template-utils'
+import type { QuillLineChartSpec } from '../types'
+
+const isDiscrete = (type: string | undefined): boolean => type === 'nominal' || type === 'ordinal'
+
+/** Quill line charts position points by label index (a band domain), so a
+ *  continuous or temporal x collapses onto its ordered distinct values — one
+ *  label per distinct x. Even spacing is exact for the regular time grids
+ *  agents chart; a truly irregular x-axis is a known limitation of this backend. */
+function buildXDomain(
+    table: Record<string, unknown>[],
+    xField: string,
+    xType: string | undefined,
+    ordinalSortOrder?: string[],
+    temporalFormat?: string
+): { labels: string[]; keyOf: (row: Record<string, unknown>) => string } {
+    if (isDiscrete(xType)) {
+        return {
+            labels: extractCategories(table, xField, ordinalSortOrder),
+            keyOf: (row) => String(row[xField] ?? ''),
+        }
+    }
+    const isTemporal = xType === 'temporal'
+    const distinct = new Map<string, number>()
+    for (const row of table) {
+        const raw = row[xField]
+        if (raw == null) {
+            continue
+        }
+        const sortVal = isTemporal ? temporalSortValue(raw) : Number(raw)
+        if (Number.isFinite(sortVal) && !distinct.has(String(raw))) {
+            distinct.set(String(raw), sortVal)
+        }
+    }
+    const orderedRaw = [...distinct.entries()].sort((a, b) => a[1] - b[1]).map(([raw]) => raw)
+    const labelOf = (raw: string): string => (isTemporal ? formatTemporalLabel(raw, temporalFormat) : raw)
+    return {
+        labels: orderedRaw.map(labelOf),
+        keyOf: (row) => labelOf(String(row[xField] ?? '')),
+    }
+}
+
+function instantiateLine(area: boolean, spec: Record<string, unknown>, ctx: InstantiateContext): void {
+    const { channelSemantics, table } = ctx
+    const xCS = channelSemantics.x
+    const yCS = channelSemantics.y
+    if (!xCS?.field || !yCS?.field) {
+        return
+    }
+
+    const domain = buildXDomain(table, xCS.field, xCS.type, xCS.ordinalSortOrder, xCS.temporalFormat)
+    // Re-key rows onto the label domain so category alignment works for
+    // discrete, temporal, and quantitative x alike
+    const keyed = table.map((row) => ({ ...row, __flint_x: domain.keyOf(row) }))
+
+    const colorField = channelSemantics.color?.field
+    const fill: Series['fill'] | undefined = area ? { opacity: 0.4 } : undefined
+
+    let series: Series[]
+    if (colorField) {
+        series = [...groupBy(keyed, colorField).entries()].map(([name, rows]) => ({
+            key: name,
+            label: name,
+            data: buildCategoryAlignedData(rows, '__flint_x', yCS.field, domain.labels),
+            fill,
+        }))
+    } else {
+        series = [
+            {
+                key: yCS.field,
+                label: yCS.field,
+                data: buildCategoryAlignedData(keyed, '__flint_x', yCS.field, domain.labels),
+                fill,
+            },
+        ]
+    }
+
+    const interpolate = ctx.chartProperties?.interpolate
+    const config: LineChartConfig = {
+        showGrid: true,
+        curve: interpolate === 'monotone' || interpolate === 'basis' ? 'monotone' : 'linear',
+        // Flint's zero decision: zero !== false means the axis includes 0
+        floatBaseline: yCS.zero?.zero === false,
+        yTickFormatter: makeTickFormatter(yCS.format),
+        xAxisLabel: xCS.field,
+        yAxisLabel: yCS.field,
+        legend: { show: series.length > 1 },
+    }
+
+    const assembled: Pick<QuillLineChartSpec, 'component' | 'series' | 'labels' | 'config'> = {
+        component: 'LineChart',
+        series,
+        labels: domain.labels,
+        config,
+    }
+    Object.assign(spec, assembled)
+    delete spec.mark
+    delete spec.encoding
+}
+
+export const quillLineChartDef: ChartTemplateDef = {
+    chart: 'Line Chart',
+    template: { mark: 'line', encoding: {} },
+    channels: ['x', 'y', 'color'],
+    markCognitiveChannel: 'position',
+    declareLayoutMode: () => ({
+        paramOverrides: { continuousMarkCrossSection: { x: 100, y: 20, seriesCountAxis: 'auto' } },
+    }),
+    instantiate: (spec, ctx) => instantiateLine(false, spec, ctx),
+}
+
+export const quillAreaChartDef: ChartTemplateDef = {
+    chart: 'Area Chart',
+    template: { mark: 'area', encoding: {} },
+    channels: ['x', 'y', 'color'],
+    markCognitiveChannel: 'area',
+    declareLayoutMode: () => ({
+        paramOverrides: { continuousMarkCrossSection: { x: 100, y: 20, seriesCountAxis: 'auto' } },
+    }),
+    // Multiple filled series auto-stack in quill's LineChart, matching Flint's
+    // stacked-by-default Area Chart semantics
+    instantiate: (spec, ctx) => instantiateLine(true, spec, ctx),
+}

--- a/frontend/src/lib/charts/flint/templates/line.ts
+++ b/frontend/src/lib/charts/flint/templates/line.ts
@@ -90,7 +90,13 @@ function instantiateLine(area: boolean, spec: Record<string, unknown>, ctx: Inst
     const interpolate = ctx.chartProperties?.interpolate
     const config: LineChartConfig = {
         showGrid: true,
-        curve: interpolate === 'monotone' || interpolate === 'basis' ? 'monotone' : 'linear',
+        // Only pin the curve when the spec asked for an interpolation — an explicit
+        // value here would override app-level styling defaults in the renderer
+        curve: interpolate
+            ? interpolate === 'monotone' || interpolate === 'basis'
+                ? 'monotone'
+                : 'linear'
+            : undefined,
         // Flint's zero decision: zero !== false means the axis includes 0
         floatBaseline: yCS.zero?.zero === false,
         yTickFormatter: makeTickFormatter(yCS.format),

--- a/frontend/src/lib/charts/flint/templates/line.ts
+++ b/frontend/src/lib/charts/flint/templates/line.ts
@@ -90,6 +90,8 @@ function instantiateLine(area: boolean, spec: Record<string, unknown>, ctx: Inst
     const interpolate = ctx.chartProperties?.interpolate
     const config: LineChartConfig = {
         showGrid: true,
+        // Flint's canonical stack property: stackMode 'normalize' → share-of-total stacking
+        percentStackView: area && ctx.chartProperties?.stackMode === 'normalize' ? true : undefined,
         // Only pin the curve when the spec asked for an interpolation — an explicit
         // value here would override app-level styling defaults in the renderer
         curve: interpolate

--- a/frontend/src/lib/charts/flint/templates/pie.ts
+++ b/frontend/src/lib/charts/flint/templates/pie.ts
@@ -1,0 +1,71 @@
+import type { ChartTemplateDef, InstantiateContext } from 'flint-chart/core'
+
+import type { PieChartConfig, Series } from '@posthog/quill-charts'
+
+import { extractCategories } from '../template-utils'
+import type { QuillPieChartSpec } from '../types'
+
+/** Slice values per category: sum of the size measure, or row counts when no
+ *  size channel is bound (same fallback as Flint's other backends). */
+function computeSlices(ctx: InstantiateContext): { label: string; value: number }[] {
+    const { channelSemantics, table } = ctx
+    const colorField = channelSemantics.color?.field
+    const sizeField = channelSemantics.size?.field
+    if (!colorField) {
+        return []
+    }
+
+    const totals = new Map<string, number>()
+    for (const row of table) {
+        const cat = String(row[colorField] ?? '')
+        const val = sizeField ? Number(row[sizeField]) || 0 : 1
+        totals.set(cat, (totals.get(cat) ?? 0) + val)
+    }
+    const categories = extractCategories(table, colorField, channelSemantics.color?.ordinalSortOrder)
+    return categories.map((cat) => ({ label: cat, value: totals.get(cat) ?? 0 }))
+}
+
+function instantiatePie(innerRadiusRatio: number, spec: Record<string, unknown>, ctx: InstantiateContext): void {
+    let slices = computeSlices(ctx)
+    if (slices.length === 0) {
+        return
+    }
+
+    const sortSlices = ctx.chartProperties?.sortSlices
+    if (sortSlices === 'descending' || sortSlices === 'ascending') {
+        slices = [...slices].sort((a, b) => (sortSlices === 'descending' ? b.value - a.value : a.value - b.value))
+    }
+
+    // Quill pie charts take one Series per slice; the slice value defaults to
+    // the sum of the series' data
+    const series: Series[] = slices.map((s) => ({ key: s.label, label: s.label, data: [s.value] }))
+    const config: PieChartConfig = {
+        innerRadiusRatio,
+        showValueOnSlice: true,
+    }
+
+    const assembled: Pick<QuillPieChartSpec, 'component' | 'series' | 'config'> = {
+        component: 'PieChart',
+        series,
+        config,
+    }
+    Object.assign(spec, assembled)
+    delete spec.mark
+    delete spec.encoding
+}
+
+export const quillPieChartDef: ChartTemplateDef = {
+    chart: 'Pie Chart',
+    template: { mark: 'arc', encoding: {} },
+    channels: ['size', 'color'],
+    markCognitiveChannel: 'area',
+    instantiate: (spec, ctx) => instantiatePie(0, spec, ctx),
+}
+
+export const quillDoughnutChartDef: ChartTemplateDef = {
+    chart: 'Doughnut Chart',
+    template: { mark: 'arc', encoding: {} },
+    channels: ['size', 'color'],
+    markCognitiveChannel: 'area',
+    instantiate: (spec, ctx) => instantiatePie(0.5, spec, ctx),
+}

--- a/frontend/src/lib/charts/flint/types.ts
+++ b/frontend/src/lib/charts/flint/types.ts
@@ -1,0 +1,39 @@
+import type { ChartWarning } from 'flint-chart/core'
+
+import type { BarChartConfig, LineChartConfig, PieChartConfig, Series } from '@posthog/quill-charts'
+
+/** Metadata every assembled spec carries, mirroring the underscore-prefixed
+ *  hints Flint's Vega-Lite / ECharts / Chart.js backends attach to their output. */
+export interface QuillSpecMeta {
+    _warnings?: ChartWarning[]
+    /** Layout-derived size hints (px). Quill computes its own layout from the
+     *  container, so these are suggestions for the host, not requirements. */
+    _width?: number
+    _height?: number
+    _dataLength?: number
+}
+
+export interface QuillBarChartSpec extends QuillSpecMeta {
+    component: 'BarChart'
+    series: Series[]
+    labels: string[]
+    config: BarChartConfig
+}
+
+export interface QuillLineChartSpec extends QuillSpecMeta {
+    component: 'LineChart'
+    series: Series[]
+    labels: string[]
+    config: LineChartConfig
+}
+
+export interface QuillPieChartSpec extends QuillSpecMeta {
+    component: 'PieChart'
+    series: Series[]
+    config: PieChartConfig
+}
+
+/** The "native spec" of the quill backend: which quill-charts component to
+ *  render and the exact props to render it with. The quill analog of the
+ *  Chart.js config object `assembleChartjs()` returns. */
+export type QuillChartSpec = QuillBarChartSpec | QuillLineChartSpec | QuillPieChartSpec

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -23,6 +23,7 @@ export const DISPLAY_TYPES_TO_CATEGORIES: Record<ChartDisplayType, ChartDisplayC
     // The slope's two points are the first and last interval bucket, so it's time-series at heart;
     // it keeps the group-by interval and InsightDisplayConfig hides the options between the ends.
     [ChartDisplayType.SlopeGraph]: ChartDisplayCategory.TimeSeries,
+    [ChartDisplayType.FlintChart]: ChartDisplayCategory.TotalValue,
 }
 export const NON_TIME_SERIES_DISPLAY_TYPES = Object.entries(DISPLAY_TYPES_TO_CATEGORIES)
     .filter(([, category]) => category === ChartDisplayCategory.TotalValue)

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
@@ -16,9 +17,14 @@ const CHART_TYPE_OPTIONS = [
     ...quillTemplateDefs.map((t) => ({ value: t.chart as string | null, label: t.chart })),
 ]
 
+export interface FlintQuillVisualizationProps {
+    /** Fixed 60vh chart height for the SQL editor pane, whose flex layout gives children no definite height. */
+    presetChartHeight?: boolean
+}
+
 /** SQL editor output-pane view: renders the query results through the
  *  flint-chart quill backend, inferring a spec from the result shape. */
-export function FlintQuillVisualization(): JSX.Element {
+export function FlintQuillVisualization({ presetChartHeight }: FlintQuillVisualizationProps): JSX.Element {
     const { response, dataVisualizationProps } = useValues(dataVisualizationLogic)
     const logic = flintQuillVisualizationLogic({ key: dataVisualizationProps.key })
     const { chartType } = useValues(logic)
@@ -55,7 +61,15 @@ export function FlintQuillVisualization(): JSX.Element {
                     data-attr="flint-chart-type"
                 />
             </div>
-            <div className="flex-1 min-h-0 rounded bg-surface-primary p-2">
+            <div
+                className={clsx(
+                    // `flex flex-col` is load-bearing: quill chart roots size themselves with
+                    // `flex-1`, which only engages inside a flex container — without it the
+                    // canvas collapses to 0px height (same pattern as SqlLineGraph)
+                    'rounded bg-surface-primary p-2 flex flex-col',
+                    presetChartHeight ? 'h-[60vh]' : 'flex-1 min-h-0'
+                )}
+            >
                 <FlintQuillChart input={input} className="h-full" dataAttr="flint-quill-visualization" />
             </div>
         </div>

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
@@ -1,0 +1,63 @@
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { FlintQuillChart, quillTemplateDefs } from 'lib/charts/flint'
+
+import type { HogQLQueryResponse } from '~/queries/schema/schema-general'
+
+import { dataVisualizationLogic } from '../../dataVisualizationLogic'
+import { flintChartInput } from './flintChartInput'
+import { flintQuillVisualizationLogic } from './flintQuillVisualizationLogic'
+
+const CHART_TYPE_OPTIONS = [
+    { value: null, label: 'Auto' },
+    ...quillTemplateDefs.map((t) => ({ value: t.chart as string | null, label: t.chart })),
+]
+
+/** SQL editor output-pane view: renders the query results through the
+ *  flint-chart quill backend, inferring a spec from the result shape. */
+export function FlintQuillVisualization(): JSX.Element {
+    const { response, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const logic = flintQuillVisualizationLogic({ key: dataVisualizationProps.key })
+    const { chartType } = useValues(logic)
+    const { setChartType } = useActions(logic)
+
+    const hogqlResponse = response as HogQLQueryResponse | null
+    const input = useMemo(() => {
+        const columns: string[] = hogqlResponse?.columns ?? []
+        const rows = (hogqlResponse?.results as unknown[][] | undefined) ?? []
+        // HogQL `types` entries are `[columnName, clickhouseType]` tuples — pull out the type string
+        const columnTypes: (string | null)[] = ((hogqlResponse?.types as unknown[][] | undefined) ?? []).map((t) =>
+            Array.isArray(t) ? ((t[1] as string | undefined) ?? null) : null
+        )
+        return flintChartInput({ columns, columnTypes, rows, chartType })
+    }, [hogqlResponse, chartType])
+
+    if (!input) {
+        return (
+            <div className="flex items-center justify-center h-full text-secondary">
+                Run a query to render its results as a Flint chart.
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 p-3 h-full">
+            <div className="flex items-center gap-2">
+                <span className="text-xs text-secondary">Chart type</span>
+                <LemonSelect
+                    size="small"
+                    value={chartType}
+                    onChange={setChartType}
+                    options={CHART_TYPE_OPTIONS}
+                    data-attr="flint-chart-type"
+                />
+            </div>
+            <div className="flex-1 min-h-0 rounded bg-surface-primary p-2">
+                <FlintQuillChart input={input} className="h-full" dataAttr="flint-quill-visualization" />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization.tsx
@@ -2,7 +2,8 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonSelect } from '@posthog/lemon-ui'
+import { IconSparkles } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { FlintQuillChart, quillTemplateDefs } from 'lib/charts/flint'
 
@@ -22,24 +23,48 @@ export interface FlintQuillVisualizationProps {
     presetChartHeight?: boolean
 }
 
-/** SQL editor output-pane view: renders the query results through the
- *  flint-chart quill backend, inferring a spec from the result shape. */
+/** SQL editor output-pane view: renders the query results through the flint-chart quill backend.
+ *  A spec is inferred from the result shape immediately; an optional prompt asks the model for a
+ *  better one (the model only maps columns to channels — rows never leave the client). */
 export function FlintQuillVisualization({ presetChartHeight }: FlintQuillVisualizationProps): JSX.Element {
-    const { response, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const { response, dataVisualizationProps, query, currentTeamId } = useValues(dataVisualizationLogic)
     const logic = flintQuillVisualizationLogic({ key: dataVisualizationProps.key })
-    const { chartType } = useValues(logic)
-    const { setChartType } = useActions(logic)
+    const { chartType, prompt, generatedInput, generationLoading, narrative, warnings } = useValues(logic)
+    const { setChartType, setPrompt, generateSpec } = useActions(logic)
 
     const hogqlResponse = response as HogQLQueryResponse | null
-    const input = useMemo(() => {
+    const { columns, columnTypes, rows } = useMemo(() => {
         const columns: string[] = hogqlResponse?.columns ?? []
         const rows = (hogqlResponse?.results as unknown[][] | undefined) ?? []
         // HogQL `types` entries are `[columnName, clickhouseType]` tuples — pull out the type string
         const columnTypes: (string | null)[] = ((hogqlResponse?.types as unknown[][] | undefined) ?? []).map((t) =>
             Array.isArray(t) ? ((t[1] as string | undefined) ?? null) : null
         )
+        return { columns, columnTypes, rows }
+    }, [hogqlResponse])
+
+    const input = useMemo(() => {
+        if (generatedInput) {
+            // A manual chart-type pick re-targets the generated spec's encodings
+            return chartType
+                ? { ...generatedInput, chart_spec: { ...generatedInput.chart_spec, chartType } }
+                : generatedInput
+        }
         return flintChartInput({ columns, columnTypes, rows, chartType })
-    }, [hogqlResponse, chartType])
+    }, [generatedInput, columns, columnTypes, rows, chartType])
+
+    const onGenerate = (): void => {
+        if (!currentTeamId) {
+            return
+        }
+        generateSpec({
+            teamId: currentTeamId,
+            query: (query.source as { query?: string }).query ?? '',
+            columns,
+            columnTypes,
+            rows,
+        })
+    }
 
     if (!input) {
         return (
@@ -52,7 +77,6 @@ export function FlintQuillVisualization({ presetChartHeight }: FlintQuillVisuali
     return (
         <div className="flex flex-col gap-2 p-3 h-full">
             <div className="flex items-center gap-2">
-                <span className="text-xs text-secondary">Chart type</span>
                 <LemonSelect
                     size="small"
                     value={chartType}
@@ -60,7 +84,39 @@ export function FlintQuillVisualization({ presetChartHeight }: FlintQuillVisuali
                     options={CHART_TYPE_OPTIONS}
                     data-attr="flint-chart-type"
                 />
+                <LemonInput
+                    className="flex-1"
+                    size="small"
+                    value={prompt}
+                    onChange={setPrompt}
+                    onPressEnter={onGenerate}
+                    placeholder="Describe the chart you want (optional)…"
+                    disabled={generationLoading}
+                />
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    icon={<IconSparkles />}
+                    onClick={onGenerate}
+                    loading={generationLoading}
+                    disabledReason={
+                        columns.length === 0 || rows.length === 0
+                            ? 'Run a query first'
+                            : !currentTeamId
+                              ? 'No team'
+                              : undefined
+                    }
+                >
+                    {generatedInput ? 'Regenerate' : 'Generate'}
+                </LemonButton>
             </div>
+
+            {warnings.map((warning, i) => (
+                <LemonBanner key={i} type="warning">
+                    {warning}
+                </LemonBanner>
+            ))}
+
             <div
                 className={clsx(
                     // `flex flex-col` is load-bearing: quill chart roots size themselves with
@@ -72,6 +128,8 @@ export function FlintQuillVisualization({ presetChartHeight }: FlintQuillVisuali
             >
                 <FlintQuillChart input={input} className="h-full" dataAttr="flint-quill-visualization" />
             </div>
+
+            {narrative && <div className="text-xs text-secondary">{narrative}</div>}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintChartInput.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintChartInput.test.ts
@@ -1,0 +1,84 @@
+import { flintChartInput } from './flintChartInput'
+
+describe('flintChartInput', () => {
+    const dateColumns = ['day', 'signups']
+    const dateTypes = ['Date', 'UInt64']
+    const dateRows = [
+        ['2026-01-01', 10],
+        ['2026-01-02', 20],
+    ]
+
+    it('returns null without columns or rows so the pane can show an empty state', () => {
+        expect(flintChartInput({ columns: [], columnTypes: [], rows: [] })).toBeNull()
+        expect(flintChartInput({ columns: dateColumns, columnTypes: dateTypes, rows: [] })).toBeNull()
+    })
+
+    it('infers a line chart with temporal x from ClickHouse column types', () => {
+        const input = flintChartInput({ columns: dateColumns, columnTypes: dateTypes, rows: dateRows })
+
+        expect(input?.chart_spec.chartType).toBe('Line Chart')
+        expect(input?.chart_spec.encodings).toEqual({ x: { field: 'day' }, y: { field: 'signups' } })
+        expect(input?.semantic_types).toEqual({ day: 'Date', signups: 'Quantity' })
+        expect(input?.data.values).toEqual([
+            { day: '2026-01-01', signups: 10 },
+            { day: '2026-01-02', signups: 20 },
+        ])
+    })
+
+    it('falls back to value sniffing when column types are missing', () => {
+        const input = flintChartInput({ columns: dateColumns, columnTypes: [null, null], rows: dateRows })
+
+        expect(input?.semantic_types).toEqual({ day: 'Date', signups: 'Quantity' })
+        expect(input?.chart_spec.chartType).toBe('Line Chart')
+    })
+
+    it('routes a leftover categorical column onto the color channel', () => {
+        const input = flintChartInput({
+            columns: ['day', 'plan', 'signups'],
+            columnTypes: ['Date', 'String', 'UInt64'],
+            rows: [['2026-01-01', 'free', 10]],
+        })
+
+        expect(input?.chart_spec.encodings).toEqual({
+            x: { field: 'day' },
+            y: { field: 'signups' },
+            color: { field: 'plan' },
+        })
+    })
+
+    it('folds multiple numeric columns into static series', () => {
+        const input = flintChartInput({
+            columns: ['day', 'signups', 'churns'],
+            columnTypes: ['Date', 'UInt64', 'UInt64'],
+            rows: [['2026-01-01', 10, 2]],
+        })
+
+        expect(input?.chart_spec.encodings).toEqual({
+            x: { field: 'day' },
+            y: [{ field: 'signups' }, { field: 'churns' }],
+        })
+    })
+
+    it('charts row counts when there is no numeric column', () => {
+        const input = flintChartInput({
+            columns: ['plan'],
+            columnTypes: ['String'],
+            rows: [['free'], ['free'], ['paid']],
+        })
+
+        expect(input?.chart_spec.chartType).toBe('Bar Chart')
+        expect(input?.chart_spec.encodings).toEqual({ x: { field: 'plan' }, y: { aggregate: 'count' } })
+    })
+
+    it('remaps encodings onto color/size when overridden to a pie chart', () => {
+        const input = flintChartInput({
+            columns: ['plan', 'signups'],
+            columnTypes: ['String', 'UInt64'],
+            rows: [['free', 10]],
+            chartType: 'Doughnut Chart',
+        })
+
+        expect(input?.chart_spec.chartType).toBe('Doughnut Chart')
+        expect(input?.chart_spec.encodings).toEqual({ color: { field: 'plan' }, size: { field: 'signups' } })
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintChartInput.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintChartInput.ts
@@ -1,0 +1,106 @@
+import type { ChartAssemblyInput } from 'flint-chart/core'
+
+export interface FlintChartInputArgs {
+    columns: string[]
+    /** ClickHouse type per column (from the HogQL response `types` tuples), when available. */
+    columnTypes: (string | null)[]
+    rows: unknown[][]
+    /** Flint chart type override; omit to infer one from the result shape. */
+    chartType?: string | null
+}
+
+type ColumnClass = 'temporal' | 'numeric' | 'categorical'
+
+const CLASS_TO_SEMANTIC_TYPE: Record<ColumnClass, string> = {
+    temporal: 'Date',
+    numeric: 'Quantity',
+    categorical: 'Category',
+}
+
+function classifyByClickhouseType(chType: string | null): ColumnClass | null {
+    if (!chType) {
+        return null
+    }
+    if (/Date/i.test(chType)) {
+        return 'temporal'
+    }
+    if (/Int|Float|Decimal/i.test(chType)) {
+        return 'numeric'
+    }
+    return 'categorical'
+}
+
+function classifyBySample(values: unknown[]): ColumnClass {
+    const sample = values.find((v) => v != null)
+    if (typeof sample === 'number') {
+        return 'numeric'
+    }
+    if (typeof sample === 'string' && /^\d{4}-\d{2}-\d{2}/.test(sample)) {
+        return 'temporal'
+    }
+    return 'categorical'
+}
+
+/**
+ * Build a Flint `ChartAssemblyInput` from raw SQL-editor results.
+ *
+ * Column roles come from the ClickHouse column types (falling back to value
+ * sniffing): the first temporal column becomes the x-axis (else the first
+ * categorical one), numeric columns become measures, and a leftover
+ * categorical column becomes the series split. Flint's compiler derives
+ * everything else — sort order, zero baseline, formatting, overflow.
+ */
+export function flintChartInput({
+    columns,
+    columnTypes,
+    rows,
+    chartType,
+}: FlintChartInputArgs): ChartAssemblyInput | null {
+    if (columns.length === 0 || rows.length === 0) {
+        return null
+    }
+
+    const values = rows.map((row) => Object.fromEntries(columns.map((c, i) => [c, row[i]])))
+    const classes: ColumnClass[] = columns.map(
+        (_, i) => classifyByClickhouseType(columnTypes[i] ?? null) ?? classifyBySample(rows.map((r) => r[i]))
+    )
+    const byClass = (cls: ColumnClass): string[] => columns.filter((_, i) => classes[i] === cls)
+    const temporal = byClass('temporal')
+    const numeric = byClass('numeric')
+    const categorical = byClass('categorical')
+
+    const semanticTypes = Object.fromEntries(columns.map((c, i) => [c, CLASS_TO_SEMANTIC_TYPE[classes[i]]]))
+    const resolvedChartType = chartType ?? (temporal.length > 0 && numeric.length > 0 ? 'Line Chart' : 'Bar Chart')
+
+    let encodings: ChartAssemblyInput['chart_spec']['encodings']
+    if (resolvedChartType === 'Pie Chart' || resolvedChartType === 'Doughnut Chart') {
+        const sliceField = categorical[0] ?? temporal[0] ?? columns[0]
+        const sizeField = numeric[0]
+        encodings = sizeField
+            ? { color: { field: sliceField }, size: { field: sizeField } }
+            : { color: { field: sliceField } }
+    } else {
+        const x = temporal[0] ?? categorical[0] ?? columns[0]
+        const measures = numeric.filter((c) => c !== x)
+        const seriesField = categorical.find((c) => c !== x)
+        if (measures.length === 0) {
+            // No measure columns: chart row counts per x value
+            encodings = { x: { field: x }, y: { aggregate: 'count' } }
+        } else if (measures.length === 1) {
+            encodings = {
+                x: { field: x },
+                y: { field: measures[0] },
+                ...(seriesField ? { color: { field: seriesField } } : {}),
+            }
+        } else {
+            // Multiple measures fold into static series (one line/bar group per column)
+            encodings = { x: { field: x }, y: measures.map((field) => ({ field })) }
+        }
+    }
+
+    return {
+        data: { values },
+        semantic_types: semanticTypes,
+        chart_spec: { chartType: resolvedChartType, encodings },
+    }
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintQuillVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintQuillVisualizationLogic.ts
@@ -1,0 +1,25 @@
+import { actions, kea, key, path, props, reducers } from 'kea'
+
+import type { flintQuillVisualizationLogicType } from './flintQuillVisualizationLogicType'
+
+export interface FlintQuillVisualizationLogicProps {
+    key: string
+}
+
+export const flintQuillVisualizationLogic = kea<flintQuillVisualizationLogicType>([
+    path(['queries', 'nodes', 'DataVisualization', 'Components', 'Charts', 'flintQuillVisualizationLogic']),
+    props({} as FlintQuillVisualizationLogicProps),
+    key((props) => props.key),
+    actions({
+        setChartType: (chartType: string | null) => ({ chartType }),
+    }),
+    reducers({
+        // null = infer the chart type from the result shape
+        chartType: [
+            null as string | null,
+            {
+                setChartType: (_, { chartType }) => chartType,
+            },
+        ],
+    }),
+])

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintQuillVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/flintQuillVisualizationLogic.ts
@@ -1,9 +1,29 @@
-import { actions, kea, key, path, props, reducers } from 'kea'
+import type { ChartAssemblyInput } from 'flint-chart/core'
+import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
 
 import type { flintQuillVisualizationLogicType } from './flintQuillVisualizationLogicType'
 
 export interface FlintQuillVisualizationLogicProps {
     key: string
+}
+
+export interface GenerateFlintSpecPayload {
+    teamId: number
+    query: string
+    columns: string[]
+    columnTypes: (string | null)[]
+    rows: unknown[][]
+}
+
+export interface SqlFlintSpecResponse {
+    chart_spec: ChartAssemblyInput['chart_spec'] | null
+    semantic_types?: Record<string, string>
+    narrative?: string | null
+    trace_id: string
+    warnings?: string[]
 }
 
 export const flintQuillVisualizationLogic = kea<flintQuillVisualizationLogicType>([
@@ -12,6 +32,8 @@ export const flintQuillVisualizationLogic = kea<flintQuillVisualizationLogicType
     key((props) => props.key),
     actions({
         setChartType: (chartType: string | null) => ({ chartType }),
+        setPrompt: (prompt: string) => ({ prompt }),
+        generateSpec: (payload: GenerateFlintSpecPayload) => payload,
     }),
     reducers({
         // null = infer the chart type from the result shape
@@ -19,7 +41,58 @@ export const flintQuillVisualizationLogic = kea<flintQuillVisualizationLogicType
             null as string | null,
             {
                 setChartType: (_, { chartType }) => chartType,
+                // A fresh generation decides its own chart type; drop any manual override
+                generateSpecSuccess: () => null,
             },
         ],
+        prompt: ['' as string, { setPrompt: (_, { prompt }) => prompt }],
+        lastColumns: [[] as string[], { generateSpec: (_, { columns }) => columns }],
+        lastRows: [[] as unknown[][], { generateSpec: (_, { rows }) => rows }],
+    }),
+    loaders(({ values }) => ({
+        generation: [
+            null as SqlFlintSpecResponse | null,
+            {
+                generateSpec: async ({ teamId, query, columns, columnTypes, rows }) => {
+                    const sampleRows = rows.slice(0, 20)
+                    return await api.create<SqlFlintSpecResponse>(`api/projects/${teamId}/sql_flint_spec`, {
+                        query,
+                        prompt: values.prompt,
+                        columns: columns.map((name, i) => ({
+                            name,
+                            type: columnTypes[i] ?? null,
+                            sampleValues: sampleRows
+                                .map((row) => row[i])
+                                .filter((value) => value != null)
+                                .slice(0, 5),
+                        })),
+                        rowCount: rows.length,
+                    })
+                },
+            },
+        ],
+    })),
+    selectors({
+        /** Flint input from the generated spec plus the real rows — null until a generation succeeds. */
+        generatedInput: [
+            (s) => [s.generation, s.lastColumns, s.lastRows],
+            (
+                generation: SqlFlintSpecResponse | null,
+                lastColumns: string[],
+                lastRows: unknown[][]
+            ): ChartAssemblyInput | null => {
+                if (!generation?.chart_spec || lastColumns.length === 0) {
+                    return null
+                }
+                const values = lastRows.map((row) => Object.fromEntries(lastColumns.map((name, i) => [name, row[i]])))
+                return {
+                    data: { values },
+                    semantic_types: generation.semantic_types ?? {},
+                    chart_spec: generation.chart_spec,
+                }
+            },
+        ],
+        narrative: [(s) => [s.generation], (generation): string | null => generation?.narrative ?? null],
+        warnings: [(s) => [s.generation], (generation): string[] => generation?.warnings ?? []],
     }),
 ])

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -35,6 +35,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
         [ChartDisplayType.TwoDimensionalHeatmap]: '2d heatmap',
         [ChartDisplayType.BoxPlot]: 'Box plot',
         [ChartDisplayType.SlopeGraph]: 'Slope graph',
+        [ChartDisplayType.FlintChart]: 'Flint chart',
     }
 
     const renderDisplayTypeLabel = (displayType: ChartDisplayType): string => {
@@ -112,6 +113,17 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.TwoDimensionalHeatmap,
                     icon: <IconHeatmap />,
                     label: '2d heatmap',
+                },
+            ],
+        },
+        {
+            title: 'Experimental',
+            options: [
+                {
+                    value: ChartDisplayType.FlintChart,
+                    icon: <IconAreaChart />,
+                    label: 'Flint chart',
+                    disabledReason: columns.length === 0 ? 'Run a query first' : undefined,
                 },
             ],
         },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4336,6 +4336,10 @@
                     "type": "string"
                 },
                 {
+                    "const": "FlintChart",
+                    "type": "string"
+                },
+                {
                     "not": {}
                 }
             ]
@@ -4434,7 +4438,8 @@
                         "CalendarHeatmap",
                         "TwoDimensionalHeatmap",
                         "BoxPlot",
-                        "SlopeGraph"
+                        "SlopeGraph",
+                        "FlintChart"
                     ],
                     "type": "string"
                 },
@@ -12819,7 +12824,8 @@
                 "CalendarHeatmap",
                 "TwoDimensionalHeatmap",
                 "BoxPlot",
-                "SlopeGraph"
+                "SlopeGraph",
+                "FlintChart"
             ],
             "type": "string"
         },

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -963,7 +963,7 @@ function InternalDataTableVisualization(
     } else if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         component = <TwoDimensionalHeatmap />
     } else if (effectiveVisualizationType === ChartDisplayType.FlintChart) {
-        component = <FlintQuillVisualization />
+        component = <FlintQuillVisualization presetChartHeight={presetChartHeight} />
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     }

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -44,6 +44,7 @@ import { ElapsedTime } from '~/queries/nodes/DataNode/ElapsedTime'
 import { LoadPreviewText } from '~/queries/nodes/DataNode/LoadNext'
 import { QueryExecutionDetails } from '~/queries/nodes/DataNode/QueryExecutionDetails'
 import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
+import { FlintQuillVisualization } from '~/queries/nodes/DataVisualization/Components/Charts/FlintQuillVisualization'
 import { LineGraph } from '~/queries/nodes/DataVisualization/Components/Charts/LineGraph'
 import { PieChart } from '~/queries/nodes/DataVisualization/Components/Charts/PieChart'
 import { TwoDimensionalHeatmap } from '~/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap'
@@ -961,6 +962,8 @@ function InternalDataTableVisualization(
         )
     } else if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         component = <TwoDimensionalHeatmap />
+    } else if (effectiveVisualizationType === ChartDisplayType.FlintChart) {
+        component = <FlintQuillVisualization />
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     }

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -204,6 +204,9 @@ const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
 
     // separate runner — only the two range endpoints, cached on its own key
     [ChartDisplayType.SlopeGraph]: ChartDisplayType.SlopeGraph,
+
+    // SQL editor only — does not affect query grouping
+    [ChartDisplayType.FlintChart]: ChartDisplayType.ActionsBarValue,
 }
 
 /** clean insight queries so that we can check for semantic equality with a deep equality check */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2946,6 +2946,8 @@ export enum ChartDisplayType {
     TwoDimensionalHeatmap = 'TwoDimensionalHeatmap',
     BoxPlot = 'BoxPlot',
     SlopeGraph = 'SlopeGraph',
+    /** Experimental: SQL editor results rendered through the flint-chart quill backend. */
+    FlintChart = 'FlintChart',
 }
 export enum ChartDisplayCategory {
     TimeSeries = 'TimeSeries',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,7 +317,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -372,7 +372,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -403,7 +403,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       jest-junit:
         specifier: 'catalog:'
         version: 16.0.0
@@ -427,7 +427,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: ^10.4.3
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/addon-links':
         specifier: ^10.4.3
         version: 10.4.6(@types/react@18.3.27)(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -439,10 +439,10 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -457,7 +457,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -963,6 +963,9 @@ importers:
       fastpriorityqueue:
         specifier: ^0.7.5
         version: 0.7.5
+      flint-chart:
+        specifier: 0.1.3
+        version: 0.1.3(chart.js@4.5.1)
       frimousse:
         specifier: ^0.3.0
         version: 0.3.0(react@18.3.1)(typescript@6.0.3)
@@ -1848,7 +1851,7 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -1869,7 +1872,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1985,7 +1988,7 @@ importers:
         version: 5.2.0(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2858,7 +2861,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -2984,7 +2987,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -3582,7 +3585,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -6079,6 +6082,7 @@ packages:
 
   '@clickhouse/client-common@1.12.0':
     resolution: {integrity: sha512-cyI4n7u9jK30d9q1q0ceQ7IwJ/MtTs5HxoQfc8yHpN+ok5wqaU2jAtq5hpa1z7C7sS1pDy/ZOFmOzg1v1F683g==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.12.0':
     resolution: {integrity: sha512-vJUSX8THhTzlVn0WxPukVjOgNRaSoY02ubQkB0LpqNoHFxXuF5jQZZAYvGZWpBGbYQ/4gfPrqu8g4TX5UKeNxA==}
@@ -15592,6 +15596,24 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  flint-chart@0.1.3:
+    resolution: {integrity: sha512-RckIdZPWmqK4iM859h8DZgdu/nGVIw85/nJ3WJXiXkz2w0KDtM5OGLRSmzi5bNQIzO5YC+4up5if6//AOvD6aA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      chart.js: ^4.0.0
+      echarts: ^5.0.0 || ^6.0.0
+      vega: ^5.0.0 || ^6.0.0
+      vega-lite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      chart.js:
+        optional: true
+      echarts:
+        optional: true
+      vega:
+        optional: true
+      vega-lite:
+        optional: true
+
   fluent-ffmpeg@2.1.3:
     resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
     engines: {node: '>=18'}
@@ -19720,6 +19742,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode.react@4.2.0:
@@ -26647,6 +26670,41 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -26682,38 +26740,39 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5':
     dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
+      '@jest/console': 30.0.5
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.0.5
+      '@jest/test-result': 30.0.5
+      '@jest/transform': 30.0.5
+      '@jest/types': 30.0.5
       '@types/node': 22.18.8
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
+      ci-info: 4.3.0
+      exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
+      jest-changed-files: 30.0.5
+      jest-config: 30.0.5(@types/node@22.18.8)
+      jest-haste-map: 30.0.5
+      jest-message-util: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-resolve-dependencies: 30.0.5
+      jest-runner: 30.0.5
+      jest-runtime: 30.0.5
+      jest-snapshot: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      jest-watcher: 30.0.5
       micromatch: 4.0.8
-      pretty-format: 29.7.0
+      pretty-format: 30.0.5
       slash: 3.0.0
-      strip-ansi: 6.0.1
     transitivePeerDependencies:
       - babel-plugin-macros
+      - esbuild-register
       - supports-color
       - ts-node
 
@@ -26769,42 +26828,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
       jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      jest-haste-map: 30.0.5
-      jest-message-util: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-resolve-dependencies: 30.0.5
-      jest-runner: 30.0.5
-      jest-runtime: 30.0.5
-      jest-snapshot: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      jest-watcher: 30.0.5
-      micromatch: 4.0.8
-      pretty-format: 30.0.5
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
-    dependencies:
-      '@jest/console': 30.0.5
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.0.5
-      '@jest/test-result': 30.0.5
-      '@jest/transform': 30.0.5
-      '@jest/types': 30.0.5
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -31055,10 +31078,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -31093,9 +31116,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -31114,7 +31137,7 @@ snapshots:
       vite: 7.3.3(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
@@ -31122,7 +31145,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.60.4
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -31177,11 +31200,11 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -31233,7 +31256,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -31243,14 +31266,14 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.39(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-circus: 30.0.5
       jest-environment-node: 30.0.5
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.0.5
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0))
       nyc: 15.1.0
       playwright: 1.60.0
       playwright-core: 1.60.0
@@ -34815,6 +34838,36 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
+  create-jest@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -34830,13 +34883,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.8.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36507,6 +36560,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  flint-chart@0.1.3(chart.js@4.5.1):
+    optionalDependencies:
+      chart.js: 4.5.1
+
   fluent-ffmpeg@2.1.3:
     dependencies:
       async: 0.2.10
@@ -37887,6 +37944,44 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest-cli@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-cli@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.18.8)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
@@ -37906,16 +38001,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.8.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -37944,15 +38039,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -37963,15 +38058,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38016,6 +38111,64 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jest-config@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -38047,38 +38200,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -38104,7 +38226,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(@types/node@22.18.8):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38177,7 +38330,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -38204,8 +38357,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+      '@types/node': 25.8.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -38239,39 +38391,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       esbuild-register: 3.6.0(esbuild@0.28.0)
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.0.1
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.0.5
-      '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.0.5
-      jest-docblock: 30.0.1
-      jest-environment-node: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-runner: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.0.5
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -38475,7 +38594,7 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38486,9 +38605,9 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.8.0)
 
-  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -38499,7 +38618,7 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -39054,11 +39173,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       ansi-escapes: 7.0.0
       chalk: 5.6.2
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-regex-util: 30.0.1
       jest-watcher: 30.0.5
       slash: 5.1.0
@@ -39130,6 +39249,30 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.18.8)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
@@ -39142,12 +39285,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39167,12 +39310,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -39180,12 +39323,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -44560,6 +44703,20 @@ snapshots:
       esbuild: 0.28.0
       postcss: 8.5.15
 
+  terser-webpack-plugin@5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+    optionalDependencies:
+      cssnano: 7.0.6(postcss@8.5.15)
+      esbuild: 0.28.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optional: true
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
@@ -45787,6 +45944,48 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.22.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
 
   webrtc-adapter@9.0.5:
     dependencies:

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -450,6 +450,7 @@ class Display(StrEnum):
     TWO_DIMENSIONAL_HEATMAP = "TwoDimensionalHeatmap"
     BOX_PLOT = "BoxPlot"
     SLOPE_GRAPH = "SlopeGraph"
+    FLINT_CHART = "FlintChart"
 
 
 class MetricSummary(StrEnum):
@@ -588,6 +589,7 @@ class ChartDisplayType(StrEnum):
     TWO_DIMENSIONAL_HEATMAP = "TwoDimensionalHeatmap"
     BOX_PLOT = "BoxPlot"
     SLOPE_GRAPH = "SlopeGraph"
+    FLINT_CHART = "FlintChart"
 
 
 class ColorMode(StrEnum):

--- a/products/data_warehouse/backend/presentation/views/sql_flint_spec.py
+++ b/products/data_warehouse/backend/presentation/views/sql_flint_spec.py
@@ -118,6 +118,11 @@ class SQLFlintSpecViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 "chart_spec": {
                     "chartType": spec.chartType,
                     "encodings": spec.encodings.model_dump(exclude_none=True),
+                    **(
+                        {"chartProperties": spec.chartProperties.model_dump(exclude_none=True)}
+                        if spec.chartProperties
+                        else {}
+                    ),
                 },
                 "semantic_types": spec.semantic_types,
                 "narrative": spec.narrative,

--- a/products/data_warehouse/backend/presentation/views/sql_flint_spec.py
+++ b/products/data_warehouse/backend/presentation/views/sql_flint_spec.py
@@ -1,0 +1,127 @@
+import uuid
+from typing import cast
+
+import structlog
+from asgiref.sync import async_to_sync
+from drf_spectacular.utils import OpenApiResponse, extend_schema_field
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+from posthog.api.documentation import _FallbackSerializer
+from posthog.api.mixins import ValidatedRequest, validated_request
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.user import User
+
+from products.data_warehouse.backend.sql_flint_spec_ai import SQLFlintSpecGenerator, SQLFlintSpecPayload
+
+logger = structlog.get_logger(__name__)
+
+JSON_VALUE_SCHEMA = {
+    "oneOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "object", "additionalProperties": True},
+        {"type": "array", "items": {}},
+        {"type": "null"},
+    ]
+}
+
+
+@extend_schema_field(JSON_VALUE_SCHEMA)
+class JSONValueField(serializers.JSONField):
+    pass
+
+
+class SQLFlintColumnSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=256, help_text="Result column name.")
+    type = serializers.CharField(
+        max_length=128, required=False, allow_null=True, allow_blank=True, help_text="Database column type, if known."
+    )
+    sampleValues = serializers.ListField(
+        child=JSONValueField(), required=False, max_length=10, help_text="Up to 10 sample values from the column."
+    )
+
+
+class SQLFlintSpecRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(max_length=100000, help_text="The SQL query that produced the results.")
+    prompt = serializers.CharField(
+        max_length=4000, allow_blank=True, help_text="User instructions for the chart to generate."
+    )
+    columns = SQLFlintColumnSerializer(many=True, help_text="Per-column result shape.")
+    rowCount = serializers.IntegerField(min_value=0, help_text="Total rows returned by the query.")
+
+    def validate_columns(self, columns: list[dict[str, object]]) -> list[dict[str, object]]:
+        if not columns:
+            raise serializers.ValidationError("At least one column is required.")
+        if len(columns) > 100:
+            raise serializers.ValidationError("At most 100 columns can be sent.")
+        return columns
+
+
+class SQLFlintSpecResponseSerializer(serializers.Serializer):
+    chart_spec = serializers.JSONField(
+        allow_null=True,
+        help_text="The generated Flint chart spec (chartType + channel encodings), or null when generation failed.",
+    )
+    semantic_types = serializers.DictField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Per-column Flint semantic type annotations for the spec.",
+    )
+    narrative = serializers.CharField(
+        required=False, allow_null=True, help_text="One-sentence description of the chart's takeaway."
+    )
+    trace_id = serializers.CharField(help_text="Trace ID for the generation request.")
+    warnings = serializers.ListField(
+        child=serializers.CharField(), required=False, help_text="Warnings about the generated chart."
+    )
+
+
+class SQLFlintSpecViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+
+    @validated_request(
+        request_serializer=SQLFlintSpecRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=SQLFlintSpecResponseSerializer),
+            400: OpenApiResponse(description="Invalid request"),
+        },
+        summary="Generate a Flint chart spec for SQL results",
+        description=(
+            "Maps SQL result columns to a compact Flint chart spec (chart type + channel encodings + "
+            "semantic types). The frontend compiles the spec with the actual result rows through the "
+            "flint-chart quill backend — no executable spec and no result data leave the client."
+        ),
+    )
+    def create(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        trace_id = f"sql_flint_spec_{uuid.uuid4()}"
+        user = cast(User, request.user)
+        payload = cast(SQLFlintSpecPayload, request.validated_data)
+
+        try:
+            generator = SQLFlintSpecGenerator(team=self.team, user=user)
+            spec = async_to_sync(generator.agenerate)(payload)
+        except Exception:
+            logger.warning("sql_flint_spec.generation_failed", team_id=self.team.id, trace_id=trace_id, exc_info=True)
+            return Response(
+                {
+                    "chart_spec": None,
+                    "trace_id": trace_id,
+                    "warnings": ["AI generation failed — showing the chart inferred from the result shape instead."],
+                }
+            )
+
+        return Response(
+            {
+                "chart_spec": {
+                    "chartType": spec.chartType,
+                    "encodings": spec.encodings.model_dump(exclude_none=True),
+                },
+                "semantic_types": spec.semantic_types,
+                "narrative": spec.narrative,
+                "trace_id": trace_id,
+                "warnings": [],
+            }
+        )

--- a/products/data_warehouse/backend/routes.py
+++ b/products/data_warehouse/backend/routes.py
@@ -14,6 +14,7 @@ from products.data_warehouse.backend.presentation.views import (
     saved_query,
     saved_query_column_annotation,
     saved_query_draft,
+    sql_flint_spec,
     table,
     view_link,
 )

--- a/products/data_warehouse/backend/routes.py
+++ b/products/data_warehouse/backend/routes.py
@@ -82,6 +82,9 @@ def register_routes(routers: RouterRegistry) -> None:
         r"data_modeling_jobs", data_modeling_job.DataModelingJobViewSet, "environment_data_modeling_jobs", ["team_id"]
     )
     routers.projects.register(
+        r"sql_flint_spec", sql_flint_spec.SQLFlintSpecViewSet, "project_sql_flint_spec", ["team_id"]
+    )
+    routers.projects.register(
         r"warehouse_column_annotations",
         column_annotation.WarehouseColumnAnnotationViewSet,
         "project_warehouse_column_annotations",

--- a/products/data_warehouse/backend/sql_flint_spec_ai.py
+++ b/products/data_warehouse/backend/sql_flint_spec_ai.py
@@ -57,6 +57,15 @@ class FlintEncodings(BaseModel):
     size: FlintEncoding | None = Field(default=None, description="Slice value column (pie charts only).")
 
 
+class FlintChartProperties(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stackMode: Literal["normalize"] | None = Field(
+        default=None,
+        description="'normalize' stacks to 100% (share of total). Stacked Bar and Area charts only.",
+    )
+
+
 class FlintChartSpec(BaseModel):
     """What the model emits: a Flint chart spec. The flint-chart compiler derives axes, scales,
     sort order, zero baselines, formatting, and layout from this plus the real rows."""
@@ -65,6 +74,9 @@ class FlintChartSpec(BaseModel):
 
     chartType: FlintChartType = Field(description="Flint chart template that best fits the columns.")
     encodings: FlintEncodings = Field(description="Column-to-channel bindings.")
+    chartProperties: FlintChartProperties | None = Field(
+        default=None, description="Template-specific display properties."
+    )
     semantic_types: dict[str, str] = Field(
         description=(
             "Per-column Flint semantic type, e.g. Date, Quantity, Price, Percentage, Duration, "
@@ -105,6 +117,8 @@ Guidelines:
   composition over time). A category column on x → "Bar Chart" ("Grouped"/"Stacked" with a color
   split). Part-of-whole → "Pie Chart" or "Doughnut Chart".
 - When rows are not pre-aggregated, set `aggregate` on y ("count" needs no field).
+- "Share of total" / "as a percentage" / "100% stacked" → a "Stacked Bar Chart" or "Area Chart"
+  with `chartProperties.stackMode` = "normalize".
 - `semantic_types` must cover every referenced column with its meaning, not its storage type:
   money → Price, ratios/rates → Percentage, timestamps/dates → Date, counts/amounts → Quantity,
   time spans → Duration, names/labels → Category, rankings → Rank, geography → Country.

--- a/products/data_warehouse/backend/sql_flint_spec_ai.py
+++ b/products/data_warehouse/backend/sql_flint_spec_ai.py
@@ -1,0 +1,202 @@
+"""AI generation of a Flint chart spec for SQL editor results.
+
+The Flint analogue of the earlier quill `ChartSpec` mapping experiment. The model emits only a
+compact, inert Flint spec — chart type, channel encodings, and per-column semantic types — and the
+flint-chart compiler derives everything else (scales, sort order, zero baselines, formatting,
+layout) deterministically on the client. The model never sees full result data: it maps result
+columns to channels and the frontend fills in the real rows.
+"""
+
+from typing import Literal, Optional, TypedDict
+
+import structlog
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import Runnable, RunnableConfig
+from pydantic import BaseModel, ConfigDict, Field
+
+from posthog.models.team import Team
+from posthog.models.user import User
+
+from ee.hogai.chat_agent.schema_generator.parsers import parse_pydantic_structured_output
+from ee.hogai.llm import MaxChatAnthropic
+from ee.hogai.utils.helpers import dereference_schema
+
+logger = structlog.get_logger(__name__)
+
+# The chart types the quill Flint backend implements (frontend/src/lib/charts/flint/templates)
+FlintChartType = Literal[
+    "Line Chart",
+    "Area Chart",
+    "Bar Chart",
+    "Grouped Bar Chart",
+    "Stacked Bar Chart",
+    "Pie Chart",
+    "Doughnut Chart",
+]
+
+
+class FlintEncoding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str | None = Field(default=None, description="Result column name bound to this channel.")
+    aggregate: Literal["count", "sum", "average"] | None = Field(
+        default=None, description="Aggregate rows onto this channel instead of (or as well as) a column."
+    )
+
+
+class FlintEncodings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x: FlintEncoding | None = Field(default=None, description="X axis (category or date column).")
+    y: list[FlintEncoding] | None = Field(
+        default=None, description="Measures to plot. Multiple entries become one series each."
+    )
+    color: FlintEncoding | None = Field(
+        default=None, description="Series split (cartesian charts) or slice category (pie charts)."
+    )
+    size: FlintEncoding | None = Field(default=None, description="Slice value column (pie charts only).")
+
+
+class FlintChartSpec(BaseModel):
+    """What the model emits: a Flint chart spec. The flint-chart compiler derives axes, scales,
+    sort order, zero baselines, formatting, and layout from this plus the real rows."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chartType: FlintChartType = Field(description="Flint chart template that best fits the columns.")
+    encodings: FlintEncodings = Field(description="Column-to-channel bindings.")
+    semantic_types: dict[str, str] = Field(
+        description=(
+            "Per-column Flint semantic type, e.g. Date, Quantity, Price, Percentage, Duration, "
+            "Category, Country, Rank. Drives formatting, zero baselines, and sort order."
+        )
+    )
+    narrative: str | None = Field(default=None, description="One plain sentence describing the takeaway.")
+
+
+class FlintSpecOutput(BaseModel):
+    spec: FlintChartSpec
+
+
+class SQLFlintColumn(TypedDict, total=False):
+    name: str
+    type: str | None
+    sampleValues: list[object]
+
+
+class SQLFlintSpecPayload(TypedDict, total=False):
+    query: str
+    prompt: str
+    columns: list[SQLFlintColumn]
+    rowCount: int
+
+
+SYSTEM_PROMPT = """
+You choose the best chart for a set of SQL query results and describe it as a compact Flint chart
+spec. You do NOT receive or output the data — you map result COLUMNS to encoding channels, and a
+deterministic compiler derives scales, axes, sort order, number/date formatting, and layout.
+
+Guidelines:
+- Cartesian charts bind `x` (the category or date column) and `y` (one entry per measure column).
+  Bind `color` to a categorical column to split one measure into series — never bind `color` and
+  multiple `y` entries at once.
+- Pie/Doughnut charts bind `color` (slice category) and `size` (slice value) instead of x/y.
+- A date column on x with measures → "Line Chart" (or "Area Chart"/"Stacked Bar Chart" for
+  composition over time). A category column on x → "Bar Chart" ("Grouped"/"Stacked" with a color
+  split). Part-of-whole → "Pie Chart" or "Doughnut Chart".
+- When rows are not pre-aggregated, set `aggregate` on y ("count" needs no field).
+- `semantic_types` must cover every referenced column with its meaning, not its storage type:
+  money → Price, ratios/rates → Percentage, timestamps/dates → Date, counts/amounts → Quantity,
+  time spans → Duration, names/labels → Category, rankings → Rank, geography → Country.
+- Set `narrative` to one plain sentence.
+
+Reference only column names that appear in the provided columns. Return only the spec.
+""".strip()
+
+USER_PROMPT = """
+Instruction:
+{{prompt}}
+
+SQL query:
+{{query}}
+
+Result columns (name, type, sample values):
+{{columns}}
+
+Row count: {{row_count}}
+""".strip()
+
+
+def _flint_spec_schema() -> dict:
+    return {
+        "name": "output_flint_spec",
+        "description": "Maps SQL result columns to a Flint chart spec.",
+        "parameters": {
+            "type": "object",
+            "properties": {"spec": dereference_schema(FlintChartSpec.model_json_schema())},
+            "additionalProperties": False,
+            "required": ["spec"],
+        },
+    }
+
+
+FLINT_SPEC_SCHEMA = _flint_spec_schema()
+
+
+def validate_spec_columns(spec: FlintChartSpec, columns: list[SQLFlintColumn]) -> None:
+    """Reject specs that reference columns not present in the results."""
+    known = {column.get("name") for column in columns}
+    referenced: list[str] = []
+    for encoding in [spec.encodings.x, spec.encodings.color, spec.encodings.size, *(spec.encodings.y or [])]:
+        if encoding and encoding.field:
+            referenced.append(encoding.field)
+    unknown = [field for field in referenced if field not in known]
+    if unknown:
+        raise ValueError(f"Spec references unknown columns: {', '.join(unknown)}")
+
+
+class SQLFlintSpecGenerator:
+    def __init__(self, team: Team, user: User) -> None:
+        self._team = team
+        self._user = user
+
+    @property
+    def _model(self) -> Runnable:
+        return MaxChatAnthropic(
+            model="claude-sonnet-4-6",
+            temperature=0.3,
+            streaming=False,
+            user=self._user,
+            team=self._team,
+            max_tokens=2048,
+            billable=True,
+        ).with_structured_output(FLINT_SPEC_SCHEMA, include_raw=False)
+
+    def _parse_output(self, output: dict) -> FlintChartSpec:
+        return parse_pydantic_structured_output(FlintSpecOutput)(output).spec
+
+    async def agenerate(self, payload: SQLFlintSpecPayload, config: Optional[RunnableConfig] = None) -> FlintChartSpec:
+        prompt = ChatPromptTemplate.from_messages(
+            [("system", SYSTEM_PROMPT), ("human", USER_PROMPT)],
+            template_format="mustache",
+        )
+        chain = prompt | self._model | self._parse_output
+        spec = await chain.ainvoke(
+            {
+                "prompt": payload.get("prompt") or "Visualize these results.",
+                "query": payload.get("query") or "",
+                "columns": _format_columns(payload.get("columns", [])),
+                "row_count": payload.get("rowCount", 0),
+            },
+            config,
+        )
+        validate_spec_columns(spec, payload.get("columns", []))
+        return spec
+
+
+def _format_columns(columns: list[SQLFlintColumn]) -> str:
+    lines = []
+    for column in columns:
+        samples = ", ".join(str(value) for value in (column.get("sampleValues") or [])[:5])
+        lines.append(f"- {column.get('name')} ({column.get('type') or 'unknown'}): {samples}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Problem

[Flint](https://github.com/microsoft/flint-chart) (`flint-chart`) is Microsoft's new visualization intermediate language for AI agents: an agent writes a ~10-line semantic chart spec (data + semantic types + encodings), and Flint's compiler derives scales, sort order, zero baselines, formatting, and layout, then a per-library backend emits a native chart config. It ships Vega-Lite, ECharts, and Chart.js backends.

**Why:** we wanted to know whether Flint could be used with `@posthog/quill-charts` so agent-generated charts (Max AI, MCP UI apps) could be specified in Flint's compact, LLM-friendly format but rendered on-brand with quill. This spike answers that question with working code.

## Changes

Adds `frontend/src/lib/charts/flint/` - an experimental quill backend for Flint, written out-of-tree against the public `flint-chart/core` exports (no fork needed):

- `assembleQuill(input)` runs Flint's unchanged compiler frontend and optimizer (semantic resolution, zero decisions, overflow filtering, layout), then instantiates quill templates instead of a rendering-library config. The "native spec" is a discriminated union of quill component props (`{ component: 'BarChart', series, labels, config }`).
- Templates for Bar, Grouped Bar, Stacked Bar, Line, Area, Pie, and Doughnut - the intersection of Flint's chart types and quill's component inventory. Names match Flint's cross-backend registry so specs are portable across backends.
- `<FlintQuillChart input={...} />` renders an assembled spec with the app chart theme (`useChartTheme`), falling back to an inline error message for unsupported chart types.
- Only Flint's semantic decisions carry through (sort order, zero baseline via `floatBaseline`, tick formatting, series routing, overflow truncation). Colors and pixel layout stay with quill, which themes from CSS variables.
- **SQL editor integration**: a "Flint chart" entry (Experimental section) in the chart-type dropdown. `flintChartInput()` infers a Flint spec from the result shape client-side (ClickHouse column types classify the x-axis, measures, and series split), and the output pane renders it with a chart-type select to re-target the same results across Line/Bar/Stacked/Area/Pie/Doughnut. Integration points mirror the closed generated-chart experiment [#66287](https://github.com/PostHog/posthog/pull/66287), with the `ChartDisplayType` schema regenerated (`schema.json` + `posthog/schema_enums.py`).
- Storybook stories under "Components/Flint quill chart" show grouped bar, stacked bar over time, multi-series line, stacked area, doughnut, and the unsupported-type error state.

> [!NOTE]
> Deliberately out of scope for the spike: faceting (`column`/`row` encodings are stripped with a warning), named-view pivots, and Flint chart types quill has no component for (scatter and heatmap are the notable gaps). `flint-chart` is v0.1.x, so the dependency is pinned exactly.

## How did you test this code?

`jest src/lib/charts/flint/assembleQuill.test.ts` - 11 tests, all passing. Each group guards a concrete regression no existing test covers, since this is all new code: chart-type routing (unknown type throws), the long-form-rows-to-quill-series pivot with category alignment, horizontal-bar detection from a y-channel category, chronological ordering of out-of-order temporal rows, area fill emission, pie/doughnut slice aggregation, the `aggregate: 'count'` derived-column path, and facet stripping with a warning.

`jest flintChartInput.test.ts` adds 7 more (18 total) covering the spec-inference heuristics: ClickHouse-type and value-sniffing column classification, color-channel routing, multi-measure static series, count fallback, and pie encoding remapping.

To try it: run a SQL query in the editor and pick "Flint chart" from the chart-type dropdown.

Also ran oxlint (clean) and confirmed `tsgo --noEmit` reports no errors in the new files. I was not able to run Storybook in this environment, so the stories are untested visually - reviewers can open "Components/Flint quill chart" to see the rendered output.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud session) from an investigation request into whether flint-chart could work with quill-charts. The investigation concluded Flint is a spec compiler rather than a renderer, and that its documented "add a backend" extension point plus the public `flint-chart/core` exports make an out-of-tree quill backend viable, so the spike was built to prove it.

Decisions along the way: placed the code in `frontend/src/lib/charts/flint/` rather than a new `packages/quill/packages/*` package to keep the spike out of the npm publish path (it can graduate later); skipped Flint internals that are not exported from `flint-chart/core` (`decideColorMaps` is intentionally unused since quill themes itself, and the small `applyAggregation` transform is reimplemented against its documented contract); renamed the output-types file away from a `-spec.ts` suffix after jest's test matcher picked it up. Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


